### PR TITLE
[Framework] Check if message author is in owners HashSet

### DIFF
--- a/src/framework/standard/parse.rs
+++ b/src/framework/standard/parse.rs
@@ -130,7 +130,7 @@ impl<'msg, 'groups, 'config, 'ctx> CommandParser<'msg, 'groups, 'config, 'ctx> {
     }
 
     fn check_discrepancy(&self, options: &impl CommonOptions) -> Result<(), DispatchError> {
-        if options.owners_only() {
+        if options.owners_only() && !self.config.owners.contains(&self.msg.author.id) {
             return Err(DispatchError::OnlyForOwners);
         }
 


### PR DESCRIPTION
Without this check the parser will fail instantly if `owners_only` is set, no matter who the user is.