### PR TITLE
Add missing guild_id to various events

### DIFF
--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -98,6 +98,7 @@ impl ChannelCategory {
         cache_http.http().edit_channel(self.id.0, &map).map(|channel| {
             let GuildChannel {
                 id,
+                guild_id,
                 category_id,
                 permission_overwrites,
                 nsfw,
@@ -109,6 +110,7 @@ impl ChannelCategory {
 
             *self = ChannelCategory {
                 id,
+                guild_id,
                 category_id,
                 permission_overwrites,
                 nsfw,

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -16,7 +16,7 @@ use crate::http::Http;
 pub struct ChannelCategory {
     /// Id of this category.
     pub id: ChannelId,
-    /// Id this category belongs to.
+    /// Guild Id this category belongs to.
     pub guild_id: GuildId,
     /// If this category belongs to another category.
     #[serde(rename = "parent_id")]

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -16,6 +16,8 @@ use crate::http::Http;
 pub struct ChannelCategory {
     /// Id of this category.
     pub id: ChannelId,
+    /// Id this category belongs to.
+    pub guild_id: GuildId,
     /// If this category belongs to another category.
     #[serde(rename = "parent_id")]
     pub category_id: Option<ChannelId>,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -190,6 +190,7 @@ impl Serialize for ChannelDeleteEvent {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ChannelPinsUpdateEvent {
+    pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub last_pin_timestamp: Option<DateTime<FixedOffset>>,
     #[serde(skip)]
@@ -888,6 +889,7 @@ impl Serialize for MessageCreateEvent {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MessageDeleteBulkEvent {
+    pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub ids: Vec<MessageId>,
     #[serde(skip)]
@@ -896,6 +898,7 @@ pub struct MessageDeleteBulkEvent {
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct MessageDeleteEvent {
+    pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     #[serde(rename = "id")] pub message_id: MessageId,
     #[serde(skip)]
@@ -905,6 +908,7 @@ pub struct MessageDeleteEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MessageUpdateEvent {
     pub id: MessageId,
+    pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub kind: Option<MessageType>,
     pub content: Option<String>,
@@ -1156,6 +1160,7 @@ impl Serialize for ReactionRemoveEvent {
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct ReactionRemoveAllEvent {
+    pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub message_id: MessageId,
     #[serde(skip)]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1240,6 +1240,7 @@ pub struct ResumedEvent {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TypingStartEvent {
+    pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub timestamp: u64,
     pub user_id: UserId,


### PR DESCRIPTION
Many events were missing the optional guild_id that is sent with them. ChannelCategory model was also updated to add the missing guild_id.