### PR TITLE
changed command identifier to match original function name

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -252,12 +252,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let name = _name.clone();
 
-    // If name starts with a number, prepend an underscore to make it a valid identifier.
-    let n = if _name.starts_with(|c: char| c.is_numeric()) {
-        format!("_{}", _name)
-    } else {
-        _name
-    };
+    let n = fun.name.to_string();
 
     let _name = Ident::new(&n, Span::call_site());
 


### PR DESCRIPTION
this changes the way the global varable is named for commands, currently it will take the $name from in 
#[command($name)] or if non existant it will use the name of the function, then if it starts with a number it will add an underscore to the front and will completely fail if it has an emoji in it.

this pr changes it to still use the name in the attribute for the command name in discord, but in code it remains as the name of the function, the only reason I can see someone putting a name in the #[command($name)] thing is because you want an invalid ident as the command name.

My fix makes emoji command names possible, removes the need for prepending the random underscore too