### PR TITLE
Add support for raw events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ native_tls = ["reqwest/default-tls", "tungstenite/tls"]
 standard_framework = ["framework", "uwl", "command_attr"]
 utils = ["base64"]
 voice = ["byteorder", "gateway", "audiopus", "rand", "sodiumoxide"]
+raw_event = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ native_tls = ["reqwest/default-tls", "tungstenite/tls"]
 standard_framework = ["framework", "uwl", "command_attr"]
 utils = ["base64"]
 voice = ["byteorder", "gateway", "audiopus", "rand", "sodiumoxide"]
-raw_event = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -139,7 +139,7 @@ impl ShardManager {
 
         let mut shard_queuer = ShardQueuer {
             data: Arc::clone(opt.data),
-            event_handler: Arc::clone(opt.event_handler),
+            event_handler: opt.event_handler.as_ref().map(|h| Arc::clone(h)),
             #[cfg(feature = "framework")]
             framework: Arc::clone(opt.framework),
             last_start: None,
@@ -352,7 +352,7 @@ impl Drop for ShardManager {
 
 pub struct ShardManagerOptions<'a, H: EventHandler + Send + Sync + 'static> {
     pub data: &'a Arc<RwLock<ShareMap>>,
-    pub event_handler: &'a Arc<H>,
+    pub event_handler: &'a Option<Arc<H>>,
     #[cfg(feature = "framework")]
     pub framework: &'a Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     pub shard_index: u64,

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -56,9 +56,10 @@ use crate::client::bridge::voice::ClientVoiceManager;
 /// #
 /// use parking_lot::{Mutex, RwLock};
 /// use serenity::client::bridge::gateway::{ShardManager, ShardManagerOptions};
-/// use serenity::client::EventHandler;
+/// use serenity::client::{EventHandler, RawEventHandler};
 /// // Of note, this imports `typemap`'s `ShareMap` type.
 /// use serenity::prelude::*;
+/// use serenity::http::Http;
 /// use serenity::CacheAndHttp;
 /// // Of note, this imports `typemap`'s `ShareMap` type.
 /// use serenity::prelude::*;
@@ -69,6 +70,7 @@ use crate::client::bridge::voice::ClientVoiceManager;
 /// struct Handler;
 ///
 /// impl EventHandler for Handler { }
+/// impl RawEventHandler for Handler { }
 ///
 /// # let cache_and_http = Arc::new(CacheAndHttp::default());
 /// # let http = &cache_and_http.http;
@@ -80,7 +82,8 @@ use crate::client::bridge::voice::ClientVoiceManager;
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,
-///     event_handler: &event_handler,
+///     event_handler: Some(&event_handler),
+///     raw_event_handler: None::<Handler>,
 ///     framework: &framework,
 ///     // the shard index to start initiating from
 ///     shard_index: 0,

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -82,8 +82,8 @@ use crate::client::bridge::voice::ClientVoiceManager;
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,
-///     event_handler: Some(&event_handler),
-///     raw_event_handler: None::<Handler>,
+///     event_handler: &Some(event_handler),
+///     raw_event_handler: &None::<Arc<Handler>>,
 ///     framework: &framework,
 ///     // the shard index to start initiating from
 ///     shard_index: 0,

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -52,7 +52,7 @@ pub struct ShardQueuer<H: EventHandler + Send + Sync + 'static> {
     /// [`Client`].
     ///
     /// [`Client`]: ../../struct.Client.html
-    pub event_handler: Arc<H>,
+    pub event_handler: Option<Arc<H>>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
     pub framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
@@ -182,7 +182,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardQueuer<H> {
 
         let mut runner = ShardRunner::new(ShardRunnerOptions {
             data: Arc::clone(&self.data),
-            event_handler: Arc::clone(&self.event_handler),
+            event_handler: self.event_handler.as_ref().map(|eh| Arc::clone(eh)),
             #[cfg(feature = "framework")]
             framework: Arc::clone(&self.framework),
             manager_tx: self.manager_tx.clone(),

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -40,7 +40,7 @@ use log::{error, debug, warn};
 /// [`Shard`]: ../../../gateway/struct.Shard.html
 pub struct ShardRunner<H: EventHandler + Send + Sync + 'static> {
     data: Arc<RwLock<ShareMap>>,
-    event_handler: Arc<H>,
+    event_handler: Option<Arc<H>>,
     #[cfg(feature = "framework")]
     framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     manager_tx: Sender<ShardManagerMessage>,
@@ -498,7 +498,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
 /// [`ShardRunner::new`]: struct.ShardRunner.html#method.new
 pub struct ShardRunnerOptions<H: EventHandler + Send + Sync + 'static> {
     pub data: Arc<RwLock<ShareMap>>,
-    pub event_handler: Arc<H>,
+    pub event_handler: Option<Arc<H>>,
     #[cfg(feature = "framework")]
     pub framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     pub manager_tx: Sender<ShardManagerMessage>,

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -19,7 +19,7 @@ use std::{
     },
 };
 use super::super::super::dispatch::{DispatchEvent, dispatch};
-use super::super::super::EventHandler;
+use super::super::super::{EventHandler, RawEventHandler};
 use super::event::{ClientEvent, ShardStageUpdateEvent};
 use super::{ShardClientMessage, ShardId, ShardManagerMessage, ShardRunnerMessage};
 use threadpool::ThreadPool;
@@ -38,9 +38,11 @@ use log::{error, debug, warn};
 /// A runner for managing a [`Shard`] and its respective WebSocket client.
 ///
 /// [`Shard`]: ../../../gateway/struct.Shard.html
-pub struct ShardRunner<H: EventHandler + Send + Sync + 'static> {
+pub struct ShardRunner<H: EventHandler + Send + Sync + 'static,
+                       RH: RawEventHandler + Send + Sync + 'static> {
     data: Arc<RwLock<ShareMap>>,
     event_handler: Option<Arc<H>>,
+    raw_event_handler: Option<Arc<RH>>,
     #[cfg(feature = "framework")]
     framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     manager_tx: Sender<ShardManagerMessage>,
@@ -55,9 +57,10 @@ pub struct ShardRunner<H: EventHandler + Send + Sync + 'static> {
     cache_and_http: Arc<CacheAndHttp>,
 }
 
-impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
+impl<H: EventHandler + Send + Sync + 'static,
+     RH: RawEventHandler + Send + Sync + 'static> ShardRunner<H, RH> {
     /// Creates a new runner for a Shard.
-    pub fn new(opt: ShardRunnerOptions<H>) -> Self {
+    pub fn new(opt: ShardRunnerOptions<H, RH>) -> Self {
         let (tx, rx) = mpsc::channel();
 
         Self {
@@ -65,6 +68,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
             runner_tx: tx,
             data: opt.data,
             event_handler: opt.event_handler,
+            raw_event_handler: opt.raw_event_handler,
             #[cfg(feature = "framework")]
             framework: opt.framework,
             manager_tx: opt.manager_tx,
@@ -217,6 +221,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
             &self.framework,
             &self.data,
             &self.event_handler,
+            &self.raw_event_handler,
             &self.runner_tx,
             &self.threadpool,
             self.shard.shard_info()[0],
@@ -496,9 +501,11 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
 /// Options to be passed to [`ShardRunner::new`].
 ///
 /// [`ShardRunner::new`]: struct.ShardRunner.html#method.new
-pub struct ShardRunnerOptions<H: EventHandler + Send + Sync + 'static> {
+pub struct ShardRunnerOptions<H: EventHandler + Send + Sync + 'static,
+                              RH: RawEventHandler + Send  + Sync + 'static> {
     pub data: Arc<RwLock<ShareMap>>,
     pub event_handler: Option<Arc<H>>,
+    pub raw_event_handler: Option<Arc<RH>>,
     #[cfg(feature = "framework")]
     pub framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     pub manager_tx: Sender<ShardManagerMessage>,

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -123,7 +123,7 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
         (Some(ref h), None) => {
             match event {
                 DispatchEvent::Model(Event::MessageCreate(mut event)) => {
-                    update!(&cache_and_http, &mut event);
+                    update(&cache_and_http, &mut event);
 
                     #[cfg(not(any(feature = "cache", feature = "http")))]
                     let context = context(data, runner_tx, shard_id);
@@ -177,7 +177,7 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
                 _ => {}
             }
         },
-        (Some(ref h), Some(ref rh)) => {
+        (Some(_), Some(_)) => {
             match event {
                 DispatchEvent::Model(ref e) => 
                     dispatch(DispatchEvent::Model(e.clone()),
@@ -221,7 +221,7 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
         (Some(ref h), None) => {
             match event {
                 DispatchEvent::Model(Event::MessageCreate(mut event)) => {
-                    update!(&cache_and_http, &mut event);
+                    update(&cache_and_http, &mut event);
 
                     #[cfg(not(any(feature = "cache", feature = "http")))]
                     let context = context(data, runner_tx, shard_id);

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -8,7 +8,7 @@ use std::{sync::{Arc, mpsc::Sender}};
 use parking_lot::{Mutex, RwLock};
 use super::{
     bridge::gateway::event::ClientEvent,
-    event_handler::EventHandler,
+    event_handler::{EventHandler, RawEventHandler},
     Context
 };
 use threadpool::ThreadPool;
@@ -105,99 +105,196 @@ pub(crate) enum DispatchEvent {
 
 #[cfg(feature = "framework")]
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static>(
+#[clippy::too_many_arguments]
+pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
+                       RH: RawEventHandler + Send + Sync + 'static>(
     event: DispatchEvent,
     framework: &Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     data: &Arc<RwLock<ShareMap>>,
     event_handler: &Option<Arc<H>>,
+    raw_event_handler: &Option<Arc<RH>>,
     runner_tx: &Sender<InterMessage>,
     threadpool: &ThreadPool,
     shard_id: u64,
     cache_and_http: Arc<CacheAndHttp>,
 ) {
-    match event {
-        DispatchEvent::Model(Event::MessageCreate(mut event)) => {
-            update(&cache_and_http, &mut event);
+    match (event_handler, raw_event_handler) {
+        (None, None) => {}, // Do nothing
+        (Some(ref h), None) => {
+            match event {
+                DispatchEvent::Model(Event::MessageCreate(mut event)) => {
+                    update!(&cache_and_http, &mut event);
 
-            #[cfg(not(any(feature = "cache", feature = "http")))]
-            let context = context(data, runner_tx, shard_id);
-            #[cfg(all(feature = "cache", not(feature = "http")))]
-            let context = context(data, runner_tx, shard_id, &cache_and_http.cache);
-            #[cfg(all(not(feature = "cache"), feature = "http"))]
-            let context = context(data, runner_tx, shard_id, &cache_and_http.http);
-            #[cfg(all(feature = "cache", feature = "http"))]
-            let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
+                    #[cfg(not(any(feature = "cache", feature = "http")))]
+                    let context = context(data, runner_tx, shard_id);
+                    #[cfg(all(feature = "cache", not(feature = "http")))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache);
+                    #[cfg(all(not(feature = "cache"), feature = "http"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.http);
+                    #[cfg(all(feature = "cache", feature = "http"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
 
-            if let Some(ref handler) = event_handler {
-                dispatch_message(
-                    context.clone(),
-                    event.message.clone(),
-                    handler,
-                    threadpool,
-                );
-            }
-
-            if let Some(ref mut framework) = *framework.lock() {
-                framework.dispatch(context, event.message, threadpool);
+                    dispatch_message(
+                        context.clone(),
+                        event.message.clone(),
+                        h,
+                        threadpool,
+                    );
+                    if let Some(ref mut framework) = *framework.lock() {
+                        framework.dispatch(context, event.message, threadpool);
+                    }
+                },
+                other => { 
+                    handle_event(
+                        other,
+                        data,
+                        h,
+                        runner_tx,
+                        threadpool,
+                        shard_id,
+                        cache_and_http,
+                    );
+                }
             }
         },
-        other => { 
-            if let Some(ref handler) = event_handler {
-                handle_event(
-                other,
-                data,
-                handler,
-                runner_tx,
-                threadpool,
-                shard_id,
-                cache_and_http,
-                );
+        (None, Some(ref rh)) => {
+            match event {
+                DispatchEvent::Model(e) => {
+                    #[cfg(not(any(feature = "cache", feature = "http")))]
+                    let context = context(data, runner_tx, shard_id);
+                    #[cfg(all(feature = "cache", not(feature = "http")))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache);
+                    #[cfg(all(not(feature = "cache"), feature = "http"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.http);
+                    #[cfg(all(feature = "cache", feature = "http"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
+
+                    let event_handler = Arc::clone(rh);
+                    threadpool.execute(move || {
+                        event_handler.raw_event(context, e);
+                    });
+                },
+                _ => {}
             }
         },
-    }
+        (Some(ref h), Some(ref rh)) => {
+            match event {
+                DispatchEvent::Model(ref e) => 
+                    dispatch(DispatchEvent::Model(e.clone()),
+                             framework,
+                             data,
+                             &None::<Arc<H>>,
+                             raw_event_handler,
+                             runner_tx,
+                             threadpool,
+                             shard_id,
+                             Arc::clone(&cache_and_http)),
+                _ => {}
+            }
+            dispatch(event,
+                     framework,
+                     data,
+                     event_handler,
+                     &None::<Arc<RH>>,
+                     runner_tx,
+                     threadpool,
+                     shard_id,
+                     cache_and_http);
+        }
+    };
 }
 
 #[cfg(not(feature = "framework"))]
-pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static>(
+pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
+                       RH: RawEventHandler + Send + Sync + 'static>(
     event: DispatchEvent,
     data: &Arc<RwLock<ShareMap>>,
     event_handler: &Option<Arc<H>>,
+    raw_event_handler: &Option<Arc<RH>>,
     runner_tx: &Sender<InterMessage>,
     threadpool: &ThreadPool,
     shard_id: u64,
     cache_and_http: Arc<CacheAndHttp>,
 ) {
-    match event {
-        DispatchEvent::Model(Event::MessageCreate(event)) => {
-            update(&cache_and_http, &mut event);
+    match (event_handler, raw_event_handler) {
+        (None, None) => {}, // Do nothing
+        (Some(ref h), None) => {
+            match event {
+                DispatchEvent::Model(Event::MessageCreate(mut event)) => {
+                    update!(&cache_and_http, &mut event);
 
-            #[cfg(not(any(feature = "cache", feature = "http")))]
-            let context = context(data, runner_tx, shard_id);
-            #[cfg(all(feature = "cache", not(feature = "http")))]
-            let context = context(data, runner_tx, shard_id, &cache_and_http.cache);
-            #[cfg(all(not(feature = "cache"), feature = "http"))]
-            let context = context(data, runner_tx, shard_id, &cache_and_http.http);
-            #[cfg(all(feature = "cache", feature = "http"))]
-            let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
+                    #[cfg(not(any(feature = "cache", feature = "http")))]
+                    let context = context(data, runner_tx, shard_id);
+                    #[cfg(all(feature = "cache", not(feature = "http")))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache);
+                    #[cfg(all(not(feature = "cache"), feature = "http"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.http);
+                    #[cfg(all(feature = "cache", feature = "http"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
 
-            if let Some(ref handler) = event_handler {
-                dispatch_message(context, event.message.clone(), handler, threadpool);
+                    dispatch_message(
+                        context.clone(),
+                        event.message.clone(),
+                        h,
+                        threadpool,
+                    );
+                },
+                other => { 
+                    handle_event(
+                        other,
+                        data,
+                        h,
+                        runner_tx,
+                        threadpool,
+                        shard_id,
+                        cache_and_http,
+                    );
+                }
             }
         },
-        other => {
-            if let Some(ref handler) = event_handler {
-                handle_event(
-                    other,
-                    data,
-                    handler,
-                    runner_tx,
-                    threadpool,
-                    shard_id,
-                    cache_and_http,
-                );
+        (None, Some(ref rh)) => {
+            match event {
+                DispatchEvent::Model(e) => {
+                    #[cfg(not(any(feature = "cache", feature = "http")))]
+                    let context = context(data, runner_tx, shard_id);
+                    #[cfg(all(feature = "cache", not(feature = "http")))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache);
+                    #[cfg(all(not(feature = "cache"), feature = "http"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.http);
+                    #[cfg(all(feature = "cache", feature = "http"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
+
+                    let event_handler = Arc::clone(rh);
+                    threadpool.execute(move || {
+                        event_handler.raw_event(context, e);
+                    });
+                },
+                _ => {}
             }
         },
-    }
+        (Some(ref h), Some(ref rh)) => {
+            match event {
+                DispatchEvent::Model(ref e) => 
+                    dispatch(DispatchEvent::Model(e.clone()),
+                             data,
+                             &None::<Arc<H>>,
+                             raw_event_handler,
+                             runner_tx,
+                             threadpool,
+                             shard_id,
+                             Arc::clone(&cache_and_http)),
+                _ => {}
+            }
+            dispatch(event,
+                     data,
+                     event_handler,
+                     &None::<Arc<RH>>,
+                     runner_tx,
+                     threadpool,
+                     shard_id,
+                     cache_and_http);
+        }
+    };
 }
 
 fn dispatch_message<H>(
@@ -236,19 +333,6 @@ fn handle_event<H: EventHandler + Send + Sync + 'static>(
     let context = context(data, runner_tx, shard_id, &cache_and_http.http);
     #[cfg(all(feature = "cache", feature = "http"))]
     let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
-
-    #[cfg(feature = "raw_event")]
-    match event {
-        DispatchEvent::Model(ref event) => {
-            let event_handler = Arc::clone(event_handler);
-            let ev = event.clone();
-            let ctx = context.clone();
-            threadpool.execute(move || {
-                event_handler.raw_event(ctx, ev);
-            });
-        },
-        _ => {}
-    }
 
     match event {
         DispatchEvent::Client(ClientEvent::ShardStageUpdate(event)) => {

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -306,4 +306,10 @@ pub trait EventHandler {
     ///
     /// Provides the guild's id and the channel's id the webhook belongs in.
     fn webhook_update(&self, _ctx: Context, _guild_id: GuildId, _belongs_to_channel_id: ChannelId) {}
+
+    /// Dispatched when any event occurs
+    /// 
+    /// If the feature is enabled the overhead for dispatching events will be 2x as big.
+    #[cfg(feature = "raw_event")]
+    fn raw_event(&self, _ctx: Context, _ev: Event) {}
 }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -306,10 +306,10 @@ pub trait EventHandler {
     ///
     /// Provides the guild's id and the channel's id the webhook belongs in.
     fn webhook_update(&self, _ctx: Context, _guild_id: GuildId, _belongs_to_channel_id: ChannelId) {}
+}
 
+/// This core trait for handling raw events
+pub trait RawEventHandler {
     /// Dispatched when any event occurs
-    /// 
-    /// If the feature is enabled the overhead for dispatching events will be 2x as big.
-    #[cfg(feature = "raw_event")]
     fn raw_event(&self, _ctx: Context, _ev: Event) {}
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -339,6 +339,13 @@ impl Client {
     /// ```
     pub fn new<H>(token: &str, handler: H) -> Result<Self>
         where H: EventHandler + Send + Sync + 'static {
+
+        Self::new_with_handler(token, Some(handler))
+    }
+    /// Creates a client with an optional Handler. If you pass `None`, events are never parsed, but
+    /// they can be received by registering a RawHandler.
+    pub fn new_with_handler<H>(token: &str, handler: Option<H>) -> Result<Self>
+        where H: EventHandler + Send + Sync + 'static {
         let token = token.trim();
 
         let token = if token.starts_with("Bot ") {
@@ -353,7 +360,7 @@ impl Client {
         let threadpool = ThreadPool::with_name(name, 5);
         let url = Arc::new(Mutex::new(http.get_gateway()?.url));
         let data = Arc::new(RwLock::new(ShareMap::custom()));
-        let event_handler = Arc::new(handler);
+        let event_handler = handler.map(|h| Arc::new(h));
 
         #[cfg(feature = "framework")]
         let framework = Arc::new(Mutex::new(None));
@@ -439,7 +446,7 @@ impl Client {
     /// # }
     /// ```
     #[cfg(all(feature = "cache", feature = "http"))]
-    pub fn new_with_cache_update_timeout<H>(token: &str, handler: H, duration: Option<Duration>) -> Result<Self>
+    pub fn new_with_cache_update_timeout<H>(token: &str, handler: Option<H>, duration: Option<Duration>) -> Result<Self>
         where H: EventHandler + Send + Sync + 'static {
         let token = token.trim();
 
@@ -455,7 +462,7 @@ impl Client {
         let threadpool = ThreadPool::with_name(name, 5);
         let url = Arc::new(Mutex::new(http.get_gateway()?.url));
         let data = Arc::new(RwLock::new(ShareMap::custom()));
-        let event_handler = Arc::new(handler);
+        let event_handler = handler.map(|h| Arc::new(h));
 
         #[cfg(feature = "framework")]
         let framework = Arc::new(Mutex::new(None));

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -452,7 +452,7 @@ impl Client {
     /// # }
     /// ```
     #[cfg(all(feature = "cache", feature = "http"))]
-    pub fn new_with_cache_update_timeout<H>(token: &str, handler: Option<H>, duration: Option<Duration>) -> Result<Self>
+    pub fn new_with_cache_update_timeout<H>(token: &str, handler: H, duration: Option<Duration>) -> Result<Self>
         where H: EventHandler + Send + Sync + 'static {
         let token = token.trim();
 
@@ -468,7 +468,7 @@ impl Client {
         let threadpool = ThreadPool::with_name(name, 5);
         let url = Arc::new(Mutex::new(http.get_gateway()?.url));
         let data = Arc::new(RwLock::new(ShareMap::custom()));
-        let event_handler = handler.map(|h| Arc::new(h));
+        let event_handler = Some(Arc::new(handler));
 
         #[cfg(feature = "framework")]
         let framework = Arc::new(Mutex::new(None));

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,7 +19,7 @@ pub use crate::model::misc::Mentionable;
 pub use parking_lot::{Mutex, RwLock};
 
 #[cfg(feature = "client")]
-pub use crate::client::{Client, ClientError as ClientError, Context, EventHandler};
+pub use crate::client::{Client, ClientError, Context, EventHandler, RawEventHandler};
 #[cfg(feature = "gateway")]
 pub use crate::gateway::GatewayError;
 #[cfg(feature = "http")]


### PR DESCRIPTION
Currently serenity does not provide any functionality to receive raw discord websocket events. This would be useful for distributed/"serverless" bots that want to feed discord events into a queue service.

This pull request adds support for another type of event handler, the RawEventHandler. It is possible to extend it to other raw event types if necessary.

As a side effect this pr makes it possible to create a Client instance without any Handler.

The code has a small performance impact on every event, however the events are only cloned if there is both a regular and a raw handler. In most cases you'll only want one of these, so this can be ignored. 

If you find a better way of implementing what this PR does, feel free to comment.