### PR TITLE
Fix Emoji::url using png for animated emoji

### DIFF
--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -198,7 +198,10 @@ impl Emoji {
     /// println!("Direct link to emoji image: {}", emoji.url());
     /// ```
     #[inline]
-    pub fn url(&self) -> String { format!(cdn!("/emojis/{}.png"), self.id) }
+    pub fn url(&self) -> String {
+        let extension = if self.animated {"gif"} else {"png"};
+        format!(cdn!("/emojis/{}.{}"), self.id, extension)
+    }
 }
 
 impl Display for Emoji {


### PR DESCRIPTION
The current behaviour of using `.png` universally will yield a valid PNG from Discord's CDN, only it is the first frame of the animation

E.g.

https://cdn.discordapp.com/emojis/395294192764583938.gif
https://cdn.discordapp.com/emojis/395294192764583938.png