### PR TITLE
Rewrite Args again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,10 @@ version = "~0.3"
 optional = true
 version = "^1.0"
 
+[dependencies.uwl]
+optional = true
+version = "^0.2"
+
 [dev-dependencies.matches]
 version = "0.1.6"
 
@@ -102,7 +106,7 @@ framework = ["client", "model", "utils"]
 gateway = ["flate2", "http", "tungstenite", "url", "utils"]
 http = ["reqwest", "lazy_static"]
 model = ["builder", "http"]
-standard_framework = ["framework"]
+standard_framework = ["framework", "uwl"]
 utils = ["base64"]
 voice = ["byteorder", "gateway", "opus", "rand", "sodiumoxide"]
 

--- a/benches/bench_args.rs
+++ b/benches/bench_args.rs
@@ -4,13 +4,13 @@
 mod benches {
     extern crate test;
 
-    use serenity::framework::standard::Args;
+    use serenity::framework::standard::{Args, Delimiter};
     use self::test::Bencher;
 
     #[bench]
     fn single_with_one_delimiter(b: &mut Bencher) {
         b.iter(|| {
-            let mut args = Args::new("1,2", &[",".to_string()]);
+            let mut args = Args::new("1,2", &[Delimiter::Single(',')]);
             args.single::<String>().unwrap();
         })
     }
@@ -18,7 +18,7 @@ mod benches {
     #[bench]
     fn single_with_one_delimiter_and_long_string(b: &mut Bencher) {
         b.iter(|| {
-            let mut args = Args::new("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25", &[",".to_string()]);
+            let mut args = Args::new("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25", &[Delimiter::Single(',')]);
             args.single::<String>().unwrap();
         })
     }
@@ -26,7 +26,7 @@ mod benches {
     #[bench]
     fn single_with_three_delimiters(b: &mut Bencher) {
         b.iter(|| {
-            let mut args = Args::new("1,2 @3@4 5,", &[",".to_string(), " ".to_string(), "@".to_string()]);
+            let mut args = Args::new("1,2 @3@4 5,", &[Delimiter::Single(','), Delimiter::Single(' '), Delimiter::Single('@')]);
             args.single::<String>().unwrap();
         })
     }
@@ -34,7 +34,7 @@ mod benches {
     #[bench]
     fn single_with_three_delimiters_and_long_string(b: &mut Bencher) {
         b.iter(|| {
-            let mut args = Args::new("1,2 @3@4 5,1,2 @3@4 5,1,2 @3@4 5,1,2 @3@4 5,1,2 @3@4 5,1,2 @3@4 5,", &[",".to_string(), " ".to_string(), "@".to_string()]);
+            let mut args = Args::new("1,2 @3@4 5,1,2 @3@4 5,1,2 @3@4 5,1,2 @3@4 5,1,2 @3@4 5,1,2 @3@4 5,", &[Delimiter::Single(','), Delimiter::Single(' '), Delimiter::Single('@')]);
             args.single::<String>().unwrap();
         })
     }
@@ -42,7 +42,7 @@ mod benches {
     #[bench]
     fn single_quoted_with_one_delimiter(b: &mut Bencher) {
         b.iter(|| {
-            let mut args = Args::new(r#""1","2""#, &[",".to_string()]);
+            let mut args = Args::new(r#""1","2""#, &[Delimiter::Single(',')]);
             args.single_quoted::<String>().unwrap();
         })
     }
@@ -50,16 +50,16 @@ mod benches {
     #[bench]
     fn multiple_with_one_delimiter(b: &mut Bencher) {
         b.iter(|| {
-            let args = Args::new("1,2,3,4,5,6,7,8,9,10", &[",".to_string()]);
-            args.multiple::<String>().unwrap();
+            let mut args = Args::new("1,2,3,4,5,6,7,8,9,10", &[Delimiter::Single(',')]);
+            args.iter::<String>().collect::<Result<Vec<_>, _>>().unwrap();
         })
     }
 
     #[bench]
     fn multiple_with_three_delimiters(b: &mut Bencher) {
         b.iter(|| {
-            let args = Args::new("1-2<3,4,5,6,7<8,9,10", &[",".to_string(), "-".to_string(), "<".to_string()]);
-            args.multiple::<String>().unwrap();
+            let mut args = Args::new("1-2<3,4,5,6,7<8,9,10", &[Delimiter::Single(','), Delimiter::Single('-'), Delimiter::Single('<')]);
+            args.iter::<String>().collect::<Result<Vec<_>, _>>().unwrap();
         })
     }
 }

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -1,69 +1,80 @@
-use std::{
-    str::FromStr,
-    error::Error as StdError,
-    fmt
-};
+use uwl::StringStream;
+
+use std::cell::Cell;
+use std::error::Error as StdError;
+use std::marker::PhantomData;
+use std::{fmt, str::FromStr};
 
 /// Defines how an operation on an `Args` method failed.
 #[derive(Debug)]
-pub enum Error<E: StdError> {
-    /// "END-OF-STRING". There's nothing to parse anymore.
+pub enum Error<E> {
+    /// "END-OF-STRING". We reached the end. There's nothing to parse anymore.
     Eos,
-    /// The parsing operation failed; the error can be anything returned from the `FromStr` trait.
+    /// Parsing operation failed. Contains how it did.
     Parse(E),
 }
 
-impl<E: StdError> From<E> for Error<E> {
+impl<E> From<E> for Error<E> {
     fn from(e: E) -> Self {
         Error::Parse(e)
     }
 }
 
-impl<E: StdError> StdError for Error<E> {
-    fn description(&self) -> &str {
+impl<E: fmt::Display> fmt::Display for Error<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Error::*;
 
         match *self {
-            Eos => "end-of-string",
-            Parse(ref e) => e.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
-        use self::Error::*;
-
-        match *self {
-            Parse(ref e) => Some(e),
-            _ => None,
+            Eos => write!(f, "ArgError(\"end of string\")"),
+            Parse(ref e) => write!(f, "ArgError(\"{}\")", e),
         }
     }
 }
 
-impl<E: StdError> fmt::Display for Error<E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use self::Error::*;
-
-        match *self {
-            Eos => write!(f, "end of string"),
-            Parse(ref e) => fmt::Display::fmt(&e, f),
+impl<E: fmt::Debug + fmt::Display> StdError for Error<E> {
+    fn description(&self) -> &str {
+        match self {
+            Error::Eos => "end-of-string",
+            Error::Parse(_) => "parse-failure",
         }
     }
 }
 
 type Result<T, E> = ::std::result::Result<T, Error<E>>;
 
-fn find_end(s: &str, i: usize) -> Option<usize> {
-    if i > s.len() {
-        return None;
+/// Dictates how `Args` should split arguments, if by one character, or a string.
+#[derive(Debug, Clone)]
+pub enum Delimiter {
+    Single(char),
+    Multiple(String),
+}
+
+impl From<char> for Delimiter {
+    #[inline]
+    fn from(c: char) -> Delimiter {
+        Delimiter::Single(c)
     }
+}
 
-    let mut end = i + 1;
-
-    while !s.is_char_boundary(end) {
-        end += 1;
+impl From<String> for Delimiter {
+    #[inline]
+    fn from(s: String) -> Delimiter {
+        Delimiter::Multiple(s)
     }
+}
 
-    Some(end)
+impl<'a> From<&'a String> for Delimiter {
+    #[inline]
+    fn from(s: &'a String) -> Delimiter {
+        Delimiter::Multiple(s.clone())
+    }
+}
+
+impl<'a> From<&'a str> for Delimiter {
+    #[inline]
+    fn from(s: &'a str) -> Delimiter {
+        Delimiter::Multiple(s.to_string())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -73,103 +84,97 @@ enum TokenKind {
     QuotedArgument,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 struct Token {
     kind: TokenKind,
-    lit: String,
-    // start position
-    pos: usize,
+    start: usize,
+    end: usize,
 }
 
 impl Token {
-    fn new(kind: TokenKind, lit: &str, pos: usize) -> Self {
-        Token { kind, lit: lit.to_string(), pos }
-    }
-}
-
-#[derive(Debug)]
-struct Lexer<'a> {
-    msg: &'a str,
-    delims: &'a [char],
-    offset: usize,
-}
-
-impl<'a> Lexer<'a> {
-    fn new(msg: &'a str, delims: &'a [char]) -> Self {
-        Lexer {
-            msg,
-            delims,
-            offset: 0,
-        }
-    }
-
     #[inline]
-    fn at_end(&self) -> bool {
-        self.offset >= self.msg.len()
+    fn new(kind: TokenKind, start: usize, end: usize) -> Self {
+        Token { kind, start, end }
+    }
+}
+
+fn lex(stream: &mut StringStream<'_>, delims: &[&Delimiter]) -> Option<Token> {
+    if stream.at_end() {
+        return None;
     }
 
-    fn current(&self) -> Option<&str> {
-        if self.at_end() {
-            return None;
-        }
-
-        let start = self.offset;
-
-        let end = find_end(&self.msg, self.offset)?;
-
-        Some(&self.msg[start..end])
-    }
-
-    fn next(&mut self) -> Option<()> {
-        self.offset += self.current()?.len();
-
-        Some(())
-    }
-
-    fn commit(&mut self) -> Option<Token> {
-        if self.at_end() {
-            return None;
-        }
-
-        if self.current()?.contains(self.delims) {
-            let start = self.offset;
-            self.next();
-            return Some(Token::new(TokenKind::Delimiter, &self.msg[start..self.offset], start));
-        }
-
-        if self.current()? == "\"" {
-            let start = self.offset;
-            self.next();
-
-            while !self.at_end() && self.current()? != "\"" {
-                self.next();
+    for delim in delims {
+        match delim {
+            Delimiter::Single(c) => {
+                if stream.current()?.contains(*c) {
+                    let start = stream.offset();
+                    stream.next();
+                    return Some(Token::new(TokenKind::Delimiter, start, stream.offset()));
+                }
             }
+            Delimiter::Multiple(s) => {
+                if *s == stream.peek_for(s.chars().count()) {
+                    let start = stream.offset();
+                    // Move the offset pointer by `s.len()` bytes.
+                    unsafe { stream.set_unchecked(start + s.len()) };
 
-            let is_quote = self.current().map_or(false, |s| s == "\"");
-            self.next();
-
-            let end = self.offset;
-
-            return Some(if is_quote {
-                Token::new(TokenKind::QuotedArgument, &self.msg[start..end], start)
-            } else {
-                // We're missing an end quote. View this as a normal argument.
-                Token::new(TokenKind::Argument, &self.msg[start..], start)
-            });
-        }
-
-        let start = self.offset;
-
-        while !self.at_end() {
-            if self.current()?.contains(self.delims) {
-                break;
+                    return Some(Token::new(TokenKind::Delimiter, start, stream.offset()));
+                }
             }
+        }
+    }
 
-            self.next();
+    if stream.current()? == "\"" {
+        let start = stream.offset();
+        stream.next();
+
+        stream.take_until(|s| s == "\"");
+
+        let is_quote = stream.current().map_or(false, |s| s == "\"");
+        stream.next();
+
+        let end = stream.offset();
+
+        return Some(if is_quote {
+            Token::new(TokenKind::QuotedArgument, start, end)
+        } else {
+            // We're missing an end quote. View this as a normal argument.
+            Token::new(TokenKind::Argument, start, stream.src.len())
+        });
+    }
+
+    let start = stream.offset();
+
+    'outer: while !stream.at_end() {
+        for delim in delims {
+            match delim {
+                Delimiter::Single(c) => {
+                    if stream.current()?.contains(*c) {
+                        break 'outer;
+                    }
+                }
+                Delimiter::Multiple(s) => {
+                    if *s == stream.peek_for(s.chars().count()) {
+                        break 'outer;
+                    }
+                }
+            }
         }
 
-        Some(Token::new(TokenKind::Argument, &self.msg[start..self.offset], start))
+        stream.next();
     }
+
+    Some(Token::new(TokenKind::Argument, start, stream.offset()))
+}
+
+#[derive(Debug, Clone, Copy)]
+enum State {
+    None,
+    Quoted,
+    Trimmed,
+    // Preserve the order they were called.
+    QuotedTrimmed,
+    TrimmedQuoted,
 }
 
 /// A utility struct for handling "arguments" of a command.
@@ -179,9 +184,9 @@ impl<'a> Lexer<'a> {
 /// # Example
 ///
 /// ```rust
-/// use serenity::framework::standard::Args;
+/// use serenity::framework::standard::{Args, Delimiter};
 ///
-/// let mut args = Args::new("hello world!", &[" ".to_string()]); // A space is our delimiter.
+/// let mut args = Args::new("hello world!", &[Delimiter::Single(' ')]); // A space is our delimiter.
 ///
 /// // Parse our argument as a `String` and assert that it's the "hello" part of the message.
 /// assert_eq!(args.single::<String>().unwrap(), "hello");
@@ -193,14 +198,14 @@ impl<'a> Lexer<'a> {
 /// We can also parse "quoted arguments" (no pun intended):
 ///
 /// ```rust
-/// use serenity::framework::standard::Args;
+/// use serenity::framework::standard::{Args, Delimiter};
 ///
 /// // Let us imagine this scenario:
 /// // You have a `photo` command that grabs the avatar url of a user. This command accepts names only.
 /// // Now, one of your users wants the avatar of a user named Princess Zelda.
 /// // Problem is, her name contains a space; our delimiter. This would result in two arguments, "Princess" and "Zelda".
 /// // So how shall we get around this? Through quotes! By surrounding her name in them we can perceive it as one single argument.
-/// let mut args = Args::new(r#""Princess Zelda""#, &[" ".to_string()]);
+/// let mut args = Args::new(r#""Princess Zelda""#, &[Delimiter::Single(' ')]);
 ///
 /// // Hooray!
 /// assert_eq!(args.single_quoted::<String>().unwrap(), "Princess Zelda");
@@ -209,9 +214,9 @@ impl<'a> Lexer<'a> {
 /// In case of a mistake, we can go back in time... er I mean, one step (or entirely):
 ///
 /// ```rust
-/// use serenity::framework::standard::Args;
+/// use serenity::framework::standard::{Args, Delimiter};
 ///
-/// let mut args = Args::new("4 2", &[" ".to_string()]);
+/// let mut args = Args::new("4 2", &[Delimiter::Single(' ')]);
 ///
 /// assert_eq!(args.single::<u32>().unwrap(), 4);
 ///
@@ -238,20 +243,20 @@ impl<'a> Lexer<'a> {
 /// ```
 ///
 /// Hmm, taking a glance at the prior example, it seems we have an issue with reading the same argument over and over.
-/// Is there a more sensible solution than rewinding...? Actually, there is! The `*_n` methods:
+/// Is there a more sensible solution than rewinding...? Actually, there is! The `current` and `parse` methods:
 ///
 /// ```rust
-/// use serenity::framework::standard::Args;
+/// use serenity::framework::standard::{Args, Delimiter};
 ///
-/// let mut args = Args::new("trois cinq quatre six", &[" ".to_string()]);
+/// let mut args = Args::new("trois cinq quatre six", &[Delimiter::Single(' ')]);
 ///
-/// assert_eq!(args.single_n::<String>().unwrap(), "trois");
+/// assert_eq!(args.parse::<String>().unwrap(), "trois");
 ///
 /// // It might suggest we've lost the `trois`. But in fact, we didn't! And not only that, we can do it an infinite amount of times!
-/// assert_eq!(args.single_n::<String>().unwrap(), "trois");
-/// assert_eq!(args.single_n::<String>().unwrap(), "trois");
-/// assert_eq!(args.single_n::<String>().unwrap(), "trois");
-/// assert_eq!(args.single_n::<String>().unwrap(), "trois");
+/// assert_eq!(args.parse::<String>().unwrap(), "trois");
+/// assert_eq!(args.current(), Some("trois"));
+/// assert_eq!(args.parse::<String>().unwrap(), "trois");
+/// assert_eq!(args.current(), Some("trois"));
 ///
 /// // Only if we use its brother method we'll then lose it.
 /// assert_eq!(args.single::<String>().unwrap(), "trois");
@@ -264,6 +269,7 @@ pub struct Args {
     message: String,
     args: Vec<Token>,
     offset: usize,
+    state: Cell<State>,
 }
 
 impl Args {
@@ -274,7 +280,7 @@ impl Args {
     /// # Example
     ///
     /// ```rust
-    /// use serenity::framework::standard::Args;
+    /// use serenity::framework::standard::{Args, Delimiter};
     ///
     /// let mut args = Args::new(
     /// // Our message from which we'll parse over.
@@ -282,7 +288,7 @@ impl Args {
     ///
     /// // The "delimiters", or aka the separators. They denote how we distinguish arguments as their own.
     /// // For this example, we'll use one delimiter, the space (`0x20`), which will separate the message.
-    /// &[" ".to_string()],
+    /// &[Delimiter::Single(' ')],
     /// );
     ///
     /// assert_eq!(args.single::<String>().unwrap(), "the");
@@ -294,38 +300,149 @@ impl Args {
     /// ```
     ///
     /// [`Args`]: #struct.Args.html
-    pub fn new(message: &str, possible_delimiters: &[String]) -> Self {
+    pub fn new(message: &str, possible_delimiters: &[Delimiter]) -> Self {
         let delims = possible_delimiters
             .iter()
-            .filter(|d| message.contains(d.as_str()))
-            .flat_map(|s| s.chars())
+            .filter(|d| match d {
+                Delimiter::Single(c) => message.contains(*c),
+                Delimiter::Multiple(s) => message.contains(s),
+            })
             .collect::<Vec<_>>();
 
-        let mut args = Vec::new();
+        let args = if delims.is_empty() && !message.is_empty() {
+            let kind = if message.starts_with('"') && message.ends_with('"') {
+                TokenKind::QuotedArgument
+            } else {
+                TokenKind::Argument
+            };
 
-        // If there are no delimiters, then the only possible argument is the whole message.
-        if delims.is_empty() && !message.is_empty() {
-            args.push(Token::new(TokenKind::Argument, &message[..], 0));
+            // If there are no delimiters, then the only possible argument is the whole message.
+            vec![Token::new(kind, 0, message.len())]
         } else {
-            let mut lex = Lexer::new(message, &delims);
+            let mut args = Vec::new();
+            let mut stream = StringStream::new(message);
 
-            while let Some(token) = lex.commit() {
+            while let Some(token) = lex(&mut stream, &delims) {
                 if token.kind == TokenKind::Delimiter {
                     continue;
                 }
 
                 args.push(token);
             }
-        }
+
+            args
+        };
 
         Args {
             args,
             message: message.to_string(),
             offset: 0,
+            state: Cell::new(State::None),
         }
     }
 
-    /// Retrieves the current argument. Does not parse.
+    fn span(&self) -> (usize, usize) {
+        let Token {
+            kind: _,
+            start,
+            end,
+        } = &self.args[self.offset];
+
+        let start = *start;
+        let end = *end;
+
+        (start, end)
+    }
+
+    #[inline]
+    fn slice(&self) -> &str {
+        let (start, end) = self.span();
+
+        &self.message[start..end]
+    }
+
+    /// Move to the next argument.
+    /// This increments the offset pointer.
+    ///
+    /// Does nothing if the message is empty.
+    pub fn next(&mut self) -> &mut Self {
+        if self.is_empty() {
+            return self;
+        }
+
+        self.offset += 1;
+
+        self
+    }
+
+    /// Go one step behind.
+    /// This decrements the offset pointer.
+    ///
+    /// Does nothing if the offset pointer is `0`.
+    #[inline]
+    pub fn rewind(&mut self) -> &mut Self {
+        if self.offset == 0 {
+            return self;
+        }
+
+        self.offset -= 1;
+
+        self
+    }
+
+    /// Go back to the starting point.
+    #[inline]
+    pub fn restore(&mut self) {
+        self.offset = 0;
+    }
+
+    fn apply<'a>(&self, s: &'a str) -> &'a str {
+        fn remove_quotes(s: &str) -> &str {
+            if s.starts_with('"') && s.ends_with('"') {
+                return &s[1..s.len() - 1];
+            }
+
+            s
+        }
+
+        fn trim(s: &str) -> &str {
+            let trimmed = s.trim();
+
+            // Search where the argument starts and ends between the whitespace.
+            let start = s.find(trimmed).unwrap_or(0);
+            let end = start + trimmed.len();
+
+            &s[start..end]
+        }
+
+        let mut s = s;
+
+        match self.state.get() {
+            State::None => {}
+            State::Quoted => {
+                s = remove_quotes(s);
+            }
+            State::Trimmed => {
+                s = trim(s);
+            }
+            State::QuotedTrimmed => {
+                s = remove_quotes(s);
+                s = trim(s);
+            }
+            State::TrimmedQuoted => {
+                s = trim(s);
+                s = remove_quotes(s);
+            }
+        }
+
+        self.state.set(State::None);
+
+        s
+    }
+
+    /// Retrieve the current argument.
+    ///
+    /// Applies modifications set by [`trimmed`] and [`quoted`].
     ///
     /// # Note
     ///
@@ -334,9 +451,9 @@ impl Args {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::framework::standard::Args;
+    /// use serenity::framework::standard::{Args, Delimiter};
     ///
-    /// let mut args = Args::new("4 2", &[" ".to_string()]);
+    /// let mut args = Args::new("4 2", &[Delimiter::Single(' ')]);
     ///
     /// assert_eq!(args.current(), Some("4"));
     /// args.next();
@@ -344,11 +461,22 @@ impl Args {
     /// args.next();
     /// assert_eq!(args.current(), None);
     /// ```
+    ///
+    /// [`trimmed`]: #method.trimmed
+    /// [`quoted`]: #method.quoted
+    #[inline]
     pub fn current(&self) -> Option<&str> {
-        self.args.get(self.offset).map(|t| t.lit.as_str())
+        if self.is_empty() {
+            return None;
+        }
+
+        let mut s = self.slice();
+        s = self.apply(s);
+
+        Some(s)
     }
 
-    /// Trims the current argument off leading and trailing whitespace.
+    /// Apply trimming the next time the current argument is accessed.
     ///
     /// # Examples
     ///
@@ -357,535 +485,283 @@ impl Args {
     ///
     /// let mut args = Args::new("     42     ", &[]);
     ///
-    /// assert_eq!(args.trim().current(), Some("42"));
+    /// assert_eq!(args.trimmed().current(), Some("42"));
+    /// // `trimmed`'s effect on argument retrieval diminishes after a call to `current`
+    /// assert_eq!(args.current(), Some("     42     "));
+    /// assert_eq!(args.message(), "     42     ");
     /// ```
-    pub fn trim(&mut self) -> &mut Self {
+    pub fn trimmed(&mut self) -> &mut Self {
         if self.is_empty() {
             return self;
         }
 
-        self.args[self.offset].lit = self.args[self.offset].lit.trim().to_string();
+        match self.state.get() {
+            State::None => self.state.set(State::Trimmed),
+            State::Quoted => self.state.set(State::QuotedTrimmed),
+            _ => {}
+        }
 
         self
     }
 
-    /// Trims all of the arguments after the offset off leading and trailing whitespace.
+    /// Remove quotations surrounding the current argument the next time it is accessed.
+    ///
+    /// Note that only the quotes of the argument are taken into account.
+    /// The quotes in the message are preserved.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use serenity::framework::standard::Args;
     ///
-    /// let mut args = Args::new("     42     , 84 ,\t168\t", &[",".to_string()]);
+    /// let mut args = Args::new("\"42\"", &[]);
     ///
-    /// args.trim_all();
-    /// assert_eq!(args.single::<String>().unwrap(), "42");
-    /// assert_eq!(args.single::<String>().unwrap(), "84");
-    /// assert_eq!(args.single::<String>().unwrap(), "168");
+    /// assert_eq!(args.quoted().current(), Some("42"));
+    /// assert_eq!(args.current(), Some("\"42\""));
+    /// assert_eq!(args.message(), "\"42\"");
     /// ```
-    pub fn trim_all(&mut self) {
+    pub fn quoted(&mut self) -> &mut Self {
         if self.is_empty() {
-            return;
+            return self;
         }
 
-        for token in &mut self.args[self.offset..] {
-            token.lit = token.lit.trim().to_string();
+        let is_quoted = self.args[self.offset].kind == TokenKind::QuotedArgument;
+
+        if is_quoted {
+            match self.state.get() {
+                State::None => self.state.set(State::Quoted),
+                State::Trimmed => self.state.set(State::TrimmedQuoted),
+                _ => {}
+            }
         }
+
+        return self;
     }
 
-    /// Parses the current argument and advances.
+    /// Parse the current argument.
+    ///
+    /// Modifications of [`trimmed`] and [`quoted`] are also applied if they were called.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::framework::standard::Args;
+    /// use serenity::framework::standard::{Args, Delimiter};
     ///
-    /// let mut args = Args::new("4 2", &[" ".to_string()]);
+    /// let mut args = Args::new("4 2", &[Delimiter::Single(' ')]);
+    ///
+    /// assert_eq!(args.parse::<u32>().unwrap(), 4);
+    /// assert_eq!(args.current(), Some("4"));
+    /// ```
+    ///
+    /// [`trimmed`]: #method.trimmed
+    /// [`quoted`]: #method.quoted
+    #[inline]
+    pub fn parse<T: FromStr>(&self) -> Result<T, T::Err> {
+        T::from_str(self.current().ok_or(Error::Eos)?).map_err(Error::Parse)
+    }
+
+    /// Parse the current argument and advance.
+    ///
+    /// Shorthand for calling [`parse`], storing the result,
+    /// calling [`next`] and returning the result.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use serenity::framework::standard::{Args, Delimiter};
+    ///
+    /// let mut args = Args::new("4 2", &[Delimiter::Single(' ')]);
     ///
     /// assert_eq!(args.single::<u32>().unwrap(), 4);
     ///
     /// // `4` is now out of the way. Next we have `2`
     /// assert_eq!(args.single::<u32>().unwrap(), 2);
+    /// assert!(args.is_empty());
     /// ```
-    pub fn single<T: FromStr>(&mut self) -> Result<T, T::Err>
-        where T::Err: StdError {
-        if self.is_empty() {
-            return Err(Error::Eos);
-        }
-
-        let cur = &self.args[self.offset];
-
-        let parsed = T::from_str(&cur.lit)?;
-        self.offset += 1;
-        Ok(parsed)
+    ///
+    /// [`parse`]: #method.parse
+    /// [`next`]: #method.next
+    #[inline]
+    pub fn single<T: FromStr>(&mut self) -> Result<T, T::Err> {
+        let p = self.parse::<T>()?;
+        self.next();
+        Ok(p)
     }
 
-    /// Like [`single`], but doesn't advance.
+    /// Remove surrounding quotations, if present, from the argument; parse it and advance.
+    ///
+    /// Shorthand for `.quoted().single::<T>()`
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::framework::standard::Args;
+    /// use serenity::framework::standard::{Args, Delimiter};
     ///
-    /// let args = Args::new("4 2", &[" ".to_string()]);
+    /// let mut args = Args::new(r#""4" "2""#, &[Delimiter::Single(' ')]);
     ///
-    /// assert_eq!(args.single_n::<u32>().unwrap(), 4);
-    /// assert_eq!(args.rest(), "4 2");
+    /// assert_eq!(args.single_quoted::<String>().unwrap(), "4");
+    /// assert_eq!(args.single_quoted::<u32>().unwrap(), 2);
+    /// assert!(args.is_empty());
     /// ```
     ///
-    /// [`single`]: #method.single
-    pub fn single_n<T: FromStr>(&self) -> Result<T, T::Err>
-        where T::Err: StdError {
-        if self.is_empty() {
-            return Err(Error::Eos);
-        }
-
-        let cur = &self.args[self.offset];
-
-        Ok(T::from_str(&cur.lit)?)
+    #[inline]
+    pub fn single_quoted<T: FromStr>(&mut self) -> Result<T, T::Err> {
+        let p = self.quoted().parse::<T>()?;
+        self.next();
+        Ok(p)
     }
 
-    /// "Skip" the argument. Equivalent to `args.single::<String>().ok()`.
+    /// By starting from the current offset, iterate over
+    /// any available arguments until there are none.
     ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("4 2", &[" ".to_string()]);
-    ///
-    /// args.skip();
-    /// assert_eq!(args.single::<u32>().unwrap(), 2);
-    /// ```
-    pub fn skip(&mut self) -> Option<String> {
-        if self.is_empty() {
-            return None;
-        }
-
-        self.single::<String>().ok()
-    }
-
-    /// Like [`skip`], but do it multiple times.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("man of culture topknot", &[" ".to_string()]);
-    ///
-    /// args.skip_for(3);
-    /// assert_eq!(args.remaining(), 1);
-    /// assert_eq!(args.single::<String>().unwrap(), "topknot");
-    /// ```
-    ///
-    /// [`skip`]: #method.skip
-    pub fn skip_for(&mut self, i: u32) -> Option<Vec<String>> {
-        if self.is_empty() {
-            return None;
-        }
-
-        let mut vec = Vec::with_capacity(i as usize);
-
-        for _ in 0..i {
-            vec.push(self.skip()?);
-        }
-
-        Some(vec)
-    }
-
-    /// Iterate until end of message.
+    /// Modifications of [`trimmed`] and [`quoted`] are also applied to all arguments if they were called.
     ///
     /// # Examples
     ///
     /// Assert that all of the numbers in the message are even.
     ///
     /// ```rust
-    /// use serenity::framework::standard::Args;
+    /// use serenity::framework::standard::{Args, Delimiter};
     ///
-    /// let mut args = Args::new("4 2", &[" ".to_string()]);
+    /// let mut args = Args::new("4 2", &[Delimiter::Single(' ')]);
     ///
     /// for arg in args.iter::<u32>() {
-    ///     // Default to zero in case some linguist turns our numbers into words and can't parse those.
+    ///     // Zero troubles, zero worries.
     ///     let arg = arg.unwrap_or(0);
     ///     assert!(arg % 2 == 0);
     /// }
     ///
     /// assert!(args.is_empty());
     /// ```
-    pub fn iter<T: FromStr>(&mut self) -> Iter<'_, T>
-        where T::Err: StdError {
-        Iter::new(self)
-    }
-
-    /// Parses all of the remaining arguments and returns them in a `Vec`.
-    /// Equivalent to `args.iter().collect::<Vec<_>>()`.
     ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let args = Args::new("4 2", &[" ".to_string()]);
-    ///
-    /// assert_eq!(*args.multiple::<u32>().unwrap(), [4, 2]);
-    /// ```
-    pub fn multiple<T: FromStr>(mut self) -> Result<Vec<T>, T::Err>
-        where T::Err: StdError {
-        if self.is_empty() {
-            return Err(Error::Eos);
+    /// [`trimmed`]: struct.Iter.html#method.trimmed
+    /// [`quoted`]: struct.Iter.html#method.quoted
+    #[inline]
+    pub fn iter<T: FromStr>(&mut self) -> Iter<T> {
+        Iter {
+            args: self,
+            state: State::None,
+            _marker: PhantomData,
         }
-
-        self.iter::<T>().collect()
     }
 
-    /// Retrieves the current argument and also removes quotes around it if they're present.
-    /// Does not parse.
+    /// Search for any available argument that can be parsed, and remove it from the "arguments queue".
     ///
     /// # Note
+    /// The removal is irreversible. And happens after the search *and* the parse were successful.
     ///
-    /// This borrows `Args` for the entire lifetime of the returned argument.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("4 \"2\"", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.current_quoted(), Some("4"));
-    /// args.next();
-    /// assert_eq!(args.current_quoted(), Some("2"));
-    /// args.next();
-    /// assert_eq!(args.current_quoted(), None);
-    /// ```
-    pub fn current_quoted(&self) -> Option<&str> {
-        self.args.get(self.offset).map(|t| quotes_extract(t))
-    }
-
-    /// Like [`single`], but accounts quotes.
+    /// # Note 2
+    /// "Arguments queue" is the list which contains all arguments that were deemed unique as defined by quotations and delimiters.
+    /// The 'removed' argument can be, likewise, still accessed via `message`.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::framework::standard::Args;
+    /// use serenity::framework::standard::{Args, Delimiter};
     ///
-    /// let mut args = Args::new(r#""4 2""#, &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.single_quoted::<String>().unwrap(), "4 2");
-    /// assert!(args.is_empty());
-    /// ```
-    ///
-    /// [`single`]: #method.single
-    pub fn single_quoted<T: FromStr>(&mut self) -> Result<T, T::Err>
-        where T::Err: StdError {
-        if self.is_empty() {
-            return Err(Error::Eos);
-        }
-
-        let current = &self.args[self.offset];
-
-        // Discard quotations if present
-        let lit = quotes_extract(current);
-
-        let parsed = T::from_str(&lit)?;
-        self.offset += 1;
-        Ok(parsed)
-    }
-
-    /// Like [`single_quoted`], but doesn't advance.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new(r#""4 2""#, &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.single_quoted_n::<String>().unwrap(), "4 2");
-    /// assert_eq!(args.rest(), r#""4 2""#);
-    /// ```
-    ///
-    /// [`single_quoted`]: #method.single_quoted
-    pub fn single_quoted_n<T: FromStr>(&self) -> Result<T, T::Err>
-        where T::Err: StdError {
-        if self.is_empty() {
-            return Err(Error::Eos);
-        }
-
-        let current = &self.args[self.offset];
-
-        let lit = quotes_extract(current);
-
-        Ok(T::from_str(&lit)?)
-    }
-
-    /// Like [`iter`], but accounts quotes.
-    ///
-    /// # Examples
-    ///
-    /// Assert that all of the numbers in quotations in the message are odd.
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new(r#""5" "3""#, &[" ".to_string()]);
-    ///
-    /// for arg in args.iter_quoted::<u32>() {
-    ///     // Default to zero in case some linguist turns our numbers into words and can't parse those.
-    ///     let arg = arg.unwrap_or(0);
-    ///     assert!(arg % 2 != 0);
-    /// }
-    ///
-    /// assert!(args.is_empty());
-    /// ```
-    ///
-    /// [`iter`]: #method.iter
-    pub fn iter_quoted<T: FromStr>(&mut self) -> IterQuoted<'_, T>
-        where T::Err: StdError {
-        IterQuoted::new(self)
-    }
-
-    /// Like [`multiple`], but accounts quotes.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new(r#""4" "2""#, &[" ".to_string()]);
-    ///
-    /// assert_eq!(*args.multiple_quoted::<u32>().unwrap(), [4, 2]);
-    /// ```
-    ///
-    /// [`multiple`]: #method.multiple
-    pub fn multiple_quoted<T: FromStr>(mut self) -> Result<Vec<T>, T::Err>
-        where T::Err: StdError {
-        if self.is_empty() {
-            return Err(Error::Eos);
-        }
-
-        self.iter_quoted::<T>().collect()
-    }
-
-    /// Returns the first argument that can be parsed and removes it from the message. The suitable argument
-    /// can be in an arbitrary position in the message. Likewise, takes quotes into account.
-    ///
-    /// # Note
-    ///
-    /// Unlike the rest, this function permantently removes the argument if it was **found** and was **succesfully** parsed.
-    /// Hence, use with caution.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("c4 2", &[" ".to_string()]);
+    /// let mut args = Args::new("c4 2", &[Delimiter::Single(' ')]);
     ///
     /// assert_eq!(args.find::<u32>().unwrap(), 2);
     /// assert_eq!(args.single::<String>().unwrap(), "c4");
     /// assert!(args.is_empty());
     /// ```
-    pub fn find<T: FromStr>(&mut self) -> Result<T, T::Err>
-        where T::Err: StdError {
+    pub fn find<T: FromStr>(&mut self) -> Result<T, T::Err> {
         if self.is_empty() {
             return Err(Error::Eos);
         }
 
-        let pos = match self.args.iter().map(|t| quotes_extract(t)).position(|s| s.parse::<T>().is_ok()) {
+        let before = self.offset;
+        self.restore();
+
+        let pos = match self.iter::<T>().quoted().position(|res| res.is_ok()) {
             Some(p) => p,
             None => return Err(Error::Eos),
         };
 
-        let parsed = T::from_str(quotes_extract(&self.args[pos]))?;
+        self.offset = pos;
+        let parsed = self.single_quoted::<T>()?;
+
         self.args.remove(pos);
+        self.offset = before;
         self.rewind();
 
         Ok(parsed)
     }
 
-    /// Like [`find`], but does not remove it.
+    /// Search for any available argument that can be parsed.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::framework::standard::Args;
+    /// use serenity::framework::standard::{Args, Delimiter};
     ///
-    /// let mut args = Args::new("c4 2", &[" ".to_string()]);
+    /// let mut args = Args::new("c4 2", &[Delimiter::Single(' ')]);
     ///
     /// assert_eq!(args.find_n::<u32>().unwrap(), 2);
     ///
-    /// // The `69` is still here, so let's parse it again.
+    /// // The `2` is still here, so let's parse it again.
     /// assert_eq!(args.single::<String>().unwrap(), "c4");
     /// assert_eq!(args.single::<u32>().unwrap(), 2);
     /// assert!(args.is_empty());
     /// ```
-    ///
-    /// [`find`]: #method.find
-    pub fn find_n<T: FromStr>(&mut self) -> Result<T, T::Err>
-        where T::Err: StdError {
+    pub fn find_n<T: FromStr>(&mut self) -> Result<T, T::Err> {
         if self.is_empty() {
             return Err(Error::Eos);
         }
 
-        let pos = match self.args.iter().map(|t| quotes_extract(t)).position(|s| s.parse::<T>().is_ok()) {
+        let before = self.offset;
+        self.restore();
+        let pos = match self.iter::<T>().quoted().position(|res| res.is_ok()) {
             Some(p) => p,
             None => return Err(Error::Eos),
         };
 
-        Ok(T::from_str(quotes_extract(&self.args[pos]))?)
+        self.offset = pos;
+        let parsed = self.quoted().parse::<T>()?;
+
+        self.offset = before;
+
+        Ok(parsed)
     }
 
-    /// Gets original message passed to the command.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let args = Args::new("42 69", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.full(), "42 69");
-    /// ```
-    pub fn full(&self) -> &str {
+    /// Get the original, unmodified message passed to the command.
+    #[inline]
+    pub fn message(&self) -> &str {
         &self.message
     }
 
-    /// Gets the original message passed to the command,
-    /// but without quotes (if both starting and ending quotes are present, otherwise returns as is).
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let args = Args::new("\"42 69\"", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.full_quoted(), "42 69");
-    /// ```
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let args = Args::new("\"42 69", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.full_quoted(), "\"42 69");
-    /// ```
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let args = Args::new("42 69\"", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.full_quoted(), "42 69\"");
-    /// ```
-    pub fn full_quoted(&self) -> &str {
-        let s = &self.message;
-
-        if !s.starts_with('"') {
-            return s;
-        }
-
-        let end = s.rfind('"').unwrap();
-
-        // If it got the quote at the start, then there's no closing quote.
-        if end == 0 {
-            return s;
-        }
-
-        &s[1..end]
-    }
-
-    /// Returns the message starting from the token in the current argument offset; the "rest" of the message.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("to tre fire", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.rest(), "to tre fire");
-    ///
-    /// args.skip();
-    ///
-    /// assert_eq!(args.rest(), "tre fire");
-    ///
-    /// args.skip();
-    ///
-    /// assert_eq!(args.rest(), "fire");
-    ///
-    /// args.skip();
-    ///
-    /// assert_eq!(args.rest(), "");
-    /// ```
+    /// Starting from the offset, return the remainder of available arguments.
+    #[inline]
     pub fn rest(&self) -> &str {
         if self.is_empty() {
             return "";
         }
 
-        let args = &self.args[self.offset..];
+        let (start, _) = self.span();
 
-        if let Some(token) = args.get(0) {
-            &self.message[token.pos..]
-        } else {
-            &self.message[..]
-        }
+        &self.message[start..]
     }
 
-    /// The full amount of recognised arguments.
+    /// Return the full amount of recognised arguments.
+    /// The length of the "arguments queue".
     ///
     /// # Note
     ///
-    /// This never changes. Except for [`find`], which upon success, subtracts the length by 1. (e.g len of `3` becomes `2`)
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("4 2", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.len(), 2); // `2` because `["4", "2"]`
-    /// ```
-    ///
-    /// [`find`]: #method.find
+    /// The value returned is to be assumed to stay static.
+    /// However, if `find` was called previously, and was succesful, then the value is substracted by one.
+    #[inline]
     pub fn len(&self) -> usize {
         self.args.len()
     }
 
-    /// Returns true if there are no arguments left.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("", &[" ".to_string()]);
-    ///
-    /// // will be `true` because passed message is empty thus no arguments.
-    /// assert!(args.is_empty());
-    /// ```
+    /// Assert that there are no more arguments left.
+    #[inline]
     pub fn is_empty(&self) -> bool {
-        self.offset >= self.args.len()
+        self.offset >= self.len()
     }
 
-    /// Amount of arguments still available.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("2 4", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.remaining(), 2);
-    ///
-    /// args.skip();
-    ///
-    /// assert_eq!(args.remaining(), 1);
-    /// ```
+    /// Return the amount of arguments still available.
+    #[inline]
     pub fn remaining(&self) -> usize {
         if self.is_empty() {
             return 0;
@@ -893,609 +769,63 @@ impl Args {
 
         self.len() - self.offset
     }
-
-    /// Move to the next argument.
-    /// This increments the offset pointer.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("4 2", &[" ".to_string()]);
-    ///
-    /// args.next();
-    ///
-    /// assert_eq!(args.single::<u32>().unwrap(), 2);
-    /// assert!(args.is_empty());
-    /// ```
-    #[inline]
-    pub fn next(&mut self) {
-        self.offset += 1;
-    }
-
-    /// Go one step behind.
-    /// This decrements the offset pointer.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("4 2", &[" ".to_string()]);
-    ///
-    /// assert_eq!(args.single::<u32>().unwrap(), 4);
-    ///
-    /// // By this point, we can only parse 2 now.
-    /// // However, with the help of `rewind`, we can mess with 4 again.
-    /// args.rewind();
-    ///
-    /// assert_eq!(args.single::<u32>().unwrap() * 2, 8);
-    /// ```
-    #[inline]
-    pub fn rewind(&mut self) {
-        if self.offset == 0 {
-            return;
-        }
-
-        self.offset -= 1;
-    }
-
-    /// Go back to the starting point.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::framework::standard::Args;
-    ///
-    /// let mut args = Args::new("42 420 69", &[" ".to_string()]);
-    ///
-    /// // Let's parse 'em numbers!
-    /// assert_eq!(args.single::<u32>().unwrap(), 42);
-    /// assert_eq!(args.single::<u32>().unwrap(), 420);
-    /// assert_eq!(args.single::<u32>().unwrap(), 69);
-    ///
-    /// // Oh, no! I actually wanted to multiply all of them by 2!
-    /// // I don't want to call `rewind` 3 times manually....
-    /// // Wait, I could just go entirely back!
-    /// args.restore();
-    ///
-    /// assert_eq!(args.single::<u32>().unwrap() * 2, 84);
-    /// assert_eq!(args.single::<u32>().unwrap() * 2, 840);
-    /// assert_eq!(args.single::<u32>().unwrap() * 2, 138);
-    /// ```
-    ///
-    #[inline]
-    pub fn restore(&mut self) {
-        self.offset = 0;
-    }
 }
-
-impl ::std::ops::Deref for Args {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target { self.full() }
-}
-
-impl PartialEq<str> for Args {
-    fn eq(&self, other: &str) -> bool {
-        self.message == other
-    }
-}
-
-impl<'a> PartialEq<&'a str> for Args {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.message == *other
-    }
-}
-
-impl PartialEq for Args {
-    fn eq(&self, other: &Self) -> bool {
-        self.message == *other.message
-    }
-}
-
-impl Eq for Args {}
-
-use std::marker::PhantomData;
 
 /// Parse each argument individually, as an iterator.
-pub struct Iter<'a, T: FromStr> where T::Err: StdError {
+pub struct Iter<'a, T: FromStr> {
     args: &'a mut Args,
+    state: State,
     _marker: PhantomData<T>,
 }
 
-impl<'a, T: FromStr> Iter<'a, T> where T::Err: StdError {
-    fn new(args: &'a mut Args) -> Self {
-        Iter { args, _marker: PhantomData }
+impl<'a, T: FromStr> Iter<'a, T> {
+    /// Retrieve the current argument.
+    pub fn current(&self) -> Option<&str> {
+        self.args.state.set(self.state);
+        self.args.current()
+    }
+
+    /// Parse the current argument independently.
+    pub fn parse(&self) -> Result<T, T::Err> {
+        self.args.state.set(self.state);
+        self.args.parse::<T>()
+    }
+
+    /// Remove surrounding quotation marks from all of the arguments.
+    #[inline]
+    pub fn quoted(&mut self) -> &mut Self {
+        match self.state {
+            State::None => self.state = State::Quoted,
+            State::Trimmed => self.state = State::TrimmedQuoted,
+            _ => {}
+        }
+
+        self
+    }
+
+    /// Trim leading and trailling whitespace off all arguments.
+    #[inline]
+    pub fn trimmed(&mut self) -> &mut Self {
+        match self.state {
+            State::None => self.state = State::Trimmed,
+            State::Quoted => self.state = State::QuotedTrimmed,
+            _ => {}
+        }
+
+        self
     }
 }
 
-impl<'a, T: FromStr> Iterator for Iter<'a, T> where T::Err: StdError  {
+impl<'a, T: FromStr> Iterator for Iter<'a, T> {
     type Item = Result<T, T::Err>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.args.is_empty() {
             None
         } else {
-            Some(self.args.single::<T>())
+            let arg = self.parse();
+            self.args.next();
+            Some(arg)
         }
-    }
-}
-
-/// Same as [`Iter`], but considers quotes.
-///
-/// [`Iter`]: #struct.Iter.html
-pub struct IterQuoted<'a, T: FromStr> where T::Err: StdError {
-    args: &'a mut Args,
-    _marker: PhantomData<T>,
-}
-
-impl<'a, T: FromStr> IterQuoted<'a, T> where T::Err: StdError {
-    fn new(args: &'a mut Args) -> Self {
-        IterQuoted { args, _marker: PhantomData }
-    }
-}
-
-impl<'a, T: FromStr> Iterator for IterQuoted<'a, T> where T::Err: StdError  {
-    type Item = Result<T, T::Err>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.args.is_empty() {
-            None
-        } else {
-            Some(self.args.single_quoted::<T>())
-        }
-    }
-}
-
-fn quotes_extract(token: &Token) -> &str {
-    if token.kind == TokenKind::QuotedArgument {
-        &token.lit[1..token.lit.len() - 1]
-    } else {
-        &token.lit
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::{Args, Error as ArgError};
-    use matches::assert_matches;
-
-    #[test]
-    fn single_with_empty_message() {
-        let mut args = Args::new("", &["".to_string()]);
-        assert_matches!(args.single::<String>().unwrap_err(), ArgError::Eos);
-
-        let mut args = Args::new("", &[",".to_string()]);
-        assert_matches!(args.single::<String>().unwrap_err(), ArgError::Eos);
-    }
-
-    #[test]
-    fn single_n_with_empty_message() {
-        let args = Args::new("", &["".to_string()]);
-        assert_matches!(args.single_n::<String>().unwrap_err(), ArgError::Eos);
-
-        let args = Args::new("", &[",".to_string()]);
-        assert_matches!(args.single_n::<String>().unwrap_err(), ArgError::Eos);
-    }
-
-    #[test]
-    fn single_quoted_with_empty_message() {
-        let mut args = Args::new("", &["".to_string()]);
-        assert_matches!(args.single_quoted::<String>().unwrap_err(), ArgError::Eos);
-
-        let mut args = Args::new("", &[",".to_string()]);
-        assert_matches!(args.single_quoted::<String>().unwrap_err(), ArgError::Eos);
-    }
-
-    #[test]
-    fn multiple_with_empty_message() {
-        let args = Args::new("", &["".to_string()]);
-        assert_matches!(args.multiple::<String>().unwrap_err(), ArgError::Eos);
-
-        let args = Args::new("", &[",".to_string()]);
-        assert_matches!(args.multiple::<String>().unwrap_err(), ArgError::Eos);
-    }
-
-    #[test]
-    fn multiple_quoted_with_empty_message() {
-        let args = Args::new("", &["".to_string()]);
-        assert_matches!(args.multiple_quoted::<String>().unwrap_err(), ArgError::Eos);
-
-        let args = Args::new("", &[",".to_string()]);
-        assert_matches!(args.multiple_quoted::<String>().unwrap_err(), ArgError::Eos);
-    }
-
-    #[test]
-    fn skip_with_empty_message() {
-        let mut args = Args::new("", &["".to_string()]);
-        assert_matches!(args.skip(), None);
-
-        let mut args = Args::new("", &[",".to_string()]);
-        assert_matches!(args.skip(), None);
-    }
-
-    #[test]
-    fn skip_for_with_empty_message() {
-        let mut args = Args::new("", &["".to_string()]);
-        assert_matches!(args.skip_for(0), None);
-
-        let mut args = Args::new("", &["".to_string()]);
-        assert_matches!(args.skip_for(5), None);
-
-        let mut args = Args::new("", &[",".to_string()]);
-        assert_matches!(args.skip_for(0), None);
-
-        let mut args = Args::new("", &[",".to_string()]);
-        assert_matches!(args.skip_for(5), None);
-    }
-
-    #[test]
-    fn single_i32_with_2_bytes_long_delimiter() {
-        let mut args = Args::new("1, 2", &[", ".to_string()]);
-
-        assert_eq!(args.single::<i32>().unwrap(), 1);
-        assert_eq!(args.single::<i32>().unwrap(), 2);
-    }
-
-    #[test]
-    fn single_i32_with_1_byte_long_delimiter_i32() {
-        let mut args = Args::new("1,2", &[",".to_string()]);
-
-        assert_eq!(args.single::<i32>().unwrap(), 1);
-        assert_eq!(args.single::<i32>().unwrap(), 2);
-    }
-
-    #[test]
-    fn single_i32_with_wrong_char_after_first_arg() {
-        let mut args = Args::new("1, 2", &[",".to_string()]);
-
-        assert_eq!(args.single::<i32>().unwrap(), 1);
-        assert!(args.single::<i32>().is_err());
-    }
-
-    #[test]
-    fn single_i32_with_one_character_being_3_bytes_long() {
-        let mut args = Args::new("1★2", &["★".to_string()]);
-
-        assert_eq!(args.single::<i32>().unwrap(), 1);
-        assert_eq!(args.single::<i32>().unwrap(), 2);
-    }
-
-    #[test]
-    fn single_i32_with_untrimmed_whitespaces() {
-        let mut args = Args::new(" 1, 2 ", &[",".to_string()]);
-
-        assert!(args.single::<i32>().is_err());
-    }
-
-    #[test]
-    fn single_i32_n() {
-        let args = Args::new("1,2", &[",".to_string()]);
-
-        assert_eq!(args.single_n::<i32>().unwrap(), 1);
-        assert_eq!(args.single_n::<i32>().unwrap(), 1);
-    }
-
-    #[test]
-    fn single_quoted_chaining() {
-        let mut args = Args::new(r#""1, 2" "2" """#, &[" ".to_string()]);
-
-        assert_eq!(args.single_quoted::<String>().unwrap(), "1, 2");
-        assert_eq!(args.single_quoted::<String>().unwrap(), "2");
-        assert_eq!(args.single_quoted::<String>().unwrap(), "");
-    }
-
-    #[test]
-    fn single_quoted_and_single_chaining() {
-        let mut args = Args::new(r#""1, 2" "2" "3" 4"#, &[" ".to_string()]);
-
-        assert_eq!(args.single_quoted::<String>().unwrap(), "1, 2");
-        assert!(args.single_n::<i32>().is_err());
-        assert_eq!(args.single::<String>().unwrap(), "\"2\"");
-        assert_eq!(args.single_quoted::<i32>().unwrap(), 3);
-        assert_eq!(args.single::<i32>().unwrap(), 4);
-    }
-
-    #[test]
-    fn full_on_args() {
-        let test_text = "Some text to ensure `full()` works.";
-        let args = Args::new(test_text, &[" ".to_string()]);
-
-        assert_eq!(args.full(), test_text);
-    }
-
-    #[test]
-    fn multiple_quoted_strings_one_delimiter() {
-        let args = Args::new(r#""1, 2" "a" "3" 4 "5"#, &[" ".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["1, 2", "a", "3", "4", "\"5"]);
-    }
-
-    #[test]
-    fn multiple_quoted_strings_with_multiple_delimiter() {
-        let args = Args::new(r#""1, 2" "a","3"4 "5"#, &[" ".to_string(), ",".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["1, 2", "a", "3", "4", "\"5"]);
-    }
-
-    #[test]
-    fn multiple_quoted_strings_with_multiple_delimiters() {
-        let args = Args::new(r#""1, 2" "a","3" """#, &[" ".to_string(), ",".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["1, 2", "a", "3", ""]);
-    }
-
-    #[test]
-    fn multiple_quoted_i32() {
-        let args = Args::new(r#""1" "2" 3"#, &[" ".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<i32>().unwrap(), [1, 2, 3]);
-    }
-
-    #[test]
-    fn multiple_quoted_quote_appears_without_delimiter_in_front() {
-        let args = Args::new(r#"hello, my name is cake" 2"#, &[",".to_string(), " ".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["hello", "my", "name", "is", "cake\"", "2"]);
-    }
-
-    #[test]
-    fn multiple_quoted_single_quote() {
-        let args = Args::new(r#"hello "2 b"#, &[",".to_string(), " ".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["hello", "\"2 b"]);
-    }
-
-    #[test]
-    fn multiple_quoted_one_quote_pair() {
-        let args = Args::new(r#"hello "2 b""#, &[",".to_string(), " ".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["hello", "2 b"]);
-    }
-
-
-    #[test]
-    fn delimiter_before_multiple_quoted() {
-        let args = Args::new(r#","hello, my name is cake" "2""#, &[",".to_string(), " ".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["hello, my name is cake", "2"]);
-    }
-
-    #[test]
-    fn no_quote() {
-        let args = Args::new("hello, my name is cake", &[",".to_string(), " ".to_string()]);
-
-        assert_eq!(args.single_quoted_n::<String>().unwrap(), "hello");
-    }
-
-    #[test]
-    fn single_quoted_n() {
-        let args = Args::new(r#""hello, my name is cake","test"#, &[",".to_string()]);
-
-        assert_eq!(args.single_quoted_n::<String>().unwrap(), "hello, my name is cake");
-        assert_eq!(args.single_quoted_n::<String>().unwrap(), "hello, my name is cake");
-    }
-
-    #[test]
-    fn multiple_quoted_starting_with_wrong_delimiter_in_first_quote() {
-        let args = Args::new(r#""hello, my name is cake" "2""#, &[",".to_string(), " ".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["hello, my name is cake", "2"]);
-    }
-
-    #[test]
-    fn multiple_quoted_with_one_correct_and_one_invalid_quote() {
-        let args = Args::new(r#""hello, my name is cake" "2""#, &[",".to_string(), " ".to_string()]);
-
-        assert_eq!(args.multiple_quoted::<String>().unwrap(), ["hello, my name is cake", "2"]);
-    }
-
-    #[test]
-    fn find_i32_one_one_byte_delimiter() {
-        let mut args = Args::new("hello,my name is cake 2", &[" ".to_string()]);
-
-        assert_eq!(args.find::<i32>().unwrap(), 2);
-    }
-
-    #[test]
-    fn find_i32_one_three_byte_delimiter() {
-        let mut args = Args::new("hello,my name is cakeé2", &["é".to_string()]);
-
-        assert_eq!(args.find::<i32>().unwrap(), 2);
-    }
-
-    #[test]
-    fn find_i32_multiple_delimiter_but_i32_not_last() {
-        let mut args = Args::new("hello,my name is 2 cake", &[" ".to_string(), ",".to_string()]);
-
-        assert_eq!(args.find::<i32>().unwrap(), 2);
-    }
-
-    #[test]
-    fn find_i32_multiple_delimiter() {
-        let mut args = Args::new("hello,my name is cake 2", &[" ".to_string(), ",".to_string()]);
-
-        assert_eq!(args.find::<i32>().unwrap(), 2);
-    }
-
-    #[test]
-    fn find_n_i32() {
-        let mut args = Args::new("a 2", &[" ".to_string()]);
-
-        assert_eq!(args.find_n::<i32>().unwrap(), 2);
-        assert_eq!(args.find_n::<i32>().unwrap(), 2);
-    }
-
-    #[test]
-    fn skip() {
-        let mut args = Args::new("1 2", &[" ".to_string()]);
-
-        assert_eq!(args.skip().unwrap(), "1");
-        assert_eq!(args.remaining(), 1);
-        assert_eq!(args.single::<String>().unwrap(), "2");
-    }
-
-    #[test]
-    fn skip_for() {
-        let mut args = Args::new("1 2 neko 100", &[" ".to_string()]);
-
-        assert_eq!(args.skip_for(2).unwrap(), ["1", "2"]);
-        assert_eq!(args.remaining(), 2);
-        assert_eq!(args.single::<String>().unwrap(), "neko");
-        assert_eq!(args.single::<String>().unwrap(), "100");
-    }
-
-    #[test]
-    fn len_with_one_delimiter() {
-        let args = Args::new("1 2 neko 100", &[" ".to_string()]);
-
-        assert_eq!(args.len(), 4);
-        assert_eq!(args.remaining(), 4);
-    }
-
-    #[test]
-    fn len_multiple_quoted() {
-        let args = Args::new(r#""hello, my name is cake" "2""#, &[" ".to_string()]);
-
-        assert_eq!(args.len(), 2);
-    }
-
-    #[test]
-    fn remaining_len_before_and_after_single() {
-        let mut args = Args::new("1 2", &[" ".to_string()]);
-
-        assert_eq!(args.remaining(), 2);
-        assert_eq!(args.single::<i32>().unwrap(), 1);
-        assert_eq!(args.remaining(), 1);
-        assert_eq!(args.single::<i32>().unwrap(), 2);
-        assert_eq!(args.remaining(), 0);
-    }
-
-    #[test]
-    fn remaining_len_before_and_after_single_quoted() {
-        let mut args = Args::new(r#""1" "2" "3""#, &[" ".to_string()]);
-
-        assert_eq!(args.remaining(), 3);
-        assert_eq!(args.single_quoted::<i32>().unwrap(), 1);
-        assert_eq!(args.remaining(), 2);
-        assert_eq!(args.single_quoted::<i32>().unwrap(), 2);
-        assert_eq!(args.remaining(), 1);
-        assert_eq!(args.single_quoted::<i32>().unwrap(), 3);
-        assert_eq!(args.remaining(), 0);
-    }
-
-    #[test]
-    fn remaining_len_before_and_after_skip() {
-        let mut args = Args::new("1 2", &[" ".to_string()]);
-
-        assert_eq!(args.remaining(), 2);
-        assert_eq!(args.skip().unwrap(), "1");
-        assert_eq!(args.remaining(), 1);
-        assert_eq!(args.skip().unwrap(), "2");
-        assert_eq!(args.remaining(), 0);
-    }
-
-    #[test]
-    fn remaining_len_before_and_after_skip_empty_string() {
-        let mut args = Args::new("", &[" ".to_string()]);
-
-        assert_eq!(args.remaining(), 0);
-        assert_eq!(args.skip(), None);
-        assert_eq!(args.remaining(), 0);
-    }
-
-    #[test]
-    fn remaining_len_before_and_after_skip_for() {
-        let mut args = Args::new("1 2", &[" ".to_string()]);
-
-        assert_eq!(args.remaining(), 2);
-        assert_eq!(args.skip_for(2), Some(vec!["1".to_string(), "2".to_string()]));
-        assert_eq!(args.skip_for(2), None);
-        assert_eq!(args.remaining(), 0);
-    }
-
-    #[test]
-    fn remaining_len_before_and_after_find() {
-        let mut args = Args::new("a 2 6", &[" ".to_string()]);
-
-        assert_eq!(args.remaining(), 3);
-        assert_eq!(args.find::<i32>().unwrap(), 2);
-        assert_eq!(args.remaining(), 2);
-        assert_eq!(args.find::<i32>().unwrap(), 6);
-        assert_eq!(args.remaining(), 1);
-        assert_eq!(args.find::<String>().unwrap(), "a");
-        assert_eq!(args.remaining(), 0);
-        assert_matches!(args.find::<String>().unwrap_err(), ArgError::Eos);
-        assert_eq!(args.remaining(), 0);
-    }
-
-    #[test]
-    fn remaining_len_before_and_after_find_n() {
-        let mut args = Args::new("a 2 6", &[" ".to_string()]);
-
-        assert_eq!(args.remaining(), 3);
-        assert_eq!(args.find_n::<i32>().unwrap(), 2);
-        assert_eq!(args.remaining(), 3);
-    }
-
-
-    #[test]
-    fn multiple_strings_with_one_delimiter() {
-        let args = Args::new("hello, my name is cake 2", &[" ".to_string()]);
-
-        assert_eq!(args.multiple::<String>().unwrap(), ["hello,", "my", "name", "is", "cake", "2"]);
-    }
-
-    #[test]
-    fn multiple_i32_with_one_delimiter() {
-        let args = Args::new("1 2 3", &[" ".to_string()]);
-
-        assert_eq!(args.multiple::<i32>().unwrap(), [1, 2, 3]);
-    }
-
-    #[test]
-    fn multiple_i32_with_one_delimiter_and_parse_error() {
-        let args = Args::new("1 2 3 abc", &[" ".to_string()]);
-
-        assert_matches!(args.multiple::<i32>().unwrap_err(), ArgError::Parse(_));
-    }
-
-    #[test]
-    fn multiple_i32_with_three_delimiters() {
-        let args = Args::new("1 2 3", &[" ".to_string(), ",".to_string()]);
-
-        assert_eq!(args.multiple::<i32>().unwrap(), [1, 2, 3]);
-    }
-
-    #[test]
-    fn single_after_failed_single() {
-        let mut args = Args::new("b 2", &[" ".to_string()]);
-
-        assert_matches!(args.single::<i32>().unwrap_err(), ArgError::Parse(_));
-        // Test that `single` short-circuts on an error and leaves the source as is.
-        assert_eq!(args.remaining(), 2);
-        assert_eq!(args.single::<String>().unwrap(), "b");
-        assert_eq!(args.single::<String>().unwrap(), "2");
-    }
-
-    #[test]
-    fn remaining_len_after_failed_single_quoted() {
-        let mut args = Args::new("b a", &[" ".to_string()]);
-
-        assert_eq!(args.remaining(), 2);
-        // Same goes for `single_quoted` and the alike.
-        assert_matches!(args.single_quoted::<i32>().unwrap_err(), ArgError::Parse(_));
-        assert_eq!(args.remaining(), 2);
-    }
-
-    #[test]
-    fn no_delims_entire_message() {
-        let mut args = Args::new("abc", &[]);
-
-        assert_eq!(args.remaining(), 1);
-        assert_eq!(args.single::<String>().unwrap(), "abc");
-        assert_eq!(args.remaining(), 0);
     }
 }

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -9,6 +9,7 @@ use std::{
     sync::Arc,
 };
 use super::command::{Command, InternalCommand, PrefixCheck};
+use super::Delimiter;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
@@ -60,7 +61,7 @@ pub struct Configuration {
     #[doc(hidden)] pub owners: HashSet<UserId>,
     #[doc(hidden)] pub prefixes: Vec<String>,
     #[doc(hidden)] pub no_dm_prefix: bool,
-    #[doc(hidden)] pub delimiters: Vec<String>,
+    #[doc(hidden)] pub delimiters: Vec<Delimiter>,
     #[doc(hidden)] pub case_insensitive: bool,
     #[doc(hidden)] pub prefix_only_cmd: Option<InternalCommand>,
 }
@@ -454,7 +455,7 @@ impl Configuration {
 
     /// Sets a single delimiter to be used when splitting the content after a command.
     ///
-    /// **Note**: Defaults to a vector with a single element of `" "`.
+    /// **Note**: Defaults to a vector with a single element of `' '`.
     ///
     /// # Examples
     ///
@@ -472,9 +473,9 @@ impl Configuration {
     /// client.with_framework(StandardFramework::new().configure(|c| c
     ///     .delimiter(", ")));
     /// ```
-    pub fn delimiter(mut self, delimiter: &str) -> Self {
+    pub fn delimiter<T: Into<Delimiter>>(mut self, delimiter: T) -> Self {
         self.delimiters.clear();
-        self.delimiters.push(delimiter.to_string());
+        self.delimiters.push(delimiter.into());
 
         self
     }
@@ -502,10 +503,10 @@ impl Configuration {
     /// ```
     ///
     /// [`delimiter`]: #method.delimiter
-    pub fn delimiters<T: ToString, It: IntoIterator<Item=T>>(mut self, delimiters: It) -> Self {
+    pub fn delimiters<T: Into<Delimiter>, It: IntoIterator<Item=T>>(mut self, delimiters: It) -> Self {
         self.delimiters.clear();
         self.delimiters
-            .extend(delimiters.into_iter().map(|s| s.to_string()));
+            .extend(delimiters.into_iter().map(|s| s.into()));
 
         self
     }
@@ -542,7 +543,7 @@ impl Default for Configuration {
     /// - **blocked_guilds** to an empty HashSet
     /// - **blocked_users** to an empty HashSet
     /// - **case_insensitive** to `false`
-    /// - **delimiters** to `vec![" "]`
+    /// - **delimiters** to `vec![' ']`
     /// - **depth** to `5`
     /// - **disabled_commands** to an empty HashSet
     /// - **dynamic_prefix** to no dynamic prefix check
@@ -560,7 +561,7 @@ impl Default for Configuration {
             blocked_guilds: HashSet::default(),
             blocked_users: HashSet::default(),
             case_insensitive: false,
-            delimiters: vec![" ".to_string()],
+            delimiters: vec![Delimiter::Single(' ')],
             depth: 5,
             disabled_commands: HashSet::default(),
             dynamic_prefix: None,

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -491,7 +491,7 @@ fn fetch_all_eligible_commands_in_group<'a>(
                         if has_correct_roles(&cmd, &guild, &member) {
 
                             if help_options.handle_checks {
-                                let mut fake_args = Args::new("", &["".to_string()]);
+                                let mut fake_args = Args::new("", &[]);
                                 let mut context = context.clone();
 
                                 let all_groups_checks_passed =
@@ -620,7 +620,7 @@ pub fn create_customised_help_data<'a, H: BuildHasher>(
     let cache = &context.cache;
 
     if !args.is_empty() {
-        let name = args.full();
+        let name = args.message();
 
         return match fetch_single_command(&cache, &groups, &name, &help_options, &msg) {
             Ok(single_command) => single_command,

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -12,8 +12,9 @@ mod args;
 
 pub use self::args::{
     Args,
+    Delimiter,
     Iter,
-    Error as ArgError
+    Error as ArgError,
 };
 pub(crate) use self::buckets::{Bucket, Ratelimit};
 pub(crate) use self::command::Help;
@@ -1254,7 +1255,7 @@ impl Framework for StandardFramework {
 
                             threadpool.execute(move || {
                                 if let Some(before) = before {
-                                    if !(before)(&mut context, &message, &args.full()) {
+                                    if !(before)(&mut context, &message, &args.message()) {
                                         return;
                                     }
                                 }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -76,7 +76,7 @@ impl Activity {
     /// use serenity::command;
     ///
     /// command!(activity(ctx, _msg, args) {
-    ///     let name = args.full();
+    ///     let name = args.message();
     ///     ctx.set_activity(Activity::playing(&name));
     /// });
     /// #
@@ -114,7 +114,7 @@ impl Activity {
     /// // Assumes command has min_args set to 2.
     /// command!(stream(ctx, _msg, args) {
     ///     # let stream_url = String::from("");
-    ///     let name = args.full();
+    ///     let name = args.message();
     ///     ctx.set_activity(Activity::streaming(&name, &stream_url));
     /// });
     /// #
@@ -149,7 +149,7 @@ impl Activity {
     /// use serenity::{command, framework::standard::Args, model::gateway::Activity};
     ///
     /// command!(listen(ctx, _msg, args) {
-    ///     let name = args.full();
+    ///     let name = args.message();
     ///     ctx.set_activity(Activity::listening(&name));
     /// });
     /// #


### PR DESCRIPTION
Now avoids doing needless allocations until requested by the user (e.g parsing an argument into a `String`), and retains the original message in its raw state.

This is an extract from [the framework rewrite](https://github.com/serenity-rs/serenity/tree/framework-a-new-beginning) as unlike the other changes there, this is standalone and arguably big enough of a change to mandate a separate pull request. The branch will be rebased off of the 0.6.x branch later.
