### PR TITLE
Update sodiumoxide to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ version = "0.2"
 default-features = false
 features = ["std"]
 optional = true
-version = "0.1"
+version = "0.2"
 
 [dependencies.threadpool]
 optional = true


### PR DESCRIPTION
Clang is no longer required for bindings

Would be nice to update it on both master and future 0.6 so that we no longer would need to have libclang dll