### PR TITLE
Add news channel

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -299,7 +299,7 @@ command!(say(ctx, msg, args) {
             .clean_role(false)
     };
 
-    let mut content = content_safe(&ctx.cache, &args.full(), &settings);
+    let mut content = content_safe(&ctx.cache, &args.rest(), &settings);
 
     if let Err(why) = msg.channel_id.say(&ctx.http, &content) {
         println!("Error sending message: {:?}", why);
@@ -351,7 +351,7 @@ command!(some_long_command(ctx, msg, args) {
 });
 
 command!(about_role(ctx, msg, args) {
-    let potential_role_name = args.full();
+    let potential_role_name = args.rest();
 
     if let Some(guild) = msg.guild(&ctx.cache) {
         // `role_by_name()` allows us to attempt attaining a reference to a role
@@ -365,7 +365,7 @@ command!(about_role(ctx, msg, args) {
         }
     }
 
-    if let Err(why) = msg.channel_id.say(&ctx.http, &format!("Could not find role named: {:?}", potential_role_name)) {
+    if let Err(why) = msg.channel_id.say(&ctx.http, format!("Could not find role named: {:?}", potential_role_name)) {
         println!("Error sending message: {:?}", why);
     }
 });
@@ -467,7 +467,7 @@ command!(bird(ctx, msg, args) {
     let say_content = if args.is_empty() {
         ":bird: can find animals for you.".to_string()
     } else {
-        format!(":bird: could not find animal named: `{}`.", args.full())
+        format!(":bird: could not find animal named: `{}`.", args.rest())
     };
 
     if let Err(why) = msg.channel_id.say(&ctx.http, say_content) {
@@ -486,7 +486,7 @@ command!(slow_mode(ctx, msg, args) {
             format!("Successfully set slow mode rate to `{}` seconds.", slow_mode_rate_seconds)
         }
     } else if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx.cache) {
-        format!("Current slow mode rate is `{}` seconds.", channel.read().slow_mode_rate)
+        format!("Current slow mode rate is `{}` seconds.", channel.read().slow_mode_rate.unwrap_or(0))
     } else {
         "Failed to find channel in cache.".to_string()
     };

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -948,7 +948,7 @@ mod test {
             topic: None,
             user_limit: None,
             nsfw: false,
-            slow_mode_rate: 0,
+            slow_mode_rate: Some(0),
         };
 
         // Add a channel delete event to the cache, the cached messages for that

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -95,8 +95,11 @@ pub struct GuildChannel {
     #[serde(default)]
     pub nsfw: bool,
     /// A rate limit that applies per user and excludes bots.
+    ///
+    /// **Note**: This is only available for text channels excluding news
+    /// channels.
     #[serde(default, rename = "rate_limit_per_user")]
-    pub slow_mode_rate: u64,
+    pub slow_mode_rate: Option<u64>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -33,8 +33,10 @@ use crate::builder::EditChannel;
 #[cfg(feature = "http")]
 use crate::http::Http;
 
-/// Represents a guild's text or voice channel. Some methods are available only
-/// for voice channels and some are only available for text channels.
+/// Represents a guild's text, news, or voice channel. Some methods are available
+/// only for voice channels and some are only available for text channels.
+/// News channels are a subset of text channels and lack slow mode hence
+/// `slow_mode_rate` will be `None`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GuildChannel {
     /// The unique Id of the channel.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -544,7 +544,7 @@ mod test {
                 topic: None,
                 user_limit: None,
                 nsfw: false,
-                slow_mode_rate: 0,
+                slow_mode_rate: Some(0),
             }
         }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -401,6 +401,10 @@ pub enum ChannelType {
     ///
     /// [`ChannelCategory`]: struct.ChannelCategory.html
     Category = 4,
+    /// An indicator that the channel is a [`NewsChannel`].
+    ///
+    /// [`NewsChannel`]: struct.NewsChannel.html
+    News = 5,
 }
 
 enum_number!(
@@ -410,6 +414,7 @@ enum_number!(
         Voice,
         Group,
         Category,
+        News,
     }
 );
 
@@ -421,6 +426,7 @@ impl ChannelType {
             ChannelType::Text => "text",
             ChannelType::Voice => "voice",
             ChannelType::Category => "category",
+            ChannelType::News => "news",
         }
     }
 
@@ -431,6 +437,7 @@ impl ChannelType {
             ChannelType::Voice => 2,
             ChannelType::Group => 3,
             ChannelType::Category => 4,
+            ChannelType::News => 5,
         }
     }
 }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -316,7 +316,7 @@ mod test {
                 topic: None,
                 user_limit: None,
                 nsfw: false,
-                slow_mode_rate: 0,
+                slow_mode_rate: Some(0),
             })));
             let emoji = Emoji {
                 animated: false,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -942,7 +942,7 @@ mod test {
             topic: None,
             user_limit: None,
             nsfw: false,
-            slow_mode_rate: 0,
+            slow_mode_rate: Some(0),
         };
 
         let cache = Arc::new(RwLock::new(Cache::default()));


### PR DESCRIPTION
Discord added a new channel-type: news-channels (see: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-types).
I sadly cannot test them as they are exclusive to some servers, but right now they are normal channels without slow-mode.

In order to test properly test potential lack of slow-mode, I fixed the framework-example. One can try running the slow-mode-command, it should fail on a news-channels.
