### PR TITLE
Implement WebSocket shutdown support

### DIFF
--- a/src/client/bridge/gateway/mod.rs
+++ b/src/client/bridge/gateway/mod.rs
@@ -123,6 +123,11 @@ pub enum ShardManagerMessage {
     /// component that receives this to also shutdown with no further action
     /// taken.
     ShutdownInitiated,
+    /// Indicator that a [`ShardRunner`] has finished the shutdown of a shard, allowing it to
+    /// move toward the next one.
+    ///
+    /// [`ShardRunner`]: struct.ShardRunner.html
+    ShutdownFinished(ShardId)
 }
 
 /// A message to be sent to the [`ShardQueuer`].


### PR DESCRIPTION
In the current version of Serenity the library doesn't actually wait for shards to properly shutdown with either shutdowns or restarts. This means that the bot will remain marked online until the next heartbeat expires on Discords end.

This is due to the runner_tx structure where the shutdown request is fired and then forgotten.
That is on top of the fact that ShardRunner::checked_shutdown doesn't wait for the WebSocket to reply with a Close Frame (which is protocol).

This commit fixes both those issues, by returning shutdown feedback to the ShardMonitor and consequently ShardManager, so that the shutdown and restart methods all nicely wait for a shard to shut down properly.

As a result, when `::start_autosharded` or any other start method return, the end user is guaranteed everything has shut down, and not still in the process of.

A quick test setup is as follows:
```rust
use std::{env, sync::Arc};

use serenity::{
    Client,
    client::{bridge::gateway::ShardManager, Context},
    model::gateway::Ready,
    prelude::{EventHandler, Mutex, TypeMapKey},
};

fn main() {
    let mut discord = Client::new(env::var("DISCORD_TOKEN").unwrap().as_str(), Handler).unwrap();
    discord.data.write().insert::<ShardManagerContainer>(discord.shard_manager.clone());
    discord.start_autosharded().unwrap();
}

struct Handler;

impl EventHandler for Handler {
    fn ready(&self, ctx: Context, _ready: Ready) {
        ctx.data.read().get::<ShardManagerContainer>().unwrap().lock().shutdown_all();
    }
}

struct ShardManagerContainer;

impl TypeMapKey for ShardManagerContainer {
    type Value = Arc<Mutex<ShardManager>>;
}
```

When running this code, the bot should be online for a very short moment, and then immediately go offline (as seen in the Discord client).

FWIW, I'm not exactly sure if this implementation is the kind that you guys would like to see in the lib (I'm very unfamiliar with the internal workings of serenity, its code style and formatting), but it is a solution to the problem. Feedback is appreciated.