### PR TITLE
Update Dependencies for `v0.6.0-rc.0`-Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ version = "0.5.11"
 edition = "2018"
 
 [dependencies]
-bitflags = "^1.0"
-log = "~0.4"
-parking_lot = "^0.6"
-serde_json = "^1.0"
+bitflags = "1.0"
+log = "0.4"
+parking_lot = "0.8"
+serde_json = "1.0"
 
 [dependencies.audiopus]
 optional = true
@@ -26,12 +26,12 @@ path = "./command_attr"
 optional = true
 
 [dependencies.serde]
-version = "^1.0"
+version = "1.0"
 features = ["derive"]
 
 [dependencies.uwl]
 optional = true
-version = "^0.3"
+version = "0.3"
 
 [dependencies.base64]
 optional = true
@@ -39,42 +39,38 @@ version = "0.10"
 
 [dependencies.byteorder]
 optional = true
-version = "^1.2"
+version = "1.3"
 
 [dependencies.chrono]
 features = ["serde"]
-version = "~0.4"
+version = "0.4"
 
 [dependencies.flate2]
 optional = true
-version = "^1.0"
+version = "1.0"
 
 [dependencies.reqwest]
 default-features = false
 optional = true
 version = "0.9"
 
-[dependencies.lazy_static]
-optional = true
-version = "^1.0"
-
 [dependencies.rand]
 optional = true
-version = "^0.4"
+version = "0.6"
 
 [dependencies.rustls]
 optional = true
-version = "^0.15"
+version = "0.15"
 
 [dependencies.sodiumoxide]
 default-features = false
 features = ["std"]
 optional = true
-version = "^0.2"
+version = "0.2"
 
 [dependencies.threadpool]
 optional = true
-version = "~1.7"
+version = "1.7"
 
 [dependencies.tungstenite]
 default-features = false
@@ -83,26 +79,26 @@ version = "0.6"
 
 [dependencies.typemap]
 optional = true
-version = "~0.3"
+version = "0.3"
 
 [dependencies.url]
 optional = true
-version = "^1.0"
+version = "1.7"
 
 [dependencies.webpki]
 optional = true
-version = "^0.19"
+version = "0.19"
 
 [dependencies.webpki-roots]
 optional = true
-version = "^0.16"
+version = "0.16"
 
 [dev-dependencies.http_crate]
-version = "~0.1"
+version = "0.1"
 package = "http"
 
 [dev-dependencies.matches]
-version = "^0.1"
+version = "0.1"
 
 [features]
 default = [
@@ -134,7 +130,6 @@ cache = []
 client = [
     "gateway",
     "http",
-    "lazy_static",
     "threadpool",
     "typemap",
 ]


### PR DESCRIPTION
Updates all dependencies and removes `lazy_static`.