### PR TITLE
Future Proofing Enums

### DIFF
--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -21,6 +21,8 @@ pub enum OnlyIn {
     Dm,
     Guild,
     None,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ToTokens for OnlyIn {
@@ -30,6 +32,7 @@ impl ToTokens for OnlyIn {
             OnlyIn::Dm => stream.extend(quote!(#only_in_path::Dm)),
             OnlyIn::Guild => stream.extend(quote!(#only_in_path::Guild)),
             OnlyIn::None => stream.extend(quote!(#only_in_path::None)),
+            OnlyIn::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -273,6 +276,8 @@ pub enum HelpBehaviour {
     Strike,
     Hide,
     Nothing,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl HelpBehaviour {
@@ -293,6 +298,7 @@ impl ToTokens for HelpBehaviour {
             HelpBehaviour::Strike => stream.extend(quote!(#help_behaviour_path::Strike)),
             HelpBehaviour::Hide => stream.extend(quote!(#help_behaviour_path::Hide)),
             HelpBehaviour::Nothing => stream.extend(quote!(#help_behaviour_path::Nothing)),
+            HelpBehaviour::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -178,8 +178,10 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
             ShardAction::Reconnect(ReconnectType::Resume) => {
                 self.shard.resume()
             },
+            ShardAction::Reconnect(ReconnectType::__Nonexhaustive) => unreachable!(),
             ShardAction::Heartbeat => self.shard.heartbeat(),
             ShardAction::Identify => self.shard.identify(),
+            ShardAction::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -305,6 +307,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
                 // Value must be forwarded over the websocket
                 self.shard.client.send_json(&value).is_ok()
             },
+            InterMessage::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -419,6 +422,7 @@ impl<H: EventHandler + Send + Sync + 'static> ShardRunner<H> {
                             return (None, None, false);
                         }
                     },
+                    ReconnectType::__Nonexhaustive => unreachable!(),
                 }
 
                 return (None, None, true);

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -99,6 +99,8 @@ fn context(
 pub(crate) enum DispatchEvent {
     Client(ClientEvent),
     Model(Event),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 #[cfg(feature = "framework")]
@@ -259,6 +261,7 @@ fn handle_event<H: EventHandler + Send + Sync + 'static>(
                         event_handler.category_create(context, channel);
                     });
                 },
+                Channel::__Nonexhaustive => unreachable!(),
             }
         },
         DispatchEvent::Model(Event::ChannelDelete(mut event)) => {
@@ -280,6 +283,7 @@ fn handle_event<H: EventHandler + Send + Sync + 'static>(
                         event_handler.category_delete(context, channel);
                     });
                 },
+                Channel::__Nonexhaustive => unreachable!(),
             }
         },
         DispatchEvent::Model(Event::ChannelPinsUpdate(event)) => {
@@ -648,5 +652,7 @@ fn handle_event<H: EventHandler + Send + Sync + 'static>(
                 event_handler.webhook_update(context, event.guild_id, event.channel_id);
             });
         },
+        DispatchEvent::Model(Event::__Nonexhaustive) => unreachable!(),
+        DispatchEvent::__Nonexhaustive => unreachable!(),
     }
 }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     /// When all shards that the client is responsible for have shutdown with an
     /// error.
     Shutdown,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl Display for Error {
@@ -42,6 +44,7 @@ impl StdError for Error {
             Error::InvalidToken => "The provided token was invalid",
             Error::ShardBootFailure => "Failed to (re-)boot a shard",
             Error::Shutdown => "The clients shards shutdown",
+            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -90,6 +90,8 @@ pub enum OpCode {
     Hello = 10,
     /// Sent immediately following a client heartbeat that was received.
     HeartbeatAck = 11,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -124,6 +126,7 @@ impl OpCode {
             OpCode::InvalidSession => 9,
             OpCode::Hello => 10,
             OpCode::HeartbeatAck => 11,
+            OpCode::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -155,6 +158,8 @@ pub enum VoiceOpCode {
     ClientConnect = 12,
     /// Message indicating that another user has disconnected from the voice channel.
     ClientDisconnect = 13,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -189,6 +194,7 @@ impl VoiceOpCode {
             VoiceOpCode::Resumed => 9,
             VoiceOpCode::ClientConnect => 12,
             VoiceOpCode::ClientDisconnect => 13,
+            VoiceOpCode::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -108,6 +108,8 @@ pub enum Error {
     /// [voice module]: voice/index.html
     #[cfg(feature = "voice")]
     Voice(VoiceError),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl From<FormatError> for Error {
@@ -201,6 +203,7 @@ impl StdError for Error {
             Error::Tungstenite(ref inner) => inner.description(),
             #[cfg(feature = "voice")]
             Error::Voice(_) => "Voice error",
+            Error::__Nonexhaustive => unreachable!(),
         }
     }
 

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -12,6 +12,8 @@ pub enum Error<E> {
     Eos,
     /// Parsing operation failed. Contains how it did.
     Parse(E),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<E> From<E> for Error<E> {
@@ -27,6 +29,7 @@ impl<E: fmt::Display> fmt::Display for Error<E> {
         match *self {
             Eos => write!(f, "ArgError(\"end of string\")"),
             Parse(ref e) => write!(f, "ArgError(\"{}\")", e),
+            __Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -36,6 +39,7 @@ impl<E: fmt::Debug + fmt::Display> StdError for Error<E> {
         match self {
             Error::Eos => "end-of-string",
             Error::Parse(_) => "parse-failure",
+            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -60,6 +60,7 @@ macro_rules! format_command_name {
             HelpBehaviour::Strike => format!("~~`{}`~~", $command_name),
             HelpBehaviour::Nothing => format!("`{}`", $command_name),
             HelpBehaviour::Hide => continue,
+            HelpBehaviour::__Nonexhaustive => unreachable!(),
         }
     };
 }
@@ -163,6 +164,8 @@ pub enum CustomisedHelpData<'a> {
     SingleCommand { command: Command<'a> },
     /// To display failure in finding a fitting command.
     NoCommandFound { help_error_message: &'a str },
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// Wraps around a `Vec<Vec<T>>` and provides access
@@ -1028,6 +1031,7 @@ pub fn with_embeds(
             &command,
             help_options.embed_success_colour,
         ),
+        CustomisedHelpData::__Nonexhaustive => unreachable!(),
     } {
         warn_about_failed_send!(&formatted_help, why);
     }
@@ -1157,7 +1161,8 @@ pub fn plain(
         } => grouped_commands_to_plain_string(&help_options, &help_description, &groups),
         CustomisedHelpData::SingleCommand { ref command } => {
             single_command_to_plain_string(&help_options, &command)
-        }
+        },
+        CustomisedHelpData::__Nonexhaustive => unreachable!(),
     };
 
     if let Err(why) = msg.channel_id.say(&context.http, result) {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -60,6 +60,8 @@ pub enum DispatchError {
     NotEnoughArguments { min: u16, given: usize },
     /// When there are too many arguments.
     TooManyArguments { max: u16, given: usize },
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 pub type DispatchHook = dyn Fn(&mut Context, &Message, DispatchError) + Send + Sync + 'static;

--- a/src/framework/standard/parse.rs
+++ b/src/framework/standard/parse.rs
@@ -8,6 +8,8 @@ pub enum Prefix<'a> {
     Punct(&'a str),
     Mention(&'a str),
     None,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 pub fn parse_prefix<'a>(

--- a/src/framework/standard/structures/check.rs
+++ b/src/framework/standard/structures/check.rs
@@ -25,6 +25,8 @@ pub enum Reason {
     Log(String),
     /// Information for the user but also for logging purposes.
     UserAndLog { user: String, log: String },
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// Returned from [`Check`]s.

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -21,6 +21,8 @@ pub enum OnlyIn {
     Dm,
     Guild,
     None,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 #[derive(Debug, PartialEq)]
@@ -149,6 +151,8 @@ pub enum HelpBehaviour {
     Hide,
     /// The command will be displayed, hence nothing will be done.
     Nothing,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -50,6 +50,8 @@ pub enum Error {
     OverloadedShard,
     /// Failed to reconnect after a number of attempts.
     ReconnectFailure,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl Display for Error {
@@ -73,6 +75,7 @@ impl StdError for Error {
             NoSessionId => "No Session Id present when required",
             OverloadedShard => "Shard has too many guilds",
             ReconnectFailure => "Failed to Reconnect",
+            __Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -114,6 +114,8 @@ pub enum ConnectionStage {
     ///
     /// [`Shard`]: struct.Shard.html
     Resuming,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ConnectionStage {
@@ -156,6 +158,7 @@ impl ConnectionStage {
         match self {
             Connecting | Handshake | Identifying | Resuming => true,
             Connected | Disconnected => false,
+            __Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -171,6 +174,7 @@ impl Display for ConnectionStage {
             Handshake => "handshaking",
             Identifying => "identifying",
             Resuming => "resuming",
+            __Nonexhaustive => unreachable!(),
         })
     }
 }
@@ -185,12 +189,16 @@ pub enum InterMessage {
     #[cfg(feature = "client")]
     Client(Box<ShardClientMessage>),
     Json(Value),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 pub enum ShardAction {
     Heartbeat,
     Identify,
     Reconnect(ReconnectType),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// The type of reconnection that should be performed.
@@ -199,4 +207,6 @@ pub enum ReconnectType {
     Reidentify,
     /// Indicator that a new connection should be made by sending a RESUME.
     Resume,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     InvalidHeader(InvalidHeaderValue),
     /// Reqwest's Error contain information on why sending a request failed.
     Request(ReqwestError),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl From<ReqwestError> for Error {
@@ -62,6 +64,7 @@ impl StdError for Error {
             Error::Url(_) => "Provided URL is incorrect.",
             Error::InvalidHeader(_) => "Provided value is an invalid header value.",
             Error::Request(_) => "Error while sending HTTP request.",
+            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -82,6 +82,8 @@ pub enum AttachmentType<'a> {
     File((&'a File, &'a str)),
     /// Indicates that the `AttachmentType` is a `Path`
     Path(&'a Path),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<'a> From<(&'a [u8], &'a str)> for AttachmentType<'a> {
@@ -115,6 +117,8 @@ pub enum GuildPagination {
     After(GuildId),
     /// The Id to get the guilds before.
     Before(GuildId),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 #[cfg(test)]

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -1214,6 +1214,7 @@ impl Http {
         let (after, before) = match *target {
             GuildPagination::After(id) => (Some(id.0), None),
             GuildPagination::Before(id) => (None, Some(id.0)),
+            GuildPagination::__Nonexhaustive => unreachable!(),
         };
 
         self.fire(Request {
@@ -1501,6 +1502,7 @@ impl Http {
                     multipart = multipart
                         .file(file_num.to_string(), path)?;
                 },
+                AttachmentType::__Nonexhaustive => unreachable!(),
             }
 
             unsafe {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -261,6 +261,8 @@ pub enum Route {
     /// This is a special case, in that if the route is `None` then pre- and
     /// post-hooks are not executed.
     None,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl Route {
@@ -910,6 +912,8 @@ pub enum RouteInfo<'a> {
         channel_id: u64,
         message_id: u64,
     },
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<'a> RouteInfo<'a> {
@@ -1428,6 +1432,7 @@ impl<'a> RouteInfo<'a> {
                 Route::ChannelsIdPinsMessageId(channel_id),
                 Cow::from(Route::channel_pin(channel_id, message_id)),
             ),
+            RouteInfo::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -89,6 +89,8 @@ pub enum RustlsError {
     HandshakeError,
     /// Standard IO error happening while creating the tcp stream
     Io(IoError),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 #[cfg(not(feature = "native_tls"))]
@@ -112,6 +114,7 @@ impl StdError for RustlsError {
             WebPKI => "Failed to validate X.509 certificate",
             HandshakeError => "TLS handshake failed when making the websocket connection",
             Io(ref inner) => inner.description(),
+            __Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -70,6 +70,7 @@ impl ChannelId {
         let (id, kind) = match target.kind {
             PermissionOverwriteType::Member(id) => (id.0, "member"),
             PermissionOverwriteType::Role(id) => (id.0, "role"),
+            PermissionOverwriteType::__Nonexhaustive => unreachable!(),
         };
 
         let map = json!({
@@ -191,6 +192,7 @@ impl ChannelId {
             match permission_type {
                 PermissionOverwriteType::Member(id) => id.0,
                 PermissionOverwriteType::Role(id) => id.0,
+                PermissionOverwriteType::__Nonexhaustive => unreachable!(),
             },
         )
     }
@@ -434,6 +436,7 @@ impl ChannelId {
             },
             Category(category) => category.read().name().to_string(),
             Private(channel) => channel.read().name(),
+            __Nonexhaustive => unreachable!(),
         })
     }
 
@@ -704,6 +707,7 @@ impl From<Channel> for ChannelId {
             Channel::Guild(ch) => ch.with(|c| c.id),
             Channel::Private(ch) => ch.with(|c| c.id),
             Channel::Category(ch) => ch.with(|c| c.id),
+            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -716,6 +720,7 @@ impl<'a> From<&'a Channel> for ChannelId {
             Channel::Guild(ref ch) => ch.with(|c| c.id),
             Channel::Private(ref ch) => ch.with(|c| c.id),
             Channel::Category(ref ch) => ch.with(|c| c.id),
+            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -649,6 +649,8 @@ pub enum MessageType {
     PinsAdd = 6,
     /// An indicator that a member joined the guild.
     MemberJoin = 7,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -677,6 +679,7 @@ impl MessageType {
             GroupIconUpdate => 5,
             PinsAdd => 6,
             MemberJoin => 7,
+            __Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -64,6 +64,8 @@ pub enum Channel {
     ///
     /// [`GuildChannel`]: struct.GuildChannel.html
     Category(Arc<RwLock<ChannelCategory>>),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl Channel {
@@ -254,6 +256,7 @@ impl Channel {
             Channel::Category(ref category) => {
                 category.read().delete(&context)?;
             },
+            Channel::__Nonexhaustive => unreachable!(),
         }
 
         Ok(())
@@ -267,6 +270,7 @@ impl Channel {
             Channel::Guild(ref channel) => channel.with(|c| c.is_nsfw()),
             Channel::Category(ref category) => category.with(|c| c.is_nsfw()),
             Channel::Group(_) | Channel::Private(_) => false,
+            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -282,6 +286,7 @@ impl Channel {
             Channel::Guild(ref ch) => ch.with(|c| c.id),
             Channel::Private(ref ch) => ch.with(|c| c.id),
             Channel::Category(ref category) => category.with(|c| c.id),
+            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -344,6 +349,7 @@ impl Serialize for Channel {
             Channel::Private(ref c) => {
                 PrivateChannel::serialize(&*c.read(), serializer)
             },
+            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -374,6 +380,7 @@ impl Display for Channel {
                 Display::fmt(&recipient.name, f)
             },
             Channel::Category(ref category) => Display::fmt(&category.read().name, f),
+            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -405,6 +412,8 @@ pub enum ChannelType {
     ///
     /// [`NewsChannel`]: struct.NewsChannel.html
     News = 5,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -427,6 +436,7 @@ impl ChannelType {
             ChannelType::Voice => "voice",
             ChannelType::Category => "category",
             ChannelType::News => "news",
+            ChannelType::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -438,6 +448,7 @@ impl ChannelType {
             ChannelType::Group => 3,
             ChannelType::Category => 4,
             ChannelType::News => 5,
+            ChannelType::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -483,6 +494,7 @@ impl Serialize for PermissionOverwrite {
         let (id, kind) = match self.kind {
             PermissionOverwriteType::Member(id) => (id.0, "member"),
             PermissionOverwriteType::Role(id) => (id.0, "role"),
+            PermissionOverwriteType::__Nonexhaustive => unreachable!(),
         };
 
         let mut state = serializer.serialize_struct("PermissionOverwrite", 4)?;
@@ -506,6 +518,8 @@ pub enum PermissionOverwriteType {
     Member(UserId),
     /// A role which is having its permission overwrites edited.
     Role(RoleId),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 #[cfg(test)]

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -217,6 +217,8 @@ pub enum ReactionType {
     },
     /// A reaction with a twemoji.
     Unicode(String),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<'de> Deserialize<'de> for ReactionType {
@@ -310,6 +312,7 @@ impl Serialize for ReactionType {
 
                 map.end()
             },
+            ReactionType::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -330,6 +333,7 @@ impl ReactionType {
                 ..
             } => format!("{}:{}", name.as_ref().map_or("", |s| s.as_str()), id),
             ReactionType::Unicode(ref unicode) => unicode.clone(),
+            ReactionType::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -418,7 +422,6 @@ impl<'a> From<&'a str> for ReactionType {
 }
 
 // TODO: Change this to `!` once it becomes stable.
-
 #[derive(Debug)]
 pub enum NeverFails {}
 
@@ -469,6 +472,7 @@ impl Display for ReactionType {
                 f.write_char('>')
             },
             ReactionType::Unicode(ref unicode) => f.write_str(unicode),
+            ReactionType::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -118,6 +118,7 @@ impl CacheUpdate for ChannelCreateEvent {
                 .categories
                 .insert(category.read().id, Arc::clone(category))
                 .map(Channel::Category),
+            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -149,7 +150,8 @@ impl CacheUpdate for ChannelDeleteEvent {
                 cache.categories.remove(&channel_id);
             },
             // We ignore these because the delete event does not fire for these.
-            Channel::Private(_) | Channel::Group(_) => unreachable!(),
+            Channel::Private(_) | Channel::Group(_)
+            | Channel::__Nonexhaustive => unreachable!(),
         };
 
         // Remove the cached messages for the channel.
@@ -311,6 +313,7 @@ impl CacheUpdate for ChannelUpdateEvent {
                     .get_mut(&category.read().id)
                     { c.clone_from(category) }
             },
+            Channel::__Nonexhaustive => unreachable!(),
         }
 
         None
@@ -1096,6 +1099,7 @@ impl CacheUpdate for ReadyEvent {
                     cache.guilds.insert(guild.id, Arc::new(RwLock::new(guild)));
                 },
                 GuildStatus::OnlinePartialGuild(_) => {},
+                GuildStatus::__Nonexhaustive => unreachable!(),
             }
         }
 
@@ -1254,6 +1258,8 @@ pub enum GatewayEvent {
     InvalidateSession(bool),
     Hello(u64),
     HeartbeatAck,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<'de> Deserialize<'de> for GatewayEvent {
@@ -1437,6 +1443,8 @@ pub enum Event {
     WebhookUpdate(WebhookUpdateEvent),
     /// An event type not covered by the above
     Unknown(UnknownEvent),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// Deserializes a `serde_json::Value` into an `Event`.
@@ -1561,6 +1569,7 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
             kind: kind.to_owned(),
             value: v,
         }),
+        EventType::__Nonexhaustive => unreachable!(),
     })
 }
 
@@ -1802,6 +1811,8 @@ pub enum EventType {
     /// This should be logged so that support for it can be added in the
     /// library.
     Other(String),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<'de> Deserialize<'de> for EventType {
@@ -1959,6 +1970,8 @@ pub enum VoiceEvent {
     ClientDisconnect(VoiceClientDisconnect),
     /// An unknown voice event not registered.
     Unknown(VoiceOpCode, Value),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl<'de> Deserialize<'de> for VoiceEvent {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -328,6 +328,8 @@ pub enum ActivityType {
     Streaming = 1,
     /// An indicator that the user is listening to something.
     Listening = 2,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -346,6 +348,7 @@ impl ActivityType {
             Playing => 0,
             Streaming => 1,
             Listening => 2,
+            __Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -25,6 +25,8 @@ pub enum Target {
     Invite = 50,
     Webhook = 60,
     Emoji = 70,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// Determines the action that was done on a target.
@@ -39,6 +41,8 @@ pub enum Action {
     Webhook(ActionWebhook),
     Emoji(ActionEmoji),
     MessageDelete,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl Action {
@@ -55,6 +59,7 @@ impl Action {
             Action::Webhook(ref x) => x.num(),
             Action::Emoji(ref x) => x.num(),
             Action::MessageDelete => 72,
+            Action::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -65,6 +70,8 @@ pub enum ActionChannel {
     Create = 10,
     Update = 11,
     Delete = 12,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ActionChannel {
@@ -73,6 +80,7 @@ impl ActionChannel {
             ActionChannel::Create => 10,
             ActionChannel::Update => 11,
             ActionChannel::Delete => 12,
+            ActionChannel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -83,6 +91,8 @@ pub enum ActionChannelOverwrite {
     Create = 13,
     Update = 14,
     Delete = 15,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ActionChannelOverwrite {
@@ -91,6 +101,7 @@ impl ActionChannelOverwrite {
             ActionChannelOverwrite::Create => 13,
             ActionChannelOverwrite::Update => 14,
             ActionChannelOverwrite::Delete => 15,
+            ActionChannelOverwrite::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -104,6 +115,8 @@ pub enum ActionMember {
     BanRemove = 23,
     Update = 24,
     RoleUpdate = 25,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ActionMember {
@@ -115,6 +128,7 @@ impl ActionMember {
             ActionMember::BanRemove => 23,
             ActionMember::Update => 24,
             ActionMember::RoleUpdate => 25,
+            ActionMember::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -125,6 +139,8 @@ pub enum ActionRole {
     Create = 30,
     Update = 31,
     Delete = 32,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ActionRole {
@@ -133,6 +149,7 @@ impl ActionRole {
             ActionRole::Create => 30,
             ActionRole::Update => 31,
             ActionRole::Delete => 32,
+            ActionRole::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -143,6 +160,8 @@ pub enum ActionInvite {
     Create = 40,
     Update = 41,
     Delete = 42,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ActionInvite {
@@ -151,6 +170,7 @@ impl ActionInvite {
             ActionInvite::Create => 40,
             ActionInvite::Update => 41,
             ActionInvite::Delete => 42,
+            ActionInvite::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -161,6 +181,8 @@ pub enum ActionWebhook {
     Create = 50,
     Update = 51,
     Delete = 52,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ActionWebhook {
@@ -169,6 +191,7 @@ impl ActionWebhook {
             ActionWebhook::Create => 50,
             ActionWebhook::Update => 51,
             ActionWebhook::Delete => 52,
+            ActionWebhook::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -179,6 +202,8 @@ pub enum ActionEmoji {
     Create = 60,
     Delete = 61,
     Update = 62,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl ActionEmoji {
@@ -187,6 +212,7 @@ impl ActionEmoji {
             ActionEmoji::Create => 60,
             ActionEmoji::Update => 61,
             ActionEmoji::Delete => 62,
+            ActionEmoji::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1781,6 +1781,8 @@ pub enum GuildContainer {
     Guild(PartialGuild),
     /// A guild's id, which can be used to search the cache for a guild.
     Id(GuildId),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// Information relating to a guild's widget embed.
@@ -1871,6 +1873,8 @@ pub enum GuildStatus {
     OnlinePartialGuild(PartialGuild),
     OnlineGuild(Guild),
     Offline(GuildUnavailable),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 #[cfg(feature = "model")]
@@ -1883,6 +1887,7 @@ impl GuildStatus {
             GuildStatus::Offline(offline) => offline.id,
             GuildStatus::OnlineGuild(ref guild) => guild.id,
             GuildStatus::OnlinePartialGuild(ref partial_guild) => partial_guild.id,
+            GuildStatus::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -1894,6 +1899,8 @@ pub enum DefaultMessageNotificationLevel {
     All = 0,
     /// Receive only mentions.
     Mentions = 1,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -1908,6 +1915,7 @@ impl DefaultMessageNotificationLevel {
         match self {
             DefaultMessageNotificationLevel::All => 0,
             DefaultMessageNotificationLevel::Mentions => 1,
+            DefaultMessageNotificationLevel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -1921,6 +1929,8 @@ pub enum ExplicitContentFilter {
     WithoutRole = 1,
     /// Scan messages sent by all members.
     All = 2,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -1937,6 +1947,7 @@ impl ExplicitContentFilter {
             ExplicitContentFilter::None => 0,
             ExplicitContentFilter::WithoutRole => 1,
             ExplicitContentFilter::All => 2,
+            ExplicitContentFilter::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -1948,6 +1959,8 @@ pub enum MfaLevel {
     None = 0,
     /// MFA is enabled.
     Elevated = 1,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -1962,6 +1975,7 @@ impl MfaLevel {
         match self {
             MfaLevel::None => 0,
             MfaLevel::Elevated => 1,
+            MfaLevel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -1987,6 +2001,8 @@ pub enum Region {
     #[serde(rename = "vip-amsterdam")] VipAmsterdam,
     #[serde(rename = "vip-us-east")] VipUsEast,
     #[serde(rename = "vip-us-west")] VipUsWest,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl Region {
@@ -2010,6 +2026,7 @@ impl Region {
             Region::VipAmsterdam => "vip-amsterdam",
             Region::VipUsEast => "vip-us-east",
             Region::VipUsWest => "vip-us-west",
+            Region::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -2030,6 +2047,8 @@ pub enum VerificationLevel {
     High = 3,
     /// Must have a verified phone on the user's Discord account.
     Higher = 4,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 enum_number!(
@@ -2050,6 +2069,7 @@ impl VerificationLevel {
             VerificationLevel::Medium => 2,
             VerificationLevel::High => 3,
             VerificationLevel::Higher => 4,
+            VerificationLevel::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -32,6 +32,7 @@ impl Mentionable for Channel {
             Channel::Private(ref x) => x.with(Mentionable::mention),
             Channel::Group(ref x) => x.with(Mentionable::mention),
             Channel::Category(ref x) => x.with(Mentionable::mention),
+            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -93,6 +94,8 @@ impl Mentionable for GuildChannel {
 pub enum UserParseError {
     InvalidUsername,
     Rest(Box<Error>),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 #[cfg(all(feature = "model", feature = "utils"))]
@@ -108,6 +111,7 @@ impl StdError for UserParseError {
         match *self {
             InvalidUsername => "invalid username",
             Rest(_) => "could not fetch",
+            __Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -267,6 +271,8 @@ pub enum IncidentStatus {
     Monitoring,
     Postmortem,
     Resolved,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// A Discord status maintenance message. This can be either for active

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -360,6 +360,8 @@ pub enum DefaultAvatar {
     /// The avatar when the result is `4`.
     #[serde(rename = "1cbd08c76f8af6dddce02c5138971129")]
     Red,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl DefaultAvatar {
@@ -383,6 +385,8 @@ pub enum OnlineStatus {
     #[serde(rename = "invisible")] Invisible,
     #[serde(rename = "offline")] Offline,
     #[serde(rename = "online")] Online,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl OnlineStatus {
@@ -393,6 +397,7 @@ impl OnlineStatus {
             OnlineStatus::Invisible => "invisible",
             OnlineStatus::Offline => "offline",
             OnlineStatus::Online => "online",
+            OnlineStatus::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -682,6 +687,7 @@ impl User {
                     }
                 }}
             },
+            GuildContainer::__Nonexhaustive => unreachable!(),
         }
     }
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -87,6 +87,7 @@ pub fn deserialize_private_channels<'de, D: Deserializer<'de>>(
             Channel::Private(ref channel) => channel.read().id,
             Channel::Guild(_) => unreachable!("Guild private channel decode"),
             Channel::Category(_) => unreachable!("Channel category private channel decode"),
+            Channel::__Nonexhaustive => unreachable!(),
         };
 
         private_channels.insert(id, private_channel);
@@ -231,6 +232,7 @@ pub fn user_has_perms(cache: impl AsRef<CacheRwLock>, channel_id: ChannelId, mut
             // just assume that all permissions are granted and return `true`.
             return Ok(true);
         },
+        Channel::__Nonexhaustive => unreachable!(),
     };
 
     let guild = match cache.guild(guild_id) {
@@ -281,26 +283,26 @@ macro_rules! num_visitors {
                     struct Id {
                         num: $type,
                     }
-                    
+
                     struct StrVisitor;
-                    
+
                     impl<'de> Visitor<'de> for StrVisitor {
                         type Value = $type;
-                        
+
                         fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                             formatter.write_str("string")
                         }
-                        
+
                         fn visit_str<E: DeError>(self, s: &str) -> StdResult<Self::Value, E> { s.parse().map_err(E::custom) }
                         fn visit_string<E: DeError>(self, s: String) -> StdResult<Self::Value, E> { s.parse().map_err(E::custom) }
                     }
-                    
+
                     impl<'de> Deserialize<'de> for Id {
                         fn deserialize<D: Deserializer<'de>>(des: D) -> StdResult<Self, D::Error> {
                             Ok(Id { num: des.deserialize_str(StrVisitor)? })
                         }
                     }
-                    
+
                     map.next_value::<Id>().map(|id| id.num)
                 }
             }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -852,6 +852,8 @@ pub enum ContentModifier {
     Code,
     Underline,
     Spoiler,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// Describes formatting on string content
@@ -937,7 +939,8 @@ impl Content {
             },
             ContentModifier::Spoiler => {
                 self.spoiler = true;
-            }
+            },
+            ContentModifier::__Nonexhaustive => unreachable!(),
         }
     }
 

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -44,6 +44,8 @@ pub trait AudioReceiver: Send {
 pub enum AudioType {
     Opus,
     Pcm,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// Control object for audio playback.

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -432,6 +432,7 @@ impl Connection {
                             None => 0,
                         }
                     },
+                    AudioType::__Nonexhaustive => unreachable!(),
                 };
 
                 // May need to force interleave/copy.

--- a/src/voice/error.rs
+++ b/src/voice/error.rs
@@ -28,6 +28,8 @@ pub enum VoiceError {
     ///
     /// The JSON output is given.
     YouTubeDLUrl(Value),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// An error returned from the dca method.
@@ -37,4 +39,6 @@ pub enum DcaError {
     InvalidHeader,
     InvalidMetadata(JsonError),
     InvalidSize(i32),
+    #[doc(hidden)]
+    __Nonexhaustive,
 }


### PR DESCRIPTION
This pull request ensures that almost all `enum`s are *marked* as *non-exhaustive*, allowing us to adjust the API to Discord API changes.
Note that the actual non-exhaustive attribute is not available on stable yet, thus this simply adds a doc-hidden variant.
As these are considered *unreachable*, Serenity will panic if it receives and processes any of these doc-hidden variants.