### PR TITLE
Fix #763

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -849,10 +849,12 @@ pub struct ChannelMention {
 
 /// Describes extra features of the message.
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
+#[cfg_attr(not(feature = "model"), derive(Debug, Deserialize, Serialize))]
 pub struct MessageFlags {
     pub bits: u64,
 }
 
+#[cfg(feature = "model")]
 __impl_bitflags! {
     MessageFlags: u64 {
         /// This message has been published to subscribed channels (via Channel Following).
@@ -864,6 +866,7 @@ __impl_bitflags! {
     }
 }
 
+#[cfg(feature = "model")]
 impl<'de> Deserialize<'de> for MessageFlags {
     fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
     where D: Deserializer<'de>
@@ -874,6 +877,7 @@ impl<'de> Deserialize<'de> for MessageFlags {
     }
 }
 
+#[cfg(feature = "model")]
 impl Serialize for MessageFlags {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
     where S: Serializer

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -441,6 +441,7 @@ pub struct User {
 }
 
 use std::hash::{Hash, Hasher};
+#[cfg(feature = "model")]
 use chrono::{DateTime, FixedOffset};
 
 impl PartialEq for User {


### PR DESCRIPTION
Signed-off-by: Valdemar Erk <valdemar@erk.io>


----

There are still other bugs when compiling with some rarely used combinations
for example `cargo check --no-default-features --features rustls_backend,builder` will fail.