### PR TITLE
Remove `type`-Field from `edit`'s Request Body

### DIFF
--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -96,7 +96,6 @@ impl ChannelCategory {
         let mut map = VecMap::new();
         map.insert("name", Value::String(self.name.clone()));
         map.insert("position", Value::Number(Number::from(self.position)));
-        map.insert("type", Value::String(self.kind.name().to_string()));
 
         let map = serenity_utils::vecmap_to_json_map(f(EditChannel(map)).0);
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -330,7 +330,6 @@ impl GuildChannel {
         let mut map = VecMap::new();
         map.insert("name", Value::String(self.name.clone()));
         map.insert("position", Value::Number(Number::from(self.position)));
-        map.insert("type", Value::String(self.kind.name().to_string()));
 
         let edited = serenity_utils::vecmap_to_json_map(f(EditChannel(map)).0);
 


### PR DESCRIPTION
Serenity passes a `type`-key and its value to Discord.
However as seen here https://discordapp.com/developers/docs/resources/channel#modify-channel
Discord does not specify `type`.
Therefore this pull requests removes passing the field and key to Discord on `Channel`'s and `ChannelCategory`'s `edit`-method.