### PR TITLE
Update Examples' Import and Unwrapping

### DIFF
--- a/examples/01_basic_ping_bot/src/main.rs
+++ b/examples/01_basic_ping_bot/src/main.rs
@@ -1,9 +1,11 @@
 extern crate serenity;
 
-use serenity::prelude::*;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
 use std::env;
+
+use serenity::{
+    model::{channel::Message, gateway::Ready},
+    prelude::*,
+};
 
 struct Handler;
 

--- a/examples/02_transparent_guild_sharding/src/main.rs
+++ b/examples/02_transparent_guild_sharding/src/main.rs
@@ -1,9 +1,11 @@
 extern crate serenity;
 
-use serenity::prelude::*;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
 use std::env;
+
+use serenity::{
+    model::{channel::Message, gateway::Ready},
+    prelude::*,
+};
 
 // Serenity implements transparent sharding in a way that you do not need to
 // manually handle separate processes or connections manually.

--- a/examples/03_struct_utilities/src/main.rs
+++ b/examples/03_struct_utilities/src/main.rs
@@ -1,9 +1,11 @@
 extern crate serenity;
 
-use serenity::prelude::*;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
 use std::env;
+
+use serenity::{
+    model::{channel::Message, gateway::Ready},
+    prelude::*,
+};
 
 struct Handler;
 

--- a/examples/04_message_builder/src/main.rs
+++ b/examples/04_message_builder/src/main.rs
@@ -1,10 +1,12 @@
 extern crate serenity;
 
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
-use serenity::prelude::*;
-use serenity::utils::MessageBuilder;
 use std::env;
+
+use serenity::{
+    model::{channel::Message, gateway::Ready},
+    prelude::*,
+    utils::MessageBuilder,
+};
 
 struct Handler;
 

--- a/examples/04_message_builder/src/main.rs
+++ b/examples/04_message_builder/src/main.rs
@@ -44,6 +44,7 @@ impl EventHandler for Handler {
         println!("{} is connected!", ready.user.name);
     }
 }
+
 fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN")

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -13,18 +13,18 @@
 extern crate serenity;
 extern crate typemap;
 
-use serenity::client::bridge::gateway::{ShardId, ShardManager};
-use serenity::framework::standard::{Args, DispatchError, StandardFramework, HelpBehaviour, CommandOptions, help_commands};
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
-use serenity::model::Permissions;
-use serenity::prelude::Mutex;
-use serenity::prelude::*;
-use serenity::utils::{content_safe, ContentSafeOptions};
-use std::collections::HashMap;
-use std::env;
-use std::fmt::Write;
-use std::sync::Arc;
+use std::{collections::HashMap, env, fmt::Write, sync::Arc};
+
+use serenity::{
+    client::bridge::gateway::{ShardId, ShardManager},
+    framework::standard::{
+        help_commands, Args, CommandOptions, DispatchError, HelpBehaviour, StandardFramework,
+    },
+    model::{channel::Message, gateway::Ready, Permissions},
+    prelude::*,
+    utils::{content_safe, ContentSafeOptions},
+};
+
 use typemap::Key;
 
 // A container type is created for inserting into the Client's `data`, which

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
             // the command's name does not exist in the counter, add a default
             // value of 0.
             let mut data = ctx.data.lock();
-            let counter = data.get_mut::<CommandCounter>().unwrap();
+            let counter = data.get_mut::<CommandCounter>().expect("Expected CommandCounter in ShareMap.");
             let entry = counter.entry(command_name.to_string()).or_insert(0);
             *entry += 1;
 
