### PR TITLE
Add Function to neutralise Mentions

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -20,7 +20,7 @@ use serenity::model::gateway::Ready;
 use serenity::model::Permissions;
 use serenity::prelude::Mutex;
 use serenity::prelude::*;
-use serenity::utils::{content_safe, Discriminator};
+use serenity::utils::{content_safe, ContentSafeOptions};
 use std::collections::HashMap;
 use std::env;
 use std::fmt::Write;
@@ -255,7 +255,8 @@ command!(commands(ctx, msg, _args) {
 // Repeats what the user passed as argument but ensures that user and role
 // mentions are replaced with a safe textual alternative.
 command!(say(_ctx, msg, args) {
-    let mut content = content_safe(&args.full(), Discriminator::Show);
+    let mut content = content_safe(&args.full(), ContentSafeOptions::default()
+        .clean_channel(false));
 
     if let Err(why) = msg.channel_id.say(&content) {
         println!("Error sending message: {:?}", why);

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -271,7 +271,7 @@ command!(say(_ctx, msg, args) {
             .clean_role(false)
     };
 
-    let mut content = content_safe(&args.full(), settings);
+    let mut content = content_safe(&args.full(), &settings);
 
     if let Err(why) = msg.channel_id.say(&content) {
         println!("Error sending message: {:?}", why);

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -254,6 +254,7 @@ command!(commands(ctx, msg, _args) {
 
 // Repeats what the user passed as argument but ensures that user and role
 // mentions are replaced with a safe textual alternative.
+// In this example channel mentions are excluded via the `ContentSafeOptions`.
 command!(say(_ctx, msg, args) {
     let mut content = content_safe(&args.full(), ContentSafeOptions::default()
         .clean_channel(false));

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -20,6 +20,7 @@ use serenity::model::gateway::Ready;
 use serenity::model::Permissions;
 use serenity::prelude::Mutex;
 use serenity::prelude::*;
+use serenity::utils::{content_safe, Discriminator};
 use std::collections::HashMap;
 use std::env;
 use std::fmt::Write;
@@ -172,6 +173,10 @@ fn main() {
             // Make this command use the "complicated" bucket.
             .bucket("complicated")
             .cmd(commands))
+        // Command that will repeat passed arguments and remove user and
+        // role mentions with safe alternative.
+        .command("say", |c| c
+            .cmd(say))
         .group("Emoji", |g| g
             // Sets multiple prefixes for a group.
             // This requires us to call commands in this group
@@ -243,6 +248,16 @@ command!(commands(ctx, msg, _args) {
     }
 
     if let Err(why) = msg.channel_id.say(&contents) {
+        println!("Error sending message: {:?}", why);
+    }
+});
+
+// Repeats what the user passed as argument but ensures that user and role
+// mentions are replaced with a safe textual alternative.
+command!(say(_ctx, msg, args) {
+    let mut content = content_safe(&args.full(), Discriminator::Show);
+
+    if let Err(why) = msg.channel_id.say(&content) {
         println!("Error sending message: {:?}", why);
     }
 });

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -256,8 +256,22 @@ command!(commands(ctx, msg, _args) {
 // mentions are replaced with a safe textual alternative.
 // In this example channel mentions are excluded via the `ContentSafeOptions`.
 command!(say(_ctx, msg, args) {
-    let mut content = content_safe(&args.full(), ContentSafeOptions::default()
-        .clean_channel(false));
+    let mut settings = if let Some(guild_id) = msg.guild_id {
+       // By default roles, users, and channel mentions are cleaned.
+       ContentSafeOptions::default()
+            // We do not want to clean channal mentions as they
+            // do not ping users.
+            .clean_channel(false)
+            // If it's a guild channel, we want mentioned users to be displayed
+            // as their display name.
+            .display_as_member_from(guild_id)
+    } else {
+        ContentSafeOptions::default()
+            .clean_channel(false)
+            .clean_role(false)
+    };
+
+    let mut content = content_safe(&args.full(), settings);
 
     if let Err(why) = msg.channel_id.say(&content) {
         println!("Error sending message: {:?}", why);

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -14,6 +14,8 @@ use builder::{
 };
 #[cfg(all(feature = "cache", feature = "model"))]
 use CACHE;
+#[cfg(all(feature = "cache", feature = "model"))]
+use Cache;
 #[cfg(feature = "model")]
 use http::{self, AttachmentType};
 #[cfg(feature = "model")]
@@ -293,7 +295,17 @@ impl ChannelId {
     /// [`Channel`]: ../channel/enum.Channel.html
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn to_channel_cached(self) -> Option<Channel> { CACHE.read().channel(self) }
+    pub fn to_channel_cached(self) -> Option<Channel> {
+        self._to_channel_cached(&CACHE)
+    }
+
+    /// To allow testing pass their own cache instead of using the globale one.
+    #[cfg(feature = "cache")]
+    #[inline]
+    pub(crate) fn _to_channel_cached(self, cache: &RwLock<Cache>) -> Option<Channel> {
+        cache.read().channel(self)
+    }
+
 
     /// Search the cache for the channel. If it can't be found, the channel is
     /// requested over REST.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -6,7 +6,7 @@ use builder::EditRole;
 #[cfg(all(feature = "cache", feature = "model"))]
 use internal::prelude::*;
 #[cfg(all(feature = "cache", feature = "model"))]
-use {CACHE, http};
+use {CACHE, Cache, http};
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use std::str::FromStr;
@@ -182,9 +182,12 @@ impl RoleId {
     /// [`Role`]: ../guild/struct.Role.html
     #[cfg(feature = "cache")]
     pub fn to_role_cached(self) -> Option<Role> {
-        let cache = CACHE.read();
+        self._to_role_cached(&CACHE)
+    }
 
-        for guild in cache.guilds.values() {
+    #[cfg(feature = "cache")]
+    pub(crate) fn _to_role_cached(self, cache: &RwLock<Cache>) -> Option<Role> {
+        for guild in cache.read().guilds.values() {
             let guild = guild.read();
 
             if !guild.roles.contains_key(&self) {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -540,6 +540,7 @@ pub fn with_cache_mut<T, F>(mut f: F) -> T
 ///
 /// [`content_safe`]: fn.content_safe.html
 #[cfg(feature = "cache")]
+#[derive(Clone, Debug)]
 pub struct ContentSafeOptions {
     clean_role: bool,
     clean_user: bool,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -801,10 +801,11 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
     }
 }
 
-/// Neutralises role, channel, and user mentions including `@everyone`
-/// and `@here` using the [`Cache`] only.
+/// Transforms role, channel, user, `@everyone` and `@here` mentions
+/// into raw text by using the [`Cache`] only.
 ///
-/// [`ContentSafeOptions`] alters behaviour of this function.
+/// [`ContentSafeOptions`] decides what kind of mentions should be filtered
+/// and how the raw-text will be displayed.
 ///
 /// # Examples
 ///

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1008,15 +1008,15 @@ mod test {
 
         let with_user_metions = "<@!100000000000000000> <@!000000000000000000> <@123> <@!123> \
         <@!123123123123123123123> <@123> <@123123123123123123> <@!invalid> \
-        <@invalid> <@invalidinvalidinvlansdlkfjsldkfjalskdf> \
+        <@invalid> <@日本語 한국어$§)[/__#\\(/&2032$§#> \
         <@!i)/==(<<>z/9080)> <@!1231invalid> <@invalid123> \
-        <@123invalid> <@>";
+        <@123invalid> <@> <@ ";
 
         let without_user_mentions = "@Crab#0000 @invalid-user @invalid-user @invalid-user \
-        @invalid-user @invalid-user @invalid-user <@!invalid> <@invalid> \
-        <@invalidinvalidinvlansdlkfjsldkfjalskdf> \
+        @invalid-user @invalid-user @invalid-user <@!invalid> \
+        <@invalid> <@日本語 한국어$§)[/__#\\(/&2032$§#> \
         <@!i)/==(<<>z/9080)> <@!1231invalid> <@invalid123> \
-        <@123invalid> <@>";
+        <@123invalid> <@> <@ ";
 
         // User mentions
         let options = ContentSafeOptions::default();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -622,6 +622,7 @@ impl Default for ContentSafeOptions {
 }
 
 #[cfg(feature = "cache")]
+#[inline]
 fn clean_roles(s: &mut String) {
     let mut progress = 0;
 
@@ -659,6 +660,7 @@ fn clean_roles(s: &mut String) {
 }
 
 #[cfg(feature = "cache")]
+#[inline]
 fn clean_channels(s: &mut String) {
     let mut progress = 0;
 
@@ -699,6 +701,7 @@ fn clean_channels(s: &mut String) {
 }
 
 #[cfg(feature = "cache")]
+#[inline]
 fn clean_users(s: &mut String, show_discriminator: bool, guild: Option<GuildId>) {
     let mut progress = 0;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -571,11 +571,9 @@ pub enum Discriminator {
 /// [`Cache`]: ../cache/struct.Cache.html
 #[cfg(feature = "cache")]
 pub fn content_safe(s: &str, show_discriminator: Discriminator) -> String {
-    let mut progress = 0;
     let mut s = s.to_string();
 
-    while let Some(mut mention_start) = s[progress..].find("<@&") {
-        mention_start += progress;
+    while let Some(mut mention_start) = s.find("<@&") {
 
         if let Some(mut mention_end) = s[mention_start..].find(">") {
             mention_end += mention_start;
@@ -590,17 +588,12 @@ pub fn content_safe(s: &str, show_discriminator: Discriminator) -> String {
                     s.replace(&to_replace, &"deleted-role")
                 };
             }
-
-            progress = mention_end;
         } else {
             break;
         }
     }
 
-    progress = 0;
-
-    while let Some(mut mention_start) = s[progress..].find("<@") {
-        mention_start += progress;
+    while let Some(mut mention_start) = s.find("<@") {
 
         if let Some(mut mention_end) = s[mention_start..].find(">") {
             mention_end += mention_start;
@@ -615,8 +608,8 @@ pub fn content_safe(s: &str, show_discriminator: Discriminator) -> String {
 
             if let Ok(id) = UserId::from_str(&s[mention_start..mention_end]) {
                 let user = CACHE.read().users.get(&id).map(|user| user.clone());
-                let mention_start = if has_exclamation { "<@!" } else { "<@" };
-                let to_replace = format!("{}{}>", mention_start, id.as_u64());
+                let code_start = if has_exclamation { "<@!" } else { "<@" };
+                let to_replace = format!("{}{}>", code_start, id.as_u64());
 
                 s = if let Some(user) = user {
                     let user = user.read();
@@ -633,8 +626,6 @@ pub fn content_safe(s: &str, show_discriminator: Discriminator) -> String {
                     s.replace(&to_replace, &"invalid-user")
                 };
             }
-
-            progress = mention_end;
         } else {
             break;
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -759,7 +759,7 @@ fn clean_users(s: &mut String, show_discriminator: bool) {
 ///
 /// assert_eq!("@\u{200B}everyone".to_string(), defused_mention);
 /// ```
-/// [`ContentSafeOptions`]: struct.Discriminator.html
+/// [`ContentSafeOptions`]: struct.ContentSafeOptions.html
 /// [`Cache`]: ../cache/struct.Cache.html
 #[cfg(feature = "cache")]
 pub fn content_safe(s: &str, options: ContentSafeOptions) -> String {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -795,7 +795,7 @@ fn clean_users(s: &mut String, show_discriminator: bool, guild: Option<GuildId>)
 /// [`ContentSafeOptions`]: struct.ContentSafeOptions.html
 /// [`Cache`]: ../cache/struct.Cache.html
 #[cfg(feature = "cache")]
-pub fn content_safe(s: &str, options: ContentSafeOptions) -> String {
+pub fn content_safe(s: &str, options: &ContentSafeOptions) -> String {
     let mut s = s.to_string();
 
     if options.clean_role {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -624,7 +624,7 @@ fn clean_roles(s: &mut String) {
                 *s = if let Some(role) = id.to_role_cached() {
                     s.replace(&to_replace, &format!("@{}", &role.name))
                 } else {
-                    s.replace(&to_replace, &"deleted-role")
+                    s.replace(&to_replace, &"@deleted-role")
                 };
             } else {
                 progress = mention_end;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -676,12 +676,10 @@ fn clean_channels(cache: &RwLock<Cache>, s: &mut String) {
             mention_end += mention_start;
             mention_start += "<#".len();
 
-            if let Ok(id) =
-                ChannelId::from_str(&s[mention_start..mention_end]) {
+            if let Ok(id) = ChannelId::from_str(&s[mention_start..mention_end]) {
                 let to_replace = format!("<#{}>", &s[mention_start..mention_end]);
 
-                *s = if let Some(Channel::Guild(channel))
-                    = id._to_channel_cached(&cache) {
+                *s = if let Some(Channel::Guild(channel)) = id._to_channel_cached(&cache) {
                     let replacement = format!("#{}", &channel.read().name);
                     s.replace(&to_replace, &replacement)
                 } else {
@@ -718,8 +716,7 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
             mention_start += "<@".len();
             let mut has_exclamation = false;
 
-            if s[mention_start..].as_bytes().get(0)
-                .map_or(false, |c| *c == b'!') {
+            if s[mention_start..].as_bytes().get(0).map_or(false, |c| *c == b'!') {
                 mention_start += "!".len();
                 has_exclamation = true;
             }
@@ -730,6 +727,7 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
                     if let Some(guild) = cache.read().guild(&guild) {
 
                         if let Some(member) = guild.read().members.get(&id) {
+
                             if show_discriminator {
                                 format!("@{}", member.distinct())
                             } else {
@@ -742,8 +740,7 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
                         "@invalid-user".to_string()
                     }
                 } else {
-                    let user = cache.read().users.get(&id)
-                        .map(|user| user.clone());
+                    let user = cache.read().users.get(&id).map(|user| user.clone());
 
                     if let Some(user) = user {
                         let user = user.read();
@@ -765,8 +762,7 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
             } else {
                 let id = &s[mention_start..mention_end].to_string();
 
-                if !id.is_empty() && id.as_bytes().iter()
-                    .all(u8::is_ascii_digit){
+                if !id.is_empty() && id.as_bytes().iter().all(u8::is_ascii_digit) {
                     let code_start = if has_exclamation { "<@!" } else { "<@" };
                     let to_replace = format!("{}{}>", code_start, id);
 
@@ -824,14 +820,11 @@ fn _content_safe(cache: &RwLock<Cache>, s: &str, options: &ContentSafeOptions) -
     }
 
     if options.clean_user {
-        clean_users(&cache, &mut s,
-            options.show_discriminator,
-            options.guild_reference);
+        clean_users(&cache, &mut s, options.show_discriminator, options.guild_reference);
     }
 
-    s
-        .replace("@everyone", "@\u{200B}everyone")
-        .replace("@here", "@\u{200B}here")
+    s.replace("@everyone", "@\u{200B}everyone")
+     .replace("@here", "@\u{200B}here")
 }
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -584,7 +584,7 @@ pub fn content_safe(s: &str, show_discriminator: Discriminator) -> String {
             if let Ok(id) = RoleId::from_str(&s[mention_start..mention_end]) {
                 let to_replace = format!("<@&{}>", &id.as_u64());
 
-                if let Some(role) = id.to_role_cached() {
+                s = if let Some(role) = id.to_role_cached() {
                     s.replace(&to_replace, &role.name)
                 } else {
                     s.replace(&to_replace, &"deleted-role")

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -700,7 +700,7 @@ fn clean_users(s: &mut String, show_discriminator: bool) {
 
                     s.replace(&to_replace, &replacement)
                 } else {
-                    s.replace(&to_replace, &"invalid-user")
+                    s.replace(&to_replace, &"@invalid-user")
                 };
             } else {
                 progress = mention_end;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -546,6 +546,8 @@ pub struct ContentSafeOptions {
     clean_role: bool,
     clean_user: bool,
     clean_channel: bool,
+    clean_here: bool,
+    clean_everyone: bool,
     show_discriminator: bool,
     guild_reference: Option<GuildId>,
 }
@@ -610,6 +612,26 @@ impl ContentSafeOptions {
 
         self
     }
+
+    /// If set, [`content_safe`] will replace `@here` with a non-pinging
+    /// alternative.
+    ///
+    /// [`content_safe`]: fn.content_safe.html
+    pub fn clean_here(mut self, b: bool) -> Self {
+        self.clean_here = b;
+
+        self
+    }
+
+    /// If set, [`content_safe`] will replace `@everyone` with a non-pinging
+    /// alternative.
+    ///
+    /// [`content_safe`]: fn.content_safe.html
+    pub fn clean_everyone(mut self, b: bool) -> Self {
+        self.clean_everyone = b;
+
+        self
+    }
 }
 
 #[cfg(feature = "cache")]
@@ -620,6 +642,8 @@ impl Default for ContentSafeOptions {
             clean_role: true,
             clean_user: true,
             clean_channel: true,
+            clean_here: true,
+            clean_everyone: true,
             show_discriminator: true,
             guild_reference: None,
         }
@@ -823,8 +847,15 @@ fn _content_safe(cache: &RwLock<Cache>, s: &str, options: &ContentSafeOptions) -
         clean_users(&cache, &mut s, options.show_discriminator, options.guild_reference);
     }
 
-    s.replace("@everyone", "@\u{200B}everyone")
-     .replace("@here", "@\u{200B}here")
+    if options.clean_here {
+        s = s.replace("@here", "@\u{200B}here");
+    }
+
+    if options.clean_everyone {
+        s = s.replace("@everyone", "@\u{200B}everyone");
+    }
+
+    s
 }
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -810,7 +810,7 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
 ///
 /// Sanitise an `@everyone` mention.
 ///
-/// ```rust,ignore
+/// ```rust
 /// use serenity::utils::{
 ///     content_safe,
 ///     ContentSafeOptions,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1076,5 +1076,28 @@ mod test {
         assert_eq!(with_role_mentions,
             _content_safe(&cache, with_role_mentions, &options));
 
+        // Everyone mentions
+        let with_everyone_mention = "@everyone";
+
+        let without_everyone_mention = "@\u{200B}everyone";
+
+        assert_eq!(without_everyone_mention,
+            _content_safe(&cache, with_everyone_mention, &options));
+
+        let options = options.clean_everyone(false);
+        assert_eq!(with_everyone_mention,
+            _content_safe(&cache, with_everyone_mention, &options));
+
+        // Here mentions
+        let with_here_mention = "@here";
+
+        let without_here_mention = "@\u{200B}here";
+
+        assert_eq!(without_here_mention,
+            _content_safe(&cache, with_here_mention, &options));
+
+        let options = options.clean_here(false);
+        assert_eq!(with_here_mention,
+            _content_safe(&cache, with_here_mention, &options));
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -589,11 +589,9 @@ pub fn content_safe(s: &str, show_discriminator: Discriminator) -> String {
                 } else {
                     s.replace(&to_replace, &"deleted-role")
                 };
-
-                progress = mention_end;
-            } else {
-                progress = mention_end;
             }
+
+            progress = mention_end;
         } else {
             break;
         }
@@ -610,7 +608,7 @@ pub fn content_safe(s: &str, show_discriminator: Discriminator) -> String {
             let mut has_exclamation = false;
 
             if s[mention_start..].as_bytes().get(0)
-                .map_or_else(|| false, |c| *c == b'!') {
+                .map_or(false, |c| *c == b'!') {
                 mention_start += "!".len();
                 has_exclamation = true;
             }
@@ -634,11 +632,9 @@ pub fn content_safe(s: &str, show_discriminator: Discriminator) -> String {
                 } else {
                     s.replace(&to_replace, &"invalid-user")
                 };
-
-                progress = mention_end;
-            } else {
-                progress = mention_end;
             }
+
+            progress = mention_end;
         } else {
             break;
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -609,7 +609,10 @@ impl Default for ContentSafeOptions {
 
 #[cfg(feature = "cache")]
 fn clean_roles(s: &mut String) {
-    while let Some(mut mention_start) = s.find("<@&") {
+    let mut progress = 0;
+
+    while let Some(mut mention_start) = s[progress..].find("<@&") {
+        mention_start += progress;
 
         if let Some(mut mention_end) = s[mention_start..].find(">") {
             mention_end += mention_start;
@@ -623,6 +626,8 @@ fn clean_roles(s: &mut String) {
                 } else {
                     s.replace(&to_replace, &"deleted-role")
                 };
+            } else {
+                progress = mention_end;
             }
         } else {
             break;
@@ -632,7 +637,10 @@ fn clean_roles(s: &mut String) {
 
 #[cfg(feature = "cache")]
 fn clean_channels(s: &mut String) {
-    while let Some(mut mention_start) = s.find("<#") {
+    let mut progress = 0;
+
+    while let Some(mut mention_start) = s[progress..].find("<#") {
+        mention_start += progress;
 
         if let Some(mut mention_end) = s[mention_start..].find(">") {
             mention_end += mention_start;
@@ -649,6 +657,8 @@ fn clean_channels(s: &mut String) {
                 } else {
                     s.replace(&to_replace, &"#deleted-channel")
                 };
+            } else {
+                progress = mention_end;
             }
         } else {
             break;
@@ -658,7 +668,10 @@ fn clean_channels(s: &mut String) {
 
 #[cfg(feature = "cache")]
 fn clean_users(s: &mut String, show_discriminator: bool) {
-    while let Some(mut mention_start) = s.find("<@") {
+    let mut progress = 0;
+
+    while let Some(mut mention_start) = s[progress..].find("<@") {
+        mention_start += progress;
 
         if let Some(mut mention_end) = s[mention_start..].find(">") {
             mention_end += mention_start;
@@ -689,6 +702,8 @@ fn clean_users(s: &mut String, show_discriminator: bool) {
                 } else {
                     s.replace(&to_replace, &"invalid-user")
                 };
+            } else {
+                progress = mention_end;
             }
         } else {
             break;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -813,13 +813,13 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
 /// ```rust,ignore
 /// use serenity::utils::{
 ///     content_safe,
-///     Discriminator,
+///     ContentSafeOptions,
 /// };
 ///
-/// let everyone_mention = "@everyone";
-/// let defused_mention = content_safe(&everyone_mention, Discriminator::Hide);
+/// let with_mention = "@everyone";
+/// let without_mention = content_safe(&with_mention, &ContentSafeOptions::default());
 ///
-/// assert_eq!("@\u{200B}everyone".to_string(), defused_mention);
+/// assert_eq!("@\u{200B}everyone".to_string(), without_mention);
 /// ```
 /// [`ContentSafeOptions`]: struct.ContentSafeOptions.html
 /// [`Cache`]: ../cache/struct.Cache.html

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -626,8 +626,17 @@ fn clean_roles(s: &mut String) {
                 } else {
                     s.replace(&to_replace, &"@deleted-role")
                 };
-            } else {
-                progress = mention_end;
+            } else  {
+                let id = &s[mention_start..mention_end].to_string();
+
+                if !id.is_empty() && id.as_bytes().iter()
+                    .all(u8::is_ascii_digit){
+                    let to_replace = format!("<@&{}>", id);
+
+                    *s = s.replace(&to_replace, &"@deleted-role");
+                } else {
+                    progress = mention_end;
+                }
             }
         } else {
             break;
@@ -657,8 +666,17 @@ fn clean_channels(s: &mut String) {
                 } else {
                     s.replace(&to_replace, &"#deleted-channel")
                 };
-            } else {
-                progress = mention_end;
+            } else  {
+                let id = &s[mention_start..mention_end].to_string();
+
+                if !id.is_empty() && id.as_bytes().iter()
+                    .all(u8::is_ascii_digit){
+                    let to_replace = format!("<#{}>", id);
+
+                    *s = s.replace(&to_replace, &"#deleted-channel");
+                } else {
+                    progress = mention_end;
+                }
             }
         } else {
             break;
@@ -702,8 +720,18 @@ fn clean_users(s: &mut String, show_discriminator: bool) {
                 } else {
                     s.replace(&to_replace, &"@invalid-user")
                 };
-            } else {
-                progress = mention_end;
+            } else  {
+                let id = &s[mention_start..mention_end].to_string();
+
+                if !id.is_empty() && id.as_bytes().iter()
+                    .all(u8::is_ascii_digit){
+                    let code_start = if has_exclamation { "<@!" } else { "<@" };
+                    let to_replace = format!("{}{}>", code_start, id);
+
+                    *s = s.replace(&to_replace, &"@invalid-user");
+                } else {
+                    progress = mention_end;
+                }
             }
         } else {
             break;


### PR DESCRIPTION
This function utilises the cache to replace user, channel, and role mentions with a safe alternative.

E.g. a mention of the user `@ferris` (internally represented as `<@!{id}>`) will be represented as: `@ferris#1234`, which does not alert the user.
`@everyone` and `@here` are replaced as well.

On another note, it's also possible to display users by their actual name or display name.

These questions are left:
- [x] Should the function-name stay the same? It's based on [content_safe](https://docs.rs/serenity/0.5.9/serenity/model/channel/struct.Message.html#method.content_safe). I would prefer `neutralise_content` etc.
- [x] What if an identifier is too short/long? They are currently marked as `deleted-user`/`deleted-role` respectively. 

  *Solution*: The function will display just like Discord would display. E.g. invalid identifiers on `<@{id}>` are displayed as `@invalid-user` on mobile - so it will display as safe non-mentioning `@invalid-user`.
- [x] Is the API acceptable?
