### PR TITLE
Display Groups Without Commands In Help

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -725,7 +725,7 @@ fn create_command_group_commands_pair_from_groups<'a>(
 
         let group_with_cmds = create_single_group(ctx, msg, group, &owners, &help_options);
 
-        if !group_with_cmds.command_names.is_empty() {
+        if !group_with_cmds.command_names.is_empty() || !group_with_cmds.sub_groups.is_empty() {
             listed_groups.push(group_with_cmds);
         }
     }


### PR DESCRIPTION
If a group lacked commands, it and its sub-groups were hidden in help but also not usable. That means, trying to display the group itself via help did not work nor any of its sub-components.

This pull request introduces an additional check to include a group without commands if it contains at least one sub-group. A group without commands but with sub-groups can help structuring the help-system.
Furthermore, they are working in dispatch thus this being a flaw within the help-system.