### PR TITLE
Update audit log model to reflect Discord's optional/mixed types

### DIFF
--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -221,8 +221,8 @@ impl ActionEmoji {
 pub struct Change {
     #[serde(rename = "key")] pub name: String,
     // TODO: Change these to an actual type.
-    #[serde(rename = "old_value")] pub old: String,
-    #[serde(rename = "new_value")] pub new: String,
+    #[serde(rename = "old_value")] pub old: Option<Value>,
+    #[serde(rename = "new_value")] pub new: Option<Value>,
 }
 
 #[derive(Debug)]
@@ -238,8 +238,8 @@ pub struct AuditLogEntry {
     /// Determines to what entity an [`action`] was used on.
     ///
     /// [`action`]: #structfield.action
-    #[serde(with = "u64_handler")]
-    pub target_id: u64,
+    #[serde(with = "option_u64_handler")]
+    pub target_id: Option<u64>,
     /// Determines what action was done on a [`target`]
     ///
     /// [`target`]: #structfield.target
@@ -287,39 +287,6 @@ pub struct Options {
     pub role_name: Option<String>,
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
-}
-
-mod u64_handler {
-    use super::*;
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(des: D) -> StdResult<u64, D::Error> {
-        struct U64Visitor;
-
-        impl<'de> Visitor<'de> for U64Visitor {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("an integer or a string with a valid number inside")
-            }
-
-            // NOTE: Serde internally delegates number types below `u64` to it.
-            fn visit_u64<E: de::Error>(self, val: u64) -> StdResult<u64, E> {
-                Ok(val)
-            }
-
-            fn visit_str<E: de::Error>(self, string: &str) -> StdResult<u64, E> {
-                string.parse().map_err(de::Error::custom)
-            }
-        }
-
-        des.deserialize_any(U64Visitor)
-    }
-
-    // Due to `Serialize`.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn serialize<S: Serializer>(num: &u64, s: S) -> StdResult<S::Ok, S::Error> {
-        s.serialize_u64(*num)
-    }
 }
 
 mod option_u64_handler {


### PR DESCRIPTION
There is an error in the currently used data structure serenity which causes Json errors on models where serenity does not expect null values, or mixed type values. While this particular change does not properly wrap all the types, it instead focuses on ensuring it works, not that it works well.

Good enough for a temporary solution I'd say.