### PR TITLE
Add CreateEmbed::Field/s to 11_create_message_builder example

### DIFF
--- a/examples/11_create_message_builder/src/main.rs
+++ b/examples/11_create_message_builder/src/main.rs
@@ -19,6 +19,11 @@ impl EventHandler for Handler {
                 .embed(|e| e
                     .title("This is a title")
                     .description("This is a description")
+                    .fields(vec![
+                        ("This is the first field", "This is a field body", true),
+                        ("This is the second field", "Both of these fields are inline", true),
+                    ])
+                    .field("This is the third field", "This is not an inline field", false)
                     .footer(|f| f
                         .text("This is a footer")))) {
                 println!("Error sending message: {:?}", why);

--- a/examples/11_create_message_builder/src/main.rs
+++ b/examples/11_create_message_builder/src/main.rs
@@ -13,7 +13,7 @@ impl EventHandler for Handler {
             // The create message builder allows you to easily create embeds and messages
             // using a builder syntax.
             // This example will create a message that says "Hello, World!", with an embed that has
-            // a title, description, and footer.
+            // a title, description, three fields, and footer.
             if let Err(why) = msg.channel_id.send_message(|m| m
                 .content("Hello, World!")
                 .embed(|e| e


### PR DESCRIPTION
Adds usage of both `CreateEmbed::Field` and `CreateEmbed::Fields`.