### PR TITLE
Abuse the compiler to do type checking for us

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ log = "0.4"
 parking_lot = "0.9"
 serde_json = "1"
 
+[dependencies.static_assertions]
+optional = true
+version = "1.1"
+
 [dependencies.audiopus]
 optional = true
 version = "0.1"
@@ -147,7 +151,7 @@ absolute_ratelimits = ["http"]
 rustls_backend = ["reqwest/rustls-tls", "tungstenite", "rustls", "webpki", "webpki-roots"]
 native_tls_backend = ["reqwest/default-tls", "tungstenite/tls"]
 model = ["builder", "http"]
-standard_framework = ["framework", "uwl", "command_attr"]
+standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]
 utils = ["base64"]
 voice = ["byteorder", "gateway", "audiopus", "rand", "sodiumoxide"]
 

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -178,14 +178,10 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
         sub_commands,
     } = options;
 
-    propagate_err!(validate_declaration(&mut fun, DeclarFor::Command));
+    propagate_err!(create_declaration_validations(&mut fun, DeclarFor::Command));
 
-    let either = [
-        parse_quote!(CommandResult),
-        parse_quote!(serenity::framework::standard::CommandResult),
-    ];
-
-    propagate_err!(validate_return_type(&mut fun, either));
+    let res = parse_quote!(serenity::framework::standard::CommandResult);
+    create_return_type_validation(&mut fun, res);
 
     let name = fun.name.clone();
     let options = name.with_suffix(COMMAND_OPTIONS);
@@ -430,14 +426,10 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     let strikethrough_commands_tip_in_dm = AsOption(strikethrough_commands_tip_in_dm);
     let strikethrough_commands_tip_in_guild = AsOption(strikethrough_commands_tip_in_guild);
 
-    propagate_err!(validate_declaration(&mut fun, DeclarFor::Help));
+    propagate_err!(create_declaration_validations(&mut fun, DeclarFor::Help));
 
-    let either = [
-        parse_quote!(CommandResult),
-        parse_quote!(serenity::framework::standard::CommandResult),
-    ];
-
-    propagate_err!(validate_return_type(&mut fun, either));
+    let res = parse_quote!(serenity::framework::standard::CommandResult);
+    create_return_type_validation(&mut fun, res);
 
     let options = fun.name.with_suffix(HELP_OPTIONS);
 
@@ -687,9 +679,9 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 /// A macro for marking a function as a condition checker to groups and commands.
-/// 
+///
 /// ## Options
-/// 
+///
 /// | Syntax                                             | Description                                                              | Argument explanation                                                                 |
 /// |----------------------------------------------------|--------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 /// | `#[name(s)]` </br> `#[name = s]`                   | How the check should be listed in help.                                  | `s` is a string. If this option isn't provided, the value is assumed to be `"<fn>"`. |
@@ -722,14 +714,10 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
 
-    propagate_err!(validate_declaration(&mut fun, DeclarFor::Check));
+    propagate_err!(create_declaration_validations(&mut fun, DeclarFor::Check));
 
