### PR TITLE
Change `owner_privilege`'s default value to `false`

### DIFF
--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -301,7 +301,6 @@ impl Options {
         let mut options = Self::default();
 
         options.help_available = true;
-        options.owner_privilege = true;
 
         options
     }
@@ -421,7 +420,6 @@ impl GroupOptions {
     pub fn new() -> Self {
         let mut options = Self::default();
 
-        options.owner_privilege = true;
         options.help_available = true;
 
         options


### PR DESCRIPTION
It turns out having this turned on (`true`) brings up surprising behaviour more than anything. When true, these features are ignored:
- Buckets
- Checks
- Blocked users, channels and guilds

In particular, forbidding checks from running may be a problem as they can introduce a property that must be upheld for a command to work properly.