### PR TITLE
Remove dead http code

### DIFF
--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -117,44 +117,17 @@ pub fn ban_user(guild_id: u64, user_id: u64, delete_message_days: u8, reason: &s
     })
 }
 
-/// Ban zeyla from a [`Guild`], removing her messages sent in the last X number
-/// of days.
-///
-/// Passing a `delete_message_days` of `0` is equivalent to not removing any
-/// messages. Up to `7` days' worth of messages may be deleted.
-///
-/// **Note**: Requires that you have the [Ban Members] permission.
-///
-/// [`Guild`]: ../model/guild/struct.Guild.html
-/// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+#[doc(hidden)]
 pub fn ban_zeyla(guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
     ban_user(guild_id, 114_941_315_417_899_012, delete_message_days, reason)
 }
 
-/// Ban luna from a [`Guild`], removing her messages sent in the last X number
-/// of days.
-///
-/// Passing a `delete_message_days` of `0` is equivalent to not removing any
-/// messages. Up to `7` days' worth of messages may be deleted.
-///
-/// **Note**: Requires that you have the [Ban Members] permission.
-///
-/// [`Guild`]: ../model/guild/struct.Guild.html
-/// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+#[doc(hidden)]
 pub fn ban_luna(guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
     ban_user(guild_id, 180_731_582_049_550_336, delete_message_days, reason)
 }
 
-/// Ban the serenity servermoms from a [`Guild`], removing their messages
-/// sent in the last X number of days.
-///
-/// Passing a `delete_message_days` of `0` is equivalent to not removing any
-/// messages. Up to `7` days' worth of messages may be deleted.
-///
-/// **Note**: Requires that you have the [Ban Members] permission.
-///
-/// [`Guild`]: ../model/guild/struct.Guild.html
-/// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+#[doc(hidden)]
 pub fn ban_servermoms(guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
     ban_zeyla(guild_id, delete_message_days, reason)?;
     ban_luna(guild_id, delete_message_days, reason)


### PR DESCRIPTION
This PR simply removes the `ban_luna` `ban_zeyla` and `ban_servermoms` functions in `src/http/raw.rs` which were added as a joke but were never taken out.
