### PR TITLE
Add new Check System

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -298,7 +298,7 @@ fn owner_check(_: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions)
     // `false` will convert into `CheckResult::Failure(Reason::Unknown)`,
     //
     // and if you want to pass a reason alongside failure you can do:
-    // `CheckResult::new_reason("Lacked admin permission.")`,
+    // `CheckResult::new_user("Lacked admin permission.")`,
     //
     // if you want to mark it as something you want to log only:
     // `CheckResult::new_log("User lacked admin permission.")`,

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -14,7 +14,8 @@ use serenity::{
     command,
     client::bridge::gateway::{ShardId, ShardManager},
     framework::standard::{
-        help_commands, Args, CommandOptions, DispatchError, HelpBehaviour, StandardFramework,
+        Args, CheckResult, CommandOptions, DispatchError, HelpBehaviour,
+        help_commands, StandardFramework,
     },
     model::{channel::{Channel, Message}, gateway::Ready, Permissions},
     prelude::*,
@@ -212,7 +213,7 @@ fn main() {
         .command("latency", |c| c
             .cmd(latency))
         .command("ping", |c| c
-            .check(owner_check) // User needs to pass this test to run command
+            .check("owner check", owner_check) // User needs to pass this test to run command
             .cmd(ping))
         .command("role", |c| c
             .cmd(about_role)
@@ -222,7 +223,7 @@ fn main() {
         .group("Owner", |g| g
             // This check applies to every command on this group.
             // User needs to pass the test for the command to execute.
-            .check(admin_check)
+            .check("admin check", admin_check)
             .command("am i admin", |c| c
                 .cmd(am_i_admin)
                 .guild_only(true))
@@ -289,24 +290,37 @@ command!(say(ctx, msg, args) {
 // In this case, this command checks to ensure you are the owner of the message
 // in order for the command to be executed. If the check fails, the command is
 // not called.
-fn owner_check(_: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> bool {
-    // Replace 7 with your ID
-    msg.author.id == 7
+fn owner_check(_: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> CheckResult {
+    // Replace 7 with your ID to make this check pass.
+    //
+    // `true` will convert into `CheckResult::Success`,
+    //
+    // `false` will convert into `CheckResult::Failure(Reason::Unknown)`,
+    //
+    // and if you want to pass a reason alongside failure you can do:
+    // `CheckResult::new_reason("Lacked admin permission.")`,
+    //
+    // if you want to mark it as something you want to log only:
+    // `CheckResult::new_log("User lacked admin permission.")`,
+    //
+    // and if the check's failure origin is unknown you can mark it as such (same as using `false.into`):
+    // `CheckResult::new_unknown()`
+    (msg.author.id == 7).into()
 }
 
 // A function which acts as a "check", to determine whether to call a command.
 //
 // This check analyses whether a guild member permissions has
 // administrator-permissions.
-fn admin_check(ctx: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> bool {
+fn admin_check(ctx: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> CheckResult {
     if let Some(member) = msg.member(&ctx.cache) {
 
         if let Ok(permissions) = member.permissions(&ctx.cache) {
-            return permissions.administrator();
+            return permissions.administrator().into();
         }
     }
 
-    false
+    false.into()
 }
 
 command!(some_long_command(ctx, msg, args) {

--- a/src/framework/standard/check.rs
+++ b/src/framework/standard/check.rs
@@ -1,0 +1,221 @@
+use std::fmt::Debug;
+use std::fmt;
+use model::channel::Message;
+use client::Context;
+use framework::standard::{Args, CommandOptions};
+
+pub type CheckFunction = dyn Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> CheckResult
+    + Send
+    + Sync
+    + 'static;
+
+/// This type describes why a check has failed and occurs on
+/// [`CheckResult::Failure`].
+///
+/// **Note**:
+/// The bot-developer is supposed to process this `enum` as the framework is not.
+/// It solely serves as a way to inform a user about why a check
+/// has failed and for the developer to log given failure (e.g. bugs or statstics)
+/// occurring in [`Check`]s.
+///
+/// [`Check`]: struct.Check.html
+/// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
+#[derive(Clone, Debug)]
+pub enum Reason {
+    /// No information on the failure.
+    Unknown,
+    /// Information dedicated to the user.
+    User(String),
+    /// Information purely for logging purposes.
+    Log(String),
+    /// Information for the user but also for logging purposes.
+    UserAndLog { user: String, log: String },
+}
+
+/// Returned from [`Check`]s.
+/// If `Success`, the [`Check`] is considered as passed.
+/// If `Failure`, the [`Check`] is considered as failed and can return further
+/// information on the cause via [`Reason`].
+///
+/// [`Check`]: struct.Check.html
+/// [`Reason`]: struct.Reason.html
+#[derive(Clone, Debug)]
+pub enum CheckResult {
+   Success,
+   Failure(Reason),
+}
+
+impl CheckResult {
+    /// Creates a new [`CheckResult::Failure`] with [`Reason::User`].
+    ///
+    /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
+    /// [`Reason::User`]: struct.Reason.html#variant.User
+    pub fn new_user<D>(d: D) -> Self
+        where D: fmt::Display {
+        CheckResult::Failure(Reason::User(d.to_string()))
+    }
+
+    /// Creates a new [`CheckResult::Failure`] with [`Reason::Log`].
+    ///
+    /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
+    /// [`Reason::Log`]: struct.Reason.html#variant.Log
+    pub fn new_log<D>(d: D) -> Self
+        where D: fmt::Display {
+        CheckResult::Failure(Reason::Log(d.to_string()))
+    }
+
+    /// Creates a new [`CheckResult::Failure`] with [`Reason::Unknown`].
+    ///
+    /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
+    /// [`Reason::Unknown`]: struct.Reason.html#variant.Unknown
+    pub fn new_unknown() -> Self {
+        CheckResult::Failure(Reason::Unknown)
+    }
+
+    /// Creates a new [`CheckResult::Failure`] with [`Reason::UserAndLog`].
+    ///
+    /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
+    /// [`Reason::UserAndLog`]: struct.Reason.html#variant.UserAndLog
+    pub fn new_user_and_log<D>(user: D, log: D) -> Self
+        where D: fmt::Display {
+        CheckResult::Failure(Reason::UserAndLog {
+            user: user.to_string(),
+            log: log.to_string(),
+        })
+    }
+
+    /// Returns `true` if [`CheckResult`] is [`CheckResult::Success`] and
+    /// `false` if not.
+    ///
+    /// [`CheckResult`]: enum.CheckResult.html
+    /// [`CheckResult::Success`]: enum.CheckResult.html#variant.Success
+    pub fn is_success(&self) -> bool {
+        if let CheckResult::Success = self {
+            return true;
+        }
+
+        false
+    }
+}
+
+impl From<bool> for CheckResult {
+    fn from(succeeded: bool) -> Self {
+        if succeeded {
+            CheckResult::Success
+        } else {
+            CheckResult::Failure(Reason::Unknown)
+        }
+    }
+}
+
+impl From<Reason> for CheckResult {
+    fn from(reason: Reason) -> Self {
+        CheckResult::Failure(reason)
+    }
+}
+
+/// A check can be part of a command or group and will be executed to
+/// determine whether a user is permitted to use related item.
+///
+/// Additionally, a check may hold additional settings.
+pub struct Check {
+    /// Name listed in help-system.
+    pub name: String,
+    /// Function that will be executed.
+    pub function: Box<CheckFunction>,
+    /// Whether a check should be evaluated in the help-system.
+    /// `false` will ignore check and won't fail execution.
+    pub check_in_help: bool,
+    /// Whether a check shall be listed in the help-system.
+    /// `false` won't affect whether the check will be evaluated help,
+    /// solely `check_in_help` sets this.
+    pub display_in_help: bool,
+}
+
+impl Check {
+    pub(crate) fn new<F>(name: &str, function: F, check_in_help: bool, display_in_help: bool) -> Self
+    where F: Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> CheckResult  + Send + Sync + 'static {
+        Self {
+            name: name.to_string(),
+            function: Box::new(function),
+            check_in_help,
+            display_in_help,
+        }
+    }
+}
+
+impl Debug for Check {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Check")
+            .field(&format!("name: {}", self.name))
+            .field(&"function: <fn>")
+            .field(&format!("check_in_help: {}", self.check_in_help))
+            .field(&format!("display_in_help: {}", self.display_in_help))
+            .finish()
+    }
+}
+
+/// A builder to create a [`Check`].
+///
+/// [`Check`]: struct.Check.html
+#[derive(Debug)]
+pub struct CreateCheck(pub Check);
+
+impl CreateCheck {
+    /// Creates a new builder to construct a [`Check`].
+    /// [`Check`]s always require a `function`, otherwise they would not be
+    /// testable as there is nothing to run.
+    ///
+    /// [`Check`]: struct.Check.html
+    pub fn new<F>(function: F) -> Self
+    where F: Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> CheckResult  + Send + Sync + 'static {
+        Self(
+            Check {
+                name: String::default(),
+                function: Box::new(function),
+                check_in_help: true,
+                display_in_help: true,
+            }
+        )
+    }
+
+    /// Sets name of the [`Check`] that will be displayed in the help-system.
+    ///
+    /// [`Check`]: struct.Check.html
+    #[inline]
+    pub fn name(&mut self, name: &str) -> &mut Self {
+        self.0.name = name.to_string();
+
+        self
+    }
+
+    /// If set to `true`, the created [`Check`] will be tested in the help-system
+    /// as well.
+    /// If set to `false`, the [`Check`]'s [`function`] won't be run.
+    ///
+    /// **Note**:
+    /// Having many checks `true` will affect the time generating the help-post.
+    /// Therefore setting performance intensive checks to `false` should
+    /// be considered.
+    /// However, if set to `false`, the [`Check`] will be considered as *passed*.
+    ///
+    /// [`Check`]: struct.Check.html
+    /// [`function`]: struct.Check.html#structfield.function
+    #[inline]
+    pub fn check_in_help(&mut self, check_in_help: bool) -> &mut Self {
+        self.0.check_in_help = check_in_help;
+
+        self
+    }
+
+    /// Hides [`Check`] from being listed in the help-system.
+    /// This does not affect whether the [`Check`] will be run.
+    ///
+    /// [`Check`]: struct.Check.html
+    #[inline]
+    pub fn display_in_help(&mut self, display_in_help: bool) -> &mut Self {
+        self.0.display_in_help = display_in_help;
+
+        self
+    }
+}

--- a/src/framework/standard/check.rs
+++ b/src/framework/standard/check.rs
@@ -146,11 +146,11 @@ impl Check {
 
 impl Debug for Check {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Check")
-            .field(&format!("name: {}", self.name))
-            .field(&"function: <fn>")
-            .field(&format!("check_in_help: {}", self.check_in_help))
-            .field(&format!("display_in_help: {}", self.display_in_help))
+        f.debug_struct("Check")
+            .field("name", &self.name)
+            .field("function", &"<fn>")
+            .field("check_in_help", &self.check_in_help)
+            .field("display_in_help", &self.display_in_help)
             .finish()
     }
 }

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -90,7 +90,10 @@ impl CreateCommand {
     /// client.with_framework(StandardFramework::new()
     ///     .configure(|c| c.prefix("~"))
     ///     .command("ping", |c| c
-    ///         .check("Bot Owner", owner_check, true, true)
+    ///         .check_customised(owner_check, |c|
+    ///             c.name("Owner Check")
+    ///              .check_in_help(true)
+    ///              .display_in_help(true))
     ///         .desc("Replies to a ping with a pong")
     ///         .exec(ping)));
     ///
@@ -108,15 +111,15 @@ impl CreateCommand {
     /// }
     /// ```
     pub fn check_customised<C, F>(mut self, function: F, create: C) -> Self
-        where C: FnOnce(&mut CreateCheck) -> CreateCheck,
+        where C: FnOnce(&mut CreateCheck) -> &mut CreateCheck,
         F: Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> CheckResult
         + Send
         + Sync
         + 'static {
         let mut create_check = CreateCheck::new(function);
-        let check = create(&mut create_check).0;
+        create(&mut create_check);
 
-        self.0.checks.push(check);
+        self.0.checks.push(create_check.0);
 
         self
     }

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -11,7 +11,7 @@ pub use super::{
     Args,
     Check,
 };
-
+use framework::standard::check::CheckResult;
 use crate::client::Context;
 use crate::model::{
     channel::Message,
@@ -212,12 +212,12 @@ impl CreateGroup {
     /// commands should be called.
     ///
     /// **Note**: These checks are bypassed for commands sent by the application owner.
-    pub fn check<F>(mut self, check: F) -> Self
-        where F: Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> bool
-                     + Send
-                     + Sync
-                     + 'static {
-        self.0.checks.push(Check::new(check));
+    pub fn check<F>(mut self, name: &str, check: F, check_in_help: bool, display_in_help: bool) -> Self
+        where F: Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> CheckResult
+        + Send
+        + Sync
+        + 'static {
+        self.0.checks.push(Check::new(name, check, check_in_help, display_in_help));
 
         self
     }


### PR DESCRIPTION
The old check-system lacked the ability to explain why a check would have failed as it boiled down to `true` and `false`.
Hence offering `CheckResult` enabling bot-devs to pass reasons of failure and then log or return it to the user.
Additionally, `Check`s can be named now and the bot-dev can mark them to be checked inside the help-system and whether they shall be displayed in the related command's help-page.
