### PR TITLE
Remove everything marked `deprecated` from `v0.5.x` or older

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -969,24 +969,6 @@ impl Args {
     pub fn restore(&mut self) {
         self.offset = 0;
     }
-
-    /// Like [`len`], but accounts quotes.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new(r#""42" "69""#, &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.len_quoted(), 2); // `2` because `["42", "69"]`
-    /// ```
-    ///
-    /// [`len`]: #method.len
-    #[deprecated(since = "0.5.3", note = "Its task was merged with `len`, please use it instead.")]
-    pub fn len_quoted(&mut self) -> usize {
-        self.len()
-    }
 }
 
 impl ::std::ops::Deref for Args {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -285,11 +285,6 @@ impl ChannelId {
         http::edit_message(self.0, message_id.0, &Value::Object(map))
     }
 
-    /// Search the cache for the channel with the Id.
-    #[cfg(feature = "cache")]
-    #[deprecated(since = "0.5.8", note = "Use the `to_channel_cached`-method instead.")]
-    pub fn find(&self) -> Option<Channel> { self.to_channel_cached() }
-
     /// Attempts to find a [`Channel`] by its Id in the cache.
     ///
     /// [`Channel`]: ../channel/enum.Channel.html
@@ -304,14 +299,6 @@ impl ChannelId {
     #[inline]
     pub(crate) fn _to_channel_cached(self, cache: &RwLock<Cache>) -> Option<Channel> {
         cache.read().channel(self)
-    }
-
-
-    /// Search the cache for the channel. If it can't be found, the channel is
-    /// requested over REST.
-    #[deprecated(since = "0.5.8", note = "Use the `to_channel`-method instead.")]
-    pub fn get(&self) -> Result<Channel> {
-        self.to_channel()
     }
 
     /// First attempts to find a [`Channel`] by its Id in the cache,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -340,17 +340,6 @@ impl Message {
         CACHE.read().guild(self.guild_id?)
     }
 
-    /// Retrieves the Id of the guild that the message was sent in, if sent in
-    /// one.
-    ///
-    /// Refer to [`guild_id`] for more information.
-    ///
-    /// [`guild_id`]: #structfield.guild_id
-    #[deprecated(note = "Use `guild_id` structfield instead", since = "0.5.5")]
-    pub fn guild_id(&self) -> Option<GuildId> {
-        self.guild_id
-    }
-
     /// True if message was sent using direct messages.
     pub fn is_private(&self) -> bool {
         self.guild_id.is_none()

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -28,10 +28,6 @@ use serde_json;
 use super::utils::deserialize_u64;
 
 #[cfg(feature = "model")]
-use builder::{CreateMessage, EditMessage, GetMessages};
-#[cfg(feature = "model")]
-use http::AttachmentType;
-#[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
@@ -223,26 +219,6 @@ impl Channel {
         }
     }
 
-    /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
-    ///
-    /// [`Message::react`] may be a more suited method of reacting in most
-    /// cases.
-    ///
-    /// Requires the [Add Reactions] permission, _if_ the current user is the
-    /// first user to perform a react with a certain emoji.
-    ///
-    /// [`Emoji`]: ../guild/struct.Emoji.html
-    /// [`Message`]: struct.Message.html
-    /// [`Message::react`]: struct.Message.html#method.react
-    /// [Add Reactions]: ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn create_reaction<M, R>(&self, message_id: M, reaction_type: R) -> Result<()>
-        where M: Into<MessageId>, R: Into<ReactionType> {
-        self.id().create_reaction(message_id, reaction_type)
-    }
-
     /// Deletes the inner channel.
     ///
     /// **Note**: There is no real function as _deleting_ a [`Group`]. The
@@ -269,70 +245,6 @@ impl Channel {
         Ok(())
     }
 
-    /// Deletes a [`Message`] given its Id.
-    ///
-    /// Refer to [`Message::delete`] for more information.
-    ///
-    /// Requires the [Manage Messages] permission, if the current user is not
-    /// the author of the message.
-    ///
-    /// [`Message`]: struct.Message.html
-    /// [`Message::delete`]: struct.Message.html#method.delete
-    /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn delete_message<M: Into<MessageId>>(&self, message_id: M) -> Result<()> {
-        self.id().delete_message(message_id)
-    }
-
-    /// Deletes the given [`Reaction`] from the channel.
-    ///
-    /// **Note**: Requires the [Manage Messages] permission, _if_ the current
-    /// user did not perform the reaction.
-    ///
-    /// [`Reaction`]: struct.Reaction.html
-    /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn delete_reaction<M, R>(&self,
-                                 message_id: M,
-                                 user_id: Option<UserId>,
-                                 reaction_type: R)
-                                 -> Result<()>
-        where M: Into<MessageId>, R: Into<ReactionType> {
-        self.id()
-            .delete_reaction(message_id, user_id, reaction_type)
-    }
-
-    /// Edits a [`Message`] in the channel given its Id.
-    ///
-    /// Message editing preserves all unchanged message data.
-    ///
-    /// Refer to the documentation for [`EditMessage`] for more information
-    /// regarding message restrictions and requirements.
-    ///
-    /// **Note**: Requires that the current user be the author of the message.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content of the message
-    /// is over the [`the limit`], containing the number of unicode code points
-    /// over the limit.
-    ///
-    /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
-    /// [`EditMessage`]: ../../builder/struct.EditMessage.html
-    /// [`Message`]: struct.Message.html
-    /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn edit_message<F, M>(&self, message_id: M, f: F) -> Result<Message>
-        where F: FnOnce(EditMessage) -> EditMessage, M: Into<MessageId> {
-        self.id().edit_message(message_id, f)
-    }
-
     /// Determines if the channel is NSFW.
     #[cfg(feature = "model")]
     #[inline]
@@ -342,72 +254,6 @@ impl Channel {
             Channel::Category(ref category) => category.with(|c| c.is_nsfw()),
             Channel::Group(_) | Channel::Private(_) => false,
         }
-    }
-
-    /// Gets a message from the channel.
-    ///
-    /// Requires the [Read Message History] permission.
-    ///
-    /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn message<M: Into<MessageId>>(&self, message_id: M) -> Result<Message> {
-        self.id().message(message_id)
-    }
-
-    /// Gets messages from the channel.
-    ///
-    /// Requires the [Read Message History] permission.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use serenity::model::MessageId;
-    ///
-    /// let id = MessageId(81392407232380928);
-    ///
-    /// // Maximum is 100.
-    /// let _messages = channel.messages(|g| g.after(id).limit(100));
-    /// ```
-    ///
-    /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn messages<F>(&self, f: F) -> Result<Vec<Message>>
-        where F: FnOnce(GetMessages) -> GetMessages {
-        self.id().messages(f)
-    }
-
-    /// Gets the list of [`User`]s who have reacted to a [`Message`] with a
-    /// certain [`Emoji`].
-    ///
-    /// The default `limit` is `50` - specify otherwise to receive a different
-    /// maximum number of users. The maximum that may be retrieve at a time is
-    /// `100`, if a greater number is provided then it is automatically reduced.
-    ///
-    /// The optional `after` attribute is to retrieve the users after a certain
-    /// user. This is useful for pagination.
-    ///
-    /// **Note**: Requires the [Read Message History] permission.
-    ///
-    /// [`Emoji`]: ../guild/struct.Emoji.html
-    /// [`Message`]: struct.Message.html
-    /// [`User`]: ../user/struct.User.html
-    /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn reaction_users<M, R, U>(&self,
-        message_id: M,
-        reaction_type: R,
-        limit: Option<u8>,
-        after: U,
-    ) -> Result<Vec<User>> where M: Into<MessageId>,
-                                 R: Into<ReactionType>,
-                                 U: Into<Option<UserId>> {
-        self.id().reaction_users(message_id, reaction_type, limit, after)
     }
 
     /// Retrieves the Id of the inner [`Group`], [`GuildChannel`], or
