### PR TITLE
Improve `cached`'s Name and Documentation

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -478,7 +478,7 @@ fn handle_event<H: EventHandler + Send + Sync + 'static>(
                     let event_handler = Arc::clone(event_handler);
 
                     threadpool.execute(move || {
-                        event_handler.cached(context, guild_amount);
+                        event_handler.cache_ready(context, guild_amount);
                     });
                 }
             }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -14,7 +14,7 @@ pub trait EventHandler {
     ///
     /// Provides the cached guilds' ids.
     #[cfg(feature = "cache")]
-    fn cached(&self, _ctx: Context, _guilds: Vec<GuildId>) {}
+    fn cache_ready(&self, _ctx: Context, _guilds: Vec<GuildId>) {}
 
     /// Dispatched when a channel is created.
     ///

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -10,7 +10,12 @@ use crate::client::bridge::gateway::event::*;
 
 /// The core trait for handling events by serenity.
 pub trait EventHandler {
-    /// Dispatched when the cache gets full.
+    /// Dispatched when the cache has received and inserted all data from
+    /// guilds.
+    ///
+    /// This process happens upon starting your bot and should be fairly quick.
+    /// However, cache actions performed prior this event may fail as the data
+    /// could be not inserted yet.
     ///
     /// Provides the cached guilds' ids.
     #[cfg(feature = "cache")]


### PR DESCRIPTION
The event `cached` is not very accurate on its meaning and its documentation is ambiguous. It referred to *when the cache gets full*, which can be interpreted as the cache reaching its maximum possible volume/size.

This pull request attempts to improve the naming and documentation.