### PR TITLE
Add Function to call if a Message without Command has been sent

### DIFF
--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -60,6 +60,7 @@ impl HelpCommand for Help {
 pub type BeforeHook = Fn(&mut Context, &Message, &str) -> bool + Send + Sync + 'static;
 pub type AfterHook = Fn(&mut Context, &Message, &str, Result<(), Error>) + Send + Sync + 'static;
 pub type UnrecognisedCommandHook = Fn(&mut Context, &Message, &str) + Send + Sync + 'static;
+pub type MessageWithoutCommandHook = Fn(&mut Context, &Message) + Send + Sync + 'static;
 pub(crate) type InternalCommand = Arc<Command>;
 pub type PrefixCheck = Fn(&mut Context, &Message) -> Option<String> + Send + Sync + 'static;
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -950,6 +950,31 @@ impl StandardFramework {
         self
     }
 
+    /// Specify the function to be called if a message contains no command.
+    ///
+    /// # Examples
+    ///
+    /// Using `message_without_command`:
+    ///
+    /// ```rust,no_run
+    /// # use serenity::prelude::*;
+    /// # struct Handler;
+    /// #
+    /// # impl EventHandler for Handler {}
+    /// # let mut client = Client::new("token", Handler).unwrap();
+    /// #
+    /// use serenity::framework::StandardFramework;
+    ///
+    /// client.with_framework(StandardFramework::new()
+    ///     .message_without_command(|ctx, msg| { }));
+    /// ```
+    pub fn message_without_command<F>(mut self, f: F) -> Self
+        where F: Fn(&mut Context, &Message) + Send + Sync + 'static {
+        self.message_without_command = Some(Arc::new(f));
+
+        self
+    }
+
     /// Sets what code should be executed when a user sends `(prefix)help`.
     ///
     /// If a command named `help` was set with [`command`], then this takes precedence first.

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1065,7 +1065,19 @@ impl Framework for StandardFramework {
 
                 positions
             },
-            None => return,
+            None => {
+                if let &Some(ref message_without_command) = &self.message_without_command {
+
+                    if !(self.configuration.ignore_bots && message.author.bot) {
+                        let message_without_command = message_without_command.clone();
+                        threadpool.execute(move || {
+                            (message_without_command)(&mut context, &message);
+                        });
+                    }
+                }
+
+                return;
+            },
         };
 
         'outer: for position in positions {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -39,7 +39,7 @@ use model::{
     id::{ChannelId, GuildId, UserId},
     Permissions
 };
-use self::command::{AfterHook, BeforeHook, UnrecognisedCommandHook};
+use self::command::{AfterHook, BeforeHook, MessageWithoutCommandHook, UnrecognisedCommandHook};
 use std::{
     collections::HashMap,
     default::Default,
@@ -217,6 +217,7 @@ pub struct StandardFramework {
     buckets: HashMap<String, Bucket>,
     after: Option<Arc<AfterHook>>,
     unrecognised_command: Option<Arc<UnrecognisedCommandHook>>,
+    message_without_command: Option<Arc<MessageWithoutCommandHook>>,
     /// Whether the framework has been "initialized".
     ///
     /// The framework is initialized once one of the following occurs:


### PR DESCRIPTION
If a user sends a message that does not contain a prefix and command, the standard framework will call a function configurable via `message_without_command` on the Framework itself.
