### PR TITLE
Link to ShardMessenger::chunk_guilds from the Guild.members field

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -110,8 +110,14 @@ pub struct Guild {
     /// if the [`member_count`] is greater than the `LARGE_THRESHOLD` set by
     /// the library.
     ///
+    /// You can manually request that the remaining members be sent by calling
+    /// [`ShardManager::chunk_guilds`], after which chunks containing guild
+    /// members will be asynchronously received until all members are
+    /// available.
+    ///
     /// [`ReadyEvent`]: ../event/struct.ReadyEvent.html
     /// [`member_count`]: #structfield.member_count
+    /// [`ShardMessenger::chunk_guilds`]: ../../client/bridge/gateway/struct.ShardMessenger.html#method.chunk_guilds
     #[serde(serialize_with = "serialize_gen_map")]
     pub members: HashMap<UserId, Member>,
     /// Indicator of whether the guild requires multi-factor authentication for

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -111,9 +111,7 @@ pub struct Guild {
     /// the library.
     ///
     /// You can manually request that the remaining members be sent by calling
-    /// [`ShardManager::chunk_guilds`], after which chunks containing guild
-    /// members will be asynchronously received until all members are
-    /// available.
+    /// [`ShardManager::chunk_guilds`].
     ///
     /// [`ReadyEvent`]: ../event/struct.ReadyEvent.html
     /// [`member_count`]: #structfield.member_count


### PR DESCRIPTION
The [Guild `members` field][1] details that not all users might be available, but doesn't specify that how one might request that the users be made available.  In addition, the method that one would use to accomplish this is kinda hard to find, being on a struct that you can write an entire program without touching once.  Linking to that method from the members field might clarify this a lot.  Sorry for the small PR, but I think this might be an important change (that would certainly have saved me a ton of time and confusion)

[1]: https://docs.rs/serenity/0.6.3/serenity/model/guild/struct.Guild.html#structfield.members