### PR TITLE
Update `on_mention` to take a `UserId`

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -145,13 +145,13 @@ fn main() {
         data.insert::<ShardManagerContainer>(Arc::clone(&client.shard_manager));
     }
 
-    // We will fetch your bot's owners
-    let owners = match client.cache_and_http.http.get_current_application_info() {
+    // We will fetch your bot's owners and id
+    let (owners, bot_id) = match client.cache_and_http.http.get_current_application_info() {
         Ok(info) => {
             let mut owners = HashSet::new();
             owners.insert(info.owner.id);
 
-            owners
+            (owners, info.id)
         },
         Err(why) => panic!("Could not access application info: {:?}", why),
     };
@@ -174,7 +174,7 @@ fn main() {
         StandardFramework::new()
         .configure(|c| c
             .with_whitespace(true)
-            .on_mention(true)
+            .on_mention(Some(bot_id))
             .prefix("~")
             // You can set multiple delimiters via delimiters()
             // or just one via delimiter(",")

--- a/examples/06_voice/src/main.rs
+++ b/examples/06_voice/src/main.rs
@@ -75,8 +75,7 @@ fn main() {
 
     client.with_framework(StandardFramework::new()
         .configure(|c| c
-            .prefix("~")
-            .on_mention(true))
+            .prefix("~"))
         .group(GENERAL_GROUP));
 
     let _ = client.start().map_err(|why| println!("Client ended: {:?}", why));

--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -113,8 +113,7 @@ fn main() {
 
     client.with_framework(StandardFramework::new()
         .configure(|c| c
-            .prefix("~")
-            .on_mention(true))
+            .prefix("~"))
         .group(GENERAL_GROUP));
 
     let _ = client.start().map_err(|why| println!("Client ended: {:?}", why));

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -85,7 +85,7 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 /// let mut client = Client::new(&token, Handler).unwrap();
 ///
 /// client.with_framework(StandardFramework::new()
-///     .configure(|c| c.on_mention(true).prefix("~")));
+///     .configure(|c| c.on_mention(Some(UserId(5))).prefix("~")));
 /// ```
 ///
 /// [`Client`]: ../../client/struct.Client.html

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -273,14 +273,14 @@ impl Configuration {
         self
     }
 
-    /// Whether or not to respond to commands initiated with a mention. Note
-    /// that this can be used in conjunction with [`prefix`].
+    /// Whether or not to respond to commands initiated with the mentioned id.
+    /// Note that this can be used in conjunction with [`prefix`].
     ///
-    /// **Note**: Defaults to `false`.
+    /// **Note**: Defaults to ignore mentions.
     ///
     /// # Examples
     ///
-    /// Setting this to `true` will allow the following types of mentions to be
+    /// Setting this to an id will allow the following types of mentions to be
     /// responded to:
     ///
     /// ```ignore
@@ -294,19 +294,8 @@ impl Configuration {
     /// encourages you to ignore differentiating between the two.
     ///
     /// [`prefix`]: #method.prefix
-    pub fn on_mention(&mut self, on_mention: bool) -> &mut Self {
-        if !on_mention {
-            return self;
-        }
-
-        let http = Http::new(
-            reqwest::Client::builder().build().expect("Could not construct Reqwest-Client."),
-            "",
-        );
-
-        if let Ok(current_user) = http.get_current_user() {
-            self.on_mention = Some(current_user.id.to_string());
-        }
+    pub fn on_mention(&mut self, on_mention: Some(UserId)) -> &mut Self {
+        self.on_mention = on_mention.map(ToString::to_string);
 
         self
     }


### PR DESCRIPTION
With the removal of global `Http` objects, `on_mention` is no longer
authorised for the necessary routes to get the bot's `UserId`.

Directly pass it an `Option<UserId>` instead.

Fixes #530