### PR TITLE
Do not suggest command if no command is actually related to input

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -497,7 +497,7 @@ pub fn plain<H: BuildHasher>(
         }
 
         let _ = msg.channel_id
-            .say(&help_options.suggestion_text.replace("{}", name));
+            .say(&help_options.command_not_found_text.replace("{}", name));
 
         return Ok(());
     }


### PR DESCRIPTION
Currently, Serenity displays suggestion-text on plain help when no actual command could be found.

With this pull request, Serenity will simply display the - to be expected - _no command found_-message.