### PR TITLE
[Voice] AudioReceiver extension, event deserialisation fixes

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -151,6 +151,8 @@ pub enum VoiceOpCode {
     Hello = 8,
     /// Sent by the server if a session coulkd successfully be resumed.
     Resumed = 9,
+    /// Message indicating that another user has connected to the voice channel.
+    ClientConnect = 12,
     /// Message indicating that another user has disconnected from the voice channel.
     ClientDisconnect = 13,
 }
@@ -167,6 +169,7 @@ enum_number!(
         Resume,
         Hello,
         Resumed,
+        ClientConnect,
         ClientDisconnect,
     }
 );
@@ -184,6 +187,7 @@ impl VoiceOpCode {
             VoiceOpCode::Resume => 7,
             VoiceOpCode::Hello => 8,
             VoiceOpCode::Resumed => 9,
+            VoiceOpCode::ClientConnect => 12,
             VoiceOpCode::ClientDisconnect => 13,
         }
     }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1926,6 +1926,14 @@ pub struct VoiceResume {
 
 #[allow(clippy::missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct VoiceClientConnect {
+    pub audio_ssrc: u32,
+    pub user_id: UserId,
+    pub video_ssrc: u32,
+}
+
+#[allow(clippy::missing_docs)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct VoiceClientDisconnect {
     pub user_id: UserId,
 }
