### PR TITLE
Implement `CacheHttp` for `Arc<Http>`

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -41,6 +41,7 @@ use crate::model::prelude::*;
 use self::{request::Request};
 use std::{
     fs::File,
+    sync::Arc,
     path::{Path, PathBuf},
 };
 
@@ -113,6 +114,11 @@ impl CacheHttp for (&CacheRwLock, &Http) {
 impl CacheHttp for &Http {
     #[cfg(feature = "http")]
     fn http(&self) -> &Http { *self }
+}
+
+impl CacheHttp for Arc<Http> {
+    #[cfg(feature = "http")]
+    fn http(&self) -> &Http { &*self }
 }
 
 #[cfg(all(feature = "cache", feature = "http"))]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -111,11 +111,13 @@ impl CacheHttp for (&CacheRwLock, &Http) {
     fn http(&self) -> &Http { &self.1 }
 }
 
+#[cfg(feature = "http")]
 impl CacheHttp for &Http {
     #[cfg(feature = "http")]
     fn http(&self) -> &Http { *self }
 }
 
+#[cfg(feature = "http")]
 impl CacheHttp for Arc<Http> {
     #[cfg(feature = "http")]
     fn http(&self) -> &Http { &*self }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -113,7 +113,6 @@ impl CacheHttp for (&CacheRwLock, &Http) {
 
 #[cfg(feature = "http")]
 impl CacheHttp for &Http {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http { *self }
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -118,7 +118,6 @@ impl CacheHttp for &Http {
 
 #[cfg(feature = "http")]
 impl CacheHttp for Arc<Http> {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http { &*self }
 }
 


### PR DESCRIPTION
Allows to pass `Arc<Http>` without having to manually dereference.