### PR TITLE
Fix Command Framework Example

### DIFF
--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -278,7 +278,7 @@ pub enum HelpBehaviour {
 
 impl HelpBehaviour {
     pub fn from_str(s: &str) -> Option<Self> {
-        Some(match s {
+        Some(match s.to_lowercase().as_str() {
             "strike" => HelpBehaviour::Strike,
             "hide" => HelpBehaviour::Hide,
             "nothing" => HelpBehaviour::Nothing,

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -534,7 +534,7 @@ impl StandardFramework {
     ///
     /// # Examples
     ///
-    /// Using `message_without_command`:
+    /// Using `normal_message`:
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;


### PR DESCRIPTION
This Pull Requests fixes command framework example. 

It contained invalid syntax (remnants from the `command!`-era), wrong identifiers, and did not use the `checks`-feature.
Last but not least, the tolerance of parsing user-input to `HelpBehaviour` has been increased by turning it case-insensitive.