### PR TITLE
Remove unused `build`-Method

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -474,8 +474,6 @@ impl CreateEmbedAuthor {
         self.0.insert("url", Value::String(url.to_string()));
         self
     }
-
-    pub fn build(&mut self) {}
 }
 
 /// A builder to create a fake [`Embed`] object's footer, for use with the


### PR DESCRIPTION
This method was added when we changed all builders to mutably borrow but there was actually no use or need for it.

This got pointed out a few times, most prominently in issue #567.