### PR TITLE
Change AttachmentType to use Cows instead

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1456,16 +1456,16 @@ impl Http {
         for file in files {
 
             match file.into() {
-                AttachmentType::Bytes((bytes, filename)) => {
+                AttachmentType::Bytes{data, filename} => {
                     multipart = multipart
-                        .part(file_num.to_string(), Part::bytes(bytes.to_vec())
-                            .file_name(filename.to_string()));
+                        .part(file_num.to_string(), Part::bytes(data.into_owned())
+                            .file_name(filename));
                 },
-                AttachmentType::File((file, filename)) => {
+                AttachmentType::File{file, filename} => {
                     multipart = multipart
                         .part(file_num.to_string(),
                             Part::reader(file.try_clone()?)
-                                .file_name(filename.to_string()));
+                                .file_name(filename));
                 },
                 AttachmentType::Path(path) => {
                     multipart = multipart

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1456,12 +1456,12 @@ impl Http {
         for file in files {
 
             match file.into() {
-                AttachmentType::Bytes{data, filename} => {
+                AttachmentType::Bytes{ data, filename } => {
                     multipart = multipart
                         .part(file_num.to_string(), Part::bytes(data.into_owned())
                             .file_name(filename));
                 },
-                AttachmentType::File{file, filename} => {
+                AttachmentType::File{ file, filename } => {
                     multipart = multipart
                         .part(file_num.to_string(),
                             Part::reader(file.try_clone()?)

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -205,8 +205,8 @@ pub enum AttachmentType<'a> {
     __Nonexhaustive,
 }
 
-impl<'a> From<(&'a [u8], &'a str)> for AttachmentType<'a> {
-    fn from(params: (&'a [u8], &'a str)) -> AttachmentType<'_> { AttachmentType::Bytes{ data: Cow::Borrowed(params.0), filename: params.1.to_string() } }
+impl<'a> From<(&'a [u8], &str)> for AttachmentType<'a> {
+    fn from(params: (&'a [u8], &str)) -> AttachmentType<'a> { AttachmentType::Bytes{ data: Cow::Borrowed(params.0), filename: params.1.to_string() } }
 }
 
 impl<'a> From<&'a str> for AttachmentType<'a> {
@@ -223,8 +223,8 @@ impl<'a> From<&'a PathBuf> for AttachmentType<'a> {
     fn from(pathbuf: &'a PathBuf) -> AttachmentType<'_> { AttachmentType::Path(pathbuf.as_path()) }
 }
 
-impl<'a> From<(&'a File, &'a str)> for AttachmentType<'a> {
-    fn from(f: (&'a File, &'a str)) -> AttachmentType<'a> { AttachmentType::File{ file: f.0, filename: f.1.to_string() } }
+impl<'a> From<(&'a File, &str)> for AttachmentType<'a> {
+    fn from(f: (&'a File, &str)) -> AttachmentType<'a> { AttachmentType::File{ file: f.0, filename: f.1.to_string() } }
 }
 
 /// Representation of the method of a query to send for the [`get_guilds`]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -38,6 +38,7 @@ use reqwest::Method;
 use crate::model::prelude::*;
 use self::request::Request;
 use std::{
+    borrow::Cow,
     fs::File,
     path::{Path, PathBuf},
 };
@@ -195,9 +196,9 @@ impl LightMethod {
 #[derive(Clone, Debug)]
 pub enum AttachmentType<'a> {
     /// Indicates that the `AttachmentType` is a byte slice with a filename.
-    Bytes((&'a [u8], &'a str)),
+    Bytes{ data: Cow<'a, [u8]>, filename: String } ,
     /// Indicates that the `AttachmentType` is a `File`
-    File((&'a File, &'a str)),
+    File{ file: &'a File, filename: String },
     /// Indicates that the `AttachmentType` is a `Path`
     Path(&'a Path),
     #[doc(hidden)]
@@ -205,7 +206,7 @@ pub enum AttachmentType<'a> {
 }
 
 impl<'a> From<(&'a [u8], &'a str)> for AttachmentType<'a> {
-    fn from(params: (&'a [u8], &'a str)) -> AttachmentType<'_> { AttachmentType::Bytes(params) }
+    fn from(params: (&'a [u8], &'a str)) -> AttachmentType<'_> { AttachmentType::Bytes{ data: Cow::Borrowed(params.0), filename: params.1.to_string() } }
 }
 
 impl<'a> From<&'a str> for AttachmentType<'a> {
@@ -223,7 +224,7 @@ impl<'a> From<&'a PathBuf> for AttachmentType<'a> {
 }
 
 impl<'a> From<(&'a File, &'a str)> for AttachmentType<'a> {
-    fn from(f: (&'a File, &'a str)) -> AttachmentType<'a> { AttachmentType::File((f.0, f.1)) }
+    fn from(f: (&'a File, &'a str)) -> AttachmentType<'a> { AttachmentType::File{ file: f.0, filename: f.1.to_string() } }
 }
 
 /// Representation of the method of a query to send for the [`get_guilds`]


### PR DESCRIPTION
This PR actually consists of three changes to make AttachmentType significantly more useable and (when done properly) significantly more efficient.

- AttachmentType variants that used a tuple before now use a struct with named fields, making the code more self-documenting.
- AttachmentType variants that needed a filename now use String instead of &str, preventing a `.to_string()` call later on and giving the end library user the responsibility (which in turn also prevents any potential lifetime pitfalls)
- AttachmentType Bytes now uses a `std::borrow::Cow` instead of a lifetimed-borrow. When uploading attachments it is not always desirable to pass a reference due to the way people structure their applications, especially as later on when actually sending the attachment the reference is copied by calling `to_vec`. Using a cow annihilates this completely because using `Cow::Owned::into_owned()` is a no-op, thus preventing a potential copy of up to 50MB.

It's worth noting that this is definitely a breaking change (hence the next branch), but with some potential huge gains.