@@ -1955,6 +1963,9 @@ pub enum VoiceEvent {
     Hello(VoiceHello),
     /// Message received if a Resume request was successful.
     Resumed,
+    /// Status update in the current channel, indicating that a user has
+    /// connected.
+    ClientConnect(VoiceClientConnect),
     /// Status update in the current channel, indicating that a user has
     /// disconnected.
     ClientDisconnect(VoiceClientDisconnect),
@@ -2005,6 +2016,11 @@ impl<'de> Deserialize<'de> for VoiceEvent {
                 VoiceEvent::Speaking(v)
             },
             VoiceOpCode::Resumed => VoiceEvent::Resumed,
+            VoiceOpCode::ClientConnect => {
+                let v = VoiceClientConnect::deserialize(v).map_err(DeError::custom)?;
+
+                VoiceEvent::ClientConnect(v)
+            },
             VoiceOpCode::ClientDisconnect => {
                 let v = VoiceClientDisconnect::deserialize(v).map_err(DeError::custom)?;
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -9,7 +9,7 @@ use serde::ser::{
 };
 use serde_json;
 use std::collections::HashMap;
-use super::utils::deserialize_emojis;
+use super::utils::{deserialize_emojis, deserialize_u64};
 use super::prelude::*;
 use crate::constants::{OpCode, VoiceOpCode};
 use crate::internal::prelude::*;
@@ -1881,9 +1881,16 @@ pub struct VoiceHeartbeat {
 }
 
 #[allow(clippy::missing_docs)]
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub struct VoiceHeartbeatAck {
     pub nonce: u64,
+}
+
+impl<'de> Deserialize<'de> for VoiceHeartbeatAck {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        deserialize_u64(deserializer)
+            .map(|nonce| Self { nonce })
+    }
 }
 
 #[allow(clippy::missing_docs)]

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -33,6 +33,8 @@ pub trait AudioReceiver: Send {
                     data: &[i16],
                     compressed_size: usize) { }
 
+    fn client_connect(&mut self, ssrc: u32, user_id: u64) { }
+
     fn client_disconnect(&mut self, user_id: u64) { }
 }
 

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -30,7 +30,8 @@ pub trait AudioReceiver: Send {
                     sequence: u16,
                     timestamp: u32,
                     stereo: bool,
-                    data: &[i16]);
+                    data: &[i16],
+                    compressed_size: usize);
 }
 
 #[derive(Clone, Copy)]

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -23,7 +23,7 @@ pub trait AudioSource: Send {
 
 /// A receiver for incoming audio.
 pub trait AudioReceiver: Send {
-    fn speaking_update(&mut self, ssrc: u32, user_id: u64, speaking: bool);
+    fn speaking_update(&mut self, ssrc: u32, user_id: u64, speaking: bool) { }
 
     fn voice_packet(&mut self,
                     ssrc: u32,
@@ -31,7 +31,9 @@ pub trait AudioReceiver: Send {
                     timestamp: u32,
                     stereo: bool,
                     data: &[i16],
-                    compressed_size: usize);
+                    compressed_size: usize) { }
+
+    fn client_disconnect(&mut self, user_id: u64) { }
 }
 
 #[derive(Clone, Copy)]

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -355,7 +355,7 @@ impl Connection {
                             let b = if is_stereo { len * 2 } else { len };
 
                             receiver
-                                .voice_packet(ssrc, seq, timestamp, is_stereo, &buffer[..b]);
+                                .voice_packet(ssrc, seq, timestamp, is_stereo, &buffer[..b], decrypted.len());
                         }
                     }
                 },

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -379,6 +379,8 @@ impl Connection {
                         Some(nonce) => {
                             if ev.nonce != nonce {
                                 warn!("[Voice] Heartbeat nonce mismatch! Expected {}, saw {}.", nonce, ev.nonce);
+                            } else {
+                                info!("[Voice] Heartbeat ACK received.");
                             }
 
                             self.last_heartbeat_nonce = None;

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -364,6 +364,11 @@ impl Connection {
                         receiver.speaking_update(ev.ssrc, ev.user_id.0, ev.speaking);
                     }
                 },
+                ReceiverStatus::Websocket(VoiceEvent::ClientConnect(ev)) => {
+                    if let Some(receiver) = receiver.as_mut() {
+                        receiver.client_connect(ev.audio_ssrc, ev.user_id.0);
+                    }
+                }
                 ReceiverStatus::Websocket(VoiceEvent::ClientDisconnect(ev)) => {
                     if let Some(receiver) = receiver.as_mut() {
                         receiver.client_disconnect(ev.user_id.0);

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -364,6 +364,11 @@ impl Connection {
                         receiver.speaking_update(ev.ssrc, ev.user_id.0, ev.speaking);
                     }
                 },
+                ReceiverStatus::Websocket(VoiceEvent::ClientDisconnect(ev)) => {
+                    if let Some(receiver) = receiver.as_mut() {
+                        receiver.client_disconnect(ev.user_id.0);
+                    }
+                }
                 ReceiverStatus::Websocket(VoiceEvent::HeartbeatAck(ev)) => {
                     match self.last_heartbeat_nonce {
                         Some(nonce) => {

--- a/src/voice/handler.rs
+++ b/src/voice/handler.rs
@@ -213,6 +213,7 @@ impl Handler {
         // Only send an update if we were in a voice channel.
         if self.channel_id.is_some() {
             self.channel_id = None;
+            self.send(VoiceStatus::Disconnect);
 
             self.update();
         }

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -133,7 +133,7 @@ fn _ffmpeg(path: &OsStr) -> Result<Box<dyn AudioSource>> {
     let is_stereo = is_stereo(path).unwrap_or(false);
     let stereo_val = if is_stereo { "2" } else { "1" };
 
-    ffmpeg_optioned(path, &[
+    _ffmpeg_optioned(path, &[
         "-f",
         "s16le",
         "-ac",
@@ -143,7 +143,7 @@ fn _ffmpeg(path: &OsStr) -> Result<Box<dyn AudioSource>> {
         "-acodec",
         "pcm_s16le",
         "-",
-    ])
+    ], Some(is_stereo))
 }
 
 /// Opens an audio file through `ffmpeg` and creates an audio source, with
@@ -175,12 +175,14 @@ fn _ffmpeg(path: &OsStr) -> Result<Box<dyn AudioSource>> {
 pub fn ffmpeg_optioned<P: AsRef<OsStr>>(
     path: P,
     args: &[&str],
-) -> Result<Box<dyn AudioSource>> {
-    _ffmpeg_optioned(path.as_ref(), args)
+) -> Result<Box<AudioSource>> {
+    _ffmpeg_optioned(path.as_ref(), args, None)
 }
 
-fn _ffmpeg_optioned(path: &OsStr, args: &[&str]) -> Result<Box<dyn AudioSource>> {
-    let is_stereo = is_stereo(path).unwrap_or(false);
+fn _ffmpeg_optioned(path: &OsStr, args: &[&str], is_stereo_known: Option<bool>) -> Result<Box<AudioSource>> {
+    let is_stereo = is_stereo_known
+        .or_else(|| is_stereo(path).ok())
+        .unwrap_or(false);
 
     let command = Command::new("ffmpeg")
         .arg("-i")

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -175,11 +175,11 @@ fn _ffmpeg(path: &OsStr) -> Result<Box<dyn AudioSource>> {
 pub fn ffmpeg_optioned<P: AsRef<OsStr>>(
     path: P,
     args: &[&str],
-) -> Result<Box<AudioSource>> {
+) -> Result<Box<dyn AudioSource>> {
     _ffmpeg_optioned(path.as_ref(), args, None)
 }
 
-fn _ffmpeg_optioned(path: &OsStr, args: &[&str], is_stereo_known: Option<bool>) -> Result<Box<AudioSource>> {
+fn _ffmpeg_optioned(path: &OsStr, args: &[&str], is_stereo_known: Option<bool>) -> Result<Box<dyn AudioSource>> {
     let is_stereo = is_stereo_known
         .or_else(|| is_stereo(path).ok())
         .unwrap_or(false);


### PR DESCRIPTION
* Ports the fixes introduced in #471 and #472 to be idiomatic Rust 2018 code.
* Adds handling for the (undocumented) `VoiceClientConnect` event which the voice thread receives over websocket.
* Adds ability to handle client (dis)connects in the `AudioReceiver`.
* Adds an extra field to `AudioReceiver::voice_packet`, `compressed_size`. This should allow better instrumentation of per-user stream bandwidth if needed without, e.g., re-encoding the raw audio data.
* Makes impls of functions on `AudioReceiver` optional.
* Fixes deserialisation of `VoiceHeartbeatAck`.