### PR TITLE
Add Nick Methods for `Message` and `UserId`

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -551,8 +551,8 @@ impl Message {
     /// **Note**:
     /// If message was sent in a private channel, then the function will return
     /// `None`.
-    pub fn author_nick(self) -> Option<String> {
-        self.guild_id.and_then(|guild_id| self.author.nick_in(guild_id))
+    pub fn author_nick(&self) -> Option<String> {
+        self.guild_id.as_ref().and_then(|guild_id| self.author.nick_in(*guild_id))
     }
 
     pub(crate) fn check_content_length(map: &JsonMap) -> Result<()> {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -546,6 +546,15 @@ impl Message {
         http::unpin_message(self.channel_id.0, self.id.0)
     }
 
+    /// Tries to return author's nickname in the current channel's guild.
+    ///
+    /// **Note**:
+    /// If message was sent in a private channel, then the function will return
+    /// `None`.
+    pub fn author_nick(self) -> Option<String> {
+        self.guild_id.and_then(|guild_id| self.author.nick_in(guild_id))
+    }
+
     pub(crate) fn check_content_length(map: &JsonMap) -> Result<()> {
         if let Some(content) = map.get("content") {
             if let Value::String(ref content) = *content {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -712,6 +712,29 @@ impl User {
     /// ```
     #[inline]
     pub fn tag(&self) -> String { tag(&self.name, self.discriminator) }
+
+    /// Returns the user's nickname in the given `guild_id`.
+    ///
+    /// If none is used, it returns `None`.
+    #[inline]
+    pub fn nick_in<G>(&self, guild_id: G) -> Option<String>
+    where G: Into<GuildId> {
+        self._nick_in(guild_id.into())
+    }
+
+    fn _nick_in(&self, guild_id: GuildId) -> Option<String> {
+        #[cfg(feature = "cache")]
+        {
+            guild_id.to_guild_cached().and_then(|guild| {
+                guild.read().members.get(&self.id).and_then(|member| member.nick.clone())
+            })
+        }
+
+        #[cfg(not(feature = "cache"))]
+        {
+            guild_id.member(&self.id).and_then(|member| member.nick.clone())
+        }
+    }
 }
 
 impl fmt::Display for User {


### PR DESCRIPTION
This pullrequest implements methods to retrieve a user's nick on both the `Message`- and the `UserId`-struct.