### PR TITLE
Old message on update v2

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -623,18 +623,18 @@ impl Cache {
     /// ```rust,no_run
     /// # extern crate parking_lot;
     /// # extern crate serenity;
-     /// #
+    /// #
     /// # use serenity::{cache::Cache, model::id::{ChannelId, MessageId}};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
-     /// #
+    /// #
     /// # let message = ChannelId(0).message(MessageId(1)).unwrap();
     /// # let cache = Arc::new(RwLock::new(Cache::default()));
     /// #
     /// let cache = cache.read();
     /// let fetched_message = cache.message(message.channel_id, message.id);
-     ///
-     /// match fetched_message {
+    ///
+    /// match fetched_message {
     ///     Some(m) => {
     ///         assert_eq!(message.content, m.content);
     ///     },

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -623,23 +623,24 @@ impl Cache {
     /// ```rust,no_run
     /// # extern crate parking_lot;
     /// # extern crate serenity;
-    ///
+     /// #
     /// # use serenity::{cache::Cache, model::id::{ChannelId, MessageId}};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
-    ///
+     /// #
     /// # let message = ChannelId(0).message(MessageId(1)).unwrap();
     /// # let cache = Arc::new(RwLock::new(Cache::default()));
     ///
     /// let cache = cache.read();
     /// let fetched_message = cache.message(message.channel_id, message.id);
-    /// match fetched_message {
+     ///
+     /// match fetched_message {
     ///     Some(m) => {
     ///         assert_eq!(message.content, m.content);
     ///     },
     ///     None => {
     ///         println!("No message found in cache.");
-    ///     }
+    ///     },
     /// }
     /// ```
     ///

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -610,6 +610,48 @@ impl Cache {
         })
     }
 
