### PR TITLE
Remove global HTTP

### DIFF
--- a/examples/01_basic_ping_bot/src/main.rs
+++ b/examples/01_basic_ping_bot/src/main.rs
@@ -13,13 +13,13 @@ impl EventHandler for Handler {
     //
     // Event handlers are dispatched through a threadpool, and so multiple
     // events can be dispatched simultaneously.
-    fn message(&self, _: Context, msg: Message) {
+    fn message(&self, ctx: Context, msg: Message) {
         if msg.content == "!ping" {
             // Sending a message can fail, due to a network error, an
             // authentication error, or lack of permissions to post in the
             // channel, so log to stdout when some error happens, with a
             // description of it.
-            if let Err(why) = msg.channel_id.say("Pong!") {
+            if let Err(why) = msg.channel_id.say(&ctx.http, "Pong!") {
                 println!("Error sending message: {:?}", why);
             }
         }

--- a/examples/02_transparent_guild_sharding/src/main.rs
+++ b/examples/02_transparent_guild_sharding/src/main.rs
@@ -30,7 +30,7 @@ impl EventHandler for Handler {
        if msg.content == "!ping" {
             println!("Shard {}", ctx.shard_id);
 
-            if let Err(why) = msg.channel_id.say("Pong!") {
+            if let Err(why) = msg.channel_id.say(&ctx.http, "Pong!") {
                 println!("Error sending message: {:?}", why);
             }
         }

--- a/examples/04_message_builder/src/main.rs
+++ b/examples/04_message_builder/src/main.rs
@@ -32,7 +32,7 @@ impl EventHandler for Handler {
                 .push(" channel")
                 .build();
 
-            if let Err(why) = msg.channel_id.say(&response) {
+            if let Err(why) = msg.channel_id.say(&context.http, &response) {
                 println!("Error sending message: {:?}", why);
             }
         }

--- a/examples/06_voice/src/main.rs
+++ b/examples/06_voice/src/main.rs
@@ -80,7 +80,7 @@ command!(deafen(ctx, msg) {
     let guild_id = match ctx.cache.read().guild_channel(msg.channel_id) {
         Some(channel) => channel.read().guild_id,
         None => {
-            check_msg(msg.channel_id.say("Groups and DMs not supported"));
+            check_msg(msg.channel_id.say(&ctx.http, "Groups and DMs not supported"));
 
             return Ok(());
         },
@@ -99,11 +99,11 @@ command!(deafen(ctx, msg) {
     };
 
     if handler.self_deaf {
-        check_msg(msg.channel_id.say("Already deafened"));
+        check_msg(msg.channel_id.say(&ctx.http, "Already deafened"));
     } else {
         handler.deafen(true);
 
-        check_msg(msg.channel_id.say("Deafened"));
+        check_msg(msg.channel_id.say(&ctx.http, "Deafened"));
     }
 });
 
@@ -111,7 +111,7 @@ command!(join(ctx, msg) {
     let guild = match msg.guild(&ctx.cache) {
         Some(guild) => guild,
         None => {
-            check_msg(msg.channel_id.say("Groups and DMs not supported"));
+            check_msg(msg.channel_id.say(&ctx.http, "Groups and DMs not supported"));
 
             return Ok(());
         }
@@ -138,9 +138,9 @@ command!(join(ctx, msg) {
     let mut manager = manager_lock.lock();
 
     if manager.join(guild_id, connect_to).is_some() {
-        check_msg(msg.channel_id.say(&format!("Joined {}", connect_to.mention())));
+        check_msg(msg.channel_id.say(&ctx.http, &format!("Joined {}", connect_to.mention())));
     } else {
-        check_msg(msg.channel_id.say("Error joining the channel"));
+        check_msg(msg.channel_id.say(&ctx.http, "Error joining the channel"));
     }
 });
 
@@ -148,7 +148,7 @@ command!(leave(ctx, msg) {
     let guild_id = match ctx.cache.read().guild_channel(msg.channel_id) {
         Some(channel) => channel.read().guild_id,
         None => {
-            check_msg(msg.channel_id.say("Groups and DMs not supported"));
+            check_msg(msg.channel_id.say(&ctx.http, "Groups and DMs not supported"));
 
             return Ok(());
         },
@@ -161,7 +161,7 @@ command!(leave(ctx, msg) {
     if has_handler {
         manager.remove(guild_id);
 
-        check_msg(msg.channel_id.say("Left voice channel"));
+        check_msg(msg.channel_id.say(&ctx.http, "Left voice channel"));
     } else {
         check_msg(msg.reply(&ctx, "Not in a voice channel"));
     }
@@ -171,7 +171,7 @@ command!(mute(ctx, msg) {
     let guild_id = match ctx.cache.read().guild_channel(msg.channel_id) {
         Some(channel) => channel.read().guild_id,
         None => {
-            check_msg(msg.channel_id.say("Groups and DMs not supported"));
+            check_msg(msg.channel_id.say(&ctx.http, "Groups and DMs not supported"));
 
             return Ok(());
         },
@@ -190,30 +190,30 @@ command!(mute(ctx, msg) {
     };
 
     if handler.self_mute {
-        check_msg(msg.channel_id.say("Already muted"));
+        check_msg(msg.channel_id.say(&ctx.http, "Already muted"));
     } else {
         handler.mute(true);
 
-        check_msg(msg.channel_id.say("Now muted"));
+        check_msg(msg.channel_id.say(&ctx.http, "Now muted"));
     }
 });
 
-command!(ping(_context, msg) {
-    check_msg(msg.channel_id.say("Pong!"));
+command!(ping(context, msg) {
+    check_msg(msg.channel_id.say(&context.http, "Pong!"));
 });
 
 command!(play(ctx, msg, args) {
     let url = match args.single::<String>() {
         Ok(url) => url,
         Err(_) => {
-            check_msg(msg.channel_id.say("Must provide a URL to a video or audio"));
+            check_msg(msg.channel_id.say(&ctx.http, "Must provide a URL to a video or audio"));
 
             return Ok(());
         },
     };
 
     if !url.starts_with("http") {
-        check_msg(msg.channel_id.say("Must provide a valid URL"));
+        check_msg(msg.channel_id.say(&ctx.http, "Must provide a valid URL"));
 
         return Ok(());
     }
@@ -221,7 +221,7 @@ command!(play(ctx, msg, args) {
     let guild_id = match ctx.cache.read().guild_channel(msg.channel_id) {
         Some(channel) => channel.read().guild_id,
         None => {
-            check_msg(msg.channel_id.say("Error finding channel info"));
+            check_msg(msg.channel_id.say(&ctx.http, "Error finding channel info"));
 
             return Ok(());
         },
@@ -236,7 +236,7 @@ command!(play(ctx, msg, args) {
             Err(why) => {
                 println!("Err starting source: {:?}", why);
 
-                check_msg(msg.channel_id.say("Error sourcing ffmpeg"));
+                check_msg(msg.channel_id.say(&ctx.http, "Error sourcing ffmpeg"));
 
                 return Ok(());
             },
@@ -244,9 +244,9 @@ command!(play(ctx, msg, args) {
 
         handler.play(source);
 
-        check_msg(msg.channel_id.say("Playing song"));
+        check_msg(msg.channel_id.say(&ctx.http, "Playing song"));
     } else {
-        check_msg(msg.channel_id.say("Not in a voice channel to play in"));
+        check_msg(msg.channel_id.say(&ctx.http, "Not in a voice channel to play in"));
     }
 });
 
@@ -254,7 +254,7 @@ command!(undeafen(ctx, msg) {
     let guild_id = match ctx.cache.read().guild_channel(msg.channel_id) {
         Some(channel) => channel.read().guild_id,
         None => {
-            check_msg(msg.channel_id.say("Error finding channel info"));
+            check_msg(msg.channel_id.say(&ctx.http, "Error finding channel info"));
 
             return Ok(());
         },
@@ -266,9 +266,9 @@ command!(undeafen(ctx, msg) {
     if let Some(handler) = manager.get_mut(guild_id) {
         handler.deafen(false);
 
-        check_msg(msg.channel_id.say("Undeafened"));
+        check_msg(msg.channel_id.say(&ctx.http, "Undeafened"));
     } else {
-        check_msg(msg.channel_id.say("Not in a voice channel to undeafen in"));
+        check_msg(msg.channel_id.say(&ctx.http, "Not in a voice channel to undeafen in"));
     }
 });
 
@@ -276,7 +276,7 @@ command!(unmute(ctx, msg) {
     let guild_id = match ctx.cache.read().guild_channel(msg.channel_id) {
         Some(channel) => channel.read().guild_id,
         None => {
-            check_msg(msg.channel_id.say("Error finding channel info"));
+            check_msg(msg.channel_id.say(&ctx.http, "Error finding channel info"));
 
             return Ok(());
         },
@@ -287,9 +287,9 @@ command!(unmute(ctx, msg) {
     if let Some(handler) = manager.get_mut(guild_id) {
         handler.mute(false);
 
-        check_msg(msg.channel_id.say("Unmuted"));
+        check_msg(msg.channel_id.say(&ctx.http, "Unmuted"));
     } else {
-        check_msg(msg.channel_id.say("Not in a voice channel to undeafen in"));
+        check_msg(msg.channel_id.say(&ctx.http, "Not in a voice channel to undeafen in"));
     }
 });
 

--- a/examples/07_sample_bot_structure/src/commands/math.rs
+++ b/examples/07_sample_bot_structure/src/commands/math.rs
@@ -1,10 +1,10 @@
 use serenity::command;
 
-command!(multiply(_ctx, msg, args) {
+command!(multiply(ctx, msg, args) {
     let one = args.single::<f64>().unwrap();
     let two = args.single::<f64>().unwrap();
 
     let product = one * two;
 
-    let _ = msg.channel_id.say(product);
+    let _ = msg.channel_id.say(&ctx.http, product);
 });

--- a/examples/07_sample_bot_structure/src/commands/meta.rs
+++ b/examples/07_sample_bot_structure/src/commands/meta.rs
@@ -1,5 +1,5 @@
 use serenity::command;
 
-command!(ping(_ctx, msg) {
-    let _ = msg.channel_id.say("Pong!");
+command!(ping(ctx, msg) {
+    let _ = msg.channel_id.say(&ctx.http, "Pong!");
 });

--- a/examples/07_sample_bot_structure/src/main.rs
+++ b/examples/07_sample_bot_structure/src/main.rs
@@ -16,7 +16,6 @@ use serenity::{
     framework::StandardFramework,
     model::{event::ResumedEvent, gateway::Ready},
     prelude::*,
-    http,
 };
 
 use log::{error, info};
@@ -49,7 +48,7 @@ fn main() {
 
     let mut client = Client::new(&token, Handler).expect("Err creating client");
 
-    let owners = match http::get_current_application_info() {
+    let owners = match client.cache_and_http.http.get_current_application_info() {
         Ok(info) => {
             let mut set = HashSet::new();
             set.insert(info.owner.id);

--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -101,7 +101,7 @@ command!(join(ctx, msg, args) {
     let guild_id = match ctx.cache.read().guild_channel(msg.channel_id) {
         Some(channel) => channel.read().guild_id,
         None => {
-            check_msg(msg.channel_id.say("Groups and DMs not supported"));
+            check_msg(msg.channel_id.say(&ctx.http, "Groups and DMs not supported"));
 
             return Ok(());
         },
@@ -112,9 +112,9 @@ command!(join(ctx, msg, args) {
 
     if let Some(handler) = manager.join(guild_id, connect_to) {
         handler.listen(Some(Box::new(Receiver::new())));
-        check_msg(msg.channel_id.say(&format!("Joined {}", connect_to.mention())));
+        check_msg(msg.channel_id.say(&ctx.http, &format!("Joined {}", connect_to.mention())));
     } else {
-        check_msg(msg.channel_id.say("Error joining the channel"));
+        check_msg(msg.channel_id.say(&ctx.http, "Error joining the channel"));
     }
 });
 
@@ -122,7 +122,7 @@ command!(leave(ctx, msg) {
     let guild_id = match ctx.cache.read().guild_channel(msg.channel_id) {
         Some(channel) => channel.read().guild_id,
         None => {
-            check_msg(msg.channel_id.say("Groups and DMs not supported"));
+            check_msg(msg.channel_id.say(&ctx.http, "Groups and DMs not supported"));
 
             return Ok(());
         },
@@ -135,14 +135,14 @@ command!(leave(ctx, msg) {
     if has_handler {
         manager.remove(guild_id);
 
-        check_msg(msg.channel_id.say("Left voice channel"));
+        check_msg(msg.channel_id.say(&ctx.http,"Left voice channel"));
     } else {
         check_msg(msg.reply(&ctx, "Not in a voice channel"));
     }
 });
 
-command!(ping(_context, msg) {
-    check_msg(msg.channel_id.say("Pong!"));
+command!(ping(ctx, msg) {
+    check_msg(msg.channel_id.say(&ctx.http,"Pong!"));
 });
 
 /// Checks that a message successfully sent; if not, then logs why to stdout.

--- a/examples/11_create_message_builder/src/main.rs
+++ b/examples/11_create_message_builder/src/main.rs
@@ -8,13 +8,13 @@ use serenity::{
 struct Handler;
 
 impl EventHandler for Handler {
-    fn message(&self, _: Context, msg: Message) {
+    fn message(&self, ctx: Context, msg: Message) {
         if msg.content == "!hello" {
             // The create message builder allows you to easily create embeds and messages
             // using a builder syntax.
             // This example will create a message that says "Hello, World!", with an embed that has
             // a title, description, three fields, and a footer.
-            let msg = msg.channel_id.send_message(|m| {
+            let msg = msg.channel_id.send_message(&ctx.http, |m| {
                 m.content("Hello, World!");
                 m.embed(|e| {
                     e.title("This is a title");

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -237,9 +237,9 @@ impl CreateEmbed {
     /// struct Handler;
     ///
     /// impl EventHandler for Handler {
-    ///     fn message(&self, _: Context, mut msg: Message) {
+    ///     fn message(&self, context: Context, mut msg: Message) {
     ///         if msg.content == "~embed" {
-    ///             let _ = msg.channel_id.send_message(|m| {
+    ///             let _ = msg.channel_id.send_message(&context.http, |m| {
     ///                 m.embed(|e| {
     ///                     e.title("hello").timestamp("2004-06-08T16:04:23")
     ///                 });

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -24,7 +24,7 @@ use crate::utils::VecMap;
 ///             let channel = match context.cache.read().guild_channel(msg.channel_id) {
 ///                 Some(channel) => channel,
 ///                 None => {
-///                     let _ = msg.channel_id.say("Error creating invite");
+///                     let _ = msg.channel_id.say(&context.http, "Error creating invite");
 ///
 ///                     return;
 ///                 },
@@ -41,7 +41,7 @@ use crate::utils::VecMap;
 ///                 Err(why) => {
 ///                     println!("Err creating invite: {:?}", why);
 ///
-///                     if let Err(why) = msg.channel_id.say("Error creating invite") {
+///                     if let Err(why) = msg.channel_id.say(&context.http, "Error creating invite") {
 ///                         println!("Err sending err msg: {:?}", why);
 ///                     }
 ///
@@ -52,7 +52,7 @@ use crate::utils::VecMap;
 ///             drop(reader);
 ///
 ///             let content = format!("Here's your invite: {}", invite.url());
-///             let _ = msg.channel_id.say(&content);
+///             let _ = msg.channel_id.say(&context.http, &content);
 ///         }
 ///     }
 /// }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -24,10 +24,14 @@ use crate::utils::{self, VecMap};
 ///
 /// ```rust,no_run
 /// use serenity::model::id::ChannelId;
+/// # use serenity::http::Http;
+/// # use std::sync::Arc;
+/// #
+/// # let http = Arc::new(Http::default());
 ///
 /// let channel_id = ChannelId(7);
 ///
-/// let _ = channel_id.send_message(|m| {
+/// let _ = channel_id.send_message(&http, |m| {
 ///     m.content("test");
 ///     m.tts(true);
 ///

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -59,18 +59,19 @@ impl EditGuild {
     /// from the cwd and encode it in base64 to send to Discord.
     ///
     /// ```rust,no_run
-    /// # use serenity::model::id::GuildId;
-    /// # use std::error::Error;
+    /// # use serenity::{http::Http, model::id::GuildId};
+    /// # use std::{error::Error, sync::Arc};
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #     let mut guild = GuildId(0).to_partial_guild()?;
+    /// #     let http = Arc::new(Http::default());
+    /// #     let mut guild = GuildId(0).to_partial_guild(&http)?;
     /// use serenity::utils;
     ///
     /// // assuming a `guild` has already been bound
     ///
     /// let base64_icon = utils::read_image("./guild_icon.png")?;
     ///
-    /// guild.edit(|mut g| {
+    /// guild.edit(&http, |mut g| {
     ///     g.icon(Some(&base64_icon))
     /// })?;
     /// #     Ok(())
@@ -119,16 +120,17 @@ impl EditGuild {
     /// Setting the region to [`Region::UsWest`]:
     ///
     /// ```rust,no_run
-    /// # use serenity::model::id::GuildId;
-    /// # use std::error::Error;
+    /// # use serenity::{http::Http, model::id::GuildId};
+    /// # use std::{error::Error, sync::Arc};
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #     let mut guild = GuildId(0).to_partial_guild()?;
+    /// #     let http = Arc::new(Http::default());
+    /// #     let mut guild = GuildId(0).to_partial_guild(&http)?;
     /// use serenity::model::guild::Region;
     ///
     /// // assuming a `guild` has already been bound
     ///
-    /// guild.edit(|g| {
+    /// guild.edit(&http, |g| {
     ///     g.region(Region::UsWest)
     /// })?;
     /// #     Ok(())
@@ -169,11 +171,17 @@ impl EditGuild {
     /// Setting the verification level to [`High`][`VerificationLevel::High`]:
     ///
     /// ```rust,ignore
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// use serenity::model::guild::VerificationLevel;
     ///
     /// // assuming a `guild` has already been bound
     ///
-    /// let edit = guild.edit(|g| {
+    /// let edit = guild.edit(&http, |g| {
     ///     g.verification_level(VerificationLevel::High)
     /// });
     ///
@@ -184,7 +192,7 @@ impl EditGuild {
     /// // additionally, you may pass in just an integer of the verification
     /// // level
     ///
-    /// let edit = guild.edit(|g| {
+    /// let edit = guild.edit(&http, |g| {
     ///     g.verification_level(3)
     /// });
     ///

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -13,7 +13,7 @@ use crate::utils::{self, VecMap};
 /// # use serenity::{command, model::id::{ChannelId, MessageId}};
 /// #
 /// # command!(example(context) {
-/// # let mut message = ChannelId(7).message(MessageId(8)).unwrap();
+/// # let mut message = ChannelId(7).message(&context.http, MessageId(8)).unwrap();
 /// let _ = message.edit(&context, |m| {
 ///     m.content("hello")
 /// });

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -23,12 +23,17 @@ use crate::utils::VecMap;
 /// Create a hoisted, mentionable role named `"a test role"`:
 ///
 /// ```rust,no_run
-/// # use serenity::model::id::{ChannelId, GuildId};
+/// # extern crate serenity;
+/// #
+/// # use serenity::{model::id::{ChannelId, GuildId}, http::Http};
+/// # use std::sync::Arc;
+/// #
+/// # let http = Arc::new(Http::default());
 /// # let (channel_id, guild_id) = (ChannelId(1), GuildId(2));
 /// #
 /// // assuming a `channel_id` and `guild_id` has been bound
 ///
-/// let role = guild_id.create_role(|r| {
+/// let role = guild_id.create_role(&http, |r| {
 ///     r.hoist(true).mentionable(true).name("a test role")
 /// });
 /// ```

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -16,14 +16,15 @@ use crate::utils::VecMap;
 /// payload of [`Webhook::execute`]:
 ///
 /// ```rust,no_run
-/// use serenity::http;
+/// use serenity::http::Http;
 /// use serenity::model::channel::Embed;
 /// use serenity::utils::Colour;
 ///
 /// let id = 245037420704169985;
 /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-///
-/// let webhook = http::get_webhook_with_token(id, token)
+/// # use std::sync::Arc;
+/// # let http = Arc::new(Http::default());
+/// let webhook = http.get_webhook_with_token(id, token)
 ///     .expect("valid webhook");
 ///
 /// let website = Embed::fake(|e| {
@@ -39,7 +40,7 @@ use crate::utils::VecMap;
 ///         .field("Rust by Example", "A collection of Rust examples", false)
 /// });
 ///
-/// let _ = webhook.execute(false, |w| {
+/// let _ = webhook.execute(&http, false, |w| {
 ///     w.content("Here's some information on Rust:").embeds(vec![website, resources])
 /// });
 /// ```
@@ -58,13 +59,15 @@ impl ExecuteWebhook {
     /// Overriding the default avatar:
     ///
     /// ```rust,no_run
-    /// # use serenity::http;
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
     /// #
-    /// # let webhook = http::get_webhook_with_token(0, "").unwrap();
+    /// # let http = Arc::new(Http::default());
+    /// # let webhook = http.get_webhook_with_token(0, "").unwrap();
     /// #
     /// let avatar_url = "https://i.imgur.com/KTs6whd.jpg";
     ///
-    /// let _ = webhook.execute(false, |w| {
+    /// let _ = webhook.execute(&http, false, |w| {
     ///     w.avatar_url(avatar_url).content("Here's a webhook")
     /// });
     /// ```
@@ -83,11 +86,15 @@ impl ExecuteWebhook {
     /// Sending a webhook with a content of `"foo"`:
     ///
     /// ```rust,no_run
-    /// # use serenity::client::rest;
+    /// # extern crate serenity;
     /// #
-    /// # let webhook = rest::get_webhook_with_token(0, "").unwrap();
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
     /// #
-    /// let execution = webhook.execute(false, |w| {
+    /// # let http = Arc::new(Http::default());
+    /// # let webhook = http.get_webhook_with_token(0, "").unwrap();
+    /// #
+    /// let execution = webhook.execute(&http, false, |w| {
     ///     w.content("foo")
     /// });
     ///
@@ -127,11 +134,13 @@ impl ExecuteWebhook {
     /// Sending a webhook with text-to-speech enabled:
     ///
     /// ```rust,no_run
-    /// # use serenity::client::rest;
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
     /// #
-    /// # let webhook = rest::get_webhook_with_token(0, "").unwrap();
+    /// # let http = Arc::new(Http::default());
+    /// # let webhook = http.get_webhook_with_token(0, "").unwrap();
     /// #
-    /// let execution = webhook.execute(false, |w| {
+    /// let execution = webhook.execute(&http, false, |w| {
     ///     w.content("hello").tts(true)
     /// });
     ///
@@ -151,11 +160,15 @@ impl ExecuteWebhook {
     /// Overriding the username to `"hakase"`:
     ///
     /// ```rust,no_run
-    /// # use serenity::client::rest;
+    /// # extern crate serenity;
     /// #
-    /// # let webhook = rest::get_webhook_with_token(0, "").unwrap();
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
     /// #
-    /// let execution = webhook.execute(false, |w| {
+    /// # let http = Arc::new(Http::default());
+    /// # let webhook = http.get_webhook_with_token(0, "").unwrap();
+    /// #
+    /// let execution = webhook.execute(&http, false, |w| {
     ///     w.content("hello").username("hakase")
     /// });
     ///

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -26,15 +26,19 @@ use crate::utils::VecMap;
 /// message with an Id of `158339864557912064`:
 ///
 /// ```rust,no_run
-/// # use std::error::Error;
+/// # extern crate serenity;
+/// #
+/// # use serenity::http::Http;
+/// # use std::{error::Error, sync::Arc};
 /// #
 /// # fn try_main() -> Result<(), Box<Error>> {
+/// # let http = Arc::new(Http::default());
 /// use serenity::model::id::{ChannelId, MessageId};
 ///
 /// // you can then pass it into a function which retrieves messages:
 /// let channel_id = ChannelId(81384788765712384);
 ///
-/// let _messages = channel_id.messages(|retriever| {
+/// let _messages = channel_id.messages(&http, |retriever| {
 ///     retriever.after(MessageId(158339864557912064)).limit(25)
 /// })?;
 /// #     Ok(())

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -475,7 +475,7 @@ impl Cache {
     ///         let channel = match cache.guild_channel(message.channel_id) {
     ///             Some(channel) => channel,
     ///             None => {
-    /// if let Err(why) = message.channel_id.say("Could not find guild's
+    /// if let Err(why) = message.channel_id.say(&context.http, "Could not find guild's
     /// channel data") {
     ///                     println!("Error sending message: {:?}", why);
     ///                 }

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -61,7 +61,7 @@ use crate::client::bridge::voice::ClientVoiceManager;
 /// use parking_lot::{Mutex, RwLock};
 /// use serenity::client::bridge::gateway::{ShardManager, ShardManagerOptions};
 /// use serenity::client::EventHandler;
-/// use serenity::http;
+/// use serenity::http::Http;
 /// use serenity::CacheAndHttp;
 /// use std::sync::Arc;
 /// use std::env;
@@ -72,16 +72,13 @@ use crate::client::bridge::voice::ClientVoiceManager;
 ///
 /// impl EventHandler for Handler { }
 ///
-/// let token = env::var("DISCORD_TOKEN")?;
-/// http::set_token(&token);
-/// let token = Arc::new(Mutex::new(token));
-///
-/// let gateway_url = Arc::new(Mutex::new(http::get_gateway()?.url));
+/// # let cache_and_http = Arc::new(CacheAndHttp::default());
+/// # let http = &cache_and_http.http;
+/// let gateway_url = Arc::new(Mutex::new(http.get_gateway()?.url));
 /// let data = Arc::new(RwLock::new(ShareMap::custom()));
 /// let event_handler = Arc::new(Handler);
 /// let framework = Arc::new(Mutex::new(None));
 /// let threadpool = ThreadPool::with_name("my threadpool".to_owned(), 5);
-/// let cache_and_http = Arc::new(CacheAndHttp::default());
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,
@@ -93,12 +90,11 @@ use crate::client::bridge::voice::ClientVoiceManager;
 ///     shard_init: 3,
 ///     // the total number of shards in use
 ///     shard_total: 5,
-///     token: &token,
 ///     threadpool,
 ///     # #[cfg(feature = "voice")]
 ///     # voice_manager: &Arc::new(Mutex::new(ClientVoiceManager::new(0, UserId(0)))),
 ///     ws_url: &gateway_url,
-///     cache_and_http: &cache_and_http,
+///     # cache_and_http: &cache_and_http,
 /// });
 /// #     Ok(())
 /// # }

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -154,7 +154,6 @@ impl ShardManager {
             runners: Arc::clone(&runners),
             rx: shard_queue_rx,
             threadpool: opt.threadpool,
-            token: Arc::clone(opt.token),
             #[cfg(feature = "voice")]
             voice_manager: Arc::clone(opt.voice_manager),
             ws_url: Arc::clone(opt.ws_url),
@@ -366,7 +365,6 @@ pub struct ShardManagerOptions<'a, H: EventHandler + Send + Sync + 'static> {
     pub shard_init: u64,
     pub shard_total: u64,
     pub threadpool: ThreadPool,
-    pub token: &'a Arc<Mutex<String>>,
     #[cfg(feature = "voice")]
     pub voice_manager: &'a Arc<Mutex<ClientVoiceManager>>,
     pub ws_url: &'a Arc<Mutex<String>>,

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -61,7 +61,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), mutex, [0, 1])?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1])?;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -91,7 +91,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), mutex, [0, 1])?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1])?;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -144,8 +144,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), mutex, [0, 1]).unwrap();
-    /// #
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1])?;
     /// use serenity::model::gateway::Activity;
     ///
     /// shard.set_activity(Some(Activity::playing("Heroes of the Storm")));
@@ -182,7 +181,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), mutex, [0, 1]).unwrap();
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1])?;
     /// #
     /// use serenity::model::{Activity, OnlineStatus};
     ///
@@ -225,7 +224,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), mutex, [0, 1]).unwrap();
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1])?;
     /// #
     /// use serenity::model::user::OnlineStatus;
     ///

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -80,8 +80,6 @@ pub struct ShardQueuer<H: EventHandler + Send + Sync + 'static> {
     /// [`Client`]: ../../struct.Client.html
     /// [`Client::threadpool`]: ../../struct.Client.html#structfield.threadpool
     pub threadpool: ThreadPool,
-    /// A copy of the token to connect with.
-    pub token: Arc<Mutex<String>>,
     /// A copy of the client's voice manager.
     #[cfg(feature = "voice")]
     pub voice_manager: Arc<Mutex<ClientVoiceManager>>,
@@ -177,7 +175,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardQueuer<H> {
 
         let shard = Shard::new(
             Arc::clone(&self.ws_url),
-            Arc::clone(&self.token),
+            &self.cache_and_http.http.token,
             shard_info,
         )?;
 

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -114,7 +114,7 @@ impl Context {
                     map.insert("email", Value::String(email));
                 }
             } else {
-                let user = http::get_current_user()?;
+                let user = http.get_current_user()?;
 
                 map.insert("username", Value::String(user.name));
 

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -2,7 +2,6 @@ use crate::builder::EditProfile;
 use crate::client::bridge::gateway::ShardMessenger;
 use crate::error::Result;
 use crate::gateway::InterMessage;
-use crate::http;
 use crate::model::prelude::*;
 use parking_lot::RwLock;
 use serde_json::Value;
@@ -15,6 +14,8 @@ use crate::utils::VecMap;
 use crate::utils::vecmap_to_json_map;
 #[cfg(feature = "cache")]
 pub use crate::cache::Cache;
+#[cfg(feature = "http")]
+use crate::http::Http;
 
 /// The context is a general utility struct provided on event dispatches, which
 /// helps with dealing with the current "context" of the event dispatch.
@@ -44,6 +45,8 @@ pub struct Context {
     pub shard_id: u64,
     #[cfg(feature = "cache")]
     pub cache: Arc<RwLock<Cache>>,
+    #[cfg(feature = "http")]
+    pub http: Arc<Http>,
 }
 
 impl Context {
@@ -53,6 +56,7 @@ impl Context {
         runner_tx: Sender<InterMessage>,
         shard_id: u64,
         cache: Arc<RwLock<Cache>>,
+        http: Arc<Http>,
     ) -> Context {
         Context {
             shard: ShardMessenger::new(runner_tx),
@@ -60,6 +64,8 @@ impl Context {
             data,
             #[cfg(feature = "cache")]
             cache,
+            #[cfg(feature = "http")]
+            http,
         }
     }
 
@@ -123,7 +129,7 @@ impl Context {
 
         let edited = vecmap_to_json_map(edit_profile.0);
 
-        http::edit_profile(&edited)
+        self.http.edit_profile(&edited)
     }
 
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -340,7 +340,7 @@ impl Client {
             format!("Bot {}", token)
         };
 
-        let http = Http::new(reqwest::Client::builder().build()?, token.to_string());
+        let http = Http::new(reqwest::Client::builder().build()?, &token);
 
         let name = "serenity client".to_owned();
         let threadpool = ThreadPool::with_name(name, 5);
@@ -442,7 +442,7 @@ impl Client {
             format!("Bot {}", token)
         };
 
-        let http = Http::new(reqwest::Client::builder().build()?, token);
+        let http = Http::new(reqwest::Client::builder().build()?, &token);
 
         let name = "serenity client".to_owned();
         let threadpool = ThreadPool::with_name(name, 5);
@@ -524,8 +524,8 @@ impl Client {
     /// let mut client = Client::new(&env::var("DISCORD_TOKEN")?, Handler)?;
     /// client.with_framework(StandardFramework::new()
     ///     .configure(|c| c.prefix("~"))
-    ///     .on("ping", |_, msg, _| {
-    ///         msg.channel_id.say("Pong!")?;
+    ///     .on("ping", |context, msg, _| {
+    ///         msg.channel_id.say(&context.http, "Pong!")?;
     ///
     ///         Ok(())
     ///      }));

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -41,7 +41,6 @@ pub use crate::http as rest;
 #[cfg(feature = "cache")]
 pub use crate::cache::Cache;
 
-use crate::http;
 use crate::internal::prelude::*;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
@@ -284,8 +283,6 @@ pub struct Client {
     /// Defaults to 5 threads, which should suffice small bots. Consider
     /// increasing this number as your bot grows.
     pub threadpool: ThreadPool,
-    /// The token in use by the client.
-    pub token: Arc<Mutex<String>>,
     /// The voice manager for the client.
     ///
     /// This is an ergonomic structure for interfacing over shards' voice
@@ -343,9 +340,7 @@ impl Client {
             format!("Bot {}", token)
         };
 
-        let http = Http::new(reqwest::Client::builder().build()?);
-        http::set_token(&token);
-        let locked = Arc::new(Mutex::new(token));
+        let http = Http::new(reqwest::Client::builder().build()?, token.to_string());
 
         let name = "serenity client".to_owned();
         let threadpool = ThreadPool::with_name(name, 5);
@@ -381,7 +376,6 @@ impl Client {
                 shard_init: 0,
                 shard_total: 0,
                 threadpool: threadpool.clone(),
-                token: &locked,
                 #[cfg(feature = "voice")]
                 voice_manager: &voice_manager,
                 ws_url: &url,
@@ -390,7 +384,6 @@ impl Client {
         };
 
         Ok(Client {
-            token: locked,
             ws_uri: url,
             #[cfg(feature = "framework")]
             framework,
@@ -449,9 +442,7 @@ impl Client {
             format!("Bot {}", token)
         };
 
-        let http = Http::new(reqwest::Client::builder().build()?);
-        http::set_token(&token);
-        let locked = Arc::new(Mutex::new(token));
+        let http = Http::new(reqwest::Client::builder().build()?, token);
 
         let name = "serenity client".to_owned();
         let threadpool = ThreadPool::with_name(name, 5);
@@ -485,7 +476,6 @@ impl Client {
                 shard_init: 0,
                 shard_total: 0,
                 threadpool: threadpool.clone(),
-                token: &locked,
                 #[cfg(feature = "voice")]
                 voice_manager: &voice_manager,
                 ws_url: &url,
@@ -494,7 +484,6 @@ impl Client {
         };
 
         Ok(Client {
-            token: locked,
             ws_uri: url,
             #[cfg(feature = "framework")]
             framework,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -56,6 +56,8 @@ use crate::framework::Framework;
 use crate::model::id::UserId;
 #[cfg(feature = "voice")]
 use self::bridge::voice::ClientVoiceManager;
+#[cfg(feature = "http")]
+use crate::http::Http;
 
 /// The Client is the way to be able to start sending authenticated requests
 /// over the REST API, as well as initializing a WebSocket connection through
@@ -341,12 +343,13 @@ impl Client {
             format!("Bot {}", token)
         };
 
+        let http = Http::new(reqwest::Client::builder().build()?);
         http::set_token(&token);
         let locked = Arc::new(Mutex::new(token));
 
         let name = "serenity client".to_owned();
         let threadpool = ThreadPool::with_name(name, 5);
-        let url = Arc::new(Mutex::new(http::get_gateway()?.url));
+        let url = Arc::new(Mutex::new(http.get_gateway()?.url));
         let data = Arc::new(RwLock::new(ShareMap::custom()));
         let event_handler = Arc::new(handler);
 
@@ -363,6 +366,8 @@ impl Client {
             cache: Arc::new(RwLock::new(Cache::default())),
             #[cfg(feature = "cache")]
             update_cache_timeout: None,
+            #[cfg(feature = "http")]
+            http: Arc::new(http),
             __nonexhaustive: (),
         });
 
@@ -433,7 +438,7 @@ impl Client {
     /// #    try_main().unwrap();
     /// # }
     /// ```
-    #[cfg(feature = "cache")]
+    #[cfg(all(feature = "cache", feature = "http"))]
     pub fn new_with_cache_update_timeout<H>(token: &str, handler: H, duration: Option<Duration>) -> Result<Self>
         where H: EventHandler + Send + Sync + 'static {
         let token = token.trim();
@@ -444,12 +449,13 @@ impl Client {
             format!("Bot {}", token)
         };
 
+        let http = Http::new(reqwest::Client::builder().build()?);
         http::set_token(&token);
         let locked = Arc::new(Mutex::new(token));
 
         let name = "serenity client".to_owned();
         let threadpool = ThreadPool::with_name(name, 5);
-        let url = Arc::new(Mutex::new(http::get_gateway()?.url));
+        let url = Arc::new(Mutex::new(http.get_gateway()?.url));
         let data = Arc::new(RwLock::new(ShareMap::custom()));
         let event_handler = Arc::new(handler);
 
@@ -464,6 +470,8 @@ impl Client {
         let cache_and_http = Arc::new(CacheAndHttp {
             cache: Arc::new(RwLock::new(Cache::default())),
             update_cache_timeout: duration,
+            #[cfg(feature = "http")]
+            http: Arc::new(http),
             __nonexhaustive: (),
         });
 
@@ -649,6 +657,7 @@ impl Client {
     /// ```
     ///
     /// [gateway docs]: ../gateway/index.html#sharding
+    #[cfg(feature = "http")]
     pub fn start(&mut self) -> Result<()> {
         self.start_connection([0, 0, 1])
     }
@@ -701,9 +710,10 @@ impl Client {
     ///
     /// [`ClientError::Shutdown`]: enum.ClientError.html#variant.Shutdown
     /// [gateway docs]: ../gateway/index.html#sharding
+    #[cfg(feature = "http")]
     pub fn start_autosharded(&mut self) -> Result<()> {
         let (x, y) = {
-            let res = http::get_bot_gateway()?;
+            let res = self.cache_and_http.http.get_bot_gateway()?;
 
             (res.shards as u64 - 1, res.shards as u64)
         };
@@ -788,6 +798,7 @@ impl Client {
     /// [`start`]: #method.start
     /// [`start_autosharded`]: #method.start_autosharded
     /// [gateway docs]: ../gateway/index.html#sharding
+    #[cfg(feature = "http")]
     pub fn start_shard(&mut self, shard: u64, shards: u64) -> Result<()> {
         self.start_connection([shard, shard, shards])
     }
@@ -842,6 +853,7 @@ impl Client {
     /// [`start_shard`]: #method.start_shard
     /// [`start_shard_range`]: #method.start_shard_range
     /// [Gateway docs]: ../gateway/index.html#sharding
+    #[cfg(feature = "http")]
     pub fn start_shards(&mut self, total_shards: u64) -> Result<()> {
         self.start_connection([0, total_shards - 1, total_shards])
     }
@@ -912,6 +924,7 @@ impl Client {
     /// [`start_shard`]: #method.start_shard
     /// [`start_shards`]: #method.start_shards
     /// [Gateway docs]: ../gateway/index.html#sharding
+    #[cfg(feature = "http")]
     pub fn start_shard_range(&mut self, range: [u64; 2], total_shards: u64) -> Result<()> {
         self.start_connection([range[0], range[1], total_shards])
     }
@@ -929,6 +942,7 @@ impl Client {
     // an error.
     //
     // [`ClientError::Shutdown`]: enum.ClientError.html#variant.Shutdown
+    #[cfg(feature = "http")]
     fn start_connection(&mut self, shard_data: [u64; 3]) -> Result<()> {
         #[cfg(feature = "voice")]
         self.voice_manager.lock().set_shard_count(shard_data[2]);
@@ -940,7 +954,7 @@ impl Client {
         #[cfg(any(all(feature = "standard_framework", feature = "framework"),
                   feature = "voice"))]
         {
-            let user = http::get_current_user()?;
+            let user = self.cache_and_http.http.get_current_user()?;
 
             // Update the framework's current user if the feature is enabled.
             //

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -53,8 +53,8 @@
 //!     .cmd("ping", ping));
 //!
 //!
-//! command!(ping(_context, message) {
-//!     message.channel_id.say("Pong!")?;
+//! command!(ping(context, message) {
+//!     message.channel_id.say(&context.http, "Pong!")?;
 //! });
 //! ```
 //!

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -1,5 +1,4 @@
 use crate::client::Context;
-use crate::http;
 use crate::model::{
     channel::Message,
     id::{ChannelId, GuildId, UserId}
@@ -10,6 +9,9 @@ use std::{
     sync::Arc,
 };
 use super::command::{Command, InternalCommand, PrefixCheck};
+
+#[cfg(feature = "http")]
+use crate::http::Http;
 
 /// The configuration to use for a [`StandardFramework`] associated with a [`Client`]
 /// instance.
@@ -315,12 +317,15 @@ impl Configuration {
     /// encourages you to ignore differentiating between the two.
     ///
     /// [`prefix`]: #method.prefix
+    #[cfg(feature = "http")]
     pub fn on_mention(mut self, on_mention: bool) -> Self {
         if !on_mention {
             return self;
         }
 
-        if let Ok(current_user) = http::get_current_user() {
+        let http = Http::new(reqwest::Client::builder().build().expect("Could not construct Reqwest-Client."));
+
+        if let Ok(current_user) = http.get_current_user() {
             self.on_mention = Some(vec![
                 format!("<@{}>", current_user.id),  // Regular mention
                 format!("<@!{}>", current_user.id), // Nickname mention

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -221,8 +221,8 @@ impl Configuration {
     /// let disabled = vec!["ping"].into_iter().map(|x| x.to_string()).collect();
     ///
     /// client.with_framework(StandardFramework::new()
-    ///     .on("ping", |_, msg, _| {
-    ///         msg.channel_id.say("Pong!")?;
+    ///     .on("ping", |context, msg, _| {
+    ///         msg.channel_id.say(&context.http, "Pong!")?;
     ///
     ///         Ok(())
     ///     })
@@ -255,8 +255,8 @@ impl Configuration {
     /// use serenity::framework::StandardFramework;
     ///
     /// client.with_framework(StandardFramework::new()
-    ///     .on("ping", |_, msg, _| {
-    ///         msg.channel_id.say("Pong!")?;
+    ///     .on("ping", |context, msg, _| {
+    ///         msg.channel_id.say(&context.http, "Pong!")?;
     ///
     ///         Ok(())
     ///      })
@@ -325,7 +325,7 @@ impl Configuration {
 
         let http = Http::new(
             reqwest::Client::builder().build().expect("Could not construct Reqwest-Client."),
-            "".to_string(),
+            "",
         );
 
         if let Ok(current_user) = http.get_current_user() {

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -323,7 +323,10 @@ impl Configuration {
             return self;
         }
 
-        let http = Http::new(reqwest::Client::builder().build().expect("Could not construct Reqwest-Client."));
+        let http = Http::new(
+            reqwest::Client::builder().build().expect("Could not construct Reqwest-Client."),
+            "".to_string(),
+        );
 
         if let Ok(current_user) = http.get_current_user() {
             self.on_mention = Some(vec![

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -91,9 +91,9 @@ impl CreateCommand {
     ///         .desc("Replies to a ping with a pong")
     ///         .exec(ping)));
     ///
-    /// fn ping(_context: &mut Context, message: &Message, _args: Args) -> Result<(),
+    /// fn ping(context: &mut Context, message: &Message, _args: Args) -> Result<(),
     /// CommandError> {
-    ///     message.channel_id.say("Pong!")?;
+    ///     message.channel_id.say(&context.http, "Pong!")?;
     ///
     ///     Ok(())
     /// }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -301,8 +301,8 @@ impl StandardFramework {
     ///     .bucket("basic", 2, 10, 3)
     ///     .command("ping", |c| c
     ///         .bucket("basic")
-    ///         .exec(|_, msg, _| {
-    ///             msg.channel_id.say("pong!")?;
+    ///         .exec(|context, msg, _| {
+    ///             msg.channel_id.say(&context.http, "pong!")?;
     ///
     ///             Ok(())
     ///         })));
@@ -345,8 +345,8 @@ impl StandardFramework {
     ///     })
     ///     .command("ping", |c| c
     ///         .bucket("basic")
-    ///         .exec(|_, msg, _| {
-    ///             msg.channel_id.say("pong!")?;
+    ///         .exec(|context, msg, _| {
+    ///             msg.channel_id.say(&context.http, "pong!")?;
     ///
     ///             Ok(())
     ///         })
@@ -402,8 +402,8 @@ impl StandardFramework {
     ///     })
     ///     .command("ping", |c| c
     ///         .bucket("basic")
-    ///         .exec(|_, mut msg, _| {
-    ///             msg.channel_id.say("pong!")?;
+    ///         .exec(|context, mut msg, _| {
+    ///             msg.channel_id.say(&context.http, "pong!")?;
     ///
     ///             Ok(())
     ///         })
@@ -455,7 +455,7 @@ impl StandardFramework {
     ///     .simple_bucket("simple", 2)
     ///     .command("ping", |c| c
     ///         .bucket("simple")
-    ///         .exec(|_, msg, _| { msg.channel_id.say("pong!")?; Ok(()) })));
+    ///         .exec(|context, msg, _| { msg.channel_id.say(&context.http, "pong!")?; Ok(()) })));
     /// ```
     pub fn simple_bucket(mut self, s: &str, delay: i64) -> Self {
         self.buckets.insert(
@@ -672,8 +672,8 @@ impl StandardFramework {
     /// #
     /// use serenity::framework::StandardFramework;
     ///
-    /// client.with_framework(StandardFramework::new().on("ping", |_, mut msg, _| {
-    ///     msg.channel_id.say("pong!")?;
+    /// client.with_framework(StandardFramework::new().on("ping", |context, mut msg, _| {
+    ///     msg.channel_id.say(&context.http, "pong!")?;
     ///
     ///     Ok(())
     /// }));
@@ -791,8 +791,8 @@ impl StandardFramework {
     ///
     /// client.with_framework(StandardFramework::new()
     ///     .group("ping-pong", |g| g
-    ///         .on("ping", |_, msg, _| { msg.channel_id.say("pong!")?; Ok(()) })
-    ///         .on("pong", |_, msg, _| { msg.channel_id.say("ping!")?; Ok(()) })));
+    ///         .on("ping", |context, msg, _| { msg.channel_id.say(&context.http, "pong!")?; Ok(()) })
+    ///         .on("pong", |context, msg, _| { msg.channel_id.say(&context.http, "ping!")?; Ok(()) })));
     /// ```
     pub fn group<F>(mut self, group_name: &str, f: F) -> Self
         where F: FnOnce(CreateGroup) -> CreateGroup {
@@ -824,17 +824,17 @@ impl StandardFramework {
     /// use serenity::framework::StandardFramework;
     ///
     /// client.with_framework(StandardFramework::new()
-    ///     .on_dispatch_error(|_, msg, error| {
+    ///     .on_dispatch_error(|context, msg, error| {
     ///         match error {
     ///             NotEnoughArguments { min, given } => {
     ///                 let s = format!("Need {} arguments, but only got {}.", min, given);
     ///
-    ///                 let _ = msg.channel_id.say(&s);
+    ///                 let _ = msg.channel_id.say(&context.http, &s);
     ///             },
     ///             TooManyArguments { max, given } => {
     ///                 let s = format!("Max arguments allowed is {}, but got {}.", max, given);
     ///
-    ///                 let _ = msg.channel_id.say(&s);
+    ///                 let _ = msg.channel_id.say(&context.http, &s);
     ///             },
     ///             _ => println!("Unhandled dispatch error."),
     ///         }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -89,7 +89,7 @@ pub struct Shard {
     // This acts as a timeout to determine if the shard has - for some reason -
     // not started within a decent amount of time.
     pub started: Instant,
-    pub token: Arc<Mutex<String>>,
+    pub token: String,
     ws_url: Arc<Mutex<String>>,
 }
 
@@ -133,7 +133,7 @@ impl Shard {
     /// ```
     pub fn new(
         ws_url: Arc<Mutex<String>>,
-        token: Arc<Mutex<String>>,
+        token: &str,
         shard_info: [u64; 2],
     ) -> Result<Shard> {
         let mut client = connect(&*ws_url.lock())?;
@@ -158,7 +158,7 @@ impl Shard {
             seq,
             stage,
             started: Instant::now(),
-            token,
+            token: token.to_string(),
             session_id,
             shard_info,
             ws_url,
@@ -751,7 +751,7 @@ impl Shard {
     // - the time that the last heartbeat sent as being now
     // - the `stage` to `Identifying`
     pub fn identify(&mut self) -> Result<()> {
-        self.client.send_identify(&self.shard_info, &self.token.lock())?;
+        self.client.send_identify(&self.shard_info, &self.token)?;
 
         self.heartbeat_instants.0 = Some(Instant::now());
         self.stage = ConnectionStage::Identifying;
@@ -805,7 +805,7 @@ impl Shard {
                     &self.shard_info,
                     session_id,
                     &self.seq,
-                    &self.token.lock(),
+                    &self.token,
                 )
             },
             None => Err(Error::Gateway(GatewayError::NoSessionId)),

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -106,21 +106,20 @@ impl Shard {
     /// ```rust,no_run
     /// extern crate parking_lot;
     /// extern crate serenity;
+    ///
+    /// use serenity::gateway::Shard;
+    /// use parking_lot::Mutex;
+    /// use std::{env, sync::Arc};
     /// #
-    /// # use std::error::Error;
+    /// # use serenity::http::Http;
+    /// # use std::{error::Error};
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #
-    /// use parking_lot::Mutex;
-    /// use serenity::gateway::Shard;
-    /// use serenity::http;
-    /// use std::env;
-    /// use std::sync::Arc;
-    ///
-    /// let token = Arc::new(Mutex::new(env::var("DISCORD_BOT_TOKEN")?));
+    /// #     let http = Arc::new(Http::default());
+    /// let token = env::var("DISCORD_BOT_TOKEN")?;
     /// // retrieve the gateway response, which contains the URL to connect to
-    /// let gateway = Arc::new(Mutex::new(http::get_gateway()?.url));
-    /// let shard = Shard::new(gateway, token, [0, 1])?;
+    /// let gateway = Arc::new(Mutex::new(http.get_gateway()?.url));
+    /// let shard = Shard::new(gateway, &token, [0, 1])?;
     ///
     /// // at this point, you can create a `loop`, and receive events and match
     /// // their variants
@@ -264,13 +263,12 @@ impl Shard {
     /// ```rust,no_run
     /// # #[cfg(feature = "model")]
     /// # fn main() {
-    /// # use serenity::client::gateway::Shard;
+    /// # use serenity::{client::gateway::Shard, prelude::Mutex};
     /// # use std::sync::Arc;
-    /// # use serenity::prelude::Mutex;
     /// #
     /// # let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// # let mut shard = Shard::new(mutex.clone(), mutex, [0, 1]).unwrap();
+    /// # let mut shard = Shard::new(mutex.clone(), "", [0, 1]).unwrap();
     /// #
     /// use serenity::model::gateway::Activity;
     ///
@@ -322,7 +320,7 @@ impl Shard {
     /// #
     /// # let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// # let shard = Shard::new(mutex.clone(), mutex, [1, 2]).unwrap();
+    /// # let mut shard = Shard::new(mutex.clone(), "", [0, 1]).unwrap();
     /// #
     /// assert_eq!(shard.shard_info(), [1, 2]);
     /// # }
@@ -682,7 +680,7 @@ impl Shard {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), mutex, [0, 1])?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1])?;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -712,7 +710,7 @@ impl Shard {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), mutex, [0, 1])?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1])?;
     /// #
     /// use serenity::model::id::GuildId;
     ///

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -45,10 +45,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-lazy_static! {
-    static ref CLIENT: ReqwestClient = ReqwestClient::new();
-}
-
 /// An method used for ratelimiting special routes.
 ///
 /// This is needed because `reqwest`'s `Method` enum does not derive Copy.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -39,13 +39,10 @@ use reqwest::{
     Method,
 };
 use crate::model::prelude::*;
-use parking_lot::Mutex;
 use self::{request::Request};
 use std::{
-    default::Default,
     fs::File,
     path::{Path, PathBuf},
-    sync::Arc
 };
 
 lazy_static! {
@@ -79,10 +76,6 @@ impl LightMethod {
             LightMethod::Put => Method::PUT,
         }
     }
-}
-
-lazy_static! {
-    static ref TOKEN: Arc<Mutex<String>> = Arc::new(Mutex::new(String::default()));
 }
 
 /// Enum that allows a user to pass a `Path` or a `File` type to `send_files`

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -35,7 +35,6 @@ pub use self::error::Error as HttpError;
 pub use self::raw::*;
 
 use reqwest::{
-    Client as ReqwestClient,
     Method,
 };
 use crate::model::prelude::*;

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -58,7 +58,7 @@ use std::{
     thread,
     i64,
 };
-use super::{HttpError, Request};
+use super::{Http, HttpError, Request};
 
 /// Refer to [`offset`].
 ///
@@ -106,7 +106,7 @@ lazy_static! {
     };
 }
 
-pub(super) fn perform(req: Request) -> Result<Response> {
+pub(super) fn perform(http: &Http, req: Request) -> Result<Response> {
     loop {
         // This will block if another thread already has the global
         // unlocked already (due to receiving an x-ratelimit-global).
@@ -144,7 +144,7 @@ pub(super) fn perform(req: Request) -> Result<Response> {
         let mut lock = bucket.lock();
         lock.pre_hook(&route);
 
-        let response = super::raw::retry(&req)?;
+        let response = http.retry(&req)?;
 
         // Check if an offset has been calculated yet to determine the time
         // difference from Discord can the client.

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -17,16 +17,19 @@ use super::{
     GuildPagination,
     HttpError,
 };
+use parking_lot::Mutex;
 use serde::de::DeserializeOwned;
 use serde_json;
 use std::{
     collections::BTreeMap,
     io::ErrorKind as IoErrorKind,
+    sync::Arc,
 };
 
 pub struct Http {
     client: Client,
     pub token: String,
+    pub limiter: Arc<Mutex<()>>,
 }
 
 impl Http {
@@ -34,6 +37,7 @@ impl Http {
         Http {
             client,
             token: token.to_string(),
+            limiter: Arc::new(Mutex::new(())),
         }
     }
 
@@ -41,6 +45,7 @@ impl Http {
         Http {
             client: Client::builder().build().expect("Cannot build Reqwest::Client."),
             token: token.to_string(),
+            limiter: Arc::new(Mutex::new(())),
         }
     }
 
@@ -1772,6 +1777,7 @@ impl Default for Http {
         Self {
             client: Client::builder().build().expect("Cannot build Reqwest::Client."),
             token: "".to_string(),
+            limiter: Arc::new(Mutex::new(())),
         }
     }
 }

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -1,6 +1,6 @@
 use crate::constants;
 use reqwest::{
-    Client as ReqwestClient,
+    Client,
     header::{AUTHORIZATION, USER_AGENT, CONTENT_TYPE, HeaderValue, HeaderMap as Headers},
     multipart::Part,
     Response as ReqwestResponse,
@@ -24,6 +24,10 @@ use std::{
     collections::BTreeMap,
     io::ErrorKind as IoErrorKind,
 };
+
+pub struct Http {
+    client: Client,
+}
 
 /// Sets the token to be used across all requests which require authentication.
 ///
@@ -51,1700 +55,1714 @@ use std::{
 /// # }
 pub fn set_token(token: &str) { TOKEN.lock().clone_from(&token.to_string()); }
 
-/// Adds a [`User`] as a recipient to a [`Group`].
-///
-/// **Note**: Groups have a limit of 10 recipients, including the current user.
-///
-/// [`Group`]: ../../model/channel/struct.Group.html
-/// [`Group::add_recipient`]: ../../model/channel/struct.Group.html#method.add_recipient
-/// [`User`]: ../../model/user/struct.User.html
-pub fn add_group_recipient(group_id: u64, user_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::AddGroupRecipient { group_id, user_id },
-    })
-}
-
-/// Adds a single [`Role`] to a [`Member`] in a [`Guild`].
-///
-/// **Note**: Requires the [Manage Roles] permission and respect of role
-/// hierarchy.
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-/// [`Member`]: ../../model/guild/struct.Member.html
-/// [`Role`]: ../../model/guild/struct.Role.html
-/// [Manage Roles]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-pub fn add_member_role(guild_id: u64, user_id: u64, role_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::AddMemberRole { guild_id, role_id, user_id },
-    })
-}
-
-/// Bans a [`User`] from a [`Guild`], removing their messages sent in the last
-/// X number of days.
-///
-/// Passing a `delete_message_days` of `0` is equivalent to not removing any
-/// messages. Up to `7` days' worth of messages may be deleted.
-///
-/// **Note**: Requires that you have the [Ban Members] permission.
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-/// [`User`]: ../../model/user/struct.User.html
-/// [Ban Members]: ../../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-pub fn ban_user(guild_id: u64, user_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GuildBanUser {
-            delete_message_days: Some(delete_message_days),
-            reason: Some(reason),
-            guild_id,
-            user_id,
-        },
-    })
-}
-
-/// Ban zeyla from a [`Guild`], removing her messages sent in the last X number
-/// of days.
-///
-/// Passing a `delete_message_days` of `0` is equivalent to not removing any
-/// messages. Up to `7` days' worth of messages may be deleted.
-///
-/// **Note**: Requires that you have the [Ban Members] permission.
-///
-/// [`Guild`]: ../model/guild/struct.Guild.html
-/// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-pub fn ban_zeyla(guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
-    ban_user(guild_id, 114_941_315_417_899_012, delete_message_days, reason)
-}
-
-/// Ban luna from a [`Guild`], removing her messages sent in the last X number
-/// of days.
-///
-/// Passing a `delete_message_days` of `0` is equivalent to not removing any
-/// messages. Up to `7` days' worth of messages may be deleted.
-///
-/// **Note**: Requires that you have the [Ban Members] permission.
-///
-/// [`Guild`]: ../model/guild/struct.Guild.html
-/// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-pub fn ban_luna(guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
-    ban_user(guild_id, 180_731_582_049_550_336, delete_message_days, reason)
-}
-
-/// Ban the serenity servermoms from a [`Guild`], removing their messages
-/// sent in the last X number of days.
-///
-/// Passing a `delete_message_days` of `0` is equivalent to not removing any
-/// messages. Up to `7` days' worth of messages may be deleted.
-///
-/// **Note**: Requires that you have the [Ban Members] permission.
-///
-/// [`Guild`]: ../model/guild/struct.Guild.html
-/// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-pub fn ban_servermoms(guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
-    ban_zeyla(guild_id, delete_message_days, reason)?;
-    ban_luna(guild_id, delete_message_days, reason)
-}
-
-/// Broadcasts that the current user is typing in the given [`Channel`].
-///
-/// This lasts for about 10 seconds, and will then need to be renewed to
-/// indicate that the current user is still typing.
-///
-/// This should rarely be used for bots, although it is a good indicator that a
-/// long-running command is still being processed.
-///
-/// [`Channel`]: ../../model/channel/enum.Channel.html
-pub fn broadcast_typing(channel_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::BroadcastTyping { channel_id },
-    })
-}
-
-/// Creates a [`GuildChannel`] in the [`Guild`] given its Id.
-///
-/// Refer to the Discord's [docs] for information on what fields this requires.
-///
-/// **Note**: Requires the [Manage Channels] permission.
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-/// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
-/// [docs]: https://discordapp.com/developers/docs/resources/guild#create-guild-channel
-/// [Manage Channels]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-pub fn create_channel(guild_id: u64, map: &Value) -> Result<GuildChannel> {
-    fire(Request {
-        body: Some(map.to_string().as_bytes()),
-        headers: None,
-        route: RouteInfo::CreateChannel { guild_id },
-    })
-}
-
-/// Creates an emoji in the given [`Guild`] with the given data.
-///
-/// View the source code for [`Guild`]'s [`create_emoji`] method to see what
-/// fields this requires.
-///
-/// **Note**: Requires the [Manage Emojis] permission.
-///
-/// [`create_emoji`]: ../../model/guild/struct.Guild.html#method.create_emoji
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-/// [Manage Emojis]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-pub fn create_emoji(guild_id: u64, map: &Value) -> Result<Emoji> {
-    fire(Request {
-        body: Some(map.to_string().as_bytes()),
-        headers: None,
-        route: RouteInfo::CreateEmoji { guild_id },
-    })
-}
-
-/// Creates a guild with the data provided.
-///
-/// Only a [`PartialGuild`] will be immediately returned, and a full [`Guild`]
-/// will be received over a [`Shard`], if at least one is running.
-///
-/// **Note**: This endpoint is currently limited to 10 active guilds. The
-/// limits are raised for whitelisted [GameBridge] applications. See the
-/// [documentation on this endpoint] for more info.
-///
-/// # Examples
-///
-/// Create a guild called `"test"` in the [US West region]:
-///
-/// ```rust,ignore
-/// extern crate serde_json;
-///
-/// use serde_json::builder::ObjectBuilder;
-/// use serde_json::Value;
-/// use serenity::http;
-///
-/// let map = ObjectBuilder::new()
-///     .insert("name", "test")
-///     .insert("region", "us-west")
-///     .build();
-///
-/// let _result = http::create_guild(map);
-/// ```
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-/// [`PartialGuild`]: ../../model/guild/struct.PartialGuild.html
-/// [`Shard`]: ../../gateway/struct.Shard.html
-/// [GameBridge]: https://discordapp.com/developers/docs/topics/gamebridge
-/// [US West Region]: ../../model/guild/enum.Region.html#variant.UsWest
-/// [documentation on this endpoint]:
-/// https://discordapp.com/developers/docs/resources/guild#create-guild
-/// [whitelist]: https://discordapp.com/developers/docs/resources/guild#create-guild
-pub fn create_guild(map: &Value) -> Result<PartialGuild> {
-    fire(Request {
-        body: Some(map.to_string().as_bytes()),
-        headers: None,
-        route: RouteInfo::CreateGuild,
-    })
-}
-
-/// Creates an [`Integration`] for a [`Guild`].
-///
-/// Refer to Discord's [docs] for field information.
-///
-/// **Note**: Requires the [Manage Guild] permission.
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-/// [`Integration`]: ../../model/guild/struct.Integration.html
-/// [Manage Guild]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-/// [docs]: https://discordapp.com/developers/docs/resources/guild#create-guild-integration
-pub fn create_guild_integration(guild_id: u64, integration_id: u64, map: &Value) -> Result<()> {
-    wind(204, Request {
-        body: Some(map.to_string().as_bytes()),
-        headers: None,
-        route: RouteInfo::CreateGuildIntegration { guild_id, integration_id },
-    })
-}
-
-/// Creates a [`RichInvite`] for the given [channel][`GuildChannel`].
-///
-/// Refer to Discord's [docs] for field information.
-///
-/// All fields are optional.
-///
-/// **Note**: Requires the [Create Invite] permission.
-///
-/// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
-/// [`RichInvite`]: ../../model/invite/struct.RichInvite.html
-/// [Create Invite]: ../../model/permissions/struct.Permissions.html#associatedconstant.CREATE_INVITE
-/// [docs]: https://discordapp.com/developers/docs/resources/channel#create-channel-invite
-pub fn create_invite(channel_id: u64, map: &JsonMap) -> Result<RichInvite> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::CreateInvite { channel_id },
-    })
-}
-
-/// Creates a permission override for a member or a role in a channel.
-pub fn create_permission(channel_id: u64, target_id: u64, map: &Value) -> Result<()> {
-    let body = serde_json::to_vec(map)?;
-
-    wind(204, Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::CreatePermission { channel_id, target_id },
-    })
-}
-
-/// Creates a private channel with a user.
-pub fn create_private_channel(map: &Value) -> Result<PrivateChannel> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::CreatePrivateChannel,
-    })
-}
-
-/// Reacts to a message.
-pub fn create_reaction(channel_id: u64,
-                       message_id: u64,
-                       reaction_type: &ReactionType)
-                       -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::CreateReaction {
-            reaction: &reaction_type.as_data(),
-            channel_id,
-            message_id,
-        },
-    })
-}
-
-/// Creates a role.
-pub fn create_role(guild_id: u64, map: &JsonMap) -> Result<Role> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::CreateRole {guild_id },
-    })
-}
-
-/// Creates a webhook for the given [channel][`GuildChannel`]'s Id, passing in
-/// the given data.
-///
-/// This method requires authentication.
-///
-/// The Value is a map with the values of:
-///
-/// - **avatar**: base64-encoded 128x128 image for the webhook's default avatar
-///   (_optional_);
-/// - **name**: the name of the webhook, limited to between 2 and 100 characters
-///   long.
-///
-/// # Examples
-///
-/// Creating a webhook named `test`:
-///
-/// ```rust,ignore
-/// extern crate serde_json;
-/// extern crate serenity;
-///
-/// use serde_json::builder::ObjectBuilder;
-/// use serenity::http;
-///
-/// let channel_id = 81384788765712384;
-/// let map = ObjectBuilder::new().insert("name", "test").build();
-///
-/// let webhook = http::create_webhook(channel_id, map).expect("Error creating");
-/// ```
-///
-/// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
-pub fn create_webhook(channel_id: u64, map: &Value) -> Result<Webhook> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::CreateWebhook { channel_id },
-    })
-}
-
-/// Deletes a private channel or a channel in a guild.
-pub fn delete_channel(channel_id: u64) -> Result<Channel> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteChannel { channel_id },
-    })
-}
-
-/// Deletes an emoji from a server.
-pub fn delete_emoji(guild_id: u64, emoji_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteEmoji { guild_id, emoji_id },
-    })
-}
-
-/// Deletes a guild, only if connected account owns it.
-pub fn delete_guild(guild_id: u64) -> Result<PartialGuild> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteGuild { guild_id },
-    })
-}
-
-/// Removes an integration from a guild.
-pub fn delete_guild_integration(guild_id: u64, integration_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteGuildIntegration { guild_id, integration_id },
-    })
-}
-
-/// Deletes an invite by code.
-pub fn delete_invite(code: &str) -> Result<Invite> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteInvite { code },
-    })
-}
-
-/// Deletes a message if created by us or we have
-/// specific permissions.
-pub fn delete_message(channel_id: u64, message_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteMessage { channel_id, message_id },
-    })
-}
-
-/// Deletes a bunch of messages, only works for bots.
-pub fn delete_messages(channel_id: u64, map: &Value) -> Result<()> {
-    wind(204, Request {
-        body: Some(map.to_string().as_bytes()),
-        headers: None,
-        route: RouteInfo::DeleteMessages { channel_id },
-    })
-}
-
-/// Deletes all of the [`Reaction`]s associated with a [`Message`].
-///
-/// # Examples
-///
-/// ```rust,no_run
-/// use serenity::http;
-/// use serenity::model::id::{ChannelId, MessageId};
-///
-/// let channel_id = ChannelId(7);
-/// let message_id = MessageId(8);
-///
-/// let _ = http::delete_message_reactions(channel_id.0, message_id.0)
-///     .expect("Error deleting reactions");
-/// ```
-///
-/// [`Message`]: ../../model/channel/struct.Message.html
-/// [`Reaction`]: ../../model/channel/struct.Reaction.html
-pub fn delete_message_reactions(channel_id: u64, message_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteMessageReactions { channel_id, message_id },
-    })
-}
-
-/// Deletes a permission override from a role or a member in a channel.
-pub fn delete_permission(channel_id: u64, target_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeletePermission { channel_id, target_id },
-    })
-}
-
-/// Deletes a reaction from a message if owned by us or
-/// we have specific permissions.
-pub fn delete_reaction(channel_id: u64,
-                       message_id: u64,
-                       user_id: Option<u64>,
-                       reaction_type: &ReactionType)
-                       -> Result<()> {
-    let user = user_id
-        .map(|uid| uid.to_string())
-        .unwrap_or_else(|| "@me".to_string());
-
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteReaction {
-            reaction: &reaction_type.as_data(),
-            user: &user,
-            channel_id,
-            message_id,
-        },
-    })
-}
-
-/// Deletes a role from a server. Can't remove the default everyone role.
-pub fn delete_role(guild_id: u64, role_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteRole { guild_id, role_id },
-    })
-}
-
-/// Deletes a [`Webhook`] given its Id.
-///
-/// This method requires authentication, whereas [`delete_webhook_with_token`]
-/// does not.
-///
-/// # Examples
-///
-/// Deletes a webhook given its Id:
-///
-/// ```rust,no_run
-/// use serenity::http;
-/// use std::env;
-///
-/// // Due to the `delete_webhook` function requiring you to authenticate, you
-/// // must have set the token first.
-/// http::set_token(&env::var("DISCORD_TOKEN").unwrap());
-///
-/// http::delete_webhook(245037420704169985).expect("Error deleting webhook");
-/// ```
-///
-/// [`Webhook`]: ../../model/webhook/struct.Webhook.html
-/// [`delete_webhook_with_token`]: fn.delete_webhook_with_token.html
-pub fn delete_webhook(webhook_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteWebhook { webhook_id },
-    })
-}
-
-/// Deletes a [`Webhook`] given its Id and unique token.
-///
-/// This method does _not_ require authentication.
-///
-/// # Examples
-///
-/// Deletes a webhook given its Id and unique token:
-///
-/// ```rust,no_run
-/// use serenity::http;
-///
-/// let id = 245037420704169985;
-/// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-///
-/// http::delete_webhook_with_token(id, token).expect("Error deleting webhook");
-/// ```
-///
-/// [`Webhook`]: ../../model/webhook/struct.Webhook.html
-pub fn delete_webhook_with_token(webhook_id: u64, token: &str) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::DeleteWebhookWithToken { token, webhook_id },
-    })
-}
-
-/// Changes channel information.
-pub fn edit_channel(channel_id: u64, map: &JsonMap) -> Result<GuildChannel> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditChannel {channel_id },
-    })
-}
-
-/// Changes emoji information.
-pub fn edit_emoji(guild_id: u64, emoji_id: u64, map: &Value) -> Result<Emoji> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditEmoji { guild_id, emoji_id },
-    })
-}
-
-/// Changes guild information.
-pub fn edit_guild(guild_id: u64, map: &JsonMap) -> Result<PartialGuild> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditGuild { guild_id },
-    })
-}
-
-/// Edits the positions of a guild's channels.
-pub fn edit_guild_channel_positions(guild_id: u64, value: &Value)
-                                    -> Result<()> {
-    let body = serde_json::to_vec(value)?;
-
-    wind(204, Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditGuildChannels { guild_id },
-    })
-}
-
-/// Edits a [`Guild`]'s embed setting.
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-pub fn edit_guild_embed(guild_id: u64, map: &Value) -> Result<GuildEmbed> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditGuildEmbed { guild_id },
-    })
-}
-
-/// Does specific actions to a member.
-pub fn edit_member(guild_id: u64, user_id: u64, map: &JsonMap) -> Result<()> {
-    let body = serde_json::to_vec(map)?;
-
-    wind(204, Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditMember { guild_id, user_id },
-    })
-}
-
-/// Edits a message by Id.
-///
-/// **Note**: Only the author of a message can modify it.
-pub fn edit_message(channel_id: u64, message_id: u64, map: &Value) -> Result<Message> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditMessage { channel_id, message_id },
-    })
-}
-
-/// Edits the current user's nickname for the provided [`Guild`] via its Id.
-///
-/// Pass `None` to reset the nickname.
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-pub fn edit_nickname(guild_id: u64, new_nickname: Option<&str>) -> Result<()> {
-    let map = json!({ "nick": new_nickname });
-    let body = serde_json::to_vec(&map)?;
-
-    wind(200, Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditNickname { guild_id },
-    })
-}
-
-/// Edits the current user's profile settings.
-///
-/// For bot users, the password is optional.
-///
-/// # User Accounts
-///
-/// If a new token is received due to a password change, then the stored token
-/// internally will be updated.
-///
-/// **Note**: this token change may cause requests made between the actual token
-/// change and when the token is internally changed to be invalid requests, as
-/// the token may be outdated.
-pub fn edit_profile(map: &JsonMap) -> Result<CurrentUser> {
-    let body = serde_json::to_vec(map)?;
-
-    let response = request(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditProfile,
-    })?;
-
-    let mut value = serde_json::from_reader::<ReqwestResponse, Value>(response)?;
-
-    if let Some(map) = value.as_object_mut() {
-        if !TOKEN.lock().starts_with("Bot ") {
-            if let Some(Value::String(token)) = map.remove("token") {
-                set_token(&token);
-            }
+impl Http {
+    pub fn new(client: Client) -> Self {
+        Http {
+            client
         }
     }
 
-    serde_json::from_value::<CurrentUser>(value).map_err(From::from)
-}
-
-/// Changes a role in a guild.
-pub fn edit_role(guild_id: u64, role_id: u64, map: &JsonMap) -> Result<Role> {
-    let body = serde_json::to_vec(&map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditRole { guild_id, role_id },
-    })
-}
-
-/// Changes the position of a role in a guild.
-pub fn edit_role_position(guild_id: u64, role_id: u64, position: u64) -> Result<Vec<Role>> {
-    let body = serde_json::to_vec(&json!({
-        "id": role_id,
-        "position": position,
-    }))?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditRole { guild_id, role_id },
-    })
-}
-
-/// Edits a the webhook with the given data.
-///
-/// The Value is a map with optional values of:
-///
-/// - **avatar**: base64-encoded 128x128 image for the webhook's default avatar
-///   (_optional_);
-/// - **name**: the name of the webhook, limited to between 2 and 100 characters
-///   long.
-///
-/// Note that, unlike with [`create_webhook`], _all_ values are optional.
-///
-/// This method requires authentication, whereas [`edit_webhook_with_token`]
-/// does not.
-///
-/// # Examples
-///
-/// Edit the image of a webhook given its Id and unique token:
-///
-/// ```rust,ignore
-/// extern crate serde_json;
-/// extern crate serenity;
-///
-/// use serde_json::builder::ObjectBuilder;
-/// use serenity::http;
-///
-/// let id = 245037420704169985;
-/// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-/// let image = serenity::utils::read_image("./webhook_img.png")
-///     .expect("Error reading image");
-/// let map = ObjectBuilder::new().insert("avatar", image).build();
-///
-/// let edited = http::edit_webhook_with_token(id, token, map)
-///     .expect("Error editing webhook");
-/// ```
-///
-/// [`create_webhook`]: fn.create_webhook.html
-/// [`edit_webhook_with_token`]: fn.edit_webhook_with_token.html
-// The tests are ignored, rather than no_run'd, due to rustdoc tests with
-// external crates being incredibly messy and misleading in the end user's view.
-pub fn edit_webhook(webhook_id: u64, map: &Value) -> Result<Webhook> {
-    fire(Request {
-        body: Some(map.to_string().as_bytes()),
-        headers: None,
-        route: RouteInfo::EditWebhook { webhook_id },
-    })
-}
-
-/// Edits the webhook with the given data.
-///
-/// Refer to the documentation for [`edit_webhook`] for more information.
-///
-/// This method does _not_ require authentication.
-///
-/// # Examples
-///
-/// Edit the name of a webhook given its Id and unique token:
-///
-/// ```rust,ignore
-/// extern crate serde_json;
-/// extern crate serenity;
-///
-/// use serde_json::builder::ObjectBuilder;
-/// use serenity::http;
-///
-/// let id = 245037420704169985;
-/// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-/// let map = ObjectBuilder::new().insert("name", "new name").build();
-///
-/// let edited = http::edit_webhook_with_token(id, token, map)
-///     .expect("Error editing webhook");
-/// ```
-///
-/// [`edit_webhook`]: fn.edit_webhook.html
-pub fn edit_webhook_with_token(webhook_id: u64, token: &str, map: &JsonMap) -> Result<Webhook> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::EditWebhookWithToken { token, webhook_id },
-    })
-}
-
-/// Executes a webhook, posting a [`Message`] in the webhook's associated
-/// [`Channel`].
-///
-/// This method does _not_ require authentication.
-///
-/// Pass `true` to `wait` to wait for server confirmation of the message sending
-/// before receiving a response. From the [Discord docs]:
-///
-/// > waits for server confirmation of message send before response, and returns
-/// > the created message body (defaults to false; when false a message that is
-/// > not saved does not return an error)
-///
-/// The map can _optionally_ contain the following data:
-///
-/// - `avatar_url`: Override the default avatar of the webhook with a URL.
-/// - `tts`: Whether this is a text-to-speech message (defaults to `false`).
-/// - `username`: Override the default username of the webhook.
-///
-/// Additionally, _at least one_ of the following must be given:
-///
-/// - `content`: The content of the message.
-/// - `embeds`: An array of rich embeds.
-///
-/// **Note**: For embed objects, all fields are registered by Discord except for
-/// `height`, `provider`, `proxy_url`, `type` (it will always be `rich`),
-/// `video`, and `width`. The rest will be determined by Discord.
-///
-/// # Examples
-///
-/// Sending a webhook with message content of `test`:
-///
-/// ```rust,ignore
-/// extern crate serde_json;
-/// extern crate serenity;
-///
-/// use serde_json::builder::ObjectBuilder;
-/// use serenity::http;
-///
-/// let id = 245037420704169985;
-/// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-/// let map = ObjectBuilder::new().insert("content", "test").build();
-///
-/// let message = match http::execute_webhook(id, token, true, map) {
-///     Ok(Some(message)) => message,
-///     Ok(None) => {
-///         println!("Expected a webhook message");
-///
-///         return;
-///     },
-///     Err(why) => {
-///         println!("Error executing webhook: {:?}", why);
-///
-///         return;
-///     },
-/// };
-/// ```
-///
-/// [`Channel`]: ../../model/channel/enum.Channel.html
-/// [`Message`]: ../../model/channel/struct.Message.html
-/// [Discord docs]: https://discordapp.com/developers/docs/resources/webhook#querystring-params
-pub fn execute_webhook(webhook_id: u64,
-                       token: &str,
-                       wait: bool,
-                       map: &JsonMap)
-                       -> Result<Option<Message>> {
-    let body = serde_json::to_vec(map)?;
-
-    let mut headers = Headers::new();
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
-
-    let response = request(Request {
-        body: Some(&body),
-        headers: Some(headers),
-        route: RouteInfo::ExecuteWebhook { token, wait, webhook_id },
-    })?;
-
-    if response.status() == StatusCode::NO_CONTENT {
-        return Ok(None);
+    /// Adds a [`User`] as a recipient to a [`Group`].
+    ///
+    /// **Note**: Groups have a limit of 10 recipients, including the current user.
+    ///
+    /// [`Group`]: ../../model/channel/struct.Group.html
+    /// [`Group::add_recipient`]: ../../model/channel/struct.Group.html#method.add_recipient
+    /// [`User`]: ../../model/user/struct.User.html
+    pub fn add_group_recipient(&self, group_id: u64, user_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::AddGroupRecipient { group_id, user_id },
+        })
     }
 
-    serde_json::from_reader::<ReqwestResponse, Message>(response)
-        .map(Some)
-        .map_err(From::from)
-}
-
-/// Gets the active maintenances from Discord's Status API.
-///
-/// Does not require authentication.
-pub fn get_active_maintenances() -> Result<Vec<Maintenance>> {
-    let response = request(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetActiveMaintenance,
-    })?;
-
-    let mut map: BTreeMap<String, Value> = serde_json::from_reader(response)?;
-
-    match map.remove("scheduled_maintenances") {
-        Some(v) => serde_json::from_value::<Vec<Maintenance>>(v)
-            .map_err(From::from),
-        None => Ok(vec![]),
-    }
-}
-
-/// Gets all the users that are banned in specific guild.
-pub fn get_bans(guild_id: u64) -> Result<Vec<Ban>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetBans { guild_id },
-    })
-}
-
-/// Gets all audit logs in a specific guild.
-pub fn get_audit_logs(guild_id: u64,
-                      action_type: Option<u8>,
-                      user_id: Option<u64>,
-                      before: Option<u64>,
-                      limit: Option<u8>) -> Result<AuditLogs> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetAuditLogs {
-            action_type,
-            before,
-            guild_id,
-            limit,
-            user_id,
-        },
-    })
-}
-
-/// Gets current bot gateway.
-pub fn get_bot_gateway() -> Result<BotGateway> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetBotGateway,
-    })
-}
-
-/// Gets all invites for a channel.
-pub fn get_channel_invites(channel_id: u64) -> Result<Vec<RichInvite>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetChannelInvites { channel_id },
-    })
-}
-
-/// Retrieves the webhooks for the given [channel][`GuildChannel`]'s Id.
-///
-/// This method requires authentication.
-///
-/// # Examples
-///
-/// Retrieve all of the webhooks owned by a channel:
-///
-/// ```rust,no_run
-/// use serenity::http;
-///
-/// let channel_id = 81384788765712384;
-///
-/// let webhooks = http::get_channel_webhooks(channel_id)
-///     .expect("Error getting channel webhooks");
-/// ```
-///
-/// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
-pub fn get_channel_webhooks(channel_id: u64) -> Result<Vec<Webhook>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetChannelWebhooks { channel_id },
-    })
-}
-
-/// Gets channel information.
-pub fn get_channel(channel_id: u64) -> Result<Channel> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetChannel { channel_id },
-    })
-}
-
-/// Gets all channels in a guild.
-pub fn get_channels(guild_id: u64) -> Result<Vec<GuildChannel>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetChannels { guild_id },
-    })
-}
-
-/// Gets information about the current application.
-///
-/// **Note**: Only applications may use this endpoint.
-pub fn get_current_application_info() -> Result<CurrentApplicationInfo> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetCurrentApplicationInfo,
-    })
-}
-
-/// Gets information about the user we're connected with.
-pub fn get_current_user() -> Result<CurrentUser> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetCurrentUser,
-    })
-}
-
-/// Gets current gateway.
-pub fn get_gateway() -> Result<Gateway> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGateway,
-    })
-}
-
-/// Gets guild information.
-pub fn get_guild(guild_id: u64) -> Result<PartialGuild> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuild { guild_id },
-    })
-}
-
-/// Gets a guild embed information.
-pub fn get_guild_embed(guild_id: u64) -> Result<GuildEmbed> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildEmbed { guild_id },
-    })
-}
-
-/// Gets integrations that a guild has.
-pub fn get_guild_integrations(guild_id: u64) -> Result<Vec<Integration>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildIntegrations { guild_id },
-    })
-}
-
-/// Gets all invites to a guild.
-pub fn get_guild_invites(guild_id: u64) -> Result<Vec<RichInvite>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildInvites { guild_id },
-    })
-}
-
-/// Gets a guild's vanity URL if it has one.
-pub fn get_guild_vanity_url(guild_id: u64) -> Result<String> {
-    #[derive(Deserialize)]
-    struct GuildVanityUrl {
-        code: String,
+    /// Adds a single [`Role`] to a [`Member`] in a [`Guild`].
+    ///
+    /// **Note**: Requires the [Manage Roles] permission and respect of role
+    /// hierarchy.
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    /// [`Member`]: ../../model/guild/struct.Member.html
+    /// [`Role`]: ../../model/guild/struct.Role.html
+    /// [Manage Roles]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
+    pub fn add_member_role(&self, guild_id: u64, user_id: u64, role_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::AddMemberRole { guild_id, role_id, user_id },
+        })
     }
 
