### PR TITLE
Conform to Clippy

### DIFF
--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -303,6 +303,8 @@ pub fn validate_declaration(fun: &mut CommandFun, is_help: bool) -> Result<()> {
 
                 index += 1;
             )*
+
+            let _ = index;
         }};
     }
 

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -244,7 +244,7 @@ pub fn validate_declaration(fun: &mut CommandFun, is_help: bool) -> Result<()> {
     let args: Type = parse_quote!(Args);
     let options: Type = parse_quote!(&'static HelpOptions);
     let groups: Type = parse_quote!(&[&'static CommandGroup]);
-    let owners: Type = parse_quote!(HashSet<UserId>);
+    let owners: Type = parse_quote!(HashSet<UserId, impl BuildHasher>);
 
     let cname = crate_name();
     let context_path: Type = parse_quote!(&mut #cname::prelude::Context);
@@ -252,14 +252,14 @@ pub fn validate_declaration(fun: &mut CommandFun, is_help: bool) -> Result<()> {
     let args_path: Type = parse_quote!(#cname::framework::standard::Args);
     let options_path: Type = parse_quote!(&'static #cname::framework::standard::HelpOptions);
     let groups_path: Type = parse_quote!(&[&'static #cname::framework::standard::CommandGroup]);
-    let owners_path: Type = parse_quote!(std::collections::HashSet<#cname::model::id::UserId>);
+    let owners_path: Type = parse_quote!(std::collections::HashSet<#cname::model::id::UserId, std::hash::BuildHasher>);
 
     let ctx_error = "first argument's type should be `&mut Context`";
     let msg_error = "second argument's type should be `&Message`";
     let args_error = "third argument's type should be `Args`";
     let options_error = "fourth argument's type should be `&'static HelpOptions`";
     let groups_error = "fifth argument's type should be `&[&'static CommandGroup]`";
-    let owners_error = "sixth argument's type should be `HashSet<UserId>`";
+    let owners_error = "sixth argument's type should be `HashSet<UserId, impl BuildHasher>`";
 
     #[allow(unused_assignments)]
     macro_rules! spoof_or_check {

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -510,7 +510,7 @@ pub struct Timestamp {
 impl From<String> for Timestamp {
     fn from(ts: String) -> Self {
         Self {
-            ts: ts,
+            ts,
         }
     }
 }

--- a/src/client/bridge/gateway/event.rs
+++ b/src/client/bridge/gateway/event.rs
@@ -4,6 +4,7 @@
 use super::ShardId;
 use crate::gateway::ConnectionStage;
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug)]
 pub(crate) enum ClientEvent {
     ShardStageUpdate(ShardStageUpdateEvent),

--- a/src/client/bridge/gateway/mod.rs
+++ b/src/client/bridge/gateway/mod.rs
@@ -79,6 +79,8 @@ use crate::gateway::{ConnectionStage, InterMessage};
 ///
 /// [`ShardManager`]: struct.ShardManager.html
 /// [`ShardRunner`]: struct.ShardRunner.html
+// Once we can use `Box` as part of a pattern, we will reconsider boxing.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum ShardClientMessage {
     /// A message intended to be worked with by a [`ShardManager`].

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -283,7 +283,7 @@ impl ShardManager {
         if let Some(runner) = self.runners.lock().get(&shard_id) {
             let shutdown = ShardManagerMessage::Shutdown(shard_id);
             let client_msg = ShardClientMessage::Manager(shutdown);
-            let msg = InterMessage::Client(client_msg);
+            let msg = InterMessage::Client(Box::new(client_msg));
 
             if let Err(why) = runner.runner_tx.send(msg) {
                 warn!(

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -255,6 +255,6 @@ impl ShardMessenger {
     #[inline]
     fn send(&self, msg: ShardRunnerMessage)
         -> Result<(), SendError<InterMessage>> {
-        self.tx.send(InterMessage::Client(ShardClientMessage::Runner(msg)))
+        self.tx.send(InterMessage::Client(Box::new(ShardClientMessage::Runner(msg))))
     }
 }

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -320,7 +320,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
             Event::VoiceServerUpdate(ref event) => {
                 if let Some(guild_id) = event.guild_id {
                     let mut manager = self.voice_manager.lock();
-                    let mut search = manager.get_mut(guild_id);
+                    let search = manager.get_mut(guild_id);
 
                     if let Some(handler) = search {
                         handler.update_server(&event.endpoint, &event.token);
@@ -330,7 +330,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
             Event::VoiceStateUpdate(ref event) => {
                 if let Some(guild_id) = event.guild_id {
                     let mut manager = self.voice_manager.lock();
-                    let mut search = manager.get_mut(guild_id);
+                    let search = manager.get_mut(guild_id);
 
                     if let Some(handler) = search {
                         handler.update_state(&event.voice_state);

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -474,7 +474,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
 
         #[cfg(feature = "voice")]
         {
-            self.voice_manager.lock().manager_remove(&shard_id.0);
+            self.voice_manager.lock().manager_remove(shard_id.0);
         }
 
         Ok(())

--- a/src/client/bridge/gateway/shard_runner_message.rs
+++ b/src/client/bridge/gateway/shard_runner_message.rs
@@ -6,6 +6,8 @@ use crate::model::{
 use tungstenite::Message;
 
 /// A message to send from a shard over a WebSocket.
+// Once we can use `Box` as part of a pattern, we will reconsider boxing.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum ShardRunnerMessage {
     /// Indicates that the client is to send a member chunk message.

--- a/src/client/bridge/voice/mod.rs
+++ b/src/client/bridge/voice/mod.rs
@@ -96,16 +96,16 @@ impl ClientVoiceManager {
         self.user_id = user_id;
     }
 
-    pub fn manager_get(&self, shard_id: &u64) -> Option<&Manager> {
-        self.managers.get(shard_id)
+    pub fn manager_get(&self, shard_id: u64) -> Option<&Manager> {
+        self.managers.get(&shard_id)
     }
 
-    pub fn manager_get_mut(&mut self, shard_id: &u64) -> Option<&mut Manager> {
-        self.managers.get_mut(shard_id)
+    pub fn manager_get_mut(&mut self, shard_id: u64) -> Option<&mut Manager> {
+        self.managers.get_mut(&shard_id)
     }
 
-    pub fn manager_remove(&mut self, shard_id: &u64) -> Option<Manager> {
-        self.managers.remove(shard_id)
+    pub fn manager_remove(&mut self, shard_id: u64) -> Option<Manager> {
+        self.managers.remove(&shard_id)
     }
 
     fn manager_info<G: Into<GuildId>>(&self, guild_id: G) -> (GuildId, u64) {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -197,7 +197,7 @@ fn dispatch_message<H>(
     });
 }
 
-#[allow(clippy::cognitive_complexity, unused_assignments, unused_mut)]
+#[allow(unused_assignments, unused_mut)]
 fn handle_event<H: EventHandler + Send + Sync + 'static>(
     event: DispatchEvent,
     data: &Arc<RwLock<ShareMap>>,

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -89,6 +89,8 @@ fn context(
     Context::new(Arc::clone(data), runner_tx.clone(), shard_id)
 }
 
+// Once we can use `Box` as part of a pattern, we will reconsider boxing.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum DispatchEvent {
     Client(ClientEvent),
     Model(Event),

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -143,7 +143,6 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static>(
 }
 
 #[cfg(not(feature = "framework"))]
-#[allow(clippy::unused_mut)]
 pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static>(
     event: DispatchEvent,
     data: &Arc<RwLock<ShareMap>>,
@@ -180,7 +179,6 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static>(
     }
 }
 
-#[allow(clippy::unused_mut)]
 fn dispatch_message<H>(
     context: Context,
     mut message: Message,

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -97,7 +97,7 @@ pub(crate) enum DispatchEvent {
 }
 
 #[cfg(feature = "framework")]
-#[clippy::too_many_arguments]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static>(
     event: DispatchEvent,
     framework: &Arc<Mutex<Option<Box<dyn Framework + Send>>>>,

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -4,7 +4,7 @@ use crate::model::{
     event::Event,
     guild::Member,
 };
-use std::{fmt, sync::{Arc, mpsc::Sender}};
+use std::{sync::{Arc, mpsc::Sender}};
 use parking_lot::{Mutex, RwLock};
 use super::{
     bridge::gateway::event::ClientEvent,
@@ -13,7 +13,6 @@ use super::{
 };
 use threadpool::ThreadPool;
 use typemap::ShareMap;
-use log::warn;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
@@ -27,6 +26,10 @@ use crate::cache::Cache;
 use crate::CacheAndHttp;
 #[cfg(feature = "cache")]
 use crate::cache::CacheUpdate;
+#[cfg(feature = "cache")]
+use std::fmt;
+#[cfg(feature = "cache")]
+use log::warn;
 
 #[inline]
 #[cfg(feature = "cache")]
@@ -47,7 +50,7 @@ fn update<E: CacheUpdate + fmt::Debug>(cache_and_http: &Arc<CacheAndHttp>, event
 
 #[inline]
 #[cfg(not(feature = "cache"))]
-fn update<E>(cache_and_http: &Arc<CacheAndHttp>, event: &mut E) -> Option<()> {
+fn update<E>(_cache_and_http: &Arc<CacheAndHttp>, _event: &mut E) -> Option<()> {
     None
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -17,7 +17,6 @@
 //! [`Client`]: struct.Client.html#examples
 //! [`Context`]: struct.Context.html
 //! [Client examples]: struct.Client.html#examples
-#![allow(clippy::zero_ptr)]
 
 pub mod bridge;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -577,7 +577,7 @@ impl Client {
     /// impl Framework for MyFramework {
     ///     fn dispatch(&mut self, _: Context, msg: Message, tokio_handle: &Handle) {
     ///         let args = msg.content.split_whitespace();
-    ///         let command = match args.next() {
+    ///         let command = match args.advance() {
     ///             Some(command) => {
     ///                 if !command.starts_with('*') { return; }
     ///                 command

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -45,7 +45,7 @@ use crate::internal::prelude::*;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
 use self::bridge::gateway::{ShardManager, ShardManagerMonitor, ShardManagerOptions};
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 use threadpool::ThreadPool;
 use typemap::ShareMap;
 use log::{error, debug, info};
@@ -58,6 +58,8 @@ use crate::model::id::UserId;
 use self::bridge::voice::ClientVoiceManager;
 #[cfg(feature = "http")]
 use crate::http::Http;
+#[cfg(feature = "cache")]
+use std::time::Duration;
 
 /// The Client is the way to be able to start sending authenticated requests
 /// over the REST API, as well as initializing a WebSocket connection through

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -110,8 +110,8 @@ enum_number!(
 );
 
 impl OpCode {
-    pub fn num(&self) -> u64 {
-        match *self {
+    pub fn num(self) -> u64 {
+        match self {
             OpCode::Event => 0,
             OpCode::Heartbeat => 1,
             OpCode::Identify => 2,
@@ -175,8 +175,8 @@ enum_number!(
 );
 
 impl VoiceOpCode {
-    pub fn num(&self) -> u64 {
-        match *self {
+    pub fn num(self) -> u64 {
+        match self {
             VoiceOpCode::Identify => 0,
             VoiceOpCode::SelectProtocol => 1,
             VoiceOpCode::Ready => 2,

--- a/src/error.rs
+++ b/src/error.rs
@@ -93,7 +93,7 @@ pub enum Error {
     ///
     /// [`http`]: http/index.html
     #[cfg(feature = "http")]
-    Http(HttpError),
+    Http(Box<HttpError>),
     /// An error occuring in rustls
     #[cfg(all(feature = "gateway", not(feature = "native_tls")))]
     Rustls(RustlsError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,7 +157,7 @@ impl From<TungsteniteError> for Error {
 
 #[cfg(feature = "http")]
 impl From<HttpError> for Error {
-    fn from(e: HttpError) -> Error { Error::Http(e) }
+    fn from(e: HttpError) -> Error { Error::Http(Box::new(e)) }
 }
 
 #[cfg(feature = "http")]

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -91,7 +91,9 @@ impl<F: Framework + ?Sized> Framework for Box<F> {
 impl<T: Framework + ?Sized> Framework for Arc<T> {
     #[inline]
     fn dispatch(&mut self, ctx: Context, msg: Message, threadpool: &threadpool::ThreadPool) {
-        Arc::get_mut(self).map(|s| (*s).dispatch(ctx, msg, threadpool));
+        if let Some(s) = Arc::get_mut(self) {
+            (*s).dispatch(ctx, msg, threadpool)
+        }
     }
 }
 

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -343,9 +343,9 @@ impl Args {
 
     fn span(&self) -> (usize, usize) {
         let Token {
-            kind: _,
             start,
             end,
+            ..
         } = &self.args[self.offset];
 
         let start = *start;

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -456,9 +456,9 @@ impl Args {
     /// let mut args = Args::new("4 2", &[Delimiter::Single(' ')]);
     ///
     /// assert_eq!(args.current(), Some("4"));
-    /// args.next();
+    /// args.advance();
     /// assert_eq!(args.current(), Some("2"));
-    /// args.next();
+    /// args.advance();
     /// assert_eq!(args.current(), None);
     /// ```
     ///

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -535,7 +535,7 @@ impl Args {
             }
         }
 
-        return self;
+        self
     }
 
     /// Parse the current argument.

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -365,7 +365,7 @@ impl Args {
     /// This increments the offset pointer.
     ///
     /// Does nothing if the message is empty.
-    pub fn next(&mut self) -> &mut Self {
+    pub fn advance(&mut self) -> &mut Self {
         if self.is_empty() {
             return self;
         }
@@ -584,7 +584,7 @@ impl Args {
     #[inline]
     pub fn single<T: FromStr>(&mut self) -> Result<T, T::Err> {
         let p = self.parse::<T>()?;
-        self.next();
+        self.advance();
         Ok(p)
     }
 
@@ -607,7 +607,7 @@ impl Args {
     #[inline]
     pub fn single_quoted<T: FromStr>(&mut self) -> Result<T, T::Err> {
         let p = self.quoted().parse::<T>()?;
-        self.next();
+        self.advance();
         Ok(p)
     }
 
@@ -824,7 +824,7 @@ impl<'a, T: FromStr> Iterator for Iter<'a, T> {
             None
         } else {
             let arg = self.parse();
-            self.args.next();
+            self.args.advance();
             Some(arg)
         }
     }

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -637,7 +637,7 @@ impl Args {
     /// [`trimmed`]: struct.Iter.html#method.trimmed
     /// [`quoted`]: struct.Iter.html#method.quoted
     #[inline]
-    pub fn iter<'a, T: FromStr>(&'a mut self) -> Iter<'a, T> {
+    pub fn iter<T: FromStr>(&mut self) -> Iter<'_, T> {
         Iter {
             args: self,
             state: State::None,

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -736,10 +736,9 @@ fn send_suggestion_embed(
     suggestions: &Suggestions,
     colour: Colour,
 ) -> Result<Message, Error> {
-    let text = format!(
-        "{}",
-        help_description.replace("{}", &suggestions.join("`, `"))
-    );
+    let text = help_description
+        .replace("{}", &suggestions.join("`, `"))
+        .to_string();
 
     channel_id.send_message(&http, |m| {
         m.embed(|e| {

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -31,8 +31,6 @@ use super::{has_correct_roles, macros::help, Args, CommandGroup, CommandOptions,
 };
 #[cfg(feature = "cache")]
 use super::has_correct_permissions;
-#[cfg(feature = "cache")]
-use crate::cache::Cache;
 use crate::client::Context;
 #[cfg(feature = "http")]
 use crate::http::Http;
@@ -44,15 +42,12 @@ use crate::model::{
 };
 use crate::utils::Colour;
 use crate::Error;
-#[cfg(feature = "cache")]
-use parking_lot::RwLock;
 use std::{
     borrow::Borrow,
     collections::HashSet,
     fmt::Write,
     hash::BuildHasher,
     ops::{Index, IndexMut},
-    sync::Arc,
 };
 
 /// Macro to format a command according to a `HelpBehaviour` or

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -327,7 +327,7 @@ fn fetch_single_command<'a>(
                     .names
                     .iter()
                     .find(|n| **n == name)
-                    .map(|o| *o)
+                    .cloned()
             } else {
                 command
                     .options
@@ -340,7 +340,7 @@ fn fetch_single_command<'a>(
                             .iter()
                             .any(|prefix| format!("{} {}", prefix, n) == name)
                     })
-                    .map(|o| *o)
+                    .cloned()
             };
 
             if let Some(n) = search_command_name_matched {
@@ -414,14 +414,14 @@ fn fetch_single_command<'a>(
             return Ok(CustomisedHelpData::SingleCommand {
                 command: Command {
                     name: options.names[0],
-                    description: options.desc.clone(),
+                    description: options.desc,
                     group_name: group.name,
                     group_prefixes: &group.options.prefixes,
                     checks: check_names,
                     aliases: options.names[1..].to_vec(),
                     availability: available_text,
-                    usage: options.usage.clone(),
-                    usage_sample: options.example.clone(),
+                    usage: options.usage,
+                    usage_sample: options.example,
                 },
             });
         }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -60,9 +60,9 @@ use std::{
 macro_rules! format_command_name {
     ($behaviour:expr, $command_name:expr) => {
         match $behaviour {
-            &HelpBehaviour::Strike => format!("~~`{}`~~", $command_name),
-            &HelpBehaviour::Nothing => format!("`{}`", $command_name),
-            &HelpBehaviour::Hide => continue,
+            HelpBehaviour::Strike => format!("~~`{}`~~", $command_name),
+            HelpBehaviour::Nothing => format!("`{}`", $command_name),
+            HelpBehaviour::Hide => continue,
         }
     };
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -515,7 +515,7 @@ fn create_command_group_commands_pair_from_groups<'a>(
 
 /// Fetches a single group with its commands.
 #[cfg(feature = "cache")]
-fn create_single_group<'a>(
+fn create_single_group(
     context: &Context,
     group: &CommandGroup,
     owners: &HashSet<UserId, impl BuildHasher>,

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -23,25 +23,24 @@
 //! [`plain`]: fn.plain.html
 //! [`with_embeds`]: fn.with_embeds.html
 
-use log::warn;
-
-use super::structures::Command as InternalCommand;
-use super::{has_correct_roles, macros::help, Args, CommandGroup, CommandOptions,
-    CommandResult, HelpBehaviour, HelpOptions, OnlyIn,
+#[cfg(all(feature = "cache", feature = "http"))]
+use super::{
+    Args, CommandGroup, CommandOptions,
+    CommandResult, has_correct_roles, HelpBehaviour, HelpOptions,
+    has_correct_permissions, macros::help, OnlyIn,
+    structures::Command as InternalCommand,
 };
-#[cfg(feature = "cache")]
-use super::has_correct_permissions;
-use crate::client::Context;
-#[cfg(feature = "http")]
-use crate::http::Http;
-#[cfg(feature = "cache")]
-use crate::cache::CacheRwLock;
-use crate::model::{
-    channel::Message,
-    id::{ChannelId, UserId},
+#[cfg(all(feature = "cache", feature = "http"))]
+use crate::{
+    cache::CacheRwLock,
+    client::Context,
+    model::channel::Message,
+    Error,
+    http::Http,
+    model::id::{ChannelId, UserId},
+    utils::Colour,
 };
-use crate::utils::Colour;
-use crate::Error;
+#[cfg(all(feature = "cache", feature = "http"))]
 use std::{
     borrow::Borrow,
     collections::HashSet,
@@ -49,9 +48,12 @@ use std::{
     hash::BuildHasher,
     ops::{Index, IndexMut},
 };
+#[cfg(all(feature = "cache", feature = "http"))]
+use log::warn;
 
 /// Macro to format a command according to a `HelpBehaviour` or
 /// continue to the next command-name upon hiding.
+#[cfg(all(feature = "cache", feature = "http"))]
 macro_rules! format_command_name {
     ($behaviour:expr, $command_name:expr) => {
         match $behaviour {
@@ -64,6 +66,7 @@ macro_rules! format_command_name {
 
 /// Wraps around `warn`-macro in order to keep
 /// the literal same for all formats of help.
+#[cfg(all(feature = "cache", feature = "http"))]
 macro_rules! warn_about_failed_send {
     ($customised_help:expr, $error:expr) => {
         warn!("Failed to send {:?} because: {:?}", $customised_help, $error);
@@ -106,6 +109,7 @@ pub struct Command<'a> {
 #[derive(Clone, Debug, Default)]
 pub struct Suggestions(Vec<SuggestedCommandName>);
 
+#[cfg(all(feature = "cache", feature = "http"))]
 impl Suggestions {
     /// Immutably borrow inner `Vec`.
     #[inline]
@@ -163,11 +167,13 @@ pub enum CustomisedHelpData<'a> {
 /// Wraps around a `Vec<Vec<T>>` and provides access
 /// via indexing of tuples representing x and y.
 #[derive(Debug)]
+#[cfg(all(feature = "cache", feature = "http"))]
 struct Matrix {
     vec: Vec<usize>,
     width: usize,
 }
 
+#[cfg(all(feature = "cache", feature = "http"))]
 impl Matrix {
     fn new(columns: usize, rows: usize) -> Matrix {
         Matrix {
@@ -177,6 +183,7 @@ impl Matrix {
     }
 }
 
+#[cfg(all(feature = "cache", feature = "http"))]
 impl Index<(usize, usize)> for Matrix {
     type Output = usize;
 
@@ -185,6 +192,7 @@ impl Index<(usize, usize)> for Matrix {
     }
 }
 
+#[cfg(all(feature = "cache", feature = "http"))]
 impl IndexMut<(usize, usize)> for Matrix {
     fn index_mut(&mut self, matrix_entry: (usize, usize)) -> &mut usize {
         &mut self.vec[matrix_entry.1 * self.width + matrix_entry.0]
@@ -193,6 +201,7 @@ impl IndexMut<(usize, usize)> for Matrix {
 
 /// Calculates and returns levenshtein distance between
 /// two passed words.
+#[cfg(all(feature = "cache", feature = "http"))]
 pub(crate) fn levenshtein_distance(word_a: &str, word_b: &str) -> usize {
     let len_a = word_a.chars().count();
     let len_b = word_b.chars().count();
@@ -632,7 +641,7 @@ pub fn create_customised_help_data<'a>(
 }
 
 /// Sends an embed listing all groups with their commands.
-#[cfg(feature = "http")]
+#[cfg(all(feature = "cache", feature = "http"))]
 fn send_grouped_commands_embed(
     http: impl AsRef<Http>,
     help_options: &HelpOptions,
@@ -669,7 +678,7 @@ fn send_grouped_commands_embed(
 }
 
 /// Sends embed showcasing information about a single command.
-#[cfg(feature = "http")]
+#[cfg(all(feature = "cache", feature = "http"))]
 fn send_single_command_embed(
     http: impl AsRef<Http>,
     help_options: &HelpOptions,
@@ -723,7 +732,7 @@ fn send_single_command_embed(
 }
 
 /// Sends embed listing commands that are similar to the sent one.
-#[cfg(feature = "http")]
+#[cfg(all(feature = "cache", feature = "http"))]
 fn send_suggestion_embed(
     http: impl AsRef<Http>,
     channel_id: ChannelId,
@@ -746,7 +755,7 @@ fn send_suggestion_embed(
 }
 
 /// Sends an embed explaining fetching commands failed.
-#[cfg(feature = "http")]
+#[cfg(all(feature = "cache", feature = "http"))]
 fn send_error_embed(
     http: impl AsRef<Http>,
     channel_id: ChannelId,
@@ -839,6 +848,7 @@ pub fn with_embeds(
 }
 
 /// Turns grouped commands into a `String` taking plain help format into account.
+#[cfg(all(feature = "cache", feature = "http"))]
 fn grouped_commands_to_plain_string(
     help_options: &HelpOptions,
     help_description: &str,
@@ -866,6 +876,7 @@ fn grouped_commands_to_plain_string(
 }
 
 /// Turns a single command into a `String` taking plain help format into account.
+#[cfg(all(feature = "cache", feature = "http"))]
 fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<'_>) -> String {
     let mut result = String::default();
     let _ = writeln!(result, "__**{}**__", command.name);

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -50,6 +50,7 @@ use std::{
     borrow::Borrow,
     collections::HashSet,
     fmt::Write,
+    hash::BuildHasher,
     ops::{Index, IndexMut},
     sync::Arc,
 };
@@ -436,7 +437,7 @@ fn fetch_single_command<'a>(
 fn fetch_all_eligible_commands_in_group<'a>(
     context: &Context,
     commands: &[&'static InternalCommand],
-    owners: &HashSet<UserId>,
+    owners: &HashSet<UserId, impl BuildHasher>,
     help_options: &'a HelpOptions,
     group: &'a CommandGroup,
     msg: &Message,
@@ -493,7 +494,7 @@ fn fetch_all_eligible_commands_in_group<'a>(
 fn create_command_group_commands_pair_from_groups<'a>(
     context: &Context,
     groups: &[&'static CommandGroup],
-    owners: &HashSet<UserId>,
+    owners: &HashSet<UserId, impl BuildHasher>,
     msg: &Message,
     help_options: &'a HelpOptions,
 ) -> Vec<GroupCommandsPair> {
@@ -517,7 +518,7 @@ fn create_command_group_commands_pair_from_groups<'a>(
 fn create_single_group<'a>(
     context: &Context,
     group: &CommandGroup,
-    owners: &HashSet<UserId>,
+    owners: &HashSet<UserId, impl BuildHasher>,
     msg: &Message,
     help_options: &HelpOptions,
 ) -> GroupCommandsPair {
@@ -546,7 +547,7 @@ fn create_single_group<'a>(
 pub fn create_customised_help_data<'a>(
     context: &Context,
     groups: &[&'static CommandGroup],
-    owners: &HashSet<UserId>,
+    owners: &HashSet<UserId, impl BuildHasher>,
     args: &'a Args,
     help_options: &'a HelpOptions,
     msg: &Message,
@@ -794,7 +795,7 @@ pub fn with_embeds(
     args: Args,
     help_options: &'static HelpOptions,
     groups: &[&'static CommandGroup],
-    owners: HashSet<UserId>,
+    owners: HashSet<UserId, impl BuildHasher>,
 ) -> CommandResult {
     let formatted_help =
         create_customised_help_data(&context, &groups, &owners, &args, help_options, msg);
@@ -948,7 +949,7 @@ pub fn plain(
     args: Args,
     help_options: &'static HelpOptions,
     groups: &[&'static CommandGroup],
-    owners: HashSet<UserId>,
+    owners: HashSet<UserId, impl BuildHasher>,
 ) -> CommandResult {
     let formatted_help =
         create_customised_help_data(&context, &groups, &owners, &args, help_options, msg);

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -984,6 +984,7 @@ pub fn plain(
 }
 
 #[cfg(test)]
+#[cfg(all(feature = "cache", feature = "http"))]
 mod levenshtein_tests {
     use super::levenshtein_distance;
 
@@ -1036,6 +1037,7 @@ mod levenshtein_tests {
 }
 
 #[cfg(test)]
+#[cfg(all(feature = "cache", feature = "http"))]
 mod matrix_tests {
     use super::Matrix;
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -619,7 +619,7 @@ pub fn create_customised_help_data<'a>(
         &help_options,
     );
 
-    return if listed_groups.is_empty() {
+    if listed_groups.is_empty() {
         CustomisedHelpData::NoCommandFound {
             help_error_message: &help_options.no_help_available_text,
         }
@@ -628,7 +628,7 @@ pub fn create_customised_help_data<'a>(
             help_description: description,
             groups: listed_groups,
         }
-    };
+    }
 }
 
 /// Sends an embed listing all groups with their commands.

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -728,14 +728,12 @@ pub(crate) fn has_correct_permissions(
 ) -> bool {
     if command.required_permissions.is_empty() {
         true
-    } else {
-        if let Some(guild) = message.guild(&cache) {
-            let perms = guild.with(|g| g.permissions_in(message.channel_id, message.author.id));
+    } else if let Some(guild) = message.guild(&cache) {
+        let perms = guild.with(|g| g.permissions_in(message.channel_id, message.author.id));
 
-            perms.contains(command.required_permissions)
-        } else {
-            false
-        }
+        perms.contains(command.required_permissions)
+    } else {
+        false
     }
 }
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -664,7 +664,7 @@ impl Framework for StandardFramework {
                 let owners = self.config.owners.clone();
 
                 // `parse_command` promises to never return a help invocation if `StandardFramework::help` is `None`.
-                let help = self.help.clone().unwrap();
+                let help = self.help.unwrap();
 
                 threadpool.execute(move || {
                     if let Some(before) = before {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -25,7 +25,6 @@ use crate::model::{
     permissions::Permissions,
 };
 use std::collections::HashMap;
-use parking_lot::RwLock;
 use std::sync::Arc;
 use threadpool::ThreadPool;
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -18,10 +18,8 @@ pub use structures::buckets::BucketBuilder;
 use self::parse::*;
 use super::Framework;
 use crate::client::Context;
-use crate::internal::RwLockExt;
 use crate::model::{
     channel::Message,
-    guild::{Guild, Member},
     permissions::Permissions,
 };
 use std::collections::HashMap;
@@ -30,6 +28,10 @@ use threadpool::ThreadPool;
 
 #[cfg(feature = "cache")]
 use crate::cache::CacheRwLock;
+#[cfg(feature = "cache")]
+use crate::model::guild::{Guild, Member};
+#[cfg(feature = "cache")]
+use crate::internal::RwLockExt;
 
 /// An enum representing all possible fail conditions under which a command won't
 /// be executed.
@@ -737,6 +739,7 @@ pub(crate) fn has_correct_permissions(
     }
 }
 
+#[cfg(all(feature = "cache", feature = "http"))]
 pub(crate) fn has_correct_roles(cmd: &CommandOptions, guild: &Guild, member: &Member) -> bool {
     if cmd.allowed_roles.is_empty() {
         true

--- a/src/framework/standard/parse.rs
+++ b/src/framework/standard/parse.rs
@@ -141,14 +141,14 @@ impl CommandGroup {
         self.commands
             .iter()
             .find(|c| c.options.names.contains(&name))
-            .map(|c| *c)
+            .cloned()
     }
 
     #[inline]
     fn command_names(&self) -> impl Iterator<Item = &'static str> {
         self.commands
             .iter()
-            .flat_map(|c| c.options.names.iter().map(|c| *c))
+            .flat_map(|c| c.options.names.iter().cloned())
     }
 
     #[inline]
@@ -168,14 +168,14 @@ impl CommandOptions {
         self.sub
             .iter()
             .find(|c| c.options.names.contains(&name))
-            .map(|c| *c)
+            .cloned()
     }
 
     #[inline]
     fn command_names(&self) -> impl Iterator<Item = &'static str> {
         self.sub
             .iter()
-            .flat_map(|c| c.options.names.iter().map(|c| *c))
+            .flat_map(|c| c.options.names.iter().cloned())
     }
 }
 

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -1,5 +1,7 @@
-use std::fmt;
-use std::collections::HashSet;
+use std::{
+    collections::{HashSet, hash_map::RandomState},
+    fmt,
+};
 use crate::client::Context;
 use crate::model::{
     channel::Message,
@@ -104,17 +106,17 @@ impl PartialEq for Command {
     }
 }
 
-pub type HelpCommandFn = fn(
+pub type HelpCommandFn<H> = fn(
     &mut Context,
     &Message,
     Args,
     &'static HelpOptions,
     &[&'static CommandGroup],
-    HashSet<UserId>,
+    HashSet<UserId, H>,
 ) -> CommandResult;
 
 pub struct HelpCommand {
-    pub fun: HelpCommandFn,
+    pub fun: HelpCommandFn<RandomState>,
     pub options: &'static HelpOptions,
 }
 

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -151,6 +151,7 @@ pub enum HelpBehaviour {
     Nothing,
 }
 
+
 #[derive(Debug, PartialEq)]
 pub struct HelpOptions {
     /// Suggests a command's name.

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -150,10 +150,10 @@ impl ConnectionStage {
     /// [`ConnectionStage::Handshake`]: #variant.Handshake
     /// [`ConnectionStage::Identifying`]: #variant.Identifying
     /// [`ConnectionStage::Resuming`]: #variant.Resuming
-    pub fn is_connecting(&self) -> bool {
+    pub fn is_connecting(self) -> bool {
         use self::ConnectionStage::*;
 
-        match *self {
+        match self {
             Connecting | Handshake | Identifying | Resuming => true,
             Connected | Disconnected => false,
         }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -183,7 +183,7 @@ impl Display for ConnectionStage {
 #[derive(Clone, Debug)]
 pub enum InterMessage {
     #[cfg(feature = "client")]
-    Client(ShardClientMessage),
+    Client(Box<ShardClientMessage>),
     Json(Value),
 }
 

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -795,7 +795,7 @@ impl Shard {
                 self.client.send_resume(
                     &self.shard_info,
                     session_id,
-                    &self.seq,
+                    self.seq,
                     &self.token,
                 )
             },

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -20,7 +20,10 @@ use super::{
     WsClient,
     WebSocketGatewayClientExt,
 };
-use tungstenite::error::Error as TungsteniteError;
+use tungstenite::{
+    error::Error as TungsteniteError,
+    protocol::frame::CloseFrame,
+};
 use url::Url;
 use log::{error, debug, info, trace, warn};
 
@@ -334,6 +337,141 @@ impl Shard {
         self.stage
     }
 
+    fn handle_gateway_dispatch(&mut self, seq: u64, event: &Event) -> Result<Option<ShardAction>> {
+        if seq > self.seq + 1 {
+            warn!("[Shard {:?}] Sequence off; them: {}, us: {}", self.shard_info, seq, self.seq);
+        }
+
+        match *event {
+            Event::Ready(ref ready) => {
+                debug!("[Shard {:?}] Received Ready", self.shard_info);
+
+                self.session_id = Some(ready.ready.session_id.clone());
+                self.stage = ConnectionStage::Connected;
+            },
+            Event::Resumed(_) => {
+                info!("[Shard {:?}] Resumed", self.shard_info);
+
+                self.stage = ConnectionStage::Connected;
+                self.last_heartbeat_acknowledged = true;
+                self.heartbeat_instants = (Some(Instant::now()), None);
+            },
+            _ => {},
+        }
+
+        self.seq = seq;
+
+        Ok(None)
+    }
+
+    fn handle_heartbeat_event(&mut self, s: u64) -> Result<Option<ShardAction>> {
+        info!("[Shard {:?}] Received shard heartbeat", self.shard_info);
+
+        // Received seq is off -- attempt to resume.
+        if s > self.seq + 1 {
+            info!(
+                "[Shard {:?}] Received off sequence (them: {}; us: {}); resuming",
+                self.shard_info,
+                s,
+                self.seq
+            );
+
+            if self.stage == ConnectionStage::Handshake {
+                self.stage = ConnectionStage::Identifying;
+
+                return Ok(Some(ShardAction::Identify));
+            } else {
+                warn!(
+                    "[Shard {:?}] Heartbeat during non-Handshake; auto-reconnecting",
+                    self.shard_info
+                );
+
+                return Ok(Some(ShardAction::Reconnect(self.reconnection_type())));
+            }
+        }
+
+        Ok(Some(ShardAction::Heartbeat))
+    }
+
+    fn handle_gateway_closed(&mut self, data: &Option<CloseFrame<'static>>) -> Result<Option<ShardAction>> {
+        let num = data.as_ref().map(|d| d.code.into());
+        let clean = num == Some(1000);
+
+        match num {
+            Some(close_codes::UNKNOWN_OPCODE) => {
+                warn!("[Shard {:?}] Sent invalid opcode",
+                        self.shard_info);
+            },
+            Some(close_codes::DECODE_ERROR) => {
+                warn!("[Shard {:?}] Sent invalid message",
+                        self.shard_info);
+            },
+            Some(close_codes::NOT_AUTHENTICATED) => {
+                warn!("[Shard {:?}] Sent no authentication",
+                        self.shard_info);
+
+                return Err(Error::Gateway(GatewayError::NoAuthentication));
+            },
+            Some(close_codes::AUTHENTICATION_FAILED) => {
+                warn!("Sent invalid authentication");
+
+                return Err(Error::Gateway(GatewayError::InvalidAuthentication));
+            },
+            Some(close_codes::ALREADY_AUTHENTICATED) => {
+                warn!("[Shard {:?}] Already authenticated",
+                        self.shard_info);
+            },
+            Some(close_codes::INVALID_SEQUENCE) => {
+                warn!("[Shard {:?}] Sent invalid seq: {}",
+                        self.shard_info,
+                        self.seq);
+
+                self.seq = 0;
+            },
+            Some(close_codes::RATE_LIMITED) => {
+                warn!("[Shard {:?}] Gateway ratelimited",
+                        self.shard_info);
+            },
+            Some(close_codes::INVALID_SHARD) => {
+                warn!("[Shard {:?}] Sent invalid shard data",
+                        self.shard_info);
+
+                return Err(Error::Gateway(GatewayError::InvalidShardData));
+            },
+            Some(close_codes::SHARDING_REQUIRED) => {
+                error!("[Shard {:?}] Shard has too many guilds",
+                        self.shard_info);
+
+                return Err(Error::Gateway(GatewayError::OverloadedShard));
+            },
+            Some(4006) | Some(close_codes::SESSION_TIMEOUT) => {
+                info!("[Shard {:?}] Invalid session", self.shard_info);
+
+                self.session_id = None;
+            },
+            Some(other) if !clean => {
+                warn!(
+                    "[Shard {:?}] Unknown unclean close {}: {:?}",
+                    self.shard_info,
+                    other,
+                    data.as_ref().map(|d| &d.reason),
+                );
+            },
+            _ => {},
+        }
+
+        let resume = num.map(|x| {
+            x != close_codes::AUTHENTICATION_FAILED &&
+            self.session_id.is_some()
+        }).unwrap_or(true);
+
+        Ok(Some(if resume {
+            ShardAction::Reconnect(ReconnectType::Resume)
+        } else {
+            ShardAction::Reconnect(ReconnectType::Reidentify)
+        }))
+    }
+
     /// Handles an event from the gateway over the receiver, requiring the
     /// receiver to be passed if a reconnect needs to occur.
     ///
@@ -362,60 +500,8 @@ impl Shard {
     pub(crate) fn handle_event(&mut self, event: &Result<GatewayEvent>)
         -> Result<Option<ShardAction>> {
         match *event {
-            Ok(GatewayEvent::Dispatch(seq, ref event)) => {
-                if seq > self.seq + 1 {
-                    warn!("[Shard {:?}] Sequence off; them: {}, us: {}", self.shard_info, seq, self.seq);
-                }
-
-                match *event {
-                    Event::Ready(ref ready) => {
-                        debug!("[Shard {:?}] Received Ready", self.shard_info);
-
-                        self.session_id = Some(ready.ready.session_id.clone());
-                        self.stage = ConnectionStage::Connected;
-                    },
-                    Event::Resumed(_) => {
-                        info!("[Shard {:?}] Resumed", self.shard_info);
-
-                        self.stage = ConnectionStage::Connected;
-                        self.last_heartbeat_acknowledged = true;
-                        self.heartbeat_instants = (Some(Instant::now()), None);
-                    },
-                    _ => {},
-                }
-
-                self.seq = seq;
-
-                Ok(None)
-            },
-            Ok(GatewayEvent::Heartbeat(s)) => {
-                info!("[Shard {:?}] Received shard heartbeat", self.shard_info);
-
-                // Received seq is off -- attempt to resume.
-                if s > self.seq + 1 {
-                    info!(
-                        "[Shard {:?}] Received off sequence (them: {}; us: {}); resuming",
-                        self.shard_info,
-                        s,
-                        self.seq
-                    );
-
-                    if self.stage == ConnectionStage::Handshake {
-                        self.stage = ConnectionStage::Identifying;
-
-                        return Ok(Some(ShardAction::Identify));
-                    } else {
-                        warn!(
-                            "[Shard {:?}] Heartbeat during non-Handshake; auto-reconnecting",
-                            self.shard_info
-                        );
-
-                        return Ok(Some(ShardAction::Reconnect(self.reconnection_type())));
-                    }
-                }
-
-                Ok(Some(ShardAction::Heartbeat))
-            },
+            Ok(GatewayEvent::Dispatch(seq, ref event)) => self.handle_gateway_dispatch(seq, event),
+            Ok(GatewayEvent::Heartbeat(s)) => self.handle_heartbeat_event(s),
             Ok(GatewayEvent::HeartbeatAck) => {
                 self.heartbeat_instants.1 = Some(Instant::now());
                 self.last_heartbeat_acknowledged = true;
@@ -461,84 +547,7 @@ impl Shard {
             Ok(GatewayEvent::Reconnect) => {
                 Ok(Some(ShardAction::Reconnect(ReconnectType::Reidentify)))
             },
-            Err(Error::Gateway(GatewayError::Closed(ref data))) => {
-                let num = data.as_ref().map(|d| d.code.into());
-                let clean = num == Some(1000);
-
-                match num {
-                    Some(close_codes::UNKNOWN_OPCODE) => {
-                        warn!("[Shard {:?}] Sent invalid opcode",
-                              self.shard_info);
-                    },
-                    Some(close_codes::DECODE_ERROR) => {
-                        warn!("[Shard {:?}] Sent invalid message",
-                              self.shard_info);
-                    },
-                    Some(close_codes::NOT_AUTHENTICATED) => {
-                        warn!("[Shard {:?}] Sent no authentication",
-                              self.shard_info);
-
-                        return Err(Error::Gateway(GatewayError::NoAuthentication));
-                    },
-                    Some(close_codes::AUTHENTICATION_FAILED) => {
-                        warn!("Sent invalid authentication");
-
-                        return Err(Error::Gateway(GatewayError::InvalidAuthentication));
-                    },
-                    Some(close_codes::ALREADY_AUTHENTICATED) => {
-                        warn!("[Shard {:?}] Already authenticated",
-                              self.shard_info);
-                    },
-                    Some(close_codes::INVALID_SEQUENCE) => {
-                        warn!("[Shard {:?}] Sent invalid seq: {}",
-                              self.shard_info,
-                              self.seq);
-
-                        self.seq = 0;
-                    },
-                    Some(close_codes::RATE_LIMITED) => {
-                        warn!("[Shard {:?}] Gateway ratelimited",
-                              self.shard_info);
-                    },
-                    Some(close_codes::INVALID_SHARD) => {
-                        warn!("[Shard {:?}] Sent invalid shard data",
-                              self.shard_info);
-
-                        return Err(Error::Gateway(GatewayError::InvalidShardData));
-                    },
-                    Some(close_codes::SHARDING_REQUIRED) => {
-                        error!("[Shard {:?}] Shard has too many guilds",
-                               self.shard_info);
-
-                        return Err(Error::Gateway(GatewayError::OverloadedShard));
-                    },
-                    Some(4006) | Some(close_codes::SESSION_TIMEOUT) => {
-                        info!("[Shard {:?}] Invalid session", self.shard_info);
-
-                        self.session_id = None;
-                    },
-                    Some(other) if !clean => {
-                        warn!(
-                            "[Shard {:?}] Unknown unclean close {}: {:?}",
-                            self.shard_info,
-                            other,
-                            data.as_ref().map(|d| &d.reason),
-                        );
-                    },
-                    _ => {},
-                }
-
-                let resume = num.map(|x| {
-                    x != close_codes::AUTHENTICATION_FAILED &&
-                    self.session_id.is_some()
-                }).unwrap_or(true);
-
-                Ok(Some(if resume {
-                    ShardAction::Reconnect(ReconnectType::Resume)
-                } else {
-                    ShardAction::Reconnect(ReconnectType::Reidentify)
-                }))
-            },
+            Err(Error::Gateway(GatewayError::Closed(ref data))) => self.handle_gateway_closed(&data),
             Err(Error::Tungstenite(ref why)) => {
                 warn!("[Shard {:?}] Websocket error: {:?}",
                       self.shard_info,

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -496,7 +496,6 @@ impl Shard {
     ///
     /// Returns a `GatewayError::OverloadedShard` if the shard would have too
     /// many guilds assigned to it.
-    #[allow(clippy::cognitive_complexity)]
     pub(crate) fn handle_event(&mut self, event: &Result<GatewayEvent>)
         -> Result<Option<ShardAction>> {
         match *event {

--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -33,7 +33,7 @@ pub trait WebSocketGatewayClientExt {
         &mut self,
         shard_info: &[u64; 2],
         session_id: &str,
-        seq: &u64,
+        seq: u64,
         token: &str,
     ) -> Result<()>;
 }
@@ -118,7 +118,7 @@ impl WebSocketGatewayClientExt for WsClient {
         &mut self,
         shard_info: &[u64; 2],
         session_id: &str,
-        seq: &u64,
+        seq: u64,
         token: &str,
     ) -> Result<()> {
         debug!("[Shard {:?}] Sending resume; seq: {}", shard_info, seq);

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -16,7 +16,7 @@ use std::{
 #[derive(Debug)]
 pub enum Error {
     /// When a non-successful status code was received for a request.
-    UnsuccessfulRequest(Response),
+    UnsuccessfulRequest(Box<Response>),
     /// When the decoding of a ratelimit header could not be properly decoded
     /// into an `i64`.
     RateLimitI64,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -62,8 +62,8 @@ pub enum LightMethod {
 }
 
 impl LightMethod {
-    pub fn reqwest_method(&self) -> Method {
-        match *self {
+    pub fn reqwest_method(self) -> Method {
+        match self {
             LightMethod::Delete => Method::DELETE,
             LightMethod::Get => Method::GET,
             LightMethod::Patch => Method::PATCH,

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -38,8 +38,6 @@
 //! differentiating between different ratelimits.
 //!
 //! [Taken from]: https://discordapp.com/developers/docs/topics/rate-limits#rate-limits
-#![allow(clippy::zero_ptr)]
-
 pub use super::routing::Route;
 
 use chrono::{DateTime, Utc};

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -295,11 +295,11 @@ fn calculate_offset(header: &Option<&[u8]>) {
 fn parse_header(headers: &Headers, header: &str) -> Result<Option<i64>> {
     headers.get(header).map_or(Ok(None), |header| {
         str::from_utf8(&header.as_bytes())
-            .map_err(|_| Error::Http(HttpError::RateLimitUtf8))
+            .map_err(|_| Error::from(HttpError::RateLimitUtf8))
             .and_then(|v| {
                 v.parse::<i64>()
                     .map(Some)
-                    .map_err(|_| Error::Http(HttpError::RateLimitI64))
+                    .map_err(|_| Error::from(HttpError::RateLimitI64))
             })
     })
 }

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -1527,7 +1527,7 @@ impl Http {
             .multipart(multipart).send()?;
 
         if !response.status().is_success() {
-            return Err(HttpError::UnsuccessfulRequest(response).into());
+            return Err(HttpError::UnsuccessfulRequest(Box::new(response)).into());
         }
 
         serde_json::from_reader(response).map_err(From::from)
@@ -1721,7 +1721,7 @@ impl Http {
         if response.status().is_success() {
             Ok(response)
         } else {
-            Err(Error::from(HttpError::UnsuccessfulRequest(response)))
+            Err(Error::from(HttpError::UnsuccessfulRequest(Box::new(response))))
         }
     }
 
@@ -1757,16 +1757,16 @@ impl Http {
     /// This is a function that performs a light amount of work and returns an
     /// empty tuple, so it's called "self.wind" to denote that it's lightweight.
     pub(super) fn wind(&self, expected: u16, req: Request<'_>) -> Result<()> {
-        let resp = self.request(req)?;
+        let response = self.request(req)?;
 
-        if resp.status().as_u16() == expected {
+        if response.status().as_u16() == expected {
             return Ok(());
         }
 
-        debug!("Expected {}, got {}", expected, resp.status());
-        trace!("Unsuccessful response: {:?}", resp);
+        debug!("Expected {}, got {}", expected, response.status());
+        trace!("Unsuccessful response: {:?}", response);
 
-        Err(Error::from(HttpError::UnsuccessfulRequest(resp)))
+        Err(Error::from(HttpError::UnsuccessfulRequest(Box::new(response))))
     }
 }
 

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -1721,7 +1721,7 @@ impl Http {
         if response.status().is_success() {
             Ok(response)
         } else {
-            Err(Error::Http(HttpError::UnsuccessfulRequest(response)))
+            Err(Error::from(HttpError::UnsuccessfulRequest(response)))
         }
     }
 
@@ -1766,7 +1766,7 @@ impl Http {
         debug!("Expected {}, got {}", expected, resp.status());
         trace!("Unsuccessful response: {:?}", resp);
 
-        Err(Error::Http(HttpError::UnsuccessfulRequest(resp)))
+        Err(Error::from(HttpError::UnsuccessfulRequest(resp)))
     }
 }
 

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -1224,7 +1224,6 @@ impl Http {
     }
 
     /// Gets information about a specific invite.
-    #[allow(clippy::unused_mut)]
     pub fn get_invite(&self, mut code: &str, stats: bool) -> Result<Invite> {
         #[cfg(feature = "utils")]
             {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -83,7 +83,7 @@ impl<'a> Request<'a> {
         let mut headers = Headers::with_capacity(4);
         headers.insert(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT));
         headers.insert(AUTHORIZATION,
-            HeaderValue::from_str(&token).map_err(|e| HttpError::InvalidHeader(e))?);
+            HeaderValue::from_str(&token).map_err(HttpError::InvalidHeader)?);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
         headers.insert(CONTENT_LENGTH, HeaderValue::from_static(&"0"));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,6 @@
 //! [examples]: https://github.com/serenity-rs/serenity/tree/current/examples
 //! [gateway docs]: gateway/index.html
 #![doc(html_root_url = "https://docs.rs/serenity/*")]
-#![allow(unknown_lints)]
-#![allow(clippy::doc_markdown, clippy::inline_always)]
-#![warn(clippy::enum_glob_use, clippy::if_not_else)]
 #![deny(rust_2018_idioms)]
 
 #[macro_use]

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -129,7 +129,6 @@ impl ChannelCategory {
                 position,
                 kind,
             };
-            ()
         })
     }
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -411,11 +411,11 @@ impl ChannelId {
 
     /// Returns the name of whatever channel this id holds.
     #[cfg(all(feature = "model", feature = "client"))]
-    pub fn name(self, context: &Context) -> Option<String> {
+    pub fn name(self, _context: &Context) -> Option<String> {
         use self::Channel::*;
 
         let finding = feature_cache! {{
-            Some(self.to_channel_cached(&context.cache))
+            Some(self.to_channel_cached(&_context.cache))
         } else {
             None
         }};

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -49,7 +49,7 @@ impl ChannelId {
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().broadcast_typing(self.0) }
+    pub fn broadcast_typing(self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().broadcast_typing(self.0) }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a
     /// single [`Member`] or [`Role`] within the channel.
@@ -66,7 +66,7 @@ impl ChannelId {
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_permission(&self, http: impl AsRef<Http>, target: &PermissionOverwrite) -> Result<()> {
+    pub fn create_permission(self, http: impl AsRef<Http>, target: &PermissionOverwrite) -> Result<()> {
         let (id, kind) = match target.kind {
             PermissionOverwriteType::Member(id) => (id.0, "member"),
             PermissionOverwriteType::Role(id) => (id.0, "role"),
@@ -96,7 +96,7 @@ impl ChannelId {
     /// [Add Reactions]: ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_reaction<M, R>(&self, http: impl AsRef<Http>, message_id: M, reaction_type: R) -> Result<()>
+    pub fn create_reaction<M, R>(self, http: impl AsRef<Http>, message_id: M, reaction_type: R) -> Result<()>
         where M: Into<MessageId>, R: Into<ReactionType> {
         self._create_reaction(&http, message_id.into(), &reaction_type.into())
     }
@@ -113,7 +113,7 @@ impl ChannelId {
     /// Deletes this channel, returning the channel on a successful deletion.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete(&self, http: impl AsRef<Http>) -> Result<Channel> { http.as_ref().delete_channel(self.0) }
+    pub fn delete(self, http: impl AsRef<Http>) -> Result<Channel> { http.as_ref().delete_channel(self.0) }
 
     /// Deletes a [`Message`] given its Id.
     ///
@@ -127,7 +127,7 @@ impl ChannelId {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
+    pub fn delete_message<M: Into<MessageId>>(self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self._delete_message(&http, message_id.into())
     }
 
@@ -155,7 +155,7 @@ impl ChannelId {
     /// [`ModelError::BulkDeleteAmount`]: ../error/enum.Error.html#variant.BulkDeleteAmount
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
-    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: impl AsRef<Http>, message_ids: It) -> Result<()> {
+    pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(self, http: impl AsRef<Http>, message_ids: It) -> Result<()> {
         let ids = message_ids
             .into_iter()
             .map(|message_id| message_id.as_ref().0)
@@ -185,7 +185,7 @@ impl ChannelId {
     ///
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
-    pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
+    pub fn delete_permission(self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         http.as_ref().delete_permission(
             self.0,
             match permission_type {
@@ -204,7 +204,7 @@ impl ChannelId {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_reaction<M, R>(&self,
+    pub fn delete_reaction<M, R>(self,
                                  http: impl AsRef<Http>,
                                  message_id: M,
                                  user_id: Option<UserId>,
@@ -256,7 +256,7 @@ impl ChannelId {
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(all(feature = "utils", feature = "http"))]
     #[inline]
-    pub fn edit<F: FnOnce(&mut EditChannel) -> &mut EditChannel>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildChannel> {
+    pub fn edit<F: FnOnce(&mut EditChannel) -> &mut EditChannel>(self, http: impl AsRef<Http>, f: F) -> Result<GuildChannel> {
         let mut channel = EditChannel::default();
         f(&mut channel);
 
@@ -286,7 +286,7 @@ impl ChannelId {
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
     #[cfg(all(feature = "utils", feature = "http"))]
     #[inline]
-    pub fn edit_message<F, M>(&self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
+    pub fn edit_message<F, M>(self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self._edit_message(&http, message_id.into(), f)
     }
@@ -352,7 +352,7 @@ impl ChannelId {
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {http.as_ref().get_channel_invites(self.0) }
+    pub fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {http.as_ref().get_channel_invites(self.0) }
 
     /// Gets a message from the channel.
     ///
@@ -361,7 +361,7 @@ impl ChannelId {
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
     #[inline]
-    pub fn message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
+    pub fn message<M: Into<MessageId>>(self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
         self._message(&http, message_id.into())
     }
 
@@ -383,7 +383,7 @@ impl ChannelId {
     /// [`Channel::messages`]: ../channel/enum.Channel.html#method.messages
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
-    pub fn messages<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Vec<Message>>
+    pub fn messages<F>(self, http: impl AsRef<Http>, f: F) -> Result<Vec<Message>>
         where F: FnOnce(&mut GetMessages) -> &mut GetMessages {
         let mut get_messages = GetMessages::default();
         f(&mut get_messages);
@@ -411,7 +411,7 @@ impl ChannelId {
 
     /// Returns the name of whatever channel this id holds.
     #[cfg(all(feature = "model", feature = "client"))]
-    pub fn name(&self, context: &Context) -> Option<String> {
+    pub fn name(self, context: &Context) -> Option<String> {
         use self::Channel::*;
 
         let finding = feature_cache! {{
@@ -442,7 +442,7 @@ impl ChannelId {
     /// [`Message`]: ../channel/struct.Message.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
+    pub fn pin<M: Into<MessageId>>(self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self._pin(&http, message_id.into())
     }
 
@@ -455,7 +455,7 @@ impl ChannelId {
     /// [`Message`]: ../channel/struct.Message.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> {http.as_ref().get_pins(self.0) }
+    pub fn pins(self, http: impl AsRef<Http>) -> Result<Vec<Message>> {http.as_ref().get_pins(self.0) }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a
     /// certain [`Emoji`].
@@ -470,7 +470,7 @@ impl ChannelId {
     /// [`User`]: ../user/struct.User.html
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[cfg(feature = "http")]
-    pub fn reaction_users<M, R, U>(&self,
+    pub fn reaction_users<M, R, U>(self,
         http: impl AsRef<Http>,
         message_id: M,
         reaction_type: R,
@@ -520,7 +520,7 @@ impl ChannelId {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say<D>(&self, http: impl AsRef<Http>, content: D) -> Result<Message>
+    pub fn say<D>(self, http: impl AsRef<Http>, content: D) -> Result<Message>
     where D: ::std::fmt::Display {
         self.send_message(&http, |m| {
             m.content(content)
@@ -596,7 +596,7 @@ impl ChannelId {
     /// [Attach Files]: ../permissions/struct.Permissions.html#associatedconstant.ATTACH_FILES
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(all(feature = "utils", feature = "http"))]
-    pub fn send_files<'a, F, T, It>(&self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It>(self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b>,
               T: Into<AttachmentType<'a>>, It: IntoIterator<Item=T> {
         let mut create_message = CreateMessage::default();
@@ -639,7 +639,7 @@ impl ChannelId {
     /// [`CreateMessage`]: ../../builder/struct.CreateMessage.html
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(all(feature = "utils", feature = "http"))]
-    pub fn send_message<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Message>
+    pub fn send_message<F>(self, http: impl AsRef<Http>, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'b>) -> &'b mut CreateMessage<'b> {
         let mut create_message = CreateMessage::default();
         let msg = f(&mut create_message);
@@ -678,7 +678,7 @@ impl ChannelId {
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn unpin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
+    pub fn unpin<M: Into<MessageId>>(self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self._unpin(&http, message_id.into())
     }
 
@@ -694,7 +694,7 @@ impl ChannelId {
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {http.as_ref().get_channel_webhooks(self.0) }
+    pub fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {http.as_ref().get_channel_webhooks(self.0) }
 }
 
 impl From<Channel> for ChannelId {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -665,10 +665,10 @@ enum_number!(
 );
 
 impl MessageType {
-    pub fn num(&self) -> u64 {
+    pub fn num(self) -> u64 {
         use self::MessageType::*;
 
-        match *self {
+        match self {
             Regular => 0,
             GroupRecipientAddition => 1,
             GroupRecipientRemoval => 2,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -430,8 +430,8 @@ impl ChannelType {
         }
     }
 
-    pub fn num(&self) -> u64 {
-        match *self {
+    pub fn num(self) -> u64 {
+        match self {
             ChannelType::Text => 0,
             ChannelType::Private => 1,
             ChannelType::Voice => 2,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -306,10 +306,10 @@ impl CacheUpdate for ChannelUpdateEvent {
                 }
             },
             Channel::Category(ref category) => {
-                cache
+                if let Some(c) = cache
                     .categories
                     .get_mut(&category.read().id)
-                    .map(|c| c.clone_from(category));
+                    { c.clone_from(category) }
             },
         }
 
@@ -728,7 +728,7 @@ impl CacheUpdate for GuildUpdateEvent {
     type Output = ();
 
     fn update(&mut self, cache: &mut Cache) -> Option<()> {
-        cache.guilds.get_mut(&self.guild.id).map(|guild| {
+        if let Some(guild) = cache.guilds.get_mut(&self.guild.id) {
             let mut guild = guild.write();
 
             guild.afk_timeout = self.guild.afk_timeout;
@@ -739,7 +739,7 @@ impl CacheUpdate for GuildUpdateEvent {
             guild.region.clone_from(&self.guild.region);
             guild.roles.clone_from(&self.guild.roles);
             guild.verification_level = self.guild.verification_level;
-        });
+        }
 
         None
     }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1864,13 +1864,11 @@ impl<'de> Deserialize<'de> for EventType {
     }
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct VoiceHeartbeat {
     pub nonce: u64,
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Copy, Debug, Serialize)]
 pub struct VoiceHeartbeatAck {
     pub nonce: u64,
@@ -1883,7 +1881,6 @@ impl<'de> Deserialize<'de> for VoiceHeartbeatAck {
     }
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VoiceReady {
     pub heartbeat_interval: u64,
@@ -1892,20 +1889,17 @@ pub struct VoiceReady {
     pub ssrc: u32,
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VoiceHello {
     pub heartbeat_interval: u64,
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VoiceSessionDescription {
     pub mode: String,
     pub secret_key: Vec<u8>,
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct VoiceSpeaking {
     pub speaking: bool,
@@ -1913,7 +1907,6 @@ pub struct VoiceSpeaking {
     pub user_id: UserId,
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VoiceResume {
     pub server_id: String,
@@ -1921,7 +1914,6 @@ pub struct VoiceResume {
     pub token: String,
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct VoiceClientConnect {
     pub audio_ssrc: u32,
@@ -1929,7 +1921,6 @@ pub struct VoiceClientConnect {
     pub video_ssrc: u32,
 }
 
-#[allow(clippy::missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct VoiceClientDisconnect {
     pub user_id: UserId,

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -430,12 +430,12 @@ impl<'de> Deserialize<'de> for Presence {
             .map_err(DeError::custom)?;
 
         Ok(Presence {
-            activity: activity,
-            last_modified: last_modified,
-            nick: nick,
-            status: status,
-            user: user,
-            user_id: user_id,
+            activity,
+            last_modified,
+            nick,
+            status,
+            user,
+            user_id,
         })
     }
 }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -339,10 +339,10 @@ enum_number!(
 );
 
 impl ActivityType {
-    pub fn num(&self) -> u64 {
+    pub fn num(self) -> u64 {
         use self::ActivityType::*;
 
-        match *self {
+        match self {
             Playing => 0,
             Streaming => 1,
             Listening => 2,

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -284,6 +284,8 @@ mod u64_handler {
         des.deserialize_any(U64Visitor)
     }
 
+    // Due to `Serialize`.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn serialize<S: Serializer>(num: &u64, s: S) -> StdResult<S::Ok, S::Error> {
         s.serialize_u64(*num)
     }

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -5,8 +5,9 @@ use std::fmt::{
     Write as FmtWrite
 };
 use super::super::id::{EmojiId, RoleId};
-use serde_json::json;
 
+#[cfg(all(feature = "cache", feature = "model"))]
+use serde_json::json;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
 #[cfg(all(feature = "cache", feature = "model"))]

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -47,7 +47,7 @@ impl GuildId {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn ban<U, BO>(&self, http: impl AsRef<Http>, user: U, ban_options: &BO) -> Result<()>
+    pub fn ban<U, BO>(self, http: impl AsRef<Http>, user: U, ban_options: &BO) -> Result<()>
         where U: Into<UserId>, BO: BanOptions {
         self._ban(&http, user.into(), (ban_options.dmd(), ban_options.reason()))
     }
@@ -74,12 +74,12 @@ impl GuildId {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn bans(&self, http: impl AsRef<Http>) -> Result<Vec<Ban>> {http.as_ref().get_bans(self.0) }
+    pub fn bans(self, http: impl AsRef<Http>) -> Result<Vec<Ban>> {http.as_ref().get_bans(self.0) }
 
     /// Gets a list of the guild's audit log entries
     #[cfg(feature = "http")]
     #[inline]
-    pub fn audit_logs(&self, http: impl AsRef<Http>,
+    pub fn audit_logs(self, http: impl AsRef<Http>,
                              action_type: Option<u8>,
                              user_id: Option<UserId>,
                              before: Option<AuditLogEntryId>,
@@ -91,7 +91,7 @@ impl GuildId {
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     #[cfg(feature = "http")]
-    pub fn channels(&self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> {
+    pub fn channels(self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> {
         let mut channels = HashMap::new();
 
         for channel in http.as_ref().get_channels(self.0)? {
@@ -123,7 +123,7 @@ impl GuildId {
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_channel<C>(&self, http: impl AsRef<Http>, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
+    pub fn create_channel<C>(self, http: impl AsRef<Http>, name: &str, kind: ChannelType, category: C) -> Result<GuildChannel>
         where C: Into<Option<ChannelId>> {
         self._create_channel(&http, name, kind, category.into())
     }
@@ -164,7 +164,7 @@ impl GuildId {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_emoji(&self, http: impl AsRef<Http>, name: &str, image: &str) -> Result<Emoji> {
+    pub fn create_emoji(self, http: impl AsRef<Http>, name: &str, image: &str) -> Result<Emoji> {
         let map = json!({
             "name": name,
             "image": image,
@@ -180,7 +180,7 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_integration<I>(&self, http: impl AsRef<Http>, integration_id: I, kind: &str) -> Result<()>
+    pub fn create_integration<I>(self, http: impl AsRef<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
         self._create_integration(&http, integration_id.into(), kind)
     }
@@ -210,7 +210,7 @@ impl GuildId {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn create_role<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Role>
+    pub fn create_role<F>(self, http: impl AsRef<Http>, f: F) -> Result<Role>
     where F: FnOnce(&mut EditRole) -> &mut EditRole {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
@@ -235,7 +235,7 @@ impl GuildId {
     /// [`Guild::delete`]: ../guild/struct.Guild.html#method.delete
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete(&self, http: impl AsRef<Http>) -> Result<PartialGuild> { http.as_ref().delete_guild(self.0) }
+    pub fn delete(self, http: impl AsRef<Http>) -> Result<PartialGuild> { http.as_ref().delete_guild(self.0) }
 
     /// Deletes an [`Emoji`] from the guild.
     ///
@@ -245,7 +245,7 @@ impl GuildId {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E) -> Result<()> {
+    pub fn delete_emoji<E: Into<EmojiId>>(self, http: impl AsRef<Http>, emoji_id: E) -> Result<()> {
         self._delete_emoji(&http, emoji_id.into())
     }
 
@@ -261,7 +261,7 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_integration<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
+    pub fn delete_integration<I: Into<IntegrationId>>(self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self._delete_integration(&http, integration_id.into())
     }
 
@@ -281,7 +281,7 @@ impl GuildId {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn delete_role<R: Into<RoleId>>(&self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
+    pub fn delete_role<R: Into<RoleId>>(self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
         self._delete_role(&http, role_id.into())
     }
 
@@ -322,7 +322,7 @@ impl GuildId {
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
+    pub fn edit_emoji<E: Into<EmojiId>>(self, http: impl AsRef<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
         self._edit_emoji(&http, emoji_id.into(), name)
     }
 
@@ -349,7 +349,7 @@ impl GuildId {
     /// ```
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_member<F, U>(&self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
+    pub fn edit_member<F, U>(self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
         self._edit_member(&http, user_id.into(), f)
     }
@@ -371,7 +371,7 @@ impl GuildId {
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_nickname(&self, http: impl AsRef<Http>, new_nickname: Option<&str>) -> Result<()> {
+    pub fn edit_nickname(self, http: impl AsRef<Http>, new_nickname: Option<&str>) -> Result<()> {
         http.as_ref().edit_nickname(self.0, new_nickname)
     }
 
@@ -393,7 +393,7 @@ impl GuildId {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_role<F, R>(&self, http: impl AsRef<Http>, role_id: R, f: F) -> Result<Role>
+    pub fn edit_role<F, R>(self, http: impl AsRef<Http>, role_id: R, f: F) -> Result<Role>
         where F: FnOnce(EditRole) -> EditRole, R: Into<RoleId> {
         self._edit_role(&http, role_id.into(), f)
     }
@@ -422,14 +422,14 @@ impl GuildId {
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
-    pub fn edit_role_position<R>(&self, http: impl AsRef<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
+    pub fn edit_role_position<R>(self, http: impl AsRef<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
         where R: Into<RoleId> {
         self._edit_role_position(&http, role_id.into(), position)
     }
 
     #[cfg(feature = "http")]
     fn _edit_role_position(
-        &self,
+        self,
         http: impl AsRef<Http>,
         role_id: RoleId,
         position: u64,
@@ -460,7 +460,7 @@ impl GuildId {
     /// This performs a request over the REST API.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {http.as_ref().get_guild_integrations(self.0) }
+    pub fn integrations(self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {http.as_ref().get_guild_integrations(self.0) }
 
     /// Gets all of the guild's invites.
     ///
@@ -469,7 +469,7 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {http.as_ref().get_guild_invites(self.0) }
+    pub fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {http.as_ref().get_guild_invites(self.0) }
 
     /// Kicks a [`Member`] from the guild.
     ///
@@ -479,14 +479,14 @@ impl GuildId {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
+    pub fn kick<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
         http.as_ref().kick_member(self.0, user_id.into().0)
     }
 
     /// Leaves the guild.
     #[cfg(feature = "http")]
     #[inline]
-    pub fn leave(&self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().leave_guild(self.0) }
+    pub fn leave(self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().leave_guild(self.0) }
 
     /// Gets a user's [`Member`] for the guild by Id.
     ///
@@ -497,12 +497,12 @@ impl GuildId {
     /// [`Member`]: ../guild/struct.Member.html
     #[cfg(feature = "client")]
     #[inline]
-    pub fn member<U: Into<UserId>>(&self, context: &Context, user_id: U) -> Result<Member> {
+    pub fn member<U: Into<UserId>>(self, context: &Context, user_id: U) -> Result<Member> {
         self._member(&context, user_id.into())
     }
 
     #[cfg(feature = "client")]
-    fn _member(&self, context: &Context, user_id: UserId) -> Result<Member> {
+    fn _member(self, context: &Context, user_id: UserId) -> Result<Member> {
         #[cfg(feature = "cache")]
         {
             if let Some(member) = context.cache.read().member(self.0, user_id) {
@@ -522,13 +522,13 @@ impl GuildId {
     /// [`User`]: ../user/struct.User.html
     #[cfg(feature = "http")]
     #[inline]
-    pub fn members<U>(&self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
+    pub fn members<U>(self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<U>) -> Result<Vec<Member>>
         where U: Into<UserId> {
         self._members(&http, limit, after.map(Into::into))
     }
 
     #[cfg(feature = "http")]
-    fn _members(&self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<UserId>) -> Result<Vec<Member>> {
+    fn _members(self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<UserId>) -> Result<Vec<Member>> {
         http.as_ref().get_guild_members(self.0, limit, after.map(|x| x.0))
     }
 
@@ -539,14 +539,14 @@ impl GuildId {
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn move_member<C, U>(&self, http: impl AsRef<Http>, user_id: U, channel_id: C) -> Result<()>
+    pub fn move_member<C, U>(self, http: impl AsRef<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
         self._move_member(&http, user_id.into(), channel_id.into())
     }
 
     #[cfg(feature = "http")]
     fn _move_member(
-        &self,
+        self,
         http: impl AsRef<Http>,
         user_id: UserId,
         channel_id: ChannelId,
@@ -568,7 +568,7 @@ impl GuildId {
     /// [`Member`]: ../guild/struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
-    pub fn prune_count(&self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
+    pub fn prune_count(self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
         let map = json!({
             "days": days,
         });
@@ -585,12 +585,12 @@ impl GuildId {
     /// regardless of whether they were updated. Otherwise, positioning can
     /// sometimes get weird.
     #[inline]
-    pub fn reorder_channels<It>(&self, http: impl AsRef<Http>, channels: It) -> Result<()>
+    pub fn reorder_channels<It>(self, http: impl AsRef<Http>, channels: It) -> Result<()>
         where It: IntoIterator<Item = (ChannelId, u64)> {
         self._reorder_channels(&http, channels.into_iter().collect())
     }
 
-    fn _reorder_channels(&self, http: impl AsRef<Http>, channels: Vec<(ChannelId, u64)>) -> Result<()> {
+    fn _reorder_channels(self, http: impl AsRef<Http>, channels: Vec<(ChannelId, u64)>) -> Result<()> {
         let items = channels.into_iter().map(|(id, pos)| json!({
             "id": id,
             "position": pos,
@@ -611,7 +611,7 @@ impl GuildId {
     /// [`utils::shard_id`]: ../../utils/fn.shard_id.html
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
-    pub fn shard_id(&self, cache: impl AsRef<CacheRwLock>) -> u64 {
+    pub fn shard_id(self, cache: impl AsRef<CacheRwLock>) -> u64 {
         crate::utils::shard_id(self.0, cache.as_ref().read().shard_count)
     }
 
@@ -638,7 +638,7 @@ impl GuildId {
     /// ```
     #[cfg(all(feature = "utils", not(feature = "cache")))]
     #[inline]
-    pub fn shard_id(&self, shard_count: u64) -> u64 { crate::utils::shard_id(self.0, shard_count) }
+    pub fn shard_id(self, shard_count: u64) -> u64 { crate::utils::shard_id(self.0, shard_count) }
 
     /// Starts an integration sync for the given integration Id.
     ///
@@ -647,13 +647,13 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
+    pub fn start_integration_sync<I: Into<IntegrationId>>(self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self._start_integration_sync(&http, integration_id.into())
     }
 
     #[cfg(feature = "http")]
     fn _start_integration_sync(
-        &self,
+        self,
         http: impl AsRef<Http>,
         integration_id: IntegrationId,
     ) -> Result<()> {
@@ -671,7 +671,7 @@ impl GuildId {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn start_prune(&self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
+    pub fn start_prune(self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
         let map = json!({
             "days": days,
         });
@@ -687,7 +687,7 @@ impl GuildId {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn unban<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
+    pub fn unban<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
         self._unban(&http, user_id.into())
     }
 
@@ -703,7 +703,7 @@ impl GuildId {
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "http")]
     #[inline]
-    pub fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
+    pub fn vanity_url(self, http: impl AsRef<Http>) -> Result<String> {
         http.as_ref().get_guild_vanity_url(self.0)
     }
 
@@ -713,7 +713,7 @@ impl GuildId {
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     #[inline]
-    pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {http.as_ref().get_guild_webhooks(self.0) }
+    pub fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {http.as_ref().get_guild_webhooks(self.0) }
 }
 
 impl From<PartialGuild> for GuildId {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use crate::utils::Colour;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::{cache::CacheRwLock, utils};
-#[cfg(all(feature = "http"))]
+#[cfg(all(feature = "http", feature = "cache"))]
 use crate::http::Http;
 
 /// A trait for allowing both u8 or &str or (u8, &str) to be passed into the `ban` methods in `Guild` and `Member`.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1958,8 +1958,8 @@ enum_number!(
 );
 
 impl MfaLevel {
-    pub fn num(&self) -> u64 {
-        match *self {
+    pub fn num(self) -> u64 {
+        match self {
             MfaLevel::None => 0,
             MfaLevel::Elevated => 1,
         }
@@ -2043,8 +2043,8 @@ enum_number!(
 );
 
 impl VerificationLevel {
-    pub fn num(&self) -> u64 {
-        match *self {
+    pub fn num(self) -> u64 {
+        match self {
             VerificationLevel::None => 0,
             VerificationLevel::Low => 1,
             VerificationLevel::Medium => 2,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1904,8 +1904,8 @@ enum_number!(
 );
 
 impl DefaultMessageNotificationLevel {
-    pub fn num(&self) -> u64 {
-        match *self {
+    pub fn num(self) -> u64 {
+        match self {
             DefaultMessageNotificationLevel::All => 0,
             DefaultMessageNotificationLevel::Mentions => 1,
         }
@@ -1932,8 +1932,8 @@ enum_number!(
 );
 
 impl ExplicitContentFilter {
-    pub fn num(&self) -> u64 {
-        match *self {
+    pub fn num(self) -> u64 {
+        match self {
             ExplicitContentFilter::None => 0,
             ExplicitContentFilter::WithoutRole => 1,
             ExplicitContentFilter::All => 2,

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -51,12 +51,6 @@ macro_rules! id_u64 {
                 }
             }
 
-            impl PartialEq for $name {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0 == other.0
-                }
-            }
-
             impl PartialEq<u64> for $name {
                 fn eq(&self, u: &u64) -> bool {
                     self.0 == *u
@@ -91,53 +85,43 @@ macro_rules! id_u64 {
 }
 
 /// An identifier for an Application.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct ApplicationId(pub u64);
 
 /// An identifier for a Channel
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct ChannelId(pub u64);
 
 /// An identifier for an Emoji
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct EmojiId(pub u64);
 
 /// An identifier for a Guild
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct GuildId(pub u64);
 
 /// An identifier for an Integration
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct IntegrationId(pub u64);
 
 /// An identifier for a Message
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct MessageId(pub u64);
 
 /// An identifier for a Role
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct RoleId(pub u64);
 
 /// An identifier for a User
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct UserId(pub u64);
 
 /// An identifier for a [`Webhook`](../webhook/struct.Webhook.html).
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct WebhookId(pub u64);
 
 /// An identifier for an audit log entry.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialOrd, Ord, Serialize)]
-#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct AuditLogEntryId(pub u64);
 
 id_u64! {

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -127,7 +127,6 @@ impl Invite {
 
     /// Gets the information about an invite.
     #[cfg(feature = "http")]
-    #[allow(clippy::unused_mut)]
     pub fn get(http: impl AsRef<Http>, code: &str, stats: bool) -> Result<Invite> {
         let mut invite = code;
 

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -274,181 +274,181 @@ impl Permissions {
     /// [Add Reactions] permission.
     ///
     /// [Add Reactions]: #associatedconstant.ADD_REACTIONS
-    pub fn add_reactions(&self) -> bool { self.contains(Self::ADD_REACTIONS) }
+    pub fn add_reactions(self) -> bool { self.contains(Self::ADD_REACTIONS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Administrator] permission.
     ///
     /// [Administrator]: #associatedconstant.ADMINISTRATOR
-    pub fn administrator(&self) -> bool { self.contains(Self::ADMINISTRATOR) }
+    pub fn administrator(self) -> bool { self.contains(Self::ADMINISTRATOR) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Attach Files] permission.
     ///
     /// [Attach Files]: #associatedconstant.ATTACH_FILES
-    pub fn attach_files(&self) -> bool { self.contains(Self::ATTACH_FILES) }
+    pub fn attach_files(self) -> bool { self.contains(Self::ATTACH_FILES) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Ban Members] permission.
     ///
     /// [Ban Members]: #associatedconstant.BAN_MEMBERS
-    pub fn ban_members(&self) -> bool { self.contains(Self::BAN_MEMBERS) }
+    pub fn ban_members(self) -> bool { self.contains(Self::BAN_MEMBERS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Change Nickname] permission.
     ///
     /// [Change Nickname]: #associatedconstant.CHANGE_NICKNAME
-    pub fn change_nickname(&self) -> bool { self.contains(Self::CHANGE_NICKNAME) }
+    pub fn change_nickname(self) -> bool { self.contains(Self::CHANGE_NICKNAME) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Connect] permission.
     ///
     /// [Connect]: #associatedconstant.CONNECT
-    pub fn connect(&self) -> bool { self.contains(Self::CONNECT) }
+    pub fn connect(self) -> bool { self.contains(Self::CONNECT) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [View Audit Log] permission.
     ///
     /// [View Audit Log]: #associatedconstant.VIEW_AUDIT_LOG
-    pub fn view_audit_log(&self) -> bool { self.contains(Self::VIEW_AUDIT_LOG) }
+    pub fn view_audit_log(self) -> bool { self.contains(Self::VIEW_AUDIT_LOG) }
 
     /// Shorthand for checking that the set of permission contains the
     /// [Priority Speaker] permission.
     ///
     /// [Priority Speaker]: #associatedconstant.PRIORITY_SPEAKER
-    pub fn priority_speaker(&self) -> bool { self.contains(Self::PRIORITY_SPEAKER) }
+    pub fn priority_speaker(self) -> bool { self.contains(Self::PRIORITY_SPEAKER) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Create Invite] permission.
     ///
     /// [Create Invite]: #associatedconstant.CREATE_INVITE
-    pub fn create_invite(&self) -> bool { self.contains(Self::CREATE_INVITE) }
+    pub fn create_invite(self) -> bool { self.contains(Self::CREATE_INVITE) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Deafen Members] permission.
     ///
     /// [Deafen Members]: #associatedconstant.DEAFEN_MEMBERS
-    pub fn deafen_members(&self) -> bool { self.contains(Self::DEAFEN_MEMBERS) }
+    pub fn deafen_members(self) -> bool { self.contains(Self::DEAFEN_MEMBERS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Embed Links] permission.
     ///
     /// [Embed Links]: #associatedconstant.EMBED_LINKS
-    pub fn embed_links(&self) -> bool { self.contains(Self::EMBED_LINKS) }
+    pub fn embed_links(self) -> bool { self.contains(Self::EMBED_LINKS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Use External Emojis] permission.
     ///
     /// [Use External Emojis]: #associatedconstant.USE_EXTERNAL_EMOJIS
-    pub fn external_emojis(&self) -> bool { self.contains(Self::USE_EXTERNAL_EMOJIS) }
+    pub fn external_emojis(self) -> bool { self.contains(Self::USE_EXTERNAL_EMOJIS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Kick Members] permission.
     ///
     /// [Kick Members]: #associatedconstant.KICK_MEMBERS
-    pub fn kick_members(&self) -> bool { self.contains(Self::KICK_MEMBERS) }
+    pub fn kick_members(self) -> bool { self.contains(Self::KICK_MEMBERS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Manage Channels] permission.
     ///
     /// [Manage Channels]: #associatedconstant.MANAGE_CHANNELS
-    pub fn manage_channels(&self) -> bool { self.contains(Self::MANAGE_CHANNELS) }
+    pub fn manage_channels(self) -> bool { self.contains(Self::MANAGE_CHANNELS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Manage Emojis] permission.
     ///
     /// [Manage Emojis]: #associatedconstant.MANAGE_EMOJIS
-    pub fn manage_emojis(&self) -> bool { self.contains(Self::MANAGE_EMOJIS) }
+    pub fn manage_emojis(self) -> bool { self.contains(Self::MANAGE_EMOJIS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Manage Guild] permission.
     ///
     /// [Manage Guild]: #associatedconstant.MANAGE_GUILD
-    pub fn manage_guild(&self) -> bool { self.contains(Self::MANAGE_GUILD) }
+    pub fn manage_guild(self) -> bool { self.contains(Self::MANAGE_GUILD) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Manage Messages] permission.
     ///
     /// [Manage Messages]: #associatedconstant.MANAGE_MESSAGES
-    pub fn manage_messages(&self) -> bool { self.contains(Self::MANAGE_MESSAGES) }
+    pub fn manage_messages(self) -> bool { self.contains(Self::MANAGE_MESSAGES) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Manage Nicknames] permission.
     ///
     /// [Manage Nicknames]: #associatedconstant.MANAGE_NICKNAMES
-    pub fn manage_nicknames(&self) -> bool { self.contains(Self::MANAGE_NICKNAMES) }
+    pub fn manage_nicknames(self) -> bool { self.contains(Self::MANAGE_NICKNAMES) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Manage Roles] permission.
     ///
     /// [Manage Roles]: #associatedconstant.MANAGE_ROLES
-    pub fn manage_roles(&self) -> bool { self.contains(Self::MANAGE_ROLES) }
+    pub fn manage_roles(self) -> bool { self.contains(Self::MANAGE_ROLES) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Manage Webhooks] permission.
     ///
     /// [Manage Webhooks]: #associatedconstant.MANAGE_WEBHOOKS
-    pub fn manage_webhooks(&self) -> bool { self.contains(Self::MANAGE_WEBHOOKS) }
+    pub fn manage_webhooks(self) -> bool { self.contains(Self::MANAGE_WEBHOOKS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Mention Everyone] permission.
     ///
     /// [Mention Everyone]: #associatedconstant.MENTION_EVERYONE
-    pub fn mention_everyone(&self) -> bool { self.contains(Self::MENTION_EVERYONE) }
+    pub fn mention_everyone(self) -> bool { self.contains(Self::MENTION_EVERYONE) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Move Members] permission.
     ///
     /// [Move Members]: #associatedconstant.MOVE_MEMBERS
-    pub fn move_members(&self) -> bool { self.contains(Self::MOVE_MEMBERS) }
+    pub fn move_members(self) -> bool { self.contains(Self::MOVE_MEMBERS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Mute Members] permission.
     ///
     /// [Mute Members]: #associatedconstant.MUTE_MEMBERS
-    pub fn mute_members(&self) -> bool { self.contains(Self::MUTE_MEMBERS) }
+    pub fn mute_members(self) -> bool { self.contains(Self::MUTE_MEMBERS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Read Message History] permission.
     ///
     /// [Read Message History]: #associatedconstant.READ_MESSAGE_HISTORY
-    pub fn read_message_history(&self) -> bool { self.contains(Self::READ_MESSAGE_HISTORY) }
+    pub fn read_message_history(self) -> bool { self.contains(Self::READ_MESSAGE_HISTORY) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Read Messages] permission.
     ///
     /// [Read Messages]: #associatedconstant.READ_MESSAGES
-    pub fn read_messages(&self) -> bool { self.contains(Self::READ_MESSAGES) }
+    pub fn read_messages(self) -> bool { self.contains(Self::READ_MESSAGES) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Send Messages] permission.
     ///
     /// [Send Messages]: #associatedconstant.SEND_MESSAGES
-    pub fn send_messages(&self) -> bool { self.contains(Self::SEND_MESSAGES) }
+    pub fn send_messages(self) -> bool { self.contains(Self::SEND_MESSAGES) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Send TTS Messages] permission.
     ///
     /// [Send TTS Messages]: #associatedconstant.SEND_TTS_MESSAGES
-    pub fn send_tts_messages(&self) -> bool { self.contains(Self::SEND_TTS_MESSAGES) }
+    pub fn send_tts_messages(self) -> bool { self.contains(Self::SEND_TTS_MESSAGES) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Speak] permission.
     ///
     /// [Speak]: #associatedconstant.SPEAK
-    pub fn speak(&self) -> bool { self.contains(Self::SPEAK) }
+    pub fn speak(self) -> bool { self.contains(Self::SPEAK) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Use External Emojis] permission.
     ///
     /// [Use External Emojis]: #associatedconstant.USE_EXTERNAL_EMOJIS
-    pub fn use_external_emojis(&self) -> bool { self.contains(Self::USE_EXTERNAL_EMOJIS) }
+    pub fn use_external_emojis(self) -> bool { self.contains(Self::USE_EXTERNAL_EMOJIS) }
 
     /// Shorthand for checking that the set of permissions contains the
     /// [Use VAD] permission.
     ///
     /// [Use VAD]: #associatedconstant.USE_VAD
-    pub fn use_vad(&self) -> bool { self.contains(Self::USE_VAD) }
+    pub fn use_vad(self) -> bool { self.contains(Self::USE_VAD) }
 }
 
 impl<'de> Deserialize<'de> for Permissions {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -692,8 +692,6 @@ impl User {
     pub fn refresh(&mut self, context: &Context) -> Result<()> {
         self.id.to_user(&context).map(|replacement| {
             mem::replace(self, replacement);
-
-            ()
         })
     }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -364,7 +364,7 @@ pub enum DefaultAvatar {
 
 impl DefaultAvatar {
     /// Retrieves the String hash of the default avatar.
-    pub fn name(&self) -> Result<String> { serde_json::to_string(self).map_err(From::from) }
+    pub fn name(self) -> Result<String> { serde_json::to_string(&self).map_err(From::from) }
 }
 
 /// The representation of a user's status.
@@ -789,7 +789,7 @@ impl UserId {
     ///
     /// [current user]: ../user/struct.CurrentUser.html
     #[cfg(feature = "http")]
-    pub fn create_dm_channel(&self, http: impl AsRef<Http>) -> Result<PrivateChannel> {
+    pub fn create_dm_channel(self, http: impl AsRef<Http>) -> Result<PrivateChannel> {
         let map = json!({
             "recipient_id": self.0,
         });

--- a/src/utils/colour.rs
+++ b/src/utils/colour.rs
@@ -142,7 +142,7 @@ impl Colour {
     ///
     /// assert_eq!(Colour::new(6573123).r(), 100);
     /// ```
-    pub fn r(&self) -> u8 { ((self.0 >> 16) & 255) as u8 }
+    pub fn r(self) -> u8 { ((self.0 >> 16) & 255) as u8 }
 
     /// Returns the green RGB component of this Colour.
     ///
@@ -153,7 +153,7 @@ impl Colour {
     ///
     /// assert_eq!(Colour::new(6573123).g(), 76);
     /// ```
-    pub fn g(&self) -> u8 { ((self.0 >> 8) & 255) as u8 }
+    pub fn g(self) -> u8 { ((self.0 >> 8) & 255) as u8 }
 
     /// Returns the blue RGB component of this Colour.
     ///
@@ -163,7 +163,7 @@ impl Colour {
     /// use serenity::utils::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).b(), 67);
-    pub fn b(&self) -> u8 { (self.0 & 255) as u8 }
+    pub fn b(self) -> u8 { (self.0 & 255) as u8 }
 
     /// Returns a tuple of the red, green, and blue components of this Colour.
     ///
@@ -181,7 +181,7 @@ impl Colour {
     /// [`r`]: #method.r
     /// [`g`]: #method.g
     /// [`b`]: #method.b
-    pub fn tuple(&self) -> (u8, u8, u8) { (self.r(), self.g(), self.b()) }
+    pub fn tuple(self) -> (u8, u8, u8) { (self.r(), self.g(), self.b()) }
 
     /// Returns a hexadecimal string of this Colour.
     ///
@@ -195,7 +195,7 @@ impl Colour {
     ///
     /// assert_eq!(Colour::new(6573123).hex(), "644C43");
     /// ```
-    pub fn hex(&self) -> String {
+    pub fn hex(self) -> String {
         format!("{:06X}", self.0)
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -721,7 +721,7 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
                         "@invalid-user".to_string()
                     }
                 } else {
-                    let user = cache.read().users.get(&id).map(|user| user.clone());
+                    let user = cache.read().users.get(&id).cloned();
 
                     if let Some(user) = user {
                         let user = user.read();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,14 +13,15 @@ pub use self::{
 
 use base64;
 use crate::internal::prelude::*;
-use crate::prelude::RwLock;
 use crate::model::{
-    channel::Channel,
     misc::EmojiIdentifier,
+    id::EmojiId,
+};
+#[cfg(feature = "cache")]
+use crate::model::{
     id::{
         ChannelId,
         GuildId,
-        EmojiId,
         RoleId,
         UserId,
     },
@@ -32,9 +33,13 @@ use std::{
     hash::{BuildHasher, Hash},
     io::Read,
     path::Path,
-    str::FromStr,
 };
-
+#[cfg(feature = "cache")]
+use crate::prelude::RwLock;
+#[cfg(feature = "cache")]
+use crate::model::channel::Channel;
+#[cfg(feature = "cache")]
+use std::str::FromStr;
 #[cfg(feature = "cache")]
 use crate::cache::{Cache, CacheRwLock};
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -613,7 +613,7 @@ fn clean_roles(cache: impl AsRef<CacheRwLock>, s: &mut String) {
     while let Some(mut mention_start) = s[progress..].find("<@&") {
         mention_start += progress;
 
-        if let Some(mut mention_end) = s[mention_start..].find(">") {
+        if let Some(mut mention_end) = s[mention_start..].find('>') {
             mention_end += mention_start;
             mention_start += "<@&".len();
 
@@ -651,7 +651,7 @@ fn clean_channels(cache: &RwLock<Cache>, s: &mut String) {
     while let Some(mut mention_start) = s[progress..].find("<#") {
         mention_start += progress;
 
-        if let Some(mut mention_end) = s[mention_start..].find(">") {
+        if let Some(mut mention_end) = s[mention_start..].find('>') {
             mention_end += mention_start;
             mention_start += "<#".len();
 
@@ -690,7 +690,7 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
     while let Some(mut mention_start) = s[progress..].find("<@") {
         mention_start += progress;
 
-        if let Some(mut mention_end) = s[mention_start..].find(">") {
+        if let Some(mut mention_end) = s[mention_start..].find('>') {
             mention_end += mention_start;
             mention_start += "<@".len();
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -693,12 +693,14 @@ fn clean_users(cache: &RwLock<Cache>, s: &mut String, show_discriminator: bool, 
         if let Some(mut mention_end) = s[mention_start..].find(">") {
             mention_end += mention_start;
             mention_start += "<@".len();
-            let mut has_exclamation = false;
 
-            if s[mention_start..].as_bytes().get(0).map_or(false, |c| *c == b'!') {
+            let has_exclamation = if s[mention_start..].as_bytes().get(0).map_or(false, |c| *c == b'!') {
                 mention_start += "!".len();
-                has_exclamation = true;
-            }
+
+                true
+            } else {
+                false
+            };
 
             if let Ok(id) = UserId::from_str(&s[mention_start..mention_end]) {
                 let replacement = if let Some(guild) = guild {

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -24,8 +24,9 @@ pub trait AudioSource: Send {
 
 /// A receiver for incoming audio.
 pub trait AudioReceiver: Send {
-    fn speaking_update(&mut self, ssrc: u32, _user_id: u64, _speaking: bool) { }
+    fn speaking_update(&mut self, _ssrc: u32, _user_id: u64, _speaking: bool) { }
 
+    #[allow(clippy::too_many_arguments)]
     fn voice_packet(&mut self,
                     _ssrc: u32,
                     _sequence: u16,

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -24,19 +24,19 @@ pub trait AudioSource: Send {
 
 /// A receiver for incoming audio.
 pub trait AudioReceiver: Send {
-    fn speaking_update(&mut self, ssrc: u32, user_id: u64, speaking: bool) { }
+    fn speaking_update(&mut self, ssrc: u32, _user_id: u64, _speaking: bool) { }
 
     fn voice_packet(&mut self,
-                    ssrc: u32,
-                    sequence: u16,
-                    timestamp: u32,
-                    stereo: bool,
-                    data: &[i16],
-                    compressed_size: usize) { }
+                    _ssrc: u32,
+                    _sequence: u16,
+                    _timestamp: u32,
+                    _stereo: bool,
+                    _data: &[i16],
+                    _compressed_size: usize) { }
 
-    fn client_connect(&mut self, ssrc: u32, user_id: u64) { }
+    fn client_connect(&mut self, _ssrc: u32, _user_id: u64) { }
 
-    fn client_disconnect(&mut self, user_id: u64) { }
+    fn client_disconnect(&mut self, _user_id: u64) { }
 }
 
 #[derive(Clone, Copy)]

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -61,7 +61,6 @@ enum ReceiverStatus {
     Websocket(VoiceEvent),
 }
 
-#[allow(clippy::dead_code)]
 struct ThreadItems {
     rx: MpscReceiver<ReceiverStatus>,
     tx: MpscSender<ReceiverStatus>,
@@ -71,7 +70,6 @@ struct ThreadItems {
     ws_thread: JoinHandle<()>,
 }
 
-#[allow(clippy::dead_code)]
 pub struct Connection {
     audio_timer: Timer,
     client: Arc<Mutex<WsClient>>,

--- a/src/voice/manager.rs
+++ b/src/voice/manager.rs
@@ -80,7 +80,6 @@ impl Manager {
     ///
     /// [`Handler`]: struct.Handler.html
     /// [`get`]: #method.get
-    #[allow(clippy::map_entry)]
     #[inline]
     pub fn join<C, G>(&mut self, guild_id: G, channel_id: C) -> &mut Handler
         where C: Into<ChannelId>, G: Into<GuildId> {

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -30,7 +30,7 @@ pub use audiopus::Bitrate;
 
 use self::connection_info::ConnectionInfo;
 
-const CRYPTO_MODE: &'static str = "xsalsa20_poly1305";
+const CRYPTO_MODE: &str = "xsalsa20_poly1305";
 
 pub(crate) enum Status {
     Connect(ConnectionInfo),

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -34,7 +34,7 @@ const CRYPTO_MODE: &'static str = "xsalsa20_poly1305";
 
 pub(crate) enum Status {
     Connect(ConnectionInfo),
-    #[allow(clippy::dead_code)] Disconnect,
+    Disconnect,
     SetReceiver(Option<Box<dyn AudioReceiver>>),
     SetSender(Option<LockedAudio>),
     AddSender(LockedAudio),

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -115,8 +115,8 @@ impl<R: Read + Send> AudioSource for InputSource<R> {
             decoder.decode_float(frame.as_slice(), &mut local_buf, false).ok()?
         };
 
-        for i in 0..1920 {
-            float_buffer[i] += local_buf[i] * volume;
+        for (i, float_buffer_element) in float_buffer.iter_mut().enumerate().take(1920) {
+            *float_buffer_element += local_buf[i] * volume;
         }
 
         Some(count)

--- a/src/voice/threading.rs
+++ b/src/voice/threading.rs
@@ -17,7 +17,7 @@ pub(crate) fn start(guild_id: GuildId, rx: MpscReceiver<Status>) {
     ThreadBuilder::new()
         .name(name)
         .spawn(move || runner(&rx))
-        .expect(&format!("[Voice] Error starting guild: {:?}", guild_id));
+        .unwrap_or_else(|_| panic!("[Voice] Error starting guild: {:?}", guild_id));
 }
 
 fn runner(rx: &MpscReceiver<Status>) {


### PR DESCRIPTION
This Pull Request fixed current Clippy-lints by either allowing them or satisfying them via a code change.
Additionally, a lot of older lints were removed if they had no actual effect.

On another note:
`Args::next` got renamed to `Args::advance` to avoid confusion with the `Iter`-trait's `next`-function.