### PR TITLE
Lock `cc` and `base64` to specific Versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ parking_lot = "^0.5"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
+cc = "=1.0.25"
 
 [dependencies.base64]
 optional = true
-version = "0.10"
+version = "=0.10.0"
 
 [dependencies.byteorder]
 optional = true

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -74,6 +74,8 @@ use self::bridge::voice::ClientVoiceManager;
 /// receive, acting as a "ping-pong" bot is simple:
 ///
 /// ```no_run
+/// extern crate serenity;
+///
 /// # fn try_main() -> Result<(), Box<std::error::Error>> {
 /// use serenity::prelude::*;
 /// use serenity::model::prelude::*;
@@ -94,7 +96,7 @@ use self::bridge::voice::ClientVoiceManager;
 /// client.start();
 /// # Ok(()) }
 /// #
-/// # fn main() { try_main().unwrap(); } 
+/// # fn main() { try_main().unwrap(); }
 /// ```
 ///
 /// [`Shard`]: ../gateway/struct.Shard.html
@@ -124,18 +126,19 @@ pub struct Client {
     /// - [`Event::MessageUpdate`]
     ///
     /// ```no_run
-    /// # fn try_main() -> Result<(), Box<std::error::Error>> {
     /// extern crate serenity;
+    /// extern crate typemap;
     ///
+    /// # fn try_main() -> Result<(), Box<std::error::Error>> {
     /// // Of note, this imports `typemap`'s `Key` as `TypeMapKey`.
     /// use serenity::prelude::*;
     /// use serenity::model::prelude::*;
-    /// use std::collections::HashMap;
-    /// use std::env;
+    /// use typemap::Key;
+    /// use std::{collections::HashMap, env};
     ///
     /// struct MessageEventCounter;
     ///
-    /// impl TypeMapKey for MessageEventCounter {
+    /// impl Key for MessageEventCounter {
     ///     type Value = HashMap<String, u64>;
     /// }
     ///
@@ -170,7 +173,7 @@ pub struct Client {
     /// client.start()?;
     /// # Ok(()) }
     /// #
-    /// # fn main() { try_main().unwrap(); } 
+    /// # fn main() { try_main().unwrap(); }
     /// ```
     ///
     /// Refer to [example 05] for an example on using the `data` field.
@@ -207,6 +210,8 @@ pub struct Client {
     /// 5 seconds:
     ///
     /// ```rust,no_run
+    /// # extern crate serenity;
+    /// #
     /// # use serenity::client::{Client, EventHandler};
     /// # use std::error::Error;
     /// # use std::time::Duration;


### PR DESCRIPTION
Serenity stopped building with our minimum required rustc-version due to our dependencies depending on `cc` and `base64` and these crates got a stable update but did not take rustc-versioning into consideration.

This pull request locks `cc` and `base64` to older versions to prevent depending on new Rust-features that would require a new rustc.