### PR TITLE
Refactor customised help

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -61,6 +61,14 @@ macro_rules! format_command_name {
     };
 }
 
+/// Wraps around `warn`-macro in order to keep
+/// the literal same for all formats of help.
+macro_rules! warn_about_failed_send {
+    ($customised_help:expr, $error:expr) => {
+        warn!("Failed to send {:?} because: {:?}", $customised_help, $error);
+    }
+}
+
 /// A single group containing its name and all related commands that are eligible
 /// in relation of help-settings measured to the user.
 #[derive(Clone, Debug, Default)]

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -147,12 +147,6 @@ pub enum CustomisedHelpData<'a> {
     NoCommandFound { help_error_message: &'a str },
 }
 
-fn error_embed(channel_id: ChannelId, input: &str, colour: Colour) {
-    let _ = channel_id.send_message(|m| {
-        m.embed(|e| e.colour(colour).description(input))
-    });
-}
-
 fn remove_aliases(cmds: &HashMap<String, CommandOrAlias>) -> HashMap<&String, &InternalCommand> {
     let mut result = HashMap::new();
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -190,7 +190,8 @@ pub fn has_all_requirements(cmd: &Arc<CommandOptions>, msg: &Message) -> bool {
 pub fn is_command_visible(command_options: &Arc<CommandOptions>, msg: &Message, help_options: &HelpOptions) -> bool {
     if !command_options.dm_only && !command_options.guild_only
     || command_options.dm_only && msg.is_private()
-    || command_options.guild_only && !msg.is_private() {
+        || command_options.guild_only && !msg.is_private()
+    {
 
         if let Some(guild) = msg.guild() {
             let guild = guild.read();
@@ -243,6 +244,7 @@ fn fetch_single_command<'a, H: BuildHasher>(
             };
 
             if name == with_prefix || name == *command_name {
+
                 match *command {
                     CommandOrAlias::Command(ref cmd) => {
                         if is_command_visible(&cmd.options(), msg, help_options) {
@@ -250,7 +252,7 @@ fn fetch_single_command<'a, H: BuildHasher>(
                         } else {
                             break;
                         }
-                    }
+                    },
                     CommandOrAlias::Alias(ref name) => {
                         let actual_command = &group.commands[name];
 
@@ -261,8 +263,7 @@ fn fetch_single_command<'a, H: BuildHasher>(
                                 } else {
                                     break;
                                 }
-                            }
-
+                            },
                             CommandOrAlias::Alias(ref name) => {
                                 return Some(CustomisedHelpData::SuggestedCommands {
                                     help_description: help_options
@@ -431,6 +432,7 @@ pub fn create_customised_help_data<'a, H: BuildHasher>(
 
     let mut group_names = groups.keys().collect::<Vec<_>>();
     group_names.sort();
+
     let listed_groups =
         create_command_group_commands_pair_from_groups(&groups, &group_names, &msg, &help_options);
 
@@ -668,13 +670,8 @@ pub fn plain<H: BuildHasher>(
             format!("{}: `{}`", help_description, suggestions.join("`, `")),
         &CustomisedHelpData::NoCommandFound { ref help_error_message } =>
             help_error_message.to_string(),
-        &CustomisedHelpData::GroupedCommands { ref help_description, ref groups } => {
-            grouped_commands_to_plain_string(
-                &help_options,
-                &help_description,
-                &groups,
-            )
-        },
+        &CustomisedHelpData::GroupedCommands { ref help_description, ref groups } =>
+            grouped_commands_to_plain_string(&help_options, &help_description, &groups),
         &CustomisedHelpData::SingleCommand { ref command } => {
             single_command_to_plain_string(&help_options, &command)
         },

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -344,8 +344,7 @@ fn fetch_all_eligible_commands_in_group<'a>(
                         }
                     }
                 } else {
-                    let name = format_command_name!(&help_options.wrong_channel, &name);
-                    group_with_cmds.command_names.push(name);
+                    group_with_cmds.command_names.push(format!("`{}`", &name));
                 }
             } else {
                 let name = format_command_name!(&help_options.lacking_permissions, &name);

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -338,16 +338,16 @@ fn fetch_all_eligible_commands_in_group<'a>(
                         if has_correct_roles(&cmd, &guild, &member) {
                             group_with_cmds.command_names.push(format!("`{}`", &name));
                         } else {
-                            let name = format_command_name!(&help_options.wrong_channel, &name);
+                            let name = format_command_name!(&help_options.lacking_role, &name);
                             group_with_cmds.command_names.push(name);
                         }
                     }
                 } else {
                     let name = format_command_name!(&help_options.wrong_channel, &name);
-                    group_with_cmds.command_names.push(name);
+                        group_with_cmds.command_names.push(name);
                 }
             } else {
-                let name = format_command_name!(&help_options.wrong_channel, &name);
+                let name = format_command_name!(&help_options.lacking_permissions, &name);
                 group_with_cmds.command_names.push(name);
             }
         } else {

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -396,7 +396,7 @@ fn create_command_group_commands_pair_from_groups<'a, H: BuildHasher>(
 /// Iterates over all commands and forges them into a `CustomisedHelpData`
 /// taking `HelpOptions` into consideration when deciding on whether a command
 /// shall be picked and in what textual format.
-pub fn create_formatted_help_post<'a, H: BuildHasher>(
+pub fn create_customised_help_data<'a, H: BuildHasher>(
     groups: &'a HashMap<String, Arc<CommandGroup>, H>,
     args: &Args,
     help_options: &'a HelpOptions,
@@ -556,7 +556,7 @@ pub fn with_embeds<H: BuildHasher>(
     groups: HashMap<String, Arc<CommandGroup>, H>,
     args: &Args
 ) -> Result<(), CommandError> {
-    let formatted_help = create_formatted_help_post(&groups, args, help_options, msg);
+    let formatted_help = create_customised_help_data(&groups, args, help_options, msg);
 
     if let Err(why) = match &formatted_help {
         &CustomisedHelpData::SuggestedCommands { ref help_description, ref suggestions } =>
@@ -661,7 +661,7 @@ pub fn plain<H: BuildHasher>(
     groups: HashMap<String, Arc<CommandGroup>, H>,
     args: &Args
 ) -> Result<(), CommandError> {
-    let formatted_help = create_formatted_help_post(&groups, args, help_options, msg);
+    let formatted_help = create_customised_help_data(&groups, args, help_options, msg);
 
     let result = match &formatted_help {
         &CustomisedHelpData::SuggestedCommands { ref help_description, ref suggestions } =>

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -48,6 +48,18 @@ use super::{
 };
 use utils::Colour;
 
+/// Macro to format a command according to a `HelpBehaviour` or
+/// continue to the next command-name upon hiding.
+macro_rules! format_command_name {
+    ($behaviour:expr, $command_name:expr) => {
+        match $behaviour {
+            &HelpBehaviour::Strike => format!("~~`{}`~~", $command_name),
+            &HelpBehaviour::Nothing => format!("`{}`", $command_name),
+            &HelpBehaviour::Hide => continue,
+        }
+    };
+}
+
 fn error_embed(channel_id: ChannelId, input: &str, colour: Colour) {
     let _ = channel_id.send_message(|m| {
         m.embed(|e| e.colour(colour).description(input))

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -170,10 +170,10 @@ pub fn has_all_requirements(cmd: &Arc<CommandOptions>, msg: &Message) -> bool {
 
             if let Ok(permissions) = member.permissions() {
 
-                if cmd.allowed_roles.is_empty() {
-                    return permissions.administrator() || has_correct_permissions(cmd, msg);
+                return if cmd.allowed_roles.is_empty() {
+                    permissions.administrator() || has_correct_permissions(cmd, msg)
                 } else {
-                    return permissions.administrator() || (has_correct_roles(cmd, &guild, member) && has_correct_permissions(cmd, msg));
+                    permissions.administrator() || (has_correct_roles(cmd, &guild, member) && has_correct_permissions(cmd, msg))
                 }
             }
         }
@@ -189,7 +189,7 @@ pub fn has_all_requirements(cmd: &Arc<CommandOptions>, msg: &Message) -> bool {
 #[cfg(feature = "cache")]
 pub fn is_command_visible(command_options: &Arc<CommandOptions>, msg: &Message, help_options: &HelpOptions) -> bool {
     if !command_options.dm_only && !command_options.guild_only
-    || command_options.dm_only && msg.is_private()
+        || command_options.dm_only && msg.is_private()
         || command_options.guild_only && !msg.is_private()
     {
 
@@ -200,23 +200,23 @@ pub fn is_command_visible(command_options: &Arc<CommandOptions>, msg: &Message, 
 
                 if command_options.help_available {
 
-                    if has_correct_permissions(command_options, msg) {
+                    return if has_correct_permissions(command_options, msg) {
 
                         if has_correct_roles(command_options, &guild, &member) {
-                            return true;
+                            true
                         } else {
-                            return help_options.lacking_role != HelpBehaviour::Hide;
+                            help_options.lacking_role != HelpBehaviour::Hide
                         }
                     } else {
-                        return help_options.lacking_permissions != HelpBehaviour::Hide;
+                        help_options.lacking_permissions != HelpBehaviour::Hide
                     }
                 }
             }
         } else if command_options.help_available {
-            if has_correct_permissions(command_options, msg) {
-                return true;
+            return if has_correct_permissions(command_options, msg) {
+                true
             } else {
-                return help_options.lacking_permissions != HelpBehaviour::Hide;
+                help_options.lacking_permissions != HelpBehaviour::Hide
             }
         }
     } else {
@@ -345,7 +345,7 @@ fn fetch_all_eligible_commands_in_group<'a>(
                     }
                 } else {
                     let name = format_command_name!(&help_options.wrong_channel, &name);
-                        group_with_cmds.command_names.push(name);
+                    group_with_cmds.command_names.push(name);
                 }
             } else {
                 let name = format_command_name!(&help_options.lacking_permissions, &name);

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -600,6 +600,47 @@ pub fn with_embeds<H: BuildHasher>(
     Ok(())
 }
 
+/// Turns grouped commands into a `String` taking plain help format into account.
+fn grouped_commands_to_plain_string(
+    help_options: &HelpOptions,
+    help_description: &str,
+    groups: &[GroupCommandsPair]) -> String
+{
+    let mut result = "**Commands**\n".to_string();
+    let _ = writeln!(result, "{}", &help_description);
+
+    for group in groups {
+        let _ = write!(result, "\n**{}**", &group.name);
+
+        if !group.prefixes.is_empty() {
+            let _ = write!(result, " ({}: `{}`)", &help_options.group_prefix, &group.prefixes.join("`, `"));
+        }
+
+        let _ = write!(result, ": {}", group.command_names.join(" "));
+    }
+
+    result
+}
+
+/// Turns a single into a `String` taking plain help format into account.
+fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command) -> String {
+    let mut result = String::default();
+    let _ = writeln!(result, "**{}**", command.name);
+
+    if !command.aliases.is_empty() {
+        let _ = writeln!(result, "**{}**: `{}`", help_options.aliases_label, command.aliases.join("`, `"));
+    }
+
+    if let &Some(ref description) = &command.description {
+        let _ = writeln!(result, "**{}**: {}", help_options.description_label, description);
+    };
+
+    let _ = writeln!(result, "**{}**: {}", help_options.grouped_label, command.group_name);
+    let _ = writeln!(result, "**{}**: {}", help_options.available_text, command.availability);
+
+    result
+}
+
 /// Posts formatted text displaying each individual command group and its commands.
 ///
 /// # Examples


### PR DESCRIPTION
This pull requests aims to improve maintainability of the help-code.

We are currently supporting an embed- and plain-format to display help. Both used the same logic to extract commands and groups from given framework-data. 
Whenever a new functionality was supposed to be added, it had to be invoked into both functions, `with_embed` and `plain`, creating a horrid code duplication.
The code also tried to do the everything at once, fetching, transforming (based on given `HelpOptions`), formatting (into a plain `String` or embed), and sending.

Therefore I broke this logic into _fetching and transforming_ and then _formatting and sending_. 

On another note, users may use the `create_customised_help_data`-function to receive all required data and then implement their own way of sending it, before they had to somehow copy the entire extracting-commands-process.