### PR TITLE
Fix building without `cache`-feature

### DIFF
--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -72,6 +72,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
             threadpool: opt.threadpool,
             #[cfg(feature = "voice")]
             voice_manager: opt.voice_manager,
+            #[cfg(any(feature = "cache", feature = "http"))]
             cache_and_http: opt.cache_and_http,
         }
     }
@@ -499,6 +500,6 @@ pub struct ShardRunnerOptions<H: EventHandler + Send + Sync + 'static> {
     pub threadpool: ThreadPool,
     #[cfg(feature = "voice")]
     pub voice_manager: Arc<Mutex<ClientVoiceManager>>,
-    #[cfg(feature = "cache")]
+    #[cfg(any(feature = "cache", feature = "http"))]
     pub cache_and_http: Arc<CacheAndHttp>,
 }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -5,7 +5,7 @@ use crate::model::{
     guild::Member,
 };
 use std::{sync::{Arc, mpsc::Sender}};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use super::{
     bridge::gateway::event::ClientEvent,
     event_handler::EventHandler,
@@ -23,10 +23,9 @@ use crate::framework::Framework;
 use crate::model::id::GuildId;
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
-#[cfg(feature = "cache")]
+#[cfg(any(feature = "cache", feature = "http"))]
 use crate::CacheAndHttp;
-#[cfg(feature = "cache")]
-use parking_lot::RwLock;
+
 
 macro_rules! update {
     ($cache_and_http:ident, $event:expr) => {
@@ -63,7 +62,7 @@ fn context(
 
 #[cfg(all(feature = "cache", not(feature = "http")))]
 fn context(
-    data: &Arc<Mutex<ShareMap>>,
+    data: &Arc<RwLock<ShareMap>>,
     runner_tx: &Sender<InterMessage>,
     shard_id: u64,
     cache: &Arc<RwLock<Cache>>,
@@ -73,7 +72,7 @@ fn context(
 
 #[cfg(all(not(feature = "cache"), feature = "http"))]
 fn context(
-    data: &Arc<Mutex<ShareMap>>,
+    data: &Arc<RwLock<ShareMap>>,
     runner_tx: &Sender<InterMessage>,
     shard_id: u64,
     http: &Arc<Http>,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -32,6 +32,7 @@ pub use self::{
     event_handler::EventHandler
 };
 
+#[cfg(any(feature = "cache", feature = "http"))]
 pub use crate::CacheAndHttp;
 
 // Note: the following re-exports are here for backwards compatibility

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,10 +138,13 @@ pub use crate::client::Client;
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
 use parking_lot::RwLock;
-#[cfg(all(feature = "client", feature = "cache"))]
-use std::{time::Duration, sync::Arc};
+#[cfg(feature = "cache")]
+use std::time::{Duration};
+#[cfg(any(feature = "client", feature = "http"))]
+use std::sync::Arc;
 #[cfg(all(feature = "client", feature = "http"))]
 use crate::http::Http;
+
 
 #[cfg(feature = "client")]
 #[derive(Default)]

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -638,7 +638,7 @@ impl GuildId {
     /// ```
     #[cfg(all(feature = "utils", not(feature = "cache")))]
     #[inline]
-    pub fn shard_id(&self, shard_count: u64) -> u64 { ::utils::shard_id(self.0, shard_count) }
+    pub fn shard_id(&self, shard_count: u64) -> u64 { crate::utils::shard_id(self.0, shard_count) }
 
     /// Starts an integration sync for the given integration Id.
     ///

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -758,7 +758,7 @@ impl User {
 
         #[cfg(not(feature = "cache"))]
         {
-            guild_id.member(&self.id).ok().and_then(|member| member.nick.clone())
+            guild_id.member(&context, &self.id).ok().and_then(|member| member.nick.clone())
         }
     }
 }


### PR DESCRIPTION
Disabling the `cache`-feature caused serenity to fail building.

This pull request makes sure that building with default features excluding `http` and/or `cache` will still work.