### PR TITLE
Implement `AsRef` for `Context` instead of `&Context`

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -495,12 +495,12 @@ impl Context {
 }
 
 #[cfg(feature = "http")]
-impl AsRef<Http> for &Context {
+impl AsRef<Http> for Context {
     fn as_ref(&self) -> &Http { &self.http }
 }
 
 #[cfg(feature = "cache")]
-impl AsRef<CacheRwLock> for &Context {
+impl AsRef<CacheRwLock> for Context {
     fn as_ref(&self) -> &CacheRwLock {
         &self.cache
     }


### PR DESCRIPTION
As of https://doc.rust-lang.org/src/core/convert.rs.html#395, `AsRef<Http>` and `AsRef<CacheRwLock>` should be implemented for `Context` instead of `&Context`.
This automatically covers it for `T` and `&T`. 
Additionally, right now, when calling providing `Context` instead of `Http` or `CacheRwLock`, it will error that `AsRef` is not implemented for `Context`.