### PR TITLE
Add the ability to have multiple examples in commands

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -165,7 +165,9 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
                 options.usage = Some(propagate_err!(attributes::parse(values)));
             }
             "example" => {
-                options.examples.push(propagate_err!(attributes::parse(values)));
+                options
+                    .examples
+                    .push(propagate_err!(attributes::parse(values)));
             }
             _ => {
                 match_options!(name, values, options, span => [

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -165,7 +165,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
                 options.usage = Some(propagate_err!(attributes::parse(values)));
             }
             "example" => {
-                options.example = Some(propagate_err!(attributes::parse(values)));
+                options.examples.push(propagate_err!(attributes::parse(values)));
             }
             _ => {
                 match_options!(name, values, options, span => [
@@ -194,7 +194,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
         description,
         delimiters,
         usage,
-        example,
+        examples,
         min_args,
         max_args,
         allowed_roles,
@@ -209,7 +209,6 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
     let description = AsOption(description);
     let usage = AsOption(usage);
     let bucket = AsOption(bucket);
-    let example = AsOption(example);
     let min_args = AsOption(min_args);
     let max_args = AsOption(max_args);
 
@@ -249,7 +248,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
             desc: #description,
             delimiters: &[#(#delimiters),*],
             usage: #usage,
-            example: #example,
+            examples: &[#(#examples),*],
             min_args: #min_args,
             max_args: #max_args,
             allowed_roles: &[#(#allowed_roles),*],

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -283,7 +283,7 @@ pub struct Options {
     pub description: Option<String>,
     pub delimiters: Vec<String>,
     pub usage: Option<String>,
-    pub example: Option<String>,
+    pub examples: Vec<String>,
     pub min_args: Option<u16>,
     pub max_args: Option<u16>,
     pub allowed_roles: Vec<String>,

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1083,11 +1083,14 @@ fn send_single_command_embed(
             if !command.usage_sample.is_empty() {
                 let format_example: Box<dyn Fn(&str) -> String> =
                     if let Some(first_prefix) = command.group_prefixes.get(0) {
-                        Box::new(move |example| format!("`{} {} {}`\n", first_prefix, command.name, example))
+                        Box::new(move |example| {
+                            format!("`{} {} {}`\n", first_prefix, command.name, example)
+                        })
                     } else {
                         Box::new(|example| format!("`{} {}`\n", command.name, example))
                     };
-                let full_example_text = command.usage_sample
+                let full_example_text = command
+                    .usage_sample
                     .iter()
                     .map(|e| format_example(e))
                     .collect::<String>();
@@ -1317,22 +1320,28 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
     }
 
     if !command.usage_sample.is_empty() {
-        let mut format_example: Box<dyn FnMut(&mut String, &str)> = if let Some(first_prefix) = command.group_prefixes.get(0) {
-            Box::new(move |result, example| {
-                let _ = writeln!(
-                    result,
-                    "**{}**: `{} {} {}`",
-                    help_options.usage_label, first_prefix, command.name, example);
-            })
-        } else {
-            Box::new(|result, example| {
-                let _ = writeln!(
-                    result,
-                    "**{}**: `{} {}`",
-                    help_options.usage_label, command.name, example);
-            })
-        };
-        command.usage_sample.iter().for_each(|e| format_example(&mut result, e));
+        let mut format_example: Box<dyn FnMut(&mut String, &str)> =
+            if let Some(first_prefix) = command.group_prefixes.get(0) {
+                Box::new(move |result, example| {
+                    let _ = writeln!(
+                        result,
+                        "**{}**: `{} {} {}`",
+                        help_options.usage_label, first_prefix, command.name, example
+                    );
+                })
+            } else {
+                Box::new(|result, example| {
+                    let _ = writeln!(
+                        result,
+                        "**{}**: `{} {}`",
+                        help_options.usage_label, command.name, example
+                    );
+                })
+            };
+        command
+            .usage_sample
+            .iter()
+            .for_each(|e| format_example(&mut result, e));
     }
 
     let _ = writeln!(

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -42,7 +42,7 @@ pub struct CommandOptions {
     /// Command usage schema, used by other commands.
     pub usage: Option<&'static str>,
     /// Example arguments, used by other commands.
-    pub example: Option<&'static str>,
+    pub examples: &'static [&'static str],
     /// Minimum amount of arguments that should be passed.
     pub min_args: Option<u16>,
     /// Maximum amount of arguments that can be passed.


### PR DESCRIPTION
Adds the ability to use the `#[example(s)]` macro multiple times on commands to add multiple examples.

It looks like this:
![image](https://user-images.githubusercontent.com/19352680/63928468-7f600a00-ca47-11e9-9ecb-19b9f9706988.png)

This does change a some public struct fields, namely
- `command_attr::structures::Options`
-  `framework::standard::structures::ComandOptions`
The latter being the most important since it's on the public API and could cause breakage.