### PR TITLE
Update packages to allow building with OpenSSL 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ version = "~0.10"
 
 [dependencies.hyper-native-tls]
 optional = true
-version = "0.2.4"
+version = "0.3.0"
 
 [dependencies.lazy_static]
 optional = true
@@ -54,7 +54,7 @@ version = "0.13"
 
 [dependencies.native-tls]
 optional = true
-version = "0.1"
+version = "0.2"
 
 [dependencies.opus]
 optional = true
@@ -73,11 +73,11 @@ version = "~1.7"
 optional = true
 version = "~0.3"
 
-[dependencies.evzht9h3nznqzwl]
+[dependencies.websocket]
 default-features = false
 features = ["sync-ssl"]
 optional = true
-version = "0.0.3"
+version = "0.21.1"
 
 [dev-dependencies.matches]
 version = "0.1.6"
@@ -111,7 +111,6 @@ model = ["builder", "http"]
 standard_framework = ["framework"]
 utils = ["base64"]
 voice = ["byteorder", "gateway", "opus", "sodiumoxide"]
-websocket = ["evzht9h3nznqzwl"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,8 @@ extern crate sodiumoxide;
 extern crate threadpool;
 #[cfg(feature = "typemap")]
 extern crate typemap;
-#[cfg(feature = "evzht9h3nznqzwl")]
-extern crate evzht9h3nznqzwl as websocket;
+#[cfg(feature = "websocket")]
+extern crate websocket;
 
 #[allow(unused_imports)]
 #[cfg(test)]


### PR DESCRIPTION
native-tls v0.1.5 does not detect OpenSSL 1.1.1 when building, causing
compile errors on systems that have it installed (such as Arch).

This patch swaps out the outdated evzht9h3nznqzwl crate with its upstream
websocket crate.

Fixes #394 


`cargo test` passes, and my light testing of my bot confirms that both chat and voice work.