### PR TITLE
Prefix only Command

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -80,7 +80,10 @@ fn main() {
         .configure(|c| c
             .allow_whitespace(true)
             .on_mention(true)
-            .prefix("~")
+            .prefixes("~")
+            // A command that will be executed
+            // if nothing but the command is passed.
+            .prefix_only_cmd(about)
             // You can set multiple delimiters via delimiters()
             // or just one via delimiter(",")
             // If you set multiple delimiters, the order you list them

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -82,7 +82,7 @@ fn main() {
             .on_mention(true)
             .prefixes("~")
             // A command that will be executed
-            // if nothing but the command is passed.
+            // if nothing but a prefix is passed.
             .prefix_only_cmd(about)
             // You can set multiple delimiters via delimiters()
             // or just one via delimiter(",")

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -80,7 +80,7 @@ fn main() {
         .configure(|c| c
             .allow_whitespace(true)
             .on_mention(true)
-            .prefixes("~")
+            .prefix("~")
             // A command that will be executed
             // if nothing but a prefix is passed.
             .prefix_only_cmd(about)

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -374,7 +374,8 @@ pub fn positions(ctx: &mut Context, msg: &Message, conf: &Configuration) -> Opti
 
             // If the above do not fill `positions`, then that means no kind of prefix was present.
             // Check if a no-prefix-execution is applicable.
-            if conf.no_dm_prefix && private && positions.is_empty() {
+            if conf.no_dm_prefix && private && positions.is_empty() &&
+            !(conf.ignore_bots && msg.author.bot) {
                 positions.push(0);
             }
         }

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -6,9 +6,10 @@ use model::{
 };
 use std::{
     collections::HashSet,
-    default::Default
+    default::Default,
+    sync::Arc,
 };
-use super::command::PrefixCheck;
+use super::command::{Command, InternalCommand, PrefixCheck};
 
 /// The configuration to use for a [`StandardFramework`] associated with a [`Client`]
 /// instance.
@@ -59,6 +60,7 @@ pub struct Configuration {
     #[doc(hidden)] pub no_dm_prefix: bool,
     #[doc(hidden)] pub delimiters: Vec<String>,
     #[doc(hidden)] pub case_insensitive: bool,
+    #[doc(hidden)] pub prefix_only_cmd: Option<InternalCommand>,
 }
 
 impl Configuration {
@@ -511,6 +513,15 @@ impl Configuration {
 
         self
     }
+
+    /// Sets a command to dispatch if user's input is a prefix only.
+    ///
+    /// **Note**: Defaults to no command and ignores prefix only.
+    pub fn prefix_only_cmd<C: Command + 'static>(mut self, c: C) -> Self {
+        self.prefix_only_cmd = Some(Arc::new(c));
+
+        self
+    }
 }
 
 impl Default for Configuration {
@@ -550,6 +561,7 @@ impl Default for Configuration {
             on_mention: None,
             owners: HashSet::default(),
             prefixes: vec![],
+            prefix_only_cmd: None,
         }
     }
 }


### PR DESCRIPTION
If user's input contains nothing but the prefix, the framework can now given a command that will be dispatched in this case.