### PR TITLE
Avoid searching the cache for the guild id when we already have it

### DIFF
--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -63,23 +63,9 @@ impl ChannelCategory {
 
 
     /// Deletes this category if required permissions are met.
-    ///
-    /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon
-    /// owning the required permissions the HTTP-request will be issued.
     #[inline]
     #[cfg(feature = "http")]
     pub fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_CHANNELS;
-
-                if !utils::user_has_perms(&cache, self.id, req)? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
-            }
-        }
-
         self.id.delete(&cache_http.http()).map(|_| ())
     }
 
@@ -96,18 +82,8 @@ impl ChannelCategory {
     /// ```
     #[cfg(all(feature = "builder", feature = "model", feature = "utils", feature = "client"))]
     pub fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
-        where F: FnOnce(&mut EditChannel) -> &mut EditChannel {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_CHANNELS;
-
-                if !utils::user_has_perms(&cache, self.id, req)? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
-            }
-        }
-
+        where F: FnOnce(&mut EditChannel) -> &mut EditChannel
+    {
         let mut map = HashMap::new();
         map.insert("name", Value::String(self.name.clone()));
         map.insert("position", Value::Number(Number::from(self.position)));

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -141,7 +141,7 @@ impl GuildChannel {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::CREATE_INVITE;
 
-                if !utils::user_has_perms(&cache, self.id, req)? {
+                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }
@@ -283,7 +283,7 @@ impl GuildChannel {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::MANAGE_CHANNELS;
 
-                if !utils::user_has_perms(&cache, self.id, req)? {
+                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }
@@ -365,7 +365,7 @@ impl GuildChannel {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::MANAGE_CHANNELS;
 
-                if !utils::user_has_perms(&cache, self.id, req)? {
+                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }
@@ -683,7 +683,7 @@ impl GuildChannel {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::SEND_MESSAGES;
 
-                if !utils::user_has_perms(&cache, self.id, req)? {
+                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -122,7 +122,7 @@ impl Message {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::MANAGE_MESSAGES;
                 let is_author = self.author.id == cache.read().user.id;
-                let has_perms = utils::user_has_perms(&cache, self.channel_id, req)?;
+                let has_perms = utils::user_has_perms(&cache, self.channel_id, self.guild_id, req)?;
 
                 if !is_author && !has_perms {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
@@ -153,7 +153,7 @@ impl Message {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::MANAGE_MESSAGES;
 
-                if !utils::user_has_perms(cache, self.channel_id, req)? {
+                if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }
@@ -390,7 +390,7 @@ impl Message {
                 if self.guild_id.is_some() {
                     let req = Permissions::MANAGE_MESSAGES;
 
-                    if !utils::user_has_perms(&cache, self.channel_id, req)? {
+                    if !utils::user_has_perms(&cache, self.channel_id, self.guild_id, req)? {
                         return Err(Error::Model(ModelError::InvalidPermissions(req)));
                     }
                 }
@@ -430,7 +430,7 @@ impl Message {
                 if self.guild_id.is_some() {
                     let req = Permissions::ADD_REACTIONS;
 
-                    if !utils::user_has_perms(cache, self.channel_id, req)? {
+                    if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req)? {
                         return Err(Error::Model(ModelError::InvalidPermissions(req)));
                     }
                 }
@@ -477,7 +477,7 @@ impl Message {
                 if self.guild_id.is_some() {
                     let req = Permissions::SEND_MESSAGES;
 
-                    if !utils::user_has_perms(cache, self.channel_id, req)? {
+                    if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req)? {
                         return Err(Error::Model(ModelError::InvalidPermissions(req)));
                     }
                 }
@@ -536,7 +536,7 @@ impl Message {
                 if self.guild_id.is_some() {
                     let req = Permissions::MANAGE_MESSAGES;
 
-                    if !utils::user_has_perms(cache, self.channel_id, req)? {
+                    if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req)? {
                         return Err(Error::Model(ModelError::InvalidPermissions(req)));
                     }
                 }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -91,7 +91,7 @@ impl Reaction {
                 if user_id.is_some() {
                     let req = Permissions::MANAGE_MESSAGES;
 
-                    if !utils::user_has_perms(cache, self.channel_id, req).unwrap_or(true) {
+                    if !utils::user_has_perms(cache, self.channel_id, None, req).unwrap_or(true) {
                         return Err(Error::Model(ModelError::InvalidPermissions(req)));
                     }
                 }

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -92,7 +92,7 @@ impl Invite {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::CREATE_INVITE;
 
-                if !model_utils::user_has_perms(cache, channel_id, req)? {
+                if !model_utils::user_has_perms(cache, channel_id, None, req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }
@@ -122,7 +122,8 @@ impl Invite {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::MANAGE_GUILD;
 
-                if !model_utils::user_has_perms(cache, self.channel.id, req)? {
+                let guild_id = self.guild.as_ref().map(|g| g.id);
+                if !model_utils::user_has_perms(cache, self.channel.id, guild_id, req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }
@@ -322,7 +323,8 @@ impl RichInvite {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::MANAGE_GUILD;
 
-                if !model_utils::user_has_perms(cache, self.channel.id, req)? {
+                let guild_id = self.guild.as_ref().map(|g| g.id);
+                if !model_utils::user_has_perms(cache, self.channel.id, guild_id, req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -281,31 +281,40 @@ pub fn serialize_gen_locked_map<K: Eq + Hash, S: Serializer, V: Serialize>(
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
-pub fn user_has_perms(cache: impl AsRef<CacheRwLock>, channel_id: ChannelId, mut permissions: Permissions) -> Result<bool> {
+pub fn user_has_perms(
+    cache: impl AsRef<CacheRwLock>,
+    channel_id: ChannelId,
+    guild_id: Option<GuildId>,
+    mut permissions: Permissions
+) -> Result<bool> {
     let cache = cache.as_ref().read();
     let current_user = &cache.user;
 
-    let channel = match cache.channel(channel_id) {
-        Some(channel) => channel,
-        None => return Err(Error::Model(ModelError::ItemMissing)),
-    };
+    let guild_id = match guild_id {
+        Some(id) => id,
+        None => {
+            let channel = match cache.channel(channel_id) {
+                Some(channel) => channel,
+                None => return Err(Error::Model(ModelError::ItemMissing)),
+            };
 
-    let guild_id = match channel {
-        Channel::Guild(channel) => channel.read().guild_id,
-        Channel::Group(_) | Channel::Private(_) | Channel::Category(_) => {
-            // Both users in DMs, and all users in groups and maybe all channels in categories will
-            // have the same
-            // permissions.
-            //
-            // The only exception to this is when the current user is blocked by
-            // the recipient in a DM channel, which results in the current user
-            // not being able to send messages.
-            //
-            // Since serenity can't _reasonably_ check and keep track of these,
-            // just assume that all permissions are granted and return `true`.
-            return Ok(true);
-        },
-        Channel::__Nonexhaustive => unreachable!(),
+            match channel {
+                Channel::Guild(channel) => channel.read().guild_id,
+                Channel::Group(_) | Channel::Private(_) | Channel::Category(_) => {
+                    // Both users in DMs, all users in groups, and maybe all channels in categories
+                    // will have the same permissions.
+                    //
+                    // The only exception to this is when the current user is blocked by
+                    // the recipient in a DM channel, preventing the current user
+                    // from sending messages.
+                    //
+                    // Since serenity can't _reasonably_ check and keep track of these,
+                    // just assume that all permissions are granted and return `true`.
+                    return Ok(true);
+                },
+                Channel::__Nonexhaustive => unreachable!(),
+            }
+        }
     };
 
     let guild = match cache.guild(guild_id) {


### PR DESCRIPTION
~This should fix #676.~ edit: Not true, another [read lock](https://github.com/serenity-rs/serenity/blob/current/src/model/guild/mod.rs#L1352) must be eliminated to combat the issue successfully. Nevertheless, this does forbid the utility function from performing a useless cache search call in almost all cases, which should improve its performance.

Because `user_has_perms` always yields `true` for category channels, I've also removed its redundant calls in `ChannelCategory`'s `delete` and `edit` methods.