### PR TITLE
Make the Cache Update API public

### DIFF
--- a/src/cache/cache_update.rs
+++ b/src/cache/cache_update.rs
@@ -1,7 +1,105 @@
 use super::Cache;
 
-pub(crate) trait CacheUpdate {
+/// Trait used for updating the cache with a type.
+///
+/// This may be implemented on a type and used to update the cache via
+/// [`Cache::update`].
+///
+/// # Examples
+///
+/// Creating a custom struct implementation to update the cache with:
+///
+/// ```rust
+/// use serenity::{
+///     cache::{Cache, CacheUpdate},
+///     model::{
+///         id::UserId,
+///         user::User,
+///     },
+///     prelude::RwLock,
+/// };
+/// use std::{
+///     collections::hash_map::Entry,
+///     sync::Arc,
+/// };
+///
+/// // For example, an update to the user's record in the database was
+/// // published to a pubsub channel.
+/// struct DatabaseUserUpdate {
+///     user_avatar: Option<String>,
+///     user_discriminator: u16,
+///     user_id: UserId,
+///     user_is_bot: bool,
+///     user_name: String,
+/// }
+///
+/// impl CacheUpdate for DatabaseUserUpdate {
+///     // A copy of the old user's data, if it existed in the cache.
+///     type Output = User;
+///
+///     fn update(&mut self, cache: &mut Cache) -> Option<Self::Output> {
+///         // If an entry for the user already exists, update its fields.
+///         match cache.users.entry(self.user_id) {
+///             Entry::Occupied(entry) => {
+///                 let user = entry.get();
+///                 let mut writer = user.write();
+///                 let old = writer.clone();
+///
+///                 writer.bot = self.user_is_bot;
+///                 writer.discriminator = self.user_discriminator;
+///                 writer.id = self.user_id;
+///
+///                 if writer.avatar != self.user_avatar {
+///                     writer.avatar = self.user_avatar.clone();
+///                 }
+///
+///                 if writer.name != self.user_name {
+///                     writer.name = self.user_name.clone();
+///                 }
+///
+///                 // Return the old copy for the user's sake.
+///                 Some(old)
+///             },
+///             Entry::Vacant(entry) => {
+///                 entry.insert(Arc::new(RwLock::new(User {
+///                     id: self.user_id,
+///                     avatar: self.user_avatar.clone(),
+///                     bot: self.user_is_bot,
+///                     discriminator: self.user_discriminator,
+///                     name: self.user_name.clone(),
+///                 })));
+///
+///                 // There was no old copy, so return None.
+///                 None
+///             },
+///         }
+///     }
+/// }
+///
+/// // Create an instance of the cache.
+/// let mut cache = Cache::new();
+///
+/// // This is a sample pubsub message that you might receive from your
+/// // database.
+/// let mut update_message = DatabaseUserUpdate {
+///     user_avatar: None,
+///     user_discriminator: 6082,
+///     user_id: UserId(379740138303127564),
+///     user_is_bot: true,
+///     user_name: "TofuBot".to_owned(),
+/// };
+///
+/// // Update the cache with the message.
+/// cache.update(&mut update_message);
+/// ```
+///
+/// [`Cache::update`]: struct.Cache.html#method.update
+pub trait CacheUpdate {
+    /// The return type of an update.
+    ///
+    /// If there is nothing to return, specify this type as an unit (`()`).
     type Output;
 
+    /// Updates the cache with the implementation.
     fn update(&mut self, &mut Cache) -> Option<Self::Output>;
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -56,7 +56,7 @@ use std::{
 
 mod cache_update;
 
-pub(crate) use self::cache_update::*;
+pub use self::cache_update::CacheUpdate;
 
 /// A cache of all events received over a [`Shard`], where storing at least
 /// some data from the event is possible.
@@ -627,8 +627,18 @@ impl Cache {
         self.categories.get(&channel_id.into()).cloned()
     }
 
-    #[cfg(feature = "client")]
-    pub(crate) fn update<E: CacheUpdate>(&mut self, e: &mut E) -> Option<E::Output> {
+    /// Updates the cache with the update implementation for an event or other
+    /// custom update implementation.
+    ///
+    /// Refer to the documentation for [`CacheUpdate`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// Refer to the [`CacheUpdate` examples].
+    ///
+    /// [`CacheUpdate`]: trait.CacheUpdate.html
+    /// [`CacheUpdate` examples]: trait.CacheUpdate.html#examples
+    pub fn update<E: CacheUpdate>(&mut self, e: &mut E) -> Option<E::Output> {
         e.update(self)
     }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -759,39 +759,6 @@ pub struct MessageCreateEvent {
     pub message: Message,
 }
 
-#[cfg(feature = "cache")]
-impl CacheUpdate for MessageCreateEvent {
-    type Output = Message;
-
-    fn update(&mut self, cache: &mut Cache) -> Option<Self::Output> {
-        let max = cache.settings().max_messages;
-
-        if max == 0 {
-            return None;
-        }
-
-        let messages = cache.messages
-            .entry(self.message.channel_id)
-            .or_insert_with(Default::default);
-        let queue = cache.message_queue
-            .entry(self.message.channel_id)
-            .or_insert_with(Default::default);
-
-        let mut removed_msg = None;
-
-        if messages.len() == max {
-            if let Some(id) = queue.pop_front() {
-                removed_msg = messages.remove(&id);
-            }
-        }
-
-        queue.push_back(self.message.id);
-        messages.insert(self.message.id, self.message.clone());
-
-        removed_msg
-    }
-}
-
 impl<'de> Deserialize<'de> for MessageCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
@@ -836,46 +803,6 @@ pub struct MessageUpdateEvent {
     pub mention_roles: Option<Vec<RoleId>>,
     pub attachments: Option<Vec<Attachment>>,
     pub embeds: Option<Vec<Value>>,
-}
-
-#[cfg(feature = "cache")]
-impl CacheUpdate for MessageUpdateEvent {
-    type Output = ();
-
-    fn update(&mut self, cache: &mut Cache) -> Option<Self::Output> {
-        let messages = cache.messages.get_mut(&self.channel_id)?;
-        let message = messages.get_mut(&self.id)?;
-
-        if let Some(attachments) = self.attachments.clone() {
-            message.attachments = attachments;
-        }
-
-        if let Some(content) = self.content.clone() {
-            message.content = content;
-        }
-
-        if let Some(edited_timestamp) = self.edited_timestamp.clone() {
-            message.edited_timestamp = Some(edited_timestamp);
-        }
-
-        if let Some(mentions) = self.mentions.clone() {
-            message.mentions = mentions;
-        }
-
-        if let Some(mention_everyone) = self.mention_everyone {
-            message.mention_everyone = mention_everyone;
-        }
-
-        if let Some(mention_roles) = self.mention_roles.clone() {
-            message.mention_roles = mention_roles;
-        }
-
-        if let Some(pinned) = self.pinned {
-            message.pinned = pinned;
-        }
-
-        None
-    }
 }
 
 #[derive(Clone, Debug, Serialize)]


### PR DESCRIPTION
This commit makes the Cache Update API public, allowing users to manually update
the cache, as well as implementing the caching API on their own types to work
with mutating the cache.

The motivation for this indirectly comes from a message cache: if a user has
multiple processes that can receive cache updates (either splitting a bot's
shards into multiple processes or other processes like web panels or pub/sub
channels), then this will allow them to easily mutate the cache and feed all
types implementing the CacheUpdate trait into `Cache::update`.