### PR TITLE
Optional impls and additional events for AudioReceiver

### DIFF
--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -53,14 +53,30 @@ impl AudioReceiver for Receiver {
         // to the user ID and handle their audio packets separately.
     }
 
-    fn voice_packet(&mut self, ssrc: u32, sequence: u16, _timestamp: u32, _stereo: bool, data: &[i16]) {
+    fn voice_packet(
+        &mut self,
+        ssrc: u32,
+        sequence: u16,
+        _timestamp: u32,
+        _stereo: bool,
+        data: &[i16],
+        compressed_size: usize,
+    ) {
         println!("Audio packet's first 5 bytes: {:?}", data.get(..5));
         println!(
-            "Audio packet sequence {:05} has {:04} bytes, SSRC {}",
+            "Audio packet sequence {:05} has {:04} bytes (decompressed from {}), SSRC {}",
             sequence,
             data.len(),
+            compressed_size,
             ssrc,
         );
+    }
+
+    fn client_disconnect(&mut self, _user_id: u64) {
+        // You can implement your own logic here to handle a user who has left the
+        // voice channel e.g., finalise processing of statistics etc.
+        // You will typically need to map the User ID to their SSRC; observed when
+        // speaking or connecting.
     }
 }
 

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -30,7 +30,8 @@ pub trait AudioReceiver: Send {
                     sequence: u16,
                     timestamp: u32,
                     stereo: bool,
-                    data: &[i16]);
+                    data: &[i16],
+                    compressed_size: usize);
 }
 
 #[derive(Clone, Copy)]

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -23,7 +23,7 @@ pub trait AudioSource: Send {
 
 /// A receiver for incoming audio.
 pub trait AudioReceiver: Send {
-    fn speaking_update(&mut self, ssrc: u32, user_id: u64, speaking: bool);
+    fn speaking_update(&mut self, ssrc: u32, user_id: u64, speaking: bool) { }
 
     fn voice_packet(&mut self,
                     ssrc: u32,
@@ -31,7 +31,9 @@ pub trait AudioReceiver: Send {
                     timestamp: u32,
                     stereo: bool,
                     data: &[i16],
-                    compressed_size: usize);
+                    compressed_size: usize) { }
+
+    fn client_disconnect(&mut self, user_id: u64) { }
 }
 
 #[derive(Clone, Copy)]

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -355,7 +355,7 @@ impl Connection {
                             let b = if is_stereo { len * 2 } else { len };
 
                             receiver
-                                .voice_packet(ssrc, seq, timestamp, is_stereo, &buffer[..b]);
+                                .voice_packet(ssrc, seq, timestamp, is_stereo, &buffer[..b], decrypted.len());
                         }
                     }
                 },

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -364,6 +364,11 @@ impl Connection {
                         receiver.speaking_update(ev.ssrc, ev.user_id.0, ev.speaking);
                     }
                 },
+                ReceiverStatus::Websocket(VoiceEvent::ClientDisconnect(ev)) => {
+                    if let Some(receiver) = receiver.as_mut() {
+                        receiver.client_disconnect(ev.user_id.0);
+                    }
+                }
                 ReceiverStatus::Websocket(VoiceEvent::HeartbeatAck(ev)) => {
                     match self.last_heartbeat_nonce {
                         Some(nonce) => {


### PR DESCRIPTION
* Adds an extra field to `AudioReceiver::voice_packet`, `compressed_size`. This should allow better instrumentation of per-user stream bandwidth if needed without, e.g., re-encoding the raw audio data.
* Makes `impl`s of functions on `AudioReceiver` optional.
* Adds ability to handle client disconnects in the `AudioReceiver`.