### PR TITLE
Replace `hyper` with `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,23 +34,14 @@ version = "~0.4"
 optional = true
 version = "^1.0"
 
-[dependencies.hyper]
+[dependencies.reqwest]
 optional = true
-version = "~0.10"
-
-[dependencies.hyper-native-tls]
-optional = true
-version = "0.2.4"
+version = "0.9"
 
 [dependencies.lazy_static]
 optional = true
 version = "^1.0"
 
-[dependencies.multipart]
-default-features = false
-features = ["client", "hyper", "safemem"]
-optional = true
-version = "0.15"
 
 [dependencies.native-tls]
 optional = true
@@ -111,7 +102,7 @@ client = [
 extras = []
 framework = ["client", "model", "utils"]
 gateway = ["flate2", "http", "websocket", "utils"]
-http = ["hyper", "hyper-native-tls", "lazy_static", "multipart", "native-tls"]
+http = ["reqwest", "lazy_static"]
 model = ["builder", "http"]
 standard_framework = ["framework"]
 utils = ["base64"]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,7 +13,7 @@ pub const LARGE_THRESHOLD: u8 = 250;
 pub const MESSAGE_CODE_LIMIT: u16 = 2000;
 /// The [UserAgent] sent along with every request.
 ///
-/// [UserAgent]: ../../hyper/header/struct.UserAgent.html
+/// [UserAgent]: ../../reqwest/header/constant.USER_AGENT.html
 pub const USER_AGENT: &str = concat!(
     "DiscordBot (https://github.com/serenity-rs/serenity, ",
     env!("CARGO_PKG_VERSION"),

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -1,4 +1,9 @@
-use hyper::client::Response;
+use reqwest::{
+    Error as ReqwestError,
+    header::InvalidHeaderValue,
+    Response,
+    UrlError
+};
 use std::{
     error::Error as StdError,
     fmt::{
@@ -18,6 +23,30 @@ pub enum Error {
     /// When the decoding of a ratelimit header could not be properly decoded
     /// from UTF-8.
     RateLimitUtf8,
+    /// When parsing an URL failed due to invalid input.
+    Url(UrlError),
+    /// Header value contains invalid input.
+    InvalidHeader(InvalidHeaderValue),
+    /// Reqwest's Error
+    Request(ReqwestError),
+}
+
+impl From<ReqwestError> for Error {
+    fn from(error: ReqwestError) -> Error {
+        Error::Request(error)
+    }
+}
+
+impl From<UrlError> for Error {
+    fn from(error: UrlError) -> Error {
+        Error::Url(error)
+    }
+}
+
+impl From<InvalidHeaderValue> for Error {
+    fn from(error: InvalidHeaderValue) -> Error {
+        Error::InvalidHeader(error)
+    }
 }
 
 impl Display for Error {
@@ -30,6 +59,9 @@ impl StdError for Error {
             Error::UnsuccessfulRequest(_) => "A non-successful response status code was received",
             Error::RateLimitI64 => "Error decoding a header into an i64",
             Error::RateLimitUtf8 => "Error decoding a header from UTF-8",
+            Error::Url(_) => "Provided URL is incorrect.",
+            Error::InvalidHeader(_) => "Provided value is an invalid header value.",
+            Error::Request(_) => "Error while sending HTTP request.",
         }
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -77,13 +77,13 @@ pub enum LightMethod {
 }
 
 impl LightMethod {
-    pub fn hyper_method(&self) -> Method {
+    pub fn reqwest_method(&self) -> Method {
         match *self {
-            LightMethod::Delete => Method::Delete,
-            LightMethod::Get => Method::Get,
-            LightMethod::Patch => Method::Patch,
-            LightMethod::Post => Method::Post,
-            LightMethod::Put => Method::Put,
+            LightMethod::Delete => Method::DELETE,
+            LightMethod::Get => Method::GET,
+            LightMethod::Patch => Method::PATCH,
+            LightMethod::Post => Method::POST,
+            LightMethod::Put => Method::PUT,
         }
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -30,16 +30,14 @@ pub mod routing;
 
 mod error;
 
-pub use hyper::status::{StatusClass, StatusCode};
+pub use reqwest::StatusCode;
 pub use self::error::Error as HttpError;
 pub use self::raw::*;
 
-use hyper::{
-    client::Client as HyperClient,
-    method::Method,
-    net::HttpsConnector,
+use reqwest::{
+    Client as ReqwestClient,
+    Method,
 };
-use hyper_native_tls::NativeTlsClient;
 use model::prelude::*;
 use parking_lot::Mutex;
 use self::{request::Request};
@@ -51,17 +49,14 @@ use std::{
 };
 
 lazy_static! {
-    static ref CLIENT: HyperClient = {
-        let tc = NativeTlsClient::new().expect("Unable to make http client");
-        let connector = HttpsConnector::new(tc);
-
-        HyperClient::with_connector(connector)
+    static ref CLIENT: ReqwestClient = {
+        ReqwestClient::new()
     };
 }
 
 /// An method used for ratelimiting special routes.
 ///
-/// This is needed because `hyper`'s `Method` enum does not derive Copy.
+/// This is needed because `reqwest`'s `Method` enum does not derive Copy.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum LightMethod {
     /// Indicates that a route is for the `DELETE` method only.

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,11 +1,13 @@
 use constants;
-use hyper::{
-    client::{Body, RequestBuilder as HyperRequestBuilder},
-    header::{Authorization, ContentType, Headers, UserAgent},
+use reqwest::{
+    RequestBuilder as ReqwestRequestBuilder,
+    header::{AUTHORIZATION, CONTENT_TYPE, USER_AGENT, HeaderMap as Headers, HeaderValue},
+    Url,
 };
 use super::{
     CLIENT,
     TOKEN,
+    HttpError,
     routing::RouteInfo,
 };
 
@@ -61,33 +63,35 @@ impl<'a> Request<'a> {
         Self { body, headers, route }
     }
 
-    pub fn build(&'a self) -> HyperRequestBuilder<'a> {
+    pub fn build(&'a self) -> Result<ReqwestRequestBuilder, HttpError> {
         let Request {
             body,
             headers: ref request_headers,
             route: ref route_info,
         } = *self;
+
         let (method, _, path) = route_info.deconstruct();
 
         let mut builder = CLIENT.request(
-            method.hyper_method(),
-            &path.into_owned(),
+            method.reqwest_method(),
+            Url::parse(&path.to_string())?,
         );
 
         if let Some(ref bytes) = body {
-            builder = builder.body(Body::BufBody(bytes, bytes.len()));
+            builder = builder.body(Vec::from(*bytes));
         }
 
-        let mut headers = Headers::new();
-        headers.set(UserAgent(constants::USER_AGENT.to_string()));
-        headers.set(Authorization(TOKEN.lock().clone()));
-        headers.set(ContentType::json());
+        let mut headers = Headers::with_capacity(3);
+        headers.insert(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT));
+        headers.insert(AUTHORIZATION,
+            HeaderValue::from_str(&TOKEN.lock()).map_err(|e| HttpError::InvalidHeader(e))?);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
 
-        if let Some(request_headers) = request_headers.clone() {
-            headers.extend(request_headers.iter());
+        if let Some(ref request_headers) = request_headers {
+            headers.extend(request_headers.clone());
         }
 
-        builder.headers(headers)
+        Ok(builder.headers(headers))
     }
 
     pub fn body_ref(&self) -> &Option<&'a [u8]> {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -46,7 +46,7 @@ pub enum Route {
     // Refer to the docs on [Rate Limits] in the yellow warning section.
     //
     // Additionally, this needs to be a `LightMethod` from the parent module
-    // and _not_ a `hyper` `Method` due to `hyper`'s not deriving `Copy`.
+    // and _not_ a `reqwest` `Method` due to `reqwest`'s not deriving `Copy`.
     //
     // [Rate Limits]: https://discordapp.com/developers/docs/topics/rate-limits
     ChannelsIdMessagesId(LightMethod, u64),

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -1,18 +1,5 @@
 //! A set of macros for easily working with internals.
 
-#[cfg(feature = "model")]
-macro_rules! request_client {
-    () => {{
-        use hyper::net::HttpsConnector;
-        use hyper_native_tls::NativeTlsClient;
-
-        let tc = NativeTlsClient::new()?;
-        let connector = HttpsConnector::new(tc);
-
-        HyperClient::with_connector(connector)
-    }}
-}
-
 #[cfg(any(feature = "model", feature = "utils"))]
 macro_rules! cdn {
     ($e:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,14 +133,10 @@ extern crate base64;
 extern crate byteorder;
 #[cfg(feature = "flate2")]
 extern crate flate2;
-#[cfg(feature = "hyper")]
-extern crate hyper;
-#[cfg(feature = "hyper-native-tls")]
-extern crate hyper_native_tls;
-#[cfg(feature = "multipart")]
-extern crate multipart;
-#[cfg(feature = "native-tls")]
-extern crate native_tls;
+#[cfg(feature = "reqwest")]
+extern crate reqwest;
+
+
 #[cfg(feature = "opus")]
 extern crate opus;
 #[cfg(feature = "rand")]

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "model")]
-use hyper::Client as HyperClient;
+use reqwest::Client as ReqwestClient;
 #[cfg(feature = "model")]
 use internal::prelude::*;
 #[cfg(feature = "model")]
@@ -100,15 +100,15 @@ impl Attachment {
     /// Returns an [`Error::Io`] when there is a problem reading the contents
     /// of the HTTP response.
     ///
-    /// Returns an [`Error::Hyper`] when there is a problem retrieving the
+    /// Returns an [`Error::Http`] when there is a problem retrieving the
     /// attachment.
     ///
-    /// [`Error::Hyper`]: ../../enum.Error.html#variant.Hyper
+    /// [`Error::Http`]: ../../enum.Error.html#variant.Http
     /// [`Error::Io`]: ../../enum.Error.html#variant.Io
     /// [`Message`]: struct.Message.html
     pub fn download(&self) -> Result<Vec<u8>> {
-        let hyper = request_client!();
-        let mut response = hyper.get(&self.url).send()?;
+        let reqwest = ReqwestClient::new();
+        let mut response = reqwest.get(&self.url).send()?;
 
         let mut bytes = vec![];
         response.read_to_end(&mut bytes)?;


### PR DESCRIPTION
This pull request replaces `hyper` with `request`. This also removes the necessity of other dependencies as `reqwest` bundles their own alternatives.

With `reqwest` we have a crate providing a high-level API around `hyper`. Therefore we indirectly update our `hyper` from `0.10.x` to `0.12.x` and can keep up to date by just adhering to `reqwest`.

`reqwest`s multipart is different than the actual `multipart`-crate.
E.g. while `multipart` accepts `AsRef<str>` on its [write_text](https://docs.rs/multipart/0.15.3/multipart/client/struct.Multipart.html#method.write_text), `reqwest` variation accepts `Into<Cow<'static, str>>`, forcing us to perform the clone or provide a `Into<Cow<'static, str>>`. In the end `multipart` clones from the passed `AsRef<str>`, too, so I assume there should not be much of a difference to before.