### PR TITLE
Add Watching Activity constructor

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -163,7 +163,7 @@ impl Activity {
         }
     }
 
-    /// Creates a `Game` struct that appears as a `Listening to <name>` status.
+    /// Creates an `Activity` struct that appears as a `Listening to <name>` status.
     ///
     /// **Note**: Maximum `name` length is 128.
     ///
@@ -198,6 +198,52 @@ impl Activity {
             flags: None,
             instance: None,
             kind: ActivityType::Listening,
+            name: name.to_string(),
+            party: None,
+            secrets: None,
+            state: None,
+            emoji: None,
+            timestamps: None,
+            url: None,
+            _nonexhaustive: (),
+        }
+    }
+
+    /// Creates an `Activity` struct that appears as a `Watching <name>` status.
+    ///
+    /// **Note**: Maximum `name` length is 128.
+    ///
+    /// # Examples
+    ///
+    /// Create a command that sets the current activity:
+    ///
+    /// ```rust,no_run
+    /// use serenity::model::gateway::Activity;
+    /// use serenity::model::channel::Message;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
+    /// # #[cfg(feature = "client")]
+    /// use serenity::client::Context;
+    ///
+    /// # #[cfg(feature = "framework")]
+    /// #[command]
+    /// fn activity(ctx: &mut Context, _msg: &Message, args: Args) -> CommandResult {
+    ///     let name = args.message();
+    ///     ctx.set_activity(Activity::watching(&name));
+    ///
+    ///     Ok(())
+    /// }
+    /// #
+    /// # fn main() {}
+    /// ```
+    pub fn watching(name: &str) -> Activity {
+        Activity {
+            application_id: None,
+            assets: None,
+            details: None,
+            flags: None,
+            instance: None,
+            kind: ActivityType::Watching,
             name: name.to_string(),
             party: None,
             secrets: None,
@@ -362,6 +408,9 @@ pub enum ActivityType {
     Streaming = 1,
     /// An indicator that the user is listening to something.
     Listening = 2,
+    // An indicator that the user is watching something.
+    Watching = 3,
+
     /// An indicator that the user uses custum statuses
     Custom = 4,
     #[doc(hidden)]
@@ -373,6 +422,7 @@ enum_number!(
         Playing,
         Streaming,
         Listening,
+        Watching,
         Custom,
     }
 );
@@ -385,6 +435,7 @@ impl ActivityType {
             Playing => 0,
             Streaming => 1,
             Listening => 2,
+            Watching => 3,
             Custom => 4,
             __Nonexhaustive => unreachable!(),
         }


### PR DESCRIPTION
I noticed the Watching Activity was missing so I added it. I'm not sure if it was intentionally left out though since there's a clear gap in the Activity enum code 