-    let response = request(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildVanityUrl { guild_id },
-    })?;
-
-    serde_json::from_reader::<ReqwestResponse, GuildVanityUrl>(response)
-        .map(|x| x.code)
-        .map_err(From::from)
-}
-
-/// Gets the members of a guild. Optionally pass a `limit` and the Id of the
-/// user to offset the result by.
-pub fn get_guild_members(guild_id: u64,
-                         limit: Option<u64>,
-                         after: Option<u64>)
-                         -> Result<Vec<Member>> {
-    let response = request(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildMembers { after, guild_id, limit },
-    })?;
-
-    let mut v = serde_json::from_reader::<ReqwestResponse, Value>(response)?;
-
-    if let Some(values) = v.as_array_mut() {
-        let num = Value::Number(Number::from(guild_id));
-
-        for value in values {
-            if let Some(element) = value.as_object_mut() {
-                element.insert("guild_id".to_string(), num.clone());
-            }
-        }
-    }
-
-    serde_json::from_value::<Vec<Member>>(v).map_err(From::from)
-}
-
-/// Gets the amount of users that can be pruned.
-pub fn get_guild_prune_count(guild_id: u64, map: &Value) -> Result<GuildPrune> {
-    // Note for 0.6.x: turn this into a function parameter.
-    #[derive(Deserialize)]
-    struct GetGuildPruneCountRequest {
-        days: u64,
-    }
-
-    let req = serde_json::from_value::<GetGuildPruneCountRequest>(map.clone())?;
-
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildPruneCount {
-            days: req.days,
-            guild_id,
-        },
-    })
-}
-
-/// Gets regions that a guild can use. If a guild has the `VIP_REGIONS` feature
-/// enabled, then additional VIP-only regions are returned.
-pub fn get_guild_regions(guild_id: u64) -> Result<Vec<VoiceRegion>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildRegions { guild_id },
-    })
-}
-
-/// Retrieves a list of roles in a [`Guild`].
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-pub fn get_guild_roles(guild_id: u64) -> Result<Vec<Role>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildRoles { guild_id },
-    })
-}
-
-/// Retrieves the webhooks for the given [guild][`Guild`]'s Id.
-///
-/// This method requires authentication.
-///
-/// # Examples
-///
-/// Retrieve all of the webhooks owned by a guild:
-///
-/// ```rust,no_run
-/// use serenity::http;
-///
-/// let guild_id = 81384788765712384;
-///
-/// let webhooks = http::get_guild_webhooks(guild_id)
-///     .expect("Error getting guild webhooks");
-/// ```
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-pub fn get_guild_webhooks(guild_id: u64) -> Result<Vec<Webhook>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuildWebhooks { guild_id },
-    })
-}
-
-/// Gets a paginated list of the current user's guilds.
-///
-/// The `limit` has a maximum value of 100.
-///
-/// [Discord's documentation][docs]
-///
-/// # Examples
-///
-/// Get the first 10 guilds after a certain guild's Id:
-///
-/// ```rust,no_run
-/// use serenity::http::{GuildPagination, get_guilds};
-/// use serenity::model::id::GuildId;
-///
-/// let guild_id = GuildId(81384788765712384);
-///
-/// let guilds = get_guilds(&GuildPagination::After(guild_id), 10).unwrap();
-/// ```
-///
-/// [docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds
-pub fn get_guilds(target: &GuildPagination, limit: u64) -> Result<Vec<GuildInfo>> {
-    let (after, before) = match *target {
-        GuildPagination::After(id) => (Some(id.0), None),
-        GuildPagination::Before(id) => (None, Some(id.0)),
-    };
-
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetGuilds { after, before, limit },
-    })
-}
-
-/// Gets information about a specific invite.
-#[allow(clippy::unused_mut)]
-pub fn get_invite(mut code: &str, stats: bool) -> Result<Invite> {
-    #[cfg(feature = "utils")]
-        {
-            code = crate::utils::parse_invite(code);
-        }
-
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetInvite { code, stats },
-    })
-}
-
-/// Gets member of a guild.
-pub fn get_member(guild_id: u64, user_id: u64) -> Result<Member> {
-    let response = request(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetMember { guild_id, user_id },
-    })?;
-
-    let mut v = serde_json::from_reader::<ReqwestResponse, Value>(response)?;
-
-    if let Some(map) = v.as_object_mut() {
-        map.insert("guild_id".to_string(), Value::Number(Number::from(guild_id)));
-    }
-
-    serde_json::from_value::<Member>(v).map_err(From::from)
-}
-
-/// Gets a message by an Id, bots only.
-pub fn get_message(channel_id: u64, message_id: u64) -> Result<Message> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetMessage { channel_id, message_id },
-    })
-}
-
-/// Gets X messages from a channel.
-pub fn get_messages(channel_id: u64, query: &str) -> Result<Vec<Message>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetMessages {
-            query: query.to_owned(),
-            channel_id,
-        },
-    })
-}
-
-/// Gets all pins of a channel.
-pub fn get_pins(channel_id: u64) -> Result<Vec<Message>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetPins { channel_id },
-    })
-}
-
-/// Gets user Ids based on their reaction to a message. This endpoint is dumb.
-pub fn get_reaction_users(channel_id: u64,
-                          message_id: u64,
-                          reaction_type: &ReactionType,
-                          limit: u8,
-                          after: Option<u64>)
-                          -> Result<Vec<User>> {
-    let reaction = reaction_type.as_data();
-
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetReactionUsers {
-            after,
-            channel_id,
-            limit,
-            message_id,
-            reaction,
-        },
-    })
-}
-
-/// Gets the current unresolved incidents from Discord's Status API.
-///
-/// Does not require authentication.
-pub fn get_unresolved_incidents() -> Result<Vec<Incident>> {
-    let response = request(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetUnresolvedIncidents,
-    })?;
-
-    let mut map: BTreeMap<String, Value> = serde_json::from_reader(response)?;
-
-    match map.remove("incidents") {
-        Some(v) => serde_json::from_value::<Vec<Incident>>(v)
-            .map_err(From::from),
-        None => Ok(vec![]),
-    }
-}
-
-/// Gets the upcoming (planned) maintenances from Discord's Status API.
-///
-/// Does not require authentication.
-pub fn get_upcoming_maintenances() -> Result<Vec<Maintenance>> {
-    let response = request(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetUpcomingMaintenances,
-    })?;
-
-    let mut map: BTreeMap<String, Value> = serde_json::from_reader(response)?;
-
-    match map.remove("scheduled_maintenances") {
-        Some(v) => serde_json::from_value::<Vec<Maintenance>>(v)
-            .map_err(From::from),
-        None => Ok(vec![]),
-    }
-}
-
-/// Gets a user by Id.
-pub fn get_user(user_id: u64) -> Result<User> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetUser { user_id },
-    })
-}
-
-/// Gets our DM channels.
-pub fn get_user_dm_channels() -> Result<Vec<PrivateChannel>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetUserDmChannels,
-    })
-}
-
-/// Gets all voice regions.
-pub fn get_voice_regions() -> Result<Vec<VoiceRegion>> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetVoiceRegions,
-    })
-}
-
-/// Retrieves a webhook given its Id.
-///
-/// This method requires authentication, whereas [`get_webhook_with_token`] does
-/// not.
-///
-/// # Examples
-///
-/// Retrieve a webhook by Id:
-///
-/// ```rust,no_run
-/// use serenity::http;
-///
-/// let id = 245037420704169985;
-/// let webhook = http::get_webhook(id).expect("Error getting webhook");
-/// ```
-///
-/// [`get_webhook_with_token`]: fn.get_webhook_with_token.html
-pub fn get_webhook(webhook_id: u64) -> Result<Webhook> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetWebhook { webhook_id },
-    })
-}
-
-/// Retrieves a webhook given its Id and unique token.
-///
-/// This method does _not_ require authentication.
-///
-/// # Examples
-///
-/// Retrieve a webhook by Id and its unique token:
-///
-/// ```rust,no_run
-/// use serenity::http;
-///
-/// let id = 245037420704169985;
-/// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-///
-/// let webhook = http::get_webhook_with_token(id, token)
-///     .expect("Error getting webhook");
-/// ```
-pub fn get_webhook_with_token(webhook_id: u64, token: &str) -> Result<Webhook> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::GetWebhookWithToken { token, webhook_id },
-    })
-}
-
-/// Kicks a member from a guild.
-pub fn kick_member(guild_id: u64, user_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::KickMember { guild_id, user_id },
-    })
-}
-
-/// Leaves a group DM.
-pub fn leave_group(group_id: u64) -> Result<Group> {
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::LeaveGroup { group_id },
-    })
-}
-
-/// Leaves a guild.
-pub fn leave_guild(guild_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::LeaveGuild { guild_id },
-    })
-}
-
-/// Deletes a user from group DM.
-pub fn remove_group_recipient(group_id: u64, user_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::RemoveGroupRecipient { group_id, user_id },
-    })
-}
-
-/// Sends file(s) to a channel.
-///
-/// # Errors
-///
-/// Returns an
-/// [`HttpError::InvalidRequest(PayloadTooLarge)`][`HttpError::InvalidRequest`]
-/// if the file is too large to send.
-///
-/// [`HttpError::InvalidRequest`]: enum.HttpError.html#variant.InvalidRequest
-pub fn send_files<'a, T, It: IntoIterator<Item=T>>(channel_id: u64, files: It, map: JsonMap) -> Result<Message>
-    where T: Into<AttachmentType<'a>> {
-    let uri = api!("/channels/{}/messages", channel_id);
-    let url = match Url::parse(&uri) {
-        Ok(url) => url,
-        Err(_) => return Err(Error::Url(uri)),
-    };
-
-    let client = ReqwestClient::new()
-        .post(url)
-        .header(AUTHORIZATION, HeaderValue::from_str(&TOKEN.lock())?)
-        .header(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT));
-
-    let mut multipart = reqwest::multipart::Form::new();
-    let mut file_num = "0".to_string();
-
-    for file in files {
-
-        match file.into() {
-            AttachmentType::Bytes((bytes, filename)) => {
-                multipart = multipart
-                    .part(file_num.to_string(), Part::bytes(bytes.to_vec())
-                        .file_name(filename.to_string()));
+    /// Bans a [`User`] from a [`Guild`], removing their messages sent in the last
+    /// X number of days.
+    ///
+    /// Passing a `delete_message_days` of `0` is equivalent to not removing any
+    /// messages. Up to `7` days' worth of messages may be deleted.
+    ///
+    /// **Note**: Requires that you have the [Ban Members] permission.
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    /// [`User`]: ../../model/user/struct.User.html
+    /// [Ban Members]: ../../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    pub fn ban_user(&self, guild_id: u64, user_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GuildBanUser {
+                delete_message_days: Some(delete_message_days),
+                reason: Some(reason),
+                guild_id,
+                user_id,
             },
-            AttachmentType::File((file, filename)) => {
-                multipart = multipart
-                    .part(file_num.to_string(),
-                        Part::reader(file.try_clone()?)
-                            .file_name(filename.to_string()));
+        })
+    }
+
+    /// Ban zeyla from a [`Guild`], removing her messages sent in the last X number
+    /// of days.
+    ///
+    /// Passing a `delete_message_days` of `0` is equivalent to not removing any
+    /// messages. Up to `7` days' worth of messages may be deleted.
+    ///
+    /// **Note**: Requires that you have the [Ban Members] permission.
+    ///
+    /// [`Guild`]: ../model/guild/struct.Guild.html
+    /// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    pub fn ban_zeyla(&self, guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
+        self.ban_user(guild_id, 114_941_315_417_899_012, delete_message_days, reason)
+    }
+
+    /// Ban luna from a [`Guild`], removing her messages sent in the last X number
+    /// of days.
+    ///
+    /// Passing a `delete_message_days` of `0` is equivalent to not removing any
+    /// messages. Up to `7` days' worth of messages may be deleted.
+    ///
+    /// **Note**: Requires that you have the [Ban Members] permission.
+    ///
+    /// [`Guild`]: ../model/guild/struct.Guild.html
+    /// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    pub fn ban_luna(&self, guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
+        self.ban_user(guild_id, 180_731_582_049_550_336, delete_message_days, reason)
+    }
+
+    /// Ban the serenity servermoms from a [`Guild`], removing their messages
+    /// sent in the last X number of days.
+    ///
+    /// Passing a `delete_message_days` of `0` is equivalent to not removing any
+    /// messages. Up to `7` days' worth of messages may be deleted.
+    ///
+    /// **Note**: Requires that you have the [Ban Members] permission.
+    ///
+    /// [`Guild`]: ../model/guild/struct.Guild.html
+    /// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    pub fn ban_servermoms(&self, guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
+        self.ban_zeyla(guild_id, delete_message_days, reason)?;
+        self.ban_luna(guild_id, delete_message_days, reason)
+    }
+
+    /// Broadcasts that the current user is typing in the given [`Channel`].
+    ///
+    /// This lasts for about 10 seconds, and will then need to be renewed to
+    /// indicate that the current user is still typing.
+    ///
+    /// This should rarely be used for bots, although it is a good indicator that a
+    /// long-running command is still being processed.
+    ///
+    /// [`Channel`]: ../../model/channel/enum.Channel.html
+    pub fn broadcast_typing(&self, channel_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::BroadcastTyping { channel_id },
+        })
+    }
+
+    /// Creates a [`GuildChannel`] in the [`Guild`] given its Id.
+    ///
+    /// Refer to the Discord's [docs] for information on what fields this requires.
+    ///
+    /// **Note**: Requires the [Manage Channels] permission.
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    /// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
+    /// [docs]: https://discordapp.com/developers/docs/resources/guild#create-guild-channel
+    /// [Manage Channels]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
+    pub fn create_channel(&self, guild_id: u64, map: &Value) -> Result<GuildChannel> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::CreateChannel { guild_id },
+        })
+    }
+
+    /// Creates an emoji in the given [`Guild`] with the given data.
+    ///
+    /// View the source code for [`Guild`]'s [`create_emoji`] method to see what
+    /// fields this requires.
+    ///
+    /// **Note**: Requires the [Manage Emojis] permission.
+    ///
+    /// [`create_emoji`]: ../../model/guild/struct.Guild.html#method.create_emoji
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    /// [Manage Emojis]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
+    pub fn create_emoji(&self, guild_id: u64, map: &Value) -> Result<Emoji> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::CreateEmoji { guild_id },
+        })
+    }
+
+    /// Creates a guild with the data provided.
+    ///
+    /// Only a [`PartialGuild`] will be immediately returned, and a full [`Guild`]
+    /// will be received over a [`Shard`], if at least one is running.
+    ///
+    /// **Note**: This endpoint is currently limited to 10 active guilds. The
+    /// limits are raised for whitelisted [GameBridge] applications. See the
+    /// [documentation on this endpoint] for more info.
+    ///
+    /// # Examples
+    ///
+    /// Create a guild called `"test"` in the [US West region]:
+    ///
+    /// ```rust,ignore
+    /// extern crate serde_json;
+    ///
+    /// use serde_json::builder::ObjectBuilder;
+    /// use serde_json::Value;
+    /// use serenity::http;
+    ///
+    /// let map = ObjectBuilder::new()
+    ///     .insert("name", "test")
+    ///     .insert("region", "us-west")
+    ///     .build();
+    ///
+    /// let _result = http::create_guild(map);
+    /// ```
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    /// [`PartialGuild`]: ../../model/guild/struct.PartialGuild.html
+    /// [`Shard`]: ../../gateway/struct.Shard.html
+    /// [GameBridge]: https://discordapp.com/developers/docs/topics/gamebridge
+    /// [US West Region]: ../../model/guild/enum.Region.html#variant.UsWest
+    /// [documentation on this endpoint]:
+    /// https://discordapp.com/developers/docs/resources/guild#create-guild
+    /// [whitelist]: https://discordapp.com/developers/docs/resources/guild#create-guild
+    pub fn create_guild(&self, map: &Value) -> Result<PartialGuild> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::CreateGuild,
+        })
+    }
+
+    /// Creates an [`Integration`] for a [`Guild`].
+    ///
+    /// Refer to Discord's [docs] for field information.
+    ///
+    /// **Note**: Requires the [Manage Guild] permission.
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    /// [`Integration`]: ../../model/guild/struct.Integration.html
+    /// [Manage Guild]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    /// [docs]: https://discordapp.com/developers/docs/resources/guild#create-guild-integration
+    pub fn create_guild_integration(&self, guild_id: u64, integration_id: u64, map: &Value) -> Result<()> {
+        self.wind(204, Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::CreateGuildIntegration { guild_id, integration_id },
+        })
+    }
+
+    /// Creates a [`RichInvite`] for the given [channel][`GuildChannel`].
+    ///
+    /// Refer to Discord's [docs] for field information.
+    ///
+    /// All fields are optional.
+    ///
+    /// **Note**: Requires the [Create Invite] permission.
+    ///
+    /// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
+    /// [`RichInvite`]: ../../model/invite/struct.RichInvite.html
+    /// [Create Invite]: ../../model/permissions/struct.Permissions.html#associatedconstant.CREATE_INVITE
+    /// [docs]: https://discordapp.com/developers/docs/resources/channel#create-channel-invite
+    pub fn create_invite(&self, channel_id: u64, map: &JsonMap) -> Result<RichInvite> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::CreateInvite { channel_id },
+        })
+    }
+
+    /// Creates a permission override for a member or a role in a channel.
+    pub fn create_permission(&self, channel_id: u64, target_id: u64, map: &Value) -> Result<()> {
+        let body = serde_json::to_vec(map)?;
+
+        self.wind(204, Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::CreatePermission { channel_id, target_id },
+        })
+    }
+
+    /// Creates a private channel with a user.
+    pub fn create_private_channel(&self, map: &Value) -> Result<PrivateChannel> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::CreatePrivateChannel,
+        })
+    }
+
+    /// Reacts to a message.
+    pub fn create_reaction(&self,
+                        channel_id: u64,
+                        message_id: u64,
+                        reaction_type: &ReactionType)
+                        -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::CreateReaction {
+                reaction: &reaction_type.as_data(),
+                channel_id,
+                message_id,
             },
