### PR TITLE
Make `MessageBuilder::push_spoiler_*` consistent with the other `push_` functions

### DIFF
--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -375,7 +375,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a spoiler'd inline text to the content.
-    pub fn push_spoiler<D: I>(mut self, content: D) -> Self {
+    pub fn push_spoiler<D: I>(&mut self, content: D) -> Self {
         self.0.push_str("||");
         self.0.push_str(&content.into().to_string());
         self.0.push_str("||");
@@ -516,7 +516,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "||hello||\nworld");
     /// ```
-    pub fn push_spoiler_line<D: I>(mut self, content: D) -> Self {
+    pub fn push_spoiler_line<D: I>(&mut self, content: D) -> Self {
         self = self.push_spoiler(content);
         self.0.push('\n');
 
@@ -624,7 +624,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a spoiler'd inline text to the content normalizing content.
-    pub fn push_spoiler_safe<D: I>(mut self, content: D) -> Self {
+    pub fn push_spoiler_safe<D: I>(&mut self, content: D) -> Self {
         self.0.push_str("||");
         {
             let mut c = content.into();
@@ -785,7 +785,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "||@\u{200B}everyone||\nIsn't a mention.");
     /// ```
-    pub fn push_spoiler_line_safe<D: I>(mut self, content: D) -> Self {
+    pub fn push_spoiler_line_safe<D: I>(&mut self, content: D) -> Self {
         self = self.push_spoiler_safe(content);
         self.0.push('\n');
 

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -517,7 +517,7 @@ impl MessageBuilder {
     /// assert_eq!(content, "||hello||\nworld");
     /// ```
     pub fn push_spoiler_line<D: I>(&mut self, content: D) -> &mut Self {
-        self = self.push_spoiler(content);
+        self.push_spoiler(content);
         self.0.push('\n');
 
         self
@@ -786,7 +786,7 @@ impl MessageBuilder {
     /// assert_eq!(content, "||@\u{200B}everyone||\nIsn't a mention.");
     /// ```
     pub fn push_spoiler_line_safe<D: I>(&mut self, content: D) -> &mut Self {
-        self = self.push_spoiler_safe(content);
+        self.push_spoiler_safe(content);
         self.0.push('\n');
 
         self

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -375,7 +375,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a spoiler'd inline text to the content.
-    pub fn push_spoiler<D: I>(&mut self, content: D) -> Self {
+    pub fn push_spoiler<D: I>(&mut self, content: D) -> &mut Self {
         self.0.push_str("||");
         self.0.push_str(&content.into().to_string());
         self.0.push_str("||");
@@ -516,7 +516,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "||hello||\nworld");
     /// ```
-    pub fn push_spoiler_line<D: I>(&mut self, content: D) -> Self {
+    pub fn push_spoiler_line<D: I>(&mut self, content: D) -> &mut Self {
         self = self.push_spoiler(content);
         self.0.push('\n');
 
@@ -624,7 +624,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a spoiler'd inline text to the content normalizing content.
-    pub fn push_spoiler_safe<D: I>(&mut self, content: D) -> Self {
+    pub fn push_spoiler_safe<D: I>(&mut self, content: D) -> &mut Self {
         self.0.push_str("||");
         {
             let mut c = content.into();
@@ -785,7 +785,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "||@\u{200B}everyone||\nIsn't a mention.");
     /// ```
-    pub fn push_spoiler_line_safe<D: I>(&mut self, content: D) -> Self {
+    pub fn push_spoiler_line_safe<D: I>(&mut self, content: D) -> &mut Self {
         self = self.push_spoiler_safe(content);
         self.0.push('\n');
 


### PR DESCRIPTION
changes `mut self` into `&mut self` for the spoiler push functions in the message builder.