### PR TITLE
Fix User::_nick_in with no-cache

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -732,7 +732,7 @@ impl User {
 
         #[cfg(not(feature = "cache"))]
         {
-            guild_id.member(&self.id).and_then(|member| member.nick.clone())
+            guild_id.member(&self.id).and_then(|member| member.nick.clone()).ok()
         }
     }
 }


### PR DESCRIPTION
User::_nick_in made a call to `GuildId::member` which returned a Result. `_nick_in` must return an Option. This converts the Result to an Option.