-            AttachmentType::Path(path) => {
-                multipart = multipart
-                    .file(file_num.to_string(), path)?;
+        })
+    }
+
+    /// Creates a role.
+    pub fn create_role(&self, guild_id: u64, map: &JsonMap) -> Result<Role> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::CreateRole {guild_id },
+        })
+    }
+
+    /// Creates a webhook for the given [channel][`GuildChannel`]'s Id, passing in
+    /// the given data.
+    ///
+    /// This method requires authentication.
+    ///
+    /// The Value is a map with the values of:
+    ///
+    /// - **avatar**: base64-encoded 128x128 image for the webhook's default avatar
+    ///   (_optional_);
+    /// - **name**: the name of the webhook, limited to between 2 and 100 characters
+    ///   long.
+    ///
+    /// # Examples
+    ///
+    /// Creating a webhook named `test`:
+    ///
+    /// ```rust,ignore
+    /// extern crate serde_json;
+    /// extern crate serenity;
+    ///
+    /// use serde_json::builder::ObjectBuilder;
+    /// use serenity::http;
+    ///
+    /// let channel_id = 81384788765712384;
+    /// let map = ObjectBuilder::new().insert("name", "test").build();
+    ///
+    /// let webhook = http::create_webhook(channel_id, map).expect("Error creating");
+    /// ```
+    ///
+    /// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
+    pub fn create_webhook(&self, channel_id: u64, map: &Value) -> Result<Webhook> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::CreateWebhook { channel_id },
+        })
+    }
+
+    /// Deletes a private channel or a channel in a guild.
+    pub fn delete_channel(&self, channel_id: u64) -> Result<Channel> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteChannel { channel_id },
+        })
+    }
+
+    /// Deletes an emoji from a server.
+    pub fn delete_emoji(&self, guild_id: u64, emoji_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteEmoji { guild_id, emoji_id },
+        })
+    }
+
+    /// Deletes a guild, only if connected account owns it.
+    pub fn delete_guild(&self, guild_id: u64) -> Result<PartialGuild> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteGuild { guild_id },
+        })
+    }
+
+    /// Removes an integration from a guild.
+    pub fn delete_guild_integration(&self, guild_id: u64, integration_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteGuildIntegration { guild_id, integration_id },
+        })
+    }
+
+    /// Deletes an invite by code.
+    pub fn delete_invite(&self, code: &str) -> Result<Invite> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteInvite { code },
+        })
+    }
+
+    /// Deletes a message if created by us or we have
+    /// specific permissions.
+    pub fn delete_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteMessage { channel_id, message_id },
+        })
+    }
+
+    /// Deletes a bunch of messages, only works for bots.
+    pub fn delete_messages(&self, channel_id: u64, map: &Value) -> Result<()> {
+        self.wind(204, Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::DeleteMessages { channel_id },
+        })
+    }
+
+    /// Deletes all of the [`Reaction`]s associated with a [`Message`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use serenity::http;
+    /// use serenity::model::id::{ChannelId, MessageId};
+    ///
+    /// let channel_id = ChannelId(7);
+    /// let message_id = MessageId(8);
+    ///
+    /// let _ = http::delete_message_reactions(channel_id.0, message_id.0)
+    ///     .expect("Error deleting reactions");
+    /// ```
+    ///
+    /// [`Message`]: ../../model/channel/struct.Message.html
+    /// [`Reaction`]: ../../model/channel/struct.Reaction.html
+    pub fn delete_message_reactions(&self, channel_id: u64, message_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteMessageReactions { channel_id, message_id },
+        })
+    }
+
+    /// Deletes a permission override from a role or a member in a channel.
+    pub fn delete_permission(&self, channel_id: u64, target_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeletePermission { channel_id, target_id },
+        })
+    }
+
+    /// Deletes a reaction from a message if owned by us or
+    /// we have specific permissions.
+    pub fn delete_reaction(&self,
+                        channel_id: u64,
+                        message_id: u64,
+                        user_id: Option<u64>,
+                        reaction_type: &ReactionType)
+                        -> Result<()> {
+        let user = user_id
+            .map(|uid| uid.to_string())
+            .unwrap_or_else(|| "@me".to_string());
+
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteReaction {
+                reaction: &reaction_type.as_data(),
+                user: &user,
+                channel_id,
+                message_id,
             },
-        }
-
-        unsafe {
-            let vec = file_num.as_mut_vec();
-            vec[0] += 1;
-        }
+        })
     }
 
