### PR TITLE
Fix Aliases not being added on Commands when using `cmd`-Method

### DIFF
--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -97,6 +97,24 @@ impl CreateGroup {
     pub fn cmd<C: Command + 'static>(mut self, name: &str, c: C) -> Self {
         let cmd: Arc<Command> = Arc::new(c);
 
+        for n in &cmd.options().aliases {
+
+            if let Some(ref prefixes) = self.0.prefixes {
+
+                for prefix in prefixes {
+                    self.0.commands.insert(
+                        format!("{} {}", prefix, n.to_string()),
+                        CommandOrAlias::Alias(format!("{} {}", prefix, name.to_string())),
+                    );
+                }
+            } else {
+                self.0.commands.insert(
+                    n.to_string(),
+                    CommandOrAlias::Alias(name.to_string()),
+                );
+            }
+        }
+
         self.0
             .commands
             .insert(name.to_string(), CommandOrAlias::Command(Arc::clone(&cmd)));

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -70,7 +70,7 @@ impl CreateGroup {
                 }
             } else {
                 self.0.commands.insert(
-                    n.to_string(),
+                    alias.to_string(),
                     CommandOrAlias::Alias(command_name.to_string()),
                 );
             }
@@ -109,7 +109,7 @@ impl CreateGroup {
                 }
             } else {
                 self.0.commands.insert(
-                    n.to_string(),
+                    alias.to_string(),
                     CommandOrAlias::Alias(name.to_string()),
                 );
             }

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -64,7 +64,7 @@ impl CreateGroup {
 
                 for prefix in prefixes {
                     self.0.commands.insert(
-                        format!("{} {}", prefix, n.to_string()),
+                        format!("{} {}", prefix, alias.to_string()),
                         CommandOrAlias::Alias(format!("{} {}", prefix, command_name.to_string())),
                     );
                 }
@@ -103,7 +103,7 @@ impl CreateGroup {
 
                 for prefix in prefixes {
                     self.0.commands.insert(
-                        format!("{} {}", prefix, n.to_string()),
+                        format!("{} {}", prefix, alias.to_string()),
                         CommandOrAlias::Alias(format!("{} {}", prefix, name.to_string())),
                     );
                 }

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -58,7 +58,7 @@ impl CreateGroup {
         where F: FnOnce(CreateCommand) -> CreateCommand {
         let cmd = f(self.build_command()).finish();
 
-        for n in &cmd.options().aliases {
+        for alias in &cmd.options().aliases {
 
             if let Some(ref prefixes) = self.0.prefixes {
 
@@ -97,7 +97,7 @@ impl CreateGroup {
     pub fn cmd<C: Command + 'static>(mut self, name: &str, c: C) -> Self {
         let cmd: Arc<Command> = Arc::new(c);
 
-        for n in &cmd.options().aliases {
+        for alias in &cmd.options().aliases {
 
             if let Some(ref prefixes) = self.0.prefixes {
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -696,6 +696,13 @@ impl StandardFramework {
             if let Some(ref mut group) = Arc::get_mut(ungrouped) {
                 let cmd: Arc<Command> = Arc::new(c);
 
+                for n in &cmd.options().aliases {
+                     group.commands.insert(
+                         n.to_string(),
+                         CommandOrAlias::Alias(name.to_string()),
+                     );
+                }
+
                 group
                     .commands
                     .insert(name.to_string(), CommandOrAlias::Command(Arc::clone(&cmd)));

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -698,7 +698,7 @@ impl StandardFramework {
 
                 for alias in &cmd.options().aliases {
                      group.commands.insert(
-                         n.to_string(),
+                         alias.to_string(),
                          CommandOrAlias::Alias(name.to_string()),
                      );
                 }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -696,7 +696,7 @@ impl StandardFramework {
             if let Some(ref mut group) = Arc::get_mut(ungrouped) {
                 let cmd: Arc<Command> = Arc::new(c);
 
-                for n in &cmd.options().aliases {
+                for alias in &cmd.options().aliases {
                      group.commands.insert(
                          n.to_string(),
                          CommandOrAlias::Alias(name.to_string()),


### PR DESCRIPTION
This PR fixes #405 