@@ -423,87 +269,6 @@ impl Channel {
             Channel::Private(ref ch) => ch.with(|c| c.id),
             Channel::Category(ref category) => category.with(|c| c.id),
         }
-    }
-
-    /// Sends a message with just the given message content in the channel.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content of the message
-    /// is over the above limit, containing the number of unicode code points
-    /// over the limit.
-    ///
-    /// [`ChannelId`]: ../id/struct.ChannelId.html
-    /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn say(&self, content: &str) -> Result<Message> { self.id().say(content) }
-
-    /// Sends (a) file(s) along with optional message contents.
-    ///
-    /// Refer to [`ChannelId::send_files`] for examples and more information.
-    ///
-    /// The [Attach Files] and [Send Messages] permissions are required.
-    ///
-    /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// If the content of the message is over the above limit, then a
-    /// [`ClientError::MessageTooLong`] will be returned, containing the number
-    /// of unicode code points over the limit.
-    ///
-    /// [`ChannelId::send_files`]: ../id/struct.ChannelId.html#method.send_files
-    /// [`ClientError::MessageTooLong`]: ../../client/enum.ClientError.html#variant.MessageTooLong
-    /// [Attach Files]: ../permissions/struct.Permissions.html#associatedconstant.ATTACH_FILES
-    /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn send_files<'a, F, T, It: IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
-        where F: FnOnce(CreateMessage) -> CreateMessage, T: Into<AttachmentType<'a>> {
-        self.id().send_files(files, f)
-    }
-
-    /// Sends a message to the channel.
-    ///
-    /// Refer to the documentation for [`CreateMessage`] for more information
-    /// regarding message restrictions and requirements.
-    ///
-    /// The [Send Messages] permission is required.
-    ///
-    /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content of the message
-    /// is over the above limit, containing the number of unicode code points
-    /// over the limit.
-    ///
-    /// [`Channel`]: enum.Channel.html
-    /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
-    /// [`CreateMessage`]: ../../builder/struct.CreateMessage.html
-    /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn send_message<F>(&self, f: F) -> Result<Message>
-        where F: FnOnce(CreateMessage) -> CreateMessage {
-        self.id().send_message(f)
-    }
-
-    /// Unpins a [`Message`] in the channel given by its Id.
-    ///
-    /// Requires the [Manage Messages] permission.
-    ///
-    /// [`Message`]: struct.Message.html
-    /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "model")]
-    #[deprecated(since = "0.4.2", note = "Use the inner channel's method")]
-    #[inline]
-    pub fn unpin<M: Into<MessageId>>(&self, message_id: M) -> Result<()> {
-        self.id().unpin(message_id)
     }
 }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -13,13 +13,6 @@ use {http, utils};
 
 #[cfg(feature = "model")]
 impl GuildId {
-    /// Converts the guild Id into the default channel's Id.
-    #[inline]
-    #[deprecated(note = "The concept of default channels is no more, use \
-                         `Guild::default_channel{_guaranteed}` to simulate the
-                         concept.")]
-    pub fn as_channel_id(&self) -> ChannelId { ChannelId(self.0) }
-
     /// Ban a [`User`] from the guild. All messages by the
     /// user within the last given number of days given will be deleted.
     ///
@@ -403,25 +396,12 @@ impl GuildId {
         http::edit_role_position(self.0, role_id.0, position)
     }
 
-    /// Search the cache for the guild.
-    #[cfg(feature = "cache")]
-    #[deprecated(since = "0.5.8", note = "Use the `to_guild_cached`-method instead.")]
-    pub fn find(&self) -> Option<Arc<RwLock<Guild>>> { self.to_guild_cached() }
-
     /// Tries to find the [`Guild`] by its Id in the cache.
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     #[cfg(feature = "cache")]
     #[inline]
     pub fn to_guild_cached(self) -> Option<Arc<RwLock<Guild>>> { CACHE.read().guild(self) }
-
-    /// Requests the guild over REST.
-    ///
-    /// Note that this will not be a complete guild, as REST does not send
-    /// all data with a guild retrieval.
-    #[inline]
-    #[deprecated(since = "0.5.8", note = "Use the `to_partial_guild`-method instead.")]
-    pub fn get(&self) -> Result<PartialGuild> { self.to_partial_guild() }
 
     /// Requests [`PartialGuild`] over REST API.
     ///

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1178,17 +1178,6 @@ impl Guild {
         self.id.move_member(user_id, channel_id)
     }
 
-    /// Alias for [`permissions_in`].
-    ///
-    /// [`permissions_in`]: #method.permissions_in
-    #[deprecated(since = "0.4.3",
-                 note = "This will serve a different purpose in 0.5")]
-    #[inline]
-    pub fn permissions_for<C, U>(&self, channel_id: C, user_id: U)
-        -> Permissions where C: Into<ChannelId>, U: Into<UserId> {
-        self.permissions_in(channel_id, user_id)
-    }
-
     /// Calculate a [`User`]'s permissions in a given channel in the guild.
     ///
     /// [`User`]: ../user/struct.User.html

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1507,7 +1507,7 @@ impl Guild {
     ///
     /// impl EventHandler for Handler {
     ///     fn message(&self, _: Context, msg: Message) {
-    ///         if let Some(arc) = msg.guild_id().unwrap().to_guild_cached() {
+    ///         if let Some(arc) = msg.guild_id.unwrap().to_guild_cached() {
     ///             if let Some(role) = arc.read().role_by_name("role_name") {
     ///                 println!("{:?}", role);
     ///             }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -468,7 +468,7 @@ impl PartialGuild {
     ///
     /// impl EventHandler for Handler {
     ///     fn message(&self, _: Context, msg: Message) {
-    ///         let guild = msg.guild_id().unwrap().to_partial_guild().unwrap();
+    ///         let guild = msg.guild_id.unwrap().to_partial_guild().unwrap();
     ///         let possible_role = guild.role_by_name("role_name");
     ///
     ///         if let Some(role) = possible_role {

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -174,13 +174,6 @@ impl PartialOrd for Role {
 
 #[cfg(feature = "model")]
 impl RoleId {
-    /// Search the cache for the role.
-    #[cfg(feature = "cache")]
-    #[deprecated(since = "0.5.8", note = "Use the `to_role_cached`-method instead.")]
-    pub fn find(&self) -> Option<Role> {
-        self.to_role_cached()
-    }
-
     /// Tries to find the [`Role`] by its Id in the cache.
     ///
     /// [`Role`]: ../guild/struct.Role.html

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -765,27 +765,12 @@ impl UserId {
         http::create_private_channel(&map)
     }
 
-    /// Search the cache for the user with the Id.
-    #[cfg(feature = "cache")]
-    #[deprecated(since = "0.5.8", note = "Use the `to_user_cached`-method instead.")]
-    pub fn find(&self) -> Option<Arc<RwLock<User>>> { self.to_user_cached() }
-
     /// Attempts to find a [`User`] by its Id in the cache.
     ///
     /// [`User`]: ../user/struct.User.html
     #[cfg(feature = "cache")]
     #[inline]
     pub fn to_user_cached(self) -> Option<Arc<RwLock<User>>> { CACHE.read().user(self) }
-
-    /// Gets a user by its Id from either the cache or the REST API.
-    ///
-    /// Searches the cache for the user first, if the cache is enabled. If the
-    /// user was not found, then the user is searched via the REST API.
-    #[inline]
-    #[deprecated(since = "0.5.8", note = "Use the `to_user`-method instead.")]
-    pub fn get(&self) -> Result<User> {
-        self.to_user()
-    }
 
     /// First attempts to find a [`User`] by its Id in the cache,
     /// upon failure requests it via the REST API.

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -229,15 +229,6 @@ impl Webhook {
 
 #[cfg(feature = "model")]
 impl WebhookId {
-    /// Retrieves the webhook by the Id.
-    ///
-    /// **Note**: Requires the [Manage Webhooks] permission.
-    ///
-    /// [Manage Webhooks]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
-    #[inline]
-    #[deprecated(since = "0.5.8", note = "Use the `to_webhook`-method instead.")]
-    pub fn get(self) -> Result<Webhook> { self.to_webhook() }
-
     /// Requests [`Webhook`] over REST API.
     ///
     /// **Note**: Requires the [Manage Webhooks] permission.

--- a/src/utils/colour.rs
+++ b/src/utils/colour.rs
@@ -8,14 +8,6 @@ macro_rules! colour {
                 #[$attr]
                 pub const $constname: Colour = Colour($val);
             )*
-
-            $(
-                #[$attr]
-                #[deprecated(note = "Use the constant instead", since = "0.5.5")]
-                pub fn $name() -> Colour {
-                    Colour::new($val)
-                }
-            )*
         }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -63,50 +63,6 @@ pub fn vecmap_to_json_map<K: PartialEq + ToString>(map: VecMap<K, Value>) -> Map
     json_map
 }
 
-/// Determines if a name is NSFW.
-///
-/// This checks that the name is either `"nsfw"` or, for names longer than that,
-/// is prefixed with `"nsfw"`.
-///
-/// # Examples
-///
-/// Check that a channel named `"nsfw"` is in fact NSFW:
-///
-/// ```rust
-/// use serenity::utils;
-///
-/// assert!(utils::is_nsfw("nsfw"));
-/// ```
-///
-/// Check that a channel named `"cats"` is _not_ NSFW:
-///
-/// ```rust
-/// use serenity::utils;
-///
-/// assert!(!utils::is_nsfw("cats"));
-/// ```
-///
-/// Check that a channel named `"nsfw-stuff"` _is_ NSFW:
-///
-/// ```rust
-/// use serenity::utils;
-///
-/// assert!(utils::is_nsfw("nsfw-stuff"));
-/// ```
-///
-/// Channels prefixed with `"nsfw"` but not the hyphen (`'-'`) are _not_
-/// considered NSFW:
-///
-/// ```rust
-/// use serenity::utils;
-///
-/// assert!(!utils::is_nsfw("nsfwstuff"));
-/// ```
-#[deprecated(since = "0.5.10", note = "Discord no longer turns a channel NSFW based on its name.")]
-pub fn is_nsfw(name: &str) -> bool {
-    name == "nsfw" || name.chars().count() > 5 && name.starts_with("nsfw-")
-}
-
 /// Retrieves the "code" part of an invite out of a URL.
 ///
 /// # Examples
@@ -898,17 +854,6 @@ mod test {
     fn test_quote_parser() {
         let parsed = parse_quotes("a \"b c\" d\"e f\"  g");
         assert_eq!(parsed, ["a", "b c", "d", "e f", "g"]);
-    }
-
-    #[allow(deprecated)]
-    #[test]
-    fn test_is_nsfw() {
-        assert!(!is_nsfw("general"));
-        assert!(is_nsfw("nsfw"));
-        assert!(is_nsfw("nsfw-test"));
-        assert!(!is_nsfw("nsfw-"));
-        assert!(!is_nsfw("général"));
-        assert!(is_nsfw("nsfw-général"));
     }
 
     #[test]


### PR DESCRIPTION
This pull request removes API-parts that were marked as `deprecated` and should not be in the new breaking release, `v0.6.x`.