### PR TITLE
Pass the old voice state to `EventHandler::voice_state_update`

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -616,11 +616,15 @@ fn handle_event<H: EventHandler + Send + Sync + 'static>(
             });
         },
         DispatchEvent::Model(Event::VoiceStateUpdate(mut event)) => {
-            update!(cache_and_http, event);
+            let _before = update!(cache_and_http, event);
             let event_handler = Arc::clone(event_handler);
 
             threadpool.execute(move || {
-                event_handler.voice_state_update(context, event.guild_id, event.voice_state);
+                feature_cache! {{
+                    event_handler.voice_state_update(context, event.guild_id, _before, event.voice_state);
+                } else {
+                    event_handler.voice_state_update(context, event.guild_id, event.voice_state);
+                }}
             });
         },
         DispatchEvent::Model(Event::WebhookUpdate(mut event)) => {

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -288,10 +288,18 @@ pub trait EventHandler {
     /// Provides the voice server's data.
     fn voice_server_update(&self, _ctx: Context, _: VoiceServerUpdateEvent) {}
 
-    /// Dispatched when a user joins, leaves or moves a voice channel.
+    /// Dispatched when a user joins, leaves or moves to a voice channel.
+    ///
+    /// Provides the guild's id (if available) and
+    /// the old and the new state of the guild's voice channels.
+    #[cfg(feature = "cache")]
+    fn voice_state_update(&self, _ctx: Context, _: Option<GuildId>, _old: Option<VoiceState>, _new: VoiceState) {}
+
+    /// Dispatched when a user joins, leaves or moves to a voice channel.
     ///
     /// Provides the guild's id (if available) and
     /// the new state of the guild's voice channels.
+    #[cfg(not(feature = "cache"))]
     fn voice_state_update(&self, _ctx: Context, _: Option<GuildId>, _: VoiceState) {}
 
     /// Dispatched when a guild's webhook is updated.

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1196,38 +1196,28 @@ pub struct VoiceStateUpdateEvent {
 
 #[cfg(feature = "cache")]
 impl CacheUpdate for VoiceStateUpdateEvent {
-    type Output = ();
+    type Output = VoiceState;
 
-    fn update(&mut self, cache: &mut Cache) -> Option<()> {
+    fn update(&mut self, cache: &mut Cache) -> Option<VoiceState> {
         if let Some(guild_id) = self.guild_id {
             if let Some(guild) = cache.guilds.get_mut(&guild_id) {
                 let mut guild = guild.write();
 
                 if self.voice_state.channel_id.is_some() {
                     // Update or add to the voice state list
-                    {
-                        let finding = guild.voice_states.get_mut(&self.voice_state.user_id);
-
-                        if let Some(srv_state) = finding {
-                            srv_state.clone_from(&self.voice_state);
-
-                            return None;
-                        }
-                    }
-
                     guild
                         .voice_states
-                        .insert(self.voice_state.user_id, self.voice_state.clone());
+                        .insert(self.voice_state.user_id, self.voice_state.clone())
                 } else {
                     // Remove the user from the voice state list
-                    guild.voice_states.remove(&self.voice_state.user_id);
+                    guild.voice_states.remove(&self.voice_state.user_id)
                 }
+            } else {
+                None
             }
-
-            return None;
+        } else {
+            None
         }
-
-        None
     }
 }
 


### PR DESCRIPTION
This is a breaking change because it changes the signature of `EventHandler::voice_state_update` if the cache is enabled.

My use case for this is tracking how voice channels are used. Without this patch I'd need to either recheck every voice channel on every voice state update or reimplement Serenity's cache inside my bot.