### PR TITLE
Add missing `crate` import prefix

### DIFF
--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -25,7 +25,7 @@ use url::Url;
 use log::{error, debug, info, trace, warn};
 
 #[cfg(not(feature = "native_tls"))]
-use internal::ws_impl::create_rustls_client;
+use crate::internal::ws_impl::create_rustls_client;
 
 #[cfg(feature = "native_tls")]
 use tungstenite::handshake::client::Request;


### PR DESCRIPTION
Without this, building with rustls (as default) fails, unable to find `create_rustls_client()`:

```
error[E0433]: failed to resolve: use of undeclared type or module `internal`
  --> /home/celti/.local/cargo/git/checkouts/serenity-8a8b65b77919dc75/c89cfec/src/gateway/shard.rs:28:5
   |
28 | use internal::ws_impl::create_rustls_client;
   |     ^^^^^^^^ use of undeclared type or module `internal`

error[E0425]: cannot find function `create_rustls_client` in this scope
   --> /home/celti/.local/cargo/git/checkouts/serenity-8a8b65b77919dc75/c89cfec/src/gateway/shard.rs:826:8
    |
826 |     Ok(create_rustls_client(url)?)
    |        ^^^^^^^^^^^^^^^^^^^^ not found in this scope
help: possible candidate is found in another module, you can import it into scope
    |
1   | use crate::internal::ws_impl::create_rustls_client;
    |

error: aborting due to 2 previous errors
```