### PR TITLE
Fix 411 when using HTTP-requests with `native_tls_backend`

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -91,9 +91,9 @@ impl<'a> Request<'a> {
         // but don't give a body.
         if self.body.is_some() {
             headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
-            headers.insert(CONTENT_LENGTH, HeaderValue::from_static(&"0"));
         }
 
+        headers.insert(CONTENT_LENGTH, HeaderValue::from_static(&"0"));
         headers.insert("X-Ratelimit-Precision", HeaderValue::from_static("millisecond"));
 
         if let Some(ref request_headers) = request_headers {


### PR DESCRIPTION
This pull requests attempts to fix receiving 411 (Length Required) when using the `native_tls_backend`.

Fixes #818 