### PR TITLE
Remove unnecessary ticks

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -999,7 +999,7 @@ fn flatten_group_to_plain_string(
         );
     }
 
-    let joined_commands = format!("`{}`", group.command_names.join("`, `"));
+    let joined_commands = format!("{}", group.command_names.join("`, `"));
 
     let _ = write!(group_text, "{}", joined_commands);
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -999,7 +999,7 @@ fn flatten_group_to_plain_string(
         );
     }
 
-    let joined_commands = format!("{}", group.command_names.join("`, `"));
+    let joined_commands = format!("{}", group.command_names.join(", "));
 
     let _ = write!(group_text, "{}", joined_commands);
 


### PR DESCRIPTION
Commands in the strikethrough-style ended up with ticks around their strikethrough characters: ~~.
We can safely remove the suggested ticks when flattening the data's commands to a `String`, as the command names are already modified and surrounded by ticks. 