### PR TITLE
Add methods to check whether `Message` is mentioning `User`

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -490,6 +490,18 @@ impl Message {
         http::send_message(self.channel_id.0, &map)
     }
 
+    /// Checks whether the message mentions the user of given Id.
+    pub fn mentions_user_id(&self, id: u64) -> bool {
+        let search_for = vec![format!("<@{}>", id), format!("<@!{}>", id)];
+
+        search_for.iter().any(|ref mention| self.content.contains(mention.as_str()))
+    }
+
+    /// Checks whether the message mentions `User`.
+    pub fn mentions_user(&self, user: User) -> bool {
+        self.mentions_user_id(user.id.0)
+    }
+
     /// Unpins the message from its channel.
     ///
     /// **Note**: Requires the [Manage Messages] permission.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -490,16 +490,18 @@ impl Message {
         http::send_message(self.channel_id.0, &map)
     }
 
-    /// Checks whether the message mentions the user of given Id.
-    pub fn mentions_user_id(&self, id: u64) -> bool {
-        let search_for = vec![format!("<@{}>", id), format!("<@!{}>", id)];
-
-        search_for.iter().any(|ref mention| self.content.contains(mention.as_str()))
+    /// Checks whether the message mentions the user of given [`UserId`].
+    ///
+    /// [`UserId`]: ../model/user/struct.UserId.html
+    pub fn mentions_user_id(&self, user_id_to_find: &UserId) -> bool {
+        self.mentions.iter().any(|mentioned_user| mentioned_user.id.0 == user_id_to_find.0)
     }
 
-    /// Checks whether the message mentions `User`.
-    pub fn mentions_user(&self, user: User) -> bool {
-        self.mentions_user_id(user.id.0)
+    /// Checks whether the message mentions passed [`User`].
+    ///
+    /// [`User`]: ../model/user/struct.User.html
+    pub fn mentions_user(&self, user: &User) -> bool {
+        self.mentions_user_id(&user.id)
     }
 
     /// Unpins the message from its channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -490,18 +490,19 @@ impl Message {
         http::send_message(self.channel_id.0, &map)
     }
 
-    /// Checks whether the message mentions the user of given [`UserId`].
+    /// Checks whether the message mentions passed [`UserId`].
     ///
-    /// [`UserId`]: ../model/user/struct.UserId.html
-    pub fn mentions_user_id(&self, user_id_to_find: &UserId) -> bool {
+    /// [`UserId`]: ../../model/id/struct.UserId.html
+    pub fn mentions_user_id<I: Into<UserId>>(&self, id: I) -> bool {
+        let user_id_to_find = id.into();
         self.mentions.iter().any(|mentioned_user| mentioned_user.id.0 == user_id_to_find.0)
     }
 
     /// Checks whether the message mentions passed [`User`].
     ///
-    /// [`User`]: ../model/user/struct.User.html
+    /// [`User`]: ../user/struct.User.html
     pub fn mentions_user(&self, user: &User) -> bool {
-        self.mentions_user_id(&user.id)
+        self.mentions_user_id(user.id)
     }
 
     /// Unpins the message from its channel.


### PR DESCRIPTION
Two methods, one that accepts `u64` Ids and the other accepting the `User`, to check whether a `Message` contains a mention.