### PR TITLE
Add Rustls and Native-TLS Backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,19 @@ default = [
     "http",
     "standard_framework",
     "utils",
+    "rustls_backend",
+]
+default_native_tls = [
+    "builder",
+    "cache",
+    "client",
+    "framework",
+    "gateway",
+    "model",
+    "http",
+    "standard_framework",
+    "utils",
+    "native_tls_backend",
 ]
 builder = ["utils"]
 cache = []
@@ -132,14 +145,13 @@ gateway = [
     "http",
     "url",
     "utils",
-    "rustls",
     "webpki",
     "webpki-roots",
-    "tungstenite",
 ]
-http = ["lazy_static", "reqwest/rustls-tls"]
+http = []
+rustls_backend = ["reqwest/rustls-tls", "tungstenite", "rustls"]
+native_tls_backend = ["reqwest/default-tls", "tungstenite/tls"]
 model = ["builder", "http"]
-native_tls = ["reqwest/default-tls", "tungstenite/tls"]
 standard_framework = ["framework", "uwl", "command_attr"]
 utils = ["base64"]
 voice = ["byteorder", "gateway", "audiopus", "rand", "sodiumoxide"]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ version = "0.5"
 ```
 
 The default features are: `builder`, `cache`, `client`, `framework`, `gateway`,
-`http`, `model`, `standard_framework`, and `utils`.
+`http`, `model`, `standard_framework`, `utils`, and `rustls_backend`.
 
 The following is a full list of features:
 
@@ -118,6 +118,13 @@ the HTTP functions.
 - **voice**: Enables compilation of voice support, so that voice channels can be
 connected to and audio can be sent/received.
 
+Serenity offers two TLS-backends, `rustls_backend` by default, you need to pick
+one if you do not use the default features:
+- **rustls_backend**: Uses Rustls for all platforms, a pure Rust
+TLS implementation.
+- **native_tls_backend**: Uses SChannel on Windows, Secure Transport on macOS,
+and OpenSSL on other platforms.
+
 If you want all of the default features except for `cache` for example, you can
 list all but that:
 
@@ -133,6 +140,7 @@ features = [
     "model",
     "standard_framework",
     "utils",
+    "rustls_backend",
 ]
 version = "0.5"
 ```

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ the HTTP functions.
 - **utils**: Utility functions for common use cases by users.
 - **voice**: Enables compilation of voice support, so that voice channels can be
 connected to and audio can be sent/received.
+- **default_native_tls**: Default features but using `native_tls_backend`
+instead of `rustls_backend`.
 
 Serenity offers two TLS-backends, `rustls_backend` by default, you need to pick
 one if you do not use the default features:
@@ -124,6 +126,7 @@ one if you do not use the default features:
 TLS implementation.
 - **native_tls_backend**: Uses SChannel on Windows, Secure Transport on macOS,
 and OpenSSL on other platforms.
+
 
 If you want all of the default features except for `cache` for example, you can
 list all but that:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,14 +28,14 @@ jobs:
     name: 'macOS_stable_no_cache'
     vmImage: 'xcode9-macos10.13'
     toolchain: 'stable'
-    features: 'builder client framework gateway model http standard_framework utils'
+    features: 'builder client framework gateway model http standard_framework utils rustls_backend'
 
 - template: 'azure-template.yml'
   parameters:
     name: 'macOS_no_gateway'
     vmImage: 'xcode9-macos10.13'
     toolchain: 'stable'
-    features: 'model http'
+    features: 'model http rustls_backend'
 
 - template: 'azure-template-win.yml'
   parameters:

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+#[cfg(all(any(feature = "http", feature = "gateway"),
+    not(any(feature = "rustls_backend", feature = "native_tls_backend"))))]
+compile_error!("You have the `http` or `gateway` feature enabled, \
+    either the `rustls_backend` or `native_tls_backend` feature must be
+    selected to let Serenity use `http` or `gateway`.\n\
+    - `rustls_backend` uses Rustls, a pure Rust TLS-implemenation.\n\
+    - `native_tls_backend` uses SChannel on Windows, Secure Transport on macOS, \
+    and OpenSSL on other platforms.\n\
+    If you are unsure, go with `rustls_backend`.");
+
+fn main() {}

--- a/examples/05_command_framework/Cargo.toml
+++ b/examples/05_command_framework/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies.serenity]
-features = ["framework", "standard_framework"]
+features = ["framework", "standard_framework", "rustls_backend"]
 path = "../../"

--- a/examples/06_voice/Cargo.toml
+++ b/examples/06_voice/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies.serenity]
-features = ["cache", "framework", "standard_framework", "voice", "http"]
+features = ["cache", "framework", "standard_framework", "voice", "http", "rustls_backend"]
 path = "../../"

--- a/examples/07_sample_bot_structure/Cargo.toml
+++ b/examples/07_sample_bot_structure/Cargo.toml
@@ -10,5 +10,5 @@ kankyo = "0.2"
 log = "0.4"
 
 [dependencies.serenity]