@@ -129,6 +129,10 @@ fn main() {
         // command could not be found.
         .unrecognised_command(|_, _, unknown_command_name| {
             println!("Could not find command named '{}'", unknown_command_name);
+        })
+        // Set a function that's called whenever a message is not a command.
+        .message_without_command(|_, message| {
+            println!("Message is not a command '{}'", message.content);
         })
         // Set a function that's called whenever a command's execution didn't complete for one
         // reason or another. For example, when a user has exceeded a rate-limit or a command
@@ -244,7 +248,7 @@ command!(commands(ctx, msg, _args) {
     let mut contents = "Commands used:\n".to_string();
 
     let data = ctx.data.lock();
-    let counter = data.get::<CommandCounter>().unwrap();
+    let counter = data.get::<CommandCounter>().expect("Expected CommandCounter in ShareMap.");
 
     for (k, v) in counter {
         let _ = write!(contents, "- {name}: {amount}\n", name=k, amount=v);
@@ -354,8 +358,8 @@ command!(about_role(_ctx, msg, args) {
 //
 // Argument type overloading is currently not supported.
 command!(multiply(_ctx, msg, args) {
-    let first = args.single::<f64>().unwrap();
-    let second = args.single::<f64>().unwrap();
+    let first = args.single::<f64>()?;
+    let second = args.single::<f64>()?;
 
     let res = first * second;
 

--- a/examples/06_voice/src/main.rs
+++ b/examples/06_voice/src/main.rs
@@ -137,7 +137,7 @@ command!(join(ctx, msg) {
         }
     };
 
-    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().unwrap();
+    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if manager.join(guild_id, connect_to).is_some() {
@@ -157,7 +157,7 @@ command!(leave(ctx, msg) {
         },
     };
 
-    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().unwrap();
+    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
     let has_handler = manager.get(guild_id).is_some();
 
@@ -180,7 +180,7 @@ command!(mute(ctx, msg) {
         },
     };
 
-    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().unwrap();
+    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     let handler = match manager.get_mut(guild_id) {
@@ -230,7 +230,7 @@ command!(play(ctx, msg, args) {
         },
     };
 
-    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().unwrap();
+    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if let Some(handler) = manager.get_mut(guild_id) {
@@ -263,7 +263,7 @@ command!(undeafen(ctx, msg) {
         },
     };
 
-    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().unwrap();
+    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if let Some(handler) = manager.get_mut(guild_id) {
@@ -284,7 +284,7 @@ command!(unmute(ctx, msg) {
             return Ok(());
         },
     };
-    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().unwrap();
+    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if let Some(handler) = manager.get_mut(guild_id) {

--- a/examples/06_voice/src/main.rs
+++ b/examples/06_voice/src/main.rs
@@ -8,29 +8,31 @@
 //! ```
 
 #[macro_use] extern crate serenity;
-
 extern crate typemap;
+
+use std::{env, sync::Arc};
 
 // Import the client's bridge to the voice manager. Since voice is a standalone
 // feature, it's not as ergonomic to work with as it could be. The client
 // provides a clean bridged integration with voice.
 use serenity::client::bridge::voice::ClientVoiceManager;
-use serenity::client::{CACHE, Client, Context, EventHandler};
-use serenity::framework::StandardFramework;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
-use serenity::model::misc::Mentionable;
+
 // Import the `Context` from the client and `parking_lot`'s `Mutex`.
 //
 // `parking_lot` offers much more efficient implementations of `std::sync`'s
 // types. You can read more about it here:
 //
 // <https://github.com/Amanieu/parking_lot#features>
-use serenity::prelude::Mutex;
-use serenity::voice;
-use serenity::Result as SerenityResult;
-use std::env;
-use std::sync::Arc;
+use serenity::{client::{Context}, prelude::Mutex};
+
+use serenity::{
+    client::{CACHE, Client, EventHandler},
+    framework::StandardFramework,
+    model::{channel::Message, gateway::Ready, misc::Mentionable},
+    Result as SerenityResult,
+    voice,
+};
+
 use typemap::Key;
 
 struct VoiceManager;

--- a/examples/07_sample_bot_structure/src/main.rs
+++ b/examples/07_sample_bot_structure/src/main.rs
@@ -17,13 +17,14 @@ extern crate kankyo;
 
 mod commands;
 
-use serenity::framework::StandardFramework;
-use serenity::model::event::ResumedEvent;
-use serenity::model::gateway::Ready;
-use serenity::prelude::*;
-use serenity::http;
-use std::collections::HashSet;
-use std::env;
+use std::{collections::HashSet, env};
+
+use serenity::{
+    framework::StandardFramework,
+    model::{event::ResumedEvent, gateway::Ready},
+    prelude::*,
+    http,
+};
 
 struct Handler;
 

--- a/examples/08_env_logging/src/main.rs
+++ b/examples/08_env_logging/src/main.rs
@@ -3,10 +3,12 @@
 extern crate env_logger;
 extern crate serenity;
 
-use serenity::prelude::*;
-use serenity::model::event::ResumedEvent;
-use serenity::model::gateway::Ready;
 use std::env;
+
+use serenity::{
+    model::{event::ResumedEvent, gateway::Ready},
+    prelude::*,
+};
 
 struct Handler;
 

--- a/examples/09_shard_manager/src/main.rs
+++ b/examples/09_shard_manager/src/main.rs
@@ -25,10 +25,12 @@
 
 extern crate serenity;
 
-use serenity::prelude::*;
-use serenity::model::gateway::Ready;
-use std::time::Duration;
-use std::{env, thread};
+use std::{env, thread, time::Duration};
+
+use serenity::{
+    model::gateway::Ready,
+    prelude::*,
+};
 
 struct Handler;
 

--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -11,18 +11,17 @@
 
 extern crate typemap;
 
-use serenity::client::bridge::voice::ClientVoiceManager;
-use serenity::client::{CACHE, Client, Context, EventHandler};
-use serenity::framework::StandardFramework;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
-use serenity::model::id::ChannelId;
-use serenity::model::misc::Mentionable;
-use serenity::prelude::Mutex;
-use serenity::voice::AudioReceiver;
-use serenity::Result as SerenityResult;
-use std::sync::Arc;
-use std::env;
+use std::{env, sync::Arc};
+
+use serenity::{
+    client::{bridge::voice::ClientVoiceManager, CACHE, Client, Context, EventHandler},
+    framework::StandardFramework,
+    model::{channel::Message, gateway::Ready, id::ChannelId, misc::Mentionable},
+    prelude::*,
+    voice::AudioReceiver,
+    Result as SerenityResult,
+};
+
 use typemap::Key;
 
 struct VoiceManager;

--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -111,7 +111,7 @@ command!(join(ctx, msg, args) {
         },
     };
 
-    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().unwrap();
+    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if let Some(handler) = manager.join(guild_id, connect_to) {
@@ -132,7 +132,7 @@ command!(leave(ctx, msg) {
         },
     };
 
-    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().unwrap();
+    let mut manager_lock = ctx.data.lock().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
     let has_handler = manager.get(guild_id).is_some();
 

--- a/examples/11_create_message_builder/src/main.rs
+++ b/examples/11_create_message_builder/src/main.rs
@@ -1,9 +1,11 @@
 extern crate serenity;
 
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
-use serenity::prelude::*;
 use std::env;
+
+use serenity::{
+    model::{channel::Message, gateway::Ready},
+    prelude::*
+};
 
 struct Handler;
 


### PR DESCRIPTION
Examples usually provide help for people new to Rust and Serenity, therefore their code should avoid `unwrap` when one could provide some knowledge why this would panic via `expect`.
While some of the `unwrap`s are very unlikely, it is still better to simply use them and potentially cover the case.

Another little flaw was using `use prelude::Mutex` when `use prelude::*` was already used, that makes no sense and could confuse a beginner.

Importing on its own has been replaced with nested importing.