### PR TITLE
Impose thread-safety requirements on the event handlers

### DIFF
--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -77,14 +77,14 @@ use crate::client::bridge::voice::ClientVoiceManager;
 /// # let http = &cache_and_http.http;
 /// let gateway_url = Arc::new(Mutex::new(http.get_gateway()?.url));
 /// let data = Arc::new(RwLock::new(ShareMap::custom()));
-/// let event_handler = Arc::new(Handler);
+/// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
 /// let framework = Arc::new(Mutex::new(None));
 /// let threadpool = ThreadPool::with_name("my threadpool".to_owned(), 5);
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,
 ///     event_handler: &Some(event_handler),
-///     raw_event_handler: &None::<Arc<Handler>>,
+///     raw_event_handler: &None,
 ///     framework: &framework,
 ///     // the shard index to start initiating from
 ///     shard_index: 0,

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -134,11 +134,7 @@ pub struct ShardManager {
 impl ShardManager {
     /// Creates a new shard manager, returning both the manager and a monitor
     /// for usage in a separate thread.
-    pub fn new<H, RH>(
-        opt: ShardManagerOptions<'_, H, RH>,
-    ) -> (Arc<Mutex<Self>>, ShardManagerMonitor)
-        where H: EventHandler + Send + Sync + 'static,
-              RH: RawEventHandler + Send + Sync + 'static {
+    pub fn new(opt: ShardManagerOptions<'_>) -> (Arc<Mutex<Self>>, ShardManagerMonitor) {
         let (thread_tx, thread_rx) = mpsc::channel();
         let (shard_queue_tx, shard_queue_rx) = mpsc::channel();
 
@@ -375,10 +371,10 @@ impl Drop for ShardManager {
     }
 }
 
-pub struct ShardManagerOptions<'a, H: EventHandler + Send + Sync + 'static, RH: RawEventHandler + Send + Sync + 'static> {
+pub struct ShardManagerOptions<'a> {
     pub data: &'a Arc<RwLock<ShareMap>>,
-    pub event_handler: &'a Option<Arc<H>>,
-    pub raw_event_handler: &'a Option<Arc<RH>>,
+    pub event_handler: &'a Option<Arc<dyn EventHandler>>,
+    pub raw_event_handler: &'a Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
     pub framework: &'a Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     pub shard_index: u64,

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -42,8 +42,7 @@ const WAIT_BETWEEN_BOOTS_IN_SECONDS: u64 = 5;
 /// A shard queuer instance _should_ be run in its own thread, due to the
 /// blocking nature of the loop itself as well as a 5 second thread sleep
 /// between shard starts.
-pub struct ShardQueuer<H: EventHandler + Send + Sync + 'static,
-                       RH: RawEventHandler + Send + Sync + 'static> {
+pub struct ShardQueuer {
     /// A copy of [`Client::data`] to be given to runners for contextual
     /// dispatching.
     ///
@@ -53,12 +52,12 @@ pub struct ShardQueuer<H: EventHandler + Send + Sync + 'static,
     /// [`Client`].
     ///
     /// [`Client`]: ../../struct.Client.html
-    pub event_handler: Option<Arc<H>>,
+    pub event_handler: Option<Arc<dyn EventHandler>>,
     /// A reference to an `RawEventHandler`, such as the one given to the
     /// [`Client`].
     ///
     /// [`Client`]: ../../struct.Client.html
-    pub raw_event_handler: Option<Arc<RH>>,
+    pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
     pub framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
@@ -95,8 +94,7 @@ pub struct ShardQueuer<H: EventHandler + Send + Sync + 'static,
     pub cache_and_http: Arc<CacheAndHttp>,
 }
 
-impl<H: EventHandler + Send + Sync + 'static,
-     RH: RawEventHandler + Send + Sync + 'static> ShardQueuer<H, RH> {
+impl ShardQueuer {
     /// Begins the shard queuer loop.
     ///
     /// This will loop over the internal [`rx`] for [`ShardQueuerMessage`]s,

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -38,11 +38,10 @@ use log::{error, debug, warn};
 /// A runner for managing a [`Shard`] and its respective WebSocket client.
 ///
 /// [`Shard`]: ../../../gateway/struct.Shard.html
-pub struct ShardRunner<H: EventHandler + Send + Sync + 'static,
-                       RH: RawEventHandler + Send + Sync + 'static> {
+pub struct ShardRunner {
     data: Arc<RwLock<ShareMap>>,
-    event_handler: Option<Arc<H>>,
-    raw_event_handler: Option<Arc<RH>>,
+    event_handler: Option<Arc<dyn EventHandler>>,
+    raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
     framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     manager_tx: Sender<ShardManagerMessage>,
@@ -57,10 +56,9 @@ pub struct ShardRunner<H: EventHandler + Send + Sync + 'static,
     cache_and_http: Arc<CacheAndHttp>,
 }
 
-impl<H: EventHandler + Send + Sync + 'static,
-     RH: RawEventHandler + Send + Sync + 'static> ShardRunner<H, RH> {
+impl ShardRunner {
     /// Creates a new runner for a Shard.
-    pub fn new(opt: ShardRunnerOptions<H, RH>) -> Self {
+    pub fn new(opt: ShardRunnerOptions) -> Self {
         let (tx, rx) = mpsc::channel();
 
         Self {
@@ -531,11 +529,10 @@ impl<H: EventHandler + Send + Sync + 'static,
 /// Options to be passed to [`ShardRunner::new`].
 ///
 /// [`ShardRunner::new`]: struct.ShardRunner.html#method.new
-pub struct ShardRunnerOptions<H: EventHandler + Send + Sync + 'static,
-                              RH: RawEventHandler + Send  + Sync + 'static> {
+pub struct ShardRunnerOptions {
     pub data: Arc<RwLock<ShareMap>>,
-    pub event_handler: Option<Arc<H>>,
-    pub raw_event_handler: Option<Arc<RH>>,
+    pub event_handler: Option<Arc<dyn EventHandler>>,
+    pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
     pub framework: Arc<Mutex<Option<Box<dyn Framework + Send>>>>,
     pub manager_tx: Sender<ShardManagerMessage>,

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -9,7 +9,7 @@ use super::context::Context;
 use crate::client::bridge::gateway::event::*;
 
 /// The core trait for handling events by serenity.
-pub trait EventHandler {
+pub trait EventHandler: Send + Sync {
     /// Dispatched when the cache has received and inserted all data from
     /// guilds.
     ///
@@ -314,7 +314,7 @@ pub trait EventHandler {
 }
 
 /// This core trait for handling raw events
-pub trait RawEventHandler {
+pub trait RawEventHandler: Send + Sync {
     /// Dispatched when any event occurs
     fn raw_event(&self, _ctx: Context, _ev: Event) {}
 }


### PR DESCRIPTION
Also change structs and functions (except the constructor functions of `Client`) to use trait objects for them. This reduces obscurity that made code quite ugly to look at, and should lower compile times a bit.
Performance might get slower because of the nature of vtables/pointers. However, it shouldn't make much of a difference.