+    /// Retrieves a [`Channel`]'s message from the cache based on the channel's and
+    /// message's given Ids.
+    ///
+    /// **Note**: This will clone the entire message.
+    ///
+    /// # Examples
+    ///
+    /// Retrieving the message object from a channel, in a
+    /// [`EventHandler::message`] context:
+    ///
+    /// ```rust,no_run
+    /// use serenity::CACHE;
+    ///
+    /// # use serenity::model::id::{ChannelId, MessageId};
+    /// # let message = ChannelId(0).message(MessageId(1)).unwrap();
+    ///
+    /// let cache = CACHE.read();
+    /// let fetched_message = cache.message(message.channel_id, message.id);
+    /// match fetched_message {
+    ///     Some(m) => {
+    ///         assert_eq!(message.content, m.content);
+    ///     },
+    ///     None => {
+    ///         println!("No message found in cache.");
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// [`EventHandler::message`]: ../client/trait.EventHandler.html#method.message
+    /// [`Channel`]: ../model/channel/struct.Channel.html
+    #[inline]
+    pub fn message<C, M>(&self, channel_id: C, message_id: M) -> Option<Message>
+        where C: Into<ChannelId>, M: Into<MessageId> {
+        self._message(channel_id.into(), message_id.into())
+    }
+
+    fn _message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<Message> {
+        self.messages.get(&channel_id).and_then(|messages| {
+            messages.get(&message_id).cloned()
+        })
+    }
+
     /// Retrieves a [`PrivateChannel`] from the cache's [`private_channels`]
     /// map, if it exists.
     ///

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -621,12 +621,17 @@ impl Cache {
     /// [`EventHandler::message`] context:
     ///
     /// ```rust,no_run
-    /// use serenity::CACHE;
+    /// # extern crate parking_lot;
+    /// # extern crate serenity;
     ///
-    /// # use serenity::model::id::{ChannelId, MessageId};
+    /// # use serenity::{cache::Cache, model::id::{ChannelId, MessageId}};
+    /// # use parking_lot::RwLock;
+    /// # use std::sync::Arc;
+    ///
     /// # let message = ChannelId(0).message(MessageId(1)).unwrap();
+    /// # let cache = Arc::new(RwLock::new(Cache::default()));
     ///
-    /// let cache = CACHE.read();
+    /// let cache = cache.read();
     /// let fetched_message = cache.message(message.channel_id, message.id);
     /// match fetched_message {
     ///     Some(m) => {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -630,7 +630,7 @@ impl Cache {
      /// #
     /// # let message = ChannelId(0).message(MessageId(1)).unwrap();
     /// # let cache = Arc::new(RwLock::new(Cache::default()));
-    ///
+    /// #
     /// let cache = cache.read();
     /// let fetched_message = cache.message(message.channel_id, message.id);
      ///

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -212,6 +212,20 @@ pub trait EventHandler {
     /// Provides the channel's id and the deleted messages' ids.
     fn message_delete_bulk(&self, _ctx: Context, _channel_id: ChannelId, _multiple_deleted_messages_ids: Vec<MessageId>) {}
 
+    /// Dispatched when a message is updated.
+    ///
+    /// Provides the old message if available,
+    /// the new message as an option in case of cache inconsistencies,
+    /// and the raw MessageUpdateEvent as a fallback.
+    #[cfg(feature = "cache")]
+    fn message_update(&self, _ctx: Context, _old_if_available: Option<Message>, _new: Option<Message>, _event: MessageUpdateEvent) {}
+
+    /// Dispatched when a message is updated.
+    ///
+    /// Provides the new data of the message.
+    #[cfg(not(feature = "cache"))]
+    fn message_update(&self, _ctx: Context, _new_data: MessageUpdateEvent) {}
+
     /// Dispatched when a new reaction is attached to a message.
     ///
     /// Provides the reaction's data.
@@ -226,11 +240,6 @@ pub trait EventHandler {
     ///
     /// Provides the channel's id and the message's id.
     fn reaction_remove_all(&self, _ctx: Context, _channel_id: ChannelId, _removed_from_message_id: MessageId) {}
-
-    /// Dispatched when a message is updated.
-    ///
-    /// Provides the new data of the message.
-    fn message_update(&self, _ctx: Context, _new_data: MessageUpdateEvent) {}
 
     fn presence_replace(&self, _ctx: Context, _: Vec<Presence>) {}
 

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -216,7 +216,9 @@ pub trait EventHandler {
     ///
     /// Provides the old message if available,
     /// the new message as an option in case of cache inconsistencies,
-    /// and the raw MessageUpdateEvent as a fallback.
+    /// and the raw [`MessageUpdateEvent`] as a fallback.
+    ///
+    /// [`MessageUpdateEvent`]: ../model/event/struct.MessageUpdateEvent.html
     #[cfg(feature = "cache")]
     fn message_update(&self, _ctx: Context, _old_if_available: Option<Message>, _new: Option<Message>, _event: MessageUpdateEvent) {}
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -847,38 +847,43 @@ pub struct MessageUpdateEvent {
 
 #[cfg(feature = "cache")]
 impl CacheUpdate for MessageUpdateEvent {
-    type Output = ();
+    type Output = Message;
 
     fn update(&mut self, cache: &mut Cache) -> Option<Self::Output> {
-        let messages = cache.messages.get_mut(&self.channel_id)?;
-        let message = messages.get_mut(&self.id)?;
+        if let Some(messages) = cache.messages.get_mut(&self.channel_id) {
+            if let Some(message) = messages.get_mut(&self.id) {
+                let item = message.clone();
 
-        if let Some(attachments) = self.attachments.clone() {
-            message.attachments = attachments;
-        }
+                if let Some(attachments) = self.attachments.clone() {
+                    message.attachments = attachments;
+                }
 
-        if let Some(content) = self.content.clone() {
-            message.content = content;
-        }
+                if let Some(content) = self.content.clone() {
+                    message.content = content;
+                }
 
-        if let Some(edited_timestamp) = self.edited_timestamp {
-            message.edited_timestamp = Some(edited_timestamp);
-        }
+                if let Some(edited_timestamp) = self.edited_timestamp {
+                    message.edited_timestamp = Some(edited_timestamp);
+                }
 
-        if let Some(mentions) = self.mentions.clone() {
-            message.mentions = mentions;
-        }
+                if let Some(mentions) = self.mentions.clone() {
+                    message.mentions = mentions;
+                }
 
-        if let Some(mention_everyone) = self.mention_everyone {
-            message.mention_everyone = mention_everyone;
-        }
+                if let Some(mention_everyone) = self.mention_everyone {
+                    message.mention_everyone = mention_everyone;
+                }
 
-        if let Some(mention_roles) = self.mention_roles.clone() {
-            message.mention_roles = mention_roles;
-        }
+                if let Some(mention_roles) = self.mention_roles.clone() {
+                    message.mention_roles = mention_roles;
+                }
 
-        if let Some(pinned) = self.pinned {
-            message.pinned = pinned;
+                if let Some(pinned) = self.pinned {
+                    message.pinned = pinned;
+                }
+
+                return Some(item);
+            }
         }
 
         None

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -851,6 +851,7 @@ impl CacheUpdate for MessageUpdateEvent {
 
     fn update(&mut self, cache: &mut Cache) -> Option<Self::Output> {
         if let Some(messages) = cache.messages.get_mut(&self.channel_id) {
+
             if let Some(message) = messages.get_mut(&self.id) {
                 let item = message.clone();
 


### PR DESCRIPTION
This re-introduces the behaviour from #368 with some modifications. In order to compensate for cache inconsistencies, the `message_update` dispatch passes both the old and new messages as options, and additionally provides the MessageUpdateEvent. This also takes into account the removal of the global cache.