### PR TITLE
Fix content of messages if there is a attachment

### DIFF
--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -61,12 +61,12 @@ impl<'a> CreateMessage<'a> {
     /// **Note**: Message contents must be under 2000 unicode code points.
     #[inline]
     pub fn content<D: ToString>(&mut self, content: D) -> &mut Self {
-        self.0.insert("content", Value::String(content.to_string()));
-        self
+        self._content(content.to_string())
     }
 
-    fn _content(&mut self, content: String) {
+    fn _content(&mut self, content: String) -> &mut Self {
         self.0.insert("content", Value::String(content));
+        self
     }
 
     /// Set an embed for the message.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -644,7 +644,11 @@ impl ChannelId {
 
         if !msg.2.is_empty() {
             if let Some(e) = msg.0.remove(&"embed") {
-                msg.0.insert("payload_json", json!({ "embed": e }));
+                if let Some(c) = msg.0.remove(&"content") {
+                    msg.0.insert("payload_json", json!({ "content": c, "embed": e }));
+                } else {
+                    msg.0.insert("payload_json", json!({ "embed": e }));
+                }
             }
         }
 


### PR DESCRIPTION
This commit prevents the message's content from being lost for an embed if there was an attachment.

Signed-off-by: Valdemar Erk <v@erk.io>