### PR TITLE
Fix current_application_info

### DIFF
--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -83,4 +83,6 @@ pub struct CurrentApplicationInfo {
     pub name: String,
     pub owner: User,
     #[serde(default)] pub rpc_origins: Vec<String>,
+    pub bot_public: bool,
+    pub bot_require_code_grant: bool,
 }


### PR DESCRIPTION
API Reference: https://discordapp.com/developers/docs/topics/oauth2#get-current-application-information