### PR TITLE
Fix Example 06, 07, and 10

### DIFF
--- a/examples/06_voice/src/main.rs
+++ b/examples/06_voice/src/main.rs
@@ -75,7 +75,7 @@ fn main() {
     client.with_framework(StandardFramework::new()
         .configure(|c| c
             .prefix("~"))
-        .group(GENERAL_GROUP));
+        .group(&GENERAL_GROUP));
 
     let _ = client.start().map_err(|why| println!("Client ended: {:?}", why));
 }
@@ -91,7 +91,7 @@ fn deafen(ctx: &mut Context, msg: &Message) -> CommandResult {
         },
     };
 
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().unwrap();
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().unwrap();
     let mut manager = manager_lock.lock();
 
     let handler = match manager.get_mut(guild_id) {
@@ -142,7 +142,7 @@ fn join(ctx: &mut Context, msg: &Message) -> CommandResult {
         }
     };
 
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if manager.join(guild_id, connect_to).is_some() {
@@ -165,7 +165,7 @@ fn leave(ctx: &mut Context, msg: &Message) -> CommandResult {
         },
     };
 
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
     let has_handler = manager.get(guild_id).is_some();
 
@@ -191,7 +191,7 @@ fn mute(ctx: &mut Context, msg: &Message) -> CommandResult {
         },
     };
 
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     let handler = match manager.get_mut(guild_id) {
@@ -247,7 +247,7 @@ fn play(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
         },
     };
 
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if let Some(handler) = manager.get_mut(guild_id) {
@@ -283,7 +283,7 @@ fn undeafen(ctx: &mut Context, msg: &Message) -> CommandResult {
         },
     };
 
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if let Some(handler) = manager.get_mut(guild_id) {
@@ -307,7 +307,7 @@ fn unmute(ctx: &mut Context, msg: &Message) -> CommandResult {
             return Ok(());
         },
     };
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if let Some(handler) = manager.get_mut(guild_id) {

--- a/examples/07_sample_bot_structure/src/main.rs
+++ b/examples/07_sample_bot_structure/src/main.rs
@@ -42,7 +42,7 @@ impl EventHandler for Handler {
 group!({
     name: "general",
     options: {},
-    commands: [math, meta, owner]
+    commands: [multiply, ping, quit]
 });
 
 fn main() {
@@ -75,7 +75,7 @@ fn main() {
         .configure(|c| c
             .owners(owners)
             .prefix("~"))
-        .group(GENERAL_GROUP));
+        .group(&GENERAL_GROUP));
 
     if let Err(why) = client.start() {
         error!("Client error: {:?}", why);

--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -9,7 +9,6 @@
 use std::{env, sync::Arc};
 
 use serenity::{
-    command,
     client::{bridge::voice::ClientVoiceManager, Client, Context, EventHandler},
     framework::{
         StandardFramework,
@@ -23,9 +22,6 @@ use serenity::{
     voice::AudioReceiver,
     Result as SerenityResult,
 };
-
-// This imports `typemap`'s `Key` as `TypeMapKey`.
-use serenity::prelude::*;
 
 struct VoiceManager;
 
@@ -114,7 +110,7 @@ fn main() {
     client.with_framework(StandardFramework::new()
         .configure(|c| c
             .prefix("~"))
-        .group(GENERAL_GROUP));
+        .group(&GENERAL_GROUP));
 
     let _ = client.start().map_err(|why| println!("Client ended: {:?}", why));
 }
@@ -139,7 +135,7 @@ fn join(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
         },
     };
 
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
 
     if let Some(handler) = manager.join(guild_id, connect_to) {
@@ -163,7 +159,7 @@ fn leave(ctx: &mut Context, msg: &Message) -> CommandResult {
         },
     };
 
-    let mut manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
+    let manager_lock = ctx.data.read().get::<VoiceManager>().cloned().expect("Expected VoiceManager in ShareMap.");
     let mut manager = manager_lock.lock();
     let has_handler = manager.get(guild_id).is_some();
 


### PR DESCRIPTION
These examples had erroneous code due to incorrect porting.
Also fixed their warnings.