### PR TITLE
Check if bots are ignored before dispatching `unrecognised_command`

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1187,11 +1187,14 @@ impl Framework for StandardFramework {
             }
         }
 
-        if let &Some(ref unrecognised_command) = &self.unrecognised_command {
-            let unrecognised_command = unrecognised_command.clone();
-            threadpool.execute(move || {
-                (unrecognised_command)(&mut context, &message, &unrecognised_command_name);
-            });
+        if !(self.configuration.ignore_bots && message.author.bot) {
+
+            if let &Some(ref unrecognised_command) = &self.unrecognised_command {
+                let unrecognised_command = unrecognised_command.clone();
+                threadpool.execute(move || {
+                    (unrecognised_command)(&mut context, &message, &unrecognised_command_name);
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Even if the framework was supposed to ignore bots, `unrecognised_command` would still work and notify if bots attempted to use a command that could not be found, therefore bots are now ignored if set so.