### PR TITLE
Unify `say`-Methods

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -520,8 +520,7 @@ impl ChannelId {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say<D>(self, http: impl AsRef<Http>, content: D) -> Result<Message>
-    where D: ::std::fmt::Display {
+    pub fn say(&self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> {
         self.send_message(&http, |m| {
             m.content(content)
         })

--- a/src/model/channel/group.rs
+++ b/src/model/channel/group.rs
@@ -308,7 +308,7 @@ impl Group {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say(&self, http: impl AsRef<Http>, content: &str) -> Result<Message> { self.channel_id.say(&http, content) }
+    pub fn say(&self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> { self.channel_id.say(&http, content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -619,7 +619,7 @@ impl GuildChannel {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say(&self, http: impl AsRef<Http>, content: &str) -> Result<Message> { self.id.say(&http, content) }
+    pub fn say(&self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> { self.id.say(&http, content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -245,7 +245,7 @@ impl PrivateChannel {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say<D: ::std::fmt::Display>(&self, http: impl AsRef<Http>, content: D) -> Result<Message> { self.id.say(&http, content) }
+    pub fn say(&self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> { self.id.say(&http, content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///


### PR DESCRIPTION
As pointed out by @zeyla, the `say`-methods were not the same despite conveying the same concept.

This pull request fixes this.