### PR TITLE
Handle Sub-Groups in the Help-System

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -402,6 +402,11 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// - `#[max_levenshtein_distance(n)]`
 /// How much should the help command search for a similiar name.
 ///
+/// Indicator for a nested guild. The prefix will be repeated based on what
+/// kind of level the item sits. A sub-group would be level two, a sub-sub-group
+/// would be level three.
+/// - `#[indention_prefix = s]`
+///
 /// [`command`]: fn.command.html
 #[proc_macro_attribute]
 pub fn help(_attr: TokenStream, input: TokenStream) -> TokenStream {
@@ -506,7 +511,8 @@ pub fn help(_attr: TokenStream, input: TokenStream) -> TokenStream {
                     strikethrough_commands_tip_in_guild;
                     embed_error_colour;
                     embed_success_colour;
-                    max_levenshtein_distance
+                    max_levenshtein_distance;
+                    indention_prefix
                 ]);
             }
         }
@@ -593,6 +599,7 @@ pub fn help(_attr: TokenStream, input: TokenStream) -> TokenStream {
         embed_error_colour,
         embed_success_colour,
         max_levenshtein_distance,
+        indention_prefix,
     } = options;
 
     let strikethrough_commands_tip_in_dm = AsOption(strikethrough_commands_tip_in_dm);
@@ -646,6 +653,7 @@ pub fn help(_attr: TokenStream, input: TokenStream) -> TokenStream {
             embed_error_colour: #colour_path(#embed_error_colour),
             embed_success_colour: #colour_path(#embed_success_colour),
             max_levenshtein_distance: #max_levenshtein_distance,
+            indention_prefix: #indention_prefix,
         };
 
         #(#cfgs2)*

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -327,6 +327,7 @@ pub struct HelpOptions {
     pub embed_error_colour: u32,
     pub embed_success_colour: u32,
     pub max_levenshtein_distance: usize,
+    pub indention_prefix: String,
 }
 
 impl Default for HelpOptions {
@@ -359,6 +360,7 @@ impl Default for HelpOptions {
             embed_error_colour: 0x992D22,   // DARK_RED
             embed_success_colour: 0xF6DBD8, // ROSEWATER
             max_levenshtein_distance: 0,
+            indention_prefix: "-".to_string(),
         }
     }
 }

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -108,6 +108,10 @@ If you want more information about a specific command, just pass the command as 
 // it will be displayed as a suggestion.
 // Setting the distance to 0 will disable suggestions.
 #[max_levenshtein_distance(3)]
+// When you use sub-groups, Serenity will use the `indention_prefix` to indicate
+// how deeply an item is indented.
+// The default value is "-", it will be changed to "+".
+#[indention_prefix = "+"]
 // On another note, you can set up the help-menu-filter-behaviour.
 // Here are all possible settings shown on all possible options.
 // First case is if a user lacks permissions for a command, we can hide the command.
@@ -248,6 +252,7 @@ fn main() {
         .group(&EMOJI_GROUP)
         .group(&MATH_GROUP)
         .group(&OWNER_GROUP)
+        .group(&MAGIC_GROUP)
     );
 
     if let Err(why) = client.start() {

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -310,12 +310,14 @@ pub fn is_command_visible(
 /// Checks if `search_on` starts with `word` and is then cleanly followed by a
 /// `" "`.
 #[inline]
+#[cfg(all(feature = "cache", feature = "http"))]
 fn starts_with_whole_word(search_on: &str, word: &str) -> bool {
     search_on.starts_with(word) && search_on.get(word.len()..word.len() + 1)
         .map_or(false, |slice| slice == " ")
 }
 
 #[inline]
+#[cfg(all(feature = "cache", feature = "http"))]
 fn find_any_command_matches(
     command: &'static InternalCommand,
     group: &CommandGroup,
@@ -342,6 +344,7 @@ fn find_any_command_matches(
         }).cloned()
 }
 
+#[cfg(all(feature = "cache", feature = "http"))]
 fn nested_group_command_search<'a>(
     cache: &CacheRwLock,
     groups: &[&'static CommandGroup],

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -215,6 +215,9 @@ pub struct HelpOptions {
     pub embed_success_colour: Colour,
     /// If not 0, help will check whether a command is similar to searched named.
     pub max_levenshtein_distance: usize,
+    /// Help will use this as prefix to express how deeply nested a command or
+    /// group is.
+    pub indention_prefix: &'static str,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This pull request adds support for providing help for nested commands with many prefixes and displaying nested groups and their commands in the general help-list.

A sub-group is considered nested, each level of nesting will cause one configurable prefix to be placed in front of given group or commands.
