### PR TITLE
Fix Help displaying Groups and their Commands

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -303,7 +303,7 @@ impl StandardFramework {
                     if let Some(member) = guild.members.get(&msg.author.id) {
                         if let Ok(permissions) = member.permissions(&ctx.cache) {
                             if !permissions.administrator()
-                                && !has_correct_roles(command, &guild, member)
+                                && !has_correct_roles(&command, &guild, member)
                             {
                                 return Some(DispatchError::LackingRole);
                             }
@@ -759,28 +759,84 @@ impl Framework for StandardFramework {
 }
 
 #[cfg(feature = "cache")]
+pub trait CommonOptions {
+    fn required_permissions(&self) -> &Permissions;
+    fn allowed_roles(&self) -> &'static [&'static str];
+    fn only_in(&self) -> OnlyIn;
+    fn help_available(&self) -> bool;
+    fn owners_only(&self) -> bool;
+}
+
+impl CommonOptions for &GroupOptions {
+    fn required_permissions(&self) -> &Permissions {
+        &self.required_permissions
+    }
+
+    fn allowed_roles(&self) -> &'static [&'static str] {
+        &self.allowed_roles
+    }
+
+    fn only_in(&self) -> OnlyIn {
+        self.only
+    }
+
+    fn help_available(&self) -> bool {
+        self.help_available
+    }
+
+    fn owners_only(&self) -> bool {
+        self.owners_only
+    }
+}
+
+impl CommonOptions for &CommandOptions {
+    fn required_permissions(&self) -> &Permissions {
+        &self.required_permissions
+    }
+
+    fn allowed_roles(&self) -> &'static [&'static str] {
+        &self.allowed_roles
+    }
+
+    fn only_in(&self) -> OnlyIn {
+        self.only_in
+    }
+
+    fn help_available(&self) -> bool {
+        self.help_available
+    }
+
+    fn owners_only(&self) -> bool {
+        self.owners_only
+    }
+}
+
 pub(crate) fn has_correct_permissions(
     cache: impl AsRef<CacheRwLock>,
-    command: &CommandOptions,
+    options: &impl CommonOptions,
     message: &Message,
 ) -> bool {
-    if command.required_permissions.is_empty() {
+    if options.required_permissions().is_empty() {
         true
     } else if let Some(guild) = message.guild(&cache) {
         let perms = guild.with(|g| g.permissions_in(message.channel_id, message.author.id));
 
-        perms.contains(command.required_permissions)
+        perms.contains(*options.required_permissions())
     } else {
         false
     }
 }
 
 #[cfg(all(feature = "cache", feature = "http"))]
-pub(crate) fn has_correct_roles(cmd: &CommandOptions, guild: &Guild, member: &Member) -> bool {
-    if cmd.allowed_roles.is_empty() {
+pub(crate) fn has_correct_roles(
+    options: &impl CommonOptions,
+    guild: &Guild,
+    member: &Member)
+-> bool {
+    if options.allowed_roles().is_empty() {
         true
     } else {
-        cmd.allowed_roles
+        options.allowed_roles()
             .iter()
             .flat_map(|r| guild.role_by_name(r))
             .any(|g| member.roles.contains(&g.id))

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -767,6 +767,7 @@ pub trait CommonOptions {
     fn owners_only(&self) -> bool;
 }
 
+#[cfg(feature = "cache")]
 impl CommonOptions for &GroupOptions {
     fn required_permissions(&self) -> &Permissions {
         &self.required_permissions
@@ -789,6 +790,7 @@ impl CommonOptions for &GroupOptions {
     }
 }
 
+#[cfg(feature = "cache")]
 impl CommonOptions for &CommandOptions {
     fn required_permissions(&self) -> &Permissions {
         &self.required_permissions
@@ -811,6 +813,7 @@ impl CommonOptions for &CommandOptions {
     }
 }
 
+#[cfg(feature = "cache")]
 pub(crate) fn has_correct_permissions(
     cache: impl AsRef<CacheRwLock>,
     options: &impl CommonOptions,

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -143,18 +143,17 @@ impl PartialEq for HelpCommand {
 /// Lacking required permissions to execute the command.
 /// Lacking required roles to execute the command.
 /// The command can't be used in the current channel (as in `DM only` or `guild only`).
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, Eq, PartialEq)]
 pub enum HelpBehaviour {
+    /// The command will be displayed, hence nothing will be done.
+    Nothing,
     /// Strikes a command by applying `~~{command_name}~~`.
     Strike,
     /// Does not list a command in the help-menu.
     Hide,
-    /// The command will be displayed, hence nothing will be done.
-    Nothing,
     #[doc(hidden)]
     __Nonexhaustive,
 }
-
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct HelpOptions {
@@ -233,4 +232,35 @@ pub struct CommandGroup {
     pub options: &'static GroupOptions,
     pub commands: &'static [&'static Command],
     pub sub_groups: &'static [&'static CommandGroup],
+}
+
+#[cfg(test)]
+#[cfg(all(feature = "cache", feature = "http"))]
+mod levenshtein_tests {
+    use super::HelpBehaviour;
+
+    #[test]
+    fn help_behaviour_eq() {
+        assert_eq!(HelpBehaviour::Hide, std::cmp::max(HelpBehaviour::Hide, HelpBehaviour::Hide));
+        assert_eq!(HelpBehaviour::Strike, std::cmp::max(HelpBehaviour::Strike, HelpBehaviour::Strike));
+        assert_eq!(HelpBehaviour::Nothing, std::cmp::max(HelpBehaviour::Nothing, HelpBehaviour::Nothing));
+    }
+
+    #[test]
+    fn help_behaviour_hide() {
+        assert_eq!(HelpBehaviour::Hide, std::cmp::max(HelpBehaviour::Hide, HelpBehaviour::Nothing));
+        assert_eq!(HelpBehaviour::Hide, std::cmp::max(HelpBehaviour::Hide, HelpBehaviour::Strike));
+    }
+
+    #[test]
+    fn help_behaviour_strike() {
+        assert_eq!(HelpBehaviour::Strike, std::cmp::max(HelpBehaviour::Strike, HelpBehaviour::Nothing));
+        assert_eq!(HelpBehaviour::Hide, std::cmp::max(HelpBehaviour::Strike, HelpBehaviour::Hide));
+    }
+
+    #[test]
+    fn help_behaviour_nothing() {
+        assert_eq!(HelpBehaviour::Strike, std::cmp::max(HelpBehaviour::Nothing, HelpBehaviour::Strike));
+        assert_eq!(HelpBehaviour::Hide, std::cmp::max(HelpBehaviour::Nothing, HelpBehaviour::Hide));
+    }
 }


### PR DESCRIPTION
This pull requests fixes the behaviour for groups to properly propagate their text-effects to sub-groups.
Empty groups will not be displayed. Therefore, if all commands are hidden, the group will be hidden and all of its sub-groups will be hidden too.