-    for (k, v) in map {
-        match v {
-            Value::Bool(false) => multipart = multipart.text(k.clone(), "false"),
-            Value::Bool(true) => multipart = multipart.text(k.clone(), "true"),
-            Value::Number(inner) => multipart = multipart.text(k.clone(), inner.to_string()),
-            Value::String(inner) => multipart = multipart.text(k.clone(), inner),
-            Value::Object(inner) =>multipart =  multipart.text(k.clone(), serde_json::to_string(&inner)?),
-            _ => continue,
-        };
+    /// Deletes a role from a server. Can't remove the default everyone role.
+    pub fn delete_role(&self, guild_id: u64, role_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteRole { guild_id, role_id },
+        })
     }
 
-    let response = client.multipart(multipart).send()?;
-
-    if !response.status().is_success() {
-        return Err(HttpError::UnsuccessfulRequest(response).into());
+    /// Deletes a [`Webhook`] given its Id.
+    ///
+    /// This method requires authentication, whereas [`delete_webhook_with_token`]
+    /// does not.
+    ///
+    /// # Examples
+    ///
+    /// Deletes a webhook given its Id:
+    ///
+    /// ```rust,no_run
+    /// use serenity::http;
+    /// use std::env;
+    ///
+    /// // Due to the `delete_webhook` function requiring you to authenticate, you
+    /// // must have set the token first.
+    /// http::set_token(&env::var("DISCORD_TOKEN").unwrap());
+    ///
+    /// http::delete_webhook(245037420704169985).expect("Error deleting webhook");
+    /// ```
+    ///
+    /// [`Webhook`]: ../../model/webhook/struct.Webhook.html
+    /// [`delete_webhook_with_token`]: fn.delete_webhook_with_token.html
+    pub fn delete_webhook(&self, webhook_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteWebhook { webhook_id },
+        })
     }
 
-    serde_json::from_reader(response).map_err(From::from)
-}
-
-/// Sends a message to a channel.
-pub fn send_message(channel_id: u64, map: &Value) -> Result<Message> {
-    let body = serde_json::to_vec(map)?;
-
-    fire(Request {
-        body: Some(&body),
-        headers: None,
-        route: RouteInfo::CreateMessage { channel_id },
-    })
-}
-
-/// Pins a message in a channel.
-pub fn pin_message(channel_id: u64, message_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::PinMessage { channel_id, message_id },
-    })
-}
-
-/// Unbans a user from a guild.
-pub fn remove_ban(guild_id: u64, user_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::RemoveBan { guild_id, user_id },
-    })
-}
-
-/// Deletes a single [`Role`] from a [`Member`] in a [`Guild`].
-///
-/// **Note**: Requires the [Manage Roles] permission and respect of role
-/// hierarchy.
-///
-/// [`Guild`]: ../../model/guild/struct.Guild.html
-/// [`Member`]: ../../model/guild/struct.Member.html
-/// [`Role`]: ../../model/guild/struct.Role.html
-/// [Manage Roles]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-pub fn remove_member_role(guild_id: u64, user_id: u64, role_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::RemoveMemberRole { guild_id, user_id, role_id },
-    })
-}
-
-/// Starts removing some members from a guild based on the last time they've been online.
-pub fn start_guild_prune(guild_id: u64, map: &Value) -> Result<GuildPrune> {
-    // Note for 0.6.x: turn this into a function parameter.
-    #[derive(Deserialize)]
-    struct StartGuildPruneRequest {
-        days: u64,
+    /// Deletes a [`Webhook`] given its Id and unique token.
+    ///
+    /// This method does _not_ require authentication.
+    ///
+    /// # Examples
+    ///
+    /// Deletes a webhook given its Id and unique token:
+    ///
+    /// ```rust,no_run
+    /// use serenity::http;
+    ///
+    /// let id = 245037420704169985;
+    /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+    ///
+    /// http::delete_webhook_with_token(id, token).expect("Error deleting webhook");
+    /// ```
+    ///
+    /// [`Webhook`]: ../../model/webhook/struct.Webhook.html
+    pub fn delete_webhook_with_token(&self, webhook_id: u64, token: &str) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteWebhookWithToken { token, webhook_id },
+        })
     }
 
-    let req = serde_json::from_value::<StartGuildPruneRequest>(map.clone())?;
+    /// Changes channel information.
+    pub fn edit_channel(&self, channel_id: u64, map: &JsonMap) -> Result<GuildChannel> {
+        let body = serde_json::to_vec(map)?;
 
-    fire(Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::StartGuildPrune {
-            days: req.days,
-            guild_id,
-        },
-    })
-}
-
-/// Starts syncing an integration with a guild.
-pub fn start_integration_sync(guild_id: u64, integration_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::StartIntegrationSync { guild_id, integration_id },
-    })
-}
-
-/// Unpins a message from a channel.
-pub fn unpin_message(channel_id: u64, message_id: u64) -> Result<()> {
-    wind(204, Request {
-        body: None,
-        headers: None,
-        route: RouteInfo::UnpinMessage { channel_id, message_id },
-    })
-}
-
-/// Fires off a request, deserializing the response reader via the given type
-/// bound.
-///
-/// If you don't need to deserialize the response and want the response instance
-/// itself, use [`request`].
-///
-/// # Examples
-///
-/// Create a new message via the [`RouteInfo::CreateMessage`] endpoint and
-/// deserialize the response into a [`Message`]:
-///
-/// ```rust,no_run
-/// # extern crate serenity;
-/// #
-/// # use std::error::Error;
-/// #
-/// # fn try_main() -> Result<(), Box<Error>> {
-/// #
-/// use serenity::{
-///     http::{
-///         self,
-///         request::RequestBuilder,
-///         routing::RouteInfo,
-///     },
-///     model::channel::Message,
-/// };
-///
-/// let bytes = vec![
-///     // payload bytes here
-/// ];
-/// let channel_id = 381880193700069377;
-/// let route_info = RouteInfo::CreateMessage { channel_id };
-///
-/// let mut request = RequestBuilder::new(route_info);
-/// request.body(Some(&bytes));
-///
-/// let message = http::fire::<Message>(request.build())?;
-///
-/// println!("Message content: {}", message.content);
-/// #
-/// #     Ok(())
-/// # }
-/// #
-/// # fn main() {
-/// #     try_main().unwrap();
-/// # }
-/// ```
-///
-/// [`request`]: fn.request.html
-pub fn fire<T: DeserializeOwned>(req: Request) -> Result<T> {
-    let response = request(req)?;
-
-    serde_json::from_reader(response).map_err(From::from)
-}
-
-/// Performs a request, ratelimiting it if necessary.
-///
-/// Returns the raw reqwest Response. Use [`fire`] to deserialize the response
-/// into some type.
-///
-/// # Examples
-///
-/// Send a body of bytes over the [`RouteInfo::CreateMessage`] endpoint:
-///
-/// ```rust,no_run
-/// # extern crate serenity;
-/// #
-/// # use std::error::Error;
-/// #
-/// # fn try_main() -> Result<(), Box<Error>> {
-/// #
-/// use serenity::http::{
-///     self,
-///     request::RequestBuilder,
-///     routing::RouteInfo,
-/// };
-///
-/// let bytes = vec![
-///     // payload bytes here
-/// ];
-/// let channel_id = 381880193700069377;
-/// let route_info = RouteInfo::CreateMessage { channel_id };
-///
-/// let mut request = RequestBuilder::new(route_info);
-/// request.body(Some(&bytes));
-///
-/// let response = http::request(request.build())?;
-///
-/// println!("Response successful?: {}", response.status().is_success());
-/// #
-/// #     Ok(())
-/// # }
-/// #
-/// # fn main() {
-/// #     try_main().unwrap();
-/// # }
-/// ```
-///
-/// [`fire`]: fn.fire.html
-pub fn request(req: Request) -> Result<ReqwestResponse> {
-    let response = ratelimiting::perform(req)?;
-
-    if response.status().is_success() {
-        Ok(response)
-    } else {
-        Err(Error::Http(HttpError::UnsuccessfulRequest(response)))
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditChannel {channel_id },
+        })
     }
-}
 
