### PR TITLE
http: make error module public

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -24,11 +24,10 @@
 //! [model]: ../model/index.html
 
 pub mod client;
+pub mod error;
 pub mod ratelimiting;
 pub mod request;
 pub mod routing;
-
-mod error;
 
 pub use reqwest::StatusCode;
 pub use self::client::*;


### PR DESCRIPTION
The `http::error::Error` type is re-exported from `http` as `HttpError`,
and while the `ErrorResponse` and `DiscordJsonError` types are public,
they aren't re-exported from the parent module and the `http::error`
module is private.

This means that the `Error::UnsuccessfulRequest` variant ends up not
being as useful as it could be, as seen here:
<https://docs.rs/serenity/0.8.0/serenity/http/enum.HttpError.html#variant.UnsuccessfulRequest>

Since these 3 types are the only ones in the `http::error` module, this
commit just makes the module public.