### PR TITLE
Store command names in lowercase when case-insensitivity is on

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -384,9 +384,12 @@ impl StandardFramework {
     /// [`group`]: #method.group
     pub fn group_add(&mut self, group: &'static CommandGroup) {
         let map = if group.options.prefixes.is_empty() {
-            Map::Prefixless(GroupMap::new(&group.options.sub_groups), CommandMap::new(&group.options.commands))
+            Map::Prefixless(
+                GroupMap::new(&group.options.sub_groups, &self.config),
+                CommandMap::new(&group.options.commands, &self.config),
+            )
         } else {
-            Map::WithPrefixes(GroupMap::new(&[group]))
+            Map::WithPrefixes(GroupMap::new(&[group], &self.config))
         };
 
         self.groups.push((group, map));


### PR DESCRIPTION
This fixes a scenario where `Configuration::case_insensitive` is `true` and a command name contains uppercase letters but only the segment of the message that we're trying to parse is changed to lowercase.