### PR TITLE
Remove 'static on `HelpOptions` for Help-Functions

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -976,10 +976,26 @@ fn send_error_embed(
 /// # impl EventHandler for Handler {}
 /// # let mut client = Client::new("token", Handler).unwrap();
 /// #
-/// use serenity::framework::standard::{StandardFramework, help_commands::*};
+/// use std::{collections::HashSet, hash::BuildHasher};
+/// use serenity::{framework::standard::{Args, CommandGroup, CommandResult,
+///     StandardFramework, macros::help, HelpOptions,
+///     help_commands::*}, model::prelude::*,
+/// };
+///
+/// #[help]
+/// fn my_help(
+///     context: &mut Context,
+///     msg: &Message,
+///     args: Args,
+///     help_options: &'static HelpOptions,
+///     groups: &[&'static CommandGroup],
+///     owners: HashSet<UserId, impl BuildHasher>
+/// ) -> CommandResult {
+///     with_embeds(context, msg, args, &help_options, groups, owners)
+/// }
 ///
 /// client.with_framework(StandardFramework::new()
-///     .help(&WITH_EMBEDS_HELP_COMMAND));
+///     .help(&MY_HELP_HELP_COMMAND));
 /// ```
 #[cfg(all(feature = "cache", feature = "http"))]
 pub fn with_embeds(
@@ -1128,10 +1144,26 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
 /// # impl EventHandler for Handler {}
 /// # let mut client = Client::new("token", Handler).unwrap();
 /// #
-/// use serenity::framework::standard::{StandardFramework, help_commands::*};
+/// use std::{collections::HashSet, hash::BuildHasher};
+/// use serenity::{framework::standard::{Args, CommandGroup, CommandResult,
+///     StandardFramework, macros::help, HelpOptions,
+///     help_commands::*}, model::prelude::*,
+/// };
+///
+/// #[help]
+/// fn my_help(
+///     context: &mut Context,
+///     msg: &Message,
+///     args: Args,
+///     help_options: &'static HelpOptions,
+///     groups: &[&'static CommandGroup],
+///     owners: HashSet<UserId, impl BuildHasher>
+/// ) -> CommandResult {
+///     plain(context, msg, args, &help_options, groups, owners)
+/// }
 ///
 /// client.with_framework(StandardFramework::new()
-///     .help(&PLAIN_HELP_COMMAND));
+///     .help(&MY_HELP_HELP_COMMAND));
 /// ```
 #[cfg(all(feature = "cache", feature = "http"))]
 pub fn plain(

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -27,7 +27,7 @@
 use super::{
     Args, CommandGroup, CommandOptions,
     CommandResult, has_correct_roles, HelpBehaviour, HelpOptions,
-    has_correct_permissions, macros::help, OnlyIn,
+    has_correct_permissions, OnlyIn,
     structures::Command as InternalCommand,
 };
 #[cfg(all(feature = "cache", feature = "http"))]
@@ -982,12 +982,11 @@ fn send_error_embed(
 ///     .help(&WITH_EMBEDS_HELP_COMMAND));
 /// ```
 #[cfg(all(feature = "cache", feature = "http"))]
-#[help]
 pub fn with_embeds(
     context: &mut Context,
     msg: &Message,
     args: Args,
-    help_options: &'static HelpOptions,
+    help_options: &HelpOptions,
     groups: &[&'static CommandGroup],
     owners: HashSet<UserId, impl BuildHasher>,
 ) -> CommandResult {
@@ -1135,12 +1134,11 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
 ///     .help(&PLAIN_HELP_COMMAND));
 /// ```
 #[cfg(all(feature = "cache", feature = "http"))]
-#[help]
 pub fn plain(
     context: &mut Context,
     msg: &Message,
     args: Args,
-    help_options: &'static HelpOptions,
+    help_options: &HelpOptions,
     groups: &[&'static CommandGroup],
     owners: HashSet<UserId, impl BuildHasher>,
 ) -> CommandResult {

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -143,7 +143,7 @@ impl PartialEq for HelpCommand {
 /// Lacking required permissions to execute the command.
 /// Lacking required roles to execute the command.
 /// The command can't be used in the current channel (as in `DM only` or `guild only`).
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum HelpBehaviour {
     /// Strikes a command by applying `~~{command_name}~~`.
     Strike,
@@ -156,7 +156,7 @@ pub enum HelpBehaviour {
 }
 
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct HelpOptions {
     /// Which names should the help command use for dispatching.
     /// Defaults to `["help"]`


### PR DESCRIPTION
As `with_embeds` and `plain` are only called from inside the actual `help`-function, they no longer need the `#[help]`-macro and thus no longer a static lifetime on `HelpOptions`. 

Additionally, I implemented `Clone` for `HelpOptions` and `HelpBehaviour`. In combination of mentioned above and `Clone`, bot-developers can now clone the received `HelpOptions` in the `help`-function, mutate it, and pass runtime-mutated `HelpOptions`, e.g. to provide randomness. 

Side-note: If you notice performance-issues due tons of help-commands being called every second, it might be beneficial to implement your own version of `with_embeds`/`plain` and simply provide runtime-mutated local variables instead of `HelpOptions`' fields. 