### PR TITLE
Implement `From<$id_struct>` for `u64` and `i64` to allow `into`'ing

### DIFF
--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -74,6 +74,18 @@ macro_rules! id_u64 {
                     deserializer.deserialize_any(U64Visitor).map($name)
                 }
             }
+
+            impl From<$name> for u64 {
+                fn from(id: $name) -> u64 {
+                    id.0 as u64
+                }
+            }
+
+            impl From<$name> for i64 {
+                fn from(id: $name) -> i64 {
+                    id.0 as i64
+                }
+            }
         )*
     }
 }


### PR DESCRIPTION
In order to get the inner value out of an Id-struct one either needs to:
`let value = *ChannelId(0).as_u64();`
or 
`let value = ChannelId(0).0;`

This pull request adds `From<T>`-implementations for u64 and i64 (to make converting easier, e.g. for databases) where T is an arbitrary Id-struct, allowing you to do:
`let value: u64 = ChannelId(0).into();` 
or to convert:
`let value: i64 = ChannelId(0).into();`