### PR TITLE
Add Methods to get Permissions of `Roles` in `GuildChannel`s

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -379,10 +379,10 @@ impl StandardFramework {
     /// Adds a group to be used by the framework. Primary use-case is runtime modification
     /// of groups in the framework; will _not_ mark the framework as initialized. Refer to
     /// [`group`] for adding groups in initial configuration.
-    /// 
+    ///
     /// Note: does _not_ return `Self` like many other commands. This is because
     /// it's not intended to be chained as the other commands are.
-    /// 
+    ///
     /// [`group`]: #method.group
     pub fn group_add(&mut self, group: &'static CommandGroup) {
         let map = if group.options.prefixes.is_empty() {
@@ -396,7 +396,7 @@ impl StandardFramework {
 
     /// Removes a group from being used in the framework. Primary use-case is runtime modification
     /// of groups in the framework.
-    /// 
+    ///
     /// Note: does _not_ return `Self` like many other commands. This is because
     /// it's not intended to be chained as the other commands are.
     pub fn group_remove(&mut self, group: &'static CommandGroup) {
@@ -865,7 +865,7 @@ pub(crate) fn has_correct_permissions(
     if options.required_permissions().is_empty() {
         true
     } else if let Some(guild) = message.guild(&cache) {
-        let perms = guild.with(|g| g.permissions_in(message.channel_id, message.author.id));
+        let perms = guild.with(|g| g.user_permissions_in(message.channel_id, message.author.id));
 
         perms.contains(*options.required_permissions())
     } else {

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -146,7 +146,7 @@ fn check_discrepancy(
 
             let guild = guild.read();
 
-            let perms = guild.permissions_in(msg.channel_id, msg.author.id);
+            let perms = guild.user_permissions_in(msg.channel_id, msg.author.id);
 
             if !perms.contains(*options.required_permissions())
                 && !(options.owner_privilege() && config.owners.contains(&msg.author.id))

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -92,6 +92,13 @@ pub enum Error {
     /// [`GuildId`]: ../id/struct.GuildId.html
     /// [`Cache`]: ../../cache/struct.Cache.html
     GuildNotFound,
+    /// An indication that a [role][`Role`] could not be found by
+    /// [Id][`RoleId`] in the [`Cache`].
+    ///
+    /// [`Role`]: ../guild/struct.Role.html
+    /// [`RoleId`]: ../id/struct.GuildId.html
+    /// [`Cache`]: ../../cache/struct.Cache.html
+    RoleNotFound,
     /// Indicates that there are hierarchy problems restricting an action.
     ///
     /// For example, when banning a user, if the other user has a role with an
@@ -142,17 +149,18 @@ impl Display for Error {
 impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::BulkDeleteAmount => "Too few/many messages to bulk delete",
-            Error::DeleteMessageDaysAmount(_) => "Invalid delete message days",
-            Error::EmbedTooLarge(_) => "Embed too large",
-            Error::GuildNotFound => "Guild not found in the cache",
-            Error::Hierarchy => "Role hierarchy prevents this action",
+            Error::BulkDeleteAmount => "Too few/many messages to bulk delete.",
+            Error::DeleteMessageDaysAmount(_) => "Invalid delete message days.",
+            Error::EmbedTooLarge(_) => "Embed too large.",
+            Error::GuildNotFound => "Guild not found in the cache.",
+            Error::RoleNotFound => "Role not found in the cache.",
+            Error::Hierarchy => "Role hierarchy prevents this action.",
             Error::InvalidChannelType => "The channel cannot perform the action.",
-            Error::InvalidPermissions(_) => "Invalid permissions",
-            Error::InvalidUser => "The current user cannot perform the action",
-            Error::ItemMissing => "The required item is missing from the cache",
-            Error::MessageTooLong(_) => "Message too large",
-            Error::MessagingBot => "Attempted to message another bot user",
+            Error::InvalidPermissions(_) => "Invalid permissions.",
+            Error::InvalidUser => "The current user cannot perform the action.",
+            Error::ItemMissing => "The required item is missing from the cache.",
+            Error::MessageTooLong(_) => "Message too large.",
+            Error::MessagingBot => "Attempted to message another bot user.",
             Error::__Nonexhaustive => unreachable!(),
         }
     }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -206,7 +206,7 @@ impl Member {
         let reader = guild.read();
 
         for (cid, channel) in &reader.channels {
-            if reader.permissions_in(*cid, self.user.read().id).read_messages() {
+            if reader.user_permissions_in(*cid, self.user.read().id).read_messages() {
                 return Some(Arc::clone(channel));
             }
         }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -324,7 +324,7 @@ pub fn user_has_perms(
 
     let perms = guild
         .read()
-        .permissions_in(channel_id, current_user.id);
+        .user_permissions_in(channel_id, current_user.id);
 
     permissions.remove(perms);
 


### PR DESCRIPTION
This pull request adds two brand new methods: `Guild::role_permissions_in` and `GuildChannel::permissions_for_role`.
At the same time deprecates the `Guild::permissions_in`-method in favour of `Guild::user_permissions_in` and `GuildId::permissions_for` with `GuildId::user_permissions_for`.
Last but not least, the `ModelError` got extended by the `RoleNotFound`-variant, in case one of the permissions-functions fails finding the role in the cache.