### PR TITLE
Update rusttls, sodiumoxide, webpki and webpki-roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ version = "^0.15"
 default-features = false
 features = ["std"]
 optional = true
-version = "0.2.1"
+version = "^0.2"
 
 [dependencies.threadpool]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ version = "^0.4"
 
 [dependencies.rustls]
 optional = true
-version = "0.14.0"
+version = "^0.15"
 
 [dependencies.sodiumoxide]
 default-features = false
 features = ["std"]
 optional = true
-version = "0.2"
+version = "0.2.1"
 
 [dependencies.threadpool]
 optional = true
@@ -85,14 +85,14 @@ version = "^0.2"
 
 [dependencies.webpki]
 optional = true
-version = "0.18.1"
+version = "^0.19"
 
 [dependencies.webpki-roots]
 optional = true
-version = "0.15.0"
+version = "^0.16"
 
 [dev-dependencies.matches]
-version = "0.1.6"
+version = "^0.1"
 
 [features]
 default = [


### PR DESCRIPTION
Currently building 0.6 with voice enabled pulls in native-tls, even on builds without the native_tls feature.
This is problematic on systems without a compatible version of openssl (like arch linux) where the crate simply cannot be built.
Updating these dependencies to a newer version results in libsodium-sys using rusttls instead of native_tls as a build-time dependency.