### PR TITLE
Fix `has_correct_permissions` when no guild is available

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -208,8 +208,8 @@ fn main() {
             // User needs to pass the test for the command to execute.
             .check(admin_check)
             .command("am i admin", |c| c
-                .cmd(am_i_admin))
-                .guild_only(true)
+                .cmd(am_i_admin)
+                .guild_only(true))
         ),
     );
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1199,18 +1199,22 @@ impl Framework for StandardFramework {
         self.user_id = user_id.0;
     }
 }
+
 #[cfg(feature = "cache")]
 pub fn has_correct_permissions(command: &Arc<CommandOptions>, message: &Message) -> bool {
     if !command.required_permissions.is_empty() {
+
         if let Some(guild) = message.guild() {
             let perms = guild
                 .with(|g| g.permissions_in(message.channel_id, message.author.id));
 
-            return perms.contains(command.required_permissions);
+            perms.contains(command.required_permissions)
+        } else {
+            false
         }
+    } else {
+        true
     }
-
-    true
 }
 
 pub fn has_correct_roles(cmd: &Arc<CommandOptions>, guild: &Guild, member: &Member) -> bool {


### PR DESCRIPTION
When no guild was available (which happens inside private channels), the function returned `true`. However commands requiring permissions should not be usable outside of guild channels.

I also fixed the order calling `guild_only`.