### PR TITLE
Commit some modifications to the command_attr codebase

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -33,7 +33,7 @@ macro_rules! match_options {
     ($v:expr, $values:ident, $options:ident, $span:expr => [$($name:ident);*]) => {
         match $v {
             $(
-                stringify!($name) => $options.$name = try_r!($crate::attributes::parse($values)),
+                stringify!($name) => $options.$name = propagate_err!($crate::attributes::parse($values)),
             )*
             _ => {
                 return Error::new($span, format_args!("invalid attribute: {:?}", $v))
@@ -144,20 +144,20 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     for attribute in &fun.attributes {
         let span = attribute.span();
-        let values = try_r!(parse_values(attribute));
+        let values = propagate_err!(parse_values(attribute));
 
         let name = values.name.to_string();
         let name = &name[..];
 
         match name {
             "num_args" => {
-                let args = try_r!(u16::parse(values));
+                let args = propagate_err!(u16::parse(values));
 
                 options.min_args = Some(args);
                 options.max_args = Some(args);
             }
             "required_permissions" => {
-                let p = try_r!(Vec::<Ident>::parse(values));
+                let p = propagate_err!(Vec::<Ident>::parse(values));
 
                 let mut permissions = Permissions::default();
                 for perm in p {
@@ -177,19 +177,19 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
                 options.required_permissions = permissions;
             }
             "checks" => {
-                options.checks = Checks(try_r!(attributes::parse(values)));
+                options.checks = Checks(propagate_err!(attributes::parse(values)));
             }
             "bucket" => {
-                options.bucket = Some(try_r!(attributes::parse(values)));
+                options.bucket = Some(propagate_err!(attributes::parse(values)));
             }
             "description" => {
-                options.description = Some(try_r!(attributes::parse(values)));
+                options.description = Some(propagate_err!(attributes::parse(values)));
             }
             "usage" => {
-                options.usage = Some(try_r!(attributes::parse(values)));
+                options.usage = Some(propagate_err!(attributes::parse(values)));
             }
             "example" => {
-                options.example = Some(try_r!(attributes::parse(values)));
+                options.example = Some(propagate_err!(attributes::parse(values)));
             }
             _ => {
                 match_options!(name, values, options, span => [
@@ -233,14 +233,14 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
     let min_args = AsOption(min_args);
     let max_args = AsOption(max_args);
 
-    try_r!(validate_declaration(&mut fun, DeclarFor::Command));
+    propagate_err!(validate_declaration(&mut fun, DeclarFor::Command));
 
     let either = [
         parse_quote!(CommandResult),
         parse_quote!(serenity::framework::standard::CommandResult),
     ];
 
-    try_r!(validate_return_type(&mut fun, either));
+    propagate_err!(validate_return_type(&mut fun, either));
 
     let Permissions(required_permissions) = required_permissions;
 
@@ -419,14 +419,14 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     for attribute in &fun.attributes {
         let span = attribute.span();
-        let values = try_r!(parse_values(attribute));
+        let values = propagate_err!(parse_values(attribute));
 
         let name = values.name.to_string();
         let name = &name[..];
 
         match name {
             "lacking_role" => {
-                let val = try_r!(String::parse(values));
+                let val = propagate_err!(String::parse(values));
 
                 options.lacking_role = match HelpBehaviour::from_str(&val) {
                     Some(h) => h,
@@ -441,7 +441,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
                 };
             }
             "embed_error_colour" => {
-                let val = try_r!(String::parse(values));
+                let val = propagate_err!(String::parse(values));
 
                 options.embed_error_colour = match Colour::from_str(&val) {
                     Some(c) => c,
@@ -453,7 +453,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
                 };
             }
             "embed_success_colour" => {
-                let val = try_r!(String::parse(values));
+                let val = propagate_err!(String::parse(values));
 
                 options.embed_success_colour = match Colour::from_str(&val) {
                     Some(c) => c,
@@ -465,7 +465,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
                 };
             }
             "lacking_permissions" => {
-                let val = try_r!(String::parse(values));
+                let val = propagate_err!(String::parse(values));
 
                 options.lacking_permissions = match HelpBehaviour::from_str(&val) {
                     Some(h) => h,
@@ -480,7 +480,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
                 };
             }
             "lacking_ownership" => {
-                let val = try_r!(String::parse(values));
+                let val = propagate_err!(String::parse(values));
 
                 options.lacking_ownership = match HelpBehaviour::from_str(&val) {
                     Some(h) => h,
@@ -495,7 +495,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
                 };
             }
             "wrong_channel" => {
-                let val = try_r!(String::parse(values));
+                let val = propagate_err!(String::parse(values));
 
                 options.wrong_channel = match HelpBehaviour::from_str(&val) {
                     Some(h) => h,
@@ -626,14 +626,14 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     let Colour(embed_error_colour) = embed_error_colour;
     let Colour(embed_success_colour) = embed_success_colour;
 
-    try_r!(validate_declaration(&mut fun, DeclarFor::Help));
+    propagate_err!(validate_declaration(&mut fun, DeclarFor::Help));
 
     let either = [
         parse_quote!(CommandResult),
         parse_quote!(serenity::framework::standard::CommandResult),
     ];
 
-    try_r!(validate_return_type(&mut fun, either));
+    propagate_err!(validate_return_type(&mut fun, either));
 
     let options = fun.name.with_suffix(HELP_OPTIONS);
 
@@ -856,15 +856,15 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
     for attribute in &fun.attributes {
         let span = attribute.span();
-        let values = try_r!(parse_values(attribute));
+        let values = propagate_err!(parse_values(attribute));
 
         let n = values.name.to_string();
         let n = &n[..];
 
         match n {
-            "name" => name = try_r!(attributes::parse(values)),
-            "display_in_help" => display_in_help = try_r!(attributes::parse(values)),
-            "check_in_help" => check_in_help = try_r!(attributes::parse(values)),
+            "name" => name = propagate_err!(attributes::parse(values)),
+            "display_in_help" => display_in_help = propagate_err!(attributes::parse(values)),
+            "check_in_help" => check_in_help = propagate_err!(attributes::parse(values)),
             _ => {
                 return Error::new(span, format_args!("invalid attribute: {:?}", n))
                     .to_compile_error()
@@ -873,14 +873,14 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
 
-    try_r!(validate_declaration(&mut fun, DeclarFor::Check));
+    propagate_err!(validate_declaration(&mut fun, DeclarFor::Check));
 
     let either = [
         parse_quote!(CheckResult),
         parse_quote!(serenity::framework::standard::CheckResult),
     ];
 
-    try_r!(validate_return_type(&mut fun, either));
+    propagate_err!(validate_return_type(&mut fun, either));
 
     let n = fun.name.clone();
     let n2 = name.clone();

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -124,12 +124,12 @@ impl Parse for CommandFun {
                                     kind,
                                 })
                             }
-                            _ => Err(Error::new(span, &format!("unsupported pattern: {:?}", pat))),
+                            _ => Err(Error::new(span, format_args!("unsupported pattern: {:?}", pat))),
                         }
                     }
                     _ => Err(Error::new(
                         span,
-                        &format!("use of a prohibited argument type: {:?}", arg),
+                        format_args!("use of a prohibited argument type: {:?}", arg),
                     )),
                 }
             })
@@ -555,7 +555,7 @@ impl Parse for GroupOptions {
                 (name, _) => {
                     return Err(Error::new(
                         span,
-                        &format!("`{}` is not a valid group option", name),
+                        format_args!("`{}` is not a valid group option", name),
                     ));
                 }
             }

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -73,7 +73,7 @@ pub fn into_stream(e: Error) -> TokenStream {
     e.to_compile_error().into()
 }
 
-macro_rules! try_r {
+macro_rules! propagate_err {
     ($res:expr) => {{
         match $res {
             Ok(v) => v,

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -1,4 +1,5 @@
 use crate::structures::CommandFun;
+use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
@@ -65,6 +66,20 @@ impl IdentExt2 for Ident {
             Span::call_site(),
         )
     }
+}
+
+#[inline]
+pub fn into_stream(e: Error) -> TokenStream {
+    e.to_compile_error().into()
+}
+
+macro_rules! try_r {
+    ($res:expr) => {{
+        match $res {
+            Ok(v) => v,
+            Err(e) => return $crate::util::into_stream(e),
+        }
+    }};
 }
 
 pub trait ParseStreamExt {
@@ -286,7 +301,7 @@ pub fn validate_declaration(fun: &mut CommandFun, dec_for: DeclarFor) -> Result<
     if fun.args.len() > len {
         return Err(Error::new(
             fun.args.last().unwrap().span(),
-            format!("function's arity exceeds more than {} arguments", len),
+            format_args!("function's arity exceeds more than {} arguments", len),
         ));
     }
 
@@ -394,7 +409,7 @@ pub fn validate_return_type(fun: &mut CommandFun, [relative, absolute]: [Type; 2
 
     Err(Error::new(
         ret.span(),
-        &format!(
+        format_args!(
             "expected either `{}` or `{}` as the return type, but got `{}`",
             quote!(#relative),
             quote!(#absolute),


### PR DESCRIPTION
1) Tweaked attribute parsing to no longer care about the name and separated validation of correct data to its function. Consequently, the `AttributeOption` trait was simplified.
2) `format_args!` instead of `format!` for error message creation. [`Error::new`](https://docs.rs/syn/0.15.39/syn/parse/struct.Error.html#method.new) accepts any type `impl`'ing `Display`. [`Arguments`](https://doc.rust-lang.org/nightly/std/fmt/struct.Arguments.html) is one that the compiler can cheaply produce and need not be allocated, unlike `String`.
3) A `try_r!` macro for early-returning a `TokenStream` out of a syn error when one's present.