### PR TITLE
Check for Ownership in Help System

### DIFF
--- a/src/framework/standard/create_help_command.rs
+++ b/src/framework/standard/create_help_command.rs
@@ -157,6 +157,14 @@ impl CreateHelpCommand {
         self
     }
 
+    /// Sets how a command requiring bot-ownership should be treated in the
+    /// help-menu.
+    pub fn lacking_ownership(mut self, behaviour: HelpBehaviour) -> Self {
+        self.0.lacking_ownership = behaviour;
+
+        self
+    }
+
     /// Sets the tip (or legend) explaining why some commands are striked,
     /// given text will be used in guilds and direct messages.
     ///
@@ -256,11 +264,23 @@ impl CreateHelpCommand {
                 strike_text.push_str(&format!(", or are limited to {}", dm_or_guild));
             } else {
                 strike_text.push_str(&format!(" are limited to {}", dm_or_guild));
+                concat_with_comma = true;
             }
         }
-        let _ = write!(strike_text, ".");
+
+        if self.0.lacking_ownership == HelpBehaviour::Strike {
+            is_any_option_strike = true;
+
+            if concat_with_comma {
+                let _ = write!(strike_text, ", require ownership");
+            } else {
+                let _ = write!(strike_text, " require ownership");
+            }
+        }
 
         if is_any_option_strike {
+            let _ = write!(strike_text, ".");
+
             Some(strike_text)
         } else {
             None

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1158,6 +1158,7 @@ impl Framework for StandardFramework {
 
                         if let Some(help) = help {
                             let groups = self.groups.clone();
+                            let owners = self.configuration.owners.clone();
                             let mut args = command_and_help_args!(&message.content, position, command_length, &self.configuration.delimiters);
 
                             threadpool.execute(move || {
@@ -1169,7 +1170,8 @@ impl Framework for StandardFramework {
                                     }
                                 }
 
-                                let result = (help.0)(&mut context, &message, &help.1, groups, &args);
+                                let result = (help.0)
+                                    (&mut context, &message, &help.1, groups, owners, &args);
 
                                 if let Some(after) = after {
                                     (after)(&mut context, &message, &built, result);
@@ -1355,7 +1357,7 @@ pub enum HelpBehaviour {
     /// Does not list a command in the help-menu.
     Hide,
     /// The command will be displayed, hence nothing will be done.
-    Nothing
+    Nothing,
 }
 
 use std::fmt;


### PR DESCRIPTION
The help system is not taking bot owners into account.
This pull requests changes the `HelpFunction` to take owners as argument and then lets the help system process according to the `lacking_ownership`-option.