### PR TITLE
Implemented various kick_with_reason() methods.

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1366,7 +1366,6 @@ impl Http {
             route: RouteInfo::KickMember {
                 guild_id,
                 user_id,
-                // Supplement an empty string when `reason` is `None`.
                 reason: reason,
             },
         })

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1359,12 +1359,6 @@ impl Http {
 
     /// Kicks a member from a guild.
     pub fn kick_member(&self, guild_id: u64, user_id: u64, reason: Option<&str>) -> Result<()> {
-        let r;
-        if let Some(_) = reason {
-            r = reason
-        } else {
-            r = Some("");
-        }
 
         self.wind(204, Request {
             body: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1358,11 +1358,22 @@ impl Http {
     }
 
     /// Kicks a member from a guild.
-    pub fn kick_member(&self, guild_id: u64, user_id: u64) -> Result<()> {
+    pub fn kick_member(&self, guild_id: u64, user_id: u64, reason: Option<&str>) -> Result<()> {
+        let r;
+        if let Some(_) = reason {
+            r = reason
+        } else {
+            r = Some("");
+        }
+
         self.wind(204, Request {
             body: None,
             headers: None,
-            route: RouteInfo::KickMember { guild_id, user_id },
+            route: RouteInfo::KickMember {
+                guild_id,
+                user_id,
+                reason: r
+            },
         })
     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1366,7 +1366,7 @@ impl Http {
             route: RouteInfo::KickMember {
                 guild_id,
                 user_id,
-                reason: reason,
+                reason,
             },
         })
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1358,7 +1358,7 @@ impl Http {
     }
 
     /// Kicks a member from a guild.
-    pub fn kick_member(&self, guild_id: u64, user_id: u64, reason: Option<&str>) -> Result<()> {
+    pub fn kick_member(&self, guild_id: u64, user_id: u64, reason: &str) -> Result<()> {
 
         self.wind(204, Request {
             body: None,
@@ -1367,7 +1367,7 @@ impl Http {
                 guild_id,
                 user_id,
                 // Supplement an empty string when `reason` is `None`.
-                reason: reason.or(Some("")),
+                reason: reason,
             },
         })
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1358,7 +1358,12 @@ impl Http {
     }
 
     /// Kicks a member from a guild.
-    pub fn kick_member(&self, guild_id: u64, user_id: u64, reason: &str) -> Result<()> {
+    pub fn kick_member(&self, guild_id: u64, user_id: u64) -> Result<()> {
+        self.kick_member_with_reason(guild_id, user_id, "")
+    }
+
+    /// Kicks a member from a guild with a provided reason.
+    pub fn kick_member_with_reason(&self, guild_id: u64, user_id: u64, reason: &str) -> Result<()> {
 
         self.wind(204, Request {
             body: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1366,7 +1366,8 @@ impl Http {
             route: RouteInfo::KickMember {
                 guild_id,
                 user_id,
-                reason: r
+                // Supplement an empty string when `reason` is `None`.
+                reason: reason.or(Some("")),
             },
         })
     }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -420,6 +420,19 @@ impl Route {
         )
     }
 
+    pub fn guild_kick_optioned(
+        guild_id: u64,
+        user_id: u64,
+        reason: &str,
+    ) -> String {
+        format!(
+            api!("/guilds/{}/members/{}?reason={}"),
+            guild_id,
+            user_id,
+            reason,
+        )
+    }
+
     pub fn guild_bans(guild_id: u64) -> String {
         format!(api!("/guilds/{}/bans"), guild_id)
     }
@@ -876,6 +889,7 @@ pub enum RouteInfo<'a> {
     KickMember {
         guild_id: u64,
         user_id: u64,
+        reason: Option<&'a str>
     },
     LeaveGroup {
         group_id: u64,
@@ -1372,10 +1386,14 @@ impl<'a> RouteInfo<'a> {
                 Route::WebhooksId(webhook_id),
                 Cow::from(Route::webhook_with_token(webhook_id, token)),
             ),
-            RouteInfo::KickMember { guild_id, user_id } => (
+            RouteInfo::KickMember { guild_id, user_id, reason } => (
                 LightMethod::Delete,
                 Route::GuildsIdMembersId(guild_id),
-                Cow::from(Route::guild_member(guild_id, user_id)),
+                Cow::from(Route::guild_kick_optioned(
+                        guild_id,
+                        user_id,
+                        reason.unwrap_or(""),
+                    )),
             ),
             RouteInfo::LeaveGroup { group_id } => (
                 LightMethod::Delete,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -889,7 +889,7 @@ pub enum RouteInfo<'a> {
     KickMember {
         guild_id: u64,
         user_id: u64,
-        reason: Option<&'a str>
+        reason: &'a str
     },
     LeaveGroup {
         group_id: u64,
@@ -1392,7 +1392,7 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild_kick_optioned(
                         guild_id,
                         user_id,
-                        reason.unwrap_or(""),
+                        reason,
                     )),
             ),
             RouteInfo::LeaveGroup { group_id } => (

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -478,7 +478,7 @@ impl GuildId {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U, reason: Option<&str>) -> Result<()> {
+    pub fn kick<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> {
         http.as_ref().kick_member(self.0, user_id.into().0, reason)
     }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -478,8 +478,8 @@ impl GuildId {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
-        http.as_ref().kick_member(self.0, user_id.into().0)
+    pub fn kick<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U, reason: Option<&str>) -> Result<()> {
+        http.as_ref().kick_member(self.0, user_id.into().0, reason)
     }
 
     /// Leaves the guild.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -478,8 +478,14 @@ impl GuildId {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> {
-        http.as_ref().kick_member(self.0, user_id.into().0, reason)
+    pub fn kick<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
+        http.as_ref().kick_member(self.0, user_id.into().0)
+    }
+
+    #[cfg(feature = "http")]
+    #[inline]
+    pub fn kick_with_reason<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> {
+        http.as_ref().kick_member_with_reason(self.0, user_id.into().0, reason)
     }
 
     /// Leaves the guild.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -325,7 +325,7 @@ impl Member {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     pub fn kick(&self, cache_http: impl CacheHttp) -> Result<()> {
-        self.kick_with_reason(cache_http, None)
+        self.kick_with_reason(cache_http, "")
     }
 
     /// Kicks the member from the guild, with a reason.
@@ -355,7 +355,7 @@ impl Member {
     ///
     /// [`kick`]: #method.kick
     #[cfg(feature = "http")]
-    pub fn kick_with_reason(&self, cache_http: impl CacheHttp, reason: Option<&str>) -> Result<()> {
+    pub fn kick_with_reason(&self, cache_http: impl CacheHttp, reason: &str) -> Result<()> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -337,7 +337,7 @@ impl Member {
     /// Kicks a member from it's guild, with an optional reason:
     ///
     /// ```rust,ignore
-    /// match member.kick(&ctx.http, Some("Reasons")) {
+    /// match member.kick(&ctx.http, "A Reason") {
     ///     Ok(()) => println!("Successfully kicked member"),
     ///     Err(Error::Model(ModelError::GuildNotFound)) => {
     ///         println!("Couldn't determine guild of member");

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -374,7 +374,7 @@ impl Member {
             }
         }
 
-        self.guild_id.kick(cache_http.http(), self.user.read().id, reason)
+        self.guild_id.kick_with_reason(cache_http.http(), self.user.read().id, reason)
     }
 
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -325,6 +325,37 @@ impl Member {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     pub fn kick(&self, cache_http: impl CacheHttp) -> Result<()> {
+        self.kick_with_reason(cache_http, None)
+    }
+
+    /// Kicks the member from the guild, with a reason.
+    ///
+    /// **Note**: Requires the [Kick Members] permission.
+    ///
+    /// # Examples
+    ///
+    /// Kicks a member from it's guild, with an optional reason:
+    ///
+    /// ```rust,ignore
+    /// match member.kick(&ctx.http, Some("Reasons")) {
+    ///     Ok(()) => println!("Successfully kicked member"),
+    ///     Err(Error::Model(ModelError::GuildNotFound)) => {
+    ///         println!("Couldn't determine guild of member");
+    ///     },
+    ///     Err(Error::Model(ModelError::InvalidPermissions(missing_perms))) => {
+    ///         println!("Didn't have permissions; missing: {:?}", missing_perms);
+    ///     },
+    ///     _ => {},
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Same as [`kick`]
+    ///
+    /// [`kick`]: #method.kick
+    #[cfg(feature = "http")]
+    pub fn kick_with_reason(&self, cache_http: impl CacheHttp, reason: Option<&str>) -> Result<()> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
@@ -343,8 +374,9 @@ impl Member {
             }
         }
 
-        self.guild_id.kick(cache_http.http(), self.user.read().id)
+        self.guild_id.kick(cache_http.http(), self.user.read().id, reason)
     }
+
 
     /// Returns the guild-level permissions for the member.
     ///

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -865,7 +865,7 @@ impl Guild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: Option<&str>) -> Result<()> { self.id.kick(&http, user_id, reason) }
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> { self.id.kick(&http, user_id, reason) }
 
     /// Leaves the guild.
     #[inline]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -865,7 +865,7 @@ impl Guild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> { self.id.kick(&http, user_id) }
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: Option<&str>) -> Result<()> { self.id.kick(&http, user_id, reason) }
 
     /// Leaves the guild.
     #[inline]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -865,7 +865,15 @@ impl Guild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> { self.id.kick(&http, user_id, reason) }
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
+        self.id.kick(&http, user_id)
+    }
+
+    #[cfg(feature = "http")]
+    #[inline]
+    pub fn kick_with_reason<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> {
+        self.id.kick_with_reason(&http, user_id, reason)
+    }
 
     /// Leaves the guild.
     #[inline]

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -333,7 +333,15 @@ impl PartialGuild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> { self.id.kick(&http, user_id, reason) }
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
+        self.id.kick(&http, user_id)
+    }
+
+    #[cfg(feature = "http")]
+    #[inline]
+    pub fn kick_with_reason<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> {
+        self.id.kick_with_reason(&http, user_id, reason)
+    }
 
     /// Returns a formatted URL of the guild's icon, if the guild has an icon.
     pub fn icon_url(&self) -> Option<String> {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -333,7 +333,7 @@ impl PartialGuild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> { self.id.kick(&http, user_id) }
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: Option<&str>) -> Result<()> { self.id.kick(&http, user_id, reason) }
 
     /// Returns a formatted URL of the guild's icon, if the guild has an icon.
     pub fn icon_url(&self) -> Option<String> {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -333,7 +333,7 @@ impl PartialGuild {
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[cfg(feature = "http")]
     #[inline]
-    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: Option<&str>) -> Result<()> { self.id.kick(&http, user_id, reason) }
+    pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> { self.id.kick(&http, user_id, reason) }
 
     /// Returns a formatted URL of the guild's icon, if the guild has an icon.
     pub fn icon_url(&self) -> Option<String> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,6 +15,7 @@ pub use self::{
     },
 	custom_message::CustomMessage,
 };
+pub type Color = Colour;
 
 use base64;
 use crate::internal::prelude::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,7 +15,6 @@ pub use self::{
     },
 	custom_message::CustomMessage,
 };
-pub type Color = Colour;
 
 use base64;
 use crate::internal::prelude::*;


### PR DESCRIPTION
	modified:   src/http/client.rs
	modified:   src/http/routing.rs
	modified:   src/model/guild/guild_id.rs
	modified:   src/model/guild/member.rs
	modified:   src/model/guild/mod.rs
	modified:   src/model/guild/partial_guild.rs
	modified:   src/utils/mod.rs

Implemented a new method `model::guild::Member.kick_with_reason(Http, Option<&str>)` that allows the user to kick a member from a guild with an optional reason. 
Should not be a breaking change. (EDIT: it is a breaking change due to the kick_member() method)