### PR TITLE
Remove redundant `cfg`s for the http feature in the client module

### DIFF
--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -74,7 +74,6 @@ impl ShardRunner {
             threadpool: opt.threadpool,
             #[cfg(feature = "voice")]
             voice_manager: opt.voice_manager,
-            #[cfg(any(feature = "cache", feature = "http"))]
             cache_and_http: opt.cache_and_http,
         }
     }
@@ -540,6 +539,5 @@ pub struct ShardRunnerOptions {
     pub threadpool: ThreadPool,
     #[cfg(feature = "voice")]
     pub voice_manager: Arc<Mutex<ClientVoiceManager>>,
-    #[cfg(any(feature = "cache", feature = "http"))]
     pub cache_and_http: Arc<CacheAndHttp>,
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,8 +33,6 @@ pub use self::{
     extras::Extras,
 };
 
-///
-#[cfg(any(feature = "cache", not(feature = "cache")))]
 pub use crate::CacheAndHttp;
 
 #[cfg(feature = "cache")]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,7 +33,8 @@ pub use self::{
     extras::Extras,
 };
 
-#[cfg(any(feature = "cache", feature = "http"))]
+///
+#[cfg(any(feature = "cache", not(feature = "cache")))]
 pub use crate::CacheAndHttp;
 
 #[cfg(feature = "cache")]
@@ -57,7 +58,6 @@ use crate::framework::Framework;
 use crate::model::id::UserId;
 #[cfg(feature = "voice")]
 use self::bridge::voice::ClientVoiceManager;
-#[cfg(feature = "http")]
 use crate::http::Http;
 
 /// The Client is the way to be able to start sending authenticated requests
@@ -424,7 +424,6 @@ impl Client {
             cache: CacheRwLock::default(),
             #[cfg(feature = "cache")]
             update_cache_timeout: timeout,
-            #[cfg(feature = "http")]
             http: Arc::new(http),
             __nonexhaustive: (),
         });
@@ -624,7 +623,6 @@ impl Client {
     /// ```
     ///
     /// [gateway docs]: ../gateway/index.html#sharding
-    #[cfg(feature = "http")]
     pub fn start(&mut self) -> Result<()> {
         self.start_connection([0, 0, 1])
     }
@@ -677,7 +675,6 @@ impl Client {
     ///
     /// [`ClientError::Shutdown`]: enum.ClientError.html#variant.Shutdown
     /// [gateway docs]: ../gateway/index.html#sharding
-    #[cfg(feature = "http")]
     pub fn start_autosharded(&mut self) -> Result<()> {
         let (x, y) = {
             let res = self.cache_and_http.http.get_bot_gateway()?;
@@ -765,7 +762,6 @@ impl Client {
     /// [`start`]: #method.start
     /// [`start_autosharded`]: #method.start_autosharded
     /// [gateway docs]: ../gateway/index.html#sharding
-    #[cfg(feature = "http")]
     pub fn start_shard(&mut self, shard: u64, shards: u64) -> Result<()> {
         self.start_connection([shard, shard, shards])
     }
@@ -820,7 +816,6 @@ impl Client {
     /// [`start_shard`]: #method.start_shard
     /// [`start_shard_range`]: #method.start_shard_range
     /// [Gateway docs]: ../gateway/index.html#sharding
-    #[cfg(feature = "http")]
     pub fn start_shards(&mut self, total_shards: u64) -> Result<()> {
         self.start_connection([0, total_shards - 1, total_shards])
     }
@@ -891,7 +886,6 @@ impl Client {
     /// [`start_shard`]: #method.start_shard
     /// [`start_shards`]: #method.start_shards
     /// [Gateway docs]: ../gateway/index.html#sharding
-    #[cfg(feature = "http")]
     pub fn start_shard_range(&mut self, range: [u64; 2], total_shards: u64) -> Result<()> {
         self.start_connection([range[0], range[1], total_shards])
     }
@@ -909,7 +903,6 @@ impl Client {
     // an error.
     //
     // [`ClientError::Shutdown`]: enum.ClientError.html#variant.Shutdown
-    #[cfg(feature = "http")]
     fn start_connection(&mut self, shard_data: [u64; 3]) -> Result<()> {
         #[cfg(feature = "voice")]
         self.voice_manager.lock().set_shard_count(shard_data[2]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,9 @@ pub use crate::client::Client;
 use crate::cache::CacheRwLock;
 #[cfg(feature = "cache")]
 use std::time::Duration;
-#[cfg(any(feature = "client", feature = "http"))]
+#[cfg(feature = "client")]
 use std::sync::Arc;
-#[cfg(all(feature = "client", feature = "http"))]
+#[cfg(feature = "client")]
 use crate::http::Http;
 
 
@@ -106,7 +106,6 @@ pub struct CacheAndHttp {
     pub cache: CacheRwLock,
     #[cfg(feature = "cache")]
     pub update_cache_timeout: Option<Duration>,
-    #[cfg(feature = "http")]
     pub http: Arc<Http>,
     __nonexhaustive: (),
 }


### PR DESCRIPTION
The `http` feature will *always* be enabled, as it is declared in the `Cargo.toml` as a dependency to the `client` feature. Performing checks whether the `http` feature is activated is thus not necessary.