### PR TITLE
prelude: re-export typemap::sharemap

### DIFF
--- a/examples/05_command_framework/Cargo.toml
+++ b/examples/05_command_framework/Cargo.toml
@@ -3,9 +3,6 @@ name = "05_command_framework"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
 
-[dependencies]
-typemap = "0.3"
-
 [dependencies.serenity]
 features = ["framework", "standard_framework"]
 path = "../../"

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -11,7 +11,6 @@
 
 #[macro_use]
 extern crate serenity;
-extern crate typemap;
 
 use std::{collections::HashMap, env, fmt::Write, sync::Arc};
 
@@ -25,20 +24,21 @@ use serenity::{
     utils::{content_safe, ContentSafeOptions},
 };
 
-use typemap::Key;
+// This imports `typemap`'s `Key` as `TypeMapKey`.
+use serenity::prelude::*;
 
 // A container type is created for inserting into the Client's `data`, which
 // allows for data to be accessible across all events and framework commands, or
 // anywhere else that has a copy of the `data` Arc.
 struct ShardManagerContainer;
 
-impl Key for ShardManagerContainer {
+impl TypeMapKey for ShardManagerContainer {
     type Value = Arc<Mutex<ShardManager>>;
 }
 
 struct CommandCounter;
 
-impl Key for CommandCounter {
+impl TypeMapKey for CommandCounter {
     type Value = HashMap<String, u64>;
 }
 

--- a/examples/06_voice/Cargo.toml
+++ b/examples/06_voice/Cargo.toml
@@ -3,9 +3,6 @@ name = "06_voice"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
 
-[dependencies]
-typemap = "~0.3"
-
 [dependencies.serenity]
 features = ["cache", "framework", "standard_framework", "voice"]
 path = "../../"

--- a/examples/06_voice/src/main.rs
+++ b/examples/06_voice/src/main.rs
@@ -8,7 +8,6 @@
 //! ```
 
 #[macro_use] extern crate serenity;
-extern crate typemap;
 
 use std::{env, sync::Arc};
 
@@ -33,11 +32,12 @@ use serenity::{
     voice,
 };
 
-use typemap::Key;
+// This imports `typemap`'s `Key` as `TypeMapKey`.
+use serenity::prelude::*;
 
 struct VoiceManager;
 
-impl Key for VoiceManager {
+impl TypeMapKey for VoiceManager {
     type Value = Arc<Mutex<ClientVoiceManager>>;
 }
 

--- a/examples/10_voice_receive/Cargo.toml
+++ b/examples/10_voice_receive/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["my name <my@email.address>"]
 [dependencies]
 env_logger = "~0.4"
 log = "~0.4"
-typemap = "~0.3"
 
 [dependencies.serenity]
 features = ["client", "standard_framework", "voice"]

--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -9,8 +9,6 @@
 
 #[macro_use] extern crate serenity;
 
-extern crate typemap;
-
 use std::{env, sync::Arc};
 
 use serenity::{
@@ -22,11 +20,12 @@ use serenity::{
     Result as SerenityResult,
 };
 
-use typemap::Key;
+// This imports `typemap`'s `Key` as `TypeMapKey`.
+use serenity::prelude::*;
 
 struct VoiceManager;
 
-impl Key for VoiceManager {
+impl TypeMapKey for VoiceManager {
     type Value = Arc<Mutex<ClientVoiceManager>>;
 }
 

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -58,10 +58,11 @@ use client::bridge::voice::ClientVoiceManager;
 /// use serenity::client::bridge::gateway::{ShardManager, ShardManagerOptions};
 /// use serenity::client::EventHandler;
 /// use serenity::http;
+/// // Of note, this imports `typemap`'s `ShareMap` type.
+/// use serenity::prelude::*;
 /// use std::sync::Arc;
 /// use std::env;
 /// use threadpool::ThreadPool;
-/// use typemap::ShareMap;
 ///
 /// struct Handler;
 ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -120,13 +120,12 @@ pub struct Client {
     ///
     /// ```rust,ignore
     /// extern crate serenity;
-    /// extern crate typemap;
     ///
+    /// // Of note, this imports `typemap`'s `Key` as `TypeMapKey`.
     /// use serenity::prelude::*;
     /// use serenity::model::*;
     /// use std::collections::HashMap;
     /// use std::env;
-    /// use typemap::Key;
     ///
     /// struct MessageEventCounter;
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -129,7 +129,7 @@ pub struct Client {
     ///
     /// struct MessageEventCounter;
     ///
-    /// impl Key for MessageEventCounter {
+    /// impl TypeMapKey for MessageEventCounter {
     ///     type Value = HashMap<String, u64>;
     /// }
     ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,5 +26,7 @@ pub use gateway::GatewayError;
 pub use http::HttpError;
 #[cfg(feature = "model")]
 pub use model::ModelError;
+#[cfg(feature = "typemap")]
+pub use typemap::{Key as TypeMapKey, ShareMap};
 #[cfg(feature = "voice")]
 pub use voice::VoiceError;


### PR DESCRIPTION
When the `typemap` feature is enabled (thus enabling the crate),
re-export the library's `ShareMap` type from serenity's `prelude`
module.

This is a useful re-export due to its use in the Client, which almost
every serenity user will be using. This avoids a direct dependency in
the user's Cargo.toml.

Examples have been updated to use this prelude instead of depending on
the `typemap` crate directly.

Closes #469.