### PR TITLE
Fix private channel deletions making serenity panic.

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -152,9 +152,17 @@ impl CacheUpdate for ChannelDeleteEvent {
 
                 cache.categories.remove(&channel_id);
             },
+            Channel::Private(ref channel) => {
+                let id = {
+                    channel.read().id
+                };
+
+                cache.private_channels.remove(&id);
+            },
+
             // We ignore these because the delete event does not fire for these.
-            Channel::Private(_) | Channel::Group(_)
-            | Channel::__Nonexhaustive => unreachable!(),
+            Channel::Group(_) |
+            Channel::__Nonexhaustive => unreachable!(),
         };
 
         // Remove the cached messages for the channel.


### PR DESCRIPTION
This only happend if the deletion event was sent by serenity,
where it would get a ChannelDeletionEvent which it does not
get if the channel is deleted by the user. This was unexpected
and made it hit a unimplemented! which paniced it.

Singed-off: Valdemar Erk <v@erk.io>