### PR TITLE
Make member.distinct() show the discriminator as a 4-digit number

### DIFF
--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -229,7 +229,7 @@ impl Member {
     #[inline]
     pub fn distinct(&self) -> String {
         format!(
-            "{}#{}",
+            "{}#{:04}",
             self.display_name(),
             self.user.read().discriminator
         )


### PR DESCRIPTION
It shows `blaah#123` instead of `blaah#0123` before.