### PR TITLE
&mut self instead of mut self for MessageBuilder methods

### DIFF
--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -384,7 +384,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a quoted inline text to the content
-    pub fn push_quote<D: I>(mut self, content: D) -> Self {
+    pub fn push_quote<D: I>(&mut self, content: D) -> &mut Self {
         self.0.push_str("> ");
         self.0.push_str(&content.into().to_string());
 
@@ -544,8 +544,8 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "> hello\nworld");
     /// ```
-    pub fn push_quote_line<D: I>(mut self, content: D) -> Self {
-        self = self.push_quote(content);
+    pub fn push_quote_line<D: I>(&mut self, content: D) -> &mut Self {
+        self.push_quote(content);
         self.0.push('\n');
 
         self
@@ -665,7 +665,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a quoted inline text to the content normalizing content.
-    pub fn push_quote_safe<D: I>(mut self, content: D) -> Self {
+    pub fn push_quote_safe<D: I>(&mut self, content: D) -> &mut Self {
         self.0.push_str("> ");
         {
             let mut c = content.into();
@@ -848,15 +848,15 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "> @\u{200B}everyone\nIsn't a mention.");
     /// ```
-    pub fn push_quote_line_safe<D: I>(mut self, content: D) -> Self {
-        self = self.push_quote_safe(content);
+    pub fn push_quote_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+        self.push_quote_safe(content);
         self.0.push('\n');
 
         self
     }
 
     /// Starts a multi-line quote, every push after this one will be quoted
-    pub fn quote_rest(mut self) -> Self {
+    pub fn quote_rest(&mut self) -> &mut Self {
         self.0.push_str("\n>>> ");
 
         self


### PR DESCRIPTION
Minor adjustments for some `MessageBuilder` methods so they can be chained.