### PR TITLE
Rename `sub` to `sub_groups`.

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -211,7 +211,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
                     only_in;
                     owners_only;
                     owner_privilege;
-                    sub
+                    sub_groups
                 ]);
             }
         }
@@ -232,7 +232,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
         only_in,
         owners_only,
         owner_privilege,
-        sub,
+        sub_groups,
     } = options;
 
     let description = AsOption(description);
@@ -264,7 +264,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
     let Permissions(required_permissions) = required_permissions;
 
     let options = _name.with_suffix(COMMAND_OPTIONS);
-    let sub = sub
+    let sub_groups = sub_groups
         .into_iter()
         .map(|i| i.with_suffix(COMMAND))
         .collect::<Vec<_>>();
@@ -296,7 +296,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
             only_in: #only_in,
             owners_only: #owners_only,
             owner_privilege: #owner_privilege,
-            sub: &[#(&#sub),*],
+            sub_groups: &[#(&#sub_groups),*],
         };
 
         #(#cfgs2)*
@@ -708,7 +708,7 @@ pub fn help(_attr: TokenStream, input: TokenStream) -> TokenStream {
 ///         prefixes: ["foo"],
 ///     },
 ///     commands: [bar],
-///     sub: [baz],
+///     sub_groups: [baz],
 /// });
 /// ```
 ///

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -242,7 +242,7 @@ pub struct Options {
     pub only_in: OnlyIn,
     pub owners_only: bool,
     pub owner_privilege: bool,
-    pub sub: Vec<Ident>,
+    pub sub_groups: Vec<Ident>,
 }
 
 impl Default for Options {
@@ -263,7 +263,7 @@ impl Default for Options {
             only_in: OnlyIn::default(),
             owners_only: false,
             owner_privilege: true,
-            sub: Vec::new(),
+            sub_groups: Vec::new(),
         }
     }
 }
@@ -667,7 +667,7 @@ pub struct Group {
     pub name: Ident,
     pub options: RefOrInstance<GroupOptions>,
     pub commands: Punctuated<Ident, Token![,]>,
-    pub sub: Vec<RefOrInstance<Group>>,
+    pub sub_groups: Vec<RefOrInstance<Group>>,
 }
 
 impl Parse for Group {
@@ -718,13 +718,13 @@ impl Parse for Group {
             input.parse::<Token![,]>()?;
         }
 
-        let mut sub = Vec::new();
+        let mut sub_groups = Vec::new();
 
         if let Ok(s) = input.parse::<Ident>() {
-            if s != "sub" {
+            if s != "sub_groups" {
                 return Err(Error::new(
                     s.span(),
-                    "a group may optionally have a `sub`-groub",
+                    "a group may optionally have a `sub_groups`",
                 ));
             }
 
@@ -735,7 +735,7 @@ impl Parse for Group {
 
             let refs: Punctuated<_, Token![,]> = content.parse_terminated(RefOrInstance::parse)?;
 
-            sub.extend(refs.into_iter());
+            sub_groups.extend(refs.into_iter());
         }
 
         if input.peek(Token![,]) {
@@ -746,7 +746,7 @@ impl Parse for Group {
             name,
             options: options.unwrap_or_default(),
             commands: content.parse_terminated(Ident::parse_any)?,
-            sub,
+            sub_groups,
         })
     }
 }
@@ -757,7 +757,7 @@ impl ToTokens for Group {
             name,
             options: opts,
             commands,
-            sub,
+            sub_groups,
         } = self;
 
         let commands = commands.into_iter().map(|cmd| {
@@ -767,7 +767,7 @@ impl ToTokens for Group {
             }
         });
 
-        let sub = sub
+        let sub_groups = sub_groups
             .into_iter()
             .map(|group| match group {
                 RefOrInstance::Instance(group) => {
@@ -804,7 +804,7 @@ impl ToTokens for Group {
                 name: #n,
                 options: &#group_ops,
                 commands: &[#(#commands),*],
-                sub: &[#(&#sub),*]
+                sub_groups: &[#(&#sub_groups),*]
             };
         });
     }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -458,7 +458,7 @@ fn nested_group_command_search<'a>(
 
         match nested_group_command_search(
             &cache,
-            &group.sub,
+            &group.sub_groups,
             name,
             &help_options,
             &msg,
@@ -571,7 +571,7 @@ fn fetch_all_eligible_commands_in_group<'a>(
         &help_options, &group, &msg,
         &mut group_with_cmds);
 
-    for sub_group in group.sub {
+    for sub_group in group.sub_groups {
         let grouped_cmd = fetch_all_eligible_commands_in_group(
             &context, &sub_group.commands, &owners,
             &help_options, &sub_group, &msg

--- a/src/framework/standard/parse.rs
+++ b/src/framework/standard/parse.rs
@@ -93,13 +93,14 @@ impl<'a, 'b, 'c> PrefixIterator<'a, 'b, 'c> {
 
         // First, check if the subgroups' prefixes were used.
         // And on success, change the current group to the matching group.
-        for sub in self.group.sub {
-            for p in sub.options.prefixes {
+        for sub_group in self.group.sub_groups {
+
+            for p in sub_group.options.prefixes {
                 let pp = self.stream.peek_for(p.chars().count());
 
                 if *p == pp {
                     self.prefix = Some(pp);
-                    self.group = *sub;
+                    self.group = *sub_group;
                     let pos = self.stream.offset();
                     self.stream.set(pos + pp.len());
 
@@ -158,14 +159,14 @@ impl CommandGroup {
 
     #[inline]
     fn has_sub_prefixes(&self) -> bool {
-        self.sub.iter().any(|s| s.has_sub_prefixes()) || self.has_prefixes()
+        self.sub_groups.iter().any(|s| s.has_sub_prefixes()) || self.has_prefixes()
     }
 }
 
 impl CommandOptions {
     #[inline]
     fn get_sub(&self, name: &str) -> Option<&'static Command> {
-        self.sub
+        self.sub_groups
             .iter()
             .find(|c| c.options.names.contains(&name))
             .cloned()
@@ -173,7 +174,7 @@ impl CommandOptions {
 
     #[inline]
     fn command_names(&self) -> impl Iterator<Item = &'static str> {
-        self.sub
+        self.sub_groups
             .iter()
             .flat_map(|c| c.options.names.iter().cloned())
     }

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -55,7 +55,7 @@ pub struct CommandOptions {
     /// Whether the command treats owners as normal users.
     pub owner_privilege: bool,
     /// Other commands belonging to this command.
-    pub sub: &'static [&'static Command],
+    pub sub_groups: &'static [&'static Command],
 }
 
 #[derive(Debug, PartialEq)]
@@ -225,5 +225,5 @@ pub struct CommandGroup {
     pub name: &'static str,
     pub options: &'static GroupOptions,
     pub commands: &'static [&'static Command],
-    pub sub: &'static [&'static CommandGroup],
+    pub sub_groups: &'static [&'static CommandGroup],
 }


### PR DESCRIPTION
Group's have a field named `sub` containing sub-groups. It does not really clarify what `sub` refers to though. For example, it does indicate a single item instead of the referred collection of sub-groups.

This pull requests renames all group-related uses of the word `sub` to `sub_groups`.