### PR TITLE
Implement `AsRef<Http>` for `Http`

### DIFF
--- a/src/http/raw.rs
+++ b/src/http/raw.rs
@@ -1772,6 +1772,10 @@ impl Http {
     }
 }
 
+impl AsRef<Http> for Http {
+    fn as_ref(&self) -> &Http { &self }
+}
+
 impl Default for Http {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
0.6.0-rc.0 was shipped with support for `AsRef<Http>` via `Context` and `Arc<Http>` while the actual type `Http` did not implement the trait, this was an oversight. 
This can become a problem if the pure `Http`-struct is used, but a user might not notice that `Context` wraps its `Http` in an `Arc`.

This simply implements the trait for `Http`.
