### PR TITLE
Remove mildly annoying, inconsistent braces

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -27,9 +27,7 @@ impl Display for Error {
 impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::UnsuccessfulRequest(_) => {
-                "A non-successful response status code was received"
-            },
+            Error::UnsuccessfulRequest(_) => "A non-successful response status code was received",
             Error::RateLimitI64 => "Error decoding a header into an i64",
             Error::RateLimitUtf8 => "Error decoding a header from UTF-8",
         }


### PR DESCRIPTION
Completely unnecessary but also completely necessary to remove because this hurts. A lot.