### PR TITLE
 Fix all Clippy-lints for Clippy `0.0.212`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-cyclomatic-complexity-threshold = 20
+cognitive-complexity-threshold = 20
 doc-valid-idents = [
     "UserAgent",
     "WebSocket",

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -253,7 +253,7 @@ pub fn validate_declaration(fun: &mut CommandFun, dec_for: DeclarFor) -> Result<
     let options: Type = parse_quote!(&CommandOptions);
     let hoptions: Type = parse_quote!(&'static HelpOptions);
     let groups: Type = parse_quote!(&[&'static CommandGroup]);
-    let owners: Type = parse_quote!(HashSet<UserId, impl BuildHasher>);
+    let owners: Type = parse_quote!(HashSet<UserId>);
 
     let context_path: Type = parse_quote!(&mut serenity::prelude::Context);
     let message_path: Type = parse_quote!(&serenity::model::channel::Message);
@@ -271,7 +271,7 @@ pub fn validate_declaration(fun: &mut CommandFun, dec_for: DeclarFor) -> Result<
     let options_error = "fourth argument's type should be `&'static CommandOptions`";
     let hoptions_error = "fourth argument's type should be `&'static HelpOptions`";
     let groups_error = "fifth argument's type should be `&[&'static CommandGroup]`";
-    let owners_error = "sixth argument's type should be `HashSet<UserId, impl BuildHasher>`";
+    let owners_error = "sixth argument's type should be `HashSet<UserId>`";
 
     #[allow(unused_assignments)]
     macro_rules! spoof_or_check {

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -8,7 +8,7 @@
 //! git = "https://github.com/serenity-rs/serenity.git"
 //! features = ["framework", "standard_framework"]
 //! ```
-use std::{collections::{HashMap, HashSet}, env, fmt::Write, hash::BuildHasher, sync::Arc};
+use std::{collections::{HashMap, HashSet}, env, fmt::Write, sync::Arc};
 use serenity::{
     client::bridge::gateway::{ShardId, ShardManager},
     framework::standard::{
@@ -131,7 +131,7 @@ fn my_help(
     args: Args,
     help_options: &'static HelpOptions,
     groups: &[&'static CommandGroup],
-    owners: HashSet<UserId, impl BuildHasher>
+    owners: HashSet<UserId>
 ) -> CommandResult {
     help_commands::with_embeds(context, msg, args, help_options, groups, owners)
 }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -105,7 +105,7 @@ pub(crate) enum DispatchEvent {
 
 #[cfg(feature = "framework")]
 #[allow(clippy::too_many_arguments)]
-#[clippy::too_many_arguments]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
                        RH: RawEventHandler + Send + Sync + 'static>(
     event: DispatchEvent,
@@ -144,7 +144,7 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
                         framework.dispatch(context, event.message, threadpool);
                     }
                 },
-                other => { 
+                other => {
                     handle_event(
                         other,
                         data,
@@ -158,28 +158,24 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
             }
         },
         (None, Some(ref rh)) => {
-            match event {
-                DispatchEvent::Model(e) => {
-                    #[cfg(not(any(feature = "cache", feature = "http")))]
-                    let context = context(data, runner_tx, shard_id);
-                    #[cfg(all(feature = "cache", not(feature = "http")))]
-                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache);
-                    #[cfg(all(not(feature = "cache"), feature = "http"))]
-                    let context = context(data, runner_tx, shard_id, &cache_and_http.http);
-                    #[cfg(all(feature = "cache", feature = "http"))]
-                    let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
+            if let DispatchEvent::Model(e) = event {
+                #[cfg(not(any(feature = "cache", feature = "http")))]
+                let context = context(data, runner_tx, shard_id);
+                #[cfg(all(feature = "cache", not(feature = "http")))]
+                let context = context(data, runner_tx, shard_id, &cache_and_http.cache);
+                #[cfg(all(not(feature = "cache"), feature = "http"))]
+                let context = context(data, runner_tx, shard_id, &cache_and_http.http);
+                #[cfg(all(feature = "cache", feature = "http"))]
+                let context = context(data, runner_tx, shard_id, &cache_and_http.cache, &cache_and_http.http);
 
-                    let event_handler = Arc::clone(rh);
-                    threadpool.execute(move || {
-                        event_handler.raw_event(context, e);
-                    });
-                },
-                _ => {}
+                let event_handler = Arc::clone(rh);
+                threadpool.execute(move || {
+                    event_handler.raw_event(context, e);
+                });
             }
         },
         (Some(_), Some(_)) => {
-            match event {
-                DispatchEvent::Model(ref e) => 
+            if let DispatchEvent::Model(ref e) = event {
                     dispatch(DispatchEvent::Model(e.clone()),
                              framework,
                              data,
@@ -188,8 +184,7 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
                              runner_tx,
                              threadpool,
                              shard_id,
-                             Arc::clone(&cache_and_http)),
-                _ => {}
+                             Arc::clone(&cache_and_http))
             }
             dispatch(event,
                      framework,
@@ -239,7 +234,7 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
                         threadpool,
                     );
                 },
-                other => { 
+                other => {
                     handle_event(
                         other,
                         data,
@@ -274,7 +269,7 @@ pub(crate) fn dispatch<H: EventHandler + Send + Sync + 'static,
         },
         (Some(ref h), Some(ref rh)) => {
             match event {
-                DispatchEvent::Model(ref e) => 
+                DispatchEvent::Model(ref e) =>
                     dispatch(DispatchEvent::Model(e.clone()),
                              data,
                              &None::<Arc<H>>,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -364,8 +364,8 @@ impl Client {
         let threadpool = ThreadPool::with_name(name, 5);
         let url = Arc::new(Mutex::new(http.get_gateway()?.url));
         let data = Arc::new(RwLock::new(ShareMap::custom()));
-        let event_handler = handler.map(|h| Arc::new(h));
-        let raw_event_handler = raw_handler.map(|rh| Arc::new(rh));
+        let event_handler = handler.map(Arc::new);
+        let raw_event_handler = raw_handler.map(Arc::new);
 
         #[cfg(feature = "framework")]
         let framework = Arc::new(Mutex::new(None));

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -352,6 +352,7 @@ impl Configuration {
     ///
     /// client.with_framework(StandardFramework::new().configure(|c| c.owners(set)));
     /// ```
+    #[allow(clippy::implicit_hasher)]
     pub fn owners(&mut self, user_ids: HashSet<UserId>) -> &mut Self {
         self.owners = user_ids;
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -46,7 +46,6 @@ use std::{
     borrow::Borrow,
     collections::HashSet,
     fmt::Write,
-    hash::BuildHasher,
     ops::{Index, IndexMut},
 };
 #[cfg(all(feature = "cache", feature = "http"))]
@@ -272,7 +271,7 @@ pub fn has_all_requirements(
 #[inline]
 #[cfg(all(feature = "cache", feature = "http"))]
 fn starts_with_whole_word(search_on: &str, word: &str) -> bool {
-    search_on.starts_with(word) && search_on.get(word.len()..word.len() + 1)
+    search_on.starts_with(word) && search_on.get(word.len()..=word.len())
         .map_or(false, |slice| slice == " ")
 }
 
@@ -294,7 +293,7 @@ fn find_any_command_matches(
                 .iter()
                 .any(|prefix|
                     if starts_with_whole_word(&name, &prefix) {
-                        name.drain(..prefix.len() + 1);
+                        name.drain(..=prefix.len());
 
                         n == &name
                     } else {
@@ -308,7 +307,7 @@ fn find_any_command_matches(
 fn check_command_behaviour(
     msg: &Message,
     options: &impl CommonOptions,
-    owners: &HashSet<UserId, impl BuildHasher>,
+    owners: &HashSet<UserId>,
     help_options: &HelpOptions,
     cache: &CacheRwLock,
 ) -> HelpBehaviour {
@@ -321,7 +320,7 @@ fn check_command_behaviour(
         || options.only_in() == OnlyIn::Guild && !msg.is_private()
     {
         if options.owners_only() && !owners.contains(&msg.author.id) {
-            return help_options.lacking_ownership.clone();
+            return help_options.lacking_ownership;
         }
 
         if has_correct_permissions(&cache, options, msg) {
@@ -333,23 +332,24 @@ fn check_command_behaviour(
                     if has_correct_roles(options, &guild, &member) {
                         return HelpBehaviour::Nothing;
                     } else {
-                        return help_options.lacking_role.clone();
+                        return help_options.lacking_role;
                     }
                 }
             } else {
                 return HelpBehaviour::Nothing;
             }
         } else {
-            return help_options.lacking_permissions.clone();
+            return help_options.lacking_permissions;
         }
     } else {
-        return help_options.wrong_channel.clone();
+        return help_options.wrong_channel;
     }
 
     HelpBehaviour::Nothing
 }
 
 #[cfg(all(feature = "cache", feature = "http"))]
+#[allow(clippy::too_many_arguments)]
 fn nested_group_command_search<'a>(
     cache: &CacheRwLock,
     groups: &[&'static CommandGroup],
@@ -357,7 +357,7 @@ fn nested_group_command_search<'a>(
     help_options: &'a HelpOptions,
     msg: &Message,
     similar_commands: &mut Vec<SuggestedCommandName>,
-    owners: &HashSet<UserId, impl BuildHasher>,
+    owners: &HashSet<UserId>,
 ) -> Result<CustomisedHelpData<'a>, ()> {
     for group in groups {
         let group = *group;
@@ -516,7 +516,7 @@ fn fetch_single_command<'a>(
     name: &str,
     help_options: &'a HelpOptions,
     msg: &Message,
-    owners: &HashSet<UserId, impl BuildHasher>,
+    owners: &HashSet<UserId>,
 ) -> Result<CustomisedHelpData<'a>, Vec<SuggestedCommandName>> {
     let mut similar_commands: Vec<SuggestedCommandName> = Vec::new();
     let cache = cache.as_ref();
@@ -537,10 +537,11 @@ fn fetch_single_command<'a>(
 }
 
 #[cfg(feature = "cache")]
+#[allow(clippy::too_many_arguments)]
 fn fill_eligible_commands<'a>(
     context: &Context,
     commands: &[&'static InternalCommand],
-    owners: &HashSet<UserId, impl BuildHasher>,
+    owners: &HashSet<UserId>,
     help_options: &'a HelpOptions,
     group: &'a CommandGroup,
     msg: &Message,
@@ -599,10 +600,11 @@ fn fill_eligible_commands<'a>(
 
 /// Tries to extract a single command matching searched command name.
 #[cfg(feature = "cache")]
+#[allow(clippy::too_many_arguments)]
 fn fetch_all_eligible_commands_in_group<'a>(
     context: &Context,
     commands: &[&'static InternalCommand],
-    owners: &HashSet<UserId, impl BuildHasher>,
+    owners: &HashSet<UserId>,
     help_options: &'a HelpOptions,
     group: &'a CommandGroup,
     msg: &Message,
@@ -645,7 +647,7 @@ fn fetch_all_eligible_commands_in_group<'a>(
 fn create_command_group_commands_pair_from_groups<'a>(
     context: &Context,
     groups: &[&'static CommandGroup],
-    owners: &HashSet<UserId, impl BuildHasher>,
+    owners: &HashSet<UserId>,
     msg: &Message,
     help_options: &'a HelpOptions,
 ) -> Vec<GroupCommandsPair> {
@@ -669,7 +671,7 @@ fn create_command_group_commands_pair_from_groups<'a>(
 fn create_single_group(
     context: &Context,
     group: &CommandGroup,
-    owners: &HashSet<UserId, impl BuildHasher>,
+    owners: &HashSet<UserId>,
     msg: &Message,
     help_options: &HelpOptions,
 ) -> GroupCommandsPair {
@@ -692,10 +694,11 @@ fn create_single_group(
 /// taking `HelpOptions` into consideration when deciding on whether a command
 /// shall be picked and in what textual format.
 #[cfg(feature = "cache")]
+#[allow(clippy::implicit_hasher)]
 pub fn create_customised_help_data<'a>(
     context: &Context,
     groups: &[&'static CommandGroup],
-    owners: &HashSet<UserId, impl BuildHasher>,
+    owners: &HashSet<UserId>,
     args: &'a Args,
     help_options: &'a HelpOptions,
     msg: &Message,
@@ -720,7 +723,7 @@ pub fn create_customised_help_data<'a>(
                             .any(|prefix| *prefix == searched_named_lowercase)
                     {
                         let single_group =
-                            create_single_group(&context, &group, &owners, &msg, &help_options);
+                            create_single_group(&context, &group, owners, &msg, &help_options);
 
                         if !single_group.command_names.is_empty() {
                             return CustomisedHelpData::GroupedCommands {
@@ -768,7 +771,7 @@ pub fn create_customised_help_data<'a>(
     let listed_groups = create_command_group_commands_pair_from_groups(
         &context,
         &groups,
-        &owners,
+        owners,
         &msg,
         &help_options,
     );
@@ -819,14 +822,14 @@ fn flatten_group_to_string(
         .join(&format!("\n{}", &repeated_indent_str));
 
 
-    if group.command_names.len() >= 1 {
+    if group.command_names.is_empty() {
         joined_commands.insert_str(0, &repeated_indent_str);
     }
 
     let _ = writeln!(group_text, "{}", joined_commands);
 
     for sub_group in &group.sub_groups {
-        
+
         if !sub_group.command_names.is_empty() {
             let mut sub_group_text = String::default();
 
@@ -1046,7 +1049,7 @@ fn send_error_embed(
 ///     args: Args,
 ///     help_options: &'static HelpOptions,
 ///     groups: &[&'static CommandGroup],
-///     owners: HashSet<UserId, impl BuildHasher>
+///     owners: HashSet<UserId>
 /// ) -> CommandResult {
 ///     with_embeds(context, msg, args, &help_options, groups, owners)
 /// }
@@ -1055,13 +1058,14 @@ fn send_error_embed(
 ///     .help(&MY_HELP_HELP_COMMAND));
 /// ```
 #[cfg(all(feature = "cache", feature = "http"))]
+#[allow(clippy::implicit_hasher)]
 pub fn with_embeds(
     context: &mut Context,
     msg: &Message,
     args: Args,
     help_options: &HelpOptions,
     groups: &[&'static CommandGroup],
-    owners: HashSet<UserId, impl BuildHasher>,
+    owners: HashSet<UserId>,
 ) -> CommandResult {
     let formatted_help =
         create_customised_help_data(&context, &groups, &owners, &args, help_options, msg);
@@ -1214,7 +1218,7 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
 ///     args: Args,
 ///     help_options: &'static HelpOptions,
 ///     groups: &[&'static CommandGroup],
-///     owners: HashSet<UserId, impl BuildHasher>
+///     owners: HashSet<UserId>
 /// ) -> CommandResult {
 ///     plain(context, msg, args, &help_options, groups, owners)
 /// }
@@ -1223,13 +1227,14 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
 ///     .help(&MY_HELP_HELP_COMMAND));
 /// ```
 #[cfg(all(feature = "cache", feature = "http"))]
+#[allow(clippy::implicit_hasher)]
 pub fn plain(
     context: &mut Context,
     msg: &Message,
     args: Args,
     help_options: &HelpOptions,
     groups: &[&'static CommandGroup],
-    owners: HashSet<UserId, impl BuildHasher>,
+    owners: HashSet<UserId>,
 ) -> CommandResult {
     let formatted_help =
         create_customised_help_data(&context, &groups, &owners, &args, help_options, msg);

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -822,7 +822,7 @@ fn flatten_group_to_string(
         .join(&format!("\n{}", &repeated_indent_str));
 
 
-    if group.command_names.is_empty() {
+    if !group.command_names.is_empty() {
         joined_commands.insert_str(0, &repeated_indent_str);
     }
 

--- a/src/framework/standard/parse.rs
+++ b/src/framework/standard/parse.rs
@@ -77,6 +77,7 @@ pub fn parse_prefix<'a>(
     (Prefix::None, args.trim())
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ParseMode {
     BySpace,

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashSet, hash_map::RandomState},
+    collections::HashSet,
     fmt,
 };
 use crate::client::Context;
@@ -108,17 +108,17 @@ impl PartialEq for Command {
     }
 }
 
-pub type HelpCommandFn<H> = fn(
+pub type HelpCommandFn = fn(
     &mut Context,
     &Message,
     Args,
     &'static HelpOptions,
     &[&'static CommandGroup],
-    HashSet<UserId, H>,
+    HashSet<UserId>,
 ) -> CommandResult;
 
 pub struct HelpCommand {
-    pub fun: HelpCommandFn<RandomState>,
+    pub fun: HelpCommandFn,
     pub options: &'static HelpOptions,
 }
 

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -129,11 +129,11 @@ mod test {
 
         let reqwest_response: reqwest::Response = response.into();
         let error_response: ErrorResponse = reqwest_response.into();
-        
+
         let known = ErrorResponse {
             status_code: reqwest::StatusCode::from_u16(403).unwrap(),
             url: String::from("https://ferris.crab").parse().unwrap(),
-            error: error,
+            error,
         };
 
         assert_eq!(error_response, known);

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -126,7 +126,7 @@ pub(crate) fn create_rustls_client(url: Url) -> Result<WsClient> {
     config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 
     let base_host = if let Some(h) = url.host_str() {
-        let (dot, _) = h.rmatch_indices('.').skip(1).next().unwrap_or((0, ""));
+        let (dot, _) = h.rmatch_indices('.').nth(1).unwrap_or((0, ""));
         // We do not want the leading '.', but if there is no leading '.' we do
         // not want to remove the leading character.
         let split_at_index = if dot == 0 { 0 } else { dot + 1 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,5 +114,6 @@ pub struct CacheAndHttp {
 }
 
 // For the procedural macros defined in `command_attr`; do not remove!
+#[allow(clippy::useless_attribute)]
 #[allow(rust_2018_idioms)]
 extern crate self as serenity;

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -523,7 +523,7 @@ impl ChannelId {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say(&self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> {
+    pub fn say(self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> {
         self.send_message(&http, |m| {
             m.content(content)
         })

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -620,7 +620,7 @@ impl GuildChannel {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     #[cfg(feature = "http")]
     #[inline]
-    pub fn say(&self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> { self.id.say(&http, content) }
+    pub fn say(self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> { self.id.say(&http, content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -94,6 +94,11 @@ impl GuildId {
     pub fn channels(self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> {
         let mut channels = HashMap::new();
 
+        // Clippy is suggesting:
+        // consider removing
+        // `http.as_ref().get_channels(self.0)?()`:
+        // `http.as_ref().get_channels(self.0)?`.
+        #[allow(clippy::identity_conversion)]
         for channel in http.as_ref().get_channels(self.0)? {
             channels.insert(channel.id, channel);
         }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -231,6 +231,7 @@ pub fn deserialize_u64<'de, D: Deserializer<'de>>(deserializer: D) -> StdResult<
     deserializer.deserialize_any(U64Visitor)
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 pub fn serialize_u64<S: Serializer>(data: &u64, ser: S) -> StdResult<S::Ok, S::Error> {
     ser.serialize_str(&data.to_string())
 }

--- a/src/utils/colour.rs
+++ b/src/utils/colour.rs
@@ -125,6 +125,9 @@ impl Colour {
     /// assert_eq!(colour.b(), 215);
     /// assert_eq!(colour.tuple(), (217, 45, 215));
     /// ```
+    // Clippy wants to use `u32::from` instead `as`-casts,
+    // but this not doable as `u32::from` is not a const fn.
+    #[allow(clippy::cast_lossless)]
     pub const fn from_rgb(red: u8, green: u8, blue: u8) -> Colour {
         Colour((red as u32) << 16 | (green as u32) << 8 | blue as u32)
     }


### PR DESCRIPTION
This updates Serenity's code to adhere to lints triggered by Clippy version `0.0.212`.

Some lints got allowed that are not helpful or false-positives.

On another note, this removes the explicit *impl BuildHasher* on `owners`' `HashSet<UserId>` which was introduced to please Clippy in a prior commit. 