-    let either = [
-        parse_quote!(CheckResult),
-        parse_quote!(serenity::framework::standard::CheckResult),
-    ];
-
-    propagate_err!(validate_return_type(&mut fun, either));
+    let res = parse_quote!(serenity::framework::standard::CheckResult);
+    create_return_type_validation(&mut fun, res);
 
     let n = fun.name.clone();
     let n2 = name.clone();

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use syn::{
     braced, bracketed, parenthesized,
-    parse::{Error, Parse, ParseStream, Result},
+    parse::{Error, Parse, ParseStream, Result as SynResult},
     parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
@@ -81,7 +81,7 @@ macro_rules! propagate_err {
 pub struct Bracketed<T>(pub Punctuated<T, Comma>);
 
 impl<T: Parse> Parse for Bracketed<T> {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> SynResult<Self> {
         let content;
         bracketed!(content in input);
 
@@ -93,7 +93,7 @@ impl<T: Parse> Parse for Bracketed<T> {
 pub struct Braced<T>(pub Punctuated<T, Comma>);
 
 impl<T: Parse> Parse for Braced<T> {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> SynResult<Self> {
         let content;
         braced!(content in input);
 
@@ -105,7 +105,7 @@ impl<T: Parse> Parse for Braced<T> {
 pub struct Parenthesised<T>(pub Punctuated<T, Comma>);
 
 impl<T: Parse> Parse for Parenthesised<T> {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> SynResult<Self> {
         let content;
         parenthesized!(content in input);
 
@@ -119,10 +119,7 @@ pub struct AsOption<T>(pub Option<T>);
 impl<T> AsOption<T> {
     #[inline]
     pub fn map<U>(self, f: impl FnOnce(T) -> U) -> AsOption<U> {
-        AsOption(match self.0 {
-            Some(v) => Some(f(v)),
-            None => None,
-        })
+        AsOption(self.0.map(f))
     }
 }
 
@@ -163,6 +160,13 @@ impl ToTokens for Argument {
     }
 }
 
+#[inline]
+pub fn generate_type_validation(have: Type, expect: Type) -> syn::Stmt {
+    parse_quote! {
+        serenity::static_assertions::assert_type_eq_all!(#have, #expect);
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeclarFor {
     Command,
@@ -170,7 +174,7 @@ pub enum DeclarFor {
     Check,
 }
 
-pub fn validate_declaration(fun: &mut CommandFun, dec_for: DeclarFor) -> Result<()> {
+pub fn create_declaration_validations(fun: &mut CommandFun, dec_for: DeclarFor) -> SynResult<()> {
     let len = match dec_for {
         DeclarFor::Command => 3,
         DeclarFor::Help => 6,
@@ -184,115 +188,53 @@ pub fn validate_declaration(fun: &mut CommandFun, dec_for: DeclarFor) -> Result<
         ));
     }
 
-    let context: Type = parse_quote!(&mut Context);
-    let message: Type = parse_quote!(&Message);
-    let args: Type = parse_quote!(Args);
-    let args2: Type = parse_quote!(&mut Args);
-    let options: Type = parse_quote!(&CommandOptions);
-    let hoptions: Type = parse_quote!(&'static HelpOptions);
-    let groups: Type = parse_quote!(&[&'static CommandGroup]);
-    let owners: Type = parse_quote!(HashSet<UserId>);
+    let context: Type = parse_quote!(&mut serenity::client::Context);
+    let message: Type = parse_quote!(&serenity::model::channel::Message);
+    let args: Type = parse_quote!(serenity::framework::standard::Args);
+    let args2: Type = parse_quote!(&mut serenity::framework::standard::Args);
+    let options: Type = parse_quote!(&serenity::framework::standard::CommandOptions);
+    let hoptions: Type = parse_quote!(&'static serenity::framework::standard::HelpOptions);
+    let groups: Type = parse_quote!(&[&'static serenity::framework::standard::CommandGroup]);
+    let owners: Type = parse_quote!(std::collections::HashSet<serenity::model::id::UserId>);
 
-    let context_path: Type = parse_quote!(&mut serenity::prelude::Context);
-    let message_path: Type = parse_quote!(&serenity::model::channel::Message);
-    let args_path: Type = parse_quote!(serenity::framework::standard::Args);
-    let args2_path: Type = parse_quote!(&mut serenity::framework::standard::Args);
-    let options_path: Type = parse_quote!(&'static serenity::framework::standard::CommandOptions);
-    let hoptions_path: Type = parse_quote!(&'static serenity::framework::standard::HelpOptions);
-    let groups_path: Type = parse_quote!(&[&'static serenity::framework::standard::CommandGroup]);
-    let owners_path: Type = parse_quote!(std::collections::HashSet<serenity::model::id::UserId, std::hash::BuildHasher>);
+    let mut index = 0;
 
-    let ctx_error = "first argument's type should be `&mut Context`";
-    let msg_error = "second argument's type should be `&Message`";
-    let args_error = "third argument's type should be `Args`";
-    let args2_error = "third argument's type should be `&mut Args`";
-    let options_error = "fourth argument's type should be `&'static CommandOptions`";
-    let hoptions_error = "fourth argument's type should be `&'static HelpOptions`";
-    let groups_error = "fifth argument's type should be `&[&'static CommandGroup]`";
-    let owners_error = "sixth argument's type should be `HashSet<UserId>`";
+    let mut spoof_or_check = |kind: Type, name: &str| {
+        match fun.args.get(index) {
+            Some(x) => fun.body.insert(0, generate_type_validation(x.kind.clone(), kind)),
+            None => fun.args.push(Argument {
+                mutable: None,
+                name: Ident::new(name, Span::call_site()),
+                kind,
+            }),
+        }
 
-    #[allow(unused_assignments)]
-    macro_rules! spoof_or_check {
-        ($(($($help:tt)?) [$($mut:tt)?] $type:ident, $name:literal, $error:ident, $path:ident);*) => {{
-            macro_rules! arg {
-                () => {
-                    None
-                };
-                (mut) => {
-                    Some(parse_quote!(mut))
-                }
-            }
+        index += 1;
+    };
 
-            macro_rules! help {
-                ($b:block) => {
-                    $b
-                };
-                (help $b:block) => {
-                    if dec_for == DeclarFor::Help {
-                        $b
-                    }
-                }
-            }
+    spoof_or_check(context, "_ctx");
+    spoof_or_check(message, "_msg");
 
-            let mut index = 0;
-            $(
-                help!($($help)? {
-                    match fun.args.get(index) {
-                        Some(x) => {
-                            if x.kind != $type {
-                                return Err(Error::new(fun.args[index].span(), $error));
-                            }
-                        },
-                        None => fun.args.push(Argument {
-                            mutable: arg!($($mut)?),
-                            name: Ident::new($name, Span::call_site()),
-                            kind: $path,
-                        }),
-                    }
-                });
+    if dec_for == DeclarFor::Check {
+        spoof_or_check(args2, "_args");
+        spoof_or_check(options, "_options");
 
-                index += 1;
-            )*
-
-            let _ = index;
-        }};
+        return Ok(());
     }
 
-    if dec_for != DeclarFor::Check {
-        spoof_or_check! {
-            ()     []    context,  "_ctx",     ctx_error,      context_path;
-            ()     []    message,  "_msg",     msg_error,      message_path;
-            ()     [mut] args,     "_args",    args_error,     args_path;
-            (help) []    hoptions, "_hoptions", hoptions_error, hoptions_path;
-            (help) []    groups,   "_groups",  groups_error,   groups_path;
-            (help) []    owners,   "_owners",  owners_error,   owners_path
-        }
-    } else {
-        spoof_or_check! {
-            ()     []    context, "_ctx",     ctx_error,     context_path;
-            ()     []    message, "_msg",     msg_error,     message_path;
-            ()     []    args2,   "_args",    args2_error,   args2_path;
-            ()     []    options, "_options", options_error, options_path
-        }
+    spoof_or_check(args, "_args");
+
+    if dec_for == DeclarFor::Help {
+        spoof_or_check(hoptions, "_hoptions");
+        spoof_or_check(groups, "_groups");
+        spoof_or_check(owners, "_owners");
     }
 
     Ok(())
 }
 
-pub fn validate_return_type(fun: &mut CommandFun, [relative, absolute]: [Type; 2]) -> Result<()> {
-    let ret = &fun.ret;
-
-    if *ret == relative || *ret == absolute {
-        return Ok(());
-    }
-
-    Err(Error::new(
-        ret.span(),
-        format_args!(
-            "expected either `{}` or `{}` as the return type, but got `{}`",
-            quote!(#relative),
-            quote!(#absolute),
-            quote!(#ret),
-        ),
-    ))
+#[inline]
+pub fn create_return_type_validation(r#fn: &mut CommandFun, expect: Type) {
+    let stmt = generate_type_validation(r#fn.ret.clone(), expect);
+    r#fn.body.insert(0, stmt);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,3 +114,7 @@ pub struct CacheAndHttp {
 #[allow(clippy::useless_attribute)]
 #[allow(rust_2018_idioms)]
 extern crate self as serenity;
+
+// For the procedural macros in `command_attr`.
+#[doc(hidden)]
+pub use static_assertions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,5 +116,6 @@ pub struct CacheAndHttp {
 extern crate self as serenity;
 
 // For the procedural macros in `command_attr`.
+#[cfg(feature = "standard_framework")]
 #[doc(hidden)]
 pub use static_assertions;


### PR DESCRIPTION
By emitting calls to `static_assertions::assert_type_eq_all`, we can utilise the excellent type checking and diagnostics of the compiler. Thus relieving ourselves from doing the work manually, and giving useful error messages when types mismatch.

For example, a simple help command:
```rust
#[help]
fn my_help(
    ctx: &mut Context,
    msg: &Message,
    args: Args,
    help_options: &'static HelpOptions,
    groups: &[&'static CommandGroup],
    owners: HashSet<UserId>,
) -> CommandResult {
    with_embeds(ctx, msg, args, help_options, groups, owners)
}
```

In the case where all of the types are already imported, this will compile. If, however, we overwrite one of the types (e.g., `struct Message;`), this results in:

```
error[E0271]: type mismatch resolving `<&Message as my_help::_::{{closure}}#0::TypeEq>::This == &serenity::model::channel::message::Message`
  --> src/main.rs:37:1
   |
37 | #[help]
   | ^^^^^^^
   | |
   | expected struct `serenity::model::channel::message::Message`, found struct `Message`
   | required by this bound in `my_help::_::{{closure}}#0::assert_type_eq_all`
   |
   = note: expected reference `&serenity::model::channel::message::Message`
                   found type `&Message`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```
The macro obscures details a bit, but the error message is still very clear of what's wrong.

Fixes #749 