### PR TITLE
Add Mutex in HttpError to make Error sync again

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -5,13 +5,15 @@ use std::{
         Display,
         Formatter,
         Result as FmtResult
-    }
+    },
+    borrow::Borrow
 };
+use parking_lot::Mutex;
 
 #[derive(Debug)]
 pub enum Error {
     /// When a non-successful status code was received for a request.
-    UnsuccessfulRequest(Response),
+    UnsuccessfulRequest(Mutex<Response>),
     /// When the decoding of a ratelimit header could not be properly decoded
     /// into an `i64`.
     RateLimitI64,
@@ -21,7 +23,7 @@ pub enum Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult { f.write_str(self.description()) }
+    fn fmt(&self, f: &mut Formatter) -> FmtResult { f.write_str(self.borrow().description()) }
 }
 
 impl StdError for Error {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -137,7 +137,7 @@ pub enum GuildPagination {
 
 #[cfg(test)]
 mod test {
-    use super::AttachmentType;
+    use super::{AttachmentType, HttpError};
     use std::path::Path;
 
     #[test]
@@ -150,5 +150,11 @@ mod test {
             AttachmentType::Path(_) => true,
             _ => false,
         });
+    }
+
+    #[test]
+    fn client_error_is_send_sync() {
+        fn accept_send_sync<T: Send + Sync>() {}
+        accept_send_sync::<HttpError>();
     }
 }


### PR DESCRIPTION
Closes https://github.com/serenity-rs/serenity/issues/362 and provides a significant usability boost when using `failure`.

This is an API breaking change so will need to wait for a major version bump. If you'd rather I place it on the `0.6.x` branch I can do that instead.