### PR TITLE
Change Functions utilising HTTP/Cache to accept `impl AsRef<Http>`

### DIFF
--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -24,7 +24,7 @@ use crate::utils::VecMap;
 /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
 /// # use std::sync::Arc;
 /// # let http = Arc::new(Http::default());
-/// let webhook = http.get_webhook_with_token(id, token)
+/// let webhook = http.as_ref().get_webhook_with_token(id, token)
 ///     .expect("valid webhook");
 ///
 /// let website = Embed::fake(|e| {
@@ -63,7 +63,7 @@ impl ExecuteWebhook {
     /// # use std::sync::Arc;
     /// #
     /// # let http = Arc::new(Http::default());
-    /// # let webhook = http.get_webhook_with_token(0, "").unwrap();
+    /// # let webhook = http.as_ref().get_webhook_with_token(0, "").unwrap();
     /// #
     /// let avatar_url = "https://i.imgur.com/KTs6whd.jpg";
     ///
@@ -90,7 +90,7 @@ impl ExecuteWebhook {
     /// # use std::sync::Arc;
     /// #
     /// # let http = Arc::new(Http::default());
-    /// # let webhook = http.get_webhook_with_token(0, "").unwrap();
+    /// # let webhook = http.as_ref().get_webhook_with_token(0, "").unwrap();
     /// #
     /// let execution = webhook.execute(&http, false, |w| {
     ///     w.content("foo")
@@ -136,7 +136,7 @@ impl ExecuteWebhook {
     /// # use std::sync::Arc;
     /// #
     /// # let http = Arc::new(Http::default());
-    /// # let webhook = http.get_webhook_with_token(0, "").unwrap();
+    /// # let webhook = http.as_ref().get_webhook_with_token(0, "").unwrap();
     /// #
     /// let execution = webhook.execute(&http, false, |w| {
     ///     w.content("hello").tts(true)
@@ -162,7 +162,7 @@ impl ExecuteWebhook {
     /// # use std::sync::Arc;
     /// #
     /// # let http = Arc::new(Http::default());
-    /// # let webhook = http.get_webhook_with_token(0, "").unwrap();
+    /// # let webhook = http.as_ref().get_webhook_with_token(0, "").unwrap();
     /// #
     /// let execution = webhook.execute(&http, false, |w| {
     ///     w.content("hello").username("hakase")

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -114,6 +114,21 @@ impl Context {
         }
     }
 
+    /// Creates a new Context without use thus for testing purposes only.
+    #[doc(hidden)]
+    pub fn new_mock() -> Self {
+        let (sender, _) = channel();
+
+        Self {
+            data: Arc::new(RwLock::new(ShareMap::custom())),
+            shard: ShardMessenger::new(sender),
+            shard_id: 0,
+            #[cfg(feature = "cache")]
+            cache: Arc::new(RwLock::new(Cache::new())),
+            http: Arc::new(Http::new_mock())
+        }
+    }
+
     /// Edits the current user's profile settings.
     ///
     /// Refer to `EditProfile`'s documentation for its methods.

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -494,6 +494,7 @@ impl Context {
     }
 }
 
+#[cfg(feature = "http")]
 impl AsRef<Http> for &Context {
     fn as_ref(&self) -> &Http { &self.http }
 }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -7,7 +7,7 @@ use parking_lot::RwLock;
 use serde_json::Value;
 use std::sync::{
     Arc,
-    mpsc::Sender
+    mpsc::{channel, Sender},
 };
 use typemap::ShareMap;
 use crate::utils::VecMap;
@@ -125,7 +125,7 @@ impl Context {
             shard_id: 0,
             #[cfg(feature = "cache")]
             cache: Arc::new(RwLock::new(Cache::new())),
-            http: Arc::new(Http::new_mock())
+            http: Arc::new(Http::default())
         }
     }
 
@@ -507,4 +507,8 @@ impl Context {
     pub fn quit(&self) {
         self.shard.shutdown_clean();
     }
+}
+
+impl AsRef<Http> for &Context {
+    fn as_ref(&self) -> &Http { &self.http }
 }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -7,7 +7,7 @@ use parking_lot::RwLock;
 use serde_json::Value;
 use std::sync::{
     Arc,
-    mpsc::{channel, Sender},
+    mpsc::Sender,
 };
 use typemap::ShareMap;
 use crate::utils::VecMap;
@@ -111,21 +111,6 @@ impl Context {
             shard: ShardMessenger::new(runner_tx),
             shard_id,
             data,
-        }
-    }
-
-    /// Creates a new Context without use thus for testing purposes only.
-    #[doc(hidden)]
-    pub fn new_mock() -> Self {
-        let (sender, _) = channel();
-
-        Self {
-            data: Arc::new(RwLock::new(ShareMap::custom())),
-            shard: ShardMessenger::new(sender),
-            shard_id: 0,
-            #[cfg(feature = "cache")]
-            cache: Arc::new(RwLock::new(Cache::new())),
-            http: Arc::new(Http::default())
         }
     }
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -701,7 +701,7 @@ pub fn create_customised_help_data<'a, H: BuildHasher>(
 /// Sends an embed listing all groups with their commands.
 #[cfg(feature = "http")]
 fn send_grouped_commands_embed(
-    http: &Arc<Http>,
+    http: impl AsRef<Http>,
     help_options: &HelpOptions,
     channel_id: ChannelId,
     help_description: &str,
@@ -738,7 +738,7 @@ fn send_grouped_commands_embed(
 /// Sends embed showcasing information about a single command.
 #[cfg(feature = "http")]
 fn send_single_command_embed(
-    http: &Arc<Http>,
+    http: impl AsRef<Http>,
     help_options: &HelpOptions,
     channel_id: ChannelId,
     command: &Command<'_>,
@@ -793,7 +793,7 @@ fn send_single_command_embed(
 /// Sends embed listing commands that are similar to the sent one.
 #[cfg(feature = "http")]
 fn send_suggestion_embed(
-    http: &Arc<Http>,
+    http: impl AsRef<Http>,
     channel_id: ChannelId,
     help_description: &str,
     suggestions: &Suggestions,
@@ -813,7 +813,7 @@ fn send_suggestion_embed(
 
 /// Sends an embed explaining fetching commands failed.
 #[cfg(feature = "http")]
-fn send_error_embed(http: &Arc<Http>, channel_id: ChannelId, input: &str, colour: Colour) -> Result<Message, Error> {
+fn send_error_embed(http: impl AsRef<Http>, channel_id: ChannelId, input: &str, colour: Colour) -> Result<Message, Error> {
     channel_id.send_message(&http, |m| {
         m.embed(|e| {
             e.colour(colour);

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -482,7 +482,7 @@ impl Http {
     /// let channel_id = ChannelId(7);
     /// let message_id = MessageId(8);
     ///
-    /// let _ = http.delete_message_reactions(channel_id.0, message_id.0)
+    /// let _ = http.as_ref().delete_message_reactions(channel_id.0, message_id.0)
     ///     .expect("Error deleting reactions");
     /// ```
     ///
@@ -555,7 +555,7 @@ impl Http {
     /// // must have set the token first.
     /// let http = Arc::new(Http::default());
     ///
-    /// http.delete_webhook(245037420704169985).expect("Error deleting webhook");
+    /// http.as_ref().delete_webhook(245037420704169985).expect("Error deleting webhook");
     /// ```
     ///
     /// [`Webhook`]: ../../model/webhook/struct.Webhook.html
@@ -584,7 +584,7 @@ impl Http {
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// http.delete_webhook_with_token(id, token).expect("Error deleting webhook");
+    /// http.as_ref().delete_webhook_with_token(id, token).expect("Error deleting webhook");
     /// ```
     ///
     /// [`Webhook`]: ../../model/webhook/struct.Webhook.html
@@ -762,7 +762,7 @@ impl Http {
     ///     .expect("Error reading image");
     /// let map = ObjectBuilder::new().insert("avatar", image).build();
     ///
-    /// let edited = http.edit_webhook_with_token(id, token, map)
+    /// let edited = http.as_ref().edit_webhook_with_token(id, token, map)
     ///     .expect("Error editing webhook");
     /// ```
     ///
@@ -796,7 +796,7 @@ impl Http {
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let map = ObjectBuilder::new().insert("name", "new name").build();
     ///
-    /// let edited = http.edit_webhook_with_token(id, token, map)
+    /// let edited = http.as_ref().edit_webhook_with_token(id, token, map)
     ///     .expect("Error editing webhook");
     /// ```
     ///
@@ -850,7 +850,7 @@ impl Http {
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let map = ObjectBuilder::new().insert("content", "test").build();
     ///
-    /// let message = match http.execute_webhook(id, token, true, map) {
+    /// let message = match http.as_ref().execute_webhook(id, token, true, map) {
     ///     Ok(Some(message)) => message,
     ///     Ok(None) => {
     ///         println!("Expected a webhook message");
@@ -976,7 +976,7 @@ impl Http {
     ///
     /// let channel_id = 81384788765712384;
     ///
-    /// let webhooks = http.get_channel_webhooks(channel_id)
+    /// let webhooks = http.as_ref().get_channel_webhooks(channel_id)
     ///     .expect("Error getting channel webhooks");
     /// ```
     ///
@@ -1174,7 +1174,7 @@ impl Http {
     /// # let http = Arc::new(Http::default());
     /// let guild_id = 81384788765712384;
     ///
-    /// let webhooks = http.get_guild_webhooks(guild_id)
+    /// let webhooks = http.as_ref().get_guild_webhooks(guild_id)
     ///     .expect("Error getting guild webhooks");
     /// ```
     ///
@@ -1206,7 +1206,7 @@ impl Http {
     ///
     /// let guild_id = GuildId(81384788765712384);
     ///
-    /// let guilds = http.get_guilds(&GuildPagination::After(guild_id), 10).unwrap();
+    /// let guilds = http.as_ref().get_guilds(&GuildPagination::After(guild_id), 10).unwrap();
     /// ```
     ///
     /// [docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds
@@ -1389,7 +1389,7 @@ impl Http {
     /// # let http = Arc::new(Http::default());
     ///
     /// let id = 245037420704169985;
-    /// let webhook = http.get_webhook(id).expect("Error getting webhook");
+    /// let webhook = http.as_ref().get_webhook(id).expect("Error getting webhook");
     /// ```
     ///
     /// [`get_webhook_with_token`]: fn.get_webhook_with_token.html
@@ -1417,7 +1417,7 @@ impl Http {
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let webhook = http.get_webhook_with_token(id, token)
+    /// let webhook = http.as_ref().get_webhook_with_token(id, token)
     ///     .expect("Error getting webhook");
     /// ```
     pub fn get_webhook_with_token(&self, webhook_id: u64, token: &str) -> Result<Webhook> {

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -44,7 +44,7 @@ impl ChannelCategory {
     /// Adds a permission overwrite to the category's channels.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_permission(&self, http: &Arc<Http>, target: &PermissionOverwrite) -> Result<()> {
+    pub fn create_permission(&self, http: impl AsRef<Http>, target: &PermissionOverwrite) -> Result<()> {
         self.id.create_permission(&http, target)
     }
 
@@ -55,7 +55,7 @@ impl ChannelCategory {
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_permission(&self, http: &Arc<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
+    pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         self.id.delete_permission(&http, permission_type)
     }
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -49,7 +49,7 @@ impl ChannelId {
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn broadcast_typing(&self, http: &Http) -> Result<()> { http.broadcast_typing(self.0) }
+    pub fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().broadcast_typing(self.0) }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a
     /// single [`Member`] or [`Role`] within the channel.
@@ -66,7 +66,7 @@ impl ChannelId {
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_permission(&self, http: &Arc<Http>, target: &PermissionOverwrite) -> Result<()> {
+    pub fn create_permission(&self, http: impl AsRef<Http>, target: &PermissionOverwrite) -> Result<()> {
         let (id, kind) = match target.kind {
             PermissionOverwriteType::Member(id) => (id.0, "member"),
             PermissionOverwriteType::Role(id) => (id.0, "role"),
@@ -79,7 +79,7 @@ impl ChannelId {
             "type": kind,
         });
 
-        http.create_permission(self.0, id, &map)
+        http.as_ref().create_permission(self.0, id, &map)
     }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
@@ -96,24 +96,24 @@ impl ChannelId {
     /// [Add Reactions]: ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_reaction<M, R>(&self, http: &Arc<Http>, message_id: M, reaction_type: R) -> Result<()>
+    pub fn create_reaction<M, R>(&self, http: impl AsRef<Http>, message_id: M, reaction_type: R) -> Result<()>
         where M: Into<MessageId>, R: Into<ReactionType> {
         self._create_reaction(&http, message_id.into(), &reaction_type.into())
     }
 
     fn _create_reaction(
         self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         message_id: MessageId,
         reaction_type: &ReactionType,
     ) -> Result<()> {
-        http.create_reaction(self.0, message_id.0, reaction_type)
+        http.as_ref().create_reaction(self.0, message_id.0, reaction_type)
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete(&self, http: &Http) -> Result<Channel> { http.delete_channel(self.0) }
+    pub fn delete(&self, http: impl AsRef<Http>) -> Result<Channel> { http.as_ref().delete_channel(self.0) }
 
     /// Deletes a [`Message`] given its Id.
     ///
@@ -127,13 +127,13 @@ impl ChannelId {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_message<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> {
+    pub fn delete_message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self._delete_message(&http, message_id.into())
     }
 
     #[cfg(feature = "http")]
-    fn _delete_message(self, http: &Arc<Http>, message_id: MessageId) -> Result<()> {
-        http.delete_message(self.0, message_id.0)
+    fn _delete_message(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+        http.as_ref().delete_message(self.0, message_id.0)
     }
 
     /// Deletes all messages by Ids from the given vector in the given channel.
@@ -155,7 +155,7 @@ impl ChannelId {
     /// [`ModelError::BulkDeleteAmount`]: ../error/enum.Error.html#variant.BulkDeleteAmount
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
-    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: &Arc<Http>, message_ids: It) -> Result<()> {
+    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: impl AsRef<Http>, message_ids: It) -> Result<()> {
         let ids = message_ids
             .into_iter()
             .map(|message_id| message_id.as_ref().0)
@@ -165,7 +165,7 @@ impl ChannelId {
     }
 
     #[cfg(feature = "http")]
-    fn _delete_messages(self, http: &Arc<Http>, ids: &[u64]) -> Result<()> {
+    fn _delete_messages(self, http: impl AsRef<Http>, ids: &[u64]) -> Result<()> {
         let len = ids.len();
 
         if len == 0 || len > 100 {
@@ -175,7 +175,7 @@ impl ChannelId {
         } else {
             let map = json!({ "messages": ids });
 
-            http.delete_messages(self.0, &map)
+            http.as_ref().delete_messages(self.0, &map)
         }
     }
 
@@ -185,8 +185,8 @@ impl ChannelId {
     ///
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
-    pub fn delete_permission(&self, http: &Arc<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
-        http.delete_permission(
+    pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
+        http.as_ref().delete_permission(
             self.0,
             match permission_type {
                 PermissionOverwriteType::Member(id) => id.0,
@@ -205,7 +205,7 @@ impl ChannelId {
     #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction<M, R>(&self,
-                                 http: &Arc<Http>,
+                                 http: impl AsRef<Http>,
                                  message_id: M,
                                  user_id: Option<UserId>,
                                  reaction_type: R)
@@ -222,12 +222,12 @@ impl ChannelId {
     #[cfg(feature = "http")]
     fn _delete_reaction(
         self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         message_id: MessageId,
         user_id: Option<UserId>,
         reaction_type: &ReactionType,
     ) -> Result<()> {
-        http.delete_reaction(
+        http.as_ref().delete_reaction(
             self.0,
             message_id.0,
             user_id.map(|uid| uid.0),
@@ -256,13 +256,13 @@ impl ChannelId {
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(all(feature = "utils", feature = "http"))]
     #[inline]
-    pub fn edit<F: FnOnce(&mut EditChannel) -> &mut EditChannel>(&self, http: &Arc<Http>, f: F) -> Result<GuildChannel> {
+    pub fn edit<F: FnOnce(&mut EditChannel) -> &mut EditChannel>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildChannel> {
         let mut channel = EditChannel::default();
         f(&mut channel);
 
         let map = utils::vecmap_to_json_map(channel.0);
 
-        http.edit_channel(self.0, &map)
+        http.as_ref().edit_channel(self.0, &map)
     }
 
     /// Edits a [`Message`] in the channel given its Id.
@@ -286,12 +286,12 @@ impl ChannelId {
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
     #[cfg(all(feature = "utils", feature = "http"))]
     #[inline]
-    pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
+    pub fn edit_message<F, M>(&self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self._edit_message(&http, message_id.into(), f)
     }
 
-    fn _edit_message<F>(self, http: &Arc<Http>, message_id: MessageId, f: F) -> Result<Message>
+    fn _edit_message<F>(self, http: impl AsRef<Http>, message_id: MessageId, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage {
         let mut msg = EditMessage::default();
         f(&mut msg);
@@ -306,7 +306,7 @@ impl ChannelId {
 
         let map = utils::vecmap_to_json_map(msg.0);
 
-        http.edit_message(self.0, message_id.0, &Value::Object(map))
+        http.as_ref().edit_message(self.0, message_id.0, &Value::Object(map))
     }
 
     /// Attempts to find a [`Channel`] by its Id in the cache.
@@ -352,7 +352,7 @@ impl ChannelId {
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> { http.get_channel_invites(self.0) }
+    pub fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {http.as_ref().get_channel_invites(self.0) }
 
     /// Gets a message from the channel.
     ///
@@ -361,13 +361,13 @@ impl ChannelId {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
     #[inline]
-    pub fn message<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<Message> {
+    pub fn message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
         self._message(&http, message_id.into())
     }
 
     #[cfg(feature = "http")]
-    fn _message(self, http: &Arc<Http>, message_id: MessageId) -> Result<Message> {
-        http.get_message(self.0, message_id.0).map(|mut msg| {
+    fn _message(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<Message> {
+        http.as_ref().get_message(self.0, message_id.0).map(|mut msg| {
             msg.transform_content();
 
             msg
@@ -383,7 +383,7 @@ impl ChannelId {
     /// [`Channel::messages`]: ../channel/enum.Channel.html#method.messages
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
-    pub fn messages<F>(&self, http: &Arc<Http>, f: F) -> Result<Vec<Message>>
+    pub fn messages<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Vec<Message>>
         where F: FnOnce(&mut GetMessages) -> &mut GetMessages {
         let mut get_messages = GetMessages::default();
         f(&mut get_messages);
@@ -398,7 +398,7 @@ impl ChannelId {
             write!(query, "&before={}", before)?;
         }
 
-        http.get_messages(self.0, &query).map(|msgs| {
+        http.as_ref().get_messages(self.0, &query).map(|msgs| {
             msgs.into_iter()
                 .map(|mut msg| {
                     msg.transform_content();
@@ -442,12 +442,12 @@ impl ChannelId {
     /// [`Message`]: ../channel/struct.Message.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> {
+    pub fn pin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self._pin(&http, message_id.into())
     }
 
-    fn _pin(self, http: &Arc<Http>, message_id: MessageId) -> Result<()> {
-        http.pin_message(self.0, message_id.0)
+    fn _pin(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+        http.as_ref().pin_message(self.0, message_id.0)
     }
 
     /// Gets the list of [`Message`]s which are pinned to the channel.
@@ -455,7 +455,7 @@ impl ChannelId {
     /// [`Message`]: ../channel/struct.Message.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pins(&self, http: &Http) -> Result<Vec<Message>> { http.get_pins(self.0) }
+    pub fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> {http.as_ref().get_pins(self.0) }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a
     /// certain [`Emoji`].
@@ -471,7 +471,7 @@ impl ChannelId {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
     pub fn reaction_users<M, R, U>(&self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         message_id: M,
         reaction_type: R,
         limit: Option<u8>,
@@ -491,7 +491,7 @@ impl ChannelId {
     #[cfg(feature = "http")]
     fn _reaction_users(
         self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         message_id: MessageId,
         reaction_type: &ReactionType,
         limit: Option<u8>,
@@ -499,7 +499,7 @@ impl ChannelId {
     ) -> Result<Vec<User>> {
         let limit = limit.map_or(50, |x| if x > 100 { 100 } else { x });
 
-        http.get_reaction_users(
+        http.as_ref().get_reaction_users(
             self.0,
             message_id.0,
             reaction_type,
@@ -520,7 +520,7 @@ impl ChannelId {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say<D>(&self, http: &Arc<Http>, content: D) -> Result<Message>
+    pub fn say<D>(&self, http: impl AsRef<Http>, content: D) -> Result<Message>
     where D: ::std::fmt::Display {
         self.send_message(&http, |m| {
             m.content(content)
@@ -596,7 +596,7 @@ impl ChannelId {
     /// [Attach Files]: ../permissions/struct.Permissions.html#associatedconstant.ATTACH_FILES
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(all(feature = "utils", feature = "http"))]
-    pub fn send_files<'a, F, T, It>(&self, http: &Arc<Http>, files: It, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It>(&self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b>,
               T: Into<AttachmentType<'a>>, It: IntoIterator<Item=T> {
         let mut create_message = CreateMessage::default();
@@ -616,7 +616,7 @@ impl ChannelId {
         }
 
         let map = utils::vecmap_to_json_map(msg.0.clone());
-        http.send_files(self.0, files, map)
+        http.as_ref().send_files(self.0, files, map)
     }
 
     /// Sends a message to the channel.
@@ -639,7 +639,7 @@ impl ChannelId {
     /// [`CreateMessage`]: ../../builder/struct.CreateMessage.html
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(all(feature = "utils", feature = "http"))]
-    pub fn send_message<F>(&self, http: &Arc<Http>, f: F) -> Result<Message>
+    pub fn send_message<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b> {
         let mut create_message = CreateMessage::default();
         let msg = f(&mut create_message);
@@ -656,9 +656,9 @@ impl ChannelId {
         Message::check_embed_length(&map)?;
 
         let message = if msg.2.is_empty() {
-            http.send_message(self.0, &Value::Object(map))?
+            http.as_ref().send_message(self.0, &Value::Object(map))?
         } else {
-            http.send_files(self.0, msg.2.clone(), map)?
+            http.as_ref().send_files(self.0, msg.2.clone(), map)?
         };
 
         if let Some(reactions) = msg.1.clone() {
@@ -678,13 +678,13 @@ impl ChannelId {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn unpin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> {
+    pub fn unpin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self._unpin(&http, message_id.into())
     }
 
     #[cfg(feature = "http")]
-    fn _unpin(self, http: &Arc<Http>, message_id: MessageId) -> Result<()> {
-        http.unpin_message(self.0, message_id.0)
+    fn _unpin(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+        http.as_ref().unpin_message(self.0, message_id.0)
     }
 
     /// Retrieves the channel's webhooks.
@@ -694,7 +694,7 @@ impl ChannelId {
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> { http.get_channel_webhooks(self.0) }
+    pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {http.as_ref().get_channel_webhooks(self.0) }
 }
 
 impl From<Channel> for ChannelId {

--- a/src/model/channel/group.rs
+++ b/src/model/channel/group.rs
@@ -57,24 +57,24 @@ impl Group {
     /// [`http::add_group_recipient`]: ../../http/fn.add_group_recipient.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn add_recipient<U: Into<UserId>>(&self, http: &Arc<Http>, user: U) -> Result<()> {
+    pub fn add_recipient<U: Into<UserId>>(&self, http: impl AsRef<Http>, user: U) -> Result<()> {
         self._add_recipient(&http, user.into())
     }
 
     #[cfg(feature = "http")]
-    fn _add_recipient(&self, http: &Arc<Http>, user: UserId) -> Result<()> {
+    fn _add_recipient(&self, http: impl AsRef<Http>, user: UserId) -> Result<()> {
         // If the group already contains the recipient, do nothing.
         if self.recipients.contains_key(&user) {
             return Ok(());
         }
 
-        http.add_group_recipient(self.channel_id.0, user.0)
+        http.as_ref().add_group_recipient(self.channel_id.0, user.0)
     }
 
     /// Broadcasts that the current user is typing in the group.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn broadcast_typing(&self, http: &Http) -> Result<()> { self.channel_id.broadcast_typing(&http) }
+    pub fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> { self.channel_id.broadcast_typing(&http) }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
     ///
@@ -90,7 +90,7 @@ impl Group {
     /// [Add Reactions]: ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_reaction<M, R>(&self, http: &Arc<Http>, message_id: M, reaction_type: R) -> Result<()>
+    pub fn create_reaction<M, R>(&self, http: impl AsRef<Http>, message_id: M, reaction_type: R) -> Result<()>
         where M: Into<MessageId>, R: Into<ReactionType> {
         self.channel_id.create_reaction(&http, message_id, reaction_type)
     }
@@ -115,7 +115,7 @@ impl Group {
     #[cfg(feature = "http")]
     #[inline]
     pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         message_ids: It)
         -> Result<()> {
         self.channel_id.delete_messages(&http, message_ids)
@@ -129,7 +129,7 @@ impl Group {
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_permission(&self, http: &Arc<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
+    pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         self.channel_id.delete_permission(&http, permission_type)
     }
 
@@ -143,7 +143,7 @@ impl Group {
     #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction<M, R>(&self,
-                                 http: &Arc<Http>,
+                                 http: impl AsRef<Http>,
                                  message_id: M,
                                  user_id: Option<UserId>,
                                  reaction_type: R)
@@ -174,7 +174,7 @@ impl Group {
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
+    pub fn edit_message<F, M>(&self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self.channel_id.edit_message(&http, message_id, f)
     }
@@ -196,7 +196,7 @@ impl Group {
     /// Leaves the group.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn leave(&self, http: &Http) -> Result<Group> { http.leave_group(self.channel_id.0) }
+    pub fn leave(&self, http: impl AsRef<Http>) -> Result<Group> { http.as_ref().leave_group(self.channel_id.0) }
 
     /// Gets a message from the channel.
     ///
@@ -205,7 +205,7 @@ impl Group {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
     #[inline]
-    pub fn message<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<Message> {
+    pub fn message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
         self.channel_id.message(&http, message_id)
     }
 
@@ -216,7 +216,7 @@ impl Group {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
     #[inline]
-    pub fn messages<F>(&self, http: &Arc<Http>, f: F) -> Result<Vec<Message>>
+    pub fn messages<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Vec<Message>>
         where F: FnOnce(&mut GetMessages) -> &mut GetMessages {
         self.channel_id.messages(&http, f)
     }
@@ -247,7 +247,7 @@ impl Group {
     /// Retrieves the list of messages that have been pinned in the group.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pins(&self, http: &Http) -> Result<Vec<Message>> { self.channel_id.pins(&http) }
+    pub fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> { self.channel_id.pins(&http) }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a
     /// certain [`Emoji`].
@@ -265,7 +265,7 @@ impl Group {
     #[inline]
     pub fn reaction_users<M, R, U>(
         &self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         message_id: M,
         reaction_type: R,
         limit: Option<u8>,
@@ -282,18 +282,18 @@ impl Group {
     /// **Note**: This is only available to the group owner.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn remove_recipient<U: Into<UserId>>(&self, http: &Arc<Http>, user: U) -> Result<()> {
+    pub fn remove_recipient<U: Into<UserId>>(&self, http: impl AsRef<Http>, user: U) -> Result<()> {
         self._remove_recipient(&http, user.into())
     }
 
     #[cfg(feature = "http")]
-    fn _remove_recipient(&self, http: &Arc<Http>, user: UserId) -> Result<()> {
+    fn _remove_recipient(&self, http: impl AsRef<Http>, user: UserId) -> Result<()> {
         // If the group does not contain the recipient already, do nothing.
         if !self.recipients.contains_key(&user) {
             return Ok(());
         }
 
-        http.remove_group_recipient(self.channel_id.0, user.0)
+        http.as_ref().remove_group_recipient(self.channel_id.0, user.0)
     }
 
     /// Sends a message with just the given message content in the channel.
@@ -308,7 +308,7 @@ impl Group {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say(&self, http: &Arc<Http>, content: &str) -> Result<Message> { self.channel_id.say(&http, content) }
+    pub fn say(&self, http: impl AsRef<Http>, content: &str) -> Result<Message> { self.channel_id.say(&http, content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///
@@ -330,7 +330,7 @@ impl Group {
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn send_files<'a, F, T, It: IntoIterator<Item=T>>(&self, http: &Arc<Http>, files: It, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It: IntoIterator<Item=T>>(&self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b>, T: Into<AttachmentType<'a>> {
         self.channel_id.send_files(&http, files, f)
     }
@@ -346,7 +346,7 @@ impl Group {
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn send_message<F>(&self, http: &Arc<Http>, f: F) -> Result<Message>
+    pub fn send_message<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b> {
         self.channel_id.send_message(&http, f)
     }
@@ -359,7 +359,7 @@ impl Group {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn unpin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> {
+    pub fn unpin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self.channel_id.unpin(&http, message_id)
     }
 }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -120,7 +120,7 @@ impl GuildChannel {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "http")]
-    pub fn broadcast_typing(&self, http: &Http) -> Result<()> { self.id.broadcast_typing(&http) }
+    pub fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> { self.id.broadcast_typing(&http) }
 
     /// Creates an invite leading to the given channel.
     ///
@@ -264,7 +264,7 @@ impl GuildChannel {
     /// [Send TTS Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_TTS_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_permission(&self, http: &Arc<Http>, target: &PermissionOverwrite) -> Result<()> {
+    pub fn create_permission(&self, http: impl AsRef<Http>, target: &PermissionOverwrite) -> Result<()> {
         self.id.create_permission(&http, target)
     }
 
@@ -305,7 +305,7 @@ impl GuildChannel {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: &Arc<Http>, message_ids: It) -> Result<()> {
+    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: impl AsRef<Http>, message_ids: It) -> Result<()> {
         self.id.delete_messages(&http, message_ids)
     }
 
@@ -317,7 +317,7 @@ impl GuildChannel {
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_permission(&self, http: &Arc<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
+    pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         self.id.delete_permission(&http, permission_type)
     }
 
@@ -331,7 +331,7 @@ impl GuildChannel {
     #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction<M, R>(&self,
-                                 http: &Arc<Http>,
+                                 http: impl AsRef<Http>,
                                  message_id: M,
                                  user_id: Option<UserId>,
                                  reaction_type: R)
@@ -403,7 +403,7 @@ impl GuildChannel {
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
+    pub fn edit_message<F, M>(&self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self.id.edit_message(&http, message_id, f)
     }
@@ -421,7 +421,7 @@ impl GuildChannel {
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> { self.id.invites(&http) }
+    pub fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> { self.id.invites(&http) }
 
     /// Determines if the channel is NSFW.
     ///
@@ -442,7 +442,7 @@ impl GuildChannel {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
     #[inline]
-    pub fn message<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<Message> {
+    pub fn message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
         self.id.message(&http, message_id)
     }
 
@@ -455,7 +455,7 @@ impl GuildChannel {
     /// [`Channel::messages`]: enum.Channel.html#method.messages
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[inline]
-    pub fn messages<F>(&self, http: &Arc<Http>, f: F) -> Result<Vec<Message>>
+    pub fn messages<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Vec<Message>>
         where F: FnOnce(&mut GetMessages) -> &mut GetMessages {
         self.id.messages(&http, f)
     }
@@ -574,12 +574,12 @@ impl GuildChannel {
     /// [`Message`]: struct.Message.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> { self.id.pin(&http, message_id) }
+    pub fn pin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> { self.id.pin(&http, message_id) }
 
     /// Gets all channel's pins.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pins(&self, http: &Http) -> Result<Vec<Message>> { self.id.pins(&http) }
+    pub fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> { self.id.pins(&http) }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a
     /// certain [`Emoji`].
@@ -596,7 +596,7 @@ impl GuildChannel {
     #[cfg(feature = "http")]
     pub fn reaction_users<M, R, U>(
         &self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         message_id: M,
         reaction_type: R,
         limit: Option<u8>,
@@ -619,7 +619,7 @@ impl GuildChannel {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say(&self, http: &Arc<Http>, content: &str) -> Result<Message> { self.id.say(&http, content) }
+    pub fn say(&self, http: impl AsRef<Http>, content: &str) -> Result<Message> { self.id.say(&http, content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///
@@ -641,7 +641,7 @@ impl GuildChannel {
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn send_files<'a, F, T, It>(&self, http: &Arc<Http>, files: It, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It>(&self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b>,
               T: Into<AttachmentType<'a>>, It: IntoIterator<Item=T> {
         self.id.send_files(&http, files, f)
@@ -689,7 +689,7 @@ impl GuildChannel {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn unpin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> {
+    pub fn unpin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self.id.unpin(&http, message_id)
     }
 
@@ -700,7 +700,7 @@ impl GuildChannel {
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
+    pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -187,7 +187,7 @@ impl Message {
             }
         }
 
-        context.http.delete_message_reactions(self.channel_id.0, self.id.0)
+        context.http.as_ref().delete_message_reactions(self.channel_id.0, self.id.0)
     }
 
     /// Edits this message, replacing the original content with new content.
@@ -335,7 +335,7 @@ impl Message {
     #[inline]
     pub fn reaction_users<R, U>(
         &self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         reaction_type: R,
         limit: Option<u8>,
         after: U,

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -51,7 +51,7 @@ pub struct PrivateChannel {
 impl PrivateChannel {
     /// Broadcasts that the current user is typing to the recipient.
     #[cfg(feature = "http")]
-    pub fn broadcast_typing(&self, http: &Http) -> Result<()> { self.id.broadcast_typing(&http) }
+    pub fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> { self.id.broadcast_typing(&http) }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
     ///
@@ -66,7 +66,7 @@ impl PrivateChannel {
     /// [`Message::react`]: struct.Message.html#method.react
     /// [Add Reactions]: ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
     #[cfg(feature = "http")]
-    pub fn create_reaction<M, R>(&self, http: &Arc<Http>, message_id: M, reaction_type: R) -> Result<()>
+    pub fn create_reaction<M, R>(&self, http: impl AsRef<Http>, message_id: M, reaction_type: R) -> Result<()>
         where M: Into<MessageId>, R: Into<ReactionType> {
         self.id.create_reaction(&http, message_id, reaction_type)
     }
@@ -76,7 +76,7 @@ impl PrivateChannel {
     /// be re-opened.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete(&self, http: &Http) -> Result<Channel> { self.id.delete(&http) }
+    pub fn delete(&self, http: impl AsRef<Http>) -> Result<Channel> { self.id.delete(&http) }
 
     /// Deletes all messages by Ids from the given vector in the channel.
     ///
@@ -97,7 +97,7 @@ impl PrivateChannel {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: &Arc<Http>, message_ids: It) -> Result<()> {
+    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: impl AsRef<Http>, message_ids: It) -> Result<()> {
         self.id.delete_messages(&http, message_ids)
     }
 
@@ -109,7 +109,7 @@ impl PrivateChannel {
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_permission(&self, http: &Arc<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
+    pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         self.id.delete_permission(&http, permission_type)
     }
 
@@ -123,7 +123,7 @@ impl PrivateChannel {
     #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction<M, R>(&self,
-                                 http: &Arc<Http>,
+                                 http: impl AsRef<Http>,
                                  message_id: M,
                                  user_id: Option<UserId>,
                                  reaction_type: R)
@@ -153,7 +153,7 @@ impl PrivateChannel {
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_message<F, M>(&self, http: &Arc<Http>, message_id: M, f: F) -> Result<Message>
+    pub fn edit_message<F, M>(&self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self.id.edit_message(&http, message_id, f)
     }
@@ -172,7 +172,7 @@ impl PrivateChannel {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
     #[inline]
-    pub fn message<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<Message> {
+    pub fn message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
         self.id.message(&http, message_id)
     }
 
@@ -186,7 +186,7 @@ impl PrivateChannel {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
     #[inline]
-    pub fn messages<F>(&self, http: &Arc<Http>, f: F) -> Result<Vec<Message>>
+    pub fn messages<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Vec<Message>>
         where F: FnOnce(&mut GetMessages) -> &mut GetMessages {
         self.id.messages(&http, f)
     }
@@ -209,7 +209,7 @@ impl PrivateChannel {
     #[cfg(feature = "http")]
     #[inline]
     pub fn reaction_users<M, R, U>(&self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         message_id: M,
         reaction_type: R,
         limit: Option<u8>,
@@ -225,13 +225,13 @@ impl PrivateChannel {
     /// [`Message`]: struct.Message.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> { self.id.pin(&http, message_id) }
+    pub fn pin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> { self.id.pin(&http, message_id) }
 
     /// Retrieves the list of messages that have been pinned in the private
     /// channel.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pins(&self, http: &Http) -> Result<Vec<Message>> { self.id.pins(&http) }
+    pub fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> { self.id.pins(&http) }
 
     /// Sends a message with just the given message content in the channel.
     ///
@@ -245,7 +245,7 @@ impl PrivateChannel {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say<D: ::std::fmt::Display>(&self, http: &Arc<Http>, content: D) -> Result<Message> { self.id.say(&http, content) }
+    pub fn say<D: ::std::fmt::Display>(&self, http: impl AsRef<Http>, content: D) -> Result<Message> { self.id.say(&http, content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///
@@ -267,7 +267,7 @@ impl PrivateChannel {
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn send_files<'a, F, T, It>(&self, http: &Arc<Http>, files: It, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It>(&self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b>,
               T: Into<AttachmentType<'a>>, It: IntoIterator<Item=T> {
         self.id.send_files(&http, files, f)
@@ -289,7 +289,7 @@ impl PrivateChannel {
     /// [`Message`]: struct.Message.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn send_message<F>(&self, http: &Arc<Http>, f: F) -> Result<Message>
+    pub fn send_message<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Message>
     where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b> {
         self.id.send_message(&http, f)
     }
@@ -302,7 +302,7 @@ impl PrivateChannel {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn unpin<M: Into<MessageId>>(&self, http: &Arc<Http>, message_id: M) -> Result<()> {
+    pub fn unpin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self.id.unpin(&http, message_id)
     }
 }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -102,7 +102,7 @@ impl Reaction {
             }
         };
 
-        context.http.delete_reaction(self.channel_id.0, self.message_id.0, user_id, &self.emoji)
+        context.http.as_ref().delete_reaction(self.channel_id.0, self.message_id.0, user_id, &self.emoji)
     }
 
     /// Retrieves the [`Message`] associated with this reaction.
@@ -117,7 +117,7 @@ impl Reaction {
     /// [`Message`]: struct.Message.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn message(&self, http: &Arc<Http>) -> Result<Message> {
+    pub fn message(&self, http: impl AsRef<Http>) -> Result<Message> {
         self.channel_id.message(&http, self.message_id)
     }
 
@@ -160,7 +160,7 @@ impl Reaction {
     #[cfg(feature = "http")]
     #[inline]
     pub fn users<R, U>(&self,
-                       http: &Arc<Http>,
+                       http: impl AsRef<Http>,
                        reaction_type: R,
                        limit: Option<u8>,
                        after: Option<U>)
@@ -172,7 +172,7 @@ impl Reaction {
     #[cfg(feature = "http")]
     fn _users(
         &self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         reaction_type: &ReactionType,
         limit: Option<u8>,
         after: Option<UserId>,
@@ -184,7 +184,7 @@ impl Reaction {
             warn!("Rection users limit clamped to 100! (API Restriction)");
         }
 
-        http.get_reaction_users(
+        http.as_ref().get_reaction_users(
             self.channel_id.0,
             self.message_id.0,
             reaction_type,

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -88,7 +88,7 @@ impl Emoji {
     #[cfg(all(feature = "cache", feature = "http"))]
     pub fn delete(&self, context: &Context) -> Result<()> {
         match self.find_guild_id(&context.cache) {
-            Some(guild_id) => context.http.delete_emoji(guild_id.0, self.id.0),
+            Some(guild_id) => context.http.as_ref().delete_emoji(guild_id.0, self.id.0),
             None => Err(Error::Model(ModelError::ItemMissing)),
         }
     }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -47,13 +47,13 @@ impl GuildId {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn ban<U, BO>(&self, http: &Arc<Http>, user: U, ban_options: &BO) -> Result<()>
+    pub fn ban<U, BO>(&self, http: impl AsRef<Http>, user: U, ban_options: &BO) -> Result<()>
         where U: Into<UserId>, BO: BanOptions {
         self._ban(&http, user.into(), (ban_options.dmd(), ban_options.reason()))
     }
 
     #[cfg(feature = "http")]
-    fn _ban(self, http: &Arc<Http>, user: UserId, ban_options: (u8, &str)) -> Result<()> {
+    fn _ban(self, http: impl AsRef<Http>, user: UserId, ban_options: (u8, &str)) -> Result<()> {
         let (dmd, reason) = ban_options;
 
         if dmd > 7 {
@@ -64,7 +64,7 @@ impl GuildId {
             return Err(Error::ExceededLimit(reason.to_string(), 512));
         }
 
-        http.ban_user(self.0, user.0, dmd, reason)
+        http.as_ref().ban_user(self.0, user.0, dmd, reason)
     }
 
     /// Gets a list of the guild's bans.
@@ -74,27 +74,27 @@ impl GuildId {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn bans(&self, http: &Http) -> Result<Vec<Ban>> { http.get_bans(self.0) }
+    pub fn bans(&self, http: impl AsRef<Http>) -> Result<Vec<Ban>> {http.as_ref().get_bans(self.0) }
 
     /// Gets a list of the guild's audit log entries
     #[cfg(feature = "http")]
     #[inline]
-    pub fn audit_logs(&self, http: &Arc<Http>,
+    pub fn audit_logs(&self, http: impl AsRef<Http>,
                              action_type: Option<u8>,
                              user_id: Option<UserId>,
                              before: Option<AuditLogEntryId>,
                              limit: Option<u8>) -> Result<AuditLogs> {
-        http.get_audit_logs(self.0, action_type, user_id.map(|u| u.0), before.map(|a| a.0), limit)
+        http.as_ref().get_audit_logs(self.0, action_type, user_id.map(|u| u.0), before.map(|a| a.0), limit)
     }
 
     /// Gets all of the guild's channels over the REST API.
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     #[cfg(feature = "http")]
-    pub fn channels(&self, http: &Http) -> Result<HashMap<ChannelId, GuildChannel>> {
+    pub fn channels(&self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> {
         let mut channels = HashMap::new();
 
-        for channel in http.get_channels(self.0)? {
+        for channel in http.as_ref().get_channels(self.0)? {
             channels.insert(channel.id, channel);
         }
 
@@ -123,7 +123,7 @@ impl GuildId {
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_channel<C>(&self, http: &Arc<Http>, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
+    pub fn create_channel<C>(&self, http: impl AsRef<Http>, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
         where C: Into<Option<ChannelId>> {
         self._create_channel(&http, name, kind, category.into())
     }
@@ -131,7 +131,7 @@ impl GuildId {
     #[cfg(feature = "http")]
     fn _create_channel(
         self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         name: &str,
         kind: ChannelType,
         category: Option<ChannelId>,
@@ -142,7 +142,7 @@ impl GuildId {
             "parent_id": category.map(|c| c.0)
         });
 
-        http.create_channel(self.0, &map)
+        http.as_ref().create_channel(self.0, &map)
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.
@@ -164,13 +164,13 @@ impl GuildId {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_emoji(&self, http: &Arc<Http>, name: &str, image: &str) -> Result<Emoji> {
+    pub fn create_emoji(&self, http: impl AsRef<Http>, name: &str, image: &str) -> Result<Emoji> {
         let map = json!({
             "name": name,
             "image": image,
         });
 
-        http.create_emoji(self.0, &map)
+        http.as_ref().create_emoji(self.0, &map)
     }
 
     /// Creates an integration for the guild.
@@ -180,7 +180,7 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_integration<I>(&self, http: &Arc<Http>, integration_id: I, kind: &str) -> Result<()>
+    pub fn create_integration<I>(&self, http: impl AsRef<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
         self._create_integration(&http, integration_id.into(), kind)
     }
@@ -188,7 +188,7 @@ impl GuildId {
     #[cfg(feature = "http")]
     fn _create_integration(
         self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         integration_id: IntegrationId,
         kind: &str,
     ) -> Result<()> {
@@ -197,7 +197,7 @@ impl GuildId {
             "type": kind,
         });
 
-        http.create_guild_integration(self.0, integration_id.0, &map)
+        http.as_ref().create_guild_integration(self.0, integration_id.0, &map)
     }
 
     /// Creates a new role in the guild with the data set, if any.
@@ -210,13 +210,13 @@ impl GuildId {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_role<F>(&self, http: &Arc<Http>, f: F) -> Result<Role>
+    pub fn create_role<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Role>
     where F: FnOnce(&mut EditRole) -> &mut EditRole {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
         let map = utils::vecmap_to_json_map(edit_role.0);
 
-        let role = http.create_role(self.0, &map)?;
+        let role = http.as_ref().create_role(self.0, &map)?;
 
         if let Some(position) = map.get("position").and_then(Value::as_u64) {
             self.edit_role_position(&http, role.id, position)?;
@@ -235,7 +235,7 @@ impl GuildId {
     /// [`Guild::delete`]: ../guild/struct.Guild.html#method.delete
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete(&self, http: &Http) -> Result<PartialGuild> { http.delete_guild(self.0) }
+    pub fn delete(&self, http: impl AsRef<Http>) -> Result<PartialGuild> { http.as_ref().delete_guild(self.0) }
 
     /// Deletes an [`Emoji`] from the guild.
     ///
@@ -245,13 +245,13 @@ impl GuildId {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E) -> Result<()> {
+    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E) -> Result<()> {
         self._delete_emoji(&http, emoji_id.into())
     }
 
     #[cfg(feature = "http")]
-    fn _delete_emoji(self, http: &Arc<Http>, emoji_id: EmojiId) -> Result<()> {
-        http.delete_emoji(self.0, emoji_id.0)
+    fn _delete_emoji(self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<()> {
+        http.as_ref().delete_emoji(self.0, emoji_id.0)
     }
 
     /// Deletes an integration by Id from the guild.
@@ -261,12 +261,12 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self._delete_integration(&http, integration_id.into())
     }
 
-    fn _delete_integration(self, http: &Arc<Http>, integration_id: IntegrationId) -> Result<()> {
-        http.delete_guild_integration(self.0, integration_id.0)
+    fn _delete_integration(self, http: impl AsRef<Http>, integration_id: IntegrationId) -> Result<()> {
+        http.as_ref().delete_guild_integration(self.0, integration_id.0)
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -281,13 +281,13 @@ impl GuildId {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_role<R: Into<RoleId>>(&self, http: &Arc<Http>, role_id: R) -> Result<()> {
+    pub fn delete_role<R: Into<RoleId>>(&self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
         self._delete_role(&http, role_id.into())
     }
 
     #[cfg(feature = "http")]
-    fn _delete_role(self, http: &Arc<Http>, role_id: RoleId) -> Result<()> {
-        http.delete_role(self.0, role_id.0)
+    fn _delete_role(self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
+        http.as_ref().delete_role(self.0, role_id.0)
     }
 
     /// Edits the current guild with new data where specified.
@@ -301,13 +301,13 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit<F>(&mut self, http: &Arc<Http>, f: F) -> Result<PartialGuild>
+    pub fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<PartialGuild>
     where F: FnOnce(&mut EditGuild) -> &mut EditGuild{
         let mut edit_guild = EditGuild::default();
         f(&mut edit_guild);
         let map = utils::vecmap_to_json_map(edit_guild.0);
 
-        http.edit_guild(self.0, &map)
+        http.as_ref().edit_guild(self.0, &map)
     }
 
     /// Edits an [`Emoji`]'s name in the guild.
@@ -322,16 +322,16 @@ impl GuildId {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
+    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
         self._edit_emoji(&http, emoji_id.into(), name)
     }
 
-    fn _edit_emoji(self, http: &Arc<Http>, emoji_id: EmojiId, name: &str) -> Result<Emoji> {
+    fn _edit_emoji(self, http: impl AsRef<Http>, emoji_id: EmojiId, name: &str) -> Result<Emoji> {
         let map = json!({
             "name": name,
         });
 
-        http.edit_emoji(self.0, emoji_id.0, &map)
+        http.as_ref().edit_emoji(self.0, emoji_id.0, &map)
     }
 
     /// Edits the properties of member of the guild, such as muting or
@@ -349,17 +349,17 @@ impl GuildId {
     /// ```
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_member<F, U>(&self, http: &Arc<Http>, user_id: U, f: F) -> Result<()>
+    pub fn edit_member<F, U>(&self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
         self._edit_member(&http, user_id.into(), f)
     }
 
     #[cfg(feature = "http")]
-    fn _edit_member<F>(self, http: &Arc<Http>, user_id: UserId, f: F) -> Result<()>
+    fn _edit_member<F>(self, http: impl AsRef<Http>, user_id: UserId, f: F) -> Result<()>
         where F: FnOnce(EditMember) -> EditMember {
         let map = utils::vecmap_to_json_map(f(EditMember::default()).0);
 
-        http.edit_member(self.0, user_id.0, &map)
+        http.as_ref().edit_member(self.0, user_id.0, &map)
     }
 
     /// Edits the current user's nickname for the guild.
@@ -371,8 +371,8 @@ impl GuildId {
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_nickname(&self, http: &Arc<Http>, new_nickname: Option<&str>) -> Result<()> {
-        http.edit_nickname(self.0, new_nickname)
+    pub fn edit_nickname(&self, http: impl AsRef<Http>, new_nickname: Option<&str>) -> Result<()> {
+        http.as_ref().edit_nickname(self.0, new_nickname)
     }
 
     /// Edits a [`Role`], optionally setting its new fields.
@@ -393,17 +393,17 @@ impl GuildId {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_role<F, R>(&self, http: &Arc<Http>, role_id: R, f: F) -> Result<Role>
+    pub fn edit_role<F, R>(&self, http: impl AsRef<Http>, role_id: R, f: F) -> Result<Role>
         where F: FnOnce(EditRole) -> EditRole, R: Into<RoleId> {
         self._edit_role(&http, role_id.into(), f)
     }
 
     #[cfg(feature = "http")]
-    fn _edit_role<F>(self, http: &Arc<Http>, role_id: RoleId, f: F) -> Result<Role>
+    fn _edit_role<F>(self, http: impl AsRef<Http>, role_id: RoleId, f: F) -> Result<Role>
         where F: FnOnce(EditRole) -> EditRole {
         let map = utils::vecmap_to_json_map(f(EditRole::default()).0);
 
-        http.edit_role(self.0, role_id.0, &map)
+        http.as_ref().edit_role(self.0, role_id.0, &map)
     }
 
     /// Edits the order of [`Role`]s
@@ -422,7 +422,7 @@ impl GuildId {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_role_position<R>(&self, http: &Arc<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
+    pub fn edit_role_position<R>(&self, http: impl AsRef<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
         where R: Into<RoleId> {
         self._edit_role_position(&http, role_id.into(), position)
     }
@@ -430,11 +430,11 @@ impl GuildId {
     #[cfg(feature = "http")]
     fn _edit_role_position(
         &self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         role_id: RoleId,
         position: u64,
     ) -> Result<Vec<Role>> {
-        http.edit_role_position(self.0, role_id.0, position)
+        http.as_ref().edit_role_position(self.0, role_id.0, position)
     }
 
     /// Tries to find the [`Guild`] by its Id in the cache.
@@ -453,14 +453,14 @@ impl GuildId {
     /// [`Guild`]: ../guild/struct.Guild.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn to_partial_guild(self, http: &Http) -> Result<PartialGuild> { http.get_guild(self.0) }
+    pub fn to_partial_guild(self, http: impl AsRef<Http>) -> Result<PartialGuild> {http.as_ref().get_guild(self.0) }
 
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn integrations(&self, http: &Http) -> Result<Vec<Integration>> { http.get_guild_integrations(self.0) }
+    pub fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {http.as_ref().get_guild_integrations(self.0) }
 
     /// Gets all of the guild's invites.
     ///
@@ -469,7 +469,7 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> { http.get_guild_invites(self.0) }
+    pub fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {http.as_ref().get_guild_invites(self.0) }
 
     /// Kicks a [`Member`] from the guild.
     ///
@@ -479,14 +479,14 @@ impl GuildId {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> {
-        http.kick_member(self.0, user_id.into().0)
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
+        http.as_ref().kick_member(self.0, user_id.into().0)
     }
 
     /// Leaves the guild.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn leave(&self, http: &Http) -> Result<()> { http.leave_guild(self.0) }
+    pub fn leave(&self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().leave_guild(self.0) }
 
     /// Gets a user's [`Member`] for the guild by Id.
     ///
@@ -522,14 +522,14 @@ impl GuildId {
     /// [`User`]: ../user/struct.User.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn members<U>(&self, http: &Arc<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
+    pub fn members<U>(&self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
         where U: Into<UserId> {
         self._members(&http, limit, after.map(Into::into))
     }
 
     #[cfg(feature = "http")]
-    fn _members(&self, http: &Arc<Http>, limit: Option<u64>, after: Option<UserId>) -> Result<Vec<Member>> {
-        http.get_guild_members(self.0, limit, after.map(|x| x.0))
+    fn _members(&self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<UserId>) -> Result<Vec<Member>> {
+        http.as_ref().get_guild_members(self.0, limit, after.map(|x| x.0))
     }
 
     /// Moves a member to a specific voice channel.
@@ -539,7 +539,7 @@ impl GuildId {
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn move_member<C, U>(&self, http: &Arc<Http>, user_id: U, channel_id: C) -> Result<()>
+    pub fn move_member<C, U>(&self, http: impl AsRef<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
         self._move_member(&http, user_id.into(), channel_id.into())
     }
@@ -547,7 +547,7 @@ impl GuildId {
     #[cfg(feature = "http")]
     fn _move_member(
         &self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         user_id: UserId,
         channel_id: ChannelId,
     ) -> Result<()> {
@@ -557,7 +557,7 @@ impl GuildId {
             Value::Number(Number::from(channel_id.0)),
         );
 
-        http.edit_member(self.0, user_id.0, &map)
+        http.as_ref().edit_member(self.0, user_id.0, &map)
     }
 
     /// Gets the number of [`Member`]s that would be pruned with the given
@@ -568,12 +568,12 @@ impl GuildId {
     /// [`Member`]: ../guild/struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
-    pub fn prune_count(&self, http: &Arc<Http>, days: u16) -> Result<GuildPrune> {
+    pub fn prune_count(&self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
         let map = json!({
             "days": days,
         });
 
-        http.get_guild_prune_count(self.0, &map)
+        http.as_ref().get_guild_prune_count(self.0, &map)
     }
 
     /// Re-orders the channels of the guild.
@@ -585,18 +585,18 @@ impl GuildId {
     /// regardless of whether they were updated. Otherwise, positioning can
     /// sometimes get weird.
     #[inline]
-    pub fn reorder_channels<It>(&self, http: &Arc<Http>, channels: It) -> Result<()>
+    pub fn reorder_channels<It>(&self, http: impl AsRef<Http>, channels: It) -> Result<()>
         where It: IntoIterator<Item = (ChannelId, u64)> {
         self._reorder_channels(&http, channels.into_iter().collect())
     }
 
-    fn _reorder_channels(&self, http: &Arc<Http>, channels: Vec<(ChannelId, u64)>) -> Result<()> {
+    fn _reorder_channels(&self, http: impl AsRef<Http>, channels: Vec<(ChannelId, u64)>) -> Result<()> {
         let items = channels.into_iter().map(|(id, pos)| json!({
             "id": id,
             "position": pos,
         })).collect();
 
-        http.edit_guild_channel_positions(self.0, &Value::Array(items))
+        http.as_ref().edit_guild_channel_positions(self.0, &Value::Array(items))
     }
 
     /// Returns the Id of the shard associated with the guild.
@@ -647,17 +647,17 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self._start_integration_sync(&http, integration_id.into())
     }
 
     #[cfg(feature = "http")]
     fn _start_integration_sync(
         &self,
-        http: &Arc<Http>,
+        http: impl AsRef<Http>,
         integration_id: IntegrationId,
     ) -> Result<()> {
-        http.start_integration_sync(self.0, integration_id.0)
+        http.as_ref().start_integration_sync(self.0, integration_id.0)
     }
 
     /// Starts a prune of [`Member`]s.
@@ -671,12 +671,12 @@ impl GuildId {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn start_prune(&self, http: &Arc<Http>, days: u16) -> Result<GuildPrune> {
+    pub fn start_prune(&self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
         let map = json!({
             "days": days,
         });
 
-        http.start_guild_prune(self.0, &map)
+        http.as_ref().start_guild_prune(self.0, &map)
     }
 
     /// Unbans a [`User`] from the guild.
@@ -687,13 +687,13 @@ impl GuildId {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn unban<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> {
+    pub fn unban<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
         self._unban(&http, user_id.into())
     }
 
     #[cfg(feature = "http")]
-    fn _unban(self, http: &Arc<Http>, user_id: UserId) -> Result<()> {
-        http.remove_ban(self.0, user_id.0)
+    fn _unban(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+        http.as_ref().remove_ban(self.0, user_id.0)
     }
 
     /// Retrieve's the guild's vanity URL.
@@ -703,8 +703,8 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn vanity_url(&self, http: &Http) -> Result<String> {
-        http.get_guild_vanity_url(self.0)
+    pub fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
+        http.as_ref().get_guild_vanity_url(self.0)
     }
 
     /// Retrieves the guild's webhooks.
@@ -713,7 +713,7 @@ impl GuildId {
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[inline]
-    pub fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> { http.get_guild_webhooks(self.0) }
+    pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {http.as_ref().get_guild_webhooks(self.0) }
 }
 
 impl From<PartialGuild> for GuildId {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -90,17 +90,17 @@ impl Member {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(all(feature = "cache", feature = "http"))]
     #[inline]
-    pub fn add_role<R: Into<RoleId>>(&mut self, http: &Arc<Http>, role_id: R) -> Result<()> {
+    pub fn add_role<R: Into<RoleId>>(&mut self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
         self._add_role(&http, role_id.into())
     }
 
     #[cfg(all(feature = "cache", feature = "http"))]
-    fn _add_role(&mut self, http: &Arc<Http>, role_id: RoleId) -> Result<()> {
+    fn _add_role(&mut self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
         if self.roles.contains(&role_id) {
             return Ok(());
         }
 
-        match http.add_member_role(self.guild_id.0, self.user.read().id.0, role_id.0) {
+        match http.as_ref().add_member_role(self.guild_id.0, self.user.read().id.0, role_id.0) {
             Ok(()) => {
                 self.roles.push(role_id);
 
@@ -118,14 +118,14 @@ impl Member {
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(all(feature = "cache", feature = "http"))]
-    pub fn add_roles(&mut self, http: &Arc<Http>, role_ids: &[RoleId]) -> Result<()> {
+    pub fn add_roles(&mut self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
         self.roles.extend_from_slice(role_ids);
 
         let mut builder = EditMember::default();
         builder.roles(&self.roles);
         let map = utils::vecmap_to_json_map(builder.0);
 
-        match http.edit_member(self.guild_id.0, self.user.read().id.0, &map) {
+        match http.as_ref().edit_member(self.guild_id.0, self.user.read().id.0, &map) {
             Ok(()) => Ok(()),
             Err(why) => {
                 self.roles.retain(|r| !role_ids.contains(r));
@@ -149,12 +149,12 @@ impl Member {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(all(feature = "cache", feature = "http"))]
     #[inline]
-    pub fn ban<BO: BanOptions>(&self, http: &Arc<Http>, ban_options: &BO) -> Result<()> {
+    pub fn ban<BO: BanOptions>(&self, http: impl AsRef<Http>, ban_options: &BO) -> Result<()> {
         self._ban(&http, ban_options.dmd(), ban_options.reason())
     }
 
     #[cfg(all(feature = "cache", feature = "http"))]
-    fn _ban(&self, http: &Arc<Http>, dmd: u8, reason: &str) -> Result<()> {
+    fn _ban(&self, http: impl AsRef<Http>, dmd: u8, reason: &str) -> Result<()> {
         if dmd > 7 {
             return Err(Error::Model(ModelError::DeleteMessageDaysAmount(dmd)));
         }
@@ -163,7 +163,7 @@ impl Member {
             return Err(Error::ExceededLimit(reason.to_string(), 512));
         }
 
-        http.ban_user(
+        http.as_ref().ban_user(
             self.guild_id.0,
             self.user.read().id.0,
             dmd,
@@ -242,10 +242,10 @@ impl Member {
     /// [`Guild::edit_member`]: struct.Guild.html#method.edit_member
     /// [`EditMember`]: ../../builder/struct.EditMember.html
     #[cfg(feature = "cache")]
-    pub fn edit<F: FnOnce(EditMember) -> EditMember>(&self, http: &Arc<Http>, f: F) -> Result<()> {
+    pub fn edit<F: FnOnce(EditMember) -> EditMember>(&self, http: impl AsRef<Http>, f: F) -> Result<()> {
         let map = utils::vecmap_to_json_map(f(EditMember::default()).0);
 
-        http.edit_member(self.guild_id.0, self.user.read().id.0, &map)
+        http.as_ref().edit_member(self.guild_id.0, self.user.read().id.0, &map)
     }
 
     /// Retrieves the ID and position of the member's highest role in the
@@ -381,17 +381,17 @@ impl Member {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(all(feature = "cache", feature = "http"))]
     #[inline]
-    pub fn remove_role<R: Into<RoleId>>(&mut self, http: &Arc<Http>, role_id: R) -> Result<()> {
+    pub fn remove_role<R: Into<RoleId>>(&mut self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
         self._remove_role(&http, role_id.into())
     }
 
     #[cfg(all(feature = "cache", feature = "http"))]
-    fn _remove_role(&mut self, http: &Arc<Http>, role_id: RoleId) -> Result<()> {
+    fn _remove_role(&mut self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
         if !self.roles.contains(&role_id) {
             return Ok(());
         }
 
-        match http.remove_member_role(self.guild_id.0, self.user.read().id.0, role_id.0) {
+        match http.as_ref().remove_member_role(self.guild_id.0, self.user.read().id.0, role_id.0) {
             Ok(()) => {
                 self.roles.retain(|r| r.0 != role_id.0);
 
@@ -408,14 +408,14 @@ impl Member {
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(all(feature = "cache", feature = "http"))]
-    pub fn remove_roles(&mut self, http: &Arc<Http>, role_ids: &[RoleId]) -> Result<()> {
+    pub fn remove_roles(&mut self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
         self.roles.retain(|r| !role_ids.contains(r));
 
         let mut builder = EditMember::default();
         builder.roles(&self.roles);
         let map = utils::vecmap_to_json_map(builder.0);
 
-        match http.edit_member(self.guild_id.0, self.user.read().id.0, &map) {
+        match http.as_ref().edit_member(self.guild_id.0, self.user.read().id.0, &map) {
             Ok(()) => Ok(()),
             Err(why) => {
                 self.roles.extend_from_slice(role_ids);
@@ -457,8 +457,8 @@ impl Member {
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(all(feature = "cache", feature = "http"))]
-    pub fn unban(&self, http: &Http) -> Result<()> {
-        http.remove_ban(self.guild_id.0, self.user.read().id.0)
+    pub fn unban(&self, http: impl AsRef<Http>) -> Result<()> {
+        http.as_ref().remove_ban(self.guild_id.0, self.user.read().id.0)
     }
 
     /// Retrieves the member's user ID.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -288,7 +288,7 @@ impl Guild {
     /// [`AuditLogs`]: audit_log/struct.AuditLogs.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn audit_logs(&self, http: &Arc<Http>,
+    pub fn audit_logs(&self, http: impl AsRef<Http>,
                              action_type: Option<u8>,
                              user_id: Option<UserId>,
                              before: Option<AuditLogEntryId>,
@@ -301,7 +301,7 @@ impl Guild {
     /// [`Guild`]: struct.Guild.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn channels(&self, http: &Http) -> Result<HashMap<ChannelId, GuildChannel>> { self.id.channels(&http) }
+    pub fn channels(&self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> { self.id.channels(&http) }
 
     /// Creates a guild with the data provided.
     ///
@@ -329,14 +329,14 @@ impl Guild {
     /// [US West region]: enum.Region.html#variant.UsWest
     /// [whitelist]: https://discordapp.com/developers/docs/resources/guild#create-guild
     #[cfg(feature = "http")]
-    pub fn create(http: &Arc<Http>, name: &str, region: Region, icon: Option<&str>) -> Result<PartialGuild> {
+    pub fn create(http: impl AsRef<Http>, name: &str, region: Region, icon: Option<&str>) -> Result<PartialGuild> {
         let map = json!({
             "icon": icon,
             "name": name,
             "region": region.name(),
         });
 
-        http.create_guild(&map)
+        http.as_ref().create_guild(&map)
     }
 
     /// Creates a new [`Channel`] in the guild.
@@ -397,7 +397,7 @@ impl Guild {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_emoji(&self, http: &Arc<Http>, name: &str, image: &str) -> Result<Emoji> {
+    pub fn create_emoji(&self, http: impl AsRef<Http>, name: &str, image: &str) -> Result<Emoji> {
         self.id.create_emoji(&http, name, image)
     }
 
@@ -408,7 +408,7 @@ impl Guild {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_integration<I>(&self, http: &Arc<Http>, integration_id: I, kind: &str) -> Result<()>
+    pub fn create_integration<I>(&self, http: impl AsRef<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
         self.id.create_integration(&http, integration_id, kind)
     }
@@ -483,7 +483,7 @@ impl Guild {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E) -> Result<()> {
+    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E) -> Result<()> {
         self.id.delete_emoji(&http, emoji_id)
     }
 
@@ -494,7 +494,7 @@ impl Guild {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self.id.delete_integration(&http, integration_id)
     }
 
@@ -510,7 +510,7 @@ impl Guild {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_role<R: Into<RoleId>>(&self, http: &Arc<Http>, role_id: R) -> Result<()> {
+    pub fn delete_role<R: Into<RoleId>>(&self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
         self.id.delete_role(&http, role_id)
     }
 
@@ -588,7 +588,7 @@ impl Guild {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
+    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
         self.id.edit_emoji(&http, emoji_id, name)
     }
 
@@ -607,7 +607,7 @@ impl Guild {
     /// ```
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_member<F, U>(&self, http: &Arc<Http>, user_id: U, f: F) -> Result<()>
+    pub fn edit_member<F, U>(&self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
         self.id.edit_member(&http, user_id, f)
     }
@@ -655,7 +655,7 @@ impl Guild {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_role<F, R>(&self, http: &Arc<Http>, role_id: R, f: F) -> Result<Role>
+    pub fn edit_role<F, R>(&self, http: impl AsRef<Http>, role_id: R, f: F) -> Result<Role>
         where F: FnOnce(EditRole) -> EditRole, R: Into<RoleId> {
         self.id.edit_role(&http, role_id, f)
     }
@@ -676,7 +676,7 @@ impl Guild {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_role_position<R>(&self, http: &Arc<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
+    pub fn edit_role_position<R>(&self, http: impl AsRef<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
         where R: Into<RoleId> {
         self.id.edit_role_position(&http, role_id, position)
     }
@@ -686,7 +686,7 @@ impl Guild {
     /// Requires that the current user be in the guild.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn get<G: Into<GuildId>>(http: &Arc<Http>, guild_id: G) -> Result<PartialGuild> { guild_id.into().to_partial_guild(&http) }
+    pub fn get<G: Into<GuildId>>(http: impl AsRef<Http>, guild_id: G) -> Result<PartialGuild> { guild_id.into().to_partial_guild(&http) }
 
     /// Returns which of two [`User`]s has a higher [`Member`] hierarchy.
     ///
@@ -773,7 +773,7 @@ impl Guild {
     /// This performs a request over the REST API.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn integrations(&self, http: &Http) -> Result<Vec<Integration>> { self.id.integrations(&http) }
+    pub fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> { self.id.integrations(&http) }
 
     /// Retrieves the active invites for the guild.
     ///
@@ -813,11 +813,11 @@ impl Guild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> { self.id.kick(&http, user_id) }
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> { self.id.kick(&http, user_id) }
 
     /// Leaves the guild.
     #[inline]
-    pub fn leave(&self, http: &Http) -> Result<()> { self.id.leave(&http) }
+    pub fn leave(&self, http: impl AsRef<Http>) -> Result<()> { self.id.leave(&http) }
 
     /// Gets a user's [`Member`] for the guild by Id.
     ///
@@ -838,7 +838,7 @@ impl Guild {
     /// [`User`]: ../user/struct.User.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn members<U>(&self, http: &Arc<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
+    pub fn members<U>(&self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
         where U: Into<UserId> {
         self.id.members(&http, limit, after)
     }
@@ -1212,7 +1212,7 @@ impl Guild {
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn move_member<C, U>(&self, http: &Arc<Http>, user_id: U, channel_id: C) -> Result<()>
+    pub fn move_member<C, U>(&self, http: impl AsRef<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
         self.id.move_member(&http, user_id, channel_id)
     }
@@ -1398,7 +1398,7 @@ impl Guild {
     /// regardless of whether they were updated. Otherwise, positioning can
     /// sometimes get weird.
     #[cfg(feature = "http")]
-    pub fn reorder_channels<It>(&self, http: &Arc<Http>, channels: It) -> Result<()>
+    pub fn reorder_channels<It>(&self, http: impl AsRef<Http>, channels: It) -> Result<()>
         where It: IntoIterator<Item = (ChannelId, u64)> {
         self.id.reorder_channels(&http, channels)
     }
@@ -1455,7 +1455,7 @@ impl Guild {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self.id.start_integration_sync(&http, integration_id)
     }
 
@@ -1521,7 +1521,7 @@ impl Guild {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn vanity_url(&self, http: &Http) -> Result<String> {
+    pub fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
         self.id.vanity_url(&http)
     }
 
@@ -1532,7 +1532,7 @@ impl Guild {
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
+    pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
 
     /// Obtain a reference to a role by its name.
     ///

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -63,7 +63,7 @@ impl PartialGuild {
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
-    pub fn ban<U: Into<UserId>>(&self, http: &Arc<Http>, user: U, delete_message_days: u8) -> Result<()> {
+    pub fn ban<U: Into<UserId>>(&self, http: impl AsRef<Http>, user: U, delete_message_days: u8) -> Result<()> {
         if delete_message_days > 7 {
             return Err(Error::Model(
                 ModelError::DeleteMessageDaysAmount(delete_message_days),
@@ -80,14 +80,14 @@ impl PartialGuild {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn bans(&self, http: &Http) -> Result<Vec<Ban>> { self.id.bans(&http) }
+    pub fn bans(&self, http: impl AsRef<Http>) -> Result<Vec<Ban>> { self.id.bans(&http) }
 
     /// Gets all of the guild's channels over the REST API.
     ///
     /// [`Guild`]: struct.Guild.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn channels(&self, http: &Http) -> Result<HashMap<ChannelId, GuildChannel>> { self.id.channels(&http) }
+    pub fn channels(&self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> { self.id.channels(&http) }
 
     /// Creates a [`GuildChannel`] in the guild.
     ///
@@ -110,7 +110,7 @@ impl PartialGuild {
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_channel<C>(&self, http: &Arc<Http>, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
+    pub fn create_channel<C>(&self, http: impl AsRef<Http>, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
         where C: Into<Option<ChannelId>> {
         self.id.create_channel(&http, name, kind, category)
     }
@@ -134,7 +134,7 @@ impl PartialGuild {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_emoji(&self, http: &Arc<Http>, name: &str, image: &str) -> Result<Emoji> {
+    pub fn create_emoji(&self, http: impl AsRef<Http>, name: &str, image: &str) -> Result<Emoji> {
         self.id.create_emoji(&http, name, image)
     }
 
@@ -145,7 +145,7 @@ impl PartialGuild {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_integration<I>(&self, http: &Arc<Http>, integration_id: I, kind: &str) -> Result<()>
+    pub fn create_integration<I>(&self, http: impl AsRef<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
         self.id.create_integration(&http, integration_id, kind)
     }
@@ -166,7 +166,7 @@ impl PartialGuild {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_role<F>(&self, http: &Arc<Http>, f: F) -> Result<Role>
+    pub fn create_role<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Role>
     where F: FnOnce(&mut EditRole) -> &mut EditRole {
         self.id.create_role(&http, f)
     }
@@ -177,7 +177,7 @@ impl PartialGuild {
     /// **Note**: Requires the current user to be the owner of the guild.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete(&self, http: &Http) -> Result<PartialGuild> { self.id.delete(&http) }
+    pub fn delete(&self, http: impl AsRef<Http>) -> Result<PartialGuild> { self.id.delete(&http) }
 
     /// Deletes an [`Emoji`] from the guild.
     ///
@@ -187,7 +187,7 @@ impl PartialGuild {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E) -> Result<()> {
+    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E) -> Result<()> {
         self.id.delete_emoji(&http, emoji_id)
     }
 
@@ -197,7 +197,7 @@ impl PartialGuild {
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[inline]
-    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self.id.delete_integration(&http, integration_id)
     }
 
@@ -212,7 +212,7 @@ impl PartialGuild {
     /// [`Role::delete`]: struct.Role.html#method.delete
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[inline]
-    pub fn delete_role<R: Into<RoleId>>(&self, http: &Arc<Http>, role_id: R) -> Result<()> {
+    pub fn delete_role<R: Into<RoleId>>(&self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
         self.id.delete_role(&http, role_id)
     }
 
@@ -223,7 +223,7 @@ impl PartialGuild {
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
-    pub fn edit<F>(&mut self, http: &Arc<Http>, f: F) -> Result<()>
+    pub fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<()>
         where F: FnOnce(&mut EditGuild) -> &mut EditGuild {
         match self.id.edit(&http, f) {
             Ok(guild) => {
@@ -260,7 +260,7 @@ impl PartialGuild {
     /// ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: &Arc<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
+    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
         self.id.edit_emoji(&http, emoji_id, name)
     }
 
@@ -281,7 +281,7 @@ impl PartialGuild {
     /// ```
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_member<F, U>(&self, http: &Arc<Http>, user_id: U, f: F) -> Result<()>
+    pub fn edit_member<F, U>(&self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
         self.id.edit_member(&http, user_id, f)
     }
@@ -302,7 +302,7 @@ impl PartialGuild {
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_nickname(&self, http: &Arc<Http>, new_nickname: Option<&str>) -> Result<()> {
+    pub fn edit_nickname(&self, http: impl AsRef<Http>, new_nickname: Option<&str>) -> Result<()> {
         self.id.edit_nickname(&http, new_nickname)
     }
 
@@ -311,7 +311,7 @@ impl PartialGuild {
     /// Requires that the current user be in the guild.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn get<G: Into<GuildId>>(http: &Arc<Http>, guild_id: G) -> Result<PartialGuild> {
+    pub fn get<G: Into<GuildId>>(http: impl AsRef<Http>, guild_id: G) -> Result<PartialGuild> {
         guild_id.into().to_partial_guild(&http)
     }
 
@@ -323,7 +323,7 @@ impl PartialGuild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> { self.id.kick(&http, user_id) }
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> { self.id.kick(&http, user_id) }
 
     /// Returns a formatted URL of the guild's icon, if the guild has an icon.
     pub fn icon_url(&self) -> Option<String> {
@@ -337,7 +337,7 @@ impl PartialGuild {
     /// This performs a request over the REST API.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn integrations(&self, http: &Http) -> Result<Vec<Integration>> { self.id.integrations(&http) }
+    pub fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> { self.id.integrations(&http) }
 
     /// Gets all of the guild's invites.
     ///
@@ -346,12 +346,12 @@ impl PartialGuild {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> { self.id.invites(&http) }
+    pub fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> { self.id.invites(&http) }
 
     /// Leaves the guild.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn leave(&self, http: &Http) -> Result<()> { self.id.leave(&http) }
+    pub fn leave(&self, http: impl AsRef<Http>) -> Result<()> { self.id.leave(&http) }
 
     /// Gets a user's [`Member`] for the guild by Id.
     ///
@@ -370,7 +370,7 @@ impl PartialGuild {
     ///
     /// [`User`]: ../user/struct.User.html
     #[cfg(feature = "http")]
-    pub fn members<U>(&self, http: &Arc<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
+    pub fn members<U>(&self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
         where U: Into<UserId> {
         self.id.members(&http, limit, after)
     }
@@ -382,7 +382,7 @@ impl PartialGuild {
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
     #[inline]
     #[cfg(feature = "http")]
-    pub fn move_member<C, U>(&self, http: &Arc<Http>, user_id: U, channel_id: C) -> Result<()>
+    pub fn move_member<C, U>(&self, http: impl AsRef<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
         self.id.move_member(&http, user_id, channel_id)
     }
@@ -396,7 +396,7 @@ impl PartialGuild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[inline]
     #[cfg(feature = "http")]
-    pub fn prune_count(&self, http: &Arc<Http>, days: u16) -> Result<GuildPrune> { self.id.prune_count(&http, days) }
+    pub fn prune_count(&self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> { self.id.prune_count(&http, days) }
 
     /// Returns the Id of the shard associated with the guild.
     ///
@@ -450,7 +450,7 @@ impl PartialGuild {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: &Arc<Http>, integration_id: I) -> Result<()> {
+    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self.id.start_integration_sync(&http, integration_id)
     }
 
@@ -462,7 +462,7 @@ impl PartialGuild {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn unban<U: Into<UserId>>(&self, http: &Arc<Http>, user_id: U) -> Result<()> { self.id.unban(&http, user_id) }
+    pub fn unban<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> { self.id.unban(&http, user_id) }
 
     /// Retrieve's the guild's vanity URL.
     ///
@@ -471,7 +471,7 @@ impl PartialGuild {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn vanity_url(&self, http: &Http) -> Result<String> {
+    pub fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
         self.id.vanity_url(&http)
     }
 
@@ -482,7 +482,7 @@ impl PartialGuild {
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
+    pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
 
     /// Obtain a reference to a role by its name.
     ///

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -78,7 +78,7 @@ impl Role {
     #[cfg(all(feature = "cache", feature = "http"))]
     #[inline]
     pub fn delete(&self, context: &Context) -> Result<()> {
-        context.http.delete_role(self.find_guild(&context.cache)?.0, self.id.0)
+        context.http.as_ref().delete_role(self.find_guild(&context.cache)?.0, self.id.0)
     }
 
     /// Edits a [`Role`], optionally setting its new fields.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -126,13 +126,13 @@ impl Invite {
             }
         }
 
-        context.http.delete_invite(&self.code)
+        context.http.as_ref().delete_invite(&self.code)
     }
 
     /// Gets the information about an invite.
     #[cfg(feature = "http")]
     #[allow(clippy::unused_mut)]
-    pub fn get(http: &Arc<Http>, code: &str, stats: bool) -> Result<Invite> {
+    pub fn get(http: impl AsRef<Http>, code: &str, stats: bool) -> Result<Invite> {
         let mut invite = code;
 
         #[cfg(feature = "utils")]
@@ -140,7 +140,7 @@ impl Invite {
             invite = crate::utils::parse_invite(invite);
         }
 
-        http.get_invite(invite, stats)
+        http.as_ref().get_invite(invite, stats)
     }
 
     /// Returns a URL to use for the invite.
@@ -313,7 +313,7 @@ impl RichInvite {
             }
         }
 
-        context.http.delete_invite(&self.code)
+        context.http.as_ref().delete_invite(&self.code)
     }
 
     /// Returns a URL to use for the invite.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -107,7 +107,7 @@ impl CurrentUser {
     ///
     /// [`EditProfile`]: ../../builder/struct.EditProfile.html
     #[cfg(feature = "http")]
-    pub fn edit<F>(&mut self, http: &Arc<Http>, f: F) -> Result<()>
+    pub fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<()>
         where F: FnOnce(EditProfile) -> EditProfile {
         let mut map = VecMap::new();
         map.insert("username", Value::String(self.name.clone()));
@@ -118,7 +118,7 @@ impl CurrentUser {
 
         let map = utils::vecmap_to_json_map(f(EditProfile(map)).0);
 
-        match http.edit_profile(&map) {
+        match http.as_ref().edit_profile(&map) {
             Ok(new) => {
                 let _ = mem::replace(self, new);
 
@@ -171,8 +171,8 @@ impl CurrentUser {
     /// # fn main() {}
     /// ```
     #[cfg(feature = "http")]
-    pub fn guilds(&self, http: &Http) -> Result<Vec<GuildInfo>> {
-        http.get_guilds(&GuildPagination::After(GuildId(1)), 100)
+    pub fn guilds(&self, http: impl AsRef<Http>) -> Result<Vec<GuildInfo>> {
+        http.as_ref().get_guilds(&GuildPagination::After(GuildId(1)), 100)
     }
 
     /// Returns the invite url for the bot with the given permissions.
@@ -260,9 +260,9 @@ impl CurrentUser {
     /// [`Error::Format`]: ../../enum.Error.html#variant.Format
     /// [`HttpError::UnsuccessfulRequest`]: ../../http/enum.HttpError.html#variant.UnsuccessfulRequest
     #[cfg(feature = "http")]
-    pub fn invite_url(&self, http: &Arc<Http>, permissions: Permissions) -> Result<String> {
+    pub fn invite_url(&self, http: impl AsRef<Http>, permissions: Permissions) -> Result<String> {
         let bits = permissions.bits();
-        let client_id = http.get_current_application_info().map(|v| v.id)?;
+        let client_id = http.as_ref().get_current_application_info().map(|v| v.id)?;
 
         let mut url = format!(
             "https://discordapp.com/api/oauth2/authorize?client_id={}&scope=bot",
@@ -454,7 +454,7 @@ impl User {
     /// [current user]: struct.CurrentUser.html
     #[inline]
     #[cfg(feature = "http")]
-    pub fn create_dm_channel(&self, http: &Http) -> Result<PrivateChannel> { self.id.create_dm_channel(&http) }
+    pub fn create_dm_channel(&self, http: impl AsRef<Http>) -> Result<PrivateChannel> { self.id.create_dm_channel(&http) }
 
     /// Retrieves the time that this user was created at.
     #[inline]
@@ -839,12 +839,12 @@ impl UserId {
     ///
     /// [current user]: ../user/struct.CurrentUser.html
     #[cfg(feature = "http")]
-    pub fn create_dm_channel(&self, http: &Http) -> Result<PrivateChannel> {
+    pub fn create_dm_channel(&self, http: impl AsRef<Http>) -> Result<PrivateChannel> {
         let map = json!({
             "recipient_id": self.0,
         });
 
-        http.create_private_channel(&map)
+        http.as_ref().create_private_channel(&map)
     }
 
     /// Attempts to find a [`User`] by its Id in the cache.

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -66,7 +66,7 @@ impl Webhook {
     ///
     /// [`http::delete_webhook_with_token`]: ../../http/fn.delete_webhook_with_token.html
     #[inline]
-    pub fn delete(&self, http: &Http) -> Result<()> { http.delete_webhook_with_token(self.id.0, &self.token) }
+    pub fn delete(&self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().delete_webhook_with_token(self.id.0, &self.token) }
 
     ///
     /// Edits the webhook in-place. All fields are optional.
@@ -92,7 +92,7 @@ impl Webhook {
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let mut webhook = http.get_webhook_with_token(id, token)
+    /// let mut webhook = http.as_ref().get_webhook_with_token(id, token)
     ///     .expect("valid webhook");
     ///
     /// let _ = webhook.edit(&http, Some("new name"), None).expect("Error editing");
@@ -108,7 +108,7 @@ impl Webhook {
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let mut webhook = http.get_webhook_with_token(id, token)
+    /// let mut webhook = http.as_ref().get_webhook_with_token(id, token)
     ///     .expect("valid webhook");
     ///
     /// let image = serenity::utils::read_image("./webhook_img.png")
@@ -119,7 +119,7 @@ impl Webhook {
     ///
     /// [`http::edit_webhook`]: ../../http/fn.edit_webhook.html
     /// [`http::edit_webhook_with_token`]: ../../http/fn.edit_webhook_with_token.html
-    pub fn edit(&mut self, http: &Arc<Http>, name: Option<&str>, avatar: Option<&str>) -> Result<()> {
+    pub fn edit(&mut self, http: impl AsRef<Http>, name: Option<&str>, avatar: Option<&str>) -> Result<()> {
         if name.is_none() && avatar.is_none() {
             return Ok(());
         }
@@ -141,7 +141,7 @@ impl Webhook {
             map.insert("name".to_string(), Value::String(name.to_string()));
         }
 
-        match http.edit_webhook_with_token(self.id.0, &self.token, &map) {
+        match http.as_ref().edit_webhook_with_token(self.id.0, &self.token, &map) {
             Ok(replacement) => {
                 mem::replace(self, replacement);
 
@@ -168,7 +168,7 @@ impl Webhook {
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let mut webhook = http.get_webhook_with_token(id, token)
+    /// let mut webhook = http.as_ref().get_webhook_with_token(id, token)
     ///     .expect("valid webhook");
     ///
     /// let _ = webhook.execute(&http, false, |mut w| {
@@ -191,7 +191,7 @@ impl Webhook {
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// let mut webhook = http.get_webhook_with_token(id, token)
+    /// let mut webhook = http.as_ref().get_webhook_with_token(id, token)
     ///     .expect("valid webhook");
     ///
     /// let embed = Embed::fake(|mut e| {
@@ -213,13 +213,13 @@ impl Webhook {
     /// });
     /// ```
     #[inline]
-    pub fn execute<F>(&self, http: &Arc<Http>, wait: bool, f: F) -> Result<Option<Message>>
+    pub fn execute<F>(&self, http: impl AsRef<Http>, wait: bool, f: F) -> Result<Option<Message>>
     where F: FnOnce(&mut ExecuteWebhook) -> &mut ExecuteWebhook {
         let mut execute_webhook = ExecuteWebhook::default();
         f(&mut execute_webhook);
         let map = utils::vecmap_to_json_map(execute_webhook.0);
 
-     http.execute_webhook(self.id.0, &self.token, wait, &map)
+     http.as_ref().execute_webhook(self.id.0, &self.token, wait, &map)
     }
 
     /// Retrieves the latest information about the webhook, editing the
@@ -229,8 +229,8 @@ impl Webhook {
     /// authentication is not required.
     ///
     /// [`http::get_webhook_with_token`]: ../../http/fn.get_webhook_with_token.html
-    pub fn refresh(&mut self, http: &Http) -> Result<()> {
-        match http.get_webhook_with_token(self.id.0, &self.token) {
+    pub fn refresh(&mut self, http: impl AsRef<Http>) -> Result<()> {
+        match http.as_ref().get_webhook_with_token(self.id.0, &self.token) {
             Ok(replacement) => {
                 let _ = mem::replace(self, replacement);
 
@@ -250,5 +250,5 @@ impl WebhookId {
     /// [`Webhook`]: struct.Webhook.html
     /// [Manage Webhooks]: ../../model/permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[inline]
-    pub fn to_webhook(self, http: &Http) -> Result<Webhook> { http.get_webhook(self.0) }
+    pub fn to_webhook(self, http: impl AsRef<Http>) -> Result<Webhook> { http.as_ref().get_webhook(self.0) }
 }


### PR DESCRIPTION
As the mentioned resolution in #470, this pull request changes all functions that accepted `&Arc<Http>` now require `impl AsRef<Http>`.

Previously, a function accepted `&Arc<Http>` if it could not utilise the `Cache` to avoid raw requests.
If it did utilise the `Cache`, it accepted `&Context` to work with and without `cache`-feature.

Nonetheless, this led to an inconsistent API, users would have to memorise when to pass either `struct`.
Forcing it to be `impl AsRef<Http>` is supposed to address this issue, as now both `struct` implement given `trait`.