### PR TITLE
Do not display Command if no `help_available`

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -438,11 +438,15 @@ fn fetch_all_eligible_commands_in_group<'a>(
         let cmd = &commands[&*name];
         let cmd = cmd.options();
 
+        if !cmd.help_available {
+            continue;
+        }
+
         if !cmd.dm_only && !cmd.guild_only
             || cmd.dm_only && msg.is_private()
             || cmd.guild_only && !msg.is_private()
         {
-            if cmd.help_available && has_correct_permissions(&cmd, msg) {
+            if has_correct_permissions(&cmd, msg) {
 
                 if let Some(guild) = msg.guild() {
                     let guild = guild.read();


### PR DESCRIPTION
As described in #557, there are circumstances in the help-system that cause commands with `help_available` set to `false` to still be displayed in help-commands.

This pull request fixes this behaviour.