### PR TITLE
Add quoting functionality to MessageBuilder

### DIFF
--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -840,7 +840,7 @@ impl MessageBuilder {
     }
 
     /// Starts a multi-line quote, every push after this one will be quoted
-    pub fn start_quote(mut self) -> Self {
+    pub fn quote_rest(mut self) -> Self {
         self.0.push_str("\n>>> ");
 
         self

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -366,6 +366,14 @@ impl MessageBuilder {
         self
     }
 
+    /// Pushes a quoted inline text to the content
+    pub fn push_quote<D: I>(mut self, content: D) -> Self {
+        self.0.push_str("> ");
+        self.0.push_str(&content.into().to_string());
+
+        self
+    }
+
     /// Pushes the given text with a newline appended to the content.
     ///
     /// # Examples
@@ -506,6 +514,26 @@ impl MessageBuilder {
         self
     }
 
+    /// Pushes a quoted inline text to the content
+    ///
+    /// # Examples
+    ///
+    /// Push content and then append a newline:
+    ///
+    /// ```rust
+    /// use serenity::utils::MessageBuilder;
+    ///
+    /// let content = MessageBuilder::new().push_quote_line("hello").push("world").build();
+    ///
+    /// assert_eq!(content, "> hello\nworld");
+    /// ```
+    pub fn push_quote_line<D: I>(mut self, content: D) -> Self {
+        self = self.push_quote(content);
+        self.0.push('\n');
+
+        self
+    }
+
     /// Pushes text to your message, but normalizing content - that means
     /// ensuring that there's no unwanted formatting, mention spam etc.
     pub fn push_safe<C: I>(mut self, content: C) -> Self {
@@ -616,6 +644,18 @@ impl MessageBuilder {
             self.0.push_str(&c.to_string());
         }
         self.0.push_str("||");
+
+        self
+    }
+
+    /// Pushes a quoted inline text to the content normalizing content.
+    pub fn push_quote_safe<D: I>(mut self, content: D) -> Self {
+        self.0.push_str("> ");
+        {
+            let mut c = content.into();
+            c.inner = normalize(&c.inner).replace("> ", " ");
+            self.0.push_str(&c.to_string());
+        }
 
         self
     }
@@ -772,6 +812,36 @@ impl MessageBuilder {
     pub fn push_spoiler_line_safe<D: I>(mut self, content: D) -> Self {
         self = self.push_spoiler_safe(content);
         self.0.push('\n');
+
+        self
+    }
+
+    /// Pushes a quoted inline text with added newline to the content normalizing
+    /// content.
+    ///
+    /// # Examples
+    ///
+    /// Push content and then append a newline:
+    ///
+    /// ```rust
+    /// use serenity::utils::MessageBuilder;
+    ///
+    /// let content = MessageBuilder::new()
+    ///                 .push_quote_line_safe("@everyone")
+    ///                 .push("Isn't a mention.").build();
+    ///
+    /// assert_eq!(content, "> @\u{200B}everyone\nIsn't a mention.");
+    /// ```
+    pub fn push_quote_line_safe<D: I>(mut self, content: D) -> Self {
+        self = self.push_quote_safe(content);
+        self.0.push('\n');
+
+        self
+    }
+
+    /// Starts a multi-line quote, every push after this one will be quoted
+    pub fn start_quote(mut self) -> Self {
+        self.0.push_str("\n>>> ");
 
         self
     }


### PR DESCRIPTION
Hello,
This PR adds quoting support for `MessageBuilder`.
It addresses #669.

Discord recently added the option to format a message with a `quote`:
![image](https://user-images.githubusercontent.com/40574704/62130811-7a8e2600-b2e2-11e9-9297-f4f9672ae364.png)


I added the following method to be compatible with the existing API for pushing to `MessageBuilder`:
`push_quote`
`push_quote_line`
`push_quote_safe`
`push_quote_line_safe`
`start_quote` - this is used for declaring multiline quotes, any pushes after this one will be quoted

All working properly + all tests passing
Have a nice day!