### PR TITLE
Fix NSFW Checks

### DIFF
--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -128,7 +128,7 @@ impl ChannelCategory {
     #[cfg(feature = "utils")]
     #[inline]
     pub fn is_nsfw(&self) -> bool {
-        self.kind == ChannelType::Text && (self.nsfw || serenity_utils::is_nsfw(&self.name))
+        self.kind == ChannelType::Text && self.nsfw
     }
 
     /// Returns the name of the category.

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -125,7 +125,6 @@ impl ChannelCategory {
         })
     }
 
-    #[cfg(feature = "utils")]
     #[inline]
     pub fn is_nsfw(&self) -> bool {
         self.kind == ChannelType::Text && self.nsfw

--- a/src/model/channel/group.rs
+++ b/src/model/channel/group.rs
@@ -174,12 +174,8 @@ impl Group {
 
     /// Determines if the channel is NSFW.
     ///
-    /// Refer to [`utils::is_nsfw`] for more details.
-    ///
     /// **Note**: This method is for consistency. This will always return
     /// `false`, due to groups not being considered NSFW.
-    ///
-    /// [`utils::is_nsfw`]: ../../utils/fn.is_nsfw.html
     #[inline]
     pub fn is_nsfw(&self) -> bool { false }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -391,7 +391,6 @@ impl GuildChannel {
     ///
     /// [`ChannelType::Text`]: enum.ChannelType.html#variant.Text
     /// [`ChannelType::Voice`]: enum.ChannelType.html#variant.Voice
-    #[cfg(feature = "utils")]
     #[inline]
     pub fn is_nsfw(&self) -> bool {
         self.kind == ChannelType::Text && self.nsfw

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -386,18 +386,15 @@ impl GuildChannel {
 
     /// Determines if the channel is NSFW.
     ///
-    /// Refer to [`utils::is_nsfw`] for more details.
-    ///
     /// Only [text channels][`ChannelType::Text`] are taken into consideration
     /// as being NSFW. [voice channels][`ChannelType::Voice`] are never NSFW.
     ///
     /// [`ChannelType::Text`]: enum.ChannelType.html#variant.Text
     /// [`ChannelType::Voice`]: enum.ChannelType.html#variant.Voice
-    /// [`utils::is_nsfw`]: ../../utils/fn.is_nsfw.html
     #[cfg(feature = "utils")]
     #[inline]
     pub fn is_nsfw(&self) -> bool {
-        self.kind == ChannelType::Text && (self.nsfw || serenity_utils::is_nsfw(&self.name))
+        self.kind == ChannelType::Text && self.nsfw
     }
 
     /// Gets a message from the channel.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -765,7 +765,7 @@ mod test {
         #[test]
         fn nsfw_checks() {
             let mut channel = guild_channel();
-            assert!(channel.is_nsfw());
+            assert!(!channel.is_nsfw());
             channel.kind = ChannelType::Voice;
             assert!(!channel.is_nsfw());
 
@@ -774,7 +774,7 @@ mod test {
             assert!(!channel.is_nsfw());
 
             channel.name = "nsfw".to_string();
-            assert!(channel.is_nsfw());
+            assert!(!channel.is_nsfw());
             channel.kind = ChannelType::Voice;
             assert!(!channel.is_nsfw());
             channel.kind = ChannelType::Text;

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -334,7 +334,7 @@ impl Channel {
     }
 
     /// Determines if the channel is NSFW.
-    #[cfg(all(feature = "model", feature = "utils"))]
+    #[cfg(feature = "model")]
     #[inline]
     pub fn is_nsfw(&self) -> bool {
         match *self {

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -334,10 +334,6 @@ impl Channel {
     }
 
     /// Determines if the channel is NSFW.
-    ///
-    /// Refer to [`utils::is_nsfw`] for more details.
-    ///
-    /// [`utils::is_nsfw`]: ../../utils/fn.is_nsfw.html
     #[cfg(all(feature = "model", feature = "utils"))]
     #[inline]
     pub fn is_nsfw(&self) -> bool {

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -150,12 +150,8 @@ impl PrivateChannel {
 
     /// Determines if the channel is NSFW.
     ///
-    /// Refer to [`utils::is_nsfw`] for more details.
-    ///
     /// **Note**: This method is for consistency. This will always return
     /// `false`, due to DMs not being considered NSFW.
-    ///
-    /// [`utils::is_nsfw`]: ../../utils/fn.is_nsfw.html
     #[inline]
     pub fn is_nsfw(&self) -> bool { false }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -566,14 +566,4 @@ mod test {
         let parsed = parse_quotes("a \"b c\" d\"e f\"  g");
         assert_eq!(parsed, ["a", "b c", "d", "e f", "g"]);
     }
-
-    #[test]
-    fn test_is_nsfw() {
-        assert!(!is_nsfw("general"));
-        assert!(is_nsfw("nsfw"));
-        assert!(is_nsfw("nsfw-test"));
-        assert!(!is_nsfw("nsfw-"));
-        assert!(!is_nsfw("général"));
-        assert!(is_nsfw("nsfw-général"));
-    }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -571,10 +571,10 @@ mod test {
     #[test]
     fn test_is_nsfw() {
         assert!(!is_nsfw("general"));
-        assert!(is_nsfw("nsfw"));
-        assert!(is_nsfw("nsfw-test"));
+        assert!(!is_nsfw("nsfw"));
+        assert!(!is_nsfw("nsfw-test"));
         assert!(!is_nsfw("nsfw-"));
         assert!(!is_nsfw("général"));
-        assert!(is_nsfw("nsfw-général"));
+        assert!(!is_nsfw("nsfw-général"));
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -566,4 +566,15 @@ mod test {
         let parsed = parse_quotes("a \"b c\" d\"e f\"  g");
         assert_eq!(parsed, ["a", "b c", "d", "e f", "g"]);
     }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_is_nsfw() {
+        assert!(!is_nsfw("general"));
+        assert!(is_nsfw("nsfw"));
+        assert!(is_nsfw("nsfw-test"));
+        assert!(!is_nsfw("nsfw-"));
+        assert!(!is_nsfw("général"));
+        assert!(is_nsfw("nsfw-général"));
+    }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -91,6 +91,7 @@ pub fn vecmap_to_json_map<K: PartialEq + ToString>(map: VecMap<K, Value>) -> Map
 ///
 /// assert!(!utils::is_nsfw("nsfwstuff"));
 /// ```
+#[deprecated(since = "0.5.10", note = "Discord no longer turns a channel NSFW based on its name.")]
 pub fn is_nsfw(name: &str) -> bool {
     name == "nsfw" || name.chars().count() > 5 && name.starts_with("nsfw-")
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -571,10 +571,10 @@ mod test {
     #[test]
     fn test_is_nsfw() {
         assert!(!is_nsfw("general"));
-        assert!(!is_nsfw("nsfw"));
-        assert!(!is_nsfw("nsfw-test"));
+        assert!(is_nsfw("nsfw"));
+        assert!(is_nsfw("nsfw-test"));
         assert!(!is_nsfw("nsfw-"));
         assert!(!is_nsfw("général"));
-        assert!(!is_nsfw("nsfw-général"));
+        assert!(is_nsfw("nsfw-général"));
     }
 }


### PR DESCRIPTION
Whether a channel or category is NSFW no longer depends on whether either contains the term `nsfw` in it thus this PR deprecates `utils::is_nsfw` and removes its usage.
This is not breaking as it only corrects behaviour.