### PR TITLE
Fix `FnOnce`s to accept `&mut`

### DIFF
--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -20,7 +20,7 @@ impl EditProfile {
     /// image from a file and return its contents in base64-encoded form:
     ///
     /// ```rust,no_run
-    /// # #[cfg(feature = "client", feature = "cache")]
+    /// # #[cfg(all(feature = "client", feature = "cache"))]
     /// # fn main() {
     /// # use serenity::prelude::*;
     /// # use serenity::model::prelude::*;

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -29,16 +29,15 @@ impl EditProfile {
     ///
     /// # impl EventHandler for Handler {
     ///    # fn message(&self, context: Context, _: Message) {
-    ///         use serenity::utils;
+    ///         use serenity::{http::raw, utils};
     ///
     ///         // assuming a `context` has been bound
     ///
     ///         let base64 = utils::read_image("./my_image.jpg")
     ///         .expect("Failed to read image");
     ///
-    ///         let _ = context.edit_profile(|mut profile| {
-    ///             profile.avatar(Some(&base64))
-    ///         });
+    ///         let _ = context.cache.write().user.edit(&context, |p|
+    ///             p.avatar(Some(&base64)));
     ///    # }
     /// # }
     /// #

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -46,7 +46,7 @@ impl EditProfile {
     /// # client.start().unwrap();
     /// # }
     /// #
-    /// # #[cfg(all(not(feature = "client"), not(feature = "cache")))]
+    /// # #[cfg(any(not(feature = "client"), not(feature = "cache")))]
     /// # fn main() {}
     /// ```
     ///

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -46,7 +46,7 @@ impl EditProfile {
     /// # client.start().unwrap();
     /// # }
     /// #
-    /// # #[cfg(not(feature = "client"))]
+    /// # #[cfg(all(not(feature = "client"), not(feature = "cache")))]
     /// # fn main() {}
     /// ```
     ///

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -20,7 +20,7 @@ impl EditProfile {
     /// image from a file and return its contents in base64-encoded form:
     ///
     /// ```rust,no_run
-    /// # #[cfg(feature = "client")]
+    /// # #[cfg(feature = "client", feature = "cache")]
     /// # fn main() {
     /// # use serenity::prelude::*;
     /// # use serenity::model::prelude::*;

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -1,17 +1,12 @@
-use crate::builder::EditProfile;
 use crate::client::bridge::gateway::ShardMessenger;
-use crate::error::Result;
 use crate::gateway::InterMessage;
 use crate::model::prelude::*;
 use parking_lot::RwLock;
-use serde_json::Value;
 use std::sync::{
     Arc,
     mpsc::Sender,
 };
 use typemap::ShareMap;
-use crate::utils::VecMap;
-use crate::utils::vecmap_to_json_map;
 #[cfg(feature = "cache")]
 pub use crate::cache::{Cache, CacheRwLock};
 #[cfg(feature = "http")]
@@ -113,70 +108,6 @@ impl Context {
             data,
         }
     }
-
-    /// Edits the current user's profile settings.
-    ///
-    /// Refer to `EditProfile`'s documentation for its methods.
-    ///
-    /// # Examples
-    ///
-    /// Change the current user's username:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::channel::Message;
-    /// #
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {
-    ///     fn message(&self, ctx: Context, msg: Message) {
-    ///         if msg.content == "!changename" {
-    ///             ctx.edit_profile(|mut e| {
-    ///                 e.username("Edward Elric");
-    ///
-    ///                 e
-    ///             });
-    ///         }
-    ///     }
-    /// }
-    /// let mut client = Client::new("token", Handler).unwrap();
-    ///
-    /// client.start().unwrap();
-    /// ```
-    #[cfg(feature = "builder")]
-    #[deprecated(since = "0.5.6", note = "Use the http module instead.")]
-    pub fn edit_profile<F>(&self, f: F) -> Result<CurrentUser>
-    where F: FnOnce(&mut EditProfile) -> &mut EditProfile {
-        let mut map = VecMap::with_capacity(2);
-
-        feature_cache! {
-            {
-                let cache = self.cache.read();
-
-                map.insert("username", Value::String(cache.user.name.clone()));
-
-                if let Some(email) = cache.user.email.clone() {
-                    map.insert("email", Value::String(email));
-                }
-            } else {
-                let user = self.http.get_current_user()?;
-
-                map.insert("username", Value::String(user.name));
-
-                if let Some(email) = user.email {
-                    map.insert("email", Value::String(email));
-                }
-            }
-        }
-
-        let mut edit_profile = EditProfile(map);
-        f(&mut edit_profile);
-
-        let edited = vecmap_to_json_map(edit_profile.0);
-
-        self.http.edit_profile(&edited)
-    }
-
 
     /// Sets the current user as being [`Online`]. This maintains the current
     /// activity.

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -88,11 +88,11 @@ impl ChannelCategory {
     /// Change a voice channels name and bitrate:
     ///
     /// ```rust,ignore
-    /// category.edit(|c| c.name("test").bitrate(86400));
+    /// category.edit(&context, |c| c.name("test").bitrate(86400));
     /// ```
     #[cfg(all(feature = "builder", feature = "model", feature = "utils", feature = "client"))]
     pub fn edit<F>(&mut self, context: &Context, f: F) -> Result<()>
-        where F: FnOnce(EditChannel) -> EditChannel {
+        where F: FnOnce(&mut EditChannel) -> &mut EditChannel {
         #[cfg(feature = "cache")]
         {
             let req = Permissions::MANAGE_CHANNELS;
@@ -106,7 +106,10 @@ impl ChannelCategory {
         map.insert("name", Value::String(self.name.clone()));
         map.insert("position", Value::Number(Number::from(self.position)));
 
-        let map = serenity_utils::vecmap_to_json_map(f(EditChannel(map)).0);
+
+        let mut edit_channel = EditChannel::default();
+        f(&mut edit_channel);
+        let map = serenity_utils::vecmap_to_json_map(edit_channel.0);
 
         context.http.edit_channel(self.id.0, &map).map(|channel| {
             let GuildChannel {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -251,7 +251,7 @@ impl ChannelId {
     /// ```rust,ignore
     /// // assuming a `channel_id` has been bound
     ///
-    /// channel_id.edit(|c| c.name("test").bitrate(64000));
+    /// channel_id.edit(&context, |c| c.name("test").bitrate(64000));
     /// ```
     ///
     /// [`Channel`]: ../channel/enum.Channel.html

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -349,11 +349,11 @@ impl GuildChannel {
     /// Change a voice channels name and bitrate:
     ///
     /// ```rust,ignore
-    /// channel.edit(|c| c.name("test").bitrate(86400));
+    /// channel.edit(&context, |c| c.name("test").bitrate(86400));
     /// ```
     #[cfg(all(feature = "utils", feature = "client", feature = "builder"))]
     pub fn edit<F>(&mut self, context: &Context, f: F) -> Result<()>
-        where F: FnOnce(EditChannel) -> EditChannel {
+        where F: FnOnce(&mut EditChannel) -> &mut EditChannel {
         #[cfg(feature = "cache")]
         {
             let req = Permissions::MANAGE_CHANNELS;
@@ -369,7 +369,9 @@ impl GuildChannel {
         map.insert("name", Value::String(self.name.clone()));
         map.insert("position", Value::Number(Number::from(self.position)));
 
-        let edited = serenity_utils::vecmap_to_json_map(f(EditChannel(map)).0);
+        let mut edit_channel = EditChannel::default();
+        f(&mut edit_channel);
+        let edited = serenity_utils::vecmap_to_json_map(edit_channel.0);
 
         match context.http.edit_channel(self.id.0, &edited) {
             Ok(channel) => {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -170,7 +170,7 @@ impl Message {
     /// ```rust,ignore
     /// // assuming a `message` has already been bound
     ///
-    /// message.edit(|m| m.content("new content"));
+    /// message.edit(&context, |m| m.content("new content"));
     /// ```
     ///
     /// # Errors

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -345,19 +345,21 @@ impl GuildId {
     /// Mute a member and set their roles to just one role with a predefined Id:
     ///
     /// ```rust,ignore
-    /// guild.edit_member(user_id, |m| m.mute(true).roles(&vec![role_id]));
+    /// guild.edit_member(&context, user_id, |m| m.mute(true).roles(&vec![role_id]));
     /// ```
     #[cfg(feature = "http")]
     #[inline]
     pub fn edit_member<F, U>(self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
-        where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
+        where F: FnOnce(&mut EditMember) -> &mut EditMember, U: Into<UserId> {
         self._edit_member(&http, user_id.into(), f)
     }
 
     #[cfg(feature = "http")]
     fn _edit_member<F>(self, http: impl AsRef<Http>, user_id: UserId, f: F) -> Result<()>
-        where F: FnOnce(EditMember) -> EditMember {
-        let map = utils::vecmap_to_json_map(f(EditMember::default()).0);
+        where F: FnOnce(&mut EditMember) -> &mut EditMember {
+        let mut edit_member = EditMember::default();
+        f(&mut edit_member);
+        let map = utils::vecmap_to_json_map(edit_member.0);
 
         http.as_ref().edit_member(self.0, user_id.0, &map)
     }
@@ -386,7 +388,7 @@ impl GuildId {
     /// ```rust,ignore
     /// use serenity::model::{GuildId, RoleId};
     ///
-    /// GuildId(7).edit_role(RoleId(8), |r| r.hoist(true));
+    /// GuildId(7).edit_role(&context, RoleId(8), |r| r.hoist(true));
     /// ```
     ///
     /// [`Role`]: ../guild/struct.Role.html
@@ -394,14 +396,16 @@ impl GuildId {
     #[cfg(feature = "http")]
     #[inline]
     pub fn edit_role<F, R>(self, http: impl AsRef<Http>, role_id: R, f: F) -> Result<Role>
-        where F: FnOnce(EditRole) -> EditRole, R: Into<RoleId> {
+        where F: FnOnce(&mut EditRole) -> &mut EditRole, R: Into<RoleId> {
         self._edit_role(&http, role_id.into(), f)
     }
 
     #[cfg(feature = "http")]
     fn _edit_role<F>(self, http: impl AsRef<Http>, role_id: RoleId, f: F) -> Result<Role>
-        where F: FnOnce(EditRole) -> EditRole {
-        let map = utils::vecmap_to_json_map(f(EditRole::default()).0);
+        where F: FnOnce(&mut EditRole) -> &mut EditRole {
+        let mut edit_role = EditRole::default();
+        f(&mut edit_role);
+        let map = utils::vecmap_to_json_map(edit_role.0);
 
         http.as_ref().edit_role(self.0, role_id.0, &map)
     }
@@ -415,7 +419,7 @@ impl GuildId {
     ///
     /// ```rust,ignore
     /// use serenity::model::{GuildId, RoleId};
-    /// GuildId(7).edit_role_position(RoleId(8), 2);
+    /// GuildId(7).edit_role_position(&context, RoleId(8), 2);
     /// ```
     ///
     /// [`Role`]: ../guild/struct.Role.html

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -242,8 +242,10 @@ impl Member {
     /// [`Guild::edit_member`]: struct.Guild.html#method.edit_member
     /// [`EditMember`]: ../../builder/struct.EditMember.html
     #[cfg(feature = "cache")]
-    pub fn edit<F: FnOnce(EditMember) -> EditMember>(&self, http: impl AsRef<Http>, f: F) -> Result<()> {
-        let map = utils::vecmap_to_json_map(f(EditMember::default()).0);
+    pub fn edit<F: FnOnce(&mut EditMember) -> &mut EditMember>(&self, http: impl AsRef<Http>, f: F) -> Result<()> {
+        let mut edit_member = EditMember::default();
+        f(&mut edit_member);
+        let map = utils::vecmap_to_json_map(edit_member.0);
 
         http.as_ref().edit_member(self.guild_id.0, self.user.read().id.0, &map)
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -608,7 +608,7 @@ impl Guild {
     #[cfg(feature = "http")]
     #[inline]
     pub fn edit_member<F, U>(&self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
-        where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
+        where F: FnOnce(&mut EditMember) -> &mut EditMember, U: Into<UserId> {
         self.id.edit_member(&http, user_id, f)
     }
 
@@ -649,14 +649,14 @@ impl Guild {
     /// Make a role hoisted:
     ///
     /// ```rust,ignore
-    /// guild.edit_role(RoleId(7), |r| r.hoist(true));
+    /// guild.edit_role(&context, RoleId(7), |r| r.hoist(true));
     /// ```
     ///
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "http")]
     #[inline]
     pub fn edit_role<F, R>(&self, http: impl AsRef<Http>, role_id: R, f: F) -> Result<Role>
-        where F: FnOnce(EditRole) -> EditRole, R: Into<RoleId> {
+        where F: FnOnce(&mut EditRole) -> &mut EditRole, R: Into<RoleId> {
         self.id.edit_role(&http, role_id, f)
     }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -282,7 +282,7 @@ impl PartialGuild {
     #[cfg(feature = "http")]
     #[inline]
     pub fn edit_member<F, U>(&self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
-        where F: FnOnce(EditMember) -> EditMember, U: Into<UserId> {
+        where F: FnOnce(&mut EditMember) -> &mut EditMember, U: Into<UserId> {
         self.id.edit_member(&http, user_id, f)
     }
 

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -104,7 +104,7 @@ impl Role {
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(all(feature = "builder", feature = "cache", feature = "http"))]
-    pub fn edit<F: FnOnce(EditRole) -> EditRole>(&self, context: &Context, f: F) -> Result<Role> {
+    pub fn edit<F: FnOnce(&mut EditRole) -> &mut EditRole>(&self, context: &Context, f: F) -> Result<Role> {
         self.find_guild(&context.cache)
             .and_then(|guild_id| guild_id.edit_role(&context.http, self.id, f))
     }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -108,7 +108,7 @@ impl CurrentUser {
     /// [`EditProfile`]: ../../builder/struct.EditProfile.html
     #[cfg(feature = "http")]
     pub fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<()>
-        where F: FnOnce(EditProfile) -> EditProfile {
+        where F: FnOnce(&mut EditProfile) -> &mut EditProfile {
         let mut map = VecMap::new();
         map.insert("username", Value::String(self.name.clone()));
 
@@ -116,7 +116,9 @@ impl CurrentUser {
             map.insert("email", Value::String(email.clone()));
         }
 
-        let map = utils::vecmap_to_json_map(f(EditProfile(map)).0);
+        let mut edit_profile = EditProfile(map);
+        f(&mut edit_profile);
+        let map = utils::vecmap_to_json_map(edit_profile.0);
 
         match http.as_ref().edit_profile(&map) {
             Ok(new) => {


### PR DESCRIPTION
Some `FnOnce`s still expected immutability, however #159 aimed to support for mutable builders.

This pull request changes forgotten `FnOnce`s, updates their code-examples not displaying the requirement of `impl AsRef<Http>`, and remove the deprecated `edit_profile`-builder.