### PR TITLE
Fix Default Command to inherit Group-Options

### DIFF
--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -198,11 +198,11 @@ impl CreateGroup {
     /// Adds a command for a group that will be executed if no command-name
     /// has been passed.
     pub fn default_cmd<C: Command + 'static>(mut self, c: C) -> Self {
-        let cmd: Arc<Command> = Arc::new(c);
+        c.init();
 
-        self.0.default_command = Some(CommandOrAlias::Command(Arc::clone(&cmd)));
-
-        cmd.init();
+        let cmd_with_group_options = self.build_command().cmd(c).finish();
+        let cmd_finished = CommandOrAlias::Command(cmd_with_group_options);
+        self.0.default_command = Some(cmd_finished);
 
         self
     }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1160,6 +1160,21 @@ impl Framework for StandardFramework {
                                 Args::new(&orginal_round[longest_matching_prefix_len..], &self.configuration.delimiters)
                             };
 
+                            if let Some(error) = self.should_fail(
+                                &mut context,
+                                &message,
+                                &command.options(),
+                                &group,
+                                &mut args,
+                                &to_check,
+                                &built,
+                            ) {
+                                if let Some(ref handler) = self.dispatch_error_handler {
+                                    handler(context, message, error);
+                                }
+                                return;
+                            }
+
                             threadpool.execute(move || {
                                 if let Some(before) = before {
                                     if !(before)(&mut context, &message, &args.full()) {


### PR DESCRIPTION
Setting a default command ended up in not inheriting already set options on a group.

Usually a command inherits group-options and can then override them.
With this pull request, default commands will inherit already set group-options too.