### PR TITLE
Provide help-details for all visible commands

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -116,8 +116,6 @@ pub fn is_command_visible(command_options: &Arc<CommandOptions>, msg: &Message, 
                     } else {
                         return help_options.lacking_permissions != HelpBehaviour::Hide;
                     }
-                } else {
-                    return help_options.lacking_permissions != HelpBehaviour::Hide;
                 }
             }
         }
@@ -125,7 +123,7 @@ pub fn is_command_visible(command_options: &Arc<CommandOptions>, msg: &Message, 
         return help_options.wrong_channel != HelpBehaviour::Hide;
     }
 
-    return false;
+    return false
 }
 
 /// Posts an embed showing each individual command group and its commands.

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -94,7 +94,7 @@ pub fn has_all_requirements(cmd: &Arc<CommandOptions>, msg: &Message) -> bool {
 /// **Note**: A command is visible when it is either normally displayed or
 /// strikethrough upon requested help by a user.
 #[cfg(feature = "cache")]
-pub fn is_command_hidden(command_options: &Arc<CommandOptions>, msg: &Message, help_options: &HelpOptions) -> bool {
+pub fn is_command_visible(command_options: &Arc<CommandOptions>, msg: &Message, help_options: &HelpOptions) -> bool {
     if !command_options.dm_only && !command_options.guild_only
     || command_options.dm_only && msg.is_private()
     || command_options.guild_only && !msg.is_private() {
@@ -170,7 +170,7 @@ pub fn with_embeds<H: BuildHasher>(
                 if name == with_prefix || name == *command_name {
                     match *command {
                         CommandOrAlias::Command(ref cmd) => {
-                            if is_command_hidden(&cmd.options(), msg, help_options) {
+                            if is_command_visible(&cmd.options(), msg, help_options) {
                                 found = Some((command_name, cmd));
                             } else {
                                 break;
@@ -181,7 +181,7 @@ pub fn with_embeds<H: BuildHasher>(
 
                             match *actual_command {
                                 CommandOrAlias::Command(ref cmd) => {
-                                    if is_command_hidden(&cmd.options(), msg, help_options) {
+                                    if is_command_visible(&cmd.options(), msg, help_options) {
                                         found = Some((name, cmd));
                                     } else {
                                         break;
@@ -419,7 +419,7 @@ pub fn plain<H: BuildHasher>(
                 if name == with_prefix || name == *command_name {
                     match *command {
                         CommandOrAlias::Command(ref cmd) => {
-                            if is_command_hidden(&cmd.options(), msg, help_options) {
+                            if is_command_visible(&cmd.options(), msg, help_options) {
                                 found = Some((command_name, cmd));
                             }
                             else {
@@ -431,7 +431,7 @@ pub fn plain<H: BuildHasher>(
 
                             match *actual_command {
                                 CommandOrAlias::Command(ref cmd) => {
-                                    if is_command_hidden(&cmd.options(), msg, help_options) {
+                                    if is_command_visible(&cmd.options(), msg, help_options) {
                                         found = Some((name, cmd));
                                     }
                                     else {


### PR DESCRIPTION
Before, the help-features did not display further information about a command that was unable to use due to wrong channel (e.g. guild-only-command used via direct message).

From now the behaviour - whether a command is available for further details - will work as following:
When the command would be normally displayed or strikethrough, the command will be available for further details via `help command-name`.

I will need to add this behaviour to `v0.6.x` once the framework is working again and #274 is merged.
On another note, this might depreciate `has_all_requirements`, since Serenity will no longer use it - might keep it for the utility.