### PR TITLE
Support multiple prefixes for command-groups

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -168,6 +168,7 @@ fn main() {
             .bucket("complicated")
             .cmd(commands))
         .group("Emoji", |g| g
+            // Sets a single prefix for a group:
             .prefix("emoji")
             .command("cat", |c| c
                 .desc("Sends an emoji with a cat.")
@@ -180,9 +181,14 @@ fn main() {
                 .desc("Sends an emoji with a dog.")
                 .bucket("emoji")
                 .cmd(dog)))
-        .command("multiply", |c| c
-            .known_as("*") // Lets us call ~* instead of ~multiply
-            .cmd(multiply))
+        .group("Math", |g| g
+            // Sets multiple prefixes for a group.
+            // This requires us to call commands in this group
+            // via `~math` (or `~m`) instead of just `~`.
+            .prefixes(vec!["m", "math"])
+            .command("multiply", |c| c
+                .known_as("*") // Lets us also call `~math *` instead of just `~math multiply`.
+                .cmd(multiply)))
         .command("latency", |c| c
             .cmd(latency))
         .command("ping", |c| c

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -87,7 +87,7 @@ impl<D: fmt::Display> From<D> for Error {
 
 #[derive(Debug)]
 pub struct CommandGroup {
-    pub prefix: Option<String>,
+    pub prefixes: Option<Vec<String>>,
     pub commands: HashMap<String, CommandOrAlias>,
     /// Some fields taken from Command
     pub bucket: Option<String>,
@@ -103,7 +103,7 @@ pub struct CommandGroup {
 impl Default for CommandGroup {
     fn default() -> CommandGroup {
         CommandGroup {
-            prefix: None,
+            prefixes: None,
             commands: HashMap::new(),
             bucket: None,
             required_permissions: Permissions::empty(),

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -12,8 +12,10 @@ pub use super::{
 };
 
 use client::Context;
-use model::channel::Message;
-use model::Permissions;
+use model::{
+    channel::Message,
+    Permissions,
+};
 use std::sync::Arc;
 
 /// Used to create command groups
@@ -55,11 +57,15 @@ impl CreateGroup {
         let cmd = f(self.build_command()).finish();
 
         for n in &cmd.options().aliases {
-            if let Some(ref prefix) = self.0.prefix {
-                self.0.commands.insert(
-                    format!("{} {}", prefix, n.to_string()),
-                    CommandOrAlias::Alias(format!("{} {}", prefix, command_name.to_string())),
-                );
+
+            if let Some(ref prefixes) = self.0.prefixes {
+
+                for prefix in prefixes {
+                    self.0.commands.insert(
+                        format!("{} {}", prefix, n.to_string()),
+                        CommandOrAlias::Alias(format!("{} {}", prefix, command_name.to_string())),
+                    );
+                }
             } else {
                 self.0.commands.insert(
                     n.to_string(),
@@ -105,8 +111,20 @@ impl CreateGroup {
     /// **Note**: serenity automatically puts a space after group prefix.
     ///
     /// **Note**: It's suggested to call this first when making a group.
-    pub fn prefix(mut self, desc: &str) -> Self {
-        self.0.prefix = Some(desc.to_string());
+    pub fn prefix(mut self, prefix: &str) -> Self {
+        self.0.prefixes = Some(vec![prefix.to_string()]);
+
+        self
+    }
+
+    /// Sets prefixes to respond to. Each can be a string slice of any
+    /// non-zero length.
+    ///
+    /// **Note**: serenity automatically puts a space after group prefix.
+    ///
+    /// **Note**: It's suggested to call this first when making a group.
+    pub fn prefixes<T: ToString, I: IntoIterator<Item=T>>(mut self, prefixes: I) -> Self {
+        self.0.prefixes = Some(prefixes.into_iter().map(|prefix| prefix.to_string()).collect());
 
         self
     }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -121,8 +121,8 @@ pub fn with_embeds<H: BuildHasher>(
             let mut found: Option<(&String, &InternalCommand)> = None;
 
             for (command_name, command) in &group.commands {
-                let with_prefix = if let Some(ref prefix) = group.prefix {
-                    format!("{} {}", prefix, command_name)
+                let with_prefix = if let Some(ref prefixes) = group.prefixes {
+                    format!("{} {}", prefixes.join("`, `"), command_name)
                 } else {
                     command_name.to_string()
                 };
@@ -191,7 +191,7 @@ pub fn with_embeds<H: BuildHasher>(
                         }
 
                         if !command.aliases.is_empty() {
-                            let aliases = command.aliases.join(", ");
+                            let aliases = command.aliases.join("`, `");
 
                             embed = embed.field(&help_options.aliases_label, aliases, true);
                         }
@@ -245,8 +245,8 @@ pub fn with_embeds<H: BuildHasher>(
                 let group = &groups[group_name];
                 let mut desc = String::new();
 
-                if let Some(ref x) = group.prefix {
-                    let _ = write!(desc, "{}: `{}`\n", &help_options.group_prefix, x);
+                if let Some(ref prefixes) = group.prefixes {
+                    let _ = write!(desc, "{}: `{}`\n", &help_options.group_prefix, prefixes.join("`, `"));
                 }
 
                 let mut has_commands = false;
@@ -370,8 +370,8 @@ pub fn plain<H: BuildHasher>(
             let mut found: Option<(&String, &InternalCommand)> = None;
 
             for (command_name, command) in &group.commands {
-                let with_prefix = if let Some(ref prefix) = group.prefix {
-                    format!("{} {}", prefix, command_name)
+                let with_prefix = if let Some(ref prefixes) = group.prefixes {
+                    format!("{} {}", prefixes.join("`, `"), command_name)
                 } else {
                     command_name.to_string()
                 };
@@ -554,8 +554,8 @@ pub fn plain<H: BuildHasher>(
         if !group_help.is_empty() {
             let _ = write!(result, "**{}:** ", group_name);
 
-            if let Some(ref x) = group.prefix {
-                let _ = write!(result, "({}: `{}`): ", help_options.group_prefix, x);
+            if let Some(ref prefixes) = group.prefixes {
+                let _ = write!(result, "({}: `{}`): ", help_options.group_prefix, prefixes.join("`, `"));
             }
 
             result.push_str(&group_help);


### PR DESCRIPTION
We have support for multiple prefixes to call commands but there is no such equivalent for groups.
Thus this pull request adds support for them.

Just call `prefixes(vec!["f", "ferris"])` on your group-builder instead of `prefix("ferris")`. 
This allows shortcuts for long prefixes while maintaining long options for new users of a bot.

An inexperienced user may use: `!ferris baneveryone` while an experienced one can do: `!f baneveryone`, assuming this command `baneveryone` is inside a group supporting the prefixes "f" and "ferris".