### PR TITLE
Remove april fools functions

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -108,49 +108,6 @@ impl Http {
         })
     }
 
-    /// Ban zeyla from a [`Guild`], removing her messages sent in the last X number
-    /// of days.
-    ///
-    /// Passing a `delete_message_days` of `0` is equivalent to not removing any
-    /// messages. Up to `7` days' worth of messages may be deleted.
-    ///
-    /// **Note**: Requires that you have the [Ban Members] permission.
-    ///
-    /// [`Guild`]: ../model/guild/struct.Guild.html
-    /// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    pub fn ban_zeyla(&self, guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
-        self.ban_user(guild_id, 114_941_315_417_899_012, delete_message_days, reason)
-    }
-
-    /// Ban luna from a [`Guild`], removing her messages sent in the last X number
-    /// of days.
-    ///
-    /// Passing a `delete_message_days` of `0` is equivalent to not removing any
-    /// messages. Up to `7` days' worth of messages may be deleted.
-    ///
-    /// **Note**: Requires that you have the [Ban Members] permission.
-    ///
-    /// [`Guild`]: ../model/guild/struct.Guild.html
-    /// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    pub fn ban_luna(&self, guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
-        self.ban_user(guild_id, 180_731_582_049_550_336, delete_message_days, reason)
-    }
-
-    /// Ban the serenity servermoms from a [`Guild`], removing their messages
-    /// sent in the last X number of days.
-    ///
-    /// Passing a `delete_message_days` of `0` is equivalent to not removing any
-    /// messages. Up to `7` days' worth of messages may be deleted.
-    ///
-    /// **Note**: Requires that you have the [Ban Members] permission.
-    ///
-    /// [`Guild`]: ../model/guild/struct.Guild.html
-    /// [Ban Members]: ../model/permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    pub fn ban_servermoms(&self, guild_id: u64, delete_message_days: u8, reason: &str) -> Result<()> {
-        self.ban_zeyla(guild_id, delete_message_days, reason)?;
-        self.ban_luna(guild_id, delete_message_days, reason)
-    }
-
     /// Broadcasts that the current user is typing in the given [`Channel`].
     ///
     /// This lasts for about 10 seconds, and will then need to be renewed to


### PR DESCRIPTION
The `ban_zeyla` function can't be used anymore because the account associated isn't in use anymore
The `ban_luna` function refers to my Discord account and I'd like it to be removed at this point
It's also a remnant from the past that serenity has moved on from