### PR TITLE
Differentiate text shown for Strikethrough-Commands on the Help-Feature

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -158,7 +158,7 @@ fn main() {
                 // The last `enum`-variant is `Strike`, which ~~strikes~~ a command.
                 .wrong_channel(HelpBehaviour::Strike)
                 // Serenity will automatically analyse and generate a hint/tip explaining the possible
-                // cases of a command being ~~striked~~, but only  if
+                // cases of ~~strikethrough-commands~~, but only if
                 // `striked_commands_tip(Some(""))` keeps `Some()` wrapping an empty `String`, which is the default value.
                 // If the `String` is not empty, your given `String` will be used instead.
                 // If you pass in a `None`, no hint will be displayed at all.

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -148,9 +148,7 @@ fn main() {
                 If you want more information about a specific command, just pass the command as argument.")
                 // Some arguments require a `{}` in order to replace it with contextual information.
                 // In this case our `{}` refers to a command's name.
-                .command_not_found_text("Could not {}, I'm sorry : (")
-                // Another argument requiring `{}`, again replaced with the command's name.
-                .suggestion_text("How about this command: {}, it's numero uno on the market...!")
+                .command_not_found_text("Could not find: `{}`.")
                 // On another note, you can set up the help-menu-filter-behaviour.
                 // Here are all possible settings shown on all possible options.
                 // First case is if a user lacks permissions for a command, we can hide the command.

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -161,13 +161,13 @@ pub struct HelpOptions {
     pub command_not_found_text: String,
     /// Explains the user on how to use access a single command's details.
     pub individual_command_tip: String,
-    /// Explains reasoning behind striked commands, see fields requiring `HelpBehaviour` for further information.
+    /// Explains reasoning behind strikethrough-commands, see fields requiring `HelpBehaviour` for further information.
     /// If `HelpBehaviour::Strike` is unused, this field will evaluate to `None` during creation
     /// inside of `CreateHelpCommand`.
     ///
     /// **Note**: Text is only used in direct messages.
     pub striked_commands_tip_in_dm: Option<String>,
-    /// Explains reasoning behind striked commands, see fields requiring `HelpBehaviour` for further information.
+    /// Explains reasoning behind strikethrough-commands, see fields requiring `HelpBehaviour` for further information.
     /// If `HelpBehaviour::Strike` is unused, this field will evaluate to `None` during creation
     /// inside of `CreateHelpCommand`.
     ///

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -164,7 +164,15 @@ pub struct HelpOptions {
     /// Explains reasoning behind striked commands, see fields requiring `HelpBehaviour` for further information.
     /// If `HelpBehaviour::Strike` is unused, this field will evaluate to `None` during creation
     /// inside of `CreateHelpCommand`.
-    pub striked_commands_tip: Option<String>,
+    ///
+    /// **Note**: Text is only used in direct messages.
+    pub striked_commands_tip_in_dm: Option<String>,
+    /// Explains reasoning behind striked commands, see fields requiring `HelpBehaviour` for further information.
+    /// If `HelpBehaviour::Strike` is unused, this field will evaluate to `None` during creation
+    /// inside of `CreateHelpCommand`.
+    ///
+    /// **Note**: Text is only used in guilds.
+    pub striked_commands_tip_in_guild: Option<String>,
     /// Announcing a group's prefix as in: {group_prefix} {prefix}.
     pub group_prefix: String,
     /// If a user lacks required roles, this will treat how these commands will be displayed.
@@ -213,7 +221,8 @@ impl Default for HelpOptions {
             individual_command_tip: "To get help with an individual command, pass its \
                  name as an argument to this command.".to_string(),
             group_prefix: "Prefix".to_string(),
-            striked_commands_tip: Some(String::new()),
+            striked_commands_tip_in_dm: Some(String::new()),
+            striked_commands_tip_in_guild: Some(String::new()),
             lacking_role: HelpBehaviour::Strike,
             lacking_permissions: HelpBehaviour::Strike,
             wrong_channel: HelpBehaviour::Strike,

--- a/src/framework/standard/create_help_command.rs
+++ b/src/framework/standard/create_help_command.rs
@@ -219,7 +219,7 @@ impl CreateHelpCommand {
     }
 
     fn produce_strike_text(&self, dm_or_guild: &str) -> String {
-        let mut strike_text = String::from("~~`Striked commands`~~ are unavailable because they");
+        let mut strike_text = String::from("~~`Strikethrough commands`~~ are unavailable because they");
 
         let mut concat_with_comma = if self.0.lacking_permissions == HelpBehaviour::Strike {
             let _ = write!(strike_text, " require permissions");

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -38,12 +38,12 @@ use std::{
 };
 use super::command::InternalCommand;
 use super::{
-    Args, 
-    CommandGroup, 
-    CommandOrAlias, 
-    HelpOptions, 
-    CommandOptions, 
-    CommandError, 
+    Args,
+    CommandGroup,
+    CommandOrAlias,
+    HelpOptions,
+    CommandOptions,
+    CommandError,
     HelpBehaviour
 };
 use utils::Colour;
@@ -222,8 +222,13 @@ pub fn with_embeds<H: BuildHasher>(
 
     let _ = msg.channel_id.send_message(|m| {
         m.embed(|mut e| {
+            let striked_command_tip = if msg.is_private() {
+                    &help_options.striked_commands_tip_in_guild
+                } else {
+                    &help_options.striked_commands_tip_in_dm
+                };
 
-            if let Some(ref striked_command_text) = help_options.striked_commands_tip {
+            if let Some(ref striked_command_text) = striked_command_tip {
                 e = e.colour(help_options.embed_success_colour).description(
                     format!("{}\n{}", &help_options.individual_command_tip, striked_command_text),
                 );
@@ -461,7 +466,13 @@ pub fn plain<H: BuildHasher>(
 
     let mut result = "**Commands**\n".to_string();
 
-    if let Some(ref striked_command_text) = help_options.striked_commands_tip {
+    let striked_command_tip = if msg.is_private() {
+            &help_options.striked_commands_tip_in_guild
+        } else {
+            &help_options.striked_commands_tip_in_dm
+    };
+
+    if let Some(ref striked_command_text) = striked_command_tip {
         let _ = write!(result, "{}\n{}\n\n", &help_options.individual_command_tip, striked_command_text);
     } else {
         let _ = write!(result, "{}\n\n", &help_options.individual_command_tip);


### PR DESCRIPTION
Originally, the help-feature did not differentiate whether the user used the help-feature via direct message or guild-channel, thus the text about struck through commands generalised to "not available in DM/guilds".

From now on, the help-feature got new methods to specify either case, DM or guild. The method used originally is still behaving the same - sets the one text for both cases.

Without setting any of the mentioned above, the builder will automatically create suiting texts for DM- and guild-contexts.