### PR TITLE
Voice reconnection pathway

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1961,7 +1961,7 @@ pub enum VoiceEvent {
     ///
     /// [`heartbeat_interval`]: struct.VoiceHello.html#structfield.heartbeat_interval
     Hello(VoiceHello),
-    /// Message received if a Resume reques was successful.
+    /// Message received if a Resume request was successful.
     Resumed,
     /// Status update in the current channel, indicating that a user has
     /// disconnected.

--- a/src/voice/payload.rs
+++ b/src/voice/payload.rs
@@ -16,6 +16,18 @@ pub fn build_identify(info: &ConnectionInfo) -> Value {
 }
 
 #[inline]
+pub fn build_resume(info: &ConnectionInfo) -> Value {
+    json!({
+        "op": VoiceOpCode::Resume.num(),
+        "d": {
+            "server_id": info.guild_id.0,
+            "session_id": &info.session_id,
+            "token": &info.token,
+        }
+    })
+}
+
+#[inline]
 pub fn build_heartbeat(nonce: u64) -> Value {
     json!({
         "op": VoiceOpCode::Heartbeat.num(),

--- a/src/voice/threading.rs
+++ b/src/voice/threading.rs
@@ -100,10 +100,13 @@ fn runner(rx: &MpscReceiver<Status>) {
             },
         };
 
-        // If there was an error, then just reset the connection and try to get
-        // another.
+        // If there was an error, then reconnect using the dedicated API path.
+        // Create a new connection if that somehow fails.
         if error {
-            connection = None;
+            let mut conn = connection.expect("[Voice] Shouldn't be able to have a voice connection error without a connection");
+            connection = conn.reconnect()
+                .ok()
+                .map(|_| conn);
         }
     }
 }


### PR DESCRIPTION
An error encountered in the voice loop should now attempt to trigger the faster Resume/Resumed pathway rather than performing a full reconnection. This is a backport/translation of the implementation I worked out for the futures version of the voice system, but it relies upon the corrections made to the voice API structs as introduced to v0.6.x.