### PR TITLE
`owner_privilege` properly bypass permissions/role check

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -321,6 +321,10 @@ fn check_command_behaviour(
             return help_options.lacking_ownership;
         }
 
+        if options.owner_privilege() && owners.contains(&msg.author.id) {
+            return HelpBehaviour::Nothing;
+        }
+
         if has_correct_permissions(&cache, options, msg) {
 
             if let Some(guild) = msg.guild(&cache) {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -765,6 +765,7 @@ pub trait CommonOptions {
     fn only_in(&self) -> OnlyIn;
     fn help_available(&self) -> bool;
     fn owners_only(&self) -> bool;
+    fn owner_privilege(&self) -> bool;
 }
 
 impl CommonOptions for &GroupOptions {
@@ -787,6 +788,10 @@ impl CommonOptions for &GroupOptions {
     fn owners_only(&self) -> bool {
         self.owners_only
     }
+
+    fn owner_privilege(&self) -> bool {
+        self.owner_privilege
+    }
 }
 
 impl CommonOptions for &CommandOptions {
@@ -808,6 +813,10 @@ impl CommonOptions for &CommandOptions {
 
     fn owners_only(&self) -> bool {
         self.owners_only
+    }
+
+    fn owner_privilege(&self) -> bool {
+        self.owner_privilege
     }
 }
 

--- a/src/framework/standard/parse.rs
+++ b/src/framework/standard/parse.rs
@@ -154,7 +154,9 @@ impl<'msg, 'groups, 'config, 'ctx> CommandParser<'msg, 'groups, 'config, 'ctx> {
 
                 let perms = guild.permissions_in(self.msg.channel_id, self.msg.author.id);
 
-                if !perms.contains(*options.required_permissions()) {
+                if !perms.contains(*options.required_permissions()) &&
+                    !(options.owner_privilege() &&
+                        self.config.owners.contains(&self.msg.author.id)) {
                     return Err(DispatchError::LackingPermissions(*options.required_permissions()));
                 }
 


### PR DESCRIPTION
Change checks so owner_privilege: true bypasses the checks for correct permissions and roles of the user, both in dispatching commands and showing the availability in help.