-pub(super) fn retry(request: &Request) -> Result<ReqwestResponse> {
-    // Retry the request twice in a loop until it succeeds.
-    //
-    // If it doesn't and the loop breaks, try one last time.
-    for _ in 0..3 {
+    /// Changes emoji information.
+    pub fn edit_emoji(&self, guild_id: u64, emoji_id: u64, map: &Value) -> Result<Emoji> {
+        let body = serde_json::to_vec(map)?;
 
-        match request.build()?.send() {
-            Ok(response) => return Ok(response),
-            Err(reqwest_error) => {
-                if let Some(io_error) = reqwest_error.get_ref().and_then(|e| e.downcast_ref::<std::io::Error>()) {
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditEmoji { guild_id, emoji_id },
+        })
+    }
 
-                    if let IoErrorKind::ConnectionAborted = io_error.kind() {
-                        continue;
-                    }
+    /// Changes guild information.
+    pub fn edit_guild(&self, guild_id: u64, map: &JsonMap) -> Result<PartialGuild> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditGuild { guild_id },
+        })
+    }
+
+    /// Edits the positions of a guild's channels.
+    pub fn edit_guild_channel_positions(&self, guild_id: u64, value: &Value)
+                                        -> Result<()> {
+        let body = serde_json::to_vec(value)?;
+
+        self.wind(204, Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditGuildChannels { guild_id },
+        })
+    }
+
+    /// Edits a [`Guild`]'s embed setting.
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    pub fn edit_guild_embed(&self, guild_id: u64, map: &Value) -> Result<GuildEmbed> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditGuildEmbed { guild_id },
+        })
+    }
+
+    /// Does specific actions to a member.
+    pub fn edit_member(&self, guild_id: u64, user_id: u64, map: &JsonMap) -> Result<()> {
+        let body = serde_json::to_vec(map)?;
+
+        self.wind(204, Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditMember { guild_id, user_id },
+        })
+    }
+
+    /// Edits a message by Id.
+    ///
+    /// **Note**: Only the author of a message can modify it.
+    pub fn edit_message(&self, channel_id: u64, message_id: u64, map: &Value) -> Result<Message> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditMessage { channel_id, message_id },
+        })
+    }
+
+    /// Edits the current user's nickname for the provided [`Guild`] via its Id.
+    ///
+    /// Pass `None` to reset the nickname.
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    pub fn edit_nickname(&self, guild_id: u64, new_nickname: Option<&str>) -> Result<()> {
+        let map = json!({ "nick": new_nickname });
+        let body = serde_json::to_vec(&map)?;
+
+        self.wind(200, Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditNickname { guild_id },
+        })
+    }
+
+    /// Edits the current user's profile settings.
+    ///
+    /// For bot users, the password is optional.
+    ///
+    /// # User Accounts
+    ///
+    /// If a new token is received due to a password change, then the stored token
+    /// internally will be updated.
+    ///
+    /// **Note**: this token change may cause requests made between the actual token
+    /// change and when the token is internally changed to be invalid requests, as
+    /// the token may be outdated.
+    pub fn edit_profile(&self, map: &JsonMap) -> Result<CurrentUser> {
+        let body = serde_json::to_vec(map)?;
+
+        let response = self.request(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditProfile,
+        })?;
+
+        let mut value = serde_json::from_reader::<ReqwestResponse, Value>(response)?;
+
+        if let Some(map) = value.as_object_mut() {
+            if !TOKEN.lock().starts_with("Bot ") {
+                if let Some(Value::String(token)) = map.remove("token") {
+                    set_token(&token);
                 }
+            }
+        }
 
-                return Err(reqwest_error.into());
-            },
+        serde_json::from_value::<CurrentUser>(value).map_err(From::from)
+    }
+
+    /// Changes a role in a guild.
+    pub fn edit_role(&self, guild_id: u64, role_id: u64, map: &JsonMap) -> Result<Role> {
+        let body = serde_json::to_vec(&map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditRole { guild_id, role_id },
+        })
+    }
+
+    /// Changes the position of a role in a guild.
+    pub fn edit_role_position(&self, guild_id: u64, role_id: u64, position: u64) -> Result<Vec<Role>> {
+        let body = serde_json::to_vec(&json!({
+            "id": role_id,
+            "position": position,
+        }))?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditRole { guild_id, role_id },
+        })
+    }
+
+    /// Edits a the webhook with the given data.
+    ///
+    /// The Value is a map with optional values of:
+    ///
+    /// - **avatar**: base64-encoded 128x128 image for the webhook's default avatar
+    ///   (_optional_);
+    /// - **name**: the name of the webhook, limited to between 2 and 100 characters
+    ///   long.
+    ///
+    /// Note that, unlike with [`create_webhook`], _all_ values are optional.
+    ///
+    /// This method requires authentication, whereas [`edit_webhook_with_token`]
+    /// does not.
+    ///
+    /// # Examples
+    ///
+    /// Edit the image of a webhook given its Id and unique token:
+    ///
+    /// ```rust,ignore
+    /// extern crate serde_json;
+    /// extern crate serenity;
+    ///
+    /// use serde_json::builder::ObjectBuilder;
+    /// use serenity::http;
+    ///
+    /// let id = 245037420704169985;
+    /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+    /// let image = serenity::utils::read_image("./webhook_img.png")
+    ///     .expect("Error reading image");
+    /// let map = ObjectBuilder::new().insert("avatar", image).build();
+    ///
+    /// let edited = http::edit_webhook_with_token(id, token, map)
+    ///     .expect("Error editing webhook");
+    /// ```
+    ///
+    /// [`create_webhook`]: fn.create_webhook.html
+    /// [`edit_webhook_with_token`]: fn.edit_webhook_with_token.html
+    // The tests are ignored, rather than no_run'd, due to rustdoc tests with
+    // external crates being incredibly messy and misleading in the end user's view.
+    pub fn edit_webhook(&self, webhook_id: u64, map: &Value) -> Result<Webhook> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::EditWebhook { webhook_id },
+        })
+    }
+
+    /// Edits the webhook with the given data.
+    ///
+    /// Refer to the documentation for [`edit_webhook`] for more information.
+    ///
+    /// This method does _not_ require authentication.
+    ///
+    /// # Examples
+    ///
+    /// Edit the name of a webhook given its Id and unique token:
+    ///
+    /// ```rust,ignore
+    /// extern crate serde_json;
+    /// extern crate serenity;
+    ///
+    /// use serde_json::builder::ObjectBuilder;
+    /// use serenity::http;
+    ///
+    /// let id = 245037420704169985;
+    /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+    /// let map = ObjectBuilder::new().insert("name", "new name").build();
+    ///
+    /// let edited = http::edit_webhook_with_token(id, token, map)
+    ///     .expect("Error editing webhook");
+    /// ```
+    ///
+    /// [`edit_webhook`]: fn.edit_webhook.html
+    pub fn edit_webhook_with_token(&self, webhook_id: u64, token: &str, map: &JsonMap) -> Result<Webhook> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditWebhookWithToken { token, webhook_id },
+        })
+    }
+
+    /// Executes a webhook, posting a [`Message`] in the webhook's associated
+    /// [`Channel`].
+    ///
+    /// This method does _not_ require authentication.
+    ///
+    /// Pass `true` to `wait` to wait for server confirmation of the message sending
+    /// before receiving a response. From the [Discord docs]:
+    ///
+    /// > waits for server confirmation of message send before response, and returns
+    /// > the created message body (defaults to false; when false a message that is
+    /// > not saved does not return an error)
+    ///
+    /// The map can _optionally_ contain the following data:
+    ///
+    /// - `avatar_url`: Override the default avatar of the webhook with a URL.
+    /// - `tts`: Whether this is a text-to-speech message (defaults to `false`).
+    /// - `username`: Override the default username of the webhook.
+    ///
+    /// Additionally, _at least one_ of the following must be given:
+    ///
+    /// - `content`: The content of the message.
+    /// - `embeds`: An array of rich embeds.
+    ///
+    /// **Note**: For embed objects, all fields are registered by Discord except for
+    /// `height`, `provider`, `proxy_url`, `type` (it will always be `rich`),
+    /// `video`, and `width`. The rest will be determined by Discord.
+    ///
+    /// # Examples
+    ///
+    /// Sending a webhook with message content of `test`:
+    ///
+    /// ```rust,ignore
+    /// extern crate serde_json;
+    /// extern crate serenity;
+    ///
+    /// use serde_json::builder::ObjectBuilder;
+    /// use serenity::http;
+    ///
+    /// let id = 245037420704169985;
+    /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+    /// let map = ObjectBuilder::new().insert("content", "test").build();
+    ///
+    /// let message = match http::execute_webhook(id, token, true, map) {
+    ///     Ok(Some(message)) => message,
+    ///     Ok(None) => {
+    ///         println!("Expected a webhook message");
+    ///
+    ///         return;
+    ///     },
+    ///     Err(why) => {
+    ///         println!("Error executing webhook: {:?}", why);
+    ///
+    ///         return;
+    ///     },
+    /// };
+    /// ```
+    ///
+    /// [`Channel`]: ../../model/channel/enum.Channel.html
+    /// [`Message`]: ../../model/channel/struct.Message.html
+    /// [Discord docs]: https://discordapp.com/developers/docs/resources/webhook#querystring-params
+    pub fn execute_webhook(&self,
+                        webhook_id: u64,
+                        token: &str,
+                        wait: bool,
+                        map: &JsonMap)
+                        -> Result<Option<Message>> {
+        let body = serde_json::to_vec(map)?;
+
+        let mut headers = Headers::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
+
+        let response = self.request(Request {
+            body: Some(&body),
+            headers: Some(headers),
+            route: RouteInfo::ExecuteWebhook { token, wait, webhook_id },
+        })?;
+
+        if response.status() == StatusCode::NO_CONTENT {
+            return Ok(None);
+        }
+
+        serde_json::from_reader::<ReqwestResponse, Message>(response)
+            .map(Some)
+            .map_err(From::from)
+    }
+
+    /// Gets the active maintenances from Discord's Status API.
+    ///
+    /// Does not require authentication.
+    pub fn get_active_maintenances(&self) -> Result<Vec<Maintenance>> {
+        let response = self.request(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetActiveMaintenance,
+        })?;
+
+        let mut map: BTreeMap<String, Value> = serde_json::from_reader(response)?;
+
+        match map.remove("scheduled_maintenances") {
+            Some(v) => serde_json::from_value::<Vec<Maintenance>>(v)
+                .map_err(From::from),
+            None => Ok(vec![]),
         }
     }
 
-    request.build()
-        .map_err(Into::into)
-        .and_then(|b| Ok(b.send()?))
-}
-
-/// Performs a request and then verifies that the response status code is equal
-/// to the expected value.
-///
-/// This is a function that performs a light amount of work and returns an
-/// empty tuple, so it's called "wind" to denote that it's lightweight.
-pub(super) fn wind(expected: u16, req: Request) -> Result<()> {
-    let resp = request(req)?;
-
-    if resp.status().as_u16() == expected {
-        return Ok(());
+    /// Gets all the users that are banned in specific guild.
+    pub fn get_bans(&self, guild_id: u64) -> Result<Vec<Ban>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetBans { guild_id },
+        })
     }
 
-    debug!("Expected {}, got {}", expected, resp.status());
-    trace!("Unsuccessful response: {:?}", resp);
+    /// Gets all audit logs in a specific guild.
+    pub fn get_audit_logs(&self,
+                        guild_id: u64,
+                        action_type: Option<u8>,
+                        user_id: Option<u64>,
+                        before: Option<u64>,
+                        limit: Option<u8>) -> Result<AuditLogs> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetAuditLogs {
+                action_type,
+                before,
+                guild_id,
+                limit,
+                user_id,
+            },
+        })
+    }
 
