### PR TITLE
Add Option to disable bypassing Checks for Owners

### DIFF
--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -157,7 +157,7 @@ pub struct CommandOptions {
     pub dm_only: bool,
     /// Whether command can be used only in guilds or not.
     pub guild_only: bool,
-    /// Whether the command can be used only in NSFW channels.
+    /// Whether the command treats owners as normal users.
     pub owner_privileges: bool,
     /// Whether command can only be used by owners or not.
     pub owners_only: bool,

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -99,6 +99,7 @@ pub struct CommandGroup {
     pub help_available: bool,
     pub dm_only: bool,
     pub guild_only: bool,
+    pub owner_privileges: bool,
     pub owners_only: bool,
     pub help: Option<Arc<Help>>,
     /// A set of checks to be called prior to executing the command-group. The checks
@@ -117,6 +118,7 @@ impl Default for CommandGroup {
             required_permissions: Permissions::empty(),
             dm_only: false,
             guild_only: false,
+            owner_privileges: true,
             help_available: true,
             owners_only: false,
             allowed_roles: Vec::new(),
@@ -155,6 +157,8 @@ pub struct CommandOptions {
     pub dm_only: bool,
     /// Whether command can be used only in guilds or not.
     pub guild_only: bool,
+    /// Whether the command can be used only in NSFW channels.
+    pub owner_privileges: bool,
     /// Whether command can only be used by owners or not.
     pub owners_only: bool,
     /// Other names that can be used to call this command instead.
@@ -335,6 +339,7 @@ impl Default for CommandOptions {
             required_permissions: Permissions::empty(),
             dm_only: false,
             guild_only: false,
+            owner_privileges: true,
             help_available: true,
             owners_only: false,
             allowed_roles: Vec::new(),

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -168,6 +168,14 @@ impl CreateCommand {
         self
     }
 
+    /// Whether owners shall bypass buckets, missing permissions,
+    /// wrong channels, missing roles, and checks.
+    pub fn owner_privileges(mut self, owner_privileges: bool) -> Self {
+        self.0.owner_privileges = owner_privileges;
+
+        self
+    }
+
     /// Whether command should be displayed in help list or not, used by other commands.
     pub fn help_available(mut self, help_available: bool) -> Self {
         self.0.help_available = help_available;

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -151,6 +151,14 @@ impl CreateGroup {
         self
     }
 
+    /// Whether owners shall bypass buckets, missing permissions,
+    /// wrong channels, missing roles, and checks.
+    pub fn owner_privileges(mut self, owner_privileges: bool) -> Self {
+        self.0.owner_privileges = owner_privileges;
+
+        self
+    }
+
     /// Whether command should be displayed in help list or not, used by other commands.
     pub fn help_available(mut self, help_available: bool) -> Self {
         self.0.help_available = help_available;

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -43,7 +43,8 @@ impl CreateGroup {
             .dm_only(self.0.dm_only)
             .guild_only(self.0.guild_only)
             .help_available(self.0.help_available)
-            .owners_only(self.0.owners_only);
+            .owners_only(self.0.owners_only)
+            .owner_privileges(self.0.owner_privileges);
 
         if let Some(ref bucket) = self.0.bucket {
             cmd = cmd.bucket(bucket);

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -532,7 +532,7 @@ impl StandardFramework {
                 }
             }
 
-            if self.configuration.owners.contains(&message.author.id) {
+            if command.owner_privileges && self.configuration.owners.contains(&message.author.id) {
                 return None;
             }
 


### PR DESCRIPTION
If a user is listed in the `HashSet` named `owners` when configuring the framework, users will automatically bypass a variety of checks including buckets (manually set rate limits).

This pull request adds the possibility to use a group's or a single command's `owner_privileges`-method to `false` and treat them as a non-owner.

To avoid breaking behaviour `owner_privileges` defaults to `true`, this might be up for discussion for the next breaking update.