### PR TITLE
Fixed typo in the message builder example

### DIFF
--- a/examples/04_message_builder/src/main.rs
+++ b/examples/04_message_builder/src/main.rs
@@ -26,7 +26,7 @@ impl EventHandler for Handler {
             // emojis, and more.
             let response = MessageBuilder::new()
                 .push("User ")
-                .push_bold_safe(msg.author.name)
+                .push_bold_safe(&msg.author.name)
                 .push(" used the 'ping' command in the ")
                 .mention(&channel)
                 .push(" channel")


### PR DESCRIPTION
In the example it said:

```rust
        .push_bold_safe(msg.author.name)
```
but it should've been
 ```rust
        .push_bold_safe(&msg.author.name)
```