### PR TITLE
Impl EventHandler for Vec<Box<EventHandler>>

### DIFF
--- a/examples/12_multiple_event_handlers/Cargo.toml
+++ b/examples/12_multiple_event_handlers/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "12_multiple_event_handlers"
+version = "0.1.0"
+authors = ["my name <my@email.address>"]
+
+[dependencies]
+serenity = { path = "../../" }

--- a/examples/12_multiple_event_handlers/src/main.rs
+++ b/examples/12_multiple_event_handlers/src/main.rs
@@ -1,0 +1,50 @@
+extern crate serenity;
+
+use serenity::prelude::*;
+use serenity::model::channel::Message;
+use serenity::model::gateway::Ready;
+use std::env;
+
+// This example uses two different EventHandlers for two different events. In a
+// real project, these handlers could live in different modules or even crates.
+// The first handler will reply to "!ping" messages:
+struct MessageHandler;
+
+impl EventHandler for MessageHandler {
+    fn message(&self, _: Context, msg: Message) {
+        if msg.content == "!ping" {
+            if let Err(why) = msg.channel_id.say("Pong!") {
+                println!("Error sending message: {:?}", why);
+            }
+        }
+    }
+}
+
+// And the second handler will log the `ready` event:
+struct ReadyHandler;
+
+impl EventHandler for ReadyHandler {
+    fn ready(&self, _: Context, ready: Ready) {
+        println!("{} is connected!", ready.user.name);
+    }
+}
+
+fn main() {
+    // Configure the client with your Discord bot token in the environment.
+    let token = env::var("DISCORD_TOKEN")
+        .expect("Expected a token in the environment");
+
+    // To combine the two handlers, make a vector. Since these handlers have
+    // different types, they need to be boxed.
+    let handlers: Vec<Box<EventHandler + Send + Sync>> = vec![
+        Box::new(MessageHandler),
+        Box::new(ReadyHandler)
+    ];
+    // Use this vector of handlers as the event handler. Each event will be
+    // forwarded to all handlers in order.
+    let mut client = Client::new(&token, handlers).expect("Err creating client");
+
+    if let Err(why) = client.start() {
+        println!("Client error: {:?}", why);
+    }
+}

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -19,7 +19,7 @@ macro_rules! impl_event_handler {
         }
 
         /// A vector of boxed event handlers can be used as an event handler. Each event is sent to each element of the vector in order.
-        impl $trait_name for Vec<Box<$trait_name>> {
+        impl $trait_name for Vec<Box<$trait_name + Send + Sync>> {
             $(
                 $(#[$fn_item])*
                 fn $fn_name(&self, $($arg_name: $arg_type),*) {


### PR DESCRIPTION
This PR adds an implementation of `EventHandler` for `Vec<Box<EventHandler>>`, which allows splitting up handler code into multiple types implementing the trait. For example, I have multiple bots that serialize voice state to disk, this would allow me to reuse the same code for these and still have specific event handler code for each bot.

The implementation is generated using a macro, so that new trait methods of `EventHandler` are automatically implemented correctly when added.