### PR TITLE
Fix serenity version on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-serenity = "0.6"
+serenity = "0.7"
 ```
 
 Serenity supports a minimum of Rust 1.35.


### PR DESCRIPTION
On the Installation section of the readme, serenity was still to 0.6 version.