### PR TITLE
Add support for the Watching activity type.

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -163,6 +163,53 @@ impl Activity {
         }
     }
 
+    /// Creates an `Activity` struct that appears as a `Watching <name>`
+    /// status.
+    ///
+    /// **Note**: Maximum `name` length is 128.
+    ///
+    /// # Examples
+    ///
+    /// Create a command that sets the current watching status:
+    ///
+    /// ```rust,no_run
+    /// use serenity::model::gateway::Activity;
+    /// use serenity::model::channel::Message;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
+    /// # #[cfg(feature = "client")]
+    /// use serenity::client::Context;
+    ///
+    /// # #[cfg(feature = "framework")]
+    /// #[command]
+    /// fn watch(ctx: &mut Context, _msg: &Message, args: Args) -> CommandResult {
+    ///     let name = args.message();
+    ///     ctx.set_activity(Activity::watching(&name));
+    ///
+    ///     Ok(())
+    /// }
+    /// #
+    /// # fn main() {}
+    /// ```    
+    pub fn watching(name: &str) -> Activity {
+        Activity {
+            application_id: None,
+            assets: None,
+            details: None,
+            flags: None,
+            instance: None,
+            kind: ActivityType::Watching,
+            name: name.to_string(),
+            party: None,
+            secrets: None,
+            state: None,
+            emoji: None,
+            timestamps: None,
+            url: None,
+            _nonexhaustive: (),
+        }
+    }
+
     /// Creates a `Game` struct that appears as a `Listening to <name>` status.
     ///
     /// **Note**: Maximum `name` length is 128.
@@ -362,6 +409,8 @@ pub enum ActivityType {
     Streaming = 1,
     /// An indicator that the user is listening to something.
     Listening = 2,
+    /// An indicator that the user is watching something.
+    Watching = 3,
     /// An indicator that the user uses custum statuses
     Custom = 4,
     #[doc(hidden)]
@@ -373,6 +422,7 @@ enum_number!(
         Playing,
         Streaming,
         Listening,
+        Watching,
         Custom,
     }
 );
@@ -385,6 +435,7 @@ impl ActivityType {
             Playing => 0,
             Streaming => 1,
             Listening => 2,
+            Watching => 3,
             Custom => 4,
             __Nonexhaustive => unreachable!(),
         }


### PR DESCRIPTION
It *is* undocumented in the Discord API documentation, however it has been supported by the API for a  while. It isn't used that often by Discord bots, but it might be good to support it, just in case.