### PR TITLE
Switch to `audiopus`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 
+[dependencies.audiopus]
+optional = true
+version = "0.1"
+
 [dependencies.base64]
 optional = true
 version = "0.10"
@@ -43,10 +47,6 @@ version = "0.9"
 [dependencies.lazy_static]
 optional = true
 version = "^1.0"
-
-[dependencies.opus]
-optional = true
-version = "0.2"
 
 [dependencies.rand]
 optional = true
@@ -132,7 +132,7 @@ model = ["builder", "http"]
 native_tls = ["reqwest/default-tls", "tungstenite/tls"]
 standard_framework = ["framework", "uwl"]
 utils = ["base64"]
-voice = ["byteorder", "gateway", "opus", "rand", "sodiumoxide"]
+voice = ["byteorder", "gateway", "audiopus", "rand", "sodiumoxide"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,4 +42,3 @@ jobs:
     name: 'Windows_default_features'
     vmImage: 'vs2017-win2016'
     toolchain: 'stable'
-    features: 'default'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,6 @@ jobs:
 
 - template: 'azure-template-win.yml'
   parameters:
-    name: 'Windows_default_features'
+    name: 'Windows_stable'
     vmImage: 'vs2017-win2016'
     toolchain: 'stable'

--- a/azure-template.yml
+++ b/azure-template.yml
@@ -6,16 +6,16 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  pool: 
+  pool:
     vmImage: ${{ parameters.vmImage }}
   variables:
     tc: ${{ parameters.toolchain }}
     os: ${{ parameters.vmImage }}
     features: ${{ parameters.features }}
-  steps: 
+  steps:
   - bash: |
       if [[ "$OS" == "xcode9-macos10.13" ]]; then
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install libsodium pkg-config
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install automake autoconf libtool libsodium pkg-config
       fi
       if [[ "$OS" == "ubuntu-16.04" ]]; then
         sudo apt-get install -y --allow-downgrades libsodium-dev libssl-dev=1.0.2g-1ubuntu4.14

--- a/examples/06_voice/Cargo.toml
+++ b/examples/06_voice/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies.serenity]
-features = ["cache", "framework", "standard_framework", "voice"]
+features = ["cache", "framework", "standard_framework", "voice", "http"]
 path = "../../"

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ use std::{
 #[cfg(feature = "http")]
 use reqwest::{Error as ReqwestError, header::InvalidHeaderValue};
 #[cfg(feature = "voice")]
-use opus::Error as OpusError;
+use audiopus::Error as OpusError;
 #[cfg(feature = "gateway")]
 use tungstenite::error::Error as TungsteniteError;
 #[cfg(feature = "client")]

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -1,12 +1,13 @@
 use parking_lot::Mutex;
+use audiopus::{Bitrate, SampleRate};
 use std::{
     sync::Arc,
     time::Duration,
 };
 
 pub const HEADER_LEN: usize = 12;
-pub const SAMPLE_RATE: u32 = 48_000;
-pub const DEFAULT_BITRATE: i32 = 128_000;
+pub const SAMPLE_RATE: SampleRate = SampleRate::Hz48000;
+pub const DEFAULT_BITRATE: Bitrate = Bitrate::BitsPerSecond(128_000);
 
 /// A readable audio source.
 pub trait AudioSource: Send {

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -14,14 +14,14 @@ use crate::internal::{
 };
 use crate::model::event::VoiceEvent;
 
-use opus::{
+use audiopus::{
     packet as opus_packet,
     Application as CodingMode,
     Bitrate,
     Channels,
-    Decoder as OpusDecoder,
-    Encoder as OpusEncoder,
-    SoftClip,
+    coder::Decoder as OpusDecoder,
+    coder::Encoder as OpusEncoder,
+    softclip::SoftClip,
 };
 use parking_lot::Mutex;
 use rand::random;
@@ -191,7 +191,7 @@ impl Connection {
 
         // Encode for Discord in Stereo, as required.
         let mut encoder = OpusEncoder::new(SAMPLE_RATE, Channels::Stereo, CodingMode::Audio)?;
-        encoder.set_bitrate(Bitrate::Bits(DEFAULT_BITRATE))?;
+        encoder.set_bitrate(DEFAULT_BITRATE)?;
         let soft_clip = SoftClip::new(Channels::Stereo);
 
         // Per discord dev team's current recommendations:
@@ -295,7 +295,7 @@ impl Connection {
         // We need to actually reserve enough space for the desired bitrate.
         let size = match bitrate {
             // If user specified, we can calculate. 20ms means 50fps.
-            Bitrate::Bits(b) => b.abs() / 50,
+            Bitrate::BitsPerSecond(b) => b / 50,
             // Otherwise, just have a lot preallocated.
             _ => 5120,
         } + 16;
@@ -319,7 +319,7 @@ impl Connection {
 
                         if let Ok(mut decrypted) =
                             secretbox::open(&packet[HEADER_LEN..], &nonce, &self.key) {
-                            let channels = opus_packet::get_nb_channels(&decrypted)?;
+                            let channels = opus_packet::nb_channels(&decrypted)?;
 
                             let entry =
                                 self.decoder_map.entry((ssrc, channels)).or_insert_with(
@@ -348,7 +348,7 @@ impl Connection {
                                 decrypted = decrypted.split_off(offset);
                             }
 
-                            let len = entry.decode(&decrypted, &mut buffer, false)?;
+                            let len = entry.decode(Some(&decrypted), &mut buffer[..], false)?;
 
                             let is_stereo = channels == Channels::Stereo;
 
@@ -493,7 +493,7 @@ impl Connection {
             }
         };
 
-        self.soft_clip.apply(&mut mix_buffer);
+        self.soft_clip.apply(&mut mix_buffer[..])?;
 
         if len == 0 {
             if self.silence_frames > 0 {

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -26,7 +26,7 @@ pub use self::{
         ytdl
     }
 };
-pub use opus::Bitrate;
+pub use audiopus::Bitrate;
 
 use self::connection_info::ConnectionInfo;
 

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -1,8 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt};
 use crate::internal::prelude::*;
-use opus::{
+use audiopus::{
     Channels,
-    Decoder as OpusDecoder,
+    coder::Decoder as OpusDecoder,
     Result as OpusResult,
 };
 use parking_lot::Mutex;

--- a/src/voice/threading.rs
+++ b/src/voice/threading.rs
@@ -6,7 +6,6 @@ use std::{
 };
 use super::{
     connection::Connection,
-    Bitrate,
     Status,
     audio,
 };
@@ -26,7 +25,7 @@ fn runner(rx: &MpscReceiver<Status>) {
     let mut receiver = None;
     let mut connection = None;
     let mut timer = Timer::new(20);
-    let mut bitrate = Bitrate::Bits(audio::DEFAULT_BITRATE);
+    let mut bitrate = audio::DEFAULT_BITRATE;
 
     'runner: loop {
         loop {


### PR DESCRIPTION
Our current Opus-crate is using a three-year-old sys-crate with no Windows-support.

This pull request switches to `audiopus`, the underlying `audiopus_sys` uses Opus version 1.3 (released October 2018).

In order to test it, I had to tweak the voice-example, it required the `http`-feature.

Last but not least, I made Azure's Windows-job build all features not just `default features` to verify that `audiopus` works with Windows on `serenity` and thus renamed it accordingly. 
Last last thing: I changed macOS's job to install Opus' required dependencies.