### PR TITLE
Turn the function-like group macro to an attribute macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ use serenity::framework::standard::{
     }
 };
 
-group!({
-    name: "general",
-    options: {},
-    commands: [ping],
-});
+#[group]
+#[commands(ping)]
+struct General;
 
 use std::env;
 

--- a/command_attr/src/attributes.rs
+++ b/command_attr/src/attributes.rs
@@ -4,7 +4,7 @@ use syn::spanned::Spanned;
 use syn::{Attribute, Ident, Lit, LitStr, Meta, NestedMeta, Path};
 
 use crate::structures::{Checks, Colour, HelpBehaviour, OnlyIn, Permissions};
-use crate::util::LitExt;
+use crate::util::{LitExt, AsOption};
 
 use std::fmt::{self, Write};
 
@@ -217,6 +217,15 @@ impl AttributeOption for bool {
     }
 }
 
+impl AttributeOption for Ident {
+    #[inline]
+    fn parse(values: Values) -> Result<Self> {
+        validate(&values, &[ValueKind::SingleList])?;
+
+        Ok(values.literals[0].to_ident())
+    }
+}
+
 impl AttributeOption for Vec<Ident> {
     #[inline]
     fn parse(values: Values) -> Result<Self> {
@@ -301,6 +310,13 @@ impl AttributeOption for Permissions {
         }
 
         Ok(permissions)
+    }
+}
+
+impl<T: AttributeOption> AttributeOption for AsOption<T> {
+    #[inline]
+    fn parse(values: Values) -> Result<Self> {
+        Ok(AsOption(Some(T::parse(values)?)))
     }
 }
 

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -7,7 +7,7 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::{
     parse::{Error, Parse, ParseStream, Result},
     parse_macro_input, parse_quote,
@@ -152,17 +152,8 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
             "num_args" => {
                 let args = propagate_err!(u16::parse(values));
 
-                options.min_args = Some(args);
-                options.max_args = Some(args);
-            }
-            "bucket" => {
-                options.bucket = Some(propagate_err!(attributes::parse(values)));
-            }
-            "description" => {
-                options.description = Some(propagate_err!(attributes::parse(values)));
-            }
-            "usage" => {
-                options.usage = Some(propagate_err!(attributes::parse(values)));
+                options.min_args = AsOption(Some(args));
+                options.max_args = AsOption(Some(args));
             }
             "example" => {
                 options
@@ -172,12 +163,14 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
             _ => {
                 match_options!(name, values, options, span => [
                     checks;
+                    bucket;
+                    aliases;
+                    description;
                     delimiters;
+                    usage;
                     min_args;
                     max_args;
                     required_permissions;
-                    aliases;
-                    usage;
                     allowed_roles;
                     help_available;
                     only_in;
@@ -208,12 +201,6 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
         sub_commands,
     } = options;
 
-    let description = AsOption(description);
-    let usage = AsOption(usage);
-    let bucket = AsOption(bucket);
-    let min_args = AsOption(min_args);
-    let max_args = AsOption(max_args);
-
     propagate_err!(validate_declaration(&mut fun, DeclarFor::Command));
 
     let either = [
@@ -222,8 +209,6 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
     ];
 
     propagate_err!(validate_return_type(&mut fun, either));
-
-    let Permissions(required_permissions) = required_permissions;
 
     let name = fun.name.clone();
     let options = name.with_suffix(COMMAND_OPTIONS);
@@ -234,15 +219,14 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let n = name.with_suffix(COMMAND);
 
-    let cfgs = fun.cfgs.clone();
-    let cfgs2 = cfgs.clone();
+    let cooked = fun.cooked.clone();
+    let cooked2 = cooked.clone();
 
     let options_path = quote!(serenity::framework::standard::CommandOptions);
     let command_path = quote!(serenity::framework::standard::Command);
-    let permissions_path = quote!(serenity::model::permissions::Permissions);
 
     (quote! {
-        #(#cfgs)*
+        #(#cooked)*
         pub static #options: #options_path = #options_path {
             checks: #checks,
             bucket: #bucket,
@@ -254,7 +238,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
             min_args: #min_args,
             max_args: #max_args,
             allowed_roles: &[#(#allowed_roles),*],
-            required_permissions: #permissions_path { bits: #required_permissions },
+            required_permissions: #required_permissions,
             help_available: #help_available,
             only_in: #only_in,
             owners_only: #owners_only,
@@ -262,7 +246,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
             sub_commands: &[#(&#sub_commands),*],
         };
 
-        #(#cfgs2)*
+        #(#cooked2)*
         pub static #n: #command_path = #command_path {
             fun: #name,
             options: &#options,
@@ -523,9 +507,6 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     let strikethrough_commands_tip_in_dm = AsOption(strikethrough_commands_tip_in_dm);
     let strikethrough_commands_tip_in_guild = AsOption(strikethrough_commands_tip_in_guild);
 
-    let Colour(embed_error_colour) = embed_error_colour;
-    let Colour(embed_success_colour) = embed_success_colour;
-
     propagate_err!(validate_declaration(&mut fun, DeclarFor::Help));
 
     let either = [
@@ -540,15 +521,14 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     let n = fun.name.to_uppercase();
     let nn = fun.name.clone();
 
-    let cfgs = fun.cfgs.clone();
-    let cfgs2 = cfgs.clone();
+    let cooked = fun.cooked.clone();
+    let cooked2 = cooked.clone();
 
     let options_path = quote!(serenity::framework::standard::HelpOptions);
     let command_path = quote!(serenity::framework::standard::HelpCommand);
-    let colour_path = quote!(serenity::utils::Colour);
 
     (quote! {
-        #(#cfgs)*
+        #(#cooked)*
         pub static #options: #options_path = #options_path {
             names: &[#(#names),*],
             suggestion_text: #suggestion_text,
@@ -573,13 +553,13 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
             lacking_permissions: #lacking_permissions,
             lacking_ownership: #lacking_ownership,
             wrong_channel: #wrong_channel,
-            embed_error_colour: #colour_path(#embed_error_colour),
-            embed_success_colour: #colour_path(#embed_success_colour),
+            embed_error_colour: #embed_error_colour,
+            embed_success_colour: #embed_success_colour,
             max_levenshtein_distance: #max_levenshtein_distance,
             indention_prefix: #indention_prefix,
         };
 
-        #(#cfgs2)*
+        #(#cooked2)*
         pub static #n: #command_path = #command_path {
             fun: #nn,
             options: &#options,
@@ -598,15 +578,13 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// A group might have one or more *prefixes* set. This will necessitate for
 /// one of the prefixes to appear before the group's command.
 /// For example, for a general prefix `!`, a group prefix `foo` and a command `bar`,
-/// the invocation would look like this: `!foo bar`.
+/// the invocation would be `!foo bar`.
 ///
 /// It might have some options apply to *all* of its commands. E.g. guild or dm only.
 ///
-/// Its options may be *inherited* from another group.
-///
 /// It may even couple other groups as well.
 ///
-/// This group macro purports all of the said purposes above, in a json-like syntax:
+/// This group macro purports all of the said purposes above, applied onto a `struct`:
 ///
 /// ```rust,no_run
 /// use command_attr::{command, group};
@@ -627,121 +605,163 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///     Ok(())
 /// }
 ///
-/// group!({
-///     name: "baz",
-///     options: {
-///         // All sub-groups must own at least one prefix.
-///         prefix: "baz",
-///     },
-///     commands: [answer_to_life],
-/// });
+/// #[group]
+/// // All sub-groups must own at least one prefix.
+/// #[prefix = "baz"]
+/// #[commands(answer_to_life)]
+/// struct Baz;
 ///
-/// group!({
-///     name: "foo",
-///     commands: [bar],
-///     sub_groups: [baz],
-/// });
+/// #[group]
+/// #[commands(bar)]
+/// // Case does not matter; the names will be all uppercased.
+/// #[sub_groups(baz)]
+/// struct Foo;
 /// ```
 ///
 /// # Options
 ///
-/// These appear inside the object of the `options` field:
+/// These appear after `#[group]` as a series of attributes:
 ///
-/// - `prefixes`: Array\<String\>\
+/// - `#[prefixes("foo", "bar", "baz")]`
 /// The group's prefixes.
 ///
-/// `allowed_roles`: Array\<String\>\
+/// - `#[allowed_roles("foo", "bar", "baz")]`
 /// Only which roles may execute this group's commands.
 ///
-/// - `only_in`: String\
+/// - `#[only_in(guilds/dms))]`
 /// Whether this group's commands are restricted to `guilds` or `dms`.
 ///
-/// - `owners_only`: Bool\
+/// - `#[owners_only(true/false)]`
 /// If only the owners of the bot may execute this group's commands.
 ///
-/// - `owner_privilege`: Bool\
+/// - `#[owner_privilege(true/false)]`
 /// Whether the owners should be treated as normal users.
 ///
 /// Default value is `true`
 ///
-/// - `help_available`: bool\
+/// - `#[help_available(true/false)]`
 /// Whether the group is visible to the help command.
 ///
 /// Default value is `true`
 ///
-/// - `checks`: Array\<Ident\>\
+/// - `#[checks(foo, bar, baz)]`
 /// A set of preconditions that must be met before a group command's execution.
 /// Refer to [`command`]'s `checks` documentation.
 ///
-/// - `required_permissions`: Array\<Ident\>\
+/// - `#[required_permissions(foo, bar, baz)]`
 /// A set of permissions needed by the user before a group command's execution.
 ///
-/// - `default_command`: Ident\
+/// - `#[default_command(foobar_baz)]`
 /// Command to be executed if none of the group's prefixes are given.
 /// Identifier must refer to a `#[command]`'d function.
 ///
-/// - `prefix`: String\
+/// - `#[prefix("...")]`/`#[prefix = "..."]`
 /// Assign a single prefix to this group.
 ///
-/// - `description`: String\
+/// - `#[description("...")]`/`#[description = "..."]`
 /// The description of the group.
 /// Used in the help command.
 ///
-/// - `inherit`: Access\
-/// Derive options from another `GroupOptions` instance.
-///
-/// On standalone `GroupOptions`: `$name_of_options$`
-/// `GroupOptions` belonging to another `Group`: `$name_of_group$.options`
-///
-/// Just like [`command`], this macro generates static instances of the group
-/// and its options. The identifiers of these instances are based off the `name` field given to differentiate
-/// this group from others. The field is also passed as the default value to the group's `help_name`, the name
-/// for use and display in the help command, which can be indepedent from the group's `name`.
+/// Similarly to [`command`], this macro generates static instances of the group
+/// and its options. The identifiers of these instances are based off the name of the struct to differentiate
+/// this group from others. This name is given as the default value of the group's `name` field,
+/// used in the help command for display and browsing of the group.
+/// It may also be passed as an argument to the macro. For example: `#[group("Banana Phone")]`.
 ///
 /// [`command`]: #fn.command.html
-#[proc_macro]
-pub fn group(input: TokenStream) -> TokenStream {
-    let group = parse_macro_input!(input as Group);
+#[proc_macro_attribute]
+pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let group = parse_macro_input!(input as GroupStruct);
 
-    group.into_token_stream().into()
-}
+    let name = if !attr.is_empty() {
+        parse_macro_input!(attr as Lit).to_str()
+    } else {
+        group.name.to_string()
+    };
 
-/// Create an instance of `GroupOptions`.
-/// Useful when making default options and then deriving them for command groups.
-///
-/// ```rust,no_run
-/// use command_attr::group_options;
-///
-/// // First argument is the name of the options; second the actual options.
-/// group_options!(Foobar {
-///     description: "I'm an example group",
-/// });
-/// ```
-#[proc_macro]
-pub fn group_options(input: TokenStream) -> TokenStream {
-    struct GroupOptionsName {
-        name: Ident,
-        options: GroupOptions,
+    let mut options = GroupOptions::new();
+
+    for attribute in &group.attributes {
+        let span = attribute.span();
+        let values = propagate_err!(parse_values(attribute));
+
+        let name = values.name.to_string();
+        let name = &name[..];
+
+        match_options!(name, values, options, span => [
+            prefixes;
+            only_in;
+            owners_only;
+            owner_privilege;
+            help_available;
+            allowed_roles;
+            required_permissions;
+            checks;
+            default_command;
+            description;
+            commands;
+            sub_groups
+        ]);
     }
 
-    impl Parse for GroupOptionsName {
-        fn parse(input: ParseStream<'_>) -> Result<Self> {
-            let name = input.parse::<Ident>()?;
+    let GroupOptions {
+        prefixes,
+        only_in,
+        owners_only,
+        owner_privilege,
+        help_available,
+        allowed_roles,
+        required_permissions,
+        checks,
+        default_command,
+        description,
+        commands,
+        sub_groups,
+    } = options;
 
-            let options = input.parse::<GroupOptions>()?;
+    let cooked = group.cooked.clone();
+    let cooked2 = cooked.clone();
 
-            Ok(GroupOptionsName { name, options })
-        }
-    }
+    let n = group.name.with_suffix(GROUP);
 
-    let GroupOptionsName { name, options } = parse_macro_input!(input as GroupOptionsName);
+    let commands = commands
+        .into_iter()
+        .map(|c| c.with_suffix(COMMAND))
+        .collect::<Vec<_>>();
 
-    let name = name.with_suffix(GROUP_OPTIONS);
+    let sub_groups = sub_groups
+        .into_iter()
+        .map(|c| c.with_suffix(GROUP))
+        .collect::<Vec<_>>();
 
+    let options = group.name.with_suffix(GROUP_OPTIONS);
     let options_path = quote!(serenity::framework::standard::GroupOptions);
+    let group_path = quote!(serenity::framework::standard::CommandGroup);
 
     (quote! {
-        pub static #name: #options_path = #options;
+        #(#cooked)*
+        pub static #options: #options_path = #options_path {
+            prefixes: &[#(#prefixes),*],
+            only_in: #only_in,
+            owners_only: #owners_only,
+            owner_privilege: #owner_privilege,
+            help_available: #help_available,
+            allowed_roles: &[#(#allowed_roles),*],
+            required_permissions: #required_permissions,
+            checks: #checks,
+            default_command: #default_command,
+            description: #description,
+            commands: &[#(&#commands),*],
+            sub_groups: &[#(&#sub_groups),*],
+        };
+
+        #(#cooked2)*
+        pub static #n: #group_path = #group_path {
+            name: #name,
+            options: &#options,
+        };
+
+        #group
     })
     .into()
 }

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -688,20 +688,25 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
         let name = values.name.to_string();
         let name = &name[..];
 
-        match_options!(name, values, options, span => [
-            prefixes;
-            only_in;
-            owners_only;
-            owner_privilege;
-            help_available;
-            allowed_roles;
-            required_permissions;
-            checks;
-            default_command;
-            description;
-            commands;
-            sub_groups
-        ]);
+        match name {
+            "prefix" => {
+                options.prefixes = vec![propagate_err!(attributes::parse(values))];
+            },
+            _ => match_options!(name, values, options, span => [
+                prefixes;
+                only_in;
+                owners_only;
+                owner_privilege;
+                help_available;
+                allowed_roles;
+                required_permissions;
+                checks;
+                default_command;
+                description;
+                commands;
+                sub_groups
+            ]),
+        }
     }
 
     let GroupOptions {

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -729,7 +729,11 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let n = group.name.with_suffix(GROUP);
 
-    let default_command = default_command.map(|ident| ident.with_suffix(COMMAND));
+    let default_command = default_command.map(|ident| {
+		let i = ident.with_suffix(COMMAND);
+		
+		quote!(&#i)
+	});
 
     let commands = commands
         .into_iter()

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -691,7 +691,7 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
         match name {
             "prefix" => {
                 options.prefixes = vec![propagate_err!(attributes::parse(values))];
-            },
+            }
             _ => match_options!(name, values, options, span => [
                 prefixes;
                 only_in;
@@ -728,6 +728,8 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
     let cooked2 = cooked.clone();
 
     let n = group.name.with_suffix(GROUP);
+
+    let default_command = default_command.map(|ident| ident.with_suffix(COMMAND));
 
     let commands = commands
         .into_iter()

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -2,15 +2,15 @@ use crate::structures::CommandFun;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{quote, ToTokens};
+use quote::{quote, ToTokens, format_ident};
 use syn::{
     braced, bracketed, parenthesized,
     parse::{Error, Parse, ParseStream, Result},
     parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
-    token::{Brace, Bracket, Comma, Mut},
-    Ident, Lit, Token, Type,
+    token::{Comma, Mut},
+    Ident, Lit, Type,
 };
 
 pub trait LitExt {
@@ -42,7 +42,7 @@ impl LitExt for Lit {
 
     #[inline]
     fn to_ident(&self) -> Ident {
-        Ident::new(&self.to_str(), Span::call_site())
+        Ident::new(&self.to_str(), self.span())
     }
 }
 
@@ -52,18 +52,14 @@ pub trait IdentExt2: Sized {
 }
 
 impl IdentExt2 for Ident {
+    #[inline]
     fn to_uppercase(&self) -> Self {
-        let ident = self.to_string();
-        let ident = ident.to_uppercase();
-
-        Ident::new(&ident, Span::call_site())
+        format_ident!("{}", self.to_string().to_uppercase())
     }
 
-    fn with_suffix(&self, suf: &str) -> Ident {
-        Ident::new(
-            &format!("{}_{}", self.to_uppercase(), suf),
-            Span::call_site(),
-        )
+    #[inline]
+    fn with_suffix(&self, suffix: &str) -> Ident {
+        format_ident!("{}_{}", self.to_string().to_uppercase(), suffix)
     }
 }
 
@@ -117,6 +113,7 @@ impl<T: Parse> Parse for Parenthesised<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct AsOption<T>(pub Option<T>);
 
 impl<T: ToTokens> ToTokens for AsOption<T> {
@@ -125,6 +122,13 @@ impl<T: ToTokens> ToTokens for AsOption<T> {
             Some(o) => stream.extend(quote!(Some(#o))),
             None => stream.extend(quote!(None)),
         }
+    }
+}
+
+impl<T> Default for AsOption<T> {
+    #[inline]
+    fn default() -> Self {
+        AsOption(None)
     }
 }
 
@@ -146,112 +150,6 @@ impl ToTokens for Argument {
         stream.extend(quote! {
             #mutable #name: #kind
         });
-    }
-}
-
-#[derive(Debug)]
-pub struct Field<T> {
-    pub name: Ident,
-    pub value: T,
-}
-
-impl<T: Parse> Parse for Field<T> {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let name = input.parse()?;
-        input.parse::<Token![:]>()?;
-
-        let value = input.parse()?;
-
-        Ok(Field { name, value })
-    }
-}
-
-#[derive(Debug)]
-pub enum RefOrInstance<T> {
-    Ref(Ident),
-    Instance(T),
-}
-
-impl<T: Parse> Parse for RefOrInstance<T> {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        if input.peek(Ident) {
-            Ok(RefOrInstance::Ref(input.parse()?))
-        } else {
-            Ok(RefOrInstance::Instance(input.parse()?))
-        }
-    }
-}
-
-impl<T: Default> Default for RefOrInstance<T> {
-    #[inline]
-    fn default() -> Self {
-        RefOrInstance::Instance(T::default())
-    }
-}
-
-#[derive(Debug)]
-pub struct IdentAccess(pub Ident, pub Option<Ident>);
-
-#[derive(Debug)]
-pub enum Expr {
-    Lit(Lit),
-    Access(IdentAccess),
-    Object(Object),
-    Array(Array),
-}
-
-impl Parse for Expr {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        if input.peek(Brace) {
-            Ok(Expr::Object(input.parse()?))
-        } else if input.peek(Bracket) {
-            Ok(Expr::Array(input.parse()?))
-        } else {
-            // Because boolean literals are converted into `Ident` tokens,
-            // we must be more vigilant with how we parse the `IdentAccess` structure and `Lit`s.
-            let access = input.step(|cursor| match cursor.ident() {
-                Some((ref i, mut cursor)) if i != "true" && i != "false" => {
-                    let i2 = match cursor.punct() {
-                        Some((ref p, c)) if p.as_char() == '.' => c.ident().map(|(i2, c)| {
-                            cursor = c;
-
-                            i2
-                        }),
-                        _ => None,
-                    };
-
-                    return Ok((IdentAccess(i.clone(), i2), cursor));
-                }
-                _ => Err(cursor.error("...")),
-            });
-
-            match access {
-                Ok(access) => Ok(Expr::Access(access)),
-                Err(_) => Ok(Expr::Lit(input.parse()?)),
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct Object(pub Vec<Field<Expr>>);
-
-impl Parse for Object {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let Braced(fields) = input.parse::<Braced<Field<Expr>>>()?;
-
-        Ok(Object(fields.into_iter().collect()))
-    }
-}
-
-#[derive(Debug)]
-pub struct Array(pub Vec<Expr>);
-
-impl Parse for Array {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let Bracketed(fields) = input.parse::<Bracketed<Expr>>()?;
-
-        Ok(Array(fields.into_iter().collect()))
     }
 }
 

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -116,6 +116,16 @@ impl<T: Parse> Parse for Parenthesised<T> {
 #[derive(Debug)]
 pub struct AsOption<T>(pub Option<T>);
 
+impl<T> AsOption<T> {
+    #[inline]
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> AsOption<U> {
+        AsOption(match self.0 {
+            Some(v) => Some(f(v)),
+            None => None,
+        })
+    }
+}
+
 impl<T: ToTokens> ToTokens for AsOption<T> {
     fn to_tokens(&self, stream: &mut TokenStream2) {
         match &self.0 {

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -46,50 +46,39 @@ impl EventHandler for Handler {
     }
 }
 
-group!({
-    name: "general",
-    options: {},
-    commands: [about, say, commands, ping, some_long_command]
-});
+#[group]
+#[commands(about, say, commands, ping, some_long_command)]
+struct General;
 
-group!({
-    name: "emoji",
-    options: {
-        // Sets multiple prefixes for a group.
-        // This requires us to call commands in this group
-        // via `~emoji` (or `~em`) instead of just `~`.
-        prefixes: ["emoji", "em"],
-        // Set a description to appear if a user wants to display a single group
-        // e.g. via help using the group-name or one of its prefixes.
-        description: "A group with commands providing an emoji as response.",
-        // Sets a command that will be executed if only a group-prefix was passed.
-        default_command: bird,
-    },
-    commands: [cat, dog],
-});
+#[group]
+// Sets multiple prefixes for a group.
+// This requires us to call commands in this group
+// via `~emoji` (or `~em`) instead of just `~`.
+#[prefixes("emoji", "em")]
+// Set a description to appear if a user wants to display a single group
+// e.g. via help using the group-name or one of its prefixes.
+#[description = "A group with commands providing an emoji as response."]
+// Sets a command that will be executed if only a group-prefix was passed.
+#[default_command(bird)]
+#[commands(cat, dog)]
+struct Emoji;
 
-group!({
-    name: "math",
-    options: {
-        // Sets a single prefix for this group.
-        // So one has to call commands in this group
-        // via `~math` instead of just `~`.
-        prefix: "math",
-    },
-    commands: [multiply],
-});
+#[group]
+// Sets a single prefix for this group.
+// So one has to call commands in this group
+// via `~math` instead of just `~`.
+#[prefix = "math"]
+#[commands(multiply)]
+struct Math;
 
-group!({
-    name: "owner",
-    options: {
-        owners_only: true,
-        // Limit all commands to be guild-restricted.
-        only_in: "guilds",
-        // Adds checks that need to be passed.
-        checks: [Admin],
-    },
-    commands: [am_i_admin, slow_mode],
-});
+#[group]
+#[owners_only]
+// Limit all commands to be guild-restricted.
+#[only_in(guilds)]
+// Adds checks that need to be passed.
+#[checks(Admin)]
+#[commands(am_i_admin, slow_mode)]
+struct Owner;
 
 // The framework provides two built-in help commands for you to use.
 // But you can also make your own customized help command that forwards
@@ -244,7 +233,7 @@ fn main() {
         .bucket("emoji", |b| b.delay(5))
         // Can't be used more than 2 times per 30 seconds, with a 5 second delay:
         .bucket("complicated", |b| b.delay(5).time_span(30).limit(2))
-        // The `group!` macro generates `static` instances of the options set for the group.
+        // The `#[group]` macro generates `static` instances of the options set for the group.
         // They're made in the pattern: `#name_GROUP` for the group instance and `#name_GROUP_OPTIONS`.
         // #name is turned all uppercase
         .group(&GENERAL_GROUP)

--- a/examples/06_voice/src/main.rs
+++ b/examples/06_voice/src/main.rs
@@ -52,11 +52,9 @@ impl EventHandler for Handler {
     }
 }
 
-group!({
-    name: "general",
-    options: {},
-    commands: [deafen, join, leave, mute, play, ping, undeafen, unmute]
-});
+#[group]
+#[commands(deafen, join, leave, mute, play, ping, undeafen, unmute)]
+struct General;
 
 fn main() {
     // Configure the client with your Discord bot token in the environment.

--- a/examples/07_sample_bot_structure/src/main.rs
+++ b/examples/07_sample_bot_structure/src/main.rs
@@ -49,11 +49,9 @@ impl EventHandler for Handler {
     }
 }
 
-group!({
-    name: "general",
-    options: {},
-    commands: [multiply, ping, quit]
-});
+#[group]
+#[commands(multiply, ping, quit)]
+struct General;
 
 fn main() {
     // This will load the environment variables located at `./.env`, relative to

--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -87,11 +87,9 @@ impl AudioReceiver for Receiver {
     }
 }
 
-group!({
-    name: "general",
-    options: {},
-    commands: [join, leave, ping]
-});
+#[group]
+#[commands(join, leave, ping)]
+struct General;
 
 fn main() {
     // Configure the client with your Discord bot token in the environment.

--- a/examples/12_timing_and_events/src/main.rs
+++ b/examples/12_timing_and_events/src/main.rs
@@ -163,7 +163,7 @@ fn main() {
         }
     })
         .help(&MY_HELP)
-        .group(&REMIND_ME_GROUP)
+        .group(&REMINDME_GROUP)
     );
 
     if let Err(why) = client.start() {
@@ -175,7 +175,7 @@ fn main() {
 // It saves us from writing the same trigger twice for repeated and non-repeated
 // tasks (see remind-me command below).
 fn thanks_for_reacting(http: Arc<Http>, channel: ChannelId) ->
-    Box<Fn(&DispatchEvent) -> Option<DispatcherRequest> + Send + Sync> {
+    Box<dyn Fn(&DispatchEvent) -> Option<DispatcherRequest> + Send + Sync> {
 
     Box::new(move |_| {
         if let Err(why) = channel.say(&http, "Thanks for reacting!") {

--- a/examples/12_timing_and_events/src/main.rs
+++ b/examples/12_timing_and_events/src/main.rs
@@ -90,13 +90,10 @@ impl EventHandler for Handler {
     }
 }
 
-group!({
-    name: "remind_me",
-    options: {
-        prefixes: ["rm", "reminder"],
-    },
-    commands: [set_reminder],
-});
+#[group("remind me")]
+#[prefixes("rm", "reminder")]
+#[commands(set_reminder)]
+struct RemindMe;
 
 #[help]
 fn my_help(

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -547,13 +547,11 @@ impl Client {
     /// }
     ///
     /// // Commands must be intermediately handled through groups.
-    /// group!({
-    ///     name: "pingpong",
-    ///     options: {},
-    ///     commands: [ping],
-    /// });
+    /// #[group("pingpong")]
+    /// #[commands(ping)]
+    /// struct PingPong;
     /// #
-    /// # fn try_main() -> Result<(), Box<Error>> {
+    /// # fn try_main() -> Result<(), Box<dyn Error>> {
     ///
     /// let mut client = Client::new(&env::var("DISCORD_TOKEN")?, Handler)?;
     /// client.with_framework(StandardFramework::new()

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -52,10 +52,9 @@
 //!     Ok(())
 //! }
 //!
-//! group!({
-//!     name: "general",
-//!     commands: [about, ping],
-//! });
+//! #[group]
+//! #[commands(about, ping)]
+//! struct General;
 //!
 //! struct Handler;
 //!
@@ -66,7 +65,7 @@
 //!
 //! client.with_framework(StandardFramework::new()
 //!     .configure(|c| c.prefix("~"))
-//!     // The `group!` (and similarly, `#[command]`) macro generates static instances
+//!     // The `#[group]` (and similarly, `#[command]`) macro generates static instances
 //!     // containing any options you gave it. For instance, the group `name` and its `commands`.
 //!     // Their identifiers, names you can use to refer to these instances in code, are an
 //!     // all-uppercased version of the `name` with a `_GROUP` suffix appended at the end.

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -274,11 +274,9 @@ impl Configuration {
     ///     Ok(())
     /// }
     ///
-    /// group!({
-    ///     name: "peng",
-    ///     options: {},
-    ///     commands: [ping]
-    /// });
+    /// #[group]
+    /// #[commands(ping)]
+    /// struct Peng;
     ///
     /// # fn main() {
     /// # use serenity::prelude::*;

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -420,12 +420,12 @@ fn nested_group_command_search<'a>(
         }
 
         let mut found_group_prefix: bool = false;
-        for command in group.commands {
+        for command in group.options.commands {
             let command = *command;
 
             let search_command_name_matched = if group.options.prefixes.is_empty() {
-                if starts_with_whole_word(&name, &group.help_name) {
-                    name.drain(..=group.help_name.len());
+                if starts_with_whole_word(&name, &group.name) {
+                    name.drain(..=group.name.len());
                 }
 
                 command
@@ -521,7 +521,7 @@ fn nested_group_command_search<'a>(
                 command: Command {
                     name: options.names[0],
                     description: options.desc,
-                    group_name: group.help_name,
+                    group_name: group.name,
                     group_prefixes: &group.options.prefixes,
                     checks: check_names,
                     aliases: options.names[1..].to_vec(),
@@ -534,7 +534,7 @@ fn nested_group_command_search<'a>(
 
         match nested_group_command_search(
             cache,
-            &group.sub_groups,
+            &group.options.sub_groups,
             name,
             help_options,
             msg,
@@ -591,7 +591,7 @@ fn fill_eligible_commands<'a>(
     to_fill: &mut GroupCommandsPair,
     highest_formatter: &mut HelpBehaviour,
 ) {
-    to_fill.name = group.help_name;
+    to_fill.name = group.name;
     to_fill.prefixes = group.options.prefixes.to_vec();
 
     let group_behaviour = {
@@ -668,16 +668,16 @@ fn fetch_all_eligible_commands_in_group<'a>(
         &mut highest_formatter,
     );
 
-    for sub_group in group.sub_groups {
+    for sub_group in group.options.sub_groups {
         if HelpBehaviour::Hide == highest_formatter {
             break;
-        } else if sub_group.commands.is_empty() && sub_group.sub_groups.is_empty() {
+        } else if sub_group.options.commands.is_empty() && sub_group.options.sub_groups.is_empty() {
             continue;
         }
 
         let grouped_cmd = fetch_all_eligible_commands_in_group(
             &context,
-            &sub_group.commands,
+            &sub_group.options.commands,
             &owners,
             &help_options,
             &sub_group,
@@ -727,7 +727,7 @@ fn create_single_group(
 ) -> GroupCommandsPair {
     let mut group_with_cmds = fetch_all_eligible_commands_in_group(
         &context,
-        &group.commands,
+        &group.options.commands,
         &owners,
         &help_options,
         &group,
@@ -735,7 +735,7 @@ fn create_single_group(
         HelpBehaviour::Nothing,
     );
 
-    group_with_cmds.name = group.help_name;
+    group_with_cmds.name = group.name;
 
     group_with_cmds
 }
@@ -772,7 +772,7 @@ pub fn searched_lowercase<'a>(
     let is_prefixless_group = {
         group.options.prefixes.is_empty()
         && trim_prefixless_group(
-            &group.help_name.to_lowercase(),
+            &group.name.to_lowercase(),
             searched_named_lowercase,
         )
     };
@@ -806,7 +806,7 @@ pub fn searched_lowercase<'a>(
             });
         }
     } else if progressed || group.options.prefixes.is_empty() {
-        for sub_group in group.sub_groups {
+        for sub_group in group.options.sub_groups {
 
             if let Some(found_set) = searched_lowercase(
                 context,

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -355,13 +355,11 @@ impl StandardFramework {
     ///     Ok(())
     /// }
     ///
-    /// group!({
-    ///   name: "bingbong",
-    ///   options: {},
-    ///   commands: [ping, pong],
-    /// });
+    /// #[group("bingbong")]
+    /// #[commands(ping, pong)]
+    /// struct BingBong;
     ///
-    /// # fn main() -> Result<(), Box<StdError>> {
+    /// # fn main() -> Result<(), Box<dyn StdError>> {
     /// #   let mut client = Client::new("token", Handler)?;
     /// client.with_framework(StandardFramework::new()
     ///     // Groups' names are changed to all uppercase, plus appended with `_GROUP`.

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1,6 +1,6 @@
 pub mod help_commands;
 pub mod macros {
-    pub use command_attr::{command, group, group_options, help, check};
+    pub use command_attr::{command, group, help, check};
 }
 
 mod args;
@@ -386,7 +386,7 @@ impl StandardFramework {
     /// [`group`]: #method.group
     pub fn group_add(&mut self, group: &'static CommandGroup) {
         let map = if group.options.prefixes.is_empty() {
-            Map::Prefixless(GroupMap::new(&group.sub_groups), CommandMap::new(&group.commands))
+            Map::Prefixless(GroupMap::new(&group.options.sub_groups), CommandMap::new(&group.options.commands))
         } else {
             Map::WithPrefixes(GroupMap::new(&[group]))
         };

--- a/src/framework/standard/parse/map.rs
+++ b/src/framework/standard/parse/map.rs
@@ -81,8 +81,8 @@ impl GroupMap {
         let mut map = Self::default();
 
         for group in groups {
-            let subgroups_map = Arc::new(Self::new(&group.sub_groups));
-            let commands_map = Arc::new(CommandMap::new(&group.commands));
+            let subgroups_map = Arc::new(Self::new(&group.options.sub_groups));
+            let commands_map = Arc::new(CommandMap::new(&group.options.commands));
 
             for prefix in group.options.prefixes {
                 let len = prefix.chars().count();

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -63,20 +63,6 @@ pub struct CommandOptions {
     pub sub_commands: &'static [&'static Command],
 }
 
-#[derive(Debug, PartialEq)]
-pub struct GroupOptions {
-    pub prefixes: &'static [&'static str],
-    pub only_in: OnlyIn,
-    pub owners_only: bool,
-    pub owner_privilege: bool,
-    pub help_available: bool,
-    pub allowed_roles: &'static [&'static str],
-    pub required_permissions: Permissions,
-    pub checks: &'static [&'static Check],
-    pub default_command: Option<&'static Command>,
-    pub description: Option<&'static str>,
-}
-
 #[derive(Debug, Clone)]
 pub struct CommandError(pub String);
 
@@ -230,12 +216,24 @@ pub struct HelpOptions {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct CommandGroup {
-    pub help_name: &'static str,
-    pub name: &'static str,
-    pub options: &'static GroupOptions,
+pub struct GroupOptions {
+    pub prefixes: &'static [&'static str],
+    pub only_in: OnlyIn,
+    pub owners_only: bool,
+    pub owner_privilege: bool,
+    pub help_available: bool,
+    pub allowed_roles: &'static [&'static str],
+    pub required_permissions: Permissions,
+    pub checks: &'static [&'static Check],
+    pub default_command: Option<&'static Command>,
+    pub description: Option<&'static str>,
     pub commands: &'static [&'static Command],
     pub sub_groups: &'static [&'static CommandGroup],
+}
+#[derive(Debug, PartialEq)]
+pub struct CommandGroup {
+    pub name: &'static str,
+    pub options: &'static GroupOptions,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This no longer makes it special (removal of the json syntax), but consistent with the bigger player: `#[command]`. 

Support for group option inheritance has been dropped as no one really used this feature and cluttered code with unnecessary complexity.

I've also improved the codebase slightly while making the switch.