### PR TITLE
Voice: add infinite retry arg to ytdl for rst packets

### DIFF
--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -277,6 +277,8 @@ pub fn ytdl(uri: &str) -> Result<Box<dyn AudioSource>> {
     let ytdl_args = [
         "-f",
         "webm[abr>0]/bestaudio/best",
+        "-R",
+        "infinite",
         "--no-playlist",
         "--ignore-config",
         uri,


### PR DESCRIPTION
Youtube periodically will send rst packets to drop the connection
likely due to the slow download rate as it is piped directly into ffmpeg
to play. The default number of retries is 10 which will abort playback
in long tracks after 10 errors. This commit sets the max retries to
infinite.