### PR TITLE
Mutably borrow EditMessage for all channel types.

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -287,13 +287,14 @@ impl ChannelId {
     #[cfg(all(feature = "utils", feature = "http"))]
     #[inline]
     pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
-        where F: FnOnce(EditMessage) -> EditMessage, M: Into<MessageId> {
+        where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self._edit_message(&http, message_id.into(), f)
     }
 
     fn _edit_message<F>(self, http: &Arc<Http>, message_id: MessageId, f: F) -> Result<Message>
-        where F: FnOnce(EditMessage) -> EditMessage {
-        let msg = f(EditMessage::default());
+        where F: FnOnce(&mut EditMessage) -> &mut EditMessage {
+        let mut msg = EditMessage::default();
+        f(&mut msg);
 
         if let Some(content) = msg.0.get(&"content") {
             if let Value::String(ref content) = *content {

--- a/src/model/channel/group.rs
+++ b/src/model/channel/group.rs
@@ -175,7 +175,7 @@ impl Group {
     #[cfg(feature = "http")]
     #[inline]
     pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
-        where F: FnOnce(EditMessage) -> EditMessage, M: Into<MessageId> {
+        where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self.channel_id.edit_message(&http, message_id, f)
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -387,7 +387,7 @@ impl GuildChannel {
     #[cfg(feature = "http")]
     #[inline]
     pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
-        where F: FnOnce(EditMessage) -> EditMessage, M: Into<MessageId> {
+        where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self.id.edit_message(&http, message_id, f)
     }
 

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -154,7 +154,7 @@ impl PrivateChannel {
     #[cfg(feature = "http")]
     #[inline]
     pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
-        where F: FnOnce(EditMessage) -> EditMessage, M: Into<MessageId> {
+        where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self.id.edit_message(&http, message_id, f)
     }
 


### PR DESCRIPTION
#443 changed `EditMessage` to return `&mut self`, and updated `Message::edit()` but not `ChannelId::edit_message()` (and various other `Channel` types that call it).