### PR TITLE
Add single group help

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -177,6 +177,9 @@ fn main() {
             // This requires us to call commands in this group
             // via `~emoji` (or `~e`) instead of just `~`.
             .prefixes(vec!["emoji", "em"])
+            // Set a description to appear if a user wants to display a single group
+            // e.g. via help using the group-name or one of its prefixes.
+            .desc("A group with commands providing an emoji as response.")
             // Sets a command that will be executed if only a group-prefix was passed.
             .default_cmd(bird)
             .command("cat", |c| c

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -105,6 +105,7 @@ pub struct CommandGroup {
     /// will short-circuit on the first check that returns `false`.
     pub checks: Vec<Check>,
     pub default_command: Option<CommandOrAlias>,
+    pub description: Option<String>,
 }
 
 impl Default for CommandGroup {
@@ -122,6 +123,7 @@ impl Default for CommandGroup {
             help: None,
             checks: Vec::new(),
             default_command: None,
+            description: None,
         }
     }
 }

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -206,4 +206,12 @@ impl CreateGroup {
 
         self
     }
+
+    /// Sets a description for the group that will be displayed if only
+    /// one specific group is requested via help.
+    pub fn desc(mut self, text: &str) -> Self {
+        self.0.description = Some(text.to_string());
+
+        self
+    }
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -552,7 +552,7 @@ pub fn create_customised_help_data<'a, H: BuildHasher>(
                         );
 
                         return CustomisedHelpData::GroupedCommands {
-                            help_description: group.description.clone().unwrap_or_else(|| "".to_string()),
+                            help_description: group.description.clone().unwrap_or_default(),
                             groups: vec![single_group],
                         };
                     }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -541,8 +541,8 @@ pub fn create_customised_help_data<'a, H: BuildHasher>(
 
                     if key.to_lowercase() == searched_named_lowercase
                         || group.prefixes.as_ref()
-                            .map(|v| v.iter().any(|prefix|
-                            *prefix == searched_named_lowercase)).unwrap_or(false) {
+                            .map_or(false, |v| v.iter().any(|prefix|
+                            *prefix == searched_named_lowercase)) {
 
                         let mut single_group = create_single_group(
                             &group,


### PR DESCRIPTION
This pull requests adds the ability to list a group in isolation by either writing its group-name or using any of its prefixes.

_Example_:
Group named `Ferris`, prefixes are `fer` and `f`.

Writing `help fer`, `help f`, and `help ferris` will all end in displaying the group `Ferris` only.

On another note, using `desc(&str)` on the group-builder will enable you to set a text headlining a single group.