### PR TITLE
ClientConnect message handling

### DIFF
--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -62,6 +62,11 @@ impl AudioReceiver for Receiver {
             ssrc,
         );
     }
+
+    fn client_connect(&mut self, _ssrc: u32, _user_id: u64) {
+        // You can implement your own logic here to handle a user who has joined the
+        // voice channel e.g., allocate structures, map their SSRC to User ID.
+    }
 }
 
 fn main() {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -151,6 +151,8 @@ pub enum VoiceOpCode {
     Hello = 8,
     /// Sent by the server if a session coulkd successfully be resumed.
     Resumed = 9,
+    /// Message indicating that another user has connected to the voice channel.
+    ClientConnect = 12,
     /// Message indicating that another user has disconnected from the voice channel.
     ClientDisconnect = 13,
 }
@@ -167,6 +169,7 @@ enum_number!(
         Resume,
         Hello,
         Resumed,
+        ClientConnect,
         ClientDisconnect,
     }
 );
@@ -184,6 +187,7 @@ impl VoiceOpCode {
             VoiceOpCode::Resume => 7,
             VoiceOpCode::Hello => 8,
             VoiceOpCode::Resumed => 9,
+            VoiceOpCode::ClientConnect => 12,
             VoiceOpCode::ClientDisconnect => 13,
         }
     }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1926,6 +1926,14 @@ pub struct VoiceResume {
 
 #[allow(clippy::missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct VoiceClientConnect {
+    pub audio_ssrc: u32,
+    pub user_id: UserId,
+    pub video_ssrc: u32,
+}
+
+#[allow(clippy::missing_docs)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct VoiceClientDisconnect {
     pub user_id: UserId,
 }
@@ -1955,6 +1963,9 @@ pub enum VoiceEvent {
     Hello(VoiceHello),
     /// Message received if a Resume request was successful.
     Resumed,
+    /// Status update in the current channel, indicating that a user has
+    /// connected.
+    ClientConnect(VoiceClientConnect),
     /// Status update in the current channel, indicating that a user has
     /// disconnected.
     ClientDisconnect(VoiceClientDisconnect),
@@ -2005,6 +2016,11 @@ impl<'de> Deserialize<'de> for VoiceEvent {
                 VoiceEvent::Speaking(v)
             },
             VoiceOpCode::Resumed => VoiceEvent::Resumed,
+            VoiceOpCode::ClientConnect => {
+                let v = VoiceClientConnect::deserialize(v).map_err(DeError::custom)?;
+
+                VoiceEvent::ClientConnect(v)
+            },
             VoiceOpCode::ClientDisconnect => {
                 let v = VoiceClientDisconnect::deserialize(v).map_err(DeError::custom)?;
 

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -31,6 +31,8 @@ pub trait AudioReceiver: Send {
                     timestamp: u32,
                     stereo: bool,
                     data: &[i16]);
+
+    fn client_connect(&mut self, ssrc: u32, user_id: u64) { }
 }
 
 #[derive(Clone, Copy)]

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -364,6 +364,11 @@ impl Connection {
                         receiver.speaking_update(ev.ssrc, ev.user_id.0, ev.speaking);
                     }
                 },
+                ReceiverStatus::Websocket(VoiceEvent::ClientConnect(ev)) => {
+                    if let Some(receiver) = receiver.as_mut() {
+                        receiver.client_connect(ev.audio_ssrc, ev.user_id.0);
+                    }
+                }
                 ReceiverStatus::Websocket(VoiceEvent::HeartbeatAck(ev)) => {
                     match self.last_heartbeat_nonce {
                         Some(nonce) => {

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -367,6 +367,7 @@ impl Connection {
                 ReceiverStatus::Websocket(VoiceEvent::ClientConnect(ev)) => {
                     if let Some(receiver) = receiver.as_mut() {
                         receiver.client_connect(ev.audio_ssrc, ev.user_id.0);
+                    }
                 },
                 ReceiverStatus::Websocket(VoiceEvent::ClientDisconnect(ev)) => {
                     if let Some(receiver) = receiver.as_mut() {


### PR DESCRIPTION
* Adds handling for the (undocumented) `VoiceClientConnect` event which the voice thread receives over websocket. This is possibly contentious, but it seems to differ from a VoiceStateUpdate in that it captures the moment a user *explicitly joins the voice call*.
* Accordingly, exposes this event over the `AudioReceiver` interface.