### PR TITLE
Suggest similar commands

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
                 // and commands. If the distance is lower than or equal the set distance,
                 // it will be displayed as a suggestion.
                 // Setting the distance to 0 will disable suggestions.
-                .maximum_levenshtein_distance(3)
+                .max_levenshtein_distance(3)
                 // On another note, you can set up the help-menu-filter-behaviour.
                 // Here are all possible settings shown on all possible options.
                 // First case is if a user lacks permissions for a command, we can hide the command.

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -149,6 +149,11 @@ fn main() {
                 // Some arguments require a `{}` in order to replace it with contextual information.
                 // In this case our `{}` refers to a command's name.
                 .command_not_found_text("Could not find: `{}`.")
+                // Define the maximum Levenshtein-distance between a searched command-name
+                // and commands. If the distance is lower than or equal the set distance,
+                // it will be displayed as a suggestion.
+                // Setting the distance to 0 will disable suggestions.
+                .maximum_levenshtein_distance(3)
                 // On another note, you can set up the help-menu-filter-behaviour.
                 // Here are all possible settings shown on all possible options.
                 // First case is if a user lacks permissions for a command, we can hide the command.

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -216,6 +216,8 @@ pub struct HelpOptions {
     pub embed_error_colour: Colour,
     /// Colour help-embed will use if no error occured.
     pub embed_success_colour: Colour,
+    /// If not 0, help will check whether a command is similar to searched named.
+    pub max_levenshtein_distance: usize,
 }
 
 pub trait HelpCommand: Send + Sync + 'static {
@@ -235,7 +237,7 @@ impl HelpCommand for Arc<HelpCommand> {
 impl Default for HelpOptions {
     fn default() -> HelpOptions {
         HelpOptions {
-            suggestion_text: "Did you mean {}?".to_string(),
+            suggestion_text: "Did you mean `{}`?".to_string(),
             no_help_available_text: "**Error**: No help available.".to_string(),
             usage_label: "Usage".to_string(),
             usage_sample_label: "Sample usage".to_string(),
@@ -258,6 +260,7 @@ impl Default for HelpOptions {
             wrong_channel: HelpBehaviour::Strike,
             embed_error_colour: Colour::DARK_RED,
             embed_success_colour: Colour::ROSEWATER,
+            max_levenshtein_distance: 2,
         }
     }
 }

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -260,7 +260,7 @@ impl Default for HelpOptions {
             wrong_channel: HelpBehaviour::Strike,
             embed_error_colour: Colour::DARK_RED,
             embed_success_colour: Colour::ROSEWATER,
-            max_levenshtein_distance: 2,
+            max_levenshtein_distance: 0,
         }
     }
 }

--- a/src/framework/standard/create_help_command.rs
+++ b/src/framework/standard/create_help_command.rs
@@ -218,6 +218,13 @@ impl CreateHelpCommand {
         self
     }
 
+    /// Sets the maximum Levenshtein-distance to find similar commands.
+    pub fn max_levenshtein_distance(mut self, distance: usize) -> Self {
+        self.0.max_levenshtein_distance = distance;
+
+        self
+    }
+
     fn produce_strike_text(&self, dm_or_guild: &str) -> Option<String> {
         let mut strike_text = String::from("~~`Strikethrough commands`~~ are unavailable because they");
         let mut is_any_option_strike = false;

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -97,7 +97,6 @@ pub struct Command<'a> {
     availability: &'a str,
     description: Option<String>,
     usage: Option<String>,
-    similar_commands: Vec<SuggestedCommandName<'a>>,
 }
 
 /// Contains possible suggestions in case a command could not be found
@@ -397,7 +396,6 @@ fn fetch_single_command<'a, H: BuildHasher>(
                     aliases: command.aliases.clone(),
                     availability: available_text,
                     usage: command.usage.clone(),
-                    similar_commands,
                 },
             });
         }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -596,7 +596,7 @@ fn send_suggestion_embed(
     suggestions: &Suggestions,
     colour: Colour,
 ) -> Result<Message, Error> {
-    let text = format!("{}: `{}`", help_description, suggestions.join("`, `"));
+    let text = format!("{}", help_description.replace("{}", &suggestions.join("`, `")));
 
     channel_id.send_message(|m| m.embed(|e| e.colour(colour).description(text)))
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -355,7 +355,7 @@ fn fetch_single_command<'a, H: BuildHasher>(
                 }
             } else if help_options.max_levenshtein_distance > 0 {
 
-                if let CommandOrAlias::Command(ref cmd) = command {
+                if let &CommandOrAlias::Command(ref cmd) = command {
                     let levenshtein_distance = levenshtein_distance(&command_name, &name);
 
                     if levenshtein_distance <= help_options.max_levenshtein_distance

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -97,6 +97,7 @@ pub struct Command<'a> {
     availability: &'a str,
     description: Option<String>,
     usage: Option<String>,
+    similar_commands: Vec<SuggestedCommandName<'a>>,
 }
 
 /// Contains possible suggestions in case a command could not be found

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -112,16 +112,23 @@ impl<'a> Suggestions<'a> {
         &self.0
     }
 
-    /// Concat names of suggestions with a given `seperator`.
+    /// Concats names of suggestions with a given `seperator`.
     fn join(&self, seperator: &str) -> String {
-        let iter = self.as_vec().iter();
+        let mut iter = self.as_vec().iter();
+
+        let first_iter_element = match iter.next() {
+            Some(first_iter_element) => first_iter_element,
+            None => return String::new(),
+        };
+
         let size = self.as_vec().iter().fold(0, |total_size, size| total_size + size.name.len());
         let byte_len_of_sep = self.as_vec().len().checked_sub(1).unwrap_or(0) * seperator.len();
         let mut result = String::with_capacity(size + byte_len_of_sep);
+        result.push_str(first_iter_element.name.borrow());
 
-        for v in iter {
+        for element in iter {
             result.push_str(&*seperator);
-            result.push_str(v.name.borrow());
+            result.push_str(element.name.borrow());
         }
 
         result


### PR DESCRIPTION
Suggesting commands used to be a functionality that suggested the real command-name if a user tried to request help for an alias. Since the help-system is able to work with aliases nowadays and simply displays the actual command, the suggestion-feature became dead code.

This pull requests adds Levenshtein-distance-analysis: A user searches for _feris_ but the actual command is named _ferris_ and the maximum Levenshtein-distance has been set to at least 1, then the help-system will display a message listing similar names, as the probably wanted one, _ferris_, but also _beris_. 
Both require one edit (adding, changing, or deleting a character) _feris_ thus are not higher than given maximum.

Nonetheless, I'm unsure whether this feature should work by default, I set the default maximum distance to 2. Strictly taken that's a behaviour change to the generated output therefore I will have to reconsider.