### PR TITLE
Added group removal and non-consuming group adding functions to StandardFramework

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -383,6 +383,15 @@ impl StandardFramework {
         self
     }
 
+    /// Removes a group from being used in the framework.
+    /// 
+    /// Note: does _not_ return `Self` like many other commands. This is because
+    /// it's not intended to be chained as the other commands are.
+    pub fn remove_group(&mut self, group: &'static CommandGroup) {
+        // Iterates through the vector and if a given group _doesn't_ match, we retain it
+        self.groups.retain(|&(g, _)| g != group)
+    }
+
     /// Specify the function that's called in case a command wasn't executed for one reason or
     /// another.
     ///

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -383,11 +383,31 @@ impl StandardFramework {
         self
     }
 
-    /// Removes a group from being used in the framework.
+    /// Adds a group to be used by the framework. Primary use-case is runtime modification
+    /// of groups in the framework; will _not_ mark the framework as initialized. Refer to
+    /// [`group`] for adding groups in initial configuration.
     /// 
     /// Note: does _not_ return `Self` like many other commands. This is because
     /// it's not intended to be chained as the other commands are.
-    pub fn remove_group(&mut self, group: &'static CommandGroup) {
+    /// 
+    /// [`group`]: #method.group
+    pub fn group_add(&mut self, group: &'static CommandGroup) {
+        // Implementation is duplicated from above group function
+        let map = if group.options.prefixes.is_empty() {
+            Map::Prefixless(GroupMap::new(&group.sub_groups), CommandMap::new(&group.commands))
+        } else {
+            Map::WithPrefixes(GroupMap::new(&[group]))
+        };
+
+        self.groups.push((group, map));
+    }
+
+    /// Removes a group from being used in the framework. Primary use-case is runtime modification
+    /// of groups in the framework.
+    /// 
+    /// Note: does _not_ return `Self` like many other commands. This is because
+    /// it's not intended to be chained as the other commands are.
+    pub fn group_remove(&mut self, group: &'static CommandGroup) {
         // Iterates through the vector and if a given group _doesn't_ match, we retain it
         self.groups.retain(|&(g, _)| g != group)
     }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -370,14 +370,7 @@ impl StandardFramework {
     /// # }
     /// ```
     pub fn group(mut self, group: &'static CommandGroup) -> Self {
-        let map = if group.options.prefixes.is_empty() {
-            Map::Prefixless(GroupMap::new(&group.sub_groups), CommandMap::new(&group.commands))
-        } else {
-            Map::WithPrefixes(GroupMap::new(&[group]))
-        };
-
-        self.groups.push((group, map));
-
+        self.group_add(group);
         self.initialized = true;
 
         self
@@ -392,7 +385,6 @@ impl StandardFramework {
     /// 
     /// [`group`]: #method.group
     pub fn group_add(&mut self, group: &'static CommandGroup) {
-        // Implementation is duplicated from above group function
         let map = if group.options.prefixes.is_empty() {
             Map::Prefixless(GroupMap::new(&group.sub_groups), CommandMap::new(&group.commands))
         } else {


### PR DESCRIPTION
At the very least, this is nice if you ever want to hard disable a group of commands on the fly. Otherwise, it allows people to do more fun things with `StandardFramework`.