### PR TITLE
Improve Help Consistency

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -185,7 +185,7 @@ fn main() {
                 .wrong_channel(HelpBehaviour::Strike)
                 // Serenity will automatically analyse and generate a hint/tip explaining the possible
                 // cases of ~~strikethrough-commands~~, but only if
-                // `striked_commands_tip(Some(""))` keeps `Some()` wrapping an empty `String`, which is the default value.
+                // `strikethrough_commands_tip(Some(""))` keeps `Some()` wrapping an empty `String`, which is the default value.
                 // If the `String` is not empty, your given `String` will be used instead.
                 // If you pass in a `None`, no hint will be displayed at all.
                  })

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -235,7 +235,7 @@ impl Default for HelpOptions {
         HelpOptions {
             suggestion_text: "Did you mean `{}`?".to_string(),
             no_help_available_text: "**Error**: No help available.".to_string(),
-            usage_label: "Sample usage".to_string(),
+            usage_label: "Usage".to_string(),
             ungrouped_label: "Ungrouped".to_string(),
             grouped_label: "Group".to_string(),
             aliases_label: "Aliases".to_string(),

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -184,13 +184,13 @@ pub struct HelpOptions {
     /// inside of `CreateHelpCommand`.
     ///
     /// **Note**: Text is only used in direct messages.
-    pub striked_commands_tip_in_dm: Option<String>,
+    pub strikethrough_commands_tip_dm: Option<String>,
     /// Explains reasoning behind strikethrough-commands, see fields requiring `HelpBehaviour` for further information.
     /// If `HelpBehaviour::Strike` is unused, this field will evaluate to `None` during creation
     /// inside of `CreateHelpCommand`.
     ///
     /// **Note**: Text is only used in guilds.
-    pub striked_commands_tip_in_guild: Option<String>,
+    pub strikethrough_commands_tip_guild: Option<String>,
     /// Announcing a group's prefix as in: {group_prefix} {prefix}.
     pub group_prefix: String,
     /// If a user lacks required roles, this will treat how these commands will be displayed.
@@ -249,8 +249,8 @@ impl Default for HelpOptions {
             individual_command_tip: "To get help with an individual command, pass its \
                  name as an argument to this command.".to_string(),
             group_prefix: "Prefix".to_string(),
-            striked_commands_tip_in_dm: Some(String::new()),
-            striked_commands_tip_in_guild: Some(String::new()),
+            strikethrough_commands_tip_dm: Some(String::new()),
+            strikethrough_commands_tip_guild: Some(String::new()),
             lacking_role: HelpBehaviour::Strike,
             lacking_permissions: HelpBehaviour::Strike,
             lacking_ownership: HelpBehaviour::Hide,

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -72,7 +72,7 @@ impl<D: fmt::Display> From<D> for Error {
 
 #[derive(Debug)]
 pub struct CommandGroup {
-    pub prefixes: Option<Vec<String>>,
+    pub prefixes: Vec<String>,
     pub commands: HashMap<String, CommandOrAlias>,
     /// Some fields taken from Command
     pub bucket: Option<String>,
@@ -94,7 +94,7 @@ pub struct CommandGroup {
 impl Default for CommandGroup {
     fn default() -> CommandGroup {
         CommandGroup {
-            prefixes: None,
+            prefixes: Vec::new(),
             commands: HashMap::new(),
             bucket: None,
             required_permissions: Permissions::empty(),
@@ -155,8 +155,6 @@ pub struct HelpOptions {
     pub no_help_available_text: String,
     /// How to use a command, `{usage_label}: {command_name} {args}`
     pub usage_label: String,
-    /// Actual sample label, `{usage_sample_label}: {command_name} {args}`
-    pub usage_sample_label: String,
     /// Text labeling ungrouped commands, `{ungrouped_label}: ...`
     pub ungrouped_label: String,
     /// Text labeling the start of the description.
@@ -237,8 +235,7 @@ impl Default for HelpOptions {
         HelpOptions {
             suggestion_text: "Did you mean `{}`?".to_string(),
             no_help_available_text: "**Error**: No help available.".to_string(),
-            usage_label: "Usage".to_string(),
-            usage_sample_label: "Sample usage".to_string(),
+            usage_label: "Sample usage".to_string(),
             ungrouped_label: "Ungrouped".to_string(),
             grouped_label: "Group".to_string(),
             aliases_label: "Aliases".to_string(),

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -60,19 +60,19 @@ impl CreateGroup {
 
         for alias in &cmd.options().aliases {
 
-            if let Some(ref prefixes) = self.0.prefixes {
+            if self.0.prefixes.is_empty() {
+                self.0.commands.insert(
+                    alias.to_string(),
+                    CommandOrAlias::Alias(command_name.to_string()),
+                );
 
-                for prefix in prefixes {
+            } else {
+                for prefix in &self.0.prefixes {
                     self.0.commands.insert(
                         format!("{} {}", prefix, alias.to_string()),
                         CommandOrAlias::Alias(format!("{} {}", prefix, command_name.to_string())),
                     );
                 }
-            } else {
-                self.0.commands.insert(
-                    alias.to_string(),
-                    CommandOrAlias::Alias(command_name.to_string()),
-                );
             }
         }
 
@@ -99,19 +99,19 @@ impl CreateGroup {
 
         for alias in &cmd.options().aliases {
 
-            if let Some(ref prefixes) = self.0.prefixes {
+            if self.0.prefixes.is_empty() {
+                self.0.commands.insert(
+                    alias.to_string(),
+                    CommandOrAlias::Alias(name.to_string()),
+                );
 
-                for prefix in prefixes {
+            } else {
+               for prefix in &self.0.prefixes {
                     self.0.commands.insert(
                         format!("{} {}", prefix, alias.to_string()),
                         CommandOrAlias::Alias(format!("{} {}", prefix, name.to_string())),
                     );
                 }
-            } else {
-                self.0.commands.insert(
-                    alias.to_string(),
-                    CommandOrAlias::Alias(name.to_string()),
-                );
             }
         }
 
@@ -132,7 +132,7 @@ impl CreateGroup {
     ///
     /// **Note**: It's suggested to call this first when making a group.
     pub fn prefix(mut self, prefix: &str) -> Self {
-        self.0.prefixes = Some(vec![prefix.to_string()]);
+        self.0.prefixes = vec![prefix.to_string()];
 
         self
     }
@@ -144,7 +144,7 @@ impl CreateGroup {
     ///
     /// **Note**: It's suggested to call this first when making a group.
     pub fn prefixes<T: ToString, I: IntoIterator<Item=T>>(mut self, prefixes: I) -> Self {
-        self.0.prefixes = Some(prefixes.into_iter().map(|prefix| prefix.to_string()).collect());
+        self.0.prefixes = prefixes.into_iter().map(|prefix| prefix.to_string()).collect();
 
         self
     }

--- a/src/framework/standard/create_help_command.rs
+++ b/src/framework/standard/create_help_command.rs
@@ -158,7 +158,7 @@ impl CreateHelpCommand {
         self
     }
 
-    /// Sets the tip (or legend) explaining why some commands are striked,
+    /// Sets the tip (or legend) explaining why some commands are in strikethrough-style,
     /// given text will be used in guilds and direct messages.
     ///
     /// By default this is `Some(String)` and the `String` is empty resulting
@@ -166,41 +166,41 @@ impl CreateHelpCommand {
     /// If set to `None`, no tip will be given nor will it be substituted.
     /// If set to a non-empty `Some(String)`, the `String` will be displayed as tip.
     ///
-    /// **Note**: [`CreateHelpCommand::striked_commands_tip_in_direct_message`] and
-    /// [`CreateHelpCommand::striked_commands_tip_in_guild`] can specifically set this text
+    /// **Note**: [`CreateHelpCommand::strikethrough_commands_tip_in_direct_message`] and
+    /// [`CreateHelpCommand::strikethrough_commands_tip_guild`] can specifically set this text
     /// for direct messages and guilds.
     ///
-    /// [`CreateHelpCommand::striked_commands_tip_in_direct_message`]: #method.striked_commands_tip_in_direct_message
-    /// [`CreateHelpCommand::striked_commands_tip_in_guild`]: #method.striked_commands_tip_in_guild
-    pub fn striked_commands_tip(mut self, text: Option<String>) -> Self {
-        self.0.striked_commands_tip_in_dm = text.clone();
-        self.0.striked_commands_tip_in_guild = text;
+    /// [`CreateHelpCommand::strikethrough_commands_tip_in_direct_message`]: #method.strikethrough_commands_tip_in_direct_message
+    /// [`CreateHelpCommand::strikethrough_commands_tip_guild`]: #method.strikethrough_commands_tip_guild
+    pub fn strikethrough_commands_tip(mut self, text: Option<String>) -> Self {
+        self.0.strikethrough_commands_tip_dm = text.clone();
+        self.0.strikethrough_commands_tip_guild = text;
 
         self
     }
 
-    /// Sets the tip (or legend) explaining why some commands are striked,
+    /// Sets the tip (or legend) explaining why some commands are in strikethrough-style,
     /// given text will be used in guilds.
     ///
     /// By default this is `Some(String)` and the `String` is empty resulting
     /// in an automated substitution based on your `HelpBehaviour`-settings.
     /// If set to `None`, no tip will be given nor will it be substituted.
     /// If set to a non-empty `Some(String)`, the `String` will be displayed as tip.
-    pub fn striked_commands_tip_in_guild(mut self, text: Option<String>) -> Self {
-        self.0.striked_commands_tip_in_guild = text;
+    pub fn strikethrough_commands_tip_guild(mut self, text: Option<String>) -> Self {
+        self.0.strikethrough_commands_tip_guild = text;
 
         self
     }
 
-    /// Sets the tip (or legend) explaining why some commands are striked,
+    /// Sets the tip (or legend) explaining why some commands are in strikethrough-style,
     /// given text will be used in direct messages.
     ///
     /// By default this is `Some(String)` and the `String` is empty resulting
     /// in an automated substitution based on your `HelpBehaviour`-settings.
     /// If set to `None`, no tip will be given nor will it be substituted.
     /// If set to a non-empty `Some(String)`, the `String` will be displayed as tip.
-    pub fn striked_commands_tip_in_direct_message(mut self, text: Option<String>) -> Self {
-        self.0.striked_commands_tip_in_dm = text;
+    pub fn strikethrough_commands_tip_in_direct_message(mut self, text: Option<String>) -> Self {
+        self.0.strikethrough_commands_tip_dm = text;
 
         self
     }
@@ -281,15 +281,15 @@ impl CreateHelpCommand {
     }
 
     /// Finishes the creation of a help-command, returning `Help`.
-    /// If `Some(String)` was set as `striked_commands_tip` and the `String` is empty,
+    /// If `Some(String)` was set as `strikethrough_commands_tip` and the `String` is empty,
     /// the creator will substitute content based on the `HelpBehaviour`-settings.
     pub(crate) fn finish(mut self) -> Arc<Help> {
-        if self.0.striked_commands_tip_in_dm == Some(String::new()) {
-            self.0.striked_commands_tip_in_dm = self.produce_strike_text("direct messages");
+        if self.0.strikethrough_commands_tip_dm == Some(String::new()) {
+            self.0.strikethrough_commands_tip_dm = self.produce_strike_text("direct messages");
         }
 
-        if self.0.striked_commands_tip_in_guild == Some(String::new()) {
-            self.0.striked_commands_tip_in_guild = self.produce_strike_text("guild messages");
+        if self.0.strikethrough_commands_tip_guild == Some(String::new()) {
+            self.0.strikethrough_commands_tip_guild = self.produce_strike_text("guild messages");
         }
 
         let CreateHelpCommand(options, function) = self;

--- a/src/framework/standard/create_help_command.rs
+++ b/src/framework/standard/create_help_command.rs
@@ -46,13 +46,6 @@ impl CreateHelpCommand {
         self
     }
 
-    /// Sets a label for the usage examples of a command.
-    pub fn usage_sample_label(mut self, text: &str) -> Self {
-        self.0.usage_sample_label = text.to_string();
-
-        self
-    }
-
     /// Sets a label for ungrouped-commands
     pub fn ungrouped_label(mut self, text: &str) -> Self {
         self.0.ungrouped_label = text.to_string();

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -49,6 +49,7 @@ use super::{
     HelpBehaviour,
 };
 use crate::utils::Colour;
+use log::warn;
 
 #[cfg(feature = "cache")]
 use crate::framework::standard::{has_correct_roles, has_correct_permissions};
@@ -58,8 +59,6 @@ use crate::cache::Cache;
 use parking_lot::RwLock;
 #[cfg(feature = "http")]
 use crate::http::Http;
-
-use log::warn;
 
 /// Macro to format a command according to a `HelpBehaviour` or
 /// continue to the next command-name upon hiding.

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -472,8 +472,8 @@ fn fetch_all_eligible_commands_in_group<'a>(
 
         if !cmd.dm_only && !cmd.guild_only
             || cmd.dm_only && msg.is_private()
-            || cmd.guild_only && !msg.is_private()
-        {
+            || cmd.guild_only && !msg.is_private() {
+
             if cmd.owners_only && !owners.contains(&msg.author.id) {
                 let name = format_command_name!(&help_options.lacking_ownership, &name);
                 group_with_cmds.command_names.push(name);
@@ -585,7 +585,7 @@ fn create_single_group<'a>(
     msg: &Message,
     help_options: &'a HelpOptions,
 ) -> GroupCommandsPair<'a> {
-let commands = remove_aliases(&group.commands);
+    let commands = remove_aliases(&group.commands);
     let mut command_names = commands.keys().collect::<Vec<_>>();
     command_names.sort();
 
@@ -605,7 +605,7 @@ let commands = remove_aliases(&group.commands);
     group_with_cmds
 }
 
-/// Iterates over all commands and forges them into a `CustomisedHelpData`
+/// Iterates over all commands and forges them into a `CustomisedHelpData`.
 /// taking `HelpOptions` into consideration when deciding on whether a command
 /// shall be picked and in what textual format.
 #[cfg(feature = "cache")]
@@ -936,9 +936,6 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command)
         } else {
             let _ = writeln!(result, "**{}**: `{} {}`", help_options.usage_label, command.name, usage);
         }
-
-    if let Some(ref usage_sample) = command.usage_sample {
-        let _ = writeln!(result, "**{}**: `{} {}`", help_options.usage_sample_label, command.name, usage_sample);
     }
 
     let _ = writeln!(result, "**{}**: {}", help_options.grouped_label, command.group_name);

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -666,15 +666,15 @@ pub fn create_customised_help_data<'a, H: BuildHasher>(
     }
 
     let strikethrough_command_tip = if msg.is_private() {
-        &help_options.striked_commands_tip_in_guild
+        &help_options.strikethrough_commands_tip_guild
     } else {
-        &help_options.striked_commands_tip_in_dm
+        &help_options.strikethrough_commands_tip_dm
     };
 
-    let description = if let Some(ref striked_command_text) = strikethrough_command_tip {
+    let description = if let Some(ref strikethrough_command_text) = strikethrough_command_tip {
         format!(
             "{}\n{}",
-            &help_options.individual_command_tip, &striked_command_text
+            &help_options.individual_command_tip, &strikethrough_command_text
         )
     } else {
         help_options.individual_command_tip.clone()


### PR DESCRIPTION
The help-system accumulated a few inconsistencies and this pull request aims to remove some.

Changes:
- Usage-text in the plain help does no longer lack ticks around the command.
- Usage-text prepends the first group-prefix if available.
- The wording "strike'd" (or `striked` in code) got replaced with the proper typographical presentation named "Strikethrough".
- Some formatting was indented on the wrong line for no particular reason.
- Usage-text had two methods to set it and one got removed.
- "Sample usage" got simplified to "Usage".
- Some public `struct`s got altered.

Due to changes to the length of help and potentially causing the created help-message to exceed the maximum length and the nature of changing public interfaces, this is a breaking pull request.
