### PR TITLE
Add and use `AttachmentId`

### DIFF
--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -4,14 +4,17 @@ use reqwest::Client as ReqwestClient;
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use std::io::Read;
+#[cfg(feature = "model")]
+use super::id::AttachmentId;
 
 /// A file uploaded with a message. Not to be confused with [`Embed`]s.
 ///
 /// [`Embed`]: struct.Embed.html
+#[cfg(feature = "model")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Attachment {
     /// The unique ID given to this attachment.
-    pub id: String,
+    pub id: AttachmentId,
     /// The filename of the file that was uploaded. This is equivalent to what
     /// the uploader had their file named.
     pub filename: String,

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -126,7 +126,12 @@ pub struct WebhookId(pub u64);
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct AuditLogEntryId(pub u64);
 
+/// An identifier for an attachment.
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct AttachmentId(u64);
+
 id_u64! {
+    AttachmentId;
     ApplicationId;
     ChannelId;
     EmojiId;


### PR DESCRIPTION
As pointed out in #536, the `Attachment`-struct uses a `String`. 

This pull request specifies a new `AttachmentId` (just like the other Id-types) and replaces the `String` with that.