### PR TITLE
Fix `create_invite`'s doc-example

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -131,7 +131,7 @@ impl GuildChannel {
     /// Create an invite that can only be used 5 times:
     ///
     /// ```rust,ignore
-    /// let invite = channel.create_invite(|i| i.max_uses(5));
+    /// let invite = channel.create_invite(&context, |i| i.max_uses(5));
     /// ```
     #[cfg(all(feature = "utils", feature = "client"))]
     pub fn create_invite<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<RichInvite>


### PR DESCRIPTION
The example was not updated after we removed global cache and HTTP.