### PR TITLE
Fix has_role returning incorrect result if member is not cached

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -683,15 +683,13 @@ impl User {
                 #[cfg(feature = "cache")]
                 {
                     if let Some(cache) = cache_http.cache() {
-                        has_role = Some(
-                            cache.read()
+                        has_role = cache.read()
                             .guilds
                             .get(&guild_id)
-                            .map_or(false, |g| {
+                            .and_then(|g| {
                                 g.read().members.get(&self.id)
-                                    .map_or(false, |m| m.roles.contains(&role))
-                            })
-                        );
+                                    .and_then(|m| Some(m.roles.contains(&role)))
+                            });
                     }
                 }
 


### PR DESCRIPTION
Currently, if the member object is not cached, the first cache check will always return `Some(false)` despite the Member object not being present, it should return None so that the later http-check can take over and actually request the object.