### PR TITLE
Use `to_`- and `as_`-methods instead of `get` and `find` on `Id`-`newtype`s

### DIFF
--- a/examples/04_message_builder/src/main.rs
+++ b/examples/04_message_builder/src/main.rs
@@ -11,7 +11,7 @@ struct Handler;
 impl EventHandler for Handler {
     fn message(&self, _: Context, msg: Message) {
         if msg.content == "!ping" {
-            let channel = match msg.channel_id.get() {
+            let channel = match msg.channel_id.to_channel() {
                 Ok(channel) => channel,
                 Err(why) => {
                     println!("Error getting channel: {:?}", why);

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -65,7 +65,7 @@ impl EditGuild {
     /// # use std::error::Error;
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #     let mut guild = GuildId(0).to_guild()?;
+    /// #     let mut guild = GuildId(0).to_partial_guild()?;
     /// use serenity::utils;
     ///
     /// // assuming a `guild` has already been bound
@@ -126,7 +126,7 @@ impl EditGuild {
     /// # use std::error::Error;
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #     let mut guild = GuildId(0).to_guild()?;
+    /// #     let mut guild = GuildId(0).to_partial_guild()?;
     /// use serenity::model::guild::Region;
     ///
     /// // assuming a `guild` has already been bound

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -65,7 +65,7 @@ impl EditGuild {
     /// # use std::error::Error;
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #     let mut guild = GuildId(0).get()?;
+    /// #     let mut guild = GuildId(0).to_guild()?;
     /// use serenity::utils;
     ///
     /// // assuming a `guild` has already been bound
@@ -126,7 +126,7 @@ impl EditGuild {
     /// # use std::error::Error;
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #     let mut guild = GuildId(0).get()?;
+    /// #     let mut guild = GuildId(0).to_guild()?;
     /// use serenity::model::guild::Region;
     ///
     /// // assuming a `guild` has already been bound

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -478,7 +478,7 @@ impl StandardFramework {
                 return true;
             }
 
-            if let Some(guild) = guild_id.find() {
+            if let Some(guild) = guild_id.to_guild_cached() {
                 return self.configuration
                     .blocked_users
                     .contains(&guild.with(|g| g.owner_id));
@@ -873,7 +873,7 @@ impl StandardFramework {
     ///
     /// client.with_framework(StandardFramework::new()
     ///     .before(|_, msg, cmd_name| {
-    ///         if let Ok(channel) = msg.channel_id.get() {
+    ///         if let Ok(channel) = msg.channel_id.to_channel() {
     ///             //  Don't run unless in nsfw channel
     ///             if !channel.is_nsfw() {
     ///                 return false;

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -312,7 +312,7 @@ impl ChannelId {
     /// upon failure requests it via the REST API.
     ///
     /// **Note**: If the cache is not enabled,
-    /// REST API will be used instead.
+    /// REST API will be used only.
     ///
     /// [`Channel`]: ../channel/enum.Channel.html
     pub fn to_channel(&self) -> Result<Channel> {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -390,7 +390,7 @@ impl ChannelId {
         use self::Channel::*;
 
         let finding = feature_cache! {{
-            Some(self.find())
+            Some(self.to_channel_cached())
         } else {
             None
         }};

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -329,6 +329,7 @@ impl ChannelId {
     /// Gets all of the channel's invites.
     ///
     /// Requires the [Manage Channels] permission.
+    ///
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[inline]
     pub fn invites(&self) -> Result<Vec<RichInvite>> { http::get_channel_invites(self.0) }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -285,11 +285,37 @@ impl ChannelId {
 
     /// Search the cache for the channel with the Id.
     #[cfg(feature = "cache")]
+    #[deprecated(since = "0.5.8", note = "Use the `to_channel_cached`-method instead.")]
     pub fn find(&self) -> Option<Channel> { CACHE.read().channel(*self) }
+
+    /// Attempts to find a [`Channel`] by its Id in the cache.
+    ///
+    /// [`Channel`]: ../channel/enum.Channel.html
+    #[cfg(feature = "cache")]
+    pub fn to_channel_cached(&self) -> Option<Channel> { CACHE.read().channel(*self) }
 
     /// Search the cache for the channel. If it can't be found, the channel is
     /// requested over REST.
+    #[deprecated(since = "0.5.8", note = "Use the `to_channel`-method instead.")]
     pub fn get(&self) -> Result<Channel> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(channel) = CACHE.read().channel(*self) {
+                return Ok(channel);
+            }
+        }
+
+        http::get_channel(self.0)
+    }
+
+    /// First attempts to find a [`Channel`] by its Id in the cache,
+    /// upon failure requests it via the REST API.
+    ///
+    /// **Note**: If the cache is not enabled,
+    /// REST API will be used instead.
+    ///
+    /// [`Channel`]: ../channel/enum.Channel.html
+    pub fn to_channel(&self) -> Result<Channel> {
         #[cfg(feature = "cache")]
         {
             if let Some(channel) = CACHE.read().channel(*self) {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -292,7 +292,7 @@ impl ChannelId {
     ///
     /// [`Channel`]: ../channel/enum.Channel.html
     #[cfg(feature = "cache")]
-    pub fn to_channel_cached(&self) -> Option<Channel> { CACHE.read().channel(*self) }
+    pub fn to_channel_cached(self) -> Option<Channel> { CACHE.read().channel(self) }
 
     /// Search the cache for the channel. If it can't be found, the channel is
     /// requested over REST.
@@ -315,10 +315,10 @@ impl ChannelId {
     /// REST API will be used only.
     ///
     /// [`Channel`]: ../channel/enum.Channel.html
-    pub fn to_channel(&self) -> Result<Channel> {
+    pub fn to_channel(self) -> Result<Channel> {
         #[cfg(feature = "cache")]
         {
-            if let Some(channel) = CACHE.read().channel(*self) {
+            if let Some(channel) = CACHE.read().channel(self) {
                 return Ok(channel);
             }
         }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -286,26 +286,20 @@ impl ChannelId {
     /// Search the cache for the channel with the Id.
     #[cfg(feature = "cache")]
     #[deprecated(since = "0.5.8", note = "Use the `to_channel_cached`-method instead.")]
-    pub fn find(&self) -> Option<Channel> { CACHE.read().channel(*self) }
+    pub fn find(&self) -> Option<Channel> { self.to_channel_cached() }
 
     /// Attempts to find a [`Channel`] by its Id in the cache.
     ///
     /// [`Channel`]: ../channel/enum.Channel.html
     #[cfg(feature = "cache")]
+    #[inline]
     pub fn to_channel_cached(self) -> Option<Channel> { CACHE.read().channel(self) }
 
     /// Search the cache for the channel. If it can't be found, the channel is
     /// requested over REST.
     #[deprecated(since = "0.5.8", note = "Use the `to_channel`-method instead.")]
     pub fn get(&self) -> Result<Channel> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(channel) = CACHE.read().channel(*self) {
-                return Ok(channel);
-            }
-        }
-
-        http::get_channel(self.0)
+        self.to_channel()
     }
 
     /// First attempts to find a [`Channel`] by its Id in the cache,
@@ -315,6 +309,7 @@ impl ChannelId {
     /// REST API will be used only.
     ///
     /// [`Channel`]: ../channel/enum.Channel.html
+    #[inline]
     pub fn to_channel(self) -> Result<Channel> {
         #[cfg(feature = "cache")]
         {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -287,7 +287,7 @@ impl Message {
         for id in &self.mention_roles {
             let mention = id.mention();
 
-            if let Some(role) = id.find() {
+            if let Some(role) = id.to_role_cached() {
                 result = result.replace(&mention, &format!("@{}", role.name));
             } else {
                 result = result.replace(&mention, "@deleted-role");
@@ -429,7 +429,7 @@ impl Message {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`Emoji`]: ../guild/struct.Emoji.html
-    /// [Add Reactions]: 
+    /// [Add Reactions]:
     /// ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
     /// [permissions]: ../permissions/index.html
     #[inline]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -34,6 +34,13 @@ use http::AttachmentType;
 #[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+use std::str::FromStr;
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+use model::misc::ChannelParseError;
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+use utils::parse_channel;
+
 /// A container for any channel.
 #[derive(Clone, Debug)]
 pub enum Channel {
@@ -790,6 +797,21 @@ mod test {
 
             let private_channel = private_channel();
             assert!(!private_channel.is_nsfw());
+        }
+    }
+}
+
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+impl FromStr for Channel {
+    type Err = ChannelParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        match parse_channel(s) {
+            Some(x) => match ChannelId(x).to_channel_cached() {
+                Some(channel) => Ok(channel),
+                _ => Err(ChannelParseError::NotPresentInCache),
+            },
+            _ => Err(ChannelParseError::InvalidChannel),
         }
     }
 }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -74,7 +74,7 @@ impl Channel {
     /// #
     /// # #[cfg(feature = "model")]
     /// # fn main() {
-    /// #     let channel = ChannelId(0).get().unwrap();
+    /// #     let channel = ChannelId(0).to_channel().unwrap();
     /// #
     /// match channel.group() {
     ///     Some(group_lock) => {
@@ -116,7 +116,7 @@ impl Channel {
     /// #
     /// # #[cfg(feature = "model")]
     /// # fn main() {
-    /// #     let channel = ChannelId(0).get().unwrap();
+    /// #     let channel = ChannelId(0).to_channel().unwrap();
     /// #
     /// match channel.guild() {
     ///     Some(guild_lock) => {
@@ -154,7 +154,7 @@ impl Channel {
     /// #
     /// # #[cfg(feature = "model")]
     /// # fn main() {
-    /// #     let channel = ChannelId(0).get().unwrap();
+    /// #     let channel = ChannelId(0).to_channel().unwrap();
     /// #
     /// match channel.private() {
     ///     Some(private_lock) => {
@@ -195,7 +195,7 @@ impl Channel {
     /// #
     /// # #[cfg(feature = "model")]
     /// # fn main() {
-    /// # let channel = ChannelId(0).get().unwrap();
+    /// # let channel = ChannelId(0).to_channel().unwrap();
     /// #
     /// match channel.category() {
     ///     Some(category_lock) => {

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -51,7 +51,7 @@ impl Reaction {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[inline]
     pub fn channel(&self) -> Result<Channel> {
-        self.channel_id.get()
+        self.channel_id.to_channel()
     }
 
     /// Deletes the reaction, but only if the current user is the user who made
@@ -123,7 +123,7 @@ impl Reaction {
     /// the REST API for the user.
     #[inline]
     pub fn user(&self) -> Result<User> {
-        self.user_id.get()
+        self.user_id.to_user()
     }
 
     /// Retrieves the list of [`User`]s who have reacted to a [`Message`] with a

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -411,7 +411,7 @@ impl GuildId {
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     #[cfg(feature = "cache")]
-    pub fn to_guild_cached(&self) -> Option<Arc<RwLock<Guild>>> { CACHE.read().guild(*self) }
+    pub fn to_guild_cached(self) -> Option<Arc<RwLock<Guild>>> { CACHE.read().guild(self) }
 
     /// Requests the guild over REST.
     ///
@@ -429,7 +429,7 @@ impl GuildId {
     /// [`PartialGuild`]: ../guild/struct.PartialGuild.html
     /// [`Guild`]: ../guild/struct.Guild.html
     #[inline]
-    pub fn to_partial_guild(&self) -> Result<PartialGuild> { http::get_guild(self.0) }
+    pub fn to_partial_guild(self) -> Result<PartialGuild> { http::get_guild(self.0) }
 
     /// Gets all integration of the guild.
     ///

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -402,17 +402,34 @@ impl GuildId {
         http::edit_role_position(self.0, role_id.0, position)
     }
 
-
     /// Search the cache for the guild.
     #[cfg(feature = "cache")]
+    #[deprecated(since = "0.5.8", note = "Use the `to_guild_cached`-method instead.")]
     pub fn find(&self) -> Option<Arc<RwLock<Guild>>> { CACHE.read().guild(*self) }
+
+    /// Tries to find the [`Guild`] by its Id in the cache.
+    ///
+    /// [`Guild`]: ../guild/struct.Guild.html
+    #[cfg(feature = "cache")]
+    pub fn to_guild_cached(&self) -> Option<Arc<RwLock<Guild>>> { CACHE.read().guild(*self) }
 
     /// Requests the guild over REST.
     ///
     /// Note that this will not be a complete guild, as REST does not send
     /// all data with a guild retrieval.
     #[inline]
+    #[deprecated(since = "0.5.8", note = "Use the `to_partial_guild`-method instead.")]
     pub fn get(&self) -> Result<PartialGuild> { http::get_guild(self.0) }
+
+    /// Requests [`PartialGuild`] over REST API.
+    ///
+    /// **Note**: This will not be a [`Guild`], as the REST API does not send
+    /// all data with a guild retrieval.
+    ///
+    /// [`PartialGuild`]: ../guild/struct.PartialGuild.html
+    /// [`Guild`]: ../guild/struct.Guild.html
+    #[inline]
+    pub fn to_partial_guild(&self) -> Result<PartialGuild> { http::get_guild(self.0) }
 
     /// Gets all integration of the guild.
     ///
@@ -443,8 +460,8 @@ impl GuildId {
     #[inline]
     pub fn leave(&self) -> Result<()> { http::leave_guild(self.0) }
 
-    /// Gets a user's [`Member`] for the guild by Id. 
-    /// 
+    /// Gets a user's [`Member`] for the guild by Id.
+    ///
     /// If the cache feature is enabled the cache will be checked
     /// first. If not found it will resort to an http request.
     ///

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -405,12 +405,13 @@ impl GuildId {
     /// Search the cache for the guild.
     #[cfg(feature = "cache")]
     #[deprecated(since = "0.5.8", note = "Use the `to_guild_cached`-method instead.")]
-    pub fn find(&self) -> Option<Arc<RwLock<Guild>>> { CACHE.read().guild(*self) }
+    pub fn find(&self) -> Option<Arc<RwLock<Guild>>> { self.to_guild_cached() }
 
     /// Tries to find the [`Guild`] by its Id in the cache.
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     #[cfg(feature = "cache")]
+    #[inline]
     pub fn to_guild_cached(self) -> Option<Arc<RwLock<Guild>>> { CACHE.read().guild(self) }
 
     /// Requests the guild over REST.
@@ -419,7 +420,7 @@ impl GuildId {
     /// all data with a guild retrieval.
     #[inline]
     #[deprecated(since = "0.5.8", note = "Use the `to_partial_guild`-method instead.")]
-    pub fn get(&self) -> Result<PartialGuild> { http::get_guild(self.0) }
+    pub fn get(&self) -> Result<PartialGuild> { self.to_partial_guild() }
 
     /// Requests [`PartialGuild`] over REST API.
     ///

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -191,7 +191,7 @@ impl Member {
     /// one returns `None`)
     #[cfg(feature = "cache")]
     pub fn default_channel(&self) -> Option<Arc<RwLock<GuildChannel>>> {
-        let guild = match self.guild_id.find() {
+        let guild = match self.guild_id.to_guild_cached() {
             Some(guild) => guild,
             None => return None,
         };
@@ -257,7 +257,7 @@ impl Member {
     /// role with the lowest ID is the highest.
     #[cfg(feature = "cache")]
     pub fn highest_role_info(&self) -> Option<(RoleId, i64)> {
-        let guild = self.guild_id.find()?;
+        let guild = self.guild_id.to_guild_cached()?;
         let reader = guild.try_read()?;
 
         let mut highest = None;
@@ -356,7 +356,7 @@ impl Member {
     /// [`ModelError::ItemMissing`]: ../error/enum.Error.html#variant.ItemMissing
     #[cfg(feature = "cache")]
     pub fn permissions(&self) -> Result<Permissions> {
-        let guild = match self.guild_id.find() {
+        let guild = match self.guild_id.to_guild_cached() {
             Some(guild) => guild,
             None => return Err(From::from(ModelError::GuildNotFound)),
         };
@@ -427,7 +427,7 @@ impl Member {
     pub fn roles(&self) -> Option<Vec<Role>> {
         self
             .guild_id
-            .find()
+            .to_guild_cached()
             .map(|g| g
                 .read()
                 .roles

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -656,7 +656,7 @@ impl Guild {
     ///
     /// Requires that the current user be in the guild.
     #[inline]
-    pub fn get<G: Into<GuildId>>(guild_id: G) -> Result<PartialGuild> { guild_id.into().get() }
+    pub fn get<G: Into<GuildId>>(guild_id: G) -> Result<PartialGuild> { guild_id.into().to_partial_guild() }
 
     /// Returns which of two [`User`]s has a higher [`Member`] hierarchy.
     ///
@@ -1518,7 +1518,7 @@ impl Guild {
     ///
     /// impl EventHandler for Handler {
     ///     fn message(&self, _: Context, msg: Message) {
-    ///         if let Some(arc) = msg.guild_id().unwrap().find() {
+    ///         if let Some(arc) = msg.guild_id().unwrap().to_guild_cached() {
     ///             if let Some(role) = arc.read().role_by_name("role_name") {
     ///                 println!("{:?}", role);
     ///             }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -241,7 +241,7 @@ impl PartialGuild {
     ///
     /// [`Emoji`]: struct.Emoji.html
     /// [`Emoji::edit`]: struct.Emoji.html#method.edit
-    /// [Manage Emojis]: 
+    /// [Manage Emojis]:
     /// ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[inline]
     pub fn edit_emoji<E: Into<EmojiId>>(&self, emoji_id: E, name: &str) -> Result<Emoji> {
@@ -292,7 +292,7 @@ impl PartialGuild {
     ///
     /// Requires that the current user be in the guild.
     #[inline]
-    pub fn get<G: Into<GuildId>>(guild_id: G) -> Result<PartialGuild> { guild_id.into().get() }
+    pub fn get<G: Into<GuildId>>(guild_id: G) -> Result<PartialGuild> { guild_id.into().to_partial_guild() }
 
     /// Kicks a [`Member`] from the guild.
     ///
@@ -468,7 +468,7 @@ impl PartialGuild {
     ///
     /// impl EventHandler for Handler {
     ///     fn message(&self, _: Context, msg: Message) {
-    ///         let guild = msg.guild_id().unwrap().get().unwrap();
+    ///         let guild = msg.guild_id().unwrap().to_guild().unwrap();
     ///         let possible_role = guild.role_by_name("role_name");
     ///
     ///         if let Some(role) = possible_role {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -468,7 +468,7 @@ impl PartialGuild {
     ///
     /// impl EventHandler for Handler {
     ///     fn message(&self, _: Context, msg: Message) {
-    ///         let guild = msg.guild_id().unwrap().to_guild().unwrap();
+    ///         let guild = msg.guild_id().unwrap().to_partial_guild().unwrap();
     ///         let possible_role = guild.role_by_name("role_name");
     ///
     ///         if let Some(role) = possible_role {

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -165,7 +165,30 @@ impl PartialOrd for Role {
 impl RoleId {
     /// Search the cache for the role.
     #[cfg(feature = "cache")]
+    #[deprecated(since = "0.5.8", note = "Use the `to_role_cached`-method instead.")]
     pub fn find(&self) -> Option<Role> {
+        let cache = CACHE.read();
+
+        for guild in cache.guilds.values() {
+            let guild = guild.read();
+
+            if !guild.roles.contains_key(self) {
+                continue;
+            }
+
+            if let Some(role) = guild.roles.get(self) {
+                return Some(role.clone());
+            }
+        }
+
+        None
+    }
+
+    /// Tries to find the [`Role`] by its Id in the cache.
+    ///
+    /// [`Role`]: ../guild/struct.Role.html
+    #[cfg(feature = "cache")]
+    pub fn to_role_cached(&self) -> Option<Role> {
         let cache = CACHE.read();
 
         for guild in cache.guilds.values() {

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -195,17 +195,17 @@ impl RoleId {
     ///
     /// [`Role`]: ../guild/struct.Role.html
     #[cfg(feature = "cache")]
-    pub fn to_role_cached(&self) -> Option<Role> {
+    pub fn to_role_cached(self) -> Option<Role> {
         let cache = CACHE.read();
 
         for guild in cache.guilds.values() {
             let guild = guild.read();
 
-            if !guild.roles.contains_key(self) {
+            if !guild.roles.contains_key(&self) {
                 continue;
             }
 
-            if let Some(role) = guild.roles.get(self) {
+            if let Some(role) = guild.roles.get(&self) {
                 return Some(role.clone());
             }
         }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -80,7 +80,7 @@ impl Role {
     ///
     /// ```rust,no_run
     /// # use serenity::model::id::RoleId;
-    /// # let role = RoleId(7).find().unwrap();
+    /// # let role = RoleId(7).to_role_cached().unwrap();
     /// // assuming a `role` has already been bound
     //
     /// role.edit(|r| r.hoist(true));

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -8,6 +8,13 @@ use internal::prelude::*;
 #[cfg(all(feature = "cache", feature = "model"))]
 use {CACHE, http};
 
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+use std::str::FromStr;
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+use model::misc::RoleParseError;
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+use utils::parse_role;
+
 /// Information about a role within a guild. A role represents a set of
 /// permissions, and can be attached to one or multiple users. A role has
 /// various miscellaneous configurations, such as being assigned a colour. Roles
@@ -215,4 +222,19 @@ impl From<Role> for RoleId {
 impl<'a> From<&'a Role> for RoleId {
     /// Gets the Id of a role.
     fn from(role: &Role) -> RoleId { role.id }
+}
+
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+impl FromStr for Role {
+    type Err = RoleParseError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        match parse_role(s) {
+            Some(x) => match RoleId(x).to_role_cached() {
+                Some(role) => Ok(role),
+                _ => Err(RoleParseError::NotPresentInCache),
+            },
+            _ => Err(RoleParseError::InvalidRole),
+        }
+    }
 }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -174,21 +174,7 @@ impl RoleId {
     #[cfg(feature = "cache")]
     #[deprecated(since = "0.5.8", note = "Use the `to_role_cached`-method instead.")]
     pub fn find(&self) -> Option<Role> {
-        let cache = CACHE.read();
-
-        for guild in cache.guilds.values() {
-            let guild = guild.read();
-
-            if !guild.roles.contains_key(self) {
-                continue;
-            }
-
-            if let Some(role) = guild.roles.get(self) {
-                return Some(role.clone());
-            }
-        }
-
-        None
+        self.to_role_cached()
     }
 
     /// Tries to find the [`Role`] by its Id in the cache.

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -16,6 +16,18 @@ macro_rules! id_u64 {
 
                     NaiveDateTime::from_timestamp(1_420_070_400 + offset as i64, 0)
                 }
+
+                /// Immutably borrow inner Id.
+                #[inline]
+                pub fn as_u64(&self) -> &u64 {
+                    &self.0
+                }
+
+                /// Mutably borrow inner Id.
+                #[inline]
+                pub fn as_mut_u64(&mut self) -> &mut u64 {
+                    &mut self.0
+                }
             }
 
             // This is a hack so functions can accept iterators that either:

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -190,21 +190,6 @@ macro_rules! impl_from_str {
                     }
                 }
             }
-
-            #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-            impl FromStr for $struct {
-                type Err = $err;
-
-                fn from_str(s: &str) -> StdResult<Self, Self::Err> {
-                    match utils::$parse_fn(s) {
-                        Some(x) => match $id(x).find() {
-                            Some(user) => Ok(user),
-                            _ => Err($err::NotPresentInCache),
-                        },
-                        _ => Err($err::$invalid_variant),
-                    }
-                }
-            }
         )*
     };
 }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -119,7 +119,7 @@ impl FromStr for User {
     fn from_str(s: &str) -> StdResult<Self, Self::Err> {
         match utils::parse_username(s) {
             Some(x) => UserId(x as u64)
-                .get()
+                .to_user()
                 .map_err(|e| UserParseError::Rest(Box::new(e))),
             _ => Err(UserParseError::InvalidUsername),
         }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -739,12 +739,13 @@ impl UserId {
     /// Search the cache for the user with the Id.
     #[cfg(feature = "cache")]
     #[deprecated(since = "0.5.8", note = "Use the `to_user_cached`-method instead.")]
-    pub fn find(&self) -> Option<Arc<RwLock<User>>> { CACHE.read().user(*self) }
+    pub fn find(&self) -> Option<Arc<RwLock<User>>> { self.to_user_cached() }
 
     /// Attempts to find a [`User`] by its Id in the cache.
     ///
     /// [`User`]: ../user/struct.User.html
     #[cfg(feature = "cache")]
+    #[inline]
     pub fn to_user_cached(self) -> Option<Arc<RwLock<User>>> { CACHE.read().user(self) }
 
     /// Gets a user by its Id from either the cache or the REST API.
@@ -754,14 +755,7 @@ impl UserId {
     #[inline]
     #[deprecated(since = "0.5.8", note = "Use the `to_user`-method instead.")]
     pub fn get(&self) -> Result<User> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(user) = CACHE.read().user(*self) {
-                return Ok(user.read().clone());
-            }
-        }
-
-        http::get_user(self.0)
+        self.to_user()
     }
 
     /// First attempts to find a [`User`] by its Id in the cache,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -745,7 +745,7 @@ impl UserId {
     ///
     /// [`User`]: ../user/struct.User.html
     #[cfg(feature = "cache")]
-    pub fn to_user_cached(&self) -> Option<Arc<RwLock<User>>> { CACHE.read().user(*self) }
+    pub fn to_user_cached(self) -> Option<Arc<RwLock<User>>> { CACHE.read().user(self) }
 
     /// Gets a user by its Id from either the cache or the REST API.
     ///
@@ -772,10 +772,10 @@ impl UserId {
     ///
     /// [`User`]: ../user/struct.User.html
     #[inline]
-    pub fn to_user(&self) -> Result<User> {
+    pub fn to_user(self) -> Result<User> {
         #[cfg(feature = "cache")]
         {
-            if let Some(user) = CACHE.read().user(*self) {
+            if let Some(user) = CACHE.read().user(self) {
                 return Ok(user.read().clone());
             }
         }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -661,7 +661,7 @@ impl User {
     /// println!("{:?}", client.start());
     /// ```
     pub fn refresh(&mut self) -> Result<()> {
-        self.id.get().map(|replacement| {
+        self.id.to_user().map(|replacement| {
             mem::replace(self, replacement);
 
             ()

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -738,14 +738,41 @@ impl UserId {
 
     /// Search the cache for the user with the Id.
     #[cfg(feature = "cache")]
+    #[deprecated(since = "0.5.8", note = "Use the `to_user_cached`-method instead.")]
     pub fn find(&self) -> Option<Arc<RwLock<User>>> { CACHE.read().user(*self) }
+
+    /// Attempts to find a [`User`] by its Id in the cache.
+    ///
+    /// [`User`]: ../user/struct.User.html
+    #[cfg(feature = "cache")]
+    pub fn to_user_cached(&self) -> Option<Arc<RwLock<User>>> { CACHE.read().user(*self) }
 
     /// Gets a user by its Id from either the cache or the REST API.
     ///
     /// Searches the cache for the user first, if the cache is enabled. If the
     /// user was not found, then the user is searched via the REST API.
     #[inline]
+    #[deprecated(since = "0.5.8", note = "Use the `to_user`-method instead.")]
     pub fn get(&self) -> Result<User> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(user) = CACHE.read().user(*self) {
+                return Ok(user.read().clone());
+            }
+        }
+
+        http::get_user(self.0)
+    }
+
+    /// First attempts to find a [`User`] by its Id in the cache,
+    /// upon failure requests it via the REST API.
+    ///
+    /// **Note**: If the cache is not enabled,
+    /// REST API will be used only.
+    ///
+    /// [`User`]: ../user/struct.User.html
+    #[inline]
+    pub fn to_user(&self) -> Result<User> {
         #[cfg(feature = "cache")]
         {
             if let Some(user) = CACHE.read().user(*self) {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -226,5 +226,15 @@ impl WebhookId {
     ///
     /// [Manage Webhooks]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[inline]
+    #[deprecated(since = "0.5.8", note = "Use the `to_webhook`-method instead.")]
     pub fn get(self) -> Result<Webhook> { http::get_webhook(self.0) }
+
+    /// Requests [`Webhook`] over REST API.
+    ///
+    /// **Note**: Requires the [Manage Webhooks] permission.
+    ///
+    /// [`Webhook`]: struct.Webhook.html
+    /// [Manage Webhooks]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
+    #[inline]
+    pub fn to_webhook(self) -> Result<Webhook> { http::get_webhook(self.0) }
 }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -227,7 +227,7 @@ impl WebhookId {
     /// [Manage Webhooks]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[inline]
     #[deprecated(since = "0.5.8", note = "Use the `to_webhook`-method instead.")]
-    pub fn get(self) -> Result<Webhook> { http::get_webhook(self.0) }
+    pub fn get(self) -> Result<Webhook> { self.to_webhook() }
 
     /// Requests [`Webhook`] over REST API.
     ///


### PR DESCRIPTION
Following [C-CONV](https://rust-lang-nursery.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv) and [C-GETTER](https://rust-lang-nursery.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter), I updated all `Id`-`newtype`s to align with the guidelines.

`get` on its own did not clearly state what would be retrieved, which is made clear by using `to_`-equivalents.

`as_u64` and `as_mut_u64` have been implemented for all `Id`-`newtype`s as well, as it is clearer than accessing the 0th field, as in `some_id.0`.

On another note, I improved a little bit on the documentation and fixed one wrong syntax-issue that prevented links from being generated.