-    Err(Error::Http(HttpError::UnsuccessfulRequest(resp)))
+    /// Gets current bot gateway.
+    pub fn get_bot_gateway(&self) -> Result<BotGateway> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetBotGateway,
+        })
+    }
+
+    /// Gets all invites for a channel.
+    pub fn get_channel_invites(&self, channel_id: u64) -> Result<Vec<RichInvite>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannelInvites { channel_id },
+        })
+    }
+
+    /// Retrieves the webhooks for the given [channel][`GuildChannel`]'s Id.
+    ///
+    /// This method requires authentication.
+    ///
+    /// # Examples
+    ///
+    /// Retrieve all of the webhooks owned by a channel:
+    ///
+    /// ```rust,no_run
+    /// use serenity::http;
+    ///
+    /// let channel_id = 81384788765712384;
+    ///
+    /// let webhooks = http::get_channel_webhooks(channel_id)
+    ///     .expect("Error getting channel webhooks");
+    /// ```
+    ///
+    /// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
+    pub fn get_channel_webhooks(&self, channel_id: u64) -> Result<Vec<Webhook>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannelWebhooks { channel_id },
+        })
+    }
+
+    /// Gets channel information.
+    pub fn get_channel(&self, channel_id: u64) -> Result<Channel> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannel { channel_id },
+        })
+    }
+
+    /// Gets all channels in a guild.
+    pub fn get_channels(&self, guild_id: u64) -> Result<Vec<GuildChannel>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannels { guild_id },
+        })
+    }
+
+    /// Gets information about the current application.
+    ///
+    /// **Note**: Only applications may use this endpoint.
+    pub fn get_current_application_info(&self) -> Result<CurrentApplicationInfo> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetCurrentApplicationInfo,
+        })
+    }
+
+    /// Gets information about the user we're connected with.
+    pub fn get_current_user(&self) -> Result<CurrentUser> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetCurrentUser,
+        })
+    }
+
+    /// Gets current gateway.
+    pub fn get_gateway(&self) -> Result<Gateway> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGateway,
+        })
+    }
+
+    /// Gets guild information.
+    pub fn get_guild(&self, guild_id: u64) -> Result<PartialGuild> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuild { guild_id },
+        })
+    }
+
+    /// Gets a guild embed information.
+    pub fn get_guild_embed(&self, guild_id: u64) -> Result<GuildEmbed> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildEmbed { guild_id },
+        })
+    }
+
+    /// Gets integrations that a guild has.
+    pub fn get_guild_integrations(&self, guild_id: u64) -> Result<Vec<Integration>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildIntegrations { guild_id },
+        })
+    }
+
+    /// Gets all invites to a guild.
+    pub fn get_guild_invites(&self, guild_id: u64) -> Result<Vec<RichInvite>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildInvites { guild_id },
+        })
+    }
+
+    /// Gets a guild's vanity URL if it has one.
+    pub fn get_guild_vanity_url(&self, guild_id: u64) -> Result<String> {
+        #[derive(Deserialize)]
+        struct GuildVanityUrl {
+            code: String,
+        }
+
+        let response = self.request(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildVanityUrl { guild_id },
+        })?;
+
+        serde_json::from_reader::<ReqwestResponse, GuildVanityUrl>(response)
+            .map(|x| x.code)
+            .map_err(From::from)
+    }
+
+    /// Gets the members of a guild. Optionally pass a `limit` and the Id of the
+    /// user to offset the result by.
+    pub fn get_guild_members(&self,
+                            guild_id: u64,
+                            limit: Option<u64>,
+                            after: Option<u64>)
+                            -> Result<Vec<Member>> {
+        let response = self.request(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildMembers { after, guild_id, limit },
+        })?;
+
+        let mut v = serde_json::from_reader::<ReqwestResponse, Value>(response)?;
+
+        if let Some(values) = v.as_array_mut() {
+            let num = Value::Number(Number::from(guild_id));
+
+            for value in values {
+                if let Some(element) = value.as_object_mut() {
+                    element.insert("guild_id".to_string(), num.clone());
+                }
+            }
+        }
+
+        serde_json::from_value::<Vec<Member>>(v).map_err(From::from)
+    }
+
+    /// Gets the amount of users that can be pruned.
+    pub fn get_guild_prune_count(&self, guild_id: u64, map: &Value) -> Result<GuildPrune> {
+        // Note for 0.6.x: turn this into a function parameter.
+        #[derive(Deserialize)]
+        struct GetGuildPruneCountRequest {
+            days: u64,
+        }
+
+        let req = serde_json::from_value::<GetGuildPruneCountRequest>(map.clone())?;
+
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildPruneCount {
+                days: req.days,
+                guild_id,
+            },
+        })
+    }
+
+    /// Gets regions that a guild can use. If a guild has the `VIP_REGIONS` feature
+    /// enabled, then additional VIP-only regions are returned.
+    pub fn get_guild_regions(&self, guild_id: u64) -> Result<Vec<VoiceRegion>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildRegions { guild_id },
+        })
+    }
+
+    /// Retrieves a list of roles in a [`Guild`].
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    pub fn get_guild_roles(&self, guild_id: u64) -> Result<Vec<Role>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildRoles { guild_id },
+        })
+    }
+
+    /// Retrieves the webhooks for the given [guild][`Guild`]'s Id.
+    ///
+    /// This method requires authentication.
+    ///
+    /// # Examples
+    ///
+    /// Retrieve all of the webhooks owned by a guild:
+    ///
+    /// ```rust,no_run
+    /// use serenity::http;
+    ///
+    /// let guild_id = 81384788765712384;
+    ///
+    /// let webhooks = http::get_guild_webhooks(guild_id)
+    ///     .expect("Error getting guild webhooks");
+    /// ```
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    pub fn get_guild_webhooks(&self, guild_id: u64) -> Result<Vec<Webhook>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildWebhooks { guild_id },
+        })
+    }
+
+    /// Gets a paginated list of the current user's guilds.
+    ///
+    /// The `limit` has a maximum value of 100.
+    ///
+    /// [Discord's documentation][docs]
+    ///
+    /// # Examples
+    ///
+    /// Get the first 10 guilds after a certain guild's Id:
+    ///
+    /// ```rust,no_run
+    /// use serenity::http::{GuildPagination, get_guilds};
+    /// use serenity::model::id::GuildId;
+    ///
+    /// let guild_id = GuildId(81384788765712384);
+    ///
+    /// let guilds = get_guilds(&GuildPagination::After(guild_id), 10).unwrap();
+    /// ```
+    ///
+    /// [docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds
+    pub fn get_guilds(&self, target: &GuildPagination, limit: u64) -> Result<Vec<GuildInfo>> {
+        let (after, before) = match *target {
+            GuildPagination::After(id) => (Some(id.0), None),
+            GuildPagination::Before(id) => (None, Some(id.0)),
+        };
+
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuilds { after, before, limit },
+        })
+    }
+
+    /// Gets information about a specific invite.
+    #[allow(clippy::unused_mut)]
+    pub fn get_invite(&self, mut code: &str, stats: bool) -> Result<Invite> {
+        #[cfg(feature = "utils")]
+            {
+                code = crate::utils::parse_invite(code);
+            }
+
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetInvite { code, stats },
+        })
+    }
+
+    /// Gets member of a guild.
+    pub fn get_member(&self, guild_id: u64, user_id: u64) -> Result<Member> {
+        let response = self.request(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetMember { guild_id, user_id },
+        })?;
+
+        let mut v = serde_json::from_reader::<ReqwestResponse, Value>(response)?;
+
+        if let Some(map) = v.as_object_mut() {
+            map.insert("guild_id".to_string(), Value::Number(Number::from(guild_id)));
+        }
+
+        serde_json::from_value::<Member>(v).map_err(From::from)
+    }
+
+    /// Gets a message by an Id, bots only.
+    pub fn get_message(&self, channel_id: u64, message_id: u64) -> Result<Message> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetMessage { channel_id, message_id },
+        })
+    }
+
+    /// Gets X messages from a channel.
+    pub fn get_messages(&self, channel_id: u64, query: &str) -> Result<Vec<Message>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetMessages {
+                query: query.to_owned(),
+                channel_id,
+            },
+        })
+    }
+
+    /// Gets all pins of a channel.
+    pub fn get_pins(&self, channel_id: u64) -> Result<Vec<Message>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetPins { channel_id },
+        })
+    }
+
+    /// Gets user Ids based on their reaction to a message. This endpoint is dumb.
+    pub fn get_reaction_users(&self,
+                            channel_id: u64,
+                            message_id: u64,
+                            reaction_type: &ReactionType,
+                            limit: u8,
+                            after: Option<u64>)
+                            -> Result<Vec<User>> {
+        let reaction = reaction_type.as_data();
+
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetReactionUsers {
+                after,
+                channel_id,
+                limit,
+                message_id,
+                reaction,
+            },
+        })
+    }
+
+    /// Gets the current unresolved incidents from Discord's Status API.
+    ///
+    /// Does not require authentication.
+    pub fn get_unresolved_incidents(&self) -> Result<Vec<Incident>> {
+        let response = self.request(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetUnresolvedIncidents,
+        })?;
+
+        let mut map: BTreeMap<String, Value> = serde_json::from_reader(response)?;
+
+        match map.remove("incidents") {
+            Some(v) => serde_json::from_value::<Vec<Incident>>(v)
+                .map_err(From::from),
+            None => Ok(vec![]),
+        }
+    }
+
+    /// Gets the upcoming (planned) maintenances from Discord's Status API.
+    ///
+    /// Does not require authentication.
+    pub fn get_upcoming_maintenances(&self) -> Result<Vec<Maintenance>> {
+        let response = self.request(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetUpcomingMaintenances,
+        })?;
+
+        let mut map: BTreeMap<String, Value> = serde_json::from_reader(response)?;
+
+        match map.remove("scheduled_maintenances") {
+            Some(v) => serde_json::from_value::<Vec<Maintenance>>(v)
+                .map_err(From::from),
+            None => Ok(vec![]),
+        }
+    }
+
+    /// Gets a user by Id.
+    pub fn get_user(&self, user_id: u64) -> Result<User> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetUser { user_id },
+        })
+    }
+
+    /// Gets our DM channels.
+    pub fn get_user_dm_channels(&self) -> Result<Vec<PrivateChannel>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetUserDmChannels,
+        })
+    }
+
+    /// Gets all voice regions.
+    pub fn get_voice_regions(&self) -> Result<Vec<VoiceRegion>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetVoiceRegions,
+        })
+    }
+
+    /// Retrieves a webhook given its Id.
+    ///
+    /// This method requires authentication, whereas [`get_webhook_with_token`] does
+    /// not.
+    ///
+    /// # Examples
+    ///
+    /// Retrieve a webhook by Id:
+    ///
+    /// ```rust,no_run
+    /// use serenity::http;
+    ///
+    /// let id = 245037420704169985;
+    /// let webhook = http::get_webhook(id).expect("Error getting webhook");
+    /// ```
+    ///
+    /// [`get_webhook_with_token`]: fn.get_webhook_with_token.html
+    pub fn get_webhook(&self, webhook_id: u64) -> Result<Webhook> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetWebhook { webhook_id },
+        })
+    }
+
+    /// Retrieves a webhook given its Id and unique token.
+    ///
+    /// This method does _not_ require authentication.
+    ///
+    /// # Examples
+    ///
+    /// Retrieve a webhook by Id and its unique token:
+    ///
+    /// ```rust,no_run
+    /// use serenity::http;
+    ///
+    /// let id = 245037420704169985;
+    /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+    ///
+    /// let webhook = http::get_webhook_with_token(id, token)
+    ///     .expect("Error getting webhook");
+    /// ```
+    pub fn get_webhook_with_token(&self, webhook_id: u64, token: &str) -> Result<Webhook> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetWebhookWithToken { token, webhook_id },
+        })
+    }
+
+    /// Kicks a member from a guild.
+    pub fn kick_member(&self, guild_id: u64, user_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::KickMember { guild_id, user_id },
+        })
+    }
+
+    /// Leaves a group DM.
+    pub fn leave_group(&self, group_id: u64) -> Result<Group> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::LeaveGroup { group_id },
+        })
+    }
+
+    /// Leaves a guild.
+    pub fn leave_guild(&self, guild_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::LeaveGuild { guild_id },
+        })
+    }
+
+    /// Deletes a user from group DM.
+    pub fn remove_group_recipient(&self, group_id: u64, user_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::RemoveGroupRecipient { group_id, user_id },
+        })
+    }
+
+    /// Sends file(s) to a channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an
+    /// [`HttpError::InvalidRequest(PayloadTooLarge)`][`HttpError::InvalidRequest`]
+    /// if the file is too large to send.
+    ///
+    /// [`HttpError::InvalidRequest`]: enum.HttpError.html#variant.InvalidRequest
+    pub fn send_files<'a, T, It: IntoIterator<Item=T>>(&self, channel_id: u64, files: It, map: JsonMap) -> Result<Message>
+        where T: Into<AttachmentType<'a>> {
+        let uri = api!("/channels/{}/messages", channel_id);
+        let url = match Url::parse(&uri) {
+            Ok(url) => url,
+            Err(_) => return Err(Error::Url(uri)),
+        };
+
+        let mut multipart = reqwest::multipart::Form::new();
+        let mut file_num = "0".to_string();
+
+        for file in files {
+
+            match file.into() {
+                AttachmentType::Bytes((bytes, filename)) => {
+                    multipart = multipart
+                        .part(file_num.to_string(), Part::bytes(bytes.to_vec())
+                            .file_name(filename.to_string()));
+                },
+                AttachmentType::File((file, filename)) => {
+                    multipart = multipart
+                        .part(file_num.to_string(),
+                            Part::reader(file.try_clone()?)
+                                .file_name(filename.to_string()));
+                },
+                AttachmentType::Path(path) => {
+                    multipart = multipart
+                        .file(file_num.to_string(), path)?;
+                },
+            }
+
+            unsafe {
+                let vec = file_num.as_mut_vec();
+                vec[0] += 1;
+            }
+        }
+
+        for (k, v) in map {
+            match v {
+                Value::Bool(false) => multipart = multipart.text(k.clone(), "false"),
+                Value::Bool(true) => multipart = multipart.text(k.clone(), "true"),
+                Value::Number(inner) => multipart = multipart.text(k.clone(), inner.to_string()),
+                Value::String(inner) => multipart = multipart.text(k.clone(), inner),
+                Value::Object(inner) =>multipart =  multipart.text(k.clone(), serde_json::to_string(&inner)?),
+                _ => continue,
+            };
+        }
+
+        let response = self.client
+            .post(url)
+            .header(AUTHORIZATION, HeaderValue::from_str(&TOKEN.lock())?)
+            .header(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT))
+            .multipart(multipart).send()?;
+
+        if !response.status().is_success() {
+            return Err(HttpError::UnsuccessfulRequest(response).into());
+        }
+
+        serde_json::from_reader(response).map_err(From::from)
+    }
+
+    /// Sends a message to a channel.
+    pub fn send_message(&self, channel_id: u64, map: &Value) -> Result<Message> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::CreateMessage { channel_id },
+        })
+    }
+
+    /// Pins a message in a channel.
+    pub fn pin_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::PinMessage { channel_id, message_id },
+        })
+    }
+
+    /// Unbans a user from a guild.
+    pub fn remove_ban(&self, guild_id: u64, user_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::RemoveBan { guild_id, user_id },
+        })
+    }
+
+    /// Deletes a single [`Role`] from a [`Member`] in a [`Guild`].
+    ///
+    /// **Note**: Requires the [Manage Roles] permission and respect of role
+    /// hierarchy.
+    ///
+    /// [`Guild`]: ../../model/guild/struct.Guild.html
+    /// [`Member`]: ../../model/guild/struct.Member.html
+    /// [`Role`]: ../../model/guild/struct.Role.html
+    /// [Manage Roles]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
+    pub fn remove_member_role(&self, guild_id: u64, user_id: u64, role_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::RemoveMemberRole { guild_id, user_id, role_id },
+        })
+    }
+
+    /// Starts removing some members from a guild based on the last time they've been online.
+    pub fn start_guild_prune(&self, guild_id: u64, map: &Value) -> Result<GuildPrune> {
+        // Note for 0.6.x: turn this into a function parameter.
+        #[derive(Deserialize)]
+        struct StartGuildPruneRequest {
+            days: u64,
+        }
+
+        let req = serde_json::from_value::<StartGuildPruneRequest>(map.clone())?;
+
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::StartGuildPrune {
+                days: req.days,
+                guild_id,
+            },
+        })
+    }
+
+    /// Starts syncing an integration with a guild.
+    pub fn start_integration_sync(&self, guild_id: u64, integration_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::StartIntegrationSync { guild_id, integration_id },
+        })
+    }
+
+    /// Unpins a message from a channel.
+    pub fn unpin_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::UnpinMessage { channel_id, message_id },
+        })
+    }
+
+    /// Fires off a request, deserializing the response reader via the given type
+    /// bound.
+    ///
+    /// If you don't need to deserialize the response and want the response instance
+    /// itself, use [`request`].
+    ///
+    /// # Examples
+    ///
+    /// Create a new message via the [`RouteInfo::CreateMessage`] endpoint and
+    /// deserialize the response into a [`Message`]:
+    ///
+    /// ```rust,no_run
+    /// # extern crate serenity;
+    /// #
+    /// # use std::error::Error;
+    /// #
+    /// # fn try_main() -> Result<(), Box<Error>> {
+    /// #
+    /// use serenity::{
+    ///  http.{
+    ///         self,
+    ///         request::RequestBuilder,
+    ///         routing::RouteInfo,
+    ///     },
+    ///     model::channel::Message,
+    /// };
+    ///
+    /// let bytes = vec![
+    ///     // payload bytes here
+    /// ];
+    /// let channel_id = 381880193700069377;
+    /// let route_info = RouteInfo::CreateMessage { channel_id };
+    ///
+    /// let mut request = RequestBuilder::new(route_info);
+    /// request.body(Some(&bytes));
+    ///
+    /// let message = http::fire::<Message>(request.build())?;
+    ///
+    /// println!("Message content: {}", message.content);
+    /// #
+    /// #     Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     try_main().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`request`]: fn.request.html
+    pub fn fire<T: DeserializeOwned>(&self, req: Request) -> Result<T> {
+        let response = self.request(req)?;
+
+        serde_json::from_reader(response).map_err(From::from)
+    }
+
+    /// Performs a request, ratelimiting it if necessary.
+    ///
+    /// Returns the raw reqwest Response. Use [`fire`] to deserialize the response
+    /// into some type.
+    ///
+    /// # Examples
+    ///
+    /// Send a body of bytes over the [`RouteInfo::CreateMessage`] endpoint:
+    ///
+    /// ```rust,no_run
+    /// # extern crate serenity;
+    /// #
+    /// # use std::error::Error;
+    /// #
+    /// # fn try_main() -> Result<(), Box<Error>> {
+    /// #
+    /// use serenity::http::{
+    ///     self,
+    ///     request::RequestBuilder,
+    ///     routing::RouteInfo,
+    /// };
+    ///
+    /// let bytes = vec![
+    ///     // payload bytes here
+    /// ];
+    /// let channel_id = 381880193700069377;
+    /// let route_info = RouteInfo::CreateMessage { channel_id };
+    ///
+    /// let mut request = RequestBuilder::new(route_info);
+    /// request.body(Some(&bytes));
+    ///
+    /// let response = http::request(request.build())?;
+    ///
+    /// println!("Response successful?: {}", response.status().is_success());
+    /// #
+    /// #     Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     try_main().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`fire`]: fn.fire.html
+    pub fn request(&self, req: Request) -> Result<ReqwestResponse> {
+        let response = ratelimiting::perform(&self, req)?;
+
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            Err(Error::Http(HttpError::UnsuccessfulRequest(response)))
+        }
+    }
+
+    pub(super) fn retry(&self, request: &Request) -> Result<ReqwestResponse> {
+        // Retry the request twice in a loop until it succeeds.
+        //
+        // If it doesn't and the loop breaks, try one last time.
+        for _ in 0..3 {
+
+            match request.build(&self.client)?.send() {
+                Ok(response) => return Ok(response),
+                Err(reqwest_error) => {
+                    if let Some(io_error) = reqwest_error.get_ref().and_then(|e| e.downcast_ref::<std::io::Error>()) {
+
+                        if let IoErrorKind::ConnectionAborted = io_error.kind() {
+                            continue;
+                        }
+                    }
+
+                    return Err(reqwest_error.into());
+                },
+            }
+        }
+
+        request.build(&self.client)
+            .map_err(Into::into)
+            .and_then(|b| Ok(b.send()?))
+    }
+
+    /// Performs a request and then verifies that the response status code is equal
+    /// to the expected value.
+    ///
+    /// This is a function that performs a light amount of work and returns an
+    /// empty tuple, so it's called "self.wind" to denote that it's lightweight.
+    pub(super) fn wind(&self, expected: u16, req: Request) -> Result<()> {
+        let resp = self.request(req)?;
+
+        if resp.status().as_u16() == expected {
+            return Ok(());
+        }
+
+        debug!("Expected {}, got {}", expected, resp.status());
+        trace!("Unsuccessful response: {:?}", resp);
+
+        Err(Error::Http(HttpError::UnsuccessfulRequest(resp)))
+    }
+
 }

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -30,10 +30,17 @@ pub struct Http {
 }
 
 impl Http {
-    pub fn new(client: Client, token: String) -> Self {
+    pub fn new(client: Client, token: &str) -> Self {
         Http {
             client,
-            token
+            token: token.to_string(),
+        }
+    }
+
+    pub fn new_with_token(token: &str) -> Self {
+        Http {
+            client: Client::builder().build().expect("Cannot build Reqwest::Client."),
+            token: token.to_string(),
         }
     }
 
@@ -207,14 +214,14 @@ impl Http {
     ///
     /// use serde_json::builder::ObjectBuilder;
     /// use serde_json::Value;
-    /// use serenity::http;
+    /// use serenity::http::Http;
     ///
     /// let map = ObjectBuilder::new()
     ///     .insert("name", "test")
     ///     .insert("region", "us-west")
     ///     .build();
     ///
-    /// let _result = http::create_guild(map);
+    /// let _result = http.create_guild(map);
     /// ```
     ///
     /// [`Guild`]: ../../model/guild/struct.Guild.html
@@ -344,12 +351,12 @@ impl Http {
     /// extern crate serenity;
     ///
     /// use serde_json::builder::ObjectBuilder;
-    /// use serenity::http;
+    /// use serenity::http::Http;
     ///
     /// let channel_id = 81384788765712384;
     /// let map = ObjectBuilder::new().insert("name", "test").build();
     ///
-    /// let webhook = http::create_webhook(channel_id, map).expect("Error creating");
+    /// let webhook = http.create_webhook(channel_id, map).expect("Error creating");
     /// ```
     ///
     /// [`GuildChannel`]: ../../model/channel/struct.GuildChannel.html
@@ -432,13 +439,18 @@ impl Http {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use serenity::http;
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// use serenity::model::id::{ChannelId, MessageId};
     ///
     /// let channel_id = ChannelId(7);
     /// let message_id = MessageId(8);
     ///
-    /// let _ = http::delete_message_reactions(channel_id.0, message_id.0)
+    /// let _ = http.delete_message_reactions(channel_id.0, message_id.0)
     ///     .expect("Error deleting reactions");
     /// ```
     ///
@@ -504,14 +516,14 @@ impl Http {
     /// Deletes a webhook given its Id:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
-    /// use std::env;
+    /// use serenity::http::Http;
+    /// use std::{env, sync::Arc};
     ///
     /// // Due to the `delete_webhook` function requiring you to authenticate, you
     /// // must have set the token first.
-    /// http::set_token(&env::var("DISCORD_TOKEN").unwrap());
+    /// let http = Arc::new(Http::default());
     ///
-    /// http::delete_webhook(245037420704169985).expect("Error deleting webhook");
+    /// http.delete_webhook(245037420704169985).expect("Error deleting webhook");
     /// ```
     ///
     /// [`Webhook`]: ../../model/webhook/struct.Webhook.html
@@ -533,12 +545,16 @@ impl Http {
     /// Deletes a webhook given its Id and unique token:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
-    ///
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// http::delete_webhook_with_token(id, token).expect("Error deleting webhook");
+    /// http.delete_webhook_with_token(id, token).expect("Error deleting webhook");
     /// ```
     ///
     /// [`Webhook`]: ../../model/webhook/struct.Webhook.html
@@ -711,7 +727,7 @@ impl Http {
     /// extern crate serenity;
     ///
     /// use serde_json::builder::ObjectBuilder;
-    /// use serenity::http;
+    /// use serenity::http::Http;
     ///
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
@@ -719,7 +735,7 @@ impl Http {
     ///     .expect("Error reading image");
     /// let map = ObjectBuilder::new().insert("avatar", image).build();
     ///
-    /// let edited = http::edit_webhook_with_token(id, token, map)
+    /// let edited = http.edit_webhook_with_token(id, token, map)
     ///     .expect("Error editing webhook");
     /// ```
     ///
@@ -750,13 +766,13 @@ impl Http {
     /// extern crate serenity;
     ///
     /// use serde_json::builder::ObjectBuilder;
-    /// use serenity::http;
+    /// use serenity::http::Http;
     ///
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let map = ObjectBuilder::new().insert("name", "new name").build();
     ///
-    /// let edited = http::edit_webhook_with_token(id, token, map)
+    /// let edited = http.edit_webhook_with_token(id, token, map)
     ///     .expect("Error editing webhook");
     /// ```
     ///
@@ -807,13 +823,13 @@ impl Http {
     /// extern crate serenity;
     ///
     /// use serde_json::builder::ObjectBuilder;
-    /// use serenity::http;
+    /// use serenity::http::Http;
     ///
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let map = ObjectBuilder::new().insert("content", "test").build();
     ///
-    /// let message = match http::execute_webhook(id, token, true, map) {
+    /// let message = match http.execute_webhook(id, token, true, map) {
     ///     Ok(Some(message)) => message,
     ///     Ok(None) => {
     ///         println!("Expected a webhook message");
@@ -932,11 +948,16 @@ impl Http {
     /// Retrieve all of the webhooks owned by a channel:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     ///
     /// let channel_id = 81384788765712384;
     ///
-    /// let webhooks = http::get_channel_webhooks(channel_id)
+    /// let webhooks = http.get_channel_webhooks(channel_id)
     ///     .expect("Error getting channel webhooks");
     /// ```
     ///
@@ -1128,11 +1149,15 @@ impl Http {
     /// Retrieve all of the webhooks owned by a guild:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
-    ///
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// let guild_id = 81384788765712384;
     ///
-    /// let webhooks = http::get_guild_webhooks(guild_id)
+    /// let webhooks = http.get_guild_webhooks(guild_id)
     ///     .expect("Error getting guild webhooks");
     /// ```
     ///
@@ -1156,12 +1181,17 @@ impl Http {
     /// Get the first 10 guilds after a certain guild's Id:
     ///
     /// ```rust,no_run
-    /// use serenity::http::{GuildPagination, get_guilds};
-    /// use serenity::model::id::GuildId;
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
+    /// use serenity::{http::GuildPagination, model::id::GuildId};
     ///
     /// let guild_id = GuildId(81384788765712384);
     ///
-    /// let guilds = get_guilds(&GuildPagination::After(guild_id), 10).unwrap();
+    /// let guilds = http.get_guilds(&GuildPagination::After(guild_id), 10).unwrap();
     /// ```
     ///
     /// [docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds
@@ -1338,10 +1368,15 @@ impl Http {
     /// Retrieve a webhook by Id:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     ///
     /// let id = 245037420704169985;
-    /// let webhook = http::get_webhook(id).expect("Error getting webhook");
+    /// let webhook = http.get_webhook(id).expect("Error getting webhook");
     /// ```
     ///
     /// [`get_webhook_with_token`]: fn.get_webhook_with_token.html
@@ -1362,12 +1397,16 @@ impl Http {
     /// Retrieve a webhook by Id and its unique token:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
-    ///
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let webhook = http::get_webhook_with_token(id, token)
+    /// let webhook = http.get_webhook_with_token(id, token)
     ///     .expect("Error getting webhook");
     /// ```
     pub fn get_webhook_with_token(&self, webhook_id: u64, token: &str) -> Result<Webhook> {
@@ -1586,11 +1625,16 @@ impl Http {
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// use serenity::{
-    ///  http.{
-    ///         self,
-    ///         request::RequestBuilder,
+    ///     http::{
     ///         routing::RouteInfo,
+    ///         request::RequestBuilder,
     ///     },
     ///     model::channel::Message,
     /// };
@@ -1604,7 +1648,7 @@ impl Http {
     /// let mut request = RequestBuilder::new(route_info);
     /// request.body(Some(&bytes));
     ///
-    /// let message = http::fire::<Message>(request.build())?;
+    /// let message = http.fire::<Message>(request.build())?;
     ///
     /// println!("Message content: {}", message.content);
     /// #
@@ -1635,10 +1679,11 @@ impl Http {
     /// ```rust,no_run
     /// # extern crate serenity;
     /// #
-    /// # use std::error::Error;
+    /// # use serenity::http::Http;
+    /// # use std::{error::Error, sync::Arc};
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #
+    /// # let http = Arc::new(Http::default());
     /// use serenity::http::{
     ///     self,
     ///     request::RequestBuilder,
@@ -1654,7 +1699,7 @@ impl Http {
     /// let mut request = RequestBuilder::new(route_info);
     /// request.body(Some(&bytes));
     ///
-    /// let response = http::request(request.build())?;
+    /// let response = http.request(request.build())?;
     ///
     /// println!("Response successful?: {}", response.status().is_success());
     /// #
@@ -1720,5 +1765,13 @@ impl Http {
 
         Err(Error::Http(HttpError::UnsuccessfulRequest(resp)))
     }
+}
 
+impl Default for Http {
+    fn default() -> Self {
+        Self {
+            client: Client::builder().build().expect("Cannot build Reqwest::Client."),
+            token: "".to_string(),
+        }
+    }
 }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -4,8 +4,8 @@ use reqwest::{
     header::{AUTHORIZATION, CONTENT_TYPE, USER_AGENT, HeaderMap as Headers, HeaderValue},
     Url,
 };
+use reqwest::Client as Http;
 use super::{
-    CLIENT,
     TOKEN,
     HttpError,
     routing::RouteInfo,
@@ -63,7 +63,7 @@ impl<'a> Request<'a> {
         Self { body, headers, route }
     }
 
-    pub fn build(&'a self) -> Result<ReqwestRequestBuilder, HttpError> {
+    pub fn build(&'a self, client: &Http) -> Result<ReqwestRequestBuilder, HttpError> {
         let Request {
             body,
             headers: ref request_headers,
@@ -72,7 +72,7 @@ impl<'a> Request<'a> {
 
         let (method, _, path) = route_info.deconstruct();
 
-        let mut builder = CLIENT.request(
+        let mut builder = client.request(
             method.reqwest_method(),
             Url::parse(&path)?,
         );

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -4,9 +4,8 @@ use reqwest::{
     header::{AUTHORIZATION, CONTENT_TYPE, USER_AGENT, HeaderMap as Headers, HeaderValue},
     Url,
 };
-use reqwest::Client as Http;
+use reqwest::Client;
 use super::{
-    TOKEN,
     HttpError,
     routing::RouteInfo,
 };
@@ -63,7 +62,7 @@ impl<'a> Request<'a> {
         Self { body, headers, route }
     }
 
-    pub fn build(&'a self, client: &Http) -> Result<ReqwestRequestBuilder, HttpError> {
+    pub fn build(&'a self, client: &Client, token: &str) -> Result<ReqwestRequestBuilder, HttpError> {
         let Request {
             body,
             headers: ref request_headers,
@@ -84,7 +83,7 @@ impl<'a> Request<'a> {
         let mut headers = Headers::with_capacity(3);
         headers.insert(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT));
         headers.insert(AUTHORIZATION,
-            HeaderValue::from_str(&TOKEN.lock()).map_err(|e| HttpError::InvalidHeader(e))?);
+            HeaderValue::from_str(&token).map_err(|e| HttpError::InvalidHeader(e))?);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
 
         if let Some(ref request_headers) = request_headers {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,14 +192,18 @@ pub use crate::client::Client;
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
 use parking_lot::RwLock;
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "client", feature = "cache"))]
 use std::{time::Duration, sync::Arc};
+#[cfg(all(feature = "client", feature = "http"))]
+use crate::http::Http;
 
-#[derive(Default)]
+#[cfg(feature = "client")]
 pub struct CacheAndHttp {
     #[cfg(feature = "cache")]
     pub cache: Arc<RwLock<Cache>>,
     #[cfg(feature = "cache")]
     pub update_cache_timeout: Option<Duration>,
+    #[cfg(feature = "http")]
+    pub http: Arc<Http>,
     __nonexhaustive: (),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ use std::{time::Duration, sync::Arc};
 use crate::http::Http;
 
 #[cfg(feature = "client")]
+#[derive(Default)]
 pub struct CacheAndHttp {
     #[cfg(feature = "cache")]
     pub cache: Arc<RwLock<Cache>>,

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -53,13 +53,13 @@ impl Attachment {
     /// struct Handler;
     ///
     /// impl EventHandler for Handler {
-    ///     fn message(&self, _: Context, mut message: Message) {
+    ///     fn message(&self, context: Context, mut message: Message) {
     ///         for attachment in message.attachments {
     ///             let content = match attachment.download() {
     ///                 Ok(content) => content,
     ///                 Err(why) => {
     ///                     println!("Error downloading attachment: {:?}", why);
-    ///                     let _ = message.channel_id.say("Error downloading attachment");
+    ///                     let _ = message.channel_id.say(&context.http, "Error downloading attachment");
     ///
     ///                     return;
     ///                 },
@@ -69,7 +69,7 @@ impl Attachment {
     ///                 Ok(file) => file,
     ///                 Err(why) => {
     ///                     println!("Error creating file: {:?}", why);
-    ///                     let _ = message.channel_id.say("Error creating file");
+    ///                     let _ = message.channel_id.say(&context.http, "Error creating file");
     ///
     ///                     return;
     ///                 },
@@ -81,7 +81,7 @@ impl Attachment {
     ///                 return;
     ///             }
     ///
-    ///             let _ = message.channel_id.say(&format!("Saved {:?}", attachment.filename));
+    ///             let _ = message.channel_id.say(&context.http, &format!("Saved {:?}", attachment.filename));
     ///         }
     ///     }
     ///

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -4,10 +4,10 @@ use crate::{model::prelude::*};
 use crate::client::Context;
 #[cfg(all(feature = "builder", feature = "model"))]
 use crate::builder::EditChannel;
-#[cfg(all(feature = "builder", feature = "model"))]
-use crate::http;
 #[cfg(all(feature = "model", feature = "utils"))]
 use crate::utils::{self as serenity_utils, VecMap};
+#[cfg(feature = "http")]
+use crate::http::Http;
 
 /// A category of [`GuildChannel`]s.
 ///
@@ -42,9 +42,10 @@ pub struct ChannelCategory {
 #[cfg(feature = "model")]
 impl ChannelCategory {
     /// Adds a permission overwrite to the category's channels.
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_permission(&self, target: &PermissionOverwrite) -> Result<()> {
-        self.id.create_permission(target)
+    pub fn create_permission(&self, http: &Arc<Http>, target: &PermissionOverwrite) -> Result<()> {
+        self.id.create_permission(&http, target)
     }
 
     /// Deletes all permission overrides in the category from the channels.
@@ -52,9 +53,10 @@ impl ChannelCategory {
     /// **Note**: Requires the [Manage Channel] permission.
     ///
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_permission(&self, permission_type: PermissionOverwriteType) -> Result<()> {
-        self.id.delete_permission(permission_type)
+    pub fn delete_permission(&self, http: &Arc<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
+        self.id.delete_permission(&http, permission_type)
     }
 
 
@@ -62,6 +64,7 @@ impl ChannelCategory {
     ///
     /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon
     /// owning the required permissions the HTTP-request will be issued.
+    #[cfg(feature = "http")]
     #[inline]
     pub fn delete(&self, context: &Context) -> Result<()> {
         #[cfg(feature = "cache")]
@@ -73,7 +76,7 @@ impl ChannelCategory {
             }
         }
 
-        self.id.delete().map(|_| ())
+        self.id.delete(&context.http).map(|_| ())
     }
 
     /// Modifies the category's settings, such as its position or name.
@@ -87,7 +90,7 @@ impl ChannelCategory {
     /// ```rust,ignore
     /// category.edit(|c| c.name("test").bitrate(86400));
     /// ```
-    #[cfg(all(feature = "builder", feature = "model", feature = "utils"))]
+    #[cfg(all(feature = "builder", feature = "model", feature = "utils", feature = "http"))]
     pub fn edit<F>(&mut self, context: &Context, f: F) -> Result<()>
         where F: FnOnce(EditChannel) -> EditChannel {
         #[cfg(feature = "cache")]
@@ -106,7 +109,7 @@ impl ChannelCategory {
 
         let map = serenity_utils::vecmap_to_json_map(f(EditChannel(map)).0);
 
-        http::edit_channel(self.id.0, &map).map(|channel| {
+        context.http.edit_channel(self.id.0, &map).map(|channel| {
             let GuildChannel {
                 id,
                 category_id,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -540,13 +540,19 @@ impl ChannelId {
     /// Send files with the paths `/path/to/file.jpg` and `/path/to/file2.jpg`:
     ///
     /// ```rust,no_run
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// use serenity::model::id::ChannelId;
     ///
     /// let channel_id = ChannelId(7);
     ///
     /// let paths = vec!["/path/to/file.jpg", "path/to/file2.jpg"];
     ///
-    /// let _ = channel_id.send_files(paths, |m| {
+    /// let _ = channel_id.send_files(&http, paths, |m| {
     ///     m.content("a file")
     /// });
     /// ```
@@ -554,6 +560,11 @@ impl ChannelId {
     /// Send files using `File`:
     ///
     /// ```rust,no_run
+    /// # extern crate serenity;
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// use serenity::model::id::ChannelId;
     /// use std::fs::File;
     ///
@@ -564,7 +575,7 @@ impl ChannelId {
     ///
     /// let files = vec![(&f1, "my_file.jpg"), (&f2, "my_file2.jpg")];
     ///
-    /// let _ = channel_id.send_files(files, |m| {
+    /// let _ = channel_id.send_files(&http, files, |m| {
     ///     m.content("a file")
     /// });
     /// ```

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -163,11 +163,12 @@ impl GuildChannel {
     /// # extern crate parking_lot;
     /// # extern crate serenity;
     /// #
-    /// # use serenity::{cache::Cache, model::id::{ChannelId, UserId}};
+    /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
     /// # use parking_lot::RwLock;
     /// # use std::{error::Error, sync::Arc};
     /// #
     /// # fn main() -> Result<(), Box<Error>> {
+    /// #     let http = Arc::new(Http::default());
     /// #     let cache = Arc::new(RwLock::new(Cache::default()));
     /// #     let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
@@ -189,7 +190,7 @@ impl GuildChannel {
     ///     .guild_channel(channel_id)
     ///     .ok_or(ModelError::ItemMissing)?;
     ///
-    /// channel.read().create_permission(&overwrite)?;
+    /// channel.read().create_permission(&http, &overwrite)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -202,12 +203,13 @@ impl GuildChannel {
     /// ```rust,no_run
     /// # extern crate parking_lot;
     /// # extern crate serenity;
-    ///
-    /// # use serenity::{cache::Cache, model::id::{ChannelId, UserId}};
+    /// #
+    /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
     /// # use parking_lot::RwLock;
     /// # use std::{error::Error, sync::Arc};
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
+    /// #   let http = Arc::new(Http::default());
     /// #   let cache = Arc::new(RwLock::new(Cache::default()));
     /// #   let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
@@ -230,7 +232,7 @@ impl GuildChannel {
     ///     .guild_channel(channel_id)
     ///     .ok_or(ModelError::ItemMissing)?;
     ///
-    /// channel.read().create_permission(&overwrite)?;
+    /// channel.read().create_permission(&http, &overwrite)?;
     /// #     Ok(())
     /// # }
     /// #
@@ -517,7 +519,7 @@ impl GuildChannel {
     ///             },
     ///         };
     ///
-    ///         let _ = msg.channel_id.send_files(vec![(&file, "cat.png")], |mut m| {
+    ///         let _ = msg.channel_id.send_files(&context.http, vec![(&file, "cat.png")], |mut m| {
     ///             m.content("here's a cat");
     ///
     ///             m

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -13,12 +13,11 @@ use std::sync::Arc;
 use crate::builder::{
     CreateInvite,
     CreateMessage,
-    EditChannel,
     EditMessage,
     GetMessages
 };
 #[cfg(feature = "model")]
-use crate::http::{self, AttachmentType};
+use crate::http::AttachmentType;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
@@ -27,10 +26,10 @@ use std::fmt::{
     Formatter,
     Result as FmtResult
 };
-#[cfg(feature = "model")]
-use std::mem;
 #[cfg(all(feature = "model", feature = "utils"))]
-use crate::utils::{self as serenity_utils, VecMap};
+use crate::utils::{self as serenity_utils};
+#[cfg(feature = "http")]
+use crate::http::Http;
 
 /// Represents a guild's text or voice channel. Some methods are available only
 /// for voice channels and some are only available for text channels.
@@ -113,7 +112,8 @@ impl GuildChannel {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    pub fn broadcast_typing(&self) -> Result<()> { self.id.broadcast_typing() }
+    #[cfg(feature = "http")]
+    pub fn broadcast_typing(&self, http: &Http) -> Result<()> { self.id.broadcast_typing(&http) }
 
     /// Creates an invite leading to the given channel.
     ///
@@ -124,7 +124,7 @@ impl GuildChannel {
     /// ```rust,ignore
     /// let invite = channel.create_invite(|i| i.max_uses(5));
     /// ```
-    #[cfg(feature = "utils")]
+    #[cfg(all(feature = "utils", feature = "http"))]
     pub fn create_invite<F>(&self, context: &Context, f: F) -> Result<RichInvite>
         where F: FnOnce(&mut CreateInvite) -> &mut CreateInvite {
         #[cfg(feature = "cache")]
@@ -141,7 +141,7 @@ impl GuildChannel {
 
         let map = serenity_utils::vecmap_to_json_map(invite.0);
 
-        http::create_invite(self.id.0, &map)
+        context.http.create_invite(self.id.0, &map)
     }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a
@@ -251,15 +251,17 @@ impl GuildChannel {
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     /// [Send TTS Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_TTS_MESSAGES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_permission(&self, target: &PermissionOverwrite) -> Result<()> {
-        self.id.create_permission(target)
+    pub fn create_permission(&self, http: &Arc<Http>, target: &PermissionOverwrite) -> Result<()> {
+        self.id.create_permission(&http, target)
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
     ///
     /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon
     /// owning the required permissions the HTTP-request will be issued.
+    #[cfg(feature = "http")]
     pub fn delete(&self, context: &Context) -> Result<Channel> {
         #[cfg(feature = "cache")]
         {
@@ -270,7 +272,7 @@ impl GuildChannel {
             }
         }
 
-        self.id.delete()
+        self.id.delete(&context.http)
     }
 
     /// Deletes all messages by Ids from the given vector in the channel.
@@ -290,9 +292,10 @@ impl GuildChannel {
     /// [`Channel::delete_messages`]: enum.Channel.html#method.delete_messages
     /// [`ModelError::BulkDeleteAmount`]: ../error/enum.Error.html#variant.BulkDeleteAmount
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, message_ids: It) -> Result<()> {
-        self.id.delete_messages(message_ids)
+    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: &Arc<Http>, message_ids: It) -> Result<()> {
+        self.id.delete_messages(&http, message_ids)
     }
 
     /// Deletes all permission overrides in the channel from a member
@@ -301,9 +304,10 @@ impl GuildChannel {
     /// **Note**: Requires the [Manage Channel] permission.
     ///
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_permission(&self, permission_type: PermissionOverwriteType) -> Result<()> {
-        self.id.delete_permission(permission_type)
+    pub fn delete_permission(&self, http: &Arc<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
+        self.id.delete_permission(&http, permission_type)
     }
 
     /// Deletes the given [`Reaction`] from the channel.
@@ -313,14 +317,16 @@ impl GuildChannel {
     ///
     /// [`Reaction`]: struct.Reaction.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
+    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction<M, R>(&self,
+                                 http: &Arc<Http>,
                                  message_id: M,
                                  user_id: Option<UserId>,
                                  reaction_type: R)
                                  -> Result<()>
         where M: Into<MessageId>, R: Into<ReactionType> {
-        self.id.delete_reaction(message_id, user_id, reaction_type)
+        self.id.delete_reaction(&http, message_id, user_id, reaction_type)
     }
 
     /// Modifies a channel's settings, such as its position or name.
@@ -334,7 +340,7 @@ impl GuildChannel {
     /// ```rust,ignore
     /// channel.edit(|c| c.name("test").bitrate(86400));
     /// ```
-    #[cfg(feature = "utils")]
+    #[cfg(all(feature = "utils", featue = "http"))]
     pub fn edit<F>(&mut self, context: &Context, f: F) -> Result<()>
         where F: FnOnce(EditChannel) -> EditChannel {
         #[cfg(feature = "cache")]
@@ -353,7 +359,7 @@ impl GuildChannel {
 
         let edited = serenity_utils::vecmap_to_json_map(f(EditChannel(map)).0);
 
-        match http::edit_channel(self.id.0, &edited) {
+        match context.http.edit_channel(self.id.0, &edited) {
             Ok(channel) => {
                 mem::replace(self, channel);
 
@@ -382,10 +388,11 @@ impl GuildChannel {
     /// [`EditMessage`]: ../../builder/struct.EditMessage.html
     /// [`Message`]: struct.Message.html
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_message<F, M>(&self, message_id: M, f: F) -> Result<Message>
+    pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(EditMessage) -> EditMessage, M: Into<MessageId> {
-        self.id.edit_message(message_id, f)
+        self.id.edit_message(&http, message_id, f)
     }
 
     /// Attempts to find this channel's guild in the Cache.
@@ -399,8 +406,9 @@ impl GuildChannel {
     ///
     /// Requires the [Manage Channels] permission.
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self) -> Result<Vec<RichInvite>> { self.id.invites() }
+    pub fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> { self.id.invites(&http) }
 
     /// Determines if the channel is NSFW.
     ///
@@ -419,9 +427,10 @@ impl GuildChannel {
     /// Requires the [Read Message History] permission.
     ///
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn message<M: Into<MessageId>>(&self, message_id: M) -> Result<Message> {
-        self.id.message(message_id)
+    pub fn message<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<Message> {
+        self.id.message(&http, message_id)
     }
 
     /// Gets messages from the channel.
@@ -433,9 +442,9 @@ impl GuildChannel {
     /// [`Channel::messages`]: enum.Channel.html#method.messages
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[inline]
-    pub fn messages<F>(&self, f: F) -> Result<Vec<Message>>
+    pub fn messages<F>(&self, http: &Arc<Http>, f: F) -> Result<Vec<Message>>
         where F: FnOnce(&mut GetMessages) -> &mut GetMessages {
-        self.id.messages(f)
+        self.id.messages(&http, f)
     }
 
     /// Returns the name of the guild channel.
@@ -550,12 +559,14 @@ impl GuildChannel {
     /// Pins a [`Message`] to the channel.
     ///
     /// [`Message`]: struct.Message.html
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn pin<M: Into<MessageId>>(&self, message_id: M) -> Result<()> { self.id.pin(message_id) }
+    pub fn pin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> { self.id.pin(&http, message_id) }
 
     /// Gets all channel's pins.
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn pins(&self) -> Result<Vec<Message>> { self.id.pins() }
+    pub fn pins(&self, http: &Http) -> Result<Vec<Message>> { self.id.pins(&http) }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a
     /// certain [`Emoji`].
@@ -569,8 +580,10 @@ impl GuildChannel {
     /// [`Message`]: struct.Message.html
     /// [`User`]: ../user/struct.User.html
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
+    #[cfg(feature = "http")]
     pub fn reaction_users<M, R, U>(
         &self,
+        http: &Arc<Http>,
         message_id: M,
         reaction_type: R,
         limit: Option<u8>,
@@ -578,7 +591,7 @@ impl GuildChannel {
     ) -> Result<Vec<User>> where M: Into<MessageId>,
                                  R: Into<ReactionType>,
                                  U: Into<Option<UserId>> {
-        self.id.reaction_users(message_id, reaction_type, limit, after)
+        self.id.reaction_users(&http, message_id, reaction_type, limit, after)
     }
 
     /// Sends a message with just the given message content in the channel.
@@ -591,8 +604,9 @@ impl GuildChannel {
     ///
     /// [`ChannelId`]: ../id/struct.ChannelId.html
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn say(&self, content: &str) -> Result<Message> { self.id.say(content) }
+    pub fn say(&self, http: &Arc<Http>, content: &str) -> Result<Message> { self.id.say(&http, content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///
@@ -612,11 +626,12 @@ impl GuildChannel {
     /// [`ClientError::MessageTooLong`]: ../../client/enum.ClientError.html#variant.MessageTooLong
     /// [Attach Files]: ../permissions/struct.Permissions.html#associatedconstant.ATTACH_FILES
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn send_files<'a, F, T, It>(&self, files: It, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It>(&self, http: &Arc<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b>,
               T: Into<AttachmentType<'a>>, It: IntoIterator<Item=T> {
-        self.id.send_files(files, f)
+        self.id.send_files(&http, files, f)
     }
 
     /// Sends a message to the channel with the given content.
@@ -638,6 +653,7 @@ impl GuildChannel {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     /// [`Message`]: struct.Message.html
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
+    #[cfg(feature = "http")]
     pub fn send_message<F>(&self, context: &Context, f: F) -> Result<Message>
     where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b> {
         #[cfg(feature = "cache")]
@@ -649,7 +665,7 @@ impl GuildChannel {
             }
         }
 
-        self.id.send_message(f)
+        self.id.send_message(&context.http, f)
     }
 
     /// Unpins a [`Message`] in the channel given by its Id.
@@ -658,9 +674,10 @@ impl GuildChannel {
     ///
     /// [`Message`]: struct.Message.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn unpin<M: Into<MessageId>>(&self, message_id: M) -> Result<()> {
-        self.id.unpin(message_id)
+    pub fn unpin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> {
+        self.id.unpin(&http, message_id)
     }
 
     /// Retrieves the channel's webhooks.
@@ -668,8 +685,9 @@ impl GuildChannel {
     /// **Note**: Requires the [Manage Webhooks] permission.
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn webhooks(&self) -> Result<Vec<Webhook>> { self.id.webhooks() }
+    pub fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -255,13 +255,13 @@ impl Channel {
     pub fn delete(&self, context: &Context) -> Result<()> {
         match *self {
             Channel::Group(ref group) => {
-                let _ = group.read().leave()?;
+                let _ = group.read().leave(&context.http)?;
             },
             Channel::Guild(ref public_channel) => {
                 let _ = public_channel.read().delete(&context)?;
             },
             Channel::Private(ref private_channel) => {
-                let _ = private_channel.read().delete()?;
+                let _ = private_channel.read().delete(&context.http)?;
             },
             Channel::Category(ref category) => {
                 category.read().delete(&context)?;

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -343,7 +343,7 @@ impl From<char> for ReactionType {
     /// # use serenity::{command, model::id::ChannelId};
     /// #
     /// # command!(example(context) {
-    /// #   let message = ChannelId(0).message(0)?;
+    /// #   let message = ChannelId(0).message(&context.http, 0)?;
     /// #
     /// message.react(&context, '🍎')?;
     /// # });

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -41,7 +41,7 @@ use super::Permissions;
 ///             return;
 ///         }
 ///
-///      match guild_id.ban(user, &8) {
+///      match guild_id.ban(&context.http, user, &8) {
 ///             Ok(()) => {
 ///                 // Ban successful.
 ///             },

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -69,12 +69,9 @@ impl Emoji {
     /// # extern crate parking_lot;
     /// # extern crate serenity;
     /// #
-    /// # use serenity::{cache::Cache, model::{guild::Emoji, id::EmojiId}};
-    /// # use parking_lot::RwLock;
-    /// # use std::sync::Arc;
+    /// # use serenity::{command, model::{guild::Emoji, id::EmojiId}};
     /// #
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
-    /// #
+    /// # command!(example(context) {
     /// # let mut emoji = Emoji {
     /// #     animated: false,
     /// #     id: EmojiId(7),
@@ -83,12 +80,12 @@ impl Emoji {
     /// #     require_colons: false,
     /// #     roles: vec![],
     /// # };
-    /// #
     /// // assuming emoji has been set already
-    /// match emoji.delete(&cache) {
+    /// match emoji.delete(&context) {
     ///     Ok(()) => println!("Emoji deleted."),
     ///     Err(_) => println!("Could not delete emoji.")
     /// }
+    /// # });
     /// ```
     #[cfg(all(feature = "cache", feature = "http"))]
     pub fn delete(&self, context: &Context) -> Result<()> {
@@ -123,7 +120,7 @@ impl Emoji {
     /// #     roles: vec![],
     /// # };
     /// // assuming emoji has been set already
-    /// let _ = emoji.edit(&context.cache, "blobuwu");
+    /// let _ = emoji.edit(&context, "blobuwu");
     /// assert_eq!(emoji.name, "blobuwu");
     /// # });
     /// ```

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -15,7 +15,9 @@ use super::super::ModelError;
 #[cfg(all(feature = "cache", feature = "model"))]
 use super::super::id::GuildId;
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::{cache::Cache, http};
+use crate::cache::Cache;
+#[cfg(all(feature = "cache", feature = "model", feature = "http"))]
+use crate::client::Context;
 #[cfg(all(feature = "cache", feature = "model"))]
 use parking_lot::RwLock;
 #[cfg(all(feature = "cache", feature = "model"))]
@@ -88,10 +90,10 @@ impl Emoji {
     ///     Err(_) => println!("Could not delete emoji.")
     /// }
     /// ```
-    #[cfg(feature = "cache")]
-    pub fn delete(&self, cache: &Arc<RwLock<Cache>>) -> Result<()> {
-        match self.find_guild_id(&cache) {
-            Some(guild_id) => http::delete_emoji(guild_id.0, self.id.0),
+    #[cfg(all(feature = "cache", feature = "http"))]
+    pub fn delete(&self, context: &Context) -> Result<()> {
+        match self.find_guild_id(&context.cache) {
+            Some(guild_id) => context.http.delete_emoji(guild_id.0, self.id.0),
             None => Err(Error::Model(ModelError::ItemMissing)),
         }
     }
@@ -125,15 +127,15 @@ impl Emoji {
     /// assert_eq!(emoji.name, "blobuwu");
     /// # });
     /// ```
-    #[cfg(feature = "cache")]
-    pub fn edit(&mut self, cache: &Arc<RwLock<Cache>>, name: &str) -> Result<()> {
-        match self.find_guild_id(&cache) {
+    #[cfg(all(feature = "cache", feature = "http"))]
+    pub fn edit(&mut self, context: &Context, name: &str) -> Result<()> {
+        match self.find_guild_id(&context.cache) {
             Some(guild_id) => {
                 let map = json!({
                     "name": name,
                 });
 
-                match http::edit_emoji(guild_id.0, self.id.0, &map) {
+                match context.http.edit_emoji(guild_id.0, self.id.0, &map) {
                     Ok(emoji) => {
                         mem::replace(self, emoji);
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -11,7 +11,9 @@ use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::guild::BanOptions;
 #[cfg(feature = "model")]
-use crate::{http, utils};
+use crate::utils;
+#[cfg(feature = "http")]
+use crate::http::Http;
 
 #[cfg(feature = "model")]
 impl GuildId {
@@ -42,13 +44,15 @@ impl GuildId {
     /// [`Guild::ban`]: ../guild/struct.Guild.html#method.ban
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn ban<U, BO>(&self, user: U, ban_options: &BO) -> Result<()>
+    pub fn ban<U, BO>(&self, http: &Arc<Http>, user: U, ban_options: &BO) -> Result<()>
         where U: Into<UserId>, BO: BanOptions {
-        self._ban(user.into(), (ban_options.dmd(), ban_options.reason()))
+        self._ban(&http, user.into(), (ban_options.dmd(), ban_options.reason()))
     }
 
-    fn _ban(self, user: UserId, ban_options: (u8, &str)) -> Result<()> {
+    #[cfg(feature = "http")]
+    fn _ban(self, http: &Arc<Http>, user: UserId, ban_options: (u8, &str)) -> Result<()> {
         let (dmd, reason) = ban_options;
 
         if dmd > 7 {
@@ -59,7 +63,7 @@ impl GuildId {
             return Err(Error::ExceededLimit(reason.to_string(), 512));
         }
 
-        http::ban_user(self.0, user.0, dmd, reason)
+        http.ban_user(self.0, user.0, dmd, reason)
     }
 
     /// Gets a list of the guild's bans.
@@ -67,25 +71,29 @@ impl GuildId {
     /// Requires the [Ban Members] permission.
     ///
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn bans(&self) -> Result<Vec<Ban>> { http::get_bans(self.0) }
+    pub fn bans(&self, http: &Http) -> Result<Vec<Ban>> { http.get_bans(self.0) }
 
     /// Gets a list of the guild's audit log entries
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn audit_logs(&self, action_type: Option<u8>,
+    pub fn audit_logs(&self, http: &Arc<Http>,
+                             action_type: Option<u8>,
                              user_id: Option<UserId>,
                              before: Option<AuditLogEntryId>,
                              limit: Option<u8>) -> Result<AuditLogs> {
-        http::get_audit_logs(self.0, action_type, user_id.map(|u| u.0), before.map(|a| a.0), limit)
+        http.get_audit_logs(self.0, action_type, user_id.map(|u| u.0), before.map(|a| a.0), limit)
     }
 
     /// Gets all of the guild's channels over the REST API.
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
-    pub fn channels(&self) -> Result<HashMap<ChannelId, GuildChannel>> {
+    #[cfg(feature = "http")]
+    pub fn channels(&self, http: &Http) -> Result<HashMap<ChannelId, GuildChannel>> {
         let mut channels = HashMap::new();
 
-        for channel in http::get_channels(self.0)? {
+        for channel in http.get_channels(self.0)? {
             channels.insert(channel.id, channel);
         }
 
@@ -112,14 +120,17 @@ impl GuildId {
     /// [`GuildChannel`]: ../channel/struct.GuildChannel.html
     /// [`http::create_channel`]: ../../http/fn.create_channel.html
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_channel<C>(&self, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
+    pub fn create_channel<C>(&self, http: &Arc<Http>, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
         where C: Into<Option<ChannelId>> {
-        self._create_channel(name, kind, category.into())
+        self._create_channel(&http, name, kind, category.into())
     }
 
+    #[cfg(feature = "http")]
     fn _create_channel(
         self,
+        http: &Arc<Http>,
         name: &str,
         kind: ChannelType,
         category: Option<ChannelId>,
@@ -130,7 +141,7 @@ impl GuildId {
             "parent_id": category.map(|c| c.0)
         });
 
-        http::create_channel(self.0, &map)
+        http.create_channel(self.0, &map)
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.
@@ -150,14 +161,15 @@ impl GuildId {
     /// [`Guild::create_emoji`]: ../guild/struct.Guild.html#method.create_emoji
     /// [`utils::read_image`]: ../../utils/fn.read_image.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_emoji(&self, name: &str, image: &str) -> Result<Emoji> {
+    pub fn create_emoji(&self, http: &Arc<Http>, name: &str, image: &str) -> Result<Emoji> {
         let map = json!({
             "name": name,
             "image": image,
         });
 
-        http::create_emoji(self.0, &map)
+        http.create_emoji(self.0, &map)
     }
 
     /// Creates an integration for the guild.
@@ -165,14 +177,17 @@ impl GuildId {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_integration<I>(&self, integration_id: I, kind: &str) -> Result<()>
+    pub fn create_integration<I>(&self, http: &Arc<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
-        self._create_integration(integration_id.into(), kind)
+        self._create_integration(&http, integration_id.into(), kind)
     }
 
+    #[cfg(feature = "http")]
     fn _create_integration(
         self,
+        http: &Arc<Http>,
         integration_id: IntegrationId,
         kind: &str,
     ) -> Result<()> {
@@ -181,7 +196,7 @@ impl GuildId {
             "type": kind,
         });
 
-        http::create_guild_integration(self.0, integration_id.0, &map)
+        http.create_guild_integration(self.0, integration_id.0, &map)
     }
 
     /// Creates a new role in the guild with the data set, if any.
@@ -192,17 +207,18 @@ impl GuildId {
     ///
     /// [`Guild::create_role`]: ../guild/struct.Guild.html#method.create_role
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_role<F>(&self, f: F) -> Result<Role>
+    pub fn create_role<F>(&self, http: &Arc<Http>, f: F) -> Result<Role>
     where F: FnOnce(&mut EditRole) -> &mut EditRole {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
         let map = utils::vecmap_to_json_map(edit_role.0);
 
-        let role = http::create_role(self.0, &map)?;
+        let role = http.create_role(self.0, &map)?;
 
         if let Some(position) = map.get("position").and_then(Value::as_u64) {
-            self.edit_role_position(role.id, position)?;
+            self.edit_role_position(&http, role.id, position)?;
         }
 
         Ok(role)
@@ -216,8 +232,9 @@ impl GuildId {
     /// **Note**: Requires the current user to be the owner of the guild.
     ///
     /// [`Guild::delete`]: ../guild/struct.Guild.html#method.delete
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete(&self) -> Result<PartialGuild> { http::delete_guild(self.0) }
+    pub fn delete(&self, http: &Http) -> Result<PartialGuild> { http.delete_guild(self.0) }
 
     /// Deletes an [`Emoji`] from the guild.
     ///
@@ -225,13 +242,15 @@ impl GuildId {
     ///
     /// [`Emoji`]: ../guild/struct.Emoji.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_emoji<E: Into<EmojiId>>(&self, emoji_id: E) -> Result<()> {
-        self._delete_emoji(emoji_id.into())
+    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E) -> Result<()> {
+        self._delete_emoji(&http, emoji_id.into())
     }
 
-    fn _delete_emoji(self, emoji_id: EmojiId) -> Result<()> {
-        http::delete_emoji(self.0, emoji_id.0)
+    #[cfg(feature = "http")]
+    fn _delete_emoji(self, http: &Arc<Http>, emoji_id: EmojiId) -> Result<()> {
+        http.delete_emoji(self.0, emoji_id.0)
     }
 
     /// Deletes an integration by Id from the guild.
@@ -239,13 +258,14 @@ impl GuildId {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_integration<I: Into<IntegrationId>>(&self, integration_id: I) -> Result<()> {
-        self._delete_integration(integration_id.into())
+    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+        self._delete_integration(&http, integration_id.into())
     }
 
-    fn _delete_integration(self, integration_id: IntegrationId) -> Result<()> {
-        http::delete_guild_integration(self.0, integration_id.0)
+    fn _delete_integration(self, http: &Arc<Http>, integration_id: IntegrationId) -> Result<()> {
+        http.delete_guild_integration(self.0, integration_id.0)
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -258,13 +278,15 @@ impl GuildId {
     /// [`Role`]: ../guild/struct.Role.html
     /// [`Role::delete`]: ../guild/struct.Role.html#method.delete
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_role<R: Into<RoleId>>(&self, role_id: R) -> Result<()> {
-        self._delete_role(role_id.into())
+    pub fn delete_role<R: Into<RoleId>>(&self, http: &Arc<Http>, role_id: R) -> Result<()> {
+        self._delete_role(&http, role_id.into())
     }
 
-    fn _delete_role(self, role_id: RoleId) -> Result<()> {
-        http::delete_role(self.0, role_id.0)
+    #[cfg(feature = "http")]
+    fn _delete_role(self, http: &Arc<Http>, role_id: RoleId) -> Result<()> {
+        http.delete_role(self.0, role_id.0)
     }
 
     /// Edits the current guild with new data where specified.
@@ -276,14 +298,15 @@ impl GuildId {
     ///
     /// [`Guild::edit`]: ../guild/struct.Guild.html#method.edit
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit<F>(&mut self, f: F) -> Result<PartialGuild>
+    pub fn edit<F>(&mut self, http: &Arc<Http>, f: F) -> Result<PartialGuild>
     where F: FnOnce(&mut EditGuild) -> &mut EditGuild{
         let mut edit_guild = EditGuild::default();
         f(&mut edit_guild);
         let map = utils::vecmap_to_json_map(edit_guild.0);
 
-        http::edit_guild(self.0, &map)
+        http.edit_guild(self.0, &map)
     }
 
     /// Edits an [`Emoji`]'s name in the guild.
@@ -296,17 +319,18 @@ impl GuildId {
     /// [`Emoji`]: ../guild/struct.Emoji.html
     /// [`Emoji::edit`]: ../guild/struct.Emoji.html#method.edit
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_emoji<E: Into<EmojiId>>(&self, emoji_id: E, name: &str) -> Result<Emoji> {
-        self._edit_emoji(emoji_id.into(), name)
+    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
+        self._edit_emoji(&http, emoji_id.into(), name)
     }
 
-    fn _edit_emoji(self, emoji_id: EmojiId, name: &str) -> Result<Emoji> {
+    fn _edit_emoji(self, http: &Arc<Http>, emoji_id: EmojiId, name: &str) -> Result<Emoji> {
         let map = json!({
             "name": name,
         });
 
-        http::edit_emoji(self.0, emoji_id.0, &map)
+        http.edit_emoji(self.0, emoji_id.0, &map)
     }
 
     /// Edits the properties of member of the guild, such as muting or
@@ -322,17 +346,19 @@ impl GuildId {
     /// ```rust,ignore
     /// guild.edit_member(user_id, |m| m.mute(true).roles(&vec![role_id]));
     /// ```
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_member<F, U>(&self, user_id: U, f: F) -> Result<()>
+    pub fn edit_member<F, U>(&self, http: &Arc<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
-        self._edit_member(user_id.into(), f)
+        self._edit_member(&http, user_id.into(), f)
     }
 
-    fn _edit_member<F>(self, user_id: UserId, f: F) -> Result<()>
+    #[cfg(feature = "http")]
+    fn _edit_member<F>(self, http: &Arc<Http>, user_id: UserId, f: F) -> Result<()>
         where F: FnOnce(EditMember) -> EditMember {
         let map = utils::vecmap_to_json_map(f(EditMember::default()).0);
 
-        http::edit_member(self.0, user_id.0, &map)
+        http.edit_member(self.0, user_id.0, &map)
     }
 
     /// Edits the current user's nickname for the guild.
@@ -342,9 +368,10 @@ impl GuildId {
     /// Requires the [Change Nickname] permission.
     ///
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_nickname(&self, new_nickname: Option<&str>) -> Result<()> {
-        http::edit_nickname(self.0, new_nickname)
+    pub fn edit_nickname(&self, http: &Arc<Http>, new_nickname: Option<&str>) -> Result<()> {
+        http.edit_nickname(self.0, new_nickname)
     }
 
     /// Edits a [`Role`], optionally setting its new fields.
@@ -363,17 +390,19 @@ impl GuildId {
     ///
     /// [`Role`]: ../guild/struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_role<F, R>(&self, role_id: R, f: F) -> Result<Role>
+    pub fn edit_role<F, R>(&self, http: &Arc<Http>, role_id: R, f: F) -> Result<Role>
         where F: FnOnce(EditRole) -> EditRole, R: Into<RoleId> {
-        self._edit_role(role_id.into(), f)
+        self._edit_role(&http, role_id.into(), f)
     }
 
-    fn _edit_role<F>(self, role_id: RoleId, f: F) -> Result<Role>
+    #[cfg(feature = "http")]
+    fn _edit_role<F>(self, http: &Arc<Http>, role_id: RoleId, f: F) -> Result<Role>
         where F: FnOnce(EditRole) -> EditRole {
         let map = utils::vecmap_to_json_map(f(EditRole::default()).0);
 
-        http::edit_role(self.0, role_id.0, &map)
+        http.edit_role(self.0, role_id.0, &map)
     }
 
     /// Edits the order of [`Role`]s
@@ -390,18 +419,21 @@ impl GuildId {
     ///
     /// [`Role`]: ../guild/struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_role_position<R>(&self, role_id: R, position: u64) -> Result<Vec<Role>>
+    pub fn edit_role_position<R>(&self, http: &Arc<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
         where R: Into<RoleId> {
-        self._edit_role_position(role_id.into(), position)
+        self._edit_role_position(&http, role_id.into(), position)
     }
 
+    #[cfg(feature = "http")]
     fn _edit_role_position(
         &self,
+        http: &Arc<Http>,
         role_id: RoleId,
         position: u64,
     ) -> Result<Vec<Role>> {
-        http::edit_role_position(self.0, role_id.0, position)
+        http.edit_role_position(self.0, role_id.0, position)
     }
 
     /// Tries to find the [`Guild`] by its Id in the cache.
@@ -418,22 +450,25 @@ impl GuildId {
     ///
     /// [`PartialGuild`]: ../guild/struct.PartialGuild.html
     /// [`Guild`]: ../guild/struct.Guild.html
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn to_partial_guild(self) -> Result<PartialGuild> { http::get_guild(self.0) }
+    pub fn to_partial_guild(self, http: &Http) -> Result<PartialGuild> { http.get_guild(self.0) }
 
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn integrations(&self) -> Result<Vec<Integration>> { http::get_guild_integrations(self.0) }
+    pub fn integrations(&self, http: &Http) -> Result<Vec<Integration>> { http.get_guild_integrations(self.0) }
 
     /// Gets all of the guild's invites.
     ///
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self) -> Result<Vec<RichInvite>> { http::get_guild_invites(self.0) }
+    pub fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> { http.get_guild_invites(self.0) }
 
     /// Kicks a [`Member`] from the guild.
     ///
@@ -441,14 +476,16 @@ impl GuildId {
     ///
     /// [`Member`]: ../guild/struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, user_id: U) -> Result<()> {
-        http::kick_member(self.0, user_id.into().0)
+    pub fn kick<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> {
+        http.kick_member(self.0, user_id.into().0)
     }
 
     /// Leaves the guild.
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn leave(&self) -> Result<()> { http::leave_guild(self.0) }
+    pub fn leave(&self, http: &Http) -> Result<()> { http.leave_guild(self.0) }
 
     /// Gets a user's [`Member`] for the guild by Id.
     ///
@@ -457,11 +494,13 @@ impl GuildId {
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     /// [`Member`]: ../guild/struct.Member.html
+    #[cfg(feature = "http")]
     #[inline]
     pub fn member<U: Into<UserId>>(&self, context: &Context, user_id: U) -> Result<Member> {
         self._member(&context, user_id.into())
     }
 
+    #[cfg(feature = "http")]
     fn _member(&self, context: &Context, user_id: UserId) -> Result<Member> {
         #[cfg(feature = "cache")]
         {
@@ -470,7 +509,7 @@ impl GuildId {
             }
         }
 
-        http::get_member(self.0, user_id.0)
+        context.http.get_member(self.0, user_id.0)
     }
 
     /// Gets a list of the guild's members.
@@ -480,14 +519,16 @@ impl GuildId {
     /// [`User`]'s Id.
     ///
     /// [`User`]: ../user/struct.User.html
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn members<U>(&self, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
+    pub fn members<U>(&self, http: &Arc<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
         where U: Into<UserId> {
-        self._members(limit, after.map(Into::into))
+        self._members(&http, limit, after.map(Into::into))
     }
 
-    fn _members(&self, limit: Option<u64>, after: Option<UserId>) -> Result<Vec<Member>> {
-        http::get_guild_members(self.0, limit, after.map(|x| x.0))
+    #[cfg(feature = "http")]
+    fn _members(&self, http: &Arc<Http>, limit: Option<u64>, after: Option<UserId>) -> Result<Vec<Member>> {
+        http.get_guild_members(self.0, limit, after.map(|x| x.0))
     }
 
     /// Moves a member to a specific voice channel.
@@ -495,14 +536,17 @@ impl GuildId {
     /// Requires the [Move Members] permission.
     ///
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn move_member<C, U>(&self, user_id: U, channel_id: C) -> Result<()>
+    pub fn move_member<C, U>(&self, http: &Arc<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
-        self._move_member(user_id.into(), channel_id.into())
+        self._move_member(&http, user_id.into(), channel_id.into())
     }
 
+    #[cfg(feature = "http")]
     fn _move_member(
         &self,
+        http: &Arc<Http>,
         user_id: UserId,
         channel_id: ChannelId,
     ) -> Result<()> {
@@ -512,7 +556,7 @@ impl GuildId {
             Value::Number(Number::from(channel_id.0)),
         );
 
-        http::edit_member(self.0, user_id.0, &map)
+        http.edit_member(self.0, user_id.0, &map)
     }
 
     /// Gets the number of [`Member`]s that would be pruned with the given
@@ -522,12 +566,13 @@ impl GuildId {
     ///
     /// [`Member`]: ../guild/struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
-    pub fn prune_count(&self, days: u16) -> Result<GuildPrune> {
+    #[cfg(feature = "http")]
+    pub fn prune_count(&self, http: &Arc<Http>, days: u16) -> Result<GuildPrune> {
         let map = json!({
             "days": days,
         });
 
-        http::get_guild_prune_count(self.0, &map)
+        http.get_guild_prune_count(self.0, &map)
     }
 
     /// Re-orders the channels of the guild.
@@ -539,18 +584,18 @@ impl GuildId {
     /// regardless of whether they were updated. Otherwise, positioning can
     /// sometimes get weird.
     #[inline]
-    pub fn reorder_channels<It>(&self, channels: It) -> Result<()>
+    pub fn reorder_channels<It>(&self, http: &Arc<Http>, channels: It) -> Result<()>
         where It: IntoIterator<Item = (ChannelId, u64)> {
-        self._reorder_channels(channels.into_iter().collect())
+        self._reorder_channels(&http, channels.into_iter().collect())
     }
 
-    fn _reorder_channels(&self, channels: Vec<(ChannelId, u64)>) -> Result<()> {
+    fn _reorder_channels(&self, http: &Arc<Http>, channels: Vec<(ChannelId, u64)>) -> Result<()> {
         let items = channels.into_iter().map(|(id, pos)| json!({
             "id": id,
             "position": pos,
         })).collect();
 
-        http::edit_guild_channel_positions(self.0, &Value::Array(items))
+        http.edit_guild_channel_positions(self.0, &Value::Array(items))
     }
 
     /// Returns the Id of the shard associated with the guild.
@@ -599,16 +644,19 @@ impl GuildId {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, integration_id: I) -> Result<()> {
-        self._start_integration_sync(integration_id.into())
+    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+        self._start_integration_sync(&http, integration_id.into())
     }
 
+    #[cfg(feature = "http")]
     fn _start_integration_sync(
         &self,
+        http: &Arc<Http>,
         integration_id: IntegrationId,
     ) -> Result<()> {
-        http::start_integration_sync(self.0, integration_id.0)
+        http.start_integration_sync(self.0, integration_id.0)
     }
 
     /// Starts a prune of [`Member`]s.
@@ -620,13 +668,14 @@ impl GuildId {
     /// [`GuildPrune`]: ../guild/struct.GuildPrune.html
     /// [`Member`]: ../guild/struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn start_prune(&self, days: u16) -> Result<GuildPrune> {
+    pub fn start_prune(&self, http: &Arc<Http>, days: u16) -> Result<GuildPrune> {
         let map = json!({
             "days": days,
         });
 
-        http::start_guild_prune(self.0, &map)
+        http.start_guild_prune(self.0, &map)
     }
 
     /// Unbans a [`User`] from the guild.
@@ -635,13 +684,15 @@ impl GuildId {
     ///
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn unban<U: Into<UserId>>(&self, user_id: U) -> Result<()> {
-        self._unban(user_id.into())
+    pub fn unban<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> {
+        self._unban(&http, user_id.into())
     }
 
-    fn _unban(self, user_id: UserId) -> Result<()> {
-        http::remove_ban(self.0, user_id.0)
+    #[cfg(feature = "http")]
+    fn _unban(self, http: &Arc<Http>, user_id: UserId) -> Result<()> {
+        http.remove_ban(self.0, user_id.0)
     }
 
     /// Retrieve's the guild's vanity URL.
@@ -649,9 +700,10 @@ impl GuildId {
     /// **Note**: Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn vanity_url(&self) -> Result<String> {
-        http::get_guild_vanity_url(self.0)
+    pub fn vanity_url(&self, http: &Http) -> Result<String> {
+        http.get_guild_vanity_url(self.0)
     }
 
     /// Retrieves the guild's webhooks.
@@ -660,7 +712,7 @@ impl GuildId {
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[inline]
-    pub fn webhooks(&self) -> Result<Vec<Webhook>> { http::get_guild_webhooks(self.0) }
+    pub fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> { http.get_guild_webhooks(self.0) }
 }
 
 impl From<PartialGuild> for GuildId {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -499,8 +499,8 @@ impl PartialGuild {
     /// struct Handler;
     ///
     /// impl EventHandler for Handler {
-    ///     fn message(&self, _: Context, msg: Message) {
-    ///         let guild = msg.guild_id.unwrap().to_partial_guild().unwrap();
+    ///     fn message(&self, context: Context, msg: Message) {
+    ///         let guild = msg.guild_id.unwrap().to_partial_guild(&context.http).unwrap();
     ///         let possible_role = guild.role_by_name("role_name");
     ///
     ///         if let Some(role) = possible_role {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -5,6 +5,8 @@ use super::super::utils::{deserialize_emojis, deserialize_roles};
 use crate::client::Context;
 #[cfg(feature = "model")]
 use crate::builder::{EditGuild, EditMember, EditRole};
+#[cfg(feature = "http")]
+use crate::http::Http;
 
 /// Partial information about a [`Guild`]. This does not include information
 /// like member data.
@@ -60,14 +62,15 @@ impl PartialGuild {
     /// [`ModelError::DeleteMessageDaysAmount`]: ../error/enum.Error.html#variant.DeleteMessageDaysAmount
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    pub fn ban<U: Into<UserId>>(&self, user: U, delete_message_days: u8) -> Result<()> {
+    #[cfg(feature = "http")]
+    pub fn ban<U: Into<UserId>>(&self, http: &Arc<Http>, user: U, delete_message_days: u8) -> Result<()> {
         if delete_message_days > 7 {
             return Err(Error::Model(
                 ModelError::DeleteMessageDaysAmount(delete_message_days),
             ));
         }
 
-        self.id.ban(user, &delete_message_days)
+        self.id.ban(&http, user, &delete_message_days)
     }
 
     /// Gets a list of the guild's bans.
@@ -75,14 +78,16 @@ impl PartialGuild {
     /// Requires the [Ban Members] permission.
     ///
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn bans(&self) -> Result<Vec<Ban>> { self.id.bans() }
+    pub fn bans(&self, http: &Http) -> Result<Vec<Ban>> { self.id.bans(&http) }
 
     /// Gets all of the guild's channels over the REST API.
     ///
     /// [`Guild`]: struct.Guild.html
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn channels(&self) -> Result<HashMap<ChannelId, GuildChannel>> { self.id.channels() }
+    pub fn channels(&self, http: &Http) -> Result<HashMap<ChannelId, GuildChannel>> { self.id.channels(&http) }
 
     /// Creates a [`GuildChannel`] in the guild.
     ///
@@ -103,10 +108,11 @@ impl PartialGuild {
     /// [`GuildChannel`]: ../channel/struct.GuildChannel.html
     /// [`http::create_channel`]: ../../http/fn.create_channel.html
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_channel<C>(&self, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
+    pub fn create_channel<C>(&self, http: &Arc<Http>, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
         where C: Into<Option<ChannelId>> {
-        self.id.create_channel(name, kind, category)
+        self.id.create_channel(&http, name, kind, category)
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.
@@ -126,9 +132,10 @@ impl PartialGuild {
     /// [`Guild::create_emoji`]: struct.Guild.html#method.create_emoji
     /// [`utils::read_image`]: ../../utils/fn.read_image.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_emoji(&self, name: &str, image: &str) -> Result<Emoji> {
-        self.id.create_emoji(name, image)
+    pub fn create_emoji(&self, http: &Arc<Http>, name: &str, image: &str) -> Result<Emoji> {
+        self.id.create_emoji(&http, name, image)
     }
 
     /// Creates an integration for the guild.
@@ -136,10 +143,11 @@ impl PartialGuild {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_integration<I>(&self, integration_id: I, kind: &str) -> Result<()>
+    pub fn create_integration<I>(&self, http: &Arc<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
-        self.id.create_integration(integration_id, kind)
+        self.id.create_integration(&http, integration_id, kind)
     }
 
     /// Creates a new role in the guild with the data set, if any.
@@ -156,18 +164,20 @@ impl PartialGuild {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`Guild::create_role`]: struct.Guild.html#method.create_role
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn create_role<F>(&self, f: F) -> Result<Role>
+    pub fn create_role<F>(&self, http: &Arc<Http>, f: F) -> Result<Role>
     where F: FnOnce(&mut EditRole) -> &mut EditRole {
-        self.id.create_role(f)
+        self.id.create_role(&http, f)
     }
 
     /// Deletes the current guild if the current user is the owner of the
     /// guild.
     ///
     /// **Note**: Requires the current user to be the owner of the guild.
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete(&self) -> Result<PartialGuild> { self.id.delete() }
+    pub fn delete(&self, http: &Http) -> Result<PartialGuild> { self.id.delete(&http) }
 
     /// Deletes an [`Emoji`] from the guild.
     ///
@@ -175,9 +185,10 @@ impl PartialGuild {
     ///
     /// [`Emoji`]: struct.Emoji.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_emoji<E: Into<EmojiId>>(&self, emoji_id: E) -> Result<()> {
-        self.id.delete_emoji(emoji_id)
+    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E) -> Result<()> {
+        self.id.delete_emoji(&http, emoji_id)
     }
 
     /// Deletes an integration by Id from the guild.
@@ -186,8 +197,8 @@ impl PartialGuild {
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[inline]
-    pub fn delete_integration<I: Into<IntegrationId>>(&self, integration_id: I) -> Result<()> {
-        self.id.delete_integration(integration_id)
+    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+        self.id.delete_integration(&http, integration_id)
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -201,8 +212,8 @@ impl PartialGuild {
     /// [`Role::delete`]: struct.Role.html#method.delete
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[inline]
-    pub fn delete_role<R: Into<RoleId>>(&self, role_id: R) -> Result<()> {
-        self.id.delete_role(role_id)
+    pub fn delete_role<R: Into<RoleId>>(&self, http: &Arc<Http>, role_id: R) -> Result<()> {
+        self.id.delete_role(&http, role_id)
     }
 
     /// Edits the current guild with new data where specified.
@@ -211,9 +222,10 @@ impl PartialGuild {
     /// permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    pub fn edit<F>(&mut self, f: F) -> Result<()>
+    #[cfg(feature = "http")]
+    pub fn edit<F>(&mut self, http: &Arc<Http>, f: F) -> Result<()>
         where F: FnOnce(&mut EditGuild) -> &mut EditGuild {
-        match self.id.edit(f) {
+        match self.id.edit(&http, f) {
             Ok(guild) => {
                 self.afk_channel_id = guild.afk_channel_id;
                 self.afk_timeout = guild.afk_timeout;
@@ -246,9 +258,10 @@ impl PartialGuild {
     /// [`Emoji::edit`]: struct.Emoji.html#method.edit
     /// [Manage Emojis]:
     /// ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_emoji<E: Into<EmojiId>>(&self, emoji_id: E, name: &str) -> Result<Emoji> {
-        self.id.edit_emoji(emoji_id, name)
+    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
+        self.id.edit_emoji(&http, emoji_id, name)
     }
 
     /// Edits the properties of member of the guild, such as muting or
@@ -266,10 +279,11 @@ impl PartialGuild {
     ///
     /// GuildId(7).edit_member(user_id, |m| m.mute(true).roles(&vec![role_id]));
     /// ```
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_member<F, U>(&self, user_id: U, f: F) -> Result<()>
+    pub fn edit_member<F, U>(&self, http: &Arc<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
-        self.id.edit_member(user_id, f)
+        self.id.edit_member(&http, user_id, f)
     }
 
     /// Edits the current user's nickname for the guild.
@@ -286,16 +300,20 @@ impl PartialGuild {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_nickname(&self, new_nickname: Option<&str>) -> Result<()> {
-        self.id.edit_nickname(new_nickname)
+    pub fn edit_nickname(&self, http: &Arc<Http>, new_nickname: Option<&str>) -> Result<()> {
+        self.id.edit_nickname(&http, new_nickname)
     }
 
     /// Gets a partial amount of guild data by its Id.
     ///
     /// Requires that the current user be in the guild.
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn get<G: Into<GuildId>>(guild_id: G) -> Result<PartialGuild> { guild_id.into().to_partial_guild() }
+    pub fn get<G: Into<GuildId>>(http: &Arc<Http>, guild_id: G) -> Result<PartialGuild> {
+        guild_id.into().to_partial_guild(&http)
+    }
 
     /// Kicks a [`Member`] from the guild.
     ///
@@ -303,8 +321,9 @@ impl PartialGuild {
     ///
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, user_id: U) -> Result<()> { self.id.kick(user_id) }
+    pub fn kick<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> { self.id.kick(&http, user_id) }
 
     /// Returns a formatted URL of the guild's icon, if the guild has an icon.
     pub fn icon_url(&self) -> Option<String> {
@@ -316,20 +335,23 @@ impl PartialGuild {
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn integrations(&self) -> Result<Vec<Integration>> { self.id.integrations() }
+    pub fn integrations(&self, http: &Http) -> Result<Vec<Integration>> { self.id.integrations(&http) }
 
     /// Gets all of the guild's invites.
     ///
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self) -> Result<Vec<RichInvite>> { self.id.invites() }
+    pub fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> { self.id.invites(&http) }
 
     /// Leaves the guild.
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn leave(&self) -> Result<()> { self.id.leave() }
+    pub fn leave(&self, http: &Http) -> Result<()> { self.id.leave(&http) }
 
     /// Gets a user's [`Member`] for the guild by Id.
     ///
@@ -346,9 +368,10 @@ impl PartialGuild {
     /// [`User`]'s Id.
     ///
     /// [`User`]: ../user/struct.User.html
-    pub fn members<U>(&self, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
+    #[cfg(feature = "http")]
+    pub fn members<U>(&self, http: &Arc<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
         where U: Into<UserId> {
-        self.id.members(limit, after)
+        self.id.members(&http, limit, after)
     }
 
     /// Moves a member to a specific voice channel.
@@ -357,9 +380,10 @@ impl PartialGuild {
     ///
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
     #[inline]
-    pub fn move_member<C, U>(&self, user_id: U, channel_id: C) -> Result<()>
+    #[cfg(feature = "http")]
+    pub fn move_member<C, U>(&self, http: &Arc<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
-        self.id.move_member(user_id, channel_id)
+        self.id.move_member(&http, user_id, channel_id)
     }
 
     /// Gets the number of [`Member`]s that would be pruned with the given
@@ -370,7 +394,8 @@ impl PartialGuild {
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[inline]
-    pub fn prune_count(&self, days: u16) -> Result<GuildPrune> { self.id.prune_count(days) }
+    #[cfg(feature = "http")]
+    pub fn prune_count(&self, http: &Arc<Http>, days: u16) -> Result<GuildPrune> { self.id.prune_count(&http, days) }
 
     /// Returns the Id of the shard associated with the guild.
     ///
@@ -422,9 +447,10 @@ impl PartialGuild {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, integration_id: I) -> Result<()> {
-        self.id.start_integration_sync(integration_id)
+    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+        self.id.start_integration_sync(&http, integration_id)
     }
 
     /// Unbans a [`User`] from the guild.
@@ -433,17 +459,19 @@ impl PartialGuild {
     ///
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn unban<U: Into<UserId>>(&self, user_id: U) -> Result<()> { self.id.unban(user_id) }
+    pub fn unban<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> { self.id.unban(&http, user_id) }
 
     /// Retrieve's the guild's vanity URL.
     ///
     /// **Note**: Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn vanity_url(&self) -> Result<String> {
-        self.id.vanity_url()
+    pub fn vanity_url(&self, http: &Http) -> Result<String> {
+        self.id.vanity_url(&http)
     }
 
     /// Retrieves the guild's webhooks.
@@ -451,8 +479,9 @@ impl PartialGuild {
     /// **Note**: Requires the [Manage Webhooks] permission.
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
+    #[cfg(feature = "http")]
     #[inline]
-    pub fn webhooks(&self) -> Result<Vec<Webhook>> { self.id.webhooks() }
+    pub fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
 
     /// Obtain a reference to a role by its name.
     ///

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -5,8 +5,10 @@ use std::cmp::Ordering;
 use crate::builder::EditRole;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
-#[cfg(all(feature = "cache", feature = "model"))]
-use crate::{cache::Cache, http};
+#[cfg(all(feature = "cache", feature = "model", feature = "http"))]
+use crate::client::Context;
+#[cfg(feature = "cache")]
+use crate::cache::Cache;
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use crate::cache::FromStrAndCache;
@@ -73,10 +75,10 @@ impl Role {
     /// **Note** Requires the [Manage Roles] permission.
     ///
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "cache")]
+    #[cfg(all(feature = "cache", feature = "http"))]
     #[inline]
-    pub fn delete(&self, cache: &Arc<RwLock<Cache>>) -> Result<()> {
-        http::delete_role(self.find_guild(&cache)?.0, self.id.0)
+    pub fn delete(&self, context: &Context) -> Result<()> {
+        context.http.delete_role(self.find_guild(&context.cache)?.0, self.id.0)
     }
 
     /// Edits a [`Role`], optionally setting its new fields.
@@ -101,10 +103,10 @@ impl Role {
     ///
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(all(feature = "builder", feature = "cache"))]
-    pub fn edit<F: FnOnce(EditRole) -> EditRole>(&self, cache: &Arc<RwLock<Cache>>, f: F) -> Result<Role> {
-        self.find_guild(&cache)
-            .and_then(|guild_id| guild_id.edit_role(self.id, f))
+    #[cfg(all(feature = "builder", feature = "cache", feature = "http"))]
+    pub fn edit<F: FnOnce(EditRole) -> EditRole>(&self, context: &Context, f: F) -> Result<Role> {
+        self.find_guild(&context.cache)
+            .and_then(|guild_id| guild_id.edit_role(&context.http, self.id, f))
     }
 
     /// Searches the cache for the guild that owns the role.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -140,16 +140,17 @@ impl CurrentUser {
     /// # extern crate parking_lot;
     /// # extern crate serenity;
     /// #
-    /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
     /// # let cache = Arc::new(RwLock::new(Cache::default()));
     /// # let cache = cache.read();
+    /// # let http = Arc::new(Http::default());
     /// // assuming the cache has been unlocked
     /// let user = &cache.user;
     ///
-    /// if let Ok(guilds) = user.guilds() {
+    /// if let Ok(guilds) = user.guilds(&http) {
     ///     for (index, guild) in guilds.into_iter().enumerate() {
     ///         println!("{}: {}", index, guild.name);
     ///     }
@@ -173,17 +174,18 @@ impl CurrentUser {
     /// # extern crate parking_lot;
     /// # extern crate serenity;
     /// #
-    /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
     /// # let cache = Arc::new(RwLock::new(Cache::default()));
     /// # let mut cache = cache.write();
+    /// # let http = Arc::new(Http::default());
     ///
     /// use serenity::model::Permissions;
     ///
     /// // assuming the cache has been unlocked
-    /// let url = match cache.user.invite_url(Permissions::empty()) {
+    /// let url = match cache.user.invite_url(&http, Permissions::empty()) {
     ///     Ok(v) => v,
     ///     Err(why) => {
     ///         println!("Error getting invite url: {:?}", why);
@@ -202,16 +204,17 @@ impl CurrentUser {
     /// # extern crate parking_lot;
     /// # extern crate serenity;
     /// #
-    /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
     /// # let cache = Arc::new(RwLock::new(Cache::default()));
     /// # let mut cache = cache.write();
+    /// # let http = Arc::new(Http::default());
     /// use serenity::model::Permissions;
     ///
     /// // assuming the cache has been unlocked
-    /// let url = match cache.user.invite_url(Permissions::READ_MESSAGES | Permissions::SEND_MESSAGES | Permissions::EMBED_LINKS) {
+    /// let url = match cache.user.invite_url(&http, Permissions::READ_MESSAGES | Permissions::SEND_MESSAGES | Permissions::EMBED_LINKS) {
     ///     Ok(v) => v,
     ///     Err(why) => {
     ///         println!("Error getting invite url: {:?}", why);
@@ -455,7 +458,7 @@ impl User {
     ///         if msg.content == "~help" {
     ///             let cache = ctx.cache.read();
     ///
-    ///             let url = match cache.user.invite_url(Permissions::empty()) {
+    ///             let url = match cache.user.invite_url(&ctx.http, Permissions::empty()) {
     ///                 Ok(v) => v,
     ///                 Err(why) => {
     ///                     println!("Error creating invite url: {:?}", why);
@@ -738,14 +741,14 @@ impl User {
     /// struct Handler;
     ///
     /// impl EventHandler for Handler {
-    ///     fn message(&self, _: Context, msg: Message) {
+    ///     fn message(&self, context: Context, msg: Message) {
     ///         if msg.content == "!mytag" {
     ///             let content = MessageBuilder::new()
     ///                 .push("Your tag is ")
     ///                 .push(Bold + msg.author.tag())
     ///                 .build();
     ///
-    ///             let _ = msg.channel_id.say(&content);
+    ///             let _ = msg.channel_id.say(&context.http, &content);
     ///         }
     ///     }
     /// }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -13,7 +13,7 @@ use crate::builder::{CreateMessage, EditProfile};
 #[cfg(feature = "model")]
 use chrono::NaiveDateTime;
 #[cfg(feature = "model")]
-use crate::http::{self, GuildPagination};
+use crate::http::GuildPagination;
 #[cfg(all(feature = "cache", feature = "model"))]
 use parking_lot::RwLock;
 #[cfg(feature = "model")]
@@ -26,6 +26,8 @@ use crate::cache::Cache;
 use std::sync::Arc;
 #[cfg(feature = "model")]
 use crate::utils::{self, VecMap};
+#[cfg(feature = "http")]
+use crate::http::Http;
 
 /// Information about the current user.
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
@@ -94,7 +96,7 @@ impl CurrentUser {
     /// ```
     ///
     /// [`EditProfile`]: ../../builder/struct.EditProfile.html
-    pub fn edit<F>(&mut self, f: F) -> Result<()>
+    pub fn edit<F>(&mut self, http: &Arc<Http>, f: F) -> Result<()>
         where F: FnOnce(EditProfile) -> EditProfile {
         let mut map = VecMap::new();
         map.insert("username", Value::String(self.name.clone()));
@@ -105,7 +107,7 @@ impl CurrentUser {
 
         let map = utils::vecmap_to_json_map(f(EditProfile(map)).0);
 
-        match http::edit_profile(&map) {
+        match http.edit_profile(&map) {
             Ok(new) => {
                 let _ = mem::replace(self, new);
 
@@ -153,8 +155,8 @@ impl CurrentUser {
     ///     }
     /// }
     /// ```
-    pub fn guilds(&self) -> Result<Vec<GuildInfo>> {
-        http::get_guilds(&GuildPagination::After(GuildId(1)), 100)
+    pub fn guilds(&self, http: &Http) -> Result<Vec<GuildInfo>> {
+     http.get_guilds(&GuildPagination::After(GuildId(1)), 100)
     }
 
     /// Returns the invite url for the bot with the given permissions.
@@ -233,9 +235,9 @@ impl CurrentUser {
     ///
     /// [`Error::Format`]: ../../enum.Error.html#variant.Format
     /// [`HttpError::UnsuccessfulRequest`]: ../../http/enum.HttpError.html#variant.UnsuccessfulRequest
-    pub fn invite_url(&self, permissions: Permissions) -> Result<String> {
+    pub fn invite_url(&self, http: &Arc<Http>, permissions: Permissions) -> Result<String> {
         let bits = permissions.bits();
-        let client_id = http::get_current_application_info().map(|v| v.id)?;
+        let client_id = http.get_current_application_info().map(|v| v.id)?;
 
         let mut url = format!(
             "https://discordapp.com/api/oauth2/authorize?client_id={}&scope=bot",
@@ -420,7 +422,7 @@ impl User {
     ///
     /// [current user]: struct.CurrentUser.html
     #[inline]
-    pub fn create_dm_channel(&self) -> Result<PrivateChannel> { self.id.create_dm_channel() }
+    pub fn create_dm_channel(&self, http: &Http) -> Result<PrivateChannel> { self.id.create_dm_channel(&http) }
 
     /// Retrieves the time that this user was created at.
     #[inline]
@@ -511,7 +513,7 @@ impl User {
     //
     // (AKA: Clippy is wrong and so we have to mark as allowing this lint.)
     #[allow(clippy::let_and_return)]
-    #[cfg(feature = "builder")]
+    #[cfg(all(feature = "builder", feature = "http"))]
     pub fn direct_message<F>(&self, context: &Context, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b> {
         if self.bot {
@@ -539,18 +541,18 @@ impl User {
                         "recipient_id": self.id.0,
                     });
 
-                    http::create_private_channel(&map)?.id
+                    context.http.create_private_channel(&map)?.id
                 }
             } else {
                 let map = json!({
                     "recipient_id": self.id.0,
                 });
 
-                http::create_private_channel(&map)?.id
+                context.http.create_private_channel(&map)?.id
             }
         };
 
-        private_channel_id.send_message(f)
+        private_channel_id.send_message(&context.http, f)
     }
 
     /// This is an alias of [direct_message].
@@ -792,12 +794,12 @@ impl UserId {
     /// user. This can also retrieve the channel if one already exists.
     ///
     /// [current user]: ../user/struct.CurrentUser.html
-    pub fn create_dm_channel(&self) -> Result<PrivateChannel> {
+    pub fn create_dm_channel(&self, http: &Http) -> Result<PrivateChannel> {
         let map = json!({
             "recipient_id": self.0,
         });
 
-        http::create_private_channel(&map)
+        http.create_private_channel(&map)
     }
 
     /// Attempts to find a [`User`] by its Id in the cache.
@@ -814,6 +816,7 @@ impl UserId {
     /// REST API will be used only.
     ///
     /// [`User`]: ../user/struct.User.html
+    #[cfg(feature = "http")]
     #[inline]
     pub fn to_user(self, context: &Context) -> Result<User> {
         #[cfg(feature = "cache")]
@@ -823,7 +826,7 @@ impl UserId {
             }
         }
 
-        http::get_user(self.0)
+        context.http.get_user(self.0)
     }
 }
 

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -84,32 +84,40 @@ impl Webhook {
     /// Editing a webhook's name:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
+    /// # extern crate serenity;
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     ///
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let mut webhook = http::get_webhook_with_token(id, token)
+    /// let mut webhook = http.get_webhook_with_token(id, token)
     ///     .expect("valid webhook");
     ///
-    /// let _ = webhook.edit(Some("new name"), None).expect("Error editing");
+    /// let _ = webhook.edit(&http, Some("new name"), None).expect("Error editing");
     /// ```
     ///
     /// Setting a webhook's avatar:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
-    ///
+    /// # extern crate serenity;
+    /// #
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let mut webhook = http::get_webhook_with_token(id, token)
+    /// let mut webhook = http.get_webhook_with_token(id, token)
     ///     .expect("valid webhook");
     ///
     /// let image = serenity::utils::read_image("./webhook_img.png")
     ///     .expect("Error reading image");
     ///
-    /// let _ = webhook.edit(None, Some(&image)).expect("Error editing");
+    /// let _ = webhook.edit(&http, None, Some(&image)).expect("Error editing");
     /// ```
     ///
     /// [`http::edit_webhook`]: ../../http/fn.edit_webhook.html
@@ -156,15 +164,18 @@ impl Webhook {
     /// Execute a webhook with message content of `test`:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
-    ///
+    /// # extern crate serenity;
+    /// use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let mut webhook = http::get_webhook_with_token(id, token)
+    /// let mut webhook = http.get_webhook_with_token(id, token)
     ///     .expect("valid webhook");
     ///
-    /// let _ = webhook.execute(false, |mut w| {
+    /// let _ = webhook.execute(&http, false, |mut w| {
     ///     w.content("test");
     ///
     ///     w
@@ -175,13 +186,17 @@ impl Webhook {
     /// username to `serenity`, and sending an embed:
     ///
     /// ```rust,no_run
-    /// use serenity::http;
+    /// # extern crate serenity;
+    /// # use serenity::http::Http;
+    /// # use std::sync::Arc;
+    /// #
+    /// # let http = Arc::new(Http::default());
     /// use serenity::model::channel::Embed;
     ///
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let mut webhook = http::get_webhook_with_token(id, token)
+    /// let mut webhook = http.get_webhook_with_token(id, token)
     ///     .expect("valid webhook");
     ///
     /// let embed = Embed::fake(|mut e| {
@@ -194,7 +209,7 @@ impl Webhook {
     ///     e
     /// });
     ///
-    /// let _ = webhook.execute(false, |mut w| {
+    /// let _ = webhook.execute(&http, false, |mut w| {
     ///     w.content("test");
     ///     w.username("serenity");
     ///     w.embeds(vec![embed]);


### PR DESCRIPTION
This pull request removes the global HTTP-client and restructures Serenity to locate the HTTP-client inside the bot-client and then pass it around.

Functions that require the HTTP-client will expect `&Arc<Http>` as first argument now - it can be borrowed from the `Context` via its `http`-field.
As seen on #448, if a method or function requires or can utilise both cache and HTTP-client, it will require a `&Context`.

On another note, examples, tests, and doc-tests have been adjusted to compile with changes.