### PR TITLE
Add missing usage on plain help

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -788,6 +788,10 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command)
         let _ = writeln!(result, "**{}**: {}", help_options.description_label, description);
     };
 
+    if let &Some(ref usage) = &command.usage {
+        let _ = writeln!(result, "**{}**: {}", help_options.usage_label, usage);
+    }
+
     let _ = writeln!(result, "**{}**: {}", help_options.grouped_label, command.group_name);
     let _ = writeln!(result, "**{}**: {}", help_options.available_text, command.availability);
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -775,7 +775,7 @@ fn grouped_commands_to_plain_string(
     result
 }
 
-/// Turns a single into a `String` taking plain help format into account.
+/// Turns a single command into a `String` taking plain help format into account.
 fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command) -> String {
     let mut result = String::default();
     let _ = writeln!(result, "**{}**", command.name);


### PR DESCRIPTION
Plain- and embed-help offer to list a usage-example on how to use a command.
This was unintentionally not included after the little help-refactoring and is hereby added.

Additionally, a plain help related function forgot a word in its documentation, fixed that as well.