### PR TITLE
 Use `CacheRwLock` in `CacheAndHttp`

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1069,6 +1069,12 @@ impl AsRef<CacheRwLock> for CacheRwLock {
     }
 }
 
+impl Default for CacheRwLock {
+    fn default() -> Self {
+        Self(Arc::new(RwLock::new(Cache::default())))
+    }
+}
+
 impl Deref for CacheRwLock {
     type Target = Arc<RwLock<Cache>>;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -373,7 +373,7 @@ impl Client {
 
         let cache_and_http = Arc::new(CacheAndHttp {
             #[cfg(feature = "cache")]
-            cache: Arc::new(RwLock::new(Cache::default())),
+            cache: CacheRwLock::default(),
             #[cfg(feature = "cache")]
             update_cache_timeout: None,
             #[cfg(feature = "http")]
@@ -475,7 +475,7 @@ impl Client {
         )));
 
         let cache_and_http = Arc::new(CacheAndHttp {
-            cache: Arc::new(RwLock::new(Cache::default())),
+            cache: CacheRwLock::default(),
             update_cache_timeout: duration,
             #[cfg(feature = "http")]
             http: Arc::new(http),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -48,6 +48,10 @@ use std::{
 use crate::cache::CacheRwLock;
 #[cfg(feature = "client")]
 use crate::client::Context;
+#[cfg(feature = "client")]
+use crate::CacheAndHttp;
+#[cfg(feature = "client")]
+use std::sync::Arc;
 
 /// This trait will be required by functions that need [`Http`] and can
 /// optionally use a [`CacheRwLock`] to potentially avoid REST-requests.
@@ -98,6 +102,30 @@ impl CacheHttp for &mut Context {
 
 #[cfg(feature = "client")]
 impl CacheHttp for &&mut Context {
+    #[cfg(feature = "http")]
+    fn http(&self) -> &Http { &self.http }
+    #[cfg(feature = "cache")]
+    fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
+}
+
+#[cfg(feature = "client")]
+impl CacheHttp for CacheAndHttp {
+    #[cfg(feature = "http")]
+    fn http(&self) -> &Http { &self.http }
+    #[cfg(feature = "cache")]
+    fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
+}
+
+#[cfg(feature = "client")]
+impl CacheHttp for &CacheAndHttp {
+    #[cfg(feature = "http")]
+    fn http(&self) -> &Http { &self.http }
+    #[cfg(feature = "cache")]
+    fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
+}
+
+#[cfg(feature = "client")]
+impl CacheHttp for Arc<CacheAndHttp> {
     #[cfg(feature = "http")]
     fn http(&self) -> &Http { &self.http }
     #[cfg(feature = "cache")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,7 @@ pub use crate::error::{Error, Result};
 pub use crate::client::Client;
 
 #[cfg(feature = "cache")]
-use crate::cache::Cache;
-#[cfg(feature = "cache")]
-use parking_lot::RwLock;
+use crate::cache::CacheRwLock;
 #[cfg(feature = "cache")]
 use std::time::Duration;
 #[cfg(any(feature = "client", feature = "http"))]
@@ -105,7 +103,7 @@ use crate::http::Http;
 #[derive(Default)]
 pub struct CacheAndHttp {
     #[cfg(feature = "cache")]
-    pub cache: Arc<RwLock<Cache>>,
+    pub cache: CacheRwLock,
     #[cfg(feature = "cache")]
     pub update_cache_timeout: Option<Duration>,
     #[cfg(feature = "http")]


### PR DESCRIPTION
Replacing the normal `Arc<RwLock<Cache>>` with the
API-friendly `CacheRwLock`.

On another note, this entitles `CacheRwLock` to implement `CacheHttp`, which is done in this pull request.