### PR TITLE
Support OpenSSL 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ version = "~0.10"
 
 [dependencies.hyper-native-tls]
 optional = true
-version = "0.2.4"
+version = "0.3"
 
 [dependencies.lazy_static]
 optional = true
@@ -54,7 +54,7 @@ version = "0.13"
 
 [dependencies.native-tls]
 optional = true
-version = "0.1"
+version = "0.2"
 
 [dependencies.opus]
 optional = true
@@ -74,11 +74,11 @@ version = "~1.7"
 optional = true
 version = "~0.3"
 
-[dependencies.evzht9h3nznqzwl]
+[dependencies.websocket]
 default-features = false
 features = ["sync-ssl"]
 optional = true
-version = "0.0.3"
+version = "0.22"
 
 [dev-dependencies.matches]
 version = "0.1.6"
@@ -112,7 +112,6 @@ model = ["builder", "http"]
 standard_framework = ["framework"]
 utils = ["base64"]
 voice = ["byteorder", "gateway", "opus", "sodiumoxide"]
-websocket = ["evzht9h3nznqzwl"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,8 @@ extern crate sodiumoxide;
 extern crate threadpool;
 #[cfg(feature = "typemap")]
 extern crate typemap;
-#[cfg(feature = "evzht9h3nznqzwl")]
-extern crate evzht9h3nznqzwl as websocket;
+#[cfg(feature = "websocket")]
+extern crate websocket;
 
 #[allow(unused_imports)]
 #[cfg(test)]


### PR DESCRIPTION
This PR updates to version 0.10 of the OpenSSL crate to support version 1.1.1 of OpenSSL.
To do this, I had to update some other crates across breaking changes, however serenity still compiles and all tests pass, but I can not assert that everything works alright.
In addition, I do not know if any of the changed crates are public dependencies, because if so, this is a breaking change too.