### PR TITLE
Use one macro instead of the same code twice, avoid seperated changes

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -147,6 +147,17 @@ macro_rules! command {
     };
 }
 
+macro_rules! command_and_help_args {
+    ($message_content:expr, $position:expr, $command_length:expr, $delimiters:expr) => {
+        {
+            let content = $message_content.chars().skip($position).skip_while(|x| x.is_whitespace())
+                .skip($command_length).collect::<String>();
+
+            Args::new(&content.trim(), $delimiters)
+        }
+    };
+}
+
 /// An enum representing all possible fail conditions under which a command won't
 /// be executed.
 #[derive(Debug)]
@@ -1073,15 +1084,7 @@ impl Framework for StandardFramework {
 
                         if let Some(help) = help {
                             let groups = self.groups.clone();
-
-                            // `Args`-construction here inside help-dispatch and the command-dispatch-section
-                            // shall stay identical, please update accordingly upon change.
-                            let mut args = {
-                                let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
-                                    .skip(command_length).collect::<String>();
-
-                                Args::new(&content.trim(), &self.configuration.delimiters)
-                            };
+                            let mut args = command_and_help_args!(&message.content, position, command_length, &self.configuration.delimiters);
 
                             threadpool.execute(move || {
 
@@ -1107,15 +1110,7 @@ impl Framework for StandardFramework {
                         if let Some(&CommandOrAlias::Command(ref command)) =
                             group.commands.get(&to_check) {
                             let command = Arc::clone(command);
-
-                            // `Args`-construction here inside command-dispatch and the help-dispatch
-                            // shall stay identical, please update accordingly upon change.
-                            let mut args = {
-                                let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
-                                    .skip(command_length).collect::<String>();
-
-                                Args::new(&content.trim(), &self.configuration.delimiters)
-                            };
+                            let mut args = command_and_help_args!(&message.content, position, command_length, &self.configuration.delimiters);
 
                             if let Some(error) = self.should_fail(
                                 &mut context,


### PR DESCRIPTION
Instead of having the exact same logic and code twice, this pull request uses a macro.

This has three advantages:
1. Code only needs to be changed inside the macro, thus no one can update one code-section and forget the other.
2. Less code repetition.
3. We do not have to rely on comments to describe that someone has to find and change both pieces of code.  