### PR TITLE
switch to hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,10 @@ version = "0.18.1"
 optional = true
 version = "0.15.0"
 
+[dependencies.hashbrown]
+version = "^0.1"
+features = ["serde"]
+
 [dev-dependencies.matches]
 version = "0.1.6"
 

--- a/src/cache/cache_update.rs
+++ b/src/cache/cache_update.rs
@@ -18,10 +18,8 @@ use super::Cache;
 ///     },
 ///     prelude::RwLock,
 /// };
-/// use std::{
-///     collections::hash_map::Entry,
-///     sync::Arc,
-/// };
+/// use std::sync::Arc;
+/// use hashbrown::hash_map::Entry;
 ///
 /// // For example, an update to the user's record in the database was
 /// // published to a pubsub channel.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -45,15 +45,15 @@
 use std::str::FromStr;
 use crate::model::prelude::*;
 use parking_lot::RwLock;
-use std::collections::{
-    hash_map::Entry,
-    HashMap,
-    HashSet,
-    VecDeque,
-};
+use std::collections::VecDeque;
 use std::{
     default::Default,
     sync::Arc,
+};
+use hashbrown::{
+    hash_map::Entry,
+    HashMap,
+    HashSet
 };
 
 mod cache_update;
@@ -858,10 +858,8 @@ impl Default for Cache {
 mod test {
     use chrono::DateTime;
     use serde_json::{Number, Value};
-    use std::{
-        collections::HashMap,
-        sync::Arc,
-    };
+    use std::sync::Arc;
+    use hashbrown::HashMap;
     use crate::{
         cache::{Cache, CacheUpdate, Settings},
         model::prelude::*,

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -4,13 +4,14 @@ use crate::CacheAndHttp;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::VecDeque,
     sync::{
         mpsc::{self, Sender},
         Arc
     },
     thread
 };
+use hashbrown::HashMap;
 use super::super::super::EventHandler;
 use super::{
     ShardClientMessage,

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -4,7 +4,7 @@ use crate::CacheAndHttp;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::VecDeque,
     sync::{
         mpsc::{
             Receiver,
@@ -15,6 +15,7 @@ use std::{
     thread,
     time::{Duration, Instant}
 };
+use hashbrown::HashMap;
 use super::super::super::EventHandler;
 use super::{
     ShardId,

--- a/src/client/bridge/voice/mod.rs
+++ b/src/client/bridge/voice/mod.rs
@@ -1,5 +1,5 @@
 use crate::gateway::InterMessage;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::sync::mpsc::Sender as MpscSender;
 use crate::model::id::{ChannelId, GuildId, UserId};
 use crate::voice::{Handler, Manager};

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -1,10 +1,8 @@
 use crate::model::prelude::*;
 use parking_lot::RwLock;
 use serde_json::Value;
-use std::{
-    collections::HashMap,
-    sync::Arc
-};
+use std::sync::Arc;
+use hashbrown::HashMap;
 use super::context::Context;
 use crate::client::bridge::gateway::event::*;
 

--- a/src/framework/standard/buckets.rs
+++ b/src/framework/standard/buckets.rs
@@ -1,10 +1,8 @@
 use chrono::Utc;
 use crate::client::Context;
 use crate::model::id::{ChannelId, GuildId, UserId};
-use std::{
-    collections::HashMap,
-    default::Default
-};
+use std::default::Default;
+use hashbrown::HashMap;
 
 #[cfg(feature = "cache")]
 type Check = dyn Fn(&mut Context, Option<GuildId>, ChannelId, UserId) -> bool + Send + Sync + 'static;

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -8,11 +8,11 @@ use crate::model::{
     Permissions,
 };
 use std::{
-    collections::{HashMap, HashSet},
     fmt,
     fmt::{Debug, Formatter},
     sync::Arc,
 };
+use hashbrown::{HashMap, HashSet};
 use crate::utils::Colour;
 use super::{Args, Configuration, HelpBehaviour};
 use super::check::Check;

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -4,10 +4,10 @@ use crate::model::{
     id::{ChannelId, GuildId, UserId}
 };
 use std::{
-    collections::HashSet,
     default::Default,
     sync::Arc,
 };
+use hashbrown::HashSet;
 use super::command::{Command, InternalCommand, PrefixCheck};
 use super::Delimiter;
 
@@ -369,7 +369,7 @@ impl Configuration {
     /// # impl EventHandler for Handler {}
     /// # let mut client = Client::new("token", Handler).unwrap();
     /// use serenity::model::id::UserId;
-    /// use std::collections::HashSet;
+    /// use hashbrown::HashSet;
     /// use serenity::framework::StandardFramework;
     ///
     /// let mut set = HashSet::new();

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -32,12 +32,12 @@ use crate::model::{
 use crate::Error;
 use std::{
     borrow::Borrow,
-    collections::{HashMap, HashSet},
     hash::BuildHasher,
     ops::{Index, IndexMut},
     sync::Arc,
     fmt::Write,
 };
+use hashbrown::{HashMap, HashSet};
 use super::command::InternalCommand;
 use super::{
     Args,

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -43,10 +43,10 @@ use crate::model::{
 };
 use self::command::{AfterHook, BeforeHook, MessageWithoutCommandHook, UnrecognisedCommandHook};
 use std::{
-    collections::HashMap,
     default::Default,
     sync::Arc
 };
+use hashbrown::HashMap;
 use super::Framework;
 use threadpool::ThreadPool;
 

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -22,10 +22,11 @@ use serde::de::DeserializeOwned;
 use serde_json::json;
 use log::{debug, trace};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     io::ErrorKind as IoErrorKind,
     sync::Arc,
 };
+use hashbrown::HashMap;
 
 pub struct Http {
     client: Client,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -507,7 +507,7 @@ mod test {
     mod model_utils {
         use crate::model::prelude::*;
         use parking_lot::RwLock;
-        use std::collections::HashMap;
+        use hashbrown::HashMap;
         use std::sync::Arc;
 
         fn group() -> Group {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -8,7 +8,7 @@ use serde::ser::{
     Serializer
 };
 use serde_json;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use super::utils::{deserialize_emojis, deserialize_u64};
 use super::prelude::*;
 use crate::constants::{OpCode, VoiceOpCode};
@@ -19,7 +19,7 @@ use crate::cache::{Cache, CacheUpdate};
 #[cfg(feature = "cache")]
 use crate::internal::RwLockExt;
 #[cfg(feature = "cache")]
-use std::collections::hash_map::Entry;
+use hashbrown::hash_map::Entry;
 #[cfg(feature = "cache")]
 use std::mem;
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2058,7 +2058,7 @@ mod test {
     mod model {
         use chrono::prelude::*;
         use crate::model::prelude::*;
-        use std::collections::*;
+        use hashbrown::HashMap;
         use std::sync::Arc;
 
         fn gen_user() -> User {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -45,7 +45,6 @@ use parking_lot::RwLock;
 use self::utils::*;
 use serde::de::Visitor;
 use std::{
-    collections::HashMap,
     fmt::{
         Display,
         Formatter,
@@ -54,6 +53,7 @@ use std::{
     sync::Arc,
     result::Result as StdResult
 };
+use hashbrown::HashMap;
 
 #[cfg(feature = "utils")]
 use crate::utils::Colour;

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -2,10 +2,10 @@ use parking_lot::RwLock;
 use serde::de::Error as DeError;
 use serde::ser::{SerializeSeq, Serialize, Serializer};
 use std::{
-    collections::HashMap,
     hash::Hash,
     sync::Arc
 };
+use hashbrown::HashMap;
 use super::prelude::*;
 
 #[cfg(feature = "cache")]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,7 +26,6 @@ use crate::model::{
     },
 };
 use std::{
-    collections::HashMap,
     ffi::OsStr,
     fs::File,
     hash::{BuildHasher, Hash},
@@ -34,6 +33,7 @@ use std::{
     path::Path,
     str::FromStr,
 };
+use hashbrown::HashMap;
 
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
@@ -865,10 +865,8 @@ mod test {
             prelude::*,
         };
         use chrono::DateTime;
-        use std::{
-            collections::HashMap,
-            sync::Arc,
-        };
+        use std::sync::Arc;
+        use hashbrown::HashMap;
 
         let user = User {
             id: UserId(100000000000000000),

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -28,7 +28,6 @@ use rand::random;
 use serde::Deserialize;
 use sodiumoxide::crypto::secretbox::{self, Key, Nonce};
 use std::{
-    collections::HashMap,
     io::Write,
     net::{SocketAddr, ToSocketAddrs, UdpSocket},
     sync::{
@@ -46,6 +45,7 @@ use std::{
     },
     time::Duration
 };
+use hashbrown::HashMap;
 
 use super::audio::{AudioReceiver, AudioType, HEADER_LEN, SAMPLE_RATE, DEFAULT_BITRATE, LockedAudio};
 use super::connection_info::ConnectionInfo;

--- a/src/voice/manager.rs
+++ b/src/voice/manager.rs
@@ -1,9 +1,9 @@
 use crate::gateway::InterMessage;
 use crate::model::id::{ChannelId, GuildId, UserId};
 use std::{
-    collections::HashMap,
     sync::mpsc::Sender as MpscSender
 };
+use hashbrown::HashMap;
 use super::Handler;
 
 /// A manager is a struct responsible for managing [`Handler`]s which belong to


### PR DESCRIPTION
@Lakelezz has suggested on the discord to switch to a faster implementation of HashMap and HashSet (hashbrown). This pull request changes all uses of `std::collection::HashMap` and `std::collection::HashSet` with the corresponding `hashbrown` implementations.

This is a breaking change. Users of the library need to change their code to use hashbrown as well. Additionally it seems like that hashbrown might get merged into rust's libstd soon.