### PR TITLE
Add a position method

### DIFF
--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -425,6 +425,21 @@ impl Channel {
         }
     }
 
+    /// Retrieves the position of the inner [`GuildChannel`] or
+    /// [`ChannelCategory`].
+    ///
+    /// If other channel types are used it will return None.
+    ///
+    /// [`GuildChannel`]: struct.GuildChannel.html
+    /// [`CatagoryChannel`]: struct.ChannelCategory.html
+    pub fn position(&self) -> Option<i64> {
+        match self {
+            Channel::Guild(ref channel) => Some(channel.with(|c| c.position)),
+            Channel::Category(ref catagory) => Some(catagory.with(|c| c.position)),
+            _ => None
+        }
+    }
+
     /// Sends a message with just the given message content in the channel.
     ///
     /// # Errors

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -433,7 +433,7 @@ impl Channel {
     /// [`GuildChannel`]: struct.GuildChannel.html
     /// [`CatagoryChannel`]: struct.ChannelCategory.html
     pub fn position(&self) -> Option<i64> {
-        match self {
+        match *self {
             Channel::Guild(ref channel) => Some(channel.with(|c| c.position)),
             Channel::Category(ref catagory) => Some(catagory.with(|c| c.position)),
             _ => None


### PR DESCRIPTION
This method can be used to get the position of a channel in the channel enum.