-features = ["cache", "framework", "standard_framework"]
+features = ["cache", "framework", "standard_framework", "rustls_backend"]
 path = "../../"

--- a/examples/08_env_logging/Cargo.toml
+++ b/examples/08_env_logging/Cargo.toml
@@ -9,5 +9,5 @@ env_logger = "0.6"
 log = "0.4"
 
 [dependencies.serenity]
-features = ["client"]
+features = ["client", "rustls_backend"]
 path = "../../"

--- a/examples/09_shard_manager/Cargo.toml
+++ b/examples/09_shard_manager/Cargo.toml
@@ -9,5 +9,5 @@ env_logger = "0.6"
 log = "0.4"
 
 [dependencies.serenity]
-features = ["client"]
+features = ["client", "rustls_backend"]
 path = "../../"

--- a/examples/10_voice_receive/Cargo.toml
+++ b/examples/10_voice_receive/Cargo.toml
@@ -9,5 +9,5 @@ env_logger = "~0.6"
 log = "~0.4"
 
 [dependencies.serenity]
-features = ["client", "standard_framework", "voice"]
+features = ["client", "standard_framework", "voice", "rustls_backend"]
 path = "../../"

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ use crate::client::ClientError;
 use crate::gateway::GatewayError;
 #[cfg(feature = "http")]
 use crate::http::HttpError;
-#[cfg(all(feature = "gateway", not(feature = "native_tls")))]
+#[cfg(all(feature = "gateway", not(feature = "native_tls_backend")))]
 use crate::internal::ws_impl::RustlsError;
 #[cfg(feature = "voice")]
 use crate::voice::VoiceError;
@@ -95,7 +95,7 @@ pub enum Error {
     #[cfg(feature = "http")]
     Http(Box<HttpError>),
     /// An error occuring in rustls
-    #[cfg(all(feature = "gateway", not(feature = "native_tls")))]
+    #[cfg(all(feature = "gateway", not(feature = "native_tls_backend")))]
     Rustls(RustlsError),
     /// An error from the `tungstenite` crate.
     #[cfg(feature = "gateway")]
@@ -147,7 +147,7 @@ impl From<VoiceError> for Error {
     fn from(e: VoiceError) -> Error { Error::Voice(e) }
 }
 
-#[cfg(all(feature = "gateway", not(feature = "native_tls")))]
+#[cfg(all(feature = "gateway", not(feature = "native_tls_backend")))]
 impl From<RustlsError> for Error {
     fn from(e: RustlsError) -> Error { Error::Rustls(e) }
 }
@@ -197,7 +197,7 @@ impl StdError for Error {
             Error::Http(ref inner) => inner.description(),
             #[cfg(feature = "voice")]
             Error::Opus(ref inner) => inner.description(),
-            #[cfg(all(feature = "gateway", not(feature = "native_tls")))]
+            #[cfg(all(feature = "gateway", not(feature = "native_tls_backend")))]
             Error::Rustls(ref inner) => inner.description(),
             #[cfg(feature = "gateway")]
             Error::Tungstenite(ref inner) => inner.description(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -211,7 +211,7 @@ impl StdError for Error {
         match *self {
             Error::Json(ref inner) => Some(inner),
             Error::Io(ref inner) => Some(inner),
-            #[cfg(feature = "tungstenite")]
+            #[cfg(feature = "gateway")]
             Error::Tungstenite(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -64,7 +64,7 @@ use serde_json::Value;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use tungstenite::protocol::WebSocket;
 
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native_tls_backend")]
 use tungstenite::client::AutoStream;
 
 #[cfg(feature = "client")]
@@ -72,10 +72,10 @@ use crate::client::bridge::gateway::ShardClientMessage;
 
 pub type CurrentPresence = (Option<Activity>, OnlineStatus);
 
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 pub type WsClient = WebSocket<rustls::StreamOwned<rustls::ClientSession, std::net::TcpStream>>;
 
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native_tls_backend")]
 pub type WsClient = WebSocket<AutoStream>;
 
 /// Indicates the current connection stage of a [`Shard`].

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -27,10 +27,10 @@ use tungstenite::{
 use url::Url;
 use log::{error, debug, info, trace, warn};
 
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 use crate::internal::ws_impl::create_rustls_client;
 
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native_tls_backend")]
 use tungstenite::handshake::client::Request;
 
 /// A Shard is a higher-level handler for a websocket connection to Discord's
@@ -828,13 +828,13 @@ impl Shard {
     }
 }
 
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 fn connect(base_url: &str) -> Result<WsClient> {
     let url = build_gateway_url(base_url)?;
     Ok(create_rustls_client(url)?)
 }
 
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native_tls_backend")]
 fn connect(base_url: &str) -> Result<WsClient> {
     let url = build_gateway_url(base_url)?;
     let client = tungstenite::connect(Request::from(url))?;
@@ -843,10 +843,10 @@ fn connect(base_url: &str) -> Result<WsClient> {
 }
 
 fn set_client_timeout(client: &mut WsClient) -> Result<()> {
-    #[cfg(not(feature = "native_tls"))]
+    #[cfg(not(feature = "native_tls_backend"))]
     let stream = &client.get_mut().sock;
 
-    #[cfg(feature = "native_tls")]
+    #[cfg(feature = "native_tls_backend")]
     let stream = match client.get_mut() {
         tungstenite::stream::Stream::Plain(stream) => stream,
         tungstenite::stream::Stream::Tls(stream) => stream.get_mut(),

--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -69,11 +69,11 @@ impl Http {
 
     pub fn new_with_token(token: &str) -> Self {
         Http {
-            #[cfg(not(feature = "native_tls"))]
+            #[cfg(not(feature = "native_tls_backend"))]
             client: Client::builder()
                 .use_rustls_tls()
                 .build().expect("Cannot build Reqwest::Client."),
-            #[cfg(feature = "native_tls")]
+            #[cfg(feature = "native_tls_backend")]
             client: Client::builder()
                 .use_default_tls()
                 .build().expect("Cannot build Reqwest::Client."),

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -8,7 +8,7 @@ use tungstenite::{
 };
 use log::warn;
 
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 use std::{
     error::Error as StdError,
     fmt::{
@@ -20,7 +20,7 @@ use std::{
     net::TcpStream,
     sync::Arc,
 };
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 use url::Url;
 
 pub trait ReceiverExt {
@@ -81,7 +81,7 @@ fn convert_ws_message(message: Option<Message>) -> Result<Option<Value>>{
 
 /// An error that occured while connecting over rustls
 #[derive(Debug)]
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 pub enum RustlsError {
     /// WebPKI X.509 Certificate Validation Error.
     WebPKI,
@@ -93,19 +93,19 @@ pub enum RustlsError {
     __Nonexhaustive,
 }
 
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 impl From<IoError> for RustlsError {
     fn from(e: IoError) -> Self {
         RustlsError::Io(e)
     }
 }
 
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 impl Display for RustlsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult { f.write_str(self.description()) }
 }
 
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 impl StdError for RustlsError {
     fn description(&self) -> &str {
         use self::RustlsError::*;
@@ -120,7 +120,7 @@ impl StdError for RustlsError {
 }
 
 // Create a tungstenite client with a rustls stream.
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 pub(crate) fn create_rustls_client(url: Url) -> Result<WsClient> {
     let mut config = rustls::ClientConfig::new();
     config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -53,7 +53,7 @@ use super::{payload, VoiceError, CRYPTO_MODE};
 use url::Url;
 use log::{debug, info, warn};
 
-#[cfg(not(feature = "native_tls"))]
+#[cfg(not(feature = "native_tls_backend"))]
 use crate::internal::ws_impl::create_rustls_client;
 
 enum ReceiverStatus {
@@ -96,10 +96,10 @@ impl Connection {
     pub fn new(mut info: ConnectionInfo) -> Result<Connection> {
         let url = generate_url(&mut info.endpoint)?;
 
-        #[cfg(not(feature = "native_tls"))]
+        #[cfg(not(feature = "native_tls_backend"))]
         let mut client = create_rustls_client(url)?;
 
-        #[cfg(feature = "native_tls")]
+        #[cfg(feature = "native_tls_backend")]
         let mut client = tungstenite::connect(url)?.0;
         let mut hello = None;
         let mut ready = None;
@@ -231,10 +231,10 @@ impl Connection {
         // (if at all possible) and then proceed as normal.
         let _ = self.thread_items.ws_close_sender.send(0);
 
-        #[cfg(not(feature = "native_tls"))]
+        #[cfg(not(feature = "native_tls_backend"))]
         let mut client = create_rustls_client(url)?;
 
-        #[cfg(feature = "native_tls")]
+        #[cfg(feature = "native_tls_backend")]
         let mut client = tungstenite::connect(url)?.0;
 
         client.send_json(&payload::build_resume(&self.connection_info))?;
@@ -782,10 +782,10 @@ fn start_ws_thread(client: Arc<Mutex<WsClient>>, tx: &MpscSender<ReceiverStatus>
 
 #[inline]
 fn unset_blocking(client: &mut WsClient) -> Result<()> {
-    #[cfg(not(feature = "native_tls"))]
+    #[cfg(not(feature = "native_tls_backend"))]
     let stream = &client.get_mut().sock;
 
-    #[cfg(feature = "native_tls")]
+    #[cfg(feature = "native_tls_backend")]
     let stream = match client.get_mut() {
         tungstenite::stream::Stream::Plain(stream) => stream,
         tungstenite::stream::Stream::Tls(stream) => stream.get_mut(),


### PR DESCRIPTION
Currently, Serenity will pull in Rustls despite explicitly specifying the`native_tls`-feature. This can become a problem on systems that are unable to build Rustls, e.g. POWER9.

This pull requests adds two backend-features, one for Rustls and one for native-tls.
By default, Serenity will pick `rustls_backend`, however the user can also pick the `default_native_tls`-feature to gain all default features with the backend switched for `native_tls_backend`.

From now on, the user must pick a either backend if they do not use the either default-feature set.