### PR TITLE
Port #471, #472 to v0.6.x

### DIFF
--- a/src/voice/handler.rs
+++ b/src/voice/handler.rs
@@ -213,6 +213,7 @@ impl Handler {
         // Only send an update if we were in a voice channel.
         if self.channel_id.is_some() {
             self.channel_id = None;
+            self.send(VoiceStatus::Disconnect);
 
             self.update();
         }

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -133,7 +133,7 @@ fn _ffmpeg(path: &OsStr) -> Result<Box<dyn AudioSource>> {
     let is_stereo = is_stereo(path).unwrap_or(false);
     let stereo_val = if is_stereo { "2" } else { "1" };
 
-    ffmpeg_optioned(path, &[
+    _ffmpeg_optioned(path, &[
         "-f",
         "s16le",
         "-ac",
@@ -143,7 +143,7 @@ fn _ffmpeg(path: &OsStr) -> Result<Box<dyn AudioSource>> {
         "-acodec",
         "pcm_s16le",
         "-",
-    ])
+    ], Some(is_stereo))
 }
 
 /// Opens an audio file through `ffmpeg` and creates an audio source, with
@@ -176,11 +176,13 @@ pub fn ffmpeg_optioned<P: AsRef<OsStr>>(
     path: P,
     args: &[&str],
 ) -> Result<Box<dyn AudioSource>> {
-    _ffmpeg_optioned(path.as_ref(), args)
+    _ffmpeg_optioned(path.as_ref(), args, None)
 }
 
-fn _ffmpeg_optioned(path: &OsStr, args: &[&str]) -> Result<Box<dyn AudioSource>> {
-    let is_stereo = is_stereo(path).unwrap_or(false);
+fn _ffmpeg_optioned(path: &OsStr, args: &[&str], is_stereo_known: Option<bool>) -> Result<Box<dyn AudioSource>> {
+    let is_stereo = is_stereo_known
+        .or_else(|| is_stereo(path).ok())
+        .unwrap_or(false);
 
     let command = Command::new("ffmpeg")
         .arg("-i")


### PR DESCRIPTION
As in the title.
The Rust 2018 idioms requiring `dyn` mandated some small changes to #472.