### PR TITLE
Fewer ffprobe calls when playing audio through ffmpeg.

### DIFF
--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -108,7 +108,7 @@ fn _ffmpeg(path: &OsStr) -> Result<Box<AudioSource>> {
     let is_stereo = is_stereo(path).unwrap_or(false);
     let stereo_val = if is_stereo { "2" } else { "1" };
 
-    ffmpeg_optioned(path, &[
+    _ffmpeg_optioned(path, &[
         "-f",
         "s16le",
         "-ac",
@@ -118,7 +118,7 @@ fn _ffmpeg(path: &OsStr) -> Result<Box<AudioSource>> {
         "-acodec",
         "pcm_s16le",
         "-",
-    ])
+    ], Some(is_stereo))
 }
 
 /// Opens an audio file through `ffmpeg` and creates an audio source, with
@@ -151,11 +151,13 @@ pub fn ffmpeg_optioned<P: AsRef<OsStr>>(
     path: P,
     args: &[&str],
 ) -> Result<Box<AudioSource>> {
-    _ffmpeg_optioned(path.as_ref(), args)
+    _ffmpeg_optioned(path.as_ref(), args, None)
 }
 
-fn _ffmpeg_optioned(path: &OsStr, args: &[&str]) -> Result<Box<AudioSource>> {
-    let is_stereo = is_stereo(path).unwrap_or(false);
+fn _ffmpeg_optioned(path: &OsStr, args: &[&str], is_stereo_known: Option<bool>) -> Result<Box<AudioSource>> {
+    let is_stereo = is_stereo_known
+        .or_else(|| is_stereo(path).ok())
+        .unwrap_or(false);
 
     let command = Command::new("ffmpeg")
         .arg("-i")


### PR DESCRIPTION
Implements a fix for a problem noticed by @JellyWX, where ffprobe would be called multiple times to determine whether an audio stream is stereo or mono. This should now only be performed once in most cases, and does not change the API.