### PR TITLE
Change `ChannelId`'s `edit`-method to expect `&mut EditChannel`

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -236,8 +236,11 @@ impl ChannelId {
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "utils")]
     #[inline]
-    pub fn edit<F: FnOnce(EditChannel) -> EditChannel>(&self, f: F) -> Result<GuildChannel> {
-        let map = utils::vecmap_to_json_map(f(EditChannel::default()).0);
+    pub fn edit<F: FnOnce(&mut EditChannel) -> &mut EditChannel>(&self, f: F) -> Result<GuildChannel> {
+        let mut channel = EditChannel::default();
+        f(&mut channel);
+
+        let map = utils::vecmap_to_json_map(channel.0);
 
         http::edit_channel(self.0, &map)
     }


### PR DESCRIPTION
Currently `examples/05_command_framework` does not build due to #443 not changing `ChannelId`'s `edit`-method, therefore it still expects `EditChannel` while `slow_mode_rate` returns `&mut EditChannel`.

This is hereby fixed.

