### PR TITLE
Add `impl AsRef<MessageId> for Message`

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -605,6 +605,12 @@ impl Message {
     }
 }
 
+impl AsRef<MessageId> for Message {
+    fn as_ref(&self) -> &MessageId {
+        &self.id
+    }
+}
+
 impl From<Message> for MessageId {
     /// Gets the Id of a `Message`.
     fn from(message: Message) -> MessageId { message.id }


### PR DESCRIPTION
This allows for Message to be used directly in places that use this bound. `GuildChannel::delete_messages` for example, with this change, is able to use `Vec<Message>` without the user needing to map and collect.