### PR TITLE
Mark the event enum as untagged

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1451,6 +1451,7 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 /// Event received over a websocket connection
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum Event {
     /// A [`Channel`] was created.
     ///


### PR DESCRIPTION
Currently, serializing events results in json that looks like
```json
{"MessageCreate":{"id":"123"}}
```
This PR gets rid of the wrapping and puts it in line with the rest of the events.

Closed and reopened because I messed up with the branch