### PR TITLE
Update Code to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "serenity"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/serenity.git"
 version = "0.5.11"
+edition = "2018"
 
 [dependencies]
 bitflags = "^1.0"

--- a/README.md
+++ b/README.md
@@ -39,11 +39,8 @@ docs.
 A basic ping-pong bot looks like:
 
 ```rust,ignore
-#[macro_use] extern crate serenity;
-
-use serenity::client::Client;
-use serenity::prelude::EventHandler;
-use serenity::framework::standard::StandardFramework;
+use serenity::{command, client::Client,
+    framework::standard::StandardFramework, prelude::EventHandler};
 use std::env;
 
 struct Handler;
@@ -81,12 +78,6 @@ Add the following to your `Cargo.toml` file:
 ```toml
 [dependencies]
 serenity = "0.5"
-```
-
-and to the top of your `main.rs`:
-
-```rust,ignore
-#[macro_use] extern crate serenity;
 ```
 
 Serenity supports a minimum of Rust 1.25.

--- a/benches/bench_args.rs
+++ b/benches/bench_args.rs
@@ -2,10 +2,9 @@
 
 #[cfg(test)]
 mod benches {
-    extern crate serenity;
     extern crate test;
 
-    use self::serenity::framework::standard::Args;
+    use serenity::framework::standard::Args;
     use self::test::Bencher;
 
     #[bench]

--- a/examples/07_sample_bot_structure/src/main.rs
+++ b/examples/07_sample_bot_structure/src/main.rs
@@ -11,13 +11,11 @@
 mod commands;
 
 use std::{collections::HashSet, env};
-
 use serenity::{
     framework::StandardFramework,
     model::{event::ResumedEvent, gateway::Ready},
     prelude::*,
 };
-
 use log::{error, info};
 
 struct Handler;

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -18,7 +18,7 @@
 use chrono::{DateTime, TimeZone};
 use crate::internal::prelude::*;
 use crate::model::channel::Embed;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::{
     default::Default,
     fmt::Display
@@ -522,10 +522,10 @@ impl<'a, Tz: TimeZone> From<&'a DateTime<Tz>> for Timestamp
 
 #[cfg(test)]
 mod test {
-    use crate::model::channel::{Embed, EmbedField, EmbedFooter, EmbedImage, EmbedVideo};
-    use serde_json::Value;
+    use crate::{model::channel::{Embed, EmbedField, EmbedFooter, EmbedImage, EmbedVideo},
+        utils::{self, Colour}};
+    use serde_json::{json, Value};
     use super::CreateEmbed;
-    use crate::utils::{self, Colour};
 
     #[test]
     fn test_from_embed() {

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -171,8 +171,6 @@ impl EditGuild {
     /// Setting the verification level to [`High`][`VerificationLevel::High`]:
     ///
     /// ```rust,ignore
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -23,8 +23,6 @@ use crate::utils::VecMap;
 /// Create a hoisted, mentionable role named `"a test role"`:
 ///
 /// ```rust,no_run
-/// # extern crate serenity;
-/// #
 /// # use serenity::{model::id::{ChannelId, GuildId}, http::Http};
 /// # use std::sync::Arc;
 /// #

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -86,8 +86,6 @@ impl ExecuteWebhook {
     /// Sending a webhook with a content of `"foo"`:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -160,8 +158,6 @@ impl ExecuteWebhook {
     /// Overriding the username to `"hakase"`:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -26,8 +26,6 @@ use crate::utils::VecMap;
 /// message with an Id of `158339864557912064`:
 ///
 /// ```rust,no_run
-/// # extern crate serenity;
-/// #
 /// # use serenity::http::Http;
 /// # use std::{error::Error, sync::Arc};
 /// #

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -307,9 +307,6 @@ impl Cache {
     /// Printing the count of all private channels and groups:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -424,9 +421,6 @@ impl Cache {
     /// Retrieve a guild from the cache and print its name:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache};
     /// # use parking_lot::RwLock;
     /// # use std::{error::Error, sync::Arc};
@@ -522,9 +516,6 @@ impl Cache {
     /// Retrieve a group from the cache and print its owner's id:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::cache::Cache;
     /// # use parking_lot::RwLock;
     /// # use std::{error::Error, sync::Arc};
@@ -558,9 +549,6 @@ impl Cache {
     /// [`Client::on_message`] context:
     ///
     /// ```rust,ignore
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -621,13 +609,10 @@ impl Cache {
     /// [`EventHandler::message`] context:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, MessageId}};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
-    /// # 
+    /// #
     /// # let http = Arc::new(Http::new_with_token("DISCORD_TOKEN"));
     /// # let message = ChannelId(0).message(&http, MessageId(1)).unwrap();
     /// # let cache = Arc::new(RwLock::new(Cache::default()));
@@ -671,9 +656,6 @@ impl Cache {
     /// name:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use std::error::Error;
     /// #
     /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
@@ -724,9 +706,6 @@ impl Cache {
     /// Retrieve a role from the cache and print its name:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::cache::Cache;
     /// # use parking_lot::RwLock;
     /// # use std::{error::Error, sync::Arc};

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -23,6 +23,7 @@ use super::{
 };
 use threadpool::ThreadPool;
 use typemap::ShareMap;
+use log::{info, warn};
 
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
@@ -41,11 +42,6 @@ use crate::client::bridge::voice::ClientVoiceManager;
 /// 2, of 5 total shards:
 ///
 /// ```rust,no_run
-/// extern crate parking_lot;
-/// extern crate serenity;
-/// extern crate threadpool;
-/// extern crate typemap;
-///
 /// # use std::error::Error;
 /// #
 /// # #[cfg(feature = "voice")]

--- a/src/client/bridge/gateway/shard_manager_monitor.rs
+++ b/src/client/bridge/gateway/shard_manager_monitor.rs
@@ -4,6 +4,7 @@ use std::sync::{
     Arc
 };
 use super::{ShardManager, ShardManagerMessage};
+use log::debug;
 
 /// The shard manager monitor does what it says on the tin -- it monitors the
 /// shard manager and performs actions on it as received.

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -50,9 +50,6 @@ impl ShardMessenger {
     /// specifying a query parameter:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use parking_lot::Mutex;
     /// # use serenity::client::gateway::Shard;
     /// # use std::error::Error;
@@ -80,9 +77,6 @@ impl ShardMessenger {
     /// query parameter of `"do"`:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use parking_lot::Mutex;
     /// # use serenity::client::gateway::Shard;
     /// # use std::error::Error;
@@ -133,9 +127,6 @@ impl ShardMessenger {
     /// Setting the current activity to playing `"Heroes of the Storm"`:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use parking_lot::Mutex;
     /// # use serenity::client::gateway::Shard;
     /// # use std::error::Error;
@@ -170,9 +161,6 @@ impl ShardMessenger {
     /// online:
     ///
     /// ```rust,ignore
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use parking_lot::Mutex;
     /// # use serenity::client::gateway::Shard;
     /// # use std::error::Error;
@@ -213,9 +201,6 @@ impl ShardMessenger {
     /// Setting the current online status for the shard to [`DoNotDisturb`].
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use parking_lot::Mutex;
     /// # use serenity::client::gateway::Shard;
     /// # use std::error::Error;

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -27,6 +27,7 @@ use super::{
 use threadpool::ThreadPool;
 use typemap::ShareMap;
 use crate::gateway::ConnectionStage;
+use log::{info, warn};
 
 #[cfg(feature = "voice")]
 use crate::client::bridge::voice::ClientVoiceManager;

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -33,7 +33,7 @@ use typemap::ShareMap;
 use crate::framework::Framework;
 #[cfg(feature = "voice")]
 use super::super::voice::ClientVoiceManager;
-
+use log::{error, debug, warn};
 
 /// A runner for managing a [`Shard`] and its respective WebSocket client.
 ///

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -13,6 +13,7 @@ use super::{
 };
 use threadpool::ThreadPool;
 use typemap::ShareMap;
+use log::warn;
 
 #[cfg(feature = "http")]
 use crate::http::Http;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -48,6 +48,7 @@ use self::bridge::gateway::{ShardManager, ShardManagerMonitor, ShardManagerOptio
 use std::{sync::Arc, time::Duration};
 use threadpool::ThreadPool;
 use typemap::ShareMap;
+use log::{error, debug, info};
 
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
@@ -123,8 +124,6 @@ pub struct Client {
     /// - [`Event::MessageUpdate`]
     ///
     /// ```rust,ignore
-    /// extern crate serenity;
-    ///
     /// // Of note, this imports `typemap`'s `Key` as `TypeMapKey`.
     /// use serenity::prelude::*;
     /// use serenity::model::*;

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -1060,6 +1060,7 @@ fn quotes_extract(token: &Token) -> &str {
 #[cfg(test)]
 mod test {
     use super::{Args, Error as ArgError};
+    use matches::assert_matches;
 
     #[test]
     fn single_with_empty_message() {

--- a/src/framework/standard/check.rs
+++ b/src/framework/standard/check.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 use std::fmt;
-use model::channel::Message;
-use client::Context;
-use framework::standard::{Args, CommandOptions};
+use crate::model::channel::Message;
+use crate::client::Context;
+use crate::framework::standard::{Args, CommandOptions};
 
 pub type CheckFunction = dyn Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> CheckResult
     + Send

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -16,6 +16,8 @@ use std::{
 use crate::utils::Colour;
 use super::{Args, Configuration, HelpBehaviour};
 use super::check::Check;
+#[cfg(feature = "lazy_static")]
+use lazy_static::lazy_static;
 
 pub type HelpFunction = fn(&mut Context, &Message, &HelpOptions, HashMap<String, Arc<CommandGroup>>, HashSet<UserId>, &Args)
     -> Result<(), Error>;

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -1,4 +1,4 @@
-use framework::standard::check::CreateCheck;
+use crate::framework::standard::check::CreateCheck;
 pub use super::{
     Args,
     Command,
@@ -9,7 +9,7 @@ pub use super::{
 };
 
 use crate::client::Context;
-use framework::standard::CheckResult;
+use crate::framework::standard::CheckResult;
 use crate::model::{
     channel::Message,
     Permissions

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -11,7 +11,7 @@ pub use super::{
     Args,
     Check,
 };
-use framework::standard::check::CheckResult;
+use crate::framework::standard::check::CheckResult;
 use crate::client::Context;
 use crate::model::{
     channel::Message,

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -59,6 +59,8 @@ use parking_lot::RwLock;
 #[cfg(feature = "http")]
 use crate::http::Http;
 
+use log::warn;
+
 /// Macro to format a command according to a `HelpBehaviour` or
 /// continue to the next command-name upon hiding.
 macro_rules! format_command_name {

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -637,7 +637,7 @@ pub fn create_customised_help_data<'a, H: BuildHasher>(
                             .map_or(false, |v| v.iter().any(|prefix|
                             *prefix == searched_named_lowercase)) {
 
-                        let mut single_group = create_single_group(
+                        let single_group = create_single_group(
                             &context,
                             &group,
                             &key,

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1159,7 +1159,7 @@ impl Framework for StandardFramework {
                         if let Some(help) = help {
                             let groups = self.groups.clone();
                             let owners = self.configuration.owners.clone();
-                            let mut args = command_and_help_args!(&message.content, position, command_length, &self.configuration.delimiters);
+                            let args = command_and_help_args!(&message.content, position, command_length, &self.configuration.delimiters);
 
                             threadpool.execute(move || {
 
@@ -1286,7 +1286,7 @@ impl Framework for StandardFramework {
                 // `Message`, else we can avoid it.
                 if let Some(ref message_without_command) = self.message_without_command {
                     let mut context_unrecognised = context.clone();
-                    let mut message_unrecognised = message.clone();
+                    let message_unrecognised = message.clone();
 
                     let unrecognised_command = unrecognised_command.clone();
                     threadpool.execute(move || {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -657,10 +657,9 @@ impl StandardFramework {
     /// Create and use a simple command:
     ///
     /// ```rust,no_run
-    /// # #[macro_use] extern crate serenity;
-    /// #
     /// # fn main() {
     /// # use serenity::prelude::*;
+    /// # use serenity::command;
     /// # use serenity::framework::standard::Args;
     /// # struct Handler;
     /// #

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -26,6 +26,7 @@ use tungstenite::{
     handshake::client::Request,
 };
 use url::Url;
+use log::{error, debug, info, trace, warn};
 
 /// A Shard is a higher-level handler for a websocket connection to Discord's
 /// gateway. The shard allows for sending and receiving messages over the
@@ -104,9 +105,6 @@ impl Shard {
     /// then listening for events:
     ///
     /// ```rust,no_run
-    /// extern crate parking_lot;
-    /// extern crate serenity;
-    ///
     /// use serenity::gateway::Shard;
     /// use parking_lot::Mutex;
     /// use std::{env, sync::Arc};
@@ -311,7 +309,6 @@ impl Shard {
     /// Retrieving the shard info for the second shard, out of two shards total:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
     /// # #[cfg(feature = "model")]
     /// # fn main() {
     /// # use serenity::client::gateway::Shard;
@@ -669,9 +666,6 @@ impl Shard {
     /// specifying a query parameter:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use parking_lot::Mutex;
     /// # use serenity::client::gateway::Shard;
     /// # use std::error::Error;
@@ -699,9 +693,6 @@ impl Shard {
     /// query parameter of `"do"`:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use parking_lot::Mutex;
     /// # use serenity::client::gateway::Shard;
     /// # use std::error::Error;

--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -4,7 +4,9 @@ use crate::gateway::{CurrentPresence, WsClient};
 use crate::internal::prelude::*;
 use crate::internal::ws_impl::SenderExt;
 use crate::model::id::GuildId;
+use serde_json::json;
 use std::env::consts;
+use log::{debug, trace};
 
 pub trait WebSocketGatewayClientExt {
     fn send_chunk_guilds<It>(

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -58,6 +58,7 @@ use std::{
     i64,
 };
 use super::{Http, HttpError, Request};
+use log::debug;
 
 /// Refer to [`offset`].
 ///

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -19,7 +19,8 @@ use super::{
 };
 use parking_lot::Mutex;
 use serde::de::DeserializeOwned;
-use serde_json;
+use serde_json::json;
+use log::{debug, trace};
 use std::{
     collections::{BTreeMap, HashMap},
     io::ErrorKind as IoErrorKind,
@@ -241,8 +242,6 @@ impl Http {
     /// Create a guild called `"test"` in the [US West region]:
     ///
     /// ```rust,ignore
-    /// extern crate serde_json;
-    ///
     /// use serde_json::builder::ObjectBuilder;
     /// use serde_json::Value;
     /// use serenity::http::Http;
@@ -378,9 +377,6 @@ impl Http {
     /// Creating a webhook named `test`:
     ///
     /// ```rust,ignore
-    /// extern crate serde_json;
-    /// extern crate serenity;
-    ///
     /// use serde_json::builder::ObjectBuilder;
     /// use serenity::http::Http;
     ///
@@ -470,8 +466,6 @@ impl Http {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -576,8 +570,6 @@ impl Http {
     /// Deletes a webhook given its Id and unique token:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -754,9 +746,6 @@ impl Http {
     /// Edit the image of a webhook given its Id and unique token:
     ///
     /// ```rust,ignore
-    /// extern crate serde_json;
-    /// extern crate serenity;
-    ///
     /// use serde_json::builder::ObjectBuilder;
     /// use serenity::http::Http;
     ///
@@ -793,9 +782,6 @@ impl Http {
     /// Edit the name of a webhook given its Id and unique token:
     ///
     /// ```rust,ignore
-    /// extern crate serde_json;
-    /// extern crate serenity;
-    ///
     /// use serde_json::builder::ObjectBuilder;
     /// use serenity::http::Http;
     ///
@@ -850,9 +836,6 @@ impl Http {
     /// Sending a webhook with message content of `test`:
     ///
     /// ```rust,ignore
-    /// extern crate serde_json;
-    /// extern crate serenity;
-    ///
     /// use serde_json::builder::ObjectBuilder;
     /// use serenity::http::Http;
     ///
@@ -979,8 +962,6 @@ impl Http {
     /// Retrieve all of the webhooks owned by a channel:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -1180,8 +1161,6 @@ impl Http {
     /// Retrieve all of the webhooks owned by a guild:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -1212,8 +1191,6 @@ impl Http {
     /// Get the first 10 guilds after a certain guild's Id:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -1399,8 +1376,6 @@ impl Http {
     /// Retrieve a webhook by Id:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -1428,8 +1403,6 @@ impl Http {
     /// Retrieve a webhook by Id and its unique token:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -1650,14 +1623,9 @@ impl Http {
     /// deserialize the response into a [`Message`]:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use std::error::Error;
     /// #
     /// # fn try_main() -> Result<(), Box<Error>> {
-    /// #
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -1708,8 +1676,6 @@ impl Http {
     /// Send a body of bytes over the [`RouteInfo::CreateMessage`] endpoint:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::{error::Error, sync::Arc};
     /// #

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -6,6 +6,7 @@ use tungstenite::{
     util::NonBlockingResult,
     Message,
 };
+use log::warn;
 
 pub trait ReceiverExt {
     fn recv_json(&mut self) -> Result<Option<Value>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,13 +30,11 @@
 //! A basic ping-pong bot looks like:
 //!
 //! ```rust,no_run
-//! #[macro_use] extern crate serenity;
-//!
 //! # #[cfg(all(feature = "client", feature = "standard_framework"))]
 //! # mod inner {
 //! #
-//! use serenity::client::{Client, EventHandler};
-//! use serenity::framework::standard::StandardFramework;
+//! use serenity::{command, client::{Client, EventHandler},
+//!     framework::standard::StandardFramework};
 //! use std::env;
 //!
 //! struct Handler;
@@ -84,12 +82,6 @@
 //! serenity = "0.5"
 //! ```
 //!
-//! and to the top of your `main.rs`:
-//!
-//! ```rs
-//! #[macro_use] extern crate serenity;
-//! ```
-//!
 //! [`Cache`]: cache/struct.Cache.html
 //! [`Client::new`]: client/struct.Client.html#method.new
 //! [`Client::on_message`]: client/struct.Client.html#method.on_message
@@ -109,53 +101,7 @@
 #![warn(clippy::enum_glob_use, clippy::if_not_else)]
 
 #[macro_use]
-extern crate bitflags;
-#[allow(clippy::unused_imports)]
-#[macro_use]
-extern crate log;
-#[macro_use]
 extern crate serde_derive;
-#[allow(clippy::unused_imports)]
-#[macro_use]
-extern crate serde_json;
-
-#[cfg(feature = "lazy_static")]
-#[macro_use]
-extern crate lazy_static;
-
-extern crate chrono;
-extern crate parking_lot;
-extern crate serde;
-
-#[cfg(feature = "base64")]
-extern crate base64;
-#[cfg(feature = "byteorder")]
-extern crate byteorder;
-#[cfg(feature = "flate2")]
-extern crate flate2;
-#[cfg(feature = "reqwest")]
-extern crate reqwest;
-
-
-#[cfg(feature = "opus")]
-extern crate opus;
-#[cfg(feature = "rand")]
-extern crate rand;
-#[cfg(feature = "sodiumoxide")]
-extern crate sodiumoxide;
-#[cfg(feature = "threadpool")]
-extern crate threadpool;
-#[cfg(feature = "tungstenite")]
-extern crate tungstenite;
-#[cfg(feature = "typemap")]
-extern crate typemap;
-#[cfg(feature = "url")]
-extern crate url;
-
-#[allow(clippy::unused_imports)]
-#[cfg(test)]
-#[macro_use]
-extern crate matches;
 
 #[macro_use]
 mod internal;

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1,4 +1,5 @@
 use crate::{internal::RwLockExt, model::prelude::*};
+use serde_json::json;
 
 #[cfg(feature = "client")]
 use crate::client::Context;
@@ -540,8 +541,6 @@ impl ChannelId {
     /// Send files with the paths `/path/to/file.jpg` and `/path/to/file2.jpg`:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -560,7 +559,6 @@ impl ChannelId {
     /// Send files using `File`:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -160,9 +160,6 @@ impl GuildChannel {
     /// permissions:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
     /// # use parking_lot::RwLock;
     /// # use std::{error::Error, sync::Arc};
@@ -201,9 +198,6 @@ impl GuildChannel {
     /// permissions:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
     /// # use parking_lot::RwLock;
     /// # use std::{error::Error, sync::Arc};

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, FixedOffset};
 use crate::{model::prelude::*};
-use serde_json::Value;
+use serde_json::{json, Value};
 
 #[cfg(feature = "client")]
 use crate::client::Context;
@@ -94,10 +94,8 @@ impl Message {
     /// On command, print the name of the channel that a message took place in:
     ///
     /// ```rust,no_run
-    /// # #[macro_use] extern crate serenity;
-    /// #
     /// # fn main() {
-    /// #   use serenity::prelude::*;
+    /// #   use serenity::{command, prelude::*};
     /// #   struct Handler;
     /// #
     /// #   impl EventHandler for Handler {}

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -241,7 +241,7 @@ impl Message {
         }
 
         if let Some(embed) = self.embeds.get(0) {
-            let mut embed = CreateEmbed::from(embed.clone());
+            let embed = CreateEmbed::from(embed.clone());
             builder.embed( |e| {
                 *e = embed;
                 e

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -78,9 +78,6 @@ impl Channel {
     /// Basic usage:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::id::ChannelId};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -124,9 +121,6 @@ impl Channel {
     /// Basic usage:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::id::ChannelId};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -166,9 +160,6 @@ impl Channel {
     /// Basic usage:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::id::ChannelId};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -211,9 +202,6 @@ impl Channel {
     /// Basic usage:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::id::ChannelId};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -11,6 +11,7 @@ use std::{
     },
     str::FromStr
 };
+use log::warn;
 
 use crate::internal::prelude::*;
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -7,6 +7,7 @@ use serde_json;
 use std::sync::Arc;
 use super::utils::*;
 use super::prelude::*;
+use bitflags::bitflags;
 
 /// A representation of the data retrieved from the bot gateway endpoint.
 ///
@@ -70,10 +71,9 @@ impl Activity {
     /// Create a command that sets the current activity:
     ///
     /// ```rust,no_run
-    /// # #[macro_use] extern crate serenity;
-    /// #
     /// use serenity::framework::standard::Args;
     /// use serenity::model::gateway::Activity;
+    /// use serenity::command;
     ///
     /// command!(activity(ctx, _msg, args) {
     ///     let name = args.full();
@@ -109,10 +109,7 @@ impl Activity {
     /// Create a command that sets the current streaming status:
     ///
     /// ```rust,no_run
-    /// # #[macro_use] extern crate serenity;
-    /// #
-    /// use serenity::framework::standard::Args;
-    /// use serenity::model::gateway::Activity;
+    /// use serenity::{command, framework::standard::Args, model::gateway::Activity};
     ///
     /// // Assumes command has min_args set to 2.
     /// command!(stream(ctx, _msg, args) {
@@ -149,10 +146,7 @@ impl Activity {
     /// Create a command that sets the current listening status:
     ///
     /// ```rust,no_run
-    /// # #[macro_use] extern crate serenity;
-    /// #
-    /// use serenity::framework::standard::Args;
-    /// use serenity::model::gateway::Activity;
+    /// use serenity::{command, framework::standard::Args, model::gateway::Activity};
     ///
     /// command!(listen(ctx, _msg, args) {
     ///     let name = args.full();

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -5,6 +5,7 @@ use std::fmt::{
     Write as FmtWrite
 };
 use super::super::id::{EmojiId, RoleId};
+use serde_json::json;
 
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
@@ -66,9 +67,6 @@ impl Emoji {
     /// Delete a given emoji:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{command, model::{guild::Emoji, id::EmojiId}};
     /// #
     /// # command!(example(context) {
@@ -154,9 +152,6 @@ impl Emoji {
     /// Print the guild id that owns this emoji:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::{guild::Emoji, id::EmojiId}};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1,4 +1,5 @@
 use crate::{model::prelude::*};
+use serde_json::json;
 
 #[cfg(feature = "client")]
 use crate::client::Context;

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -19,8 +19,9 @@ pub use self::audit_log::*;
 use chrono::{DateTime, FixedOffset};
 use crate::{model::prelude::*};
 use serde::de::Error as DeError;
-use serde_json;
+use serde_json::{json};
 use super::utils::*;
+use log::{error, warn};
 
 #[cfg(feature = "client")]
 use crate::client::Context;

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -47,6 +47,7 @@
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use super::utils::U64Visitor;
+use bitflags::__impl_bitflags;
 
 /// Returns a set of permissions with the original @everyone permissions set
 /// to true.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use super::utils::deserialize_u16;
 use super::prelude::*;
 use crate::{internal::prelude::*, model::misc::Mentionable};
+use serde_json::json;
 
 #[cfg(feature = "client")]
 use crate::client::Context;
@@ -53,9 +54,6 @@ impl CurrentUser {
     /// Print out the current user's avatar url if one is set:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -137,9 +135,6 @@ impl CurrentUser {
     /// Print out the names of all guilds the current user is in:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -171,9 +166,6 @@ impl CurrentUser {
     /// Get the invite url with no permissions set:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -201,9 +193,6 @@ impl CurrentUser {
     /// Get the invite url with some basic permissions set:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -263,9 +252,6 @@ impl CurrentUser {
     /// Print out the current user's static avatar url if one is set:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -292,9 +278,6 @@ impl CurrentUser {
     /// Print out the current user's distinct identifier (e.g., Username#1234):
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
@@ -656,9 +639,6 @@ impl User {
     /// out-of-sync:
     ///
     /// ```rust,no_run
-    /// # extern crate parking_lot;
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -84,7 +84,6 @@ impl Webhook {
     /// Editing a webhook's name:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -102,8 +101,6 @@ impl Webhook {
     /// Setting a webhook's avatar:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
-    /// #
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -164,7 +161,6 @@ impl Webhook {
     /// Execute a webhook with message content of `test`:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
     /// use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #
@@ -186,7 +182,6 @@ impl Webhook {
     /// username to `serenity`, and sending an embed:
     ///
     /// ```rust,no_run
-    /// # extern crate serenity;
     /// # use serenity::http::Http;
     /// # use std::sync::Arc;
     /// #

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -996,7 +996,7 @@ fn normalize(text: &str) -> String {
 mod test {
     use crate::model::prelude::*;
     use super::{
-        ContentModifier::*,
+        ContentModifier::{Bold, Code, Italic},
         MessageBuilder,
     };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -769,9 +769,6 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
 /// Sanitise an `@everyone` mention.
 ///
 /// ```rust
-/// # extern crate serenity;
-/// # extern crate parking_lot;
-/// #
 /// # use std::sync::Arc;
 /// # use serenity::client::Cache;
 /// # use parking_lot::RwLock;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -703,7 +703,7 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
             }
 
             if let Ok(id) = UserId::from_str(&s[mention_start..mention_end]) {
-                let mut replacement = if let Some(guild) = guild {
+                let replacement = if let Some(guild) = guild {
 
                     if let Some(guild) = cache.read().guild(&guild) {
 

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -51,6 +51,7 @@ use super::connection_info::ConnectionInfo;
 use super::{payload, VoiceError, CRYPTO_MODE};
 use tungstenite::{self, handshake::client::Request};
 use url::Url;
+use log::{debug, info, warn};
 
 enum ReceiverStatus {
     Udp(Vec<u8>),
@@ -700,16 +701,16 @@ fn start_ws_thread(client: Arc<Mutex<WsClient>>, tx: &MpscSender<ReceiverStatus>
                         Ok(msg) => msg,
                         Err(_) => break,
                     };
-    
+
                     if tx_ws.send(ReceiverStatus::Websocket(msg)).is_err() {
                         break 'outer;
                     }
-                } 
-    
+                }
+
                 if ws_close_reader.try_recv().is_ok() {
                     break 'outer;
                 }
-    
+
                 thread::sleep(Duration::from_millis(25));
             }
             info!("[Voice] WS thread exited.");

--- a/src/voice/handler.rs
+++ b/src/voice/handler.rs
@@ -15,6 +15,7 @@ use std::sync::{
 };
 use super::connection_info::ConnectionInfo;
 use super::{Audio, AudioReceiver, AudioSource, Bitrate, Status as VoiceStatus, threading, LockedAudio};
+use serde_json::json;
 
 /// The handler is responsible for "handling" a single voice connection, acting
 /// as a clean API above the inner connection.

--- a/src/voice/payload.rs
+++ b/src/voice/payload.rs
@@ -1,5 +1,5 @@
 use crate::constants::VoiceOpCode;
-use serde_json::Value;
+use serde_json::{json, Value};
 use super::connection_info::ConnectionInfo;
 
 #[inline]

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -16,6 +16,7 @@ use std::{
     sync::Arc,
 };
 use super::{AudioSource, AudioType, DcaError, DcaMetadata, VoiceError, audio};
+use log::{debug, warn};
 
 struct ChildContainer(Child);
 

--- a/src/voice/threading.rs
+++ b/src/voice/threading.rs
@@ -10,6 +10,7 @@ use super::{
     Status,
     audio,
 };
+use log::{error, warn};
 
 pub(crate) fn start(guild_id: GuildId, rx: MpscReceiver<Status>) {
     let name = format!("Serenity Voice (G{})", guild_id);

--- a/tests/test_deser.rs
+++ b/tests/test_deser.rs
@@ -1,7 +1,3 @@
-extern crate serde;
-extern crate serde_json;
-extern crate serenity;
-
 use serde::de::Deserialize;
 use serde_json::Value;
 use serenity::model::prelude::*;

--- a/tests/test_prelude.rs
+++ b/tests/test_prelude.rs
@@ -1,7 +1,5 @@
 #![allow(unused_imports)]
 
-extern crate serenity;
-
 use serenity::prelude::{Mentionable, SerenityError};
 
 #[cfg(feature = "client")]


### PR DESCRIPTION
This fully updates serenity's code to Rust 2018.

- Added `edition`-field and pointed to "2018".
- Fixed all warnings.
- Removed `extern crate` from all doc-tests.
- Removed `extern crate` almost everywhere but for `serde_derive` and `test`.
- Imported macros whenever required.
