### PR TITLE
Fix default command upon shortcut prefix and passing sub-commands to default-command

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -168,10 +168,12 @@ fn main() {
             .bucket("complicated")
             .cmd(commands))
         .group("Emoji", |g| g
-            // Sets a single prefix for a group:
-            .prefix("emoji")
+            // Sets multiple prefixes for a group.
+            // This requires us to call commands in this group
+            // via `~emoji` (or `~e`) instead of just `~`.
+            .prefixes(vec!["emoji", "em"])
             // Sets a command that will be executed if only a group-prefix was passed.
-            .default_cmd(dog)
+            .default_cmd(bird)
             .command("cat", |c| c
                 .desc("Sends an emoji with a cat.")
                 .batch_known_as(vec!["kitty", "neko"]) // Adds multiple aliases
@@ -184,10 +186,10 @@ fn main() {
                 .bucket("emoji")
                 .cmd(dog)))
         .group("Math", |g| g
-            // Sets multiple prefixes for a group.
-            // This requires us to call commands in this group
-            // via `~math` (or `~m`) instead of just `~`.
-            .prefixes(vec!["m", "math"])
+            // Sets a single prefix for this group.
+            // So one has to call commands in this group
+            // via `~math` instead of just `~`.
+            .prefix("math")
             .command("multiply", |c| c
                 .known_as("*") // Lets us also call `~math *` instead of just `~math multiply`.
                 .cmd(multiply)))
@@ -204,7 +206,7 @@ fn main() {
         .group("Owner", |g| g
             // This check applies to every command on this group.
             // User needs to pass the test for the command to execute.
-            .check(admin_check) 
+            .check(admin_check)
             .command("am i admin", |c| c
                 .cmd(am_i_admin))
                 .guild_only(true)
@@ -249,7 +251,7 @@ fn owner_check(_: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions)
 
 // A function which acts as a "check", to determine whether to call a command.
 //
-// This check analyses whether a guild member permissions has 
+// This check analyses whether a guild member permissions has
 // administrator-permissions.
 fn admin_check(_: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> bool {
     if let Some(member) = msg.member() {
@@ -263,7 +265,7 @@ fn admin_check(_: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions)
 }
 
 command!(some_long_command(_ctx, msg, args) {
-    if let Err(why) = msg.channel_id.say(&format!("Arguments: {}", args.full())) {
+    if let Err(why) = msg.channel_id.say(&format!("Arguments: {:?}", args)) {
         println!("Error sending message: {:?}", why);
     }
 });
@@ -378,6 +380,18 @@ command!(dog(_ctx, msg, _args) {
 
 command!(cat(_ctx, msg, _args) {
     if let Err(why) = msg.channel_id.say(":cat:") {
+        println!("Error sending message: {:?}", why);
+    }
+});
+
+command!(bird(_ctx, msg, args) {
+    let say_content = if args.is_empty() {
+        ":bird: can find animals for you.".to_string()
+    } else {
+        format!(":bird: could not find animal named: `{}`.", args.full())
+    };
+
+    if let Err(why) = msg.channel_id.say(say_content) {
         println!("Error sending message: {:?}", why);
     }
 });

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1043,8 +1043,9 @@ impl Framework for StandardFramework {
                         // than the last matching one, this prevents picking a wrong prefix,
                         // e.g. "f" instead of "ferris" due to "f" having a lower index in the `Vec`.
                         let longest_matching_prefix_len = prefixes.iter().fold(0, |longest_prefix_len, prefix|
-                            if prefix.len() > longest_prefix_len && built.starts_with(prefix)
-                            && (orginal_round.len() == built.len() || command_length > prefix.len() + 1) {
+                            if prefix.len() > longest_prefix_len
+                            && built.starts_with(prefix)
+                            && (orginal_round.len() == prefix.len() || built.get(prefix.len()..prefix.len() + 1) == Some(" ")) {
                                 prefix.len()
                             } else {
                                 longest_prefix_len

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1073,6 +1073,9 @@ impl Framework for StandardFramework {
 
                         if let Some(help) = help {
                             let groups = self.groups.clone();
+
+                            // `Args`-construction here inside help-dispatch and the command-dispatch-section
+                            // shall stay identical, please update accordingly upon change.
                             let mut args = {
                                 let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
                                     .skip(command_length).collect::<String>();
@@ -1105,6 +1108,8 @@ impl Framework for StandardFramework {
                             group.commands.get(&to_check) {
                             let command = Arc::clone(command);
 
+                            // `Args`-construction here inside command-dispatch and the help-dispatch
+                            // shall stay identical, please update accordingly upon change.
                             let mut args = {
                                 let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
                                     .skip(command_length).collect::<String>();

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1065,13 +1065,6 @@ impl Framework for StandardFramework {
                         built.clone()
                     };
 
-                    let mut args = {
-                        let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
-                            .skip(command_length).collect::<String>();
-
-                        Args::new(&content.trim(), &self.configuration.delimiters)
-                    };
-
                     let before = self.before.clone();
                     let after = self.after.clone();
 
@@ -1080,6 +1073,13 @@ impl Framework for StandardFramework {
 
                         if let Some(help) = help {
                             let groups = self.groups.clone();
+                            let mut args = {
+                                let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
+                                    .skip(command_length).collect::<String>();
+
+                                Args::new(&content.trim(), &self.configuration.delimiters)
+                            };
+
                             threadpool.execute(move || {
 
                                 if let Some(before) = before {
@@ -1099,12 +1099,18 @@ impl Framework for StandardFramework {
                         }
                     }
 
-
                     if !to_check.is_empty() {
 
                         if let Some(&CommandOrAlias::Command(ref command)) =
                             group.commands.get(&to_check) {
                             let command = Arc::clone(command);
+
+                            let mut args = {
+                                let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
+                                    .skip(command_length).collect::<String>();
+
+                                Args::new(&content.trim(), &self.configuration.delimiters)
+                            };
 
                             if let Some(error) = self.should_fail(
                                 &mut context,
@@ -1150,10 +1156,15 @@ impl Framework for StandardFramework {
 
                         if let &Some(CommandOrAlias::Command(ref command)) = &group.default_command {
                             let command = Arc::clone(command);
+                            let mut args = {
+                                let content = to_check;
+
+                                Args::new(&content.trim(), &self.configuration.delimiters)
+                            };
 
                             threadpool.execute(move || {
                                 if let Some(before) = before {
-                                    if !(before)(&mut context, &message, &to_check) {
+                                    if !(before)(&mut context, &message, &args.full()) {
                                         return;
                                     }
                                 }


### PR DESCRIPTION
This pull request makes sure that group-prefixes that are a substring of another group-prefix are never picked when they are not explicitly meant to be used.

On another note, this pull requests moves the creation of `Args` close to the actual used code-locations, causing three seperated creations.
One of these is modified to enable the default-command to gain information about what sub-command has been erroneously attempted to be used.

To finish it, the framework-example has been updated to showcase the possibilities with the default-command.
