### PR TITLE
Replace `Context` as Argument

### DIFF
--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -87,13 +87,13 @@ impl CreateInvite {
     /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// # use serenity::model::id::ChannelId;
     /// #
-    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework"))]
+    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # fn example(context: &mut Context) -> CommandResult {
     /// #     let channel = context.cache.read().guild_channel(81384788765712384).unwrap();
     /// #     let channel = channel.read();
     /// #
-    /// let invite = channel.create_invite(&context, |i| {
+    /// let invite = channel.create_invite(context, |i| {
     ///     i.max_age(3600)
     /// })?;
     /// # Ok(())
@@ -124,13 +124,13 @@ impl CreateInvite {
     /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// # use serenity::model::id::ChannelId;
     /// #
-    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework"))]
+    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # fn example(context: &mut Context) -> CommandResult {
     /// #     let channel = context.cache.read().guild_channel(81384788765712384).unwrap();
     /// #     let channel = channel.read();
     /// #
-    /// let invite = channel.create_invite(&context, |i| {
+    /// let invite = channel.create_invite(context, |i| {
     ///     i.max_uses(5)
     /// })?;
     /// # Ok(())
@@ -159,13 +159,13 @@ impl CreateInvite {
     /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// # use serenity::model::id::ChannelId;
     /// #
-    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework"))]
+    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # fn example(context: &mut Context) -> CommandResult {
     /// #     let channel = context.cache.read().guild_channel(81384788765712384).unwrap();
     /// #     let channel = channel.read();
     /// #
-    /// let invite = channel.create_invite(&context, |i| {
+    /// let invite = channel.create_invite(context, |i| {
     ///     i.temporary(true)
     /// })?;
     /// # Ok(())
@@ -193,13 +193,13 @@ impl CreateInvite {
     /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// # use serenity::model::id::ChannelId;
     /// #
-    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework"))]
+    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # fn example(context: &mut Context) -> CommandResult {
     /// #     let channel = context.cache.read().guild_channel(81384788765712384).unwrap();
     /// #     let channel = channel.read();
     /// #
-    /// let invite = channel.create_invite(&context, |i| {
+    /// let invite = channel.create_invite(context, |i| {
     ///     i.unique(true)
     /// })?;
     /// # Ok(())

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -17,11 +17,11 @@ use std::collections::HashMap;
 /// # #[cfg(feature = "framework")]
 /// # use serenity::framework::standard::{CommandResult, macros::command};
 /// #
-/// # #[cfg(all(feature = "client", feature = "framework"))]
+/// # #[cfg(all(feature = "http", feature = "framework"))]
 /// # #[command]
 /// # fn example(ctx: &mut Context) -> CommandResult {
 /// # let mut message = ChannelId(7).message(&ctx.http, MessageId(8)).unwrap();
-/// let _ = message.edit(&ctx, |m| {
+/// let _ = message.edit(ctx, |m| {
 ///     m.content("hello")
 /// });
 /// # Ok(())

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -471,7 +471,7 @@ impl StandardFramework {
     ///
     /// client.with_framework(StandardFramework::new()
     ///     .before(|ctx, msg, cmd_name| {
-    ///         if let Ok(channel) = msg.channel_id.to_channel(&ctx) {
+    ///         if let Ok(channel) = msg.channel_id.to_channel(ctx) {
     ///             //  Don't run unless in nsfw channel
     ///             if !channel.is_nsfw() {
     ///                 return false;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -80,12 +80,10 @@ impl CacheHttp for &Context {
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
 }
 
+#[cfg(all(feature = "cache", feature = "http"))]
 impl CacheHttp for (&CacheRwLock, &Http) {
-    #[cfg(feature = "http")]
-    fn http(&self) -> &Http { &self.1 }
-
-    #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.0) }
+    fn http(&self) -> &Http { &self.1 }
 }
 
 impl CacheHttp for &Http {
@@ -93,7 +91,7 @@ impl CacheHttp for &Http {
     fn http(&self) -> &Http { *self }
 }
 
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "cache", feature = "http"))]
 impl AsRef<CacheRwLock> for (&CacheRwLock, &Http) {
     fn as_ref(&self) -> &CacheRwLock {
         self.0

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -80,6 +80,14 @@ impl CacheHttp for &Context {
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
 }
 
+#[cfg(feature = "client")]
+impl CacheHttp for &mut Context {
+    #[cfg(feature = "http")]
+    fn http(&self) -> &Http { &self.http }
+    #[cfg(feature = "cache")]
+    fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
+}
+
 #[cfg(all(feature = "cache", feature = "http"))]
 impl CacheHttp for (&CacheRwLock, &Http) {
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.0) }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -49,7 +49,7 @@ use crate::cache::CacheRwLock;
 #[cfg(feature = "client")]
 use crate::client::Context;
 
-/// This trait will be required by functions the need [`Http`] and can
+/// This trait will be required by functions that need [`Http`] and can
 /// optionally use a [`CacheRwLock`] to potentially avoid REST-requests.
 ///
 /// The types [`Context`], [`CacheRwLock`], and [`Http`] implement this trait

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1,11 +1,11 @@
 //! Models relating to Discord channels.
 
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
 use chrono::{DateTime, FixedOffset};
 use crate::{model::prelude::*};
 use serde_json::{json, Value};
 
-#[cfg(feature = "client")]
-use crate::client::Context;
 #[cfg(feature = "model")]
 use crate::builder::{CreateEmbed, EditMessage};
 #[cfg(all(feature = "cache", feature = "model"))]
@@ -111,20 +111,22 @@ impl Message {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`ModelError::InvalidUser`]: ../error/enum.Error.html#variant.InvalidUser
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "client")]
-    pub fn delete(&self, context: &Context) -> Result<()> {
+    #[cfg(feature = "http")]
+    pub fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::MANAGE_MESSAGES;
-            let is_author = self.author.id == context.cache.read().user.id;
-            let has_perms = utils::user_has_perms(&context.cache, self.channel_id, req)?;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::MANAGE_MESSAGES;
+                let is_author = self.author.id == cache.read().user.id;
+                let has_perms = utils::user_has_perms(&cache, self.channel_id, req)?;
 
-            if !is_author && !has_perms {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !is_author && !has_perms {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.channel_id.delete_message(&context.http, self.id)
+        self.channel_id.delete_message(&cache_http.http(), self.id)
     }
 
     /// Deletes all of the [`Reaction`]s associated with the message.
@@ -140,18 +142,20 @@ impl Message {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`Reaction`]: struct.Reaction.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "client")]
-    pub fn delete_reactions(&self, context: &Context) -> Result<()> {
+    #[cfg(feature = "http")]
+    pub fn delete_reactions(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::MANAGE_MESSAGES;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::MANAGE_MESSAGES;
 
-            if !utils::user_has_perms(&context.cache, self.channel_id, req)? {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !utils::user_has_perms(cache, self.channel_id, req)? {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        context.http.as_ref().delete_message_reactions(self.channel_id.0, self.id.0)
+        cache_http.http().as_ref().delete_message_reactions(self.channel_id.0, self.id.0)
     }
 
     /// Edits this message, replacing the original content with new content.
@@ -187,12 +191,15 @@ impl Message {
     /// [`EditMessage`]: ../../builder/struct.EditMessage.html
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
     #[cfg(feature = "client")]
-    pub fn edit<F>(&mut self, context: &Context, f: F) -> Result<()>
+    pub fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage {
         #[cfg(feature = "cache")]
         {
-            if self.author.id != context.cache.read().user.id {
-                return Err(Error::Model(ModelError::InvalidUser));
+            if let Some(cache) = cache_http.cache() {
+
+                if self.author.id != cache.read().user.id {
+                    return Err(Error::Model(ModelError::InvalidUser));
+                }
             }
         }
 
@@ -214,7 +221,7 @@ impl Message {
 
         let map = serenity_utils::hashmap_to_json_map(builder.0);
 
-        match context.http.edit_message(self.channel_id.0, self.id.0, &Value::Object(map)) {
+        match cache_http.http().edit_message(self.channel_id.0, self.id.0, &Value::Object(map)) {
             Ok(edited) => {
                 mem::replace(self, edited);
 
@@ -370,20 +377,23 @@ impl Message {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES.html
-    #[cfg(feature = "client")]
-    pub fn pin(&self, context: &Context) -> Result<()> {
+    #[cfg(feature = "http")]
+    pub fn pin(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            if self.guild_id.is_some() {
-                let req = Permissions::MANAGE_MESSAGES;
+            if let Some(cache) = cache_http.cache() {
 
-                if !utils::user_has_perms(&context.cache, self.channel_id, req)? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if self.guild_id.is_some() {
+                    let req = Permissions::MANAGE_MESSAGES;
+
+                    if !utils::user_has_perms(&cache, self.channel_id, req)? {
+                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                    }
                 }
             }
         }
 
-        self.channel_id.pin(&context.http, self.id.0)
+        self.channel_id.pin(cache_http.http(), self.id.0)
     }
 
     /// React to the message with a custom [`Emoji`] or unicode character.
@@ -403,24 +413,27 @@ impl Message {
     /// [permissions]: ../permissions/index.html
     #[inline]
     #[cfg(feature = "client")]
-    pub fn react<R: Into<ReactionType>>(&self, context: &Context, reaction_type: R) -> Result<()> {
-        self._react(&context, &reaction_type.into())
+    pub fn react<R: Into<ReactionType>>(&self, cache_http: impl CacheHttp, reaction_type: R) -> Result<()> {
+        self._react(cache_http, &reaction_type.into())
     }
 
     #[cfg(feature = "client")]
-    fn _react(&self, context: &Context, reaction_type: &ReactionType) -> Result<()> {
+    fn _react(&self, cache_http: impl CacheHttp, reaction_type: &ReactionType) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            if self.guild_id.is_some() {
-                let req = Permissions::ADD_REACTIONS;
+            if let Some(cache) = cache_http.cache() {
 
-                if !utils::user_has_perms(&context.cache, self.channel_id, req)? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if self.guild_id.is_some() {
+                    let req = Permissions::ADD_REACTIONS;
+
+                    if !utils::user_has_perms(cache, self.channel_id, req)? {
+                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                    }
                 }
             }
         }
 
-        context.http.create_reaction(self.channel_id.0, self.id.0, reaction_type)
+        cache_http.http().create_reaction(self.channel_id.0, self.id.0, reaction_type)
     }
 
     /// Replies to the user, mentioning them prior to the content in the form
@@ -446,18 +459,21 @@ impl Message {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     #[cfg(feature = "client")]
-    pub fn reply(&self, context: &Context, content: &str) -> Result<Message> {
+    pub fn reply(&self, cache_http: impl CacheHttp, content: &str) -> Result<Message> {
         if let Some(length_over) = Message::overflow_length(content) {
             return Err(Error::Model(ModelError::MessageTooLong(length_over)));
         }
 
         #[cfg(feature = "cache")]
         {
-            if self.guild_id.is_some() {
-                let req = Permissions::SEND_MESSAGES;
+            if let Some(cache) = cache_http.cache() {
 
-                if !utils::user_has_perms(&context.cache, self.channel_id, req)? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if self.guild_id.is_some() {
+                    let req = Permissions::SEND_MESSAGES;
+
+                    if !utils::user_has_perms(cache, self.channel_id, req)? {
+                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                    }
                 }
             }
         }
@@ -471,7 +487,7 @@ impl Message {
             "tts": false,
         });
 
-        context.http.send_message(self.channel_id.0, &map)
+        cache_http.http().send_message(self.channel_id.0, &map)
     }
 
     /// Checks whether the message mentions passed [`UserId`].
@@ -505,20 +521,23 @@ impl Message {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "client")]
-    pub fn unpin(&self, context: &Context) -> Result<()> {
+    #[cfg(feature = "http")]
+    pub fn unpin(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            if self.guild_id.is_some() {
-                let req = Permissions::MANAGE_MESSAGES;
+            if let Some(cache) = cache_http.cache() {
 
-                if !utils::user_has_perms(&context.cache, self.channel_id, req)? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if self.guild_id.is_some() {
+                    let req = Permissions::MANAGE_MESSAGES;
+
+                    if !utils::user_has_perms(cache, self.channel_id, req)? {
+                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                    }
                 }
             }
         }
 
-        context.http.unpin_message(self.channel_id.0, self.id.0)
+        cache_http.http().unpin_message(self.channel_id.0, self.id.0)
     }
 
     /// Tries to return author's nickname in the current channel's guild.
@@ -526,9 +545,9 @@ impl Message {
     /// **Note**:
     /// If message was sent in a private channel, then the function will return
     /// `None`.
-    #[cfg(feature = "client")]
-    pub fn author_nick(&self, context: &Context) -> Option<String> {
-        self.guild_id.as_ref().and_then(|guild_id| self.author.nick_in(&context, *guild_id))
+    #[cfg(feature = "http")]
+    pub fn author_nick(&self, cache_http: impl CacheHttp) -> Option<String> {
+        self.guild_id.as_ref().and_then(|guild_id| self.author.nick_in(cache_http, *guild_id))
     }
 
     pub(crate) fn check_content_length(map: &JsonMap) -> Result<()> {

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -10,6 +10,8 @@ mod private_channel;
 mod reaction;
 mod channel_category;
 
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
 pub use self::attachment::*;
 pub use self::channel_id::*;
 pub use self::embed::*;
@@ -26,8 +28,6 @@ use serde::ser::{SerializeStruct, Serialize, Serializer};
 use serde_json;
 use super::utils::deserialize_u64;
 
-#[cfg(feature = "client")]
-use crate::client::Context;
 #[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
@@ -241,20 +241,20 @@ impl Channel {
     /// closest functionality is leaving it.
     ///
     /// [`Group`]: struct.Group.html
-    #[cfg(all(feature = "model", feature = "client"))]
-    pub fn delete(&self, context: &Context) -> Result<()> {
+    #[cfg(all(feature = "model", feature = "http"))]
+    pub fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
         match *self {
             Channel::Group(ref group) => {
-                let _ = group.read().leave(&context.http)?;
+                let _ = group.read().leave(cache_http.http())?;
             },
             Channel::Guild(ref public_channel) => {
-                let _ = public_channel.read().delete(&context)?;
+                let _ = public_channel.read().delete(cache_http)?;
             },
             Channel::Private(ref private_channel) => {
-                let _ = private_channel.read().delete(&context.http)?;
+                let _ = private_channel.read().delete(cache_http.http())?;
             },
             Channel::Category(ref category) => {
-                category.read().delete(&context)?;
+                category.read().delete(cache_http)?;
             },
             Channel::__Nonexhaustive => unreachable!(),
         }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -346,12 +346,12 @@ impl From<char> for ReactionType {
     /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// # use serenity::model::id::ChannelId;
     /// #
-    /// # #[cfg(all(feature = "client", feature = "framework"))]
+    /// # #[cfg(all(feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # fn example(ctx: &mut Context) -> CommandResult {
     /// #   let message = ChannelId(0).message(&ctx.http, 0)?;
     /// #
-    /// message.react(&ctx, '🍎')?;
+    /// message.react(ctx, '🍎')?;
     /// # Ok(())
     /// # }
     /// #

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -493,13 +493,13 @@ impl GuildId {
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     /// [`Member`]: ../guild/struct.Member.html
-    #[cfg(feature = "client")]
+    #[cfg(feature = "http")]
     #[inline]
     pub fn member<U: Into<UserId>>(self, cache_http: impl CacheHttp, user_id: U) -> Result<Member> {
         self._member(cache_http, user_id.into())
     }
 
-    #[cfg(feature = "client")]
+    #[cfg(feature = "http")]
     fn _member(self, cache_http: impl CacheHttp, user_id: UserId) -> Result<Member> {
         #[cfg(feature = "cache")]
         {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -8,6 +8,8 @@ mod partial_guild;
 mod role;
 mod audit_log;
 
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
 pub use self::emoji::*;
 pub use self::guild_id::*;
 pub use self::integration::*;
@@ -23,8 +25,6 @@ use serde_json::json;
 use super::utils::*;
 use log::{error, warn};
 
-#[cfg(feature = "client")]
-use crate::client::Context;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::CacheRwLock;
 #[cfg(all(feature = "cache", feature = "model"))]
@@ -252,24 +252,26 @@ impl Guild {
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "client")]
     #[inline]
-    pub fn ban<U: Into<UserId>, BO: BanOptions>(&self, context: &Context, user: U, options: &BO) -> Result<()> {
-        self._ban(&context, user.into(), options)
+    pub fn ban<U: Into<UserId>, BO: BanOptions>(&self, cache_http: impl CacheHttp, user: U, options: &BO) -> Result<()> {
+        self._ban(cache_http, user.into(), options)
     }
 
     #[cfg(feature = "client")]
-    fn _ban<BO: BanOptions>(&self, context: &Context, user: UserId, options: &BO) -> Result<()> {
+    fn _ban<BO: BanOptions>(&self, cache_http: impl CacheHttp, user: UserId, options: &BO) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::BAN_MEMBERS;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::BAN_MEMBERS;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
+
+                self.check_hierarchy(cache, user)?;
             }
-
-            self.check_hierarchy(&context.cache, user)?;
         }
 
-        self.id.ban(&context.http, user, options)
+        self.id.ban(cache_http.http(), user, options)
     }
 
     /// Retrieves a list of [`Ban`]s for the guild.
@@ -284,18 +286,20 @@ impl Guild {
     /// [`Ban`]: struct.Ban.html
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "client")]
-    pub fn bans(&self, context: &Context) -> Result<Vec<Ban>> {
+    #[cfg(feature = "http")]
+    pub fn bans(&self, cache_http: impl CacheHttp) -> Result<Vec<Ban>> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::BAN_MEMBERS;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::BAN_MEMBERS;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.bans(&context.http)
+        self.id.bans(cache_http.http())
     }
 
     /// Retrieves a list of [`AuditLogs`] for the guild.
@@ -377,17 +381,19 @@ impl Guild {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
     #[cfg(feature = "client")]
-    pub fn create_channel(&self, context: &Context, f: impl FnOnce(&mut CreateChannel) -> &mut CreateChannel) -> Result<GuildChannel> {
+    pub fn create_channel(&self, cache_http: impl CacheHttp, f: impl FnOnce(&mut CreateChannel) -> &mut CreateChannel) -> Result<GuildChannel> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::MANAGE_CHANNELS;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::MANAGE_CHANNELS;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.create_channel(&context.http, f)
+        self.id.create_channel(cache_http.http(), f)
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image. The
@@ -450,18 +456,20 @@ impl Guild {
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     #[cfg(feature = "client")]
-    pub fn create_role<F>(&self, context: &Context, f: F) -> Result<Role>
+    pub fn create_role<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Role>
         where F: FnOnce(&mut EditRole) -> &mut EditRole {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::MANAGE_ROLES;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::MANAGE_ROLES;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.create_role(&context.http, f)
+        self.id.create_role(cache_http.http(), f)
     }
 
     /// Deletes the current guild if the current user is the owner of the
@@ -475,18 +483,21 @@ impl Guild {
     /// if the current user is not the guild owner.
     ///
     /// [`ModelError::InvalidUser`]: ../error/enum.Error.html#variant.InvalidUser
-    #[cfg(feature = "client")]
-    pub fn delete(&self, context: &Context) -> Result<PartialGuild> {
+    #[cfg(feature = "http")]
+    pub fn delete(&self, cache_http: impl CacheHttp) -> Result<PartialGuild> {
         #[cfg(feature = "cache")]
         {
-            if self.owner_id != context.cache.read().user.id {
-                let req = Permissions::MANAGE_GUILD;
+            if let Some(cache) = cache_http.cache() {
 
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if self.owner_id != cache.read().user.id {
+                    let req = Permissions::MANAGE_GUILD;
+
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.delete(&context.http)
+        self.id.delete(cache_http.http())
     }
 
     /// Deletes an [`Emoji`] from the guild.
@@ -557,18 +568,20 @@ impl Guild {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     #[cfg(feature = "client")]
-    pub fn edit<F>(&mut self, context: &Context, f: F) -> Result<()>
+    pub fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
         where F: FnOnce(&mut EditGuild) -> &mut EditGuild {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::MANAGE_GUILD;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::MANAGE_GUILD;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        match self.id.edit(&context.http, f) {
+        match self.id.edit(cache_http.http(), f) {
             Ok(guild) => {
                 self.afk_channel_id = guild.afk_channel_id;
                 self.afk_timeout = guild.afk_timeout;
@@ -641,17 +654,19 @@ impl Guild {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
     #[cfg(feature = "client")]
-    pub fn edit_nickname(&self, context: &Context, new_nickname: Option<&str>) -> Result<()> {
+    pub fn edit_nickname(&self, cache_http: impl CacheHttp, new_nickname: Option<&str>) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::CHANGE_NICKNAME;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::CHANGE_NICKNAME;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.edit_nickname(&context.http, new_nickname)
+        self.id.edit_nickname(cache_http.http(), new_nickname)
     }
 
     /// Edits a role, optionally setting its fields.
@@ -800,18 +815,20 @@ impl Guild {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "client")]
-    pub fn invites(&self, context: &Context) -> Result<Vec<RichInvite>> {
+    #[cfg(feature = "http")]
+    pub fn invites(&self, cache_http: impl CacheHttp) -> Result<Vec<RichInvite>> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::MANAGE_GUILD;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::MANAGE_GUILD;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.invites(&context.http)
+        self.id.invites(cache_http.http())
     }
 
     /// Checks if the guild is 'large'. A guild is considered large if it has
@@ -839,8 +856,8 @@ impl Guild {
     /// [`Member`]: struct.Member.html
     #[inline]
     #[cfg(feature = "client")]
-    pub fn member<U: Into<UserId>>(&self, context: &Context, user_id: U) -> Result<Member> {
-        self.id.member(&context, user_id)
+    pub fn member<U: Into<UserId>>(&self, cache_http: impl CacheHttp, user_id: U) -> Result<Member> {
+        self.id.member(cache_http, user_id)
     }
 
     /// Gets a list of the guild's members.
@@ -1393,17 +1410,19 @@ impl Guild {
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "client")]
-    pub fn prune_count(&self, context: &Context, days: u16) -> Result<GuildPrune> {
+    pub fn prune_count(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::KICK_MEMBERS;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::KICK_MEMBERS;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.prune_count(&context.http, days)
+        self.id.prune_count(cache_http.http(), days)
     }
 
     /// Re-orders the channels of the guild.
@@ -1489,17 +1508,19 @@ impl Guild {
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "client")]
-    pub fn start_prune(&self, context: &Context, days: u16) -> Result<GuildPrune> {
+    pub fn start_prune(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::KICK_MEMBERS;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::KICK_MEMBERS;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.start_prune(&context.http, days)
+        self.id.start_prune(cache_http.http(), days)
     }
 
     /// Unbans the given [`User`] from the guild.
@@ -1515,17 +1536,19 @@ impl Guild {
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
     #[cfg(feature = "client")]
-    pub fn unban<U: Into<UserId>>(&self, context: &Context, user_id: U) -> Result<()> {
+    pub fn unban<U: Into<UserId>>(&self, cache_http: impl CacheHttp, user_id: U) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            let req = Permissions::BAN_MEMBERS;
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::BAN_MEMBERS;
 
-            if !self.has_perms(&context.cache, req) {
-                return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !self.has_perms(cache, req) {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
             }
         }
 
-        self.id.unban(&context.http, user_id)
+        self.id.unban(&cache_http.http(), user_id)
     }
 
     /// Retrieve's the guild's vanity URL.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,12 +1,14 @@
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
 use crate::{model::prelude::*};
 use super::super::utils::{deserialize_emojis, deserialize_roles};
 
-#[cfg(feature = "client")]
-use crate::client::Context;
 #[cfg(feature = "model")]
 use crate::builder::{CreateChannel, EditGuild, EditMember, EditRole};
 #[cfg(feature = "http")]
 use crate::http::Http;
+#[cfg(all(feature = "cache", feature = "utils", feature = "client"))]
+use crate::cache::CacheRwLock;
 
 /// Partial information about a [`Guild`]. This does not include information
 /// like member data.
@@ -357,8 +359,8 @@ impl PartialGuild {
     /// [`Guild`]: struct.Guild.html
     /// [`Member`]: struct.Member.html
     #[cfg(feature = "client")]
-    pub fn member<U: Into<UserId>>(&self, context: &Context, user_id: U) -> Result<Member> {
-        self.id.member(&context, user_id)
+    pub fn member<U: Into<UserId>>(&self, cache_http: impl CacheHttp, user_id: U) -> Result<Member> {
+        self.id.member(cache_http, user_id)
     }
 
     /// Gets a list of the guild's members.
@@ -409,7 +411,7 @@ impl PartialGuild {
     /// [`utils::shard_id`]: ../../utils/fn.shard_id.html
     #[cfg(all(feature = "cache", feature = "utils", feature = "client"))]
     #[inline]
-    pub fn shard_id(&self, context: &Context) -> u64 { self.id.shard_id(&context.cache) }
+    pub fn shard_id(&self, cache: impl AsRef<CacheRwLock>) -> u64 { self.id.shard_id(cache) }
 
     /// Returns the Id of the shard associated with the guild.
     ///


### PR DESCRIPTION
Prior this pull request, if a function needed the HTTP-client and optionally was able to utilise the cache too, it expected `Context`. This causes issues when such a function was called outside the framework.

This pull requests adds the `CacheHttp`-trait and implements it for `Context`, `Http`, and a tuple of `(CacheRwLock, Http)`.
`Context`s has been replaced with `impl CacheHttp` and therefore accepting any of the mentioned above. If the passed type does not contain a cache, the function will behave as if no `cache`-feature is enabled.

If a function requires HTTP-client and cache, it will expect a generic-bound of `AsRef<CacheRwLock> + AsRef<Http>`, which is also implemented for the tuple of `(CacheRwLock, Http)` if the `cache`- and `http`-feature are enabled.

