### PR TITLE
Fix broken the 10_voice_receive example

### DIFF
--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -325,9 +325,8 @@ impl Connection {
                         offset += 1 + (0b1111 & (byte >> 4)) as usize;
                     }
 
-                    while decrypted[offset] == 0 {
-                        offset += 1;
-                    }
+                    // Skip over undocumented Discord byte
+                    offset += 1;
 
                     decrypted = decrypted.split_off(offset);
                 }


### PR DESCRIPTION
Hello,

I found that the `10_voice_receive` example is broken. We miss some `voice_packet` event because the decoding of opus packets [here](https://github.com/serenity-rs/serenity/blob/next/src/voice/connection.rs#L335) can fail.

Originally, the parsing logic for voice packets was copied from [discord.js](https://github.com/discordjs/discord.js/commit/99419a36706a52ac2372712a86229c3e0a2c0666), which has already fixed this issue by https://github.com/discordjs/discord.js/pull/3555. This PR does the same thing.

To check this PR, use the `10_voice_receive` example with the following patch, and check if you don't fail decoding any opus packets at https://github.com/serenity-rs/serenity/blob/next/src/voice/connection.rs#L335.

```diff
diff --git a/examples/10_voice_receive/src/main.rs b/examples/10_voice_receive/src/main.rs
index 3d1f9451..a2e25e34 100644
--- a/examples/10_voice_receive/src/main.rs
+++ b/examples/10_voice_receive/src/main.rs
@@ -7,6 +7,23 @@
 //! features = ["client", "standard_framework", "voice"]
 //! ```
 use std::{env, sync::Arc};
+use log::{Record, Level, Metadata, LevelFilter};
+
+struct SimpleLogger;
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Info
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
 
 use serenity::{
     client::{bridge::voice::ClientVoiceManager, Client, Context, EventHandler},
@@ -91,7 +108,12 @@ impl AudioReceiver for Receiver {
 #[commands(join, leave, ping)]
 struct General;
 
+static LOGGER: SimpleLogger = SimpleLogger;
+
 fn main() {
+    log::set_logger(&LOGGER)
+        .map(|()| log::set_max_level(LevelFilter::Info)).unwrap();
+
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN")
         .expect("Expected a token in the environment");
```