### PR TITLE
Use the threadpool from uvth instead of the threadpool crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ version = "0.2"
 
 [dependencies.uvth]
 optional = true
-version = "1.0.1"
+version = "1.0.3"
 
 [dependencies.tungstenite]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ features = ["std"]
 optional = true
 version = "0.2"
 
-[dependencies.threadpool]
+[dependencies.uvth]
 optional = true
-version = "1.7"
+version = "1.0.1"
 
 [dependencies.tungstenite]
 default-features = false
@@ -131,7 +131,7 @@ cache = []
 client = [
     "gateway",
     "http",
-    "threadpool",
+    "uvth",
     "typemap",
 ]
 extras = []

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -65,7 +65,7 @@ use crate::client::bridge::voice::ClientVoiceManager;
 /// use serenity::prelude::*;
 /// use std::sync::Arc;
 /// use std::env;
-/// use threadpool::ThreadPool;
+/// use uvth::ThreadPool;
 ///
 /// struct Handler;
 ///
@@ -78,7 +78,7 @@ use crate::client::bridge::voice::ClientVoiceManager;
 /// let data = Arc::new(RwLock::new(ShareMap::custom()));
 /// let event_handler = Arc::new(Handler);
 /// let framework = Arc::new(Mutex::new(None));
-/// let threadpool = ThreadPool::with_name("my threadpool".to_owned(), 5);
+/// let threadpool = ThreadPool::new(5);
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -21,7 +21,7 @@ use super::{
     ShardQueuerMessage,
     ShardRunnerInfo,
 };
-use threadpool::ThreadPool;
+use uvth::ThreadPool;
 use typemap::ShareMap;
 use log::{info, warn};
 

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -24,7 +24,7 @@ use super::{
     ShardRunnerInfo,
     ShardRunnerOptions,
 };
-use threadpool::ThreadPool;
+use uvth::ThreadPool;
 use typemap::ShareMap;
 use crate::gateway::ConnectionStage;
 use log::{info, warn};

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -22,7 +22,7 @@ use super::super::super::dispatch::{DispatchEvent, dispatch};
 use super::super::super::{EventHandler, RawEventHandler};
 use super::event::{ClientEvent, ShardStageUpdateEvent};
 use super::{ShardClientMessage, ShardId, ShardManagerMessage, ShardRunnerMessage};
-use threadpool::ThreadPool;
+use uvth::ThreadPool;
 use tungstenite::{
     error::Error as TungsteniteError,
     protocol::frame::CloseFrame,

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -11,7 +11,7 @@ use super::{
     event_handler::{EventHandler, RawEventHandler},
     Context
 };
-use threadpool::ThreadPool;
+use uvth::ThreadPool;
 use typemap::ShareMap;
 
 #[cfg(feature = "http")]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -42,7 +42,7 @@ use parking_lot::Mutex;
 use parking_lot::RwLock;
 use self::bridge::gateway::{ShardManager, ShardManagerMonitor, ShardManagerOptions};
 use std::sync::Arc;
-use threadpool::ThreadPool;
+use uvth::ThreadPool;
 use typemap::ShareMap;
 use log::{error, debug, info};
 
@@ -356,8 +356,7 @@ impl Client {
 
         let http = Http::new_with_token(&token);
 
-        let name = "serenity client".to_owned();
-        let threadpool = ThreadPool::with_name(name, 5);
+        let threadpool = ThreadPool::new(5);
         let url = Arc::new(Mutex::new(http.get_gateway()?.url));
         let data = Arc::new(RwLock::new(ShareMap::custom()));
         let event_handler = handler.map(Arc::new);
@@ -460,8 +459,7 @@ impl Client {
 
         let http = Http::new_with_token(&token);
 
-        let name = "serenity client".to_owned();
-        let threadpool = ThreadPool::with_name(name, 5);
+        let threadpool = ThreadPool::new(5);
         let url = Arc::new(Mutex::new(http.get_gateway()?.url));
         let data = Arc::new(RwLock::new(ShareMap::custom()));
         let event_handler = Some(Arc::new(handler));

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -68,7 +68,7 @@ pub use self::standard::StandardFramework;
 
 use crate::client::Context;
 use crate::model::channel::Message;
-use threadpool::ThreadPool;
+use uvth::ThreadPool;
 use std::sync::Arc;
 
 /// A trait for defining your own framework for serenity to use.
@@ -90,7 +90,7 @@ impl<F: Framework + ?Sized> Framework for Box<F> {
 
 impl<T: Framework + ?Sized> Framework for Arc<T> {
     #[inline]
-    fn dispatch(&mut self, ctx: Context, msg: Message, threadpool: &threadpool::ThreadPool) {
+    fn dispatch(&mut self, ctx: Context, msg: Message, threadpool: &uvth::ThreadPool) {
         if let Some(s) = Arc::get_mut(self) {
             (*s).dispatch(ctx, msg, threadpool)
         }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -24,7 +24,7 @@ use crate::model::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
-use threadpool::ThreadPool;
+use uvth::ThreadPool;
 
 #[cfg(feature = "cache")]
 use crate::cache::CacheRwLock;


### PR DESCRIPTION
The official `threadpool` crate is very unoptimized and somewhat slow. `uvth` implements a still very compact but much more efficient pool with less overhead. It is still not as optimized as it can be (far from) but it is better than the `threadpool` crate. This pull swaps threadpool for uvth.