### PR TITLE
Add default-commands for command-groups

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -170,6 +170,8 @@ fn main() {
         .group("Emoji", |g| g
             // Sets a single prefix for a group:
             .prefix("emoji")
+            // Sets a command that will be executed if only a group-prefix was passed.
+            .default_cmd(dog)
             .command("cat", |c| c
                 .desc("Sends an emoji with a cat.")
                 .batch_known_as(vec!["kitty", "neko"]) // Adds multiple aliases

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -104,6 +104,7 @@ pub struct CommandGroup {
     /// A set of checks to be called prior to executing the command-group. The checks
     /// will short-circuit on the first check that returns `false`.
     pub checks: Vec<Check>,
+    pub default_command: Option<CommandOrAlias>,
 }
 
 impl Default for CommandGroup {
@@ -120,6 +121,7 @@ impl Default for CommandGroup {
             allowed_roles: Vec::new(),
             help: None,
             checks: Vec::new(),
+            default_command: None,
         }
     }
 }

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -194,4 +194,16 @@ impl CreateGroup {
 
         self
     }
+
+    /// Adds a command for a group that will be executed if no command-name
+    /// has been passed.
+    pub fn default_cmd<C: Command + 'static>(mut self, c: C) -> Self {
+        let cmd: Arc<Command> = Arc::new(c);
+
+        self.0.default_command = Some(CommandOrAlias::Command(Arc::clone(&cmd)));
+
+        cmd.init();
+
+        self
+    }
 }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1036,7 +1036,6 @@ impl Framework for StandardFramework {
                         );
 
                         if longest_matching_prefix_len == built.len() {
-
                             String::new()
                         } else if longest_matching_prefix_len > 0 {
                             built[longest_matching_prefix_len + 1..].to_string()

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1020,14 +1020,14 @@ impl Framework for StandardFramework {
                     if let Some(&CommandOrAlias::Alias(ref points_to)) = cmd {
                         built = points_to.to_string();
                     }
-                    
+
                     let to_check = if let Some(ref prefixes) = group.prefixes {
                         // Once `built` starts with a set prefix,
                         // we want to make sure that all following matching prefixes are longer
                         // than the last matching one, this prevents picking a wrong prefix,
                         // e.g. "f" instead of "ferris" due to "f" having a lower index in the `Vec`.
                         let longest_matching_prefix_len = prefixes.iter().fold(0, |longest_prefix_len, prefix|
-                            if prefix.len() > longest_prefix_len && built.starts_with(prefix) 
+                            if prefix.len() > longest_prefix_len && built.starts_with(prefix)
                             && (index + 1 == positions.len() || command_length > prefix.len() + 1) {
                                 prefix.len()
                             } else {
@@ -1036,7 +1036,7 @@ impl Framework for StandardFramework {
                         );
 
                         if longest_matching_prefix_len == built.len() {
-                            
+
                             String::new()
                         } else if longest_matching_prefix_len > 0 {
                             built[longest_matching_prefix_len + 1..].to_string()
@@ -1056,12 +1056,12 @@ impl Framework for StandardFramework {
 
                     let before = self.before.clone();
                     let after = self.after.clone();
-                    
+
                     if to_check.is_empty() {
 
                         if let Some(CommandOrAlias::Command(ref command)) = &group.default_command {
                             let command = Arc::clone(command);
-                            
+
                             threadpool.execute(move || {
                                 if let Some(before) = before {
                                     if !(before)(&mut context, &message, &built) {


### PR DESCRIPTION
This adds a fallback or _default-command_ that will be executed if:

1. A valid normal command-prefix has been entered.
2. A valid prefix of a group has been entered.
3. No command-name has been entered.

Example: `! group-prefix` 

This allows to create CLI-style commands where possible arguments are listed in the help-list-feature. Opposed to using one single command where possible arguments would have to be dispatched within that command and are not listed in the help-list.

Usage is fairly simple, just call `default_cmd()` as one would call `cmd` on a command-creator (`CreateCommand`).

