### PR TITLE
Add Link to the `Voice on Windows`-Wiki-Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Voice+youtube-dl:
 
 - youtube-dl (Arch: `community/youtube-dl`)
 
+Building the `voice`-feature on Windows can be done by following these instructions: https://github.com/serenity-rs/serenity/wiki/Voice-on-Windows
+
 # Related Projects
 
 - [Discord.net][library:Discord.net]


### PR DESCRIPTION
There is a new Wiki-entry https://github.com/serenity-rs/serenity/wiki/Voice-on-Windows informing on how to build Serenity with the `Voice`-feature.