### PR TITLE
Change Functions accepting Cache to accept `impl AsRef<CacheRwLock>`

### DIFF
--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -76,7 +76,7 @@ impl AudioReceiver for Receiver {
         // You can implement your own logic here to handle a user who has joined the
         // voice channel e.g., allocate structures, map their SSRC to User ID.
     }
-  
+
     fn client_disconnect(&mut self, _user_id: u64) {
         // You can implement your own logic here to handle a user who has left the
         // voice channel e.g., finalise processing of statistics etc.

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -13,7 +13,7 @@ use typemap::ShareMap;
 use crate::utils::VecMap;
 use crate::utils::vecmap_to_json_map;
 #[cfg(feature = "cache")]
-pub use crate::cache::Cache;
+pub use crate::cache::{Cache, CacheRwLock};
 #[cfg(feature = "http")]
 use crate::http::Http;
 
@@ -44,7 +44,7 @@ pub struct Context {
     /// The ID of the shard this context is related to.
     pub shard_id: u64,
     #[cfg(feature = "cache")]
-    pub cache: Arc<RwLock<Cache>>,
+    pub cache: CacheRwLock,
     #[cfg(feature = "http")]
     pub http: Arc<Http>,
 }
@@ -63,7 +63,7 @@ impl Context {
             shard: ShardMessenger::new(runner_tx),
             shard_id,
             data,
-            cache,
+            cache: cache.into(),
             http,
         }
     }
@@ -96,7 +96,7 @@ impl Context {
             shard: ShardMessenger::new(runner_tx),
             shard_id,
             data,
-            cache,
+            cache: cache.into(),
         }
     }
 
@@ -497,4 +497,11 @@ impl Context {
 #[cfg(feature = "http")]
 impl AsRef<Http> for &Context {
     fn as_ref(&self) -> &Http { &self.http }
+}
+
+#[cfg(feature = "cache")]
+impl AsRef<CacheRwLock> for &Context {
+    fn as_ref(&self) -> &CacheRwLock {
+        &self.cache
+    }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,7 +40,7 @@ pub use crate::gateway;
 pub use crate::http as rest;
 
 #[cfg(feature = "cache")]
-pub use crate::cache::Cache;
+pub use crate::cache::{Cache, CacheRwLock};
 
 use crate::internal::prelude::*;
 use parking_lot::Mutex;

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -54,9 +54,7 @@ use log::warn;
 #[cfg(feature = "cache")]
 use crate::framework::standard::{has_correct_roles, has_correct_permissions};
 #[cfg(feature = "cache")]
-use crate::cache::Cache;
-#[cfg(feature = "cache")]
-use parking_lot::RwLock;
+use crate::cache::CacheRwLock;
 #[cfg(feature = "http")]
 use crate::http::Http;
 
@@ -248,7 +246,7 @@ fn remove_aliases(cmds: &HashMap<String, CommandOrAlias>) -> HashMap<&String, &I
 /// Checks whether a user is member of required roles
 /// and given the required permissions.
 #[cfg(feature = "cache")]
-pub fn has_all_requirements(cache: &Arc<RwLock<Cache>>, cmd: &Arc<CommandOptions>, msg: &Message) -> bool {
+pub fn has_all_requirements(cache: impl AsRef<CacheRwLock>, cmd: &Arc<CommandOptions>, msg: &Message) -> bool {
     if let Some(guild) = msg.guild(&cache) {
         let guild = guild.read();
 
@@ -273,7 +271,7 @@ pub fn has_all_requirements(cache: &Arc<RwLock<Cache>>, cmd: &Arc<CommandOptions
 /// **Note**: A command is visible when it is either normally displayed or
 /// strikethrough upon requested help by a user.
 #[cfg(feature = "cache")]
-pub fn is_command_visible(cache: &Arc<RwLock<Cache>>, command_options: &Arc<CommandOptions>, msg: &Message,
+pub fn is_command_visible(cache: impl AsRef<CacheRwLock>, command_options: &Arc<CommandOptions>, msg: &Message,
     help_options: &HelpOptions) -> bool {
 
     if !command_options.dm_only && !command_options.guild_only
@@ -318,7 +316,7 @@ pub fn is_command_visible(cache: &Arc<RwLock<Cache>>, command_options: &Arc<Comm
 /// returns similar commands.
 #[cfg(feature = "cache")]
 fn fetch_single_command<'a, H: BuildHasher>(
-    cache: &Arc<RwLock<Cache>>,
+    cache: impl AsRef<CacheRwLock>,
     groups: &'a HashMap<String, Arc<CommandGroup>, H>,
     name: &str,
     help_options: &'a HelpOptions,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -15,7 +15,7 @@ use crate::builder::{
     GetMessages
 };
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache:: {Cache, CacheRwLock};
 #[cfg(all(feature = "cache", feature = "model"))]
 use parking_lot::RwLock;
 #[cfg(feature = "model")]
@@ -314,8 +314,8 @@ impl ChannelId {
     /// [`Channel`]: ../channel/enum.Channel.html
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn to_channel_cached(self, cache: &Arc<RwLock<Cache>>) -> Option<Channel> {
-        self._to_channel_cached(&cache)
+    pub fn to_channel_cached(self, cache: impl AsRef<CacheRwLock>) -> Option<Channel> {
+        self._to_channel_cached(&cache.as_ref())
     }
 
     /// To allow testing pass their own cache instead of using the globale one.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -4,7 +4,7 @@ use crate::{model::prelude::*};
 #[cfg(feature = "client")]
 use crate::client::Context;
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::CacheRwLock;
 #[cfg(feature = "cache")]
 use parking_lot::RwLock;
 #[cfg(feature = "cache")]
@@ -171,12 +171,12 @@ impl GuildChannel {
     /// #
     /// # #[cfg(feature = "cache")]
     /// # fn main() -> Result<(), Box<Error>> {
-    /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, http::Http, model::id::{ChannelId, UserId}};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
     /// #     let http = Arc::new(Http::default());
-    /// #     let cache = Arc::new(RwLock::new(Cache::default()));
+    /// #     let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// #     let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
     /// use serenity::model::channel::{
@@ -215,12 +215,12 @@ impl GuildChannel {
     /// #
     /// # #[cfg(feature = "cache")]
     /// # fn main() -> Result<(), Box<Error>> {
-    /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, http::Http, model::id::{ChannelId, UserId}};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
     /// #   let http = Arc::new(Http::default());
-    /// #   let cache = Arc::new(RwLock::new(Cache::default()));
+    /// #   let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// #   let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
     /// use serenity::model::channel::{
@@ -413,7 +413,7 @@ impl GuildChannel {
     /// **Note**: Right now this performs a clone of the guild. This will be
     /// optimized in the future.
     #[cfg(feature = "cache")]
-    pub fn guild(&self, cache: &Arc<RwLock<Cache>>) -> Option<Arc<RwLock<Guild>>> { cache.read().guild(self.guild_id) }
+    pub fn guild(&self, cache: impl AsRef<CacheRwLock>) -> Option<Arc<RwLock<Guild>>> {cache.as_ref().read().guild(self.guild_id) }
 
     /// Gets all of the channel's invites.
     ///
@@ -558,12 +558,12 @@ impl GuildChannel {
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn permissions_for<U: Into<UserId>>(&self, cache: &Arc<RwLock<Cache>>, user_id: U) -> Result<Permissions> {
+    pub fn permissions_for<U: Into<UserId>>(&self, cache: impl AsRef<CacheRwLock>, user_id: U) -> Result<Permissions> {
         self._permissions_for(&cache, user_id.into())
     }
 
     #[cfg(feature = "cache")]
-    fn _permissions_for(&self, cache: &Arc<RwLock<Cache>>, user_id: UserId) -> Result<Permissions> {
+    fn _permissions_for(&self, cache: impl AsRef<CacheRwLock>, user_id: UserId) -> Result<Permissions> {
         self.guild(&cache)
             .ok_or_else(|| Error::Model(ModelError::GuildNotFound))
             .map(|g| g.read().permissions_in(self.id, user_id))

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -9,7 +9,7 @@ use crate::client::Context;
 #[cfg(feature = "model")]
 use crate::builder::{CreateEmbed, EditMessage};
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::CacheRwLock;
 #[cfg(all(feature = "cache", feature = "model"))]
 use parking_lot::RwLock;
 #[cfg(all(feature = "cache", feature = "model"))]
@@ -126,12 +126,12 @@ impl Message {
     /// ```
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn channel(&self, cache: &Arc<RwLock<Cache>>) -> Option<Channel> { cache.read().channel(self.channel_id) }
+    pub fn channel(&self, cache: impl AsRef<CacheRwLock>) -> Option<Channel> { cache.as_ref().read().channel(self.channel_id) }
 
     /// A util function for determining whether this message was sent by someone else, or the
     /// bot.
     #[cfg(all(feature = "cache", feature = "utils"))]
-    pub fn is_own(&self, cache: &Arc<RwLock<Cache>>) -> bool { self.author.id == cache.read().user.id }
+    pub fn is_own(&self, cache: impl AsRef<CacheRwLock>) -> bool { self.author.id == cache.as_ref().read().user.id }
 
     /// Deletes the message.
     ///
@@ -285,7 +285,7 @@ impl Message {
     /// Returns message content, but with user and role mentions replaced with
     /// names and everyone/here mentions cancelled.
     #[cfg(feature = "cache")]
-    pub fn content_safe(&self, cache: &Arc<RwLock<Cache>>) -> String {
+    pub fn content_safe(&self, cache: impl AsRef<CacheRwLock>) -> String {
         let mut result = self.content.clone();
 
         // First replace all user mentions.
@@ -353,8 +353,8 @@ impl Message {
     ///
     /// [`guild_id`]: #method.guild_id
     #[cfg(feature = "cache")]
-    pub fn guild(&self, cache: &Arc<RwLock<Cache>>) -> Option<Arc<RwLock<Guild>>> {
-        cache.read().guild(self.guild_id?)
+    pub fn guild(&self, cache: impl AsRef<CacheRwLock>) -> Option<Arc<RwLock<Guild>>> {
+       cache.as_ref().read().guild(self.guild_id?)
     }
 
     /// True if message was sent using direct messages.
@@ -371,7 +371,7 @@ impl Message {
     ///
     /// [`Guild::members`]: ../guild/struct.Guild.html#structfield.members
     #[cfg(feature = "cache")]
-    pub fn member(&self, cache: &Arc<RwLock<Cache>>) -> Option<Member> {
+    pub fn member(&self, cache: impl AsRef<CacheRwLock>) -> Option<Member> {
         self.guild(&cache).and_then(|g| g.read().members.get(&self.author.id).cloned())
     }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -38,7 +38,7 @@ use crate::model::misc::ChannelParseError;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use crate::utils::parse_channel;
 #[cfg(feature = "cache")]
-use crate::cache::Cache;
+use crate::cache::CacheRwLock;
 #[cfg(feature = "cache")]
 use std::sync::Arc;
 #[cfg(feature = "cache")]
@@ -80,11 +80,11 @@ impl Channel {
     /// ```rust,no_run
     /// # #[cfg(all(feature = "model", feature = "cache"))]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, model::id::ChannelId};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, model::id::ChannelId};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// #     let cache = Arc::new(RwLock::new(Cache::default()));
+    /// #     let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// #     let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
     /// #
     /// match channel.group() {
@@ -123,11 +123,11 @@ impl Channel {
     /// ```rust,no_run
     /// # #[cfg(all(feature = "model", feature = "cache"))]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, model::id::ChannelId};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, model::id::ChannelId};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// #   let cache = Arc::new(RwLock::new(Cache::default()));
+    /// #   let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
     /// #
     /// match channel.guild() {
@@ -162,11 +162,11 @@ impl Channel {
     /// ```rust,no_run
     /// # #[cfg(all(feature = "model", feature = "cache"))]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, model::id::ChannelId};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, model::id::ChannelId};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// #   let cache = Arc::new(RwLock::new(Cache::default()));
+    /// #   let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
     /// #
     /// match channel.private() {
@@ -204,11 +204,11 @@ impl Channel {
     /// ```rust,no_run
     /// # #[cfg(all(feature = "model", feature = "cache"))]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, model::id::ChannelId};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, model::id::ChannelId};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// #   let cache = Arc::new(RwLock::new(Cache::default()));
+    /// #   let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
     /// #
     /// match channel.category() {
@@ -603,7 +603,7 @@ mod test {
 impl FromStrAndCache for Channel {
     type Err = ChannelParseError;
 
-    fn from_str(cache: &Arc<RwLock<Cache>>, s: &str) -> StdResult<Self, Self::Err> {
+    fn from_str(cache: impl AsRef<CacheRwLock>, s: &str) -> StdResult<Self, Self::Err> {
         match parse_channel(s) {
             Some(x) => match ChannelId(x).to_channel_cached(&cache) {
                 Some(channel) => Ok(channel),

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -16,13 +16,9 @@ use super::super::ModelError;
 #[cfg(all(feature = "cache", feature = "model"))]
 use super::super::id::GuildId;
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::CacheRwLock;
 #[cfg(all(feature = "cache", feature = "model", feature = "http"))]
 use crate::client::Context;
-#[cfg(all(feature = "cache", feature = "model"))]
-use parking_lot::RwLock;
-#[cfg(all(feature = "cache", feature = "model"))]
-use std::sync::Arc;
 
 /// Represents a custom guild emoji, which can either be created using the API,
 /// or via an integration. Emojis created using the API only work within the
@@ -152,11 +148,11 @@ impl Emoji {
     /// Print the guild id that owns this emoji:
     ///
     /// ```rust,no_run
-    /// # use serenity::{cache::Cache, model::{guild::Emoji, id::EmojiId}};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, model::{guild::Emoji, id::EmojiId}};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
+    /// # let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// #
     /// # let mut emoji = Emoji {
     /// #     animated: false,
@@ -173,8 +169,8 @@ impl Emoji {
     /// }
     /// ```
     #[cfg(feature = "cache")]
-    pub fn find_guild_id(&self, cache: &Arc<RwLock<Cache>>) -> Option<GuildId> {
-        for guild in cache.read().guilds.values() {
+    pub fn find_guild_id(&self, cache: impl AsRef<CacheRwLock>) -> Option<GuildId> {
+        for guild in cache.as_ref().read().guilds.values() {
             let guild = guild.read();
 
             if guild.emojis.contains_key(&self.id) {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 #[cfg(feature = "client")]
 use crate::client::Context;
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::CacheRwLock;
 #[cfg(feature = "model")]
 use crate::builder::{EditGuild, EditMember, EditRole};
 #[cfg(feature = "model")]
@@ -442,7 +442,7 @@ impl GuildId {
     /// [`Guild`]: ../guild/struct.Guild.html
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn to_guild_cached(self, cache: &Arc<RwLock<Cache>>) -> Option<Arc<RwLock<Guild>>> { cache.read().guild(self) }
+    pub fn to_guild_cached(self, cache: impl AsRef<CacheRwLock>) -> Option<Arc<RwLock<Guild>>> {cache.as_ref().read().guild(self) }
 
     /// Requests [`PartialGuild`] over REST API.
     ///
@@ -611,8 +611,8 @@ impl GuildId {
     /// [`utils::shard_id`]: ../../utils/fn.shard_id.html
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
-    pub fn shard_id(&self, cache: &Arc<RwLock<Cache>>) -> u64 {
-        crate::utils::shard_id(self.0, cache.read().shard_count)
+    pub fn shard_id(&self, cache: impl AsRef<CacheRwLock>) -> u64 {
+        crate::utils::shard_id(self.0, cache.as_ref().read().shard_count)
     }
 
     /// Returns the Id of the shard associated with the guild.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -18,7 +18,7 @@ use std::borrow::Cow;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use crate::utils::Colour;
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::{cache::Cache, utils};
+use crate::{cache::CacheRwLock, utils};
 #[cfg(all(feature = "http"))]
 use crate::http::Http;
 
@@ -173,8 +173,8 @@ impl Member {
 
     /// Determines the member's colour.
     #[cfg(all(feature = "cache", feature = "utils"))]
-    pub fn colour(&self, cache: &Arc<RwLock<Cache>>) -> Option<Colour> {
-        let cache = cache.read();
+    pub fn colour(&self, cache: impl AsRef<CacheRwLock>) -> Option<Colour> {
+        let cache = cache.as_ref().read();
         let guild = cache.guilds.get(&self.guild_id)?.read();
 
         let mut roles = self.roles
@@ -195,7 +195,7 @@ impl Member {
     /// (This returns the first channel that can be read by the member, if there isn't
     /// one returns `None`)
     #[cfg(feature = "cache")]
-    pub fn default_channel(&self, cache: &Arc<RwLock<Cache>>) -> Option<Arc<RwLock<GuildChannel>>> {
+    pub fn default_channel(&self, cache: impl AsRef<CacheRwLock>) -> Option<Arc<RwLock<GuildChannel>>> {
         let guild = match self.guild_id.to_guild_cached(&cache) {
             Some(guild) => guild,
             None => return None,
@@ -261,7 +261,7 @@ impl Member {
     /// position. If two or more roles have the same highest position, then the
     /// role with the lowest ID is the highest.
     #[cfg(feature = "cache")]
-    pub fn highest_role_info(&self, cache: &Arc<RwLock<Cache>>) -> Option<(RoleId, i64)> {
+    pub fn highest_role_info(&self, cache: impl AsRef<CacheRwLock>) -> Option<(RoleId, i64)> {
         let guild = self.guild_id.to_guild_cached(&cache)?;
         let reader = guild.try_read()?;
 
@@ -361,7 +361,7 @@ impl Member {
     /// [`ModelError::GuildNotFound`]: ../error/enum.Error.html#variant.GuildNotFound
     /// [`ModelError::ItemMissing`]: ../error/enum.Error.html#variant.ItemMissing
     #[cfg(feature = "cache")]
-    pub fn permissions(&self, cache: &Arc<RwLock<Cache>>) -> Result<Permissions> {
+    pub fn permissions(&self, cache: impl AsRef<CacheRwLock>) -> Result<Permissions> {
         let guild = match self.guild_id.to_guild_cached(&cache) {
             Some(guild) => guild,
             None => return Err(From::from(ModelError::GuildNotFound)),
@@ -427,11 +427,11 @@ impl Member {
 
     /// Retrieves the full role data for the user's roles.
     ///
-    /// This is shorthand for manually searching through the CACHE.
+    /// This is shorthand for manually searching through the Cache.
     ///
     /// If role data can not be found for the member, then `None` is returned.
     #[cfg(feature = "cache")]
-    pub fn roles(&self, cache: &Arc<RwLock<Cache>>) -> Option<Vec<Role>> {
+    pub fn roles(&self, cache: impl AsRef<CacheRwLock>) -> Option<Vec<Role>> {
         self
             .guild_id
             .to_guild_cached(&cache)

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -26,7 +26,7 @@ use log::{error, warn};
 #[cfg(feature = "client")]
 use crate::client::Context;
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::CacheRwLock;
 #[cfg(all(feature = "cache", feature = "model"))]
 use parking_lot::RwLock;
 #[cfg(all(feature = "cache", feature = "model"))]
@@ -153,8 +153,8 @@ pub struct Guild {
 #[cfg(feature = "model")]
 impl Guild {
     #[cfg(feature = "cache")]
-    fn check_hierarchy(&self, cache: &Arc<RwLock<Cache>>, other_user: UserId) -> Result<()> {
-        let current_id = cache.read().user.id;
+    fn check_hierarchy(&self, cache: impl AsRef<CacheRwLock>, other_user: UserId) -> Result<()> {
+        let current_id = cache.as_ref().read().user.id;
 
         if let Some(higher) = self.greater_member_hierarchy(&cache, other_user, current_id) {
             if higher != current_id {
@@ -197,8 +197,8 @@ impl Guild {
     }
 
     #[cfg(feature = "cache")]
-    fn has_perms(&self, cache: &Arc<RwLock<Cache>>, mut permissions: Permissions) -> bool {
-        let user_id = cache.read().user.id;
+    fn has_perms(&self, cache: impl AsRef<CacheRwLock>, mut permissions: Permissions) -> bool {
+        let user_id = cache.as_ref().read().user.id;
 
         let perms = self.member_permissions(user_id);
         permissions.remove(perms);
@@ -703,7 +703,7 @@ impl Guild {
     /// [`position`]: struct.Role.html#structfield.position
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn greater_member_hierarchy<T, U>(&self, cache: &Arc<RwLock<Cache>>, lhs_id: T, rhs_id: U)
+    pub fn greater_member_hierarchy<T, U>(&self, cache: impl AsRef<CacheRwLock>, lhs_id: T, rhs_id: U)
         -> Option<UserId> where T: Into<UserId>, U: Into<UserId> {
         self._greater_member_hierarchy(&cache, lhs_id.into(), rhs_id.into())
     }
@@ -711,7 +711,7 @@ impl Guild {
     #[cfg(feature = "cache")]
     fn _greater_member_hierarchy(
         &self,
-        cache: &Arc<RwLock<Cache>>,
+        cache: impl AsRef<CacheRwLock>,
         lhs_id: UserId,
         rhs_id: UserId,
     ) -> Option<UserId> {
@@ -1415,7 +1415,7 @@ impl Guild {
     /// [`utils::shard_id`]: ../../utils/fn.shard_id.html
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
-    pub fn shard_id(&self, cache: &Arc<RwLock<Cache>>) -> u64 { self.id.shard_id(&cache) }
+    pub fn shard_id(&self, cache: impl AsRef<CacheRwLock>) -> u64 { self.id.shard_id(&cache) }
 
     /// Returns the Id of the shard associated with the guild.
     ///

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -14,11 +14,7 @@ use super::{Permissions, utils as model_utils};
 #[cfg(feature = "model")]
 use crate::utils;
 #[cfg(feature = "cache")]
-use crate::cache::Cache;
-#[cfg(feature = "cache")]
-use parking_lot::RwLock;
-#[cfg(feature = "cache")]
-use std::sync::Arc;
+use crate::cache::CacheRwLock;
 #[cfg(feature = "http")]
 use crate::http::Http;
 
@@ -209,7 +205,7 @@ impl InviteGuild {
     /// [`utils::shard_id`]: ../../utils/fn.shard_id.html
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
-    pub fn shard_id(&self, cache: &Arc<RwLock<Cache>>) -> u64 { self.id.shard_id(&cache) }
+    pub fn shard_id(&self, cache: impl AsRef<CacheRwLock>) -> u64 { self.id.shard_id(&cache) }
 
     /// Returns the Id of the shard associated with the guild.
     ///

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -22,7 +22,7 @@ use std::fmt::Write;
 #[cfg(feature = "model")]
 use std::mem;
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::CacheRwLock;
 #[cfg(all(feature = "cache", feature = "model"))]
 use std::sync::Arc;
 #[cfg(feature = "model")]
@@ -56,11 +56,11 @@ impl CurrentUser {
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
+    /// # let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// # let cache = cache.read();
     /// // assuming the cache has been unlocked
     /// let user = &cache.user;
@@ -150,11 +150,11 @@ impl CurrentUser {
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
+    /// # let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// # let cache = cache.read();
     /// # let http = Arc::new(Http::default());
     /// // assuming the cache has been unlocked
@@ -188,11 +188,11 @@ impl CurrentUser {
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
+    /// # let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// # let mut cache = cache.write();
     /// # let http = Arc::new(Http::default());
     ///
@@ -221,11 +221,11 @@ impl CurrentUser {
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, http::Http, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, http::Http, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
+    /// # let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// # let mut cache = cache.write();
     /// # let http = Arc::new(Http::default());
     /// use serenity::model::Permissions;
@@ -287,11 +287,11 @@ impl CurrentUser {
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
+    /// # let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// # let cache = cache.read();
     /// // assuming the cache has been unlocked
     /// let user = &cache.user;
@@ -319,11 +319,11 @@ impl CurrentUser {
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
     /// # fn main() {
-    /// # use serenity::{cache::Cache, model::prelude::*, prelude::*};
+    /// # use serenity::{cache::{Cache, CacheRwLock}, model::prelude::*, prelude::*};
     /// # use parking_lot::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
+    /// # let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     /// # let cache = cache.read();
     /// // assuming the cache has been unlocked
     /// println!("The current user's distinct identifier is {}", cache.user.tag());
@@ -709,13 +709,13 @@ impl User {
     /// // every 12 hours
     /// # #[cfg(feature = "cache")]
     /// # command!(example(context) {
-    /// # use serenity::cache::Cache;
+    /// # use serenity::cache::{Cache, CacheRwLock};
     /// #
     /// # let context = context.clone();
     ///
     /// let handle = thread::spawn(move || {
     /// let special_users = vec![UserId(114941315417899012), UserId(87600987040120832)];
-    /// # let cache = Arc::new(RwLock::new(Cache::default()));
+    /// # let cache: CacheRwLock = Arc::new(RwLock::new(Cache::default())).into();
     ///     // 12 hours in seconds
     ///     let duration = Duration::from_secs(43200);
     ///
@@ -852,7 +852,7 @@ impl UserId {
     /// [`User`]: ../user/struct.User.html
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn to_user_cached(self, cache: &Arc<RwLock<Cache>>) -> Option<Arc<RwLock<User>>> { cache.read().user(self) }
+    pub fn to_user_cached(self, cache: impl AsRef<CacheRwLock>) -> Option<Arc<RwLock<User>>> {cache.as_ref().read().user(self) }
 
     /// First attempts to find a [`User`] by its Id in the cache,
     /// upon failure requests it via the REST API.

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -14,7 +14,7 @@ use crate::internal::prelude::*;
 #[cfg(all(feature = "cache", feature = "model"))]
 use super::permissions::Permissions;
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::CacheRwLock;
 
 pub fn default_true() -> bool {
     true
@@ -206,8 +206,8 @@ pub fn serialize_gen_locked_map<K: Eq + Hash, S: Serializer, V: Serialize>(
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
-pub fn user_has_perms(cache: &Arc<RwLock<Cache>>, channel_id: ChannelId, mut permissions: Permissions) -> Result<bool> {
-    let cache = cache.read();
+pub fn user_has_perms(cache: impl AsRef<CacheRwLock>, channel_id: ChannelId, mut permissions: Permissions) -> Result<bool> {
+    let cache = cache.as_ref().read();
     let current_user = &cache.user;
 
     let channel = match cache.channel(channel_id) {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -20,8 +20,6 @@ use super::channel::Message;
 #[cfg(feature = "model")]
 use crate::utils;
 #[cfg(feature = "http")]
-use std::sync::Arc;
-#[cfg(feature = "http")]
 use crate::http::Http;
 
 /// A representation of a webhook, which is a low-effort way to post messages to


### PR DESCRIPTION
As suggested after #523 to provide similar ease for the `Cache`, this pull requests allows functions expecting the `Cache` to also accept `Context`.

Functions requiring `&Arc<RwLock<Cache>>` and thus expect the user to explicitly access the `cache`-field of `Context` each time will now simply take types implementing `AsRef<CacheRwLock>`.

`CacheRwLock` is minimal magic, I call it a _neworphantype_: It is a newtype with the automatically dereferenced underlying `Arc<RwLock<Cache>>` and thus allows us to implement traits for this while behaving like the underlying type but yet respecting the _Orphan Rule_.