### PR TITLE
Limit users requested from reaction to 100

### DIFF
--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -167,11 +167,16 @@ impl Reaction {
         limit: Option<u8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
+        let mut limit = limit.unwrap_or(50);
+        if limit > 100 {
+            limit = 100;
+            warn!("Rection users limit clamped to 100! (API Restriction)");
+        }
         http::get_reaction_users(
             self.channel_id.0,
             self.message_id.0,
             reaction_type,
-            limit.unwrap_or(50),
+            limit,
             after.map(|u| u.0),
         )
     }


### PR DESCRIPTION
Clamp upper limit of `limit` to 100 for `reaction.users()`.
If the value is clamped a warning will be emitted. If a value over 100
is sent to the API it will return an error.