### PR TITLE
Return `&mut self` on `voice_channel`

### DIFF
--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -67,8 +67,10 @@ impl EditMember {
     ///
     /// [Move Members]: ../model/permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
     #[inline]
-    pub fn voice_channel<C: Into<ChannelId>>(&mut self, channel_id: C) {
-        self._voice_channel(channel_id.into())
+    pub fn voice_channel<C: Into<ChannelId>>(&mut self, channel_id: C) -> &mut Self {
+        self._voice_channel(channel_id.into());
+
+        self
     }
 
     fn _voice_channel(&mut self, channel_id: ChannelId) {


### PR DESCRIPTION
The builder-method `EditMember::voice_channel` used to return `Self` and was supposed to return `&mut Self` after the builder-rework but instead returns nothing.