### PR TITLE
Adhere to Rust 2018's Idioms

### DIFF
--- a/src/client/bridge/gateway/mod.rs
+++ b/src/client/bridge/gateway/mod.rs
@@ -144,7 +144,7 @@ pub enum ShardQueuerMessage {
 pub struct ShardId(pub u64);
 
 impl Display for ShardId {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}", self.0)
     }
 }

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -129,7 +129,7 @@ impl ShardManager {
     /// Creates a new shard manager, returning both the manager and a monitor
     /// for usage in a separate thread.
     pub fn new<H>(
-        opt: ShardManagerOptions<H>,
+        opt: ShardManagerOptions<'_, H>,
     ) -> (Arc<Mutex<Self>>, ShardManagerMonitor) where H: EventHandler + Send + Sync + 'static {
         let (thread_tx, thread_rx) = mpsc::channel();
         let (shard_queue_tx, shard_queue_rx) = mpsc::channel();
@@ -353,7 +353,7 @@ pub struct ShardManagerOptions<'a, H: EventHandler + Send + Sync + 'static> {
     pub data: &'a Arc<RwLock<ShareMap>>,
     pub event_handler: &'a Arc<H>,
     #[cfg(feature = "framework")]
-    pub framework: &'a Arc<Mutex<Option<Box<Framework + Send>>>>,
+    pub framework: &'a Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     pub shard_index: u64,
     pub shard_init: u64,
     pub shard_total: u64,

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -55,7 +55,7 @@ pub struct ShardQueuer<H: EventHandler + Send + Sync + 'static> {
     pub event_handler: Arc<H>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
-    pub framework: Arc<Mutex<Option<Box<Framework + Send>>>>,
+    pub framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     /// The instant that a shard was last started.
     ///
     /// This is used to determine how long to wait between shard IDENTIFYs.

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -42,7 +42,7 @@ pub struct ShardRunner<H: EventHandler + Send + Sync + 'static> {
     data: Arc<RwLock<ShareMap>>,
     event_handler: Arc<H>,
     #[cfg(feature = "framework")]
-    framework: Arc<Mutex<Option<Box<Framework + Send>>>>,
+    framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     manager_tx: Sender<ShardManagerMessage>,
     // channel to receive messages from the shard manager and dispatches
     runner_rx: Receiver<InterMessage>,
@@ -493,7 +493,7 @@ pub struct ShardRunnerOptions<H: EventHandler + Send + Sync + 'static> {
     pub data: Arc<RwLock<ShareMap>>,
     pub event_handler: Arc<H>,
     #[cfg(feature = "framework")]
-    pub framework: Arc<Mutex<Option<Box<Framework + Send>>>>,
+    pub framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     pub manager_tx: Sender<ShardManagerMessage>,
     pub shard: Shard,
     pub threadpool: ThreadPool,

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -99,7 +99,7 @@ pub(crate) enum DispatchEvent {
 #[clippy::too_many_arguments]
 pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static>(
     event: DispatchEvent,
-    framework: &Arc<Mutex<Option<Box<Framework + Send>>>>,
+    framework: &Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     data: &Arc<RwLock<ShareMap>>,
     event_handler: &Arc<H>,
     runner_tx: &Sender<InterMessage>,

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult { f.write_str(self.description()) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult { f.write_str(self.description()) }
 }
 
 impl StdError for Error {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -184,7 +184,7 @@ pub struct Client {
     ///
     /// [`Event::Ready`]: ../model/event/enum.Event.html#variant.Ready
     /// [`on_ready`]: #method.on_ready
-    #[cfg(feature = "framework")] framework: Arc<Mutex<Option<Box<Framework + Send>>>>,
+    #[cfg(feature = "framework")] framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     /// A HashMap of all shards instantiated by the Client.
     ///
     /// The key is the shard ID and the value is the shard itself.

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,7 +156,7 @@ impl From<ReqwestError> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.description())
     }
 }
@@ -187,7 +187,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             Error::Json(ref inner) => Some(inner),
             Error::Io(ref inner) => Some(inner),

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -29,7 +29,7 @@ impl<E: StdError> StdError for Error<E> {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         use self::Error::*;
 
         match *self {
@@ -40,7 +40,7 @@ impl<E: StdError> StdError for Error<E> {
 }
 
 impl<E: StdError> fmt::Display for Error<E> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::Error::*;
 
         match *self {
@@ -513,7 +513,7 @@ impl Args {
     ///
     /// assert!(args.is_empty());
     /// ```
-    pub fn iter<T: FromStr>(&mut self) -> Iter<T>
+    pub fn iter<T: FromStr>(&mut self) -> Iter<'_, T>
         where T::Err: StdError {
         Iter::new(self)
     }
@@ -641,7 +641,7 @@ impl Args {
     /// ```
     ///
     /// [`iter`]: #method.iter
-    pub fn iter_quoted<T: FromStr>(&mut self) -> IterQuoted<T>
+    pub fn iter_quoted<T: FromStr>(&mut self) -> IterQuoted<'_, T>
         where T::Err: StdError {
         IterQuoted::new(self)
     }

--- a/src/framework/standard/buckets.rs
+++ b/src/framework/standard/buckets.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 #[cfg(feature = "cache")]
-type Check = Fn(&mut Context, Option<GuildId>, ChannelId, UserId) -> bool + Send + Sync + 'static;
+type Check = dyn Fn(&mut Context, Option<GuildId>, ChannelId, UserId) -> bool + Send + Sync + 'static;
 
 #[cfg(not(feature = "cache"))]
 type Check = Fn(&mut Context, ChannelId, UserId) -> bool + Send + Sync + 'static;

--- a/src/framework/standard/check.rs
+++ b/src/framework/standard/check.rs
@@ -145,7 +145,7 @@ impl Check {
 }
 
 impl Debug for Check {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Check")
             .field("name", &self.name)
             .field("function", &"<fn>")

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -25,7 +25,7 @@ pub type HelpFunction = fn(&mut Context, &Message, &HelpOptions, HashMap<String,
 pub struct Help(pub HelpFunction, pub Arc<HelpOptions>);
 
 impl Debug for Help {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Help")
             .field("options", &self.1)
             .finish()
@@ -38,12 +38,12 @@ impl HelpCommand for Help {
     }
 }
 
-pub type BeforeHook = Fn(&mut Context, &Message, &str) -> bool + Send + Sync + 'static;
-pub type AfterHook = Fn(&mut Context, &Message, &str, Result<(), Error>) + Send + Sync + 'static;
-pub type UnrecognisedCommandHook = Fn(&mut Context, &Message, &str) + Send + Sync + 'static;
-pub type MessageWithoutCommandHook = Fn(&mut Context, &Message) + Send + Sync + 'static;
-pub(crate) type InternalCommand = Arc<Command>;
-pub type PrefixCheck = Fn(&mut Context, &Message) -> Option<String> + Send + Sync + 'static;
+pub type BeforeHook = dyn Fn(&mut Context, &Message, &str) -> bool + Send + Sync + 'static;
+pub type AfterHook = dyn Fn(&mut Context, &Message, &str, Result<(), Error>) + Send + Sync + 'static;
+pub type UnrecognisedCommandHook = dyn Fn(&mut Context, &Message, &str) + Send + Sync + 'static;
+pub type MessageWithoutCommandHook = dyn Fn(&mut Context, &Message) + Send + Sync + 'static;
+pub(crate) type InternalCommand = Arc<dyn Command>;
+pub type PrefixCheck = dyn Fn(&mut Context, &Message) -> Option<String> + Send + Sync + 'static;
 
 pub enum CommandOrAlias {
     Alias(String),
@@ -51,7 +51,7 @@ pub enum CommandOrAlias {
 }
 
 impl fmt::Debug for CommandOrAlias {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             CommandOrAlias::Alias(ref s) => f.debug_tuple("CommandOrAlias::Alias").field(&s).finish(),
             CommandOrAlias::Command(ref arc) => f.debug_tuple("CommandOrAlias::Command").field(&arc.options()).finish(),
@@ -226,7 +226,7 @@ pub trait HelpCommand: Send + Sync + 'static {
     }
 }
 
-impl HelpCommand for Arc<HelpCommand> {
+impl HelpCommand for Arc<dyn HelpCommand> {
     fn execute(&self, c: &mut Context, m: &Message, ho: &HelpOptions, hm: HashMap<String, Arc<CommandGroup>>, owners: HashSet<UserId>, a: &Args) -> Result<(), Error> {
         (**self).execute(c, m, ho, hm, owners, a)
     }
@@ -289,7 +289,7 @@ pub trait Command: Send + Sync + 'static {
     fn after(&self, _: &mut Context, _: &Message, _: &Result<(), Error>) { }
 }
 
-impl Command for Arc<Command> {
+impl Command for Arc<dyn Command> {
     fn execute(&self, c: &mut Context, m: &Message, a: Args) -> Result<(), Error> {
         (**self).execute(c, m, a)
     }

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 
 pub enum FnOrCommand {
     Fn(fn(&mut Context, &Message, Args) -> Result<(), CommandError>),
-    Command(Arc<Command>),
-    CommandWithOptions(Arc<Command>),
+    Command(Arc<dyn Command>),
+    CommandWithOptions(Arc<dyn Command>),
 }
 
 impl Default for FnOrCommand {
@@ -28,9 +28,9 @@ impl Default for FnOrCommand {
     }
 }
 
-type Init = Fn() + Send + Sync + 'static;
-type Before = Fn(&mut Context, &Message) -> bool + Send + Sync + 'static;
-type After = Fn(&mut Context, &Message, &Result<(), CommandError>) + Send + Sync + 'static;
+type Init = dyn Fn() + Send + Sync + 'static;
+type Before = dyn Fn(&mut Context, &Message) -> bool + Send + Sync + 'static;
+type After = dyn Fn(&mut Context, &Message, &Result<(), CommandError>) + Send + Sync + 'static;
 
 #[derive(Default)]
 pub struct Handlers {
@@ -287,7 +287,7 @@ impl CreateCommand {
         self
     }
 
-    pub(crate) fn finish(self) -> Arc<Command> {
+    pub(crate) fn finish(self) -> Arc<dyn Command> {
         struct A<C: Command>(Arc<CommandOptions>, C, Handlers);
 
         impl<C: Command> Command for A<C> {

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -95,7 +95,7 @@ impl CreateGroup {
     ///
     /// [`on`]: #method.on
     pub fn cmd<C: Command + 'static>(mut self, name: &str, c: C) -> Self {
-        let cmd: Arc<Command> = Arc::new(c);
+        let cmd: Arc<dyn Command> = Arc::new(c);
 
         for alias in &cmd.options().aliases {
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -555,7 +555,7 @@ fn create_command_group_commands_pair_from_groups<'a, H: BuildHasher>(
     msg: &Message,
     help_options: &'a HelpOptions,
 ) -> Vec<GroupCommandsPair<'a>> {
-    let mut listed_groups: Vec<GroupCommandsPair> = Vec::default();
+    let mut listed_groups: Vec<GroupCommandsPair<'_>> = Vec::default();
 
     for group_name in group_names {
         let group = &groups[&**group_name];
@@ -711,7 +711,7 @@ fn send_grouped_commands_embed(
     help_options: &HelpOptions,
     channel_id: ChannelId,
     help_description: &str,
-    groups: &[GroupCommandsPair],
+    groups: &[GroupCommandsPair<'_>],
     colour: Colour,
 ) -> Result<Message, Error> {
     channel_id.send_message(&http, |m| {
@@ -747,7 +747,7 @@ fn send_single_command_embed(
     http: &Arc<Http>,
     help_options: &HelpOptions,
     channel_id: ChannelId,
-    command: &Command,
+    command: &Command<'_>,
     colour: Colour,
 ) -> Result<Message, Error> {
     channel_id.send_message(&http, |m| {
@@ -902,7 +902,7 @@ pub fn with_embeds<H: BuildHasher>(
 fn grouped_commands_to_plain_string(
     help_options: &HelpOptions,
     help_description: &str,
-    groups: &[GroupCommandsPair]) -> String
+    groups: &[GroupCommandsPair<'_>]) -> String
 {
     let mut result = "__**Commands**__\n".to_string();
     let _ = writeln!(result, "{}", &help_description);
@@ -921,7 +921,7 @@ fn grouped_commands_to_plain_string(
 }
 
 /// Turns a single command into a `String` taking plain help format into account.
-fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command) -> String {
+fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<'_>) -> String {
     let mut result = String::default();
     let _ = writeln!(result, "__**{}**__", command.name);
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -203,7 +203,7 @@ pub enum DispatchError {
     WebhookAuthor,
 }
 
-type DispatchErrorHook = Fn(Context, Message, DispatchError) + Send + Sync + 'static;
+type DispatchErrorHook = dyn Fn(Context, Message, DispatchError) + Send + Sync + 'static;
 
 /// A utility for easily managing dispatches to commands.
 ///
@@ -692,7 +692,7 @@ impl StandardFramework {
                 .or_insert_with(|| Arc::new(CommandGroup::default()));
 
             if let Some(ref mut group) = Arc::get_mut(ungrouped) {
-                let cmd: Arc<Command> = Arc::new(c);
+                let cmd: Arc<dyn Command> = Arc::new(c);
 
                 for alias in &cmd.options().aliases {
                      group.commands.insert(
@@ -1362,7 +1362,7 @@ pub enum HelpBehaviour {
 use std::fmt;
 
 impl fmt::Display for HelpBehaviour {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        fmt::Debug::fmt(self, f)
     }
 }

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -53,7 +53,7 @@ pub enum Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult { f.write_str(self.description()) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult { f.write_str(self.description()) }
 }
 
 impl StdError for Error {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -156,7 +156,7 @@ impl ConnectionStage {
 }
 
 impl Display for ConnectionStage {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         use self::ConnectionStage::*;
 
         f.write_str(match *self {

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -50,7 +50,7 @@ impl From<InvalidHeaderValue> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult { f.write_str(self.description()) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult { f.write_str(self.description()) }
 }
 
 impl StdError for Error {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -85,21 +85,21 @@ pub enum AttachmentType<'a> {
 }
 
 impl<'a> From<(&'a [u8], &'a str)> for AttachmentType<'a> {
-    fn from(params: (&'a [u8], &'a str)) -> AttachmentType { AttachmentType::Bytes(params) }
+    fn from(params: (&'a [u8], &'a str)) -> AttachmentType<'_> { AttachmentType::Bytes(params) }
 }
 
 impl<'a> From<&'a str> for AttachmentType<'a> {
-    fn from(s: &'a str) -> AttachmentType { AttachmentType::Path(Path::new(s)) }
+    fn from(s: &'a str) -> AttachmentType<'_> { AttachmentType::Path(Path::new(s)) }
 }
 
 impl<'a> From<&'a Path> for AttachmentType<'a> {
-    fn from(path: &'a Path) -> AttachmentType {
+    fn from(path: &'a Path) -> AttachmentType<'_> {
         AttachmentType::Path(path)
     }
 }
 
 impl<'a> From<&'a PathBuf> for AttachmentType<'a> {
-    fn from(pathbuf: &'a PathBuf) -> AttachmentType { AttachmentType::Path(pathbuf.as_path()) }
+    fn from(pathbuf: &'a PathBuf) -> AttachmentType<'_> { AttachmentType::Path(pathbuf.as_path()) }
 }
 
 impl<'a> From<(&'a File, &'a str)> for AttachmentType<'a> {

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -65,7 +65,7 @@ use log::debug;
 /// [`offset`]: fn.offset.html
 static mut OFFSET: Option<i64> = None;
 
-pub(super) fn perform(http: &Http, req: Request) -> Result<Response> {
+pub(super) fn perform(http: &Http, req: Request<'_>) -> Result<Response> {
     loop {
         // This will block if another thread is trying to send
         // an HTTP-request already (due to receiving an x-ratelimit-global).

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -1660,7 +1660,7 @@ impl Http {
     /// ```
     ///
     /// [`request`]: fn.request.html
-    pub fn fire<T: DeserializeOwned>(&self, req: Request) -> Result<T> {
+    pub fn fire<T: DeserializeOwned>(&self, req: Request<'_>) -> Result<T> {
         let response = self.request(req)?;
 
         serde_json::from_reader(response).map_err(From::from)
@@ -1709,7 +1709,7 @@ impl Http {
     /// ```
     ///
     /// [`fire`]: fn.fire.html
-    pub fn request(&self, req: Request) -> Result<ReqwestResponse> {
+    pub fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
         let response = perform(&self, req)?;
 
         if response.status().is_success() {
@@ -1719,7 +1719,7 @@ impl Http {
         }
     }
 
-    pub(super) fn retry(&self, request: &Request) -> Result<ReqwestResponse> {
+    pub(super) fn retry(&self, request: &Request<'_>) -> Result<ReqwestResponse> {
         // Retry the request twice in a loop until it succeeds.
         //
         // If it doesn't and the loop breaks, try one last time.
@@ -1750,7 +1750,7 @@ impl Http {
     ///
     /// This is a function that performs a light amount of work and returns an
     /// empty tuple, so it's called "self.wind" to denote that it's lightweight.
-    pub(super) fn wind(&self, expected: u16, req: Request) -> Result<()> {
+    pub(super) fn wind(&self, expected: u16, req: Request<'_>) -> Result<()> {
         let resp = self.request(req)?;
 
         if resp.status().as_u16() == expected {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -109,7 +109,7 @@ impl<'a> Request<'a> {
         &mut self.headers
     }
 
-    pub fn route_ref(&self) -> &RouteInfo {
+    pub fn route_ref(&self) -> &RouteInfo<'_> {
         &self.route
     }
 

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -913,7 +913,7 @@ pub enum RouteInfo<'a> {
 }
 
 impl<'a> RouteInfo<'a> {
-    pub fn deconstruct(&self) -> (LightMethod, Route, Cow<str>) {
+    pub fn deconstruct(&self) -> (LightMethod, Route, Cow<'_, str>) {
         match *self {
             RouteInfo::AddGroupRecipient { group_id, user_id } => (
                 LightMethod::Put,

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -66,7 +66,7 @@ macro_rules! enum_number {
                 impl<'de> ::serde::de::Visitor<'de> for Visitor {
                     type Value = $name;
 
-                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter)
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>)
                         -> ::std::fmt::Result {
                         formatter.write_str("positive integer")
                     }

--- a/src/model/channel/group.rs
+++ b/src/model/channel/group.rs
@@ -226,7 +226,7 @@ impl Group {
     /// If there are no recipients in the group, the name will be "Empty Group".
     /// Otherwise, the name is generated in a Comma Separated Value list, such
     /// as "person 1, person 2, person 3".
-    pub fn name(&self) -> Cow<str> {
+    pub fn name(&self) -> Cow<'_, str> {
         match self.name {
             Some(ref name) => Cow::Borrowed(name),
             None => {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -689,5 +689,5 @@ impl GuildChannel {
 #[cfg(feature = "model")]
 impl Display for GuildChannel {
     /// Formats the channel, creating a mention of it.
-    fn fmt(&self, f: &mut Formatter) -> FmtResult { Display::fmt(&self.id.mention(), f) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult { Display::fmt(&self.id.mention(), f) }
 }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -363,7 +363,7 @@ impl Display for Channel {
     /// [`Group::name`]: struct.Group.html#method.name
     /// [`GuildChannel`]: struct.GuildChannel.html
     /// [`PrivateChannel`]: struct.PrivateChannel.html
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match *self {
             Channel::Group(ref group) => Display::fmt(&group.read().name(), f),
             Channel::Guild(ref ch) => Display::fmt(&ch.read().id.mention(), f),

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -309,7 +309,7 @@ impl PrivateChannel {
 
 impl Display for PrivateChannel {
     /// Formats the private channel, displaying the recipient's username.
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.write_str(&self.recipient.read().name)
     }
 }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -232,7 +232,7 @@ impl<'de> Deserialize<'de> for ReactionType {
         impl<'de> Visitor<'de> for ReactionTypeVisitor {
             type Value = ReactionType;
 
-            fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                 formatter.write_str("enum ReactionType")
             }
 
@@ -412,7 +412,7 @@ impl<'a> From<&'a str> for ReactionType {
 pub enum NeverFails {}
 
 impl Display for NeverFails {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "never fails")
     }
 }
@@ -443,7 +443,7 @@ impl Display for ReactionType {
     /// [`Emoji::fmt`]: ../guild/struct.Emoji.html#method.fmt
     /// [`ReactionType::Custom`]: enum.ReactionType.html#variant.Custom
     /// [`ReactionType::Unicode`]: enum.ReactionType.html#variant.Unicode
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match *self {
             ReactionType::Custom {
                 id,

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -130,7 +130,7 @@ pub enum Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult { f.write_str(self.description()) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult { f.write_str(self.description()) }
 }
 
 impl StdError for Error {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1822,7 +1822,7 @@ impl<'de> Deserialize<'de> for EventType {
         impl<'de> Visitor<'de> for EventTypeVisitor {
             type Value = EventType;
 
-            fn expecting(&self, f: &mut Formatter) -> FmtResult {
+            fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
                 f.write_str("event type str")
             }
 

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -267,7 +267,7 @@ mod u64_handler {
         impl<'de> Visitor<'de> for U64Visitor {
             type Value = u64;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("an integer or a string with a valid number inside")
             }
 
@@ -298,7 +298,7 @@ mod option_u64_handler {
         impl<'de> Visitor<'de> for OptionU64Visitor {
             type Value = Option<u64>;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("an optional integer or a string with a valid number inside")
             }
 
@@ -338,7 +338,7 @@ mod action_handler {
         impl<'de> Visitor<'de> for ActionVisitor {
             type Value = Action;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("an integer between 1 to 72")
             }
 
@@ -348,13 +348,13 @@ mod action_handler {
 
                 Ok(match value {
                     1 => Action::GuildUpdate,
-                    10...12 => Action::Channel(unsafe { transmute(value) }),
-                    13...15 => Action::ChannelOverwrite(unsafe { transmute(value) }),
-                    20...25 => Action::Member(unsafe { transmute(value) }),
-                    30...32 => Action::Role(unsafe { transmute(value) }),
-                    40...42 => Action::Invite(unsafe { transmute(value) }),
-                    50...52 => Action::Webhook(unsafe { transmute(value) }),
-                    60...62 => Action::Emoji(unsafe { transmute(value) }),
+                    10..=12 => Action::Channel(unsafe { transmute(value) }),
+                    13..=15 => Action::ChannelOverwrite(unsafe { transmute(value) }),
+                    20..=25 => Action::Member(unsafe { transmute(value) }),
+                    30..=32 => Action::Role(unsafe { transmute(value) }),
+                    40..=42 => Action::Invite(unsafe { transmute(value) }),
+                    50..=52 => Action::Webhook(unsafe { transmute(value) }),
+                    60..=62 => Action::Emoji(unsafe { transmute(value) }),
                     72 => Action::MessageDelete,
                     _ => return Err(E::custom(format!("Unexpected action number: {}", value))),
                 })
@@ -386,7 +386,7 @@ impl<'de> Deserialize<'de> for AuditLogs {
         impl<'de> Visitor<'de> for EntriesVisitor {
             type Value = AuditLogs;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("audit log entries")
             }
 

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -218,7 +218,7 @@ impl Display for Emoji {
     /// render the emoji.
     ///
     /// This is in the format of: `<:NAME:EMOJI_ID>`.
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.write_str("<:")?;
         f.write_str(&self.name)?;
         FmtWrite::write_char(f, ':')?;

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -216,7 +216,7 @@ impl Member {
     ///
     /// The nickname takes priority over the member's username if it exists.
     #[inline]
-    pub fn display_name(&self) -> Cow<String> {
+    pub fn display_name(&self) -> Cow<'_, String> {
         self.nick
             .as_ref()
             .map(Cow::Borrowed)
@@ -486,7 +486,7 @@ impl Display for Member {
     /// ```
     ///
     // This is in the format of `<@USER_ID>`.
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Display::fmt(&self.user.read().mention(), f)
     }
 }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -153,7 +153,7 @@ impl Role {
 impl Display for Role {
     /// Format a mention for the role, pinging its members.
     // This is in the format of: `<@&ROLE_ID>`.
-    fn fmt(&self, f: &mut Formatter) -> FmtResult { Display::fmt(&self.mention(), f) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult { Display::fmt(&self.mention(), f) }
 }
 
 impl Eq for Role {}

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -64,7 +64,7 @@ macro_rules! id_u64 {
             }
 
             impl Display for $name {
-                fn fmt(&self, f: &mut Formatter) -> FmtResult {
+                fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
                     Display::fmt(&self.0, f)
                 }
             }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -97,7 +97,7 @@ pub enum UserParseError {
 
 #[cfg(all(feature = "model", feature = "utils"))]
 impl fmt::Display for UserParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", self.description()) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.description()) }
 }
 
 #[cfg(all(feature = "model", feature = "utils"))]
@@ -123,7 +123,7 @@ macro_rules! impl_from_str {
 
             #[cfg(all(feature = "model", feature = "utils"))]
             impl fmt::Display for $err {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", self.description()) }
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.description()) }
             }
 
             #[cfg(all(feature = "model", feature = "utils"))]
@@ -162,7 +162,7 @@ macro_rules! impl_from_str {
 
             #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
             impl fmt::Display for $err {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", self.description()) }
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.description()) }
             }
 
             #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -766,7 +766,7 @@ impl User {
 impl fmt::Display for User {
     /// Formats a string which will mention the user.
     // This is in the format of: `<@USER_ID>`
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.id.mention(), f)
     }
 }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -255,7 +255,7 @@ macro_rules! num_visitors {
             impl<'de> Visitor<'de> for $visitor {
                 type Value = $type;
 
-                fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+                fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                     formatter.write_str("identifier")
                 }
 

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -762,7 +762,7 @@ impl Display for MessageBuilder {
     /// use serenity::utils::MessageBuilder;
     ///
     ///
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
 

--- a/src/utils/vec_map.rs
+++ b/src/utils/vec_map.rs
@@ -95,7 +95,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     }
 }
 
-pub struct VacantEntry<'a, K: 'a, V: 'a> {
+pub struct VacantEntry<'a, K, V> {
     vec: &'a mut Vec<(K, V)>,
     key: K,
 }
@@ -108,7 +108,7 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
     }
 }
 
-pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
+pub struct OccupiedEntry<'a, K, V> {
     vec: &'a mut Vec<(K, V)>,
     pos: usize,
 }

--- a/src/utils/vec_map.rs
+++ b/src/utils/vec_map.rs
@@ -25,7 +25,7 @@ impl<K: PartialEq, V> VecMap<K, V> {
         self.pos(key).map(|pos| self.0.remove(pos)).map(|entry| entry.1)
     }
 
-    pub fn entry(&mut self, key: K) -> Entry<K, V> {
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
         match self.pos(&key) {
             Some(pos) => Entry::Occupied(OccupiedEntry {
                 vec: &mut self.0,
@@ -43,7 +43,7 @@ impl<K: PartialEq, V> VecMap<K, V> {
     }
 
     #[inline]
-    pub fn iter(&self) -> ::std::slice::Iter<(K, V)> {
+    pub fn iter(&self) -> ::std::slice::Iter<'_, (K, V)> {
         self.into_iter()
     }
 


### PR DESCRIPTION
This changes serenity to adhere idioms introduced in Rust 2018.

- `...` for inclusive-range is deprecated and got replaced with `..=`
- Silent lifetime elision is no longer silent, e.g. `std::fmt::Formatter` => `fmt::Formatter<'_>`
- Some outlive requirements could be removed, e.g. `VacantEntry<'a, K: 'a, V: 'a>` => `VacantEntry<'a, K, V>`
- Trait objects are prefixed with `dyn` now, e.g. `Arc<Command>` => `Arc<dyn Command>`
