### PR TITLE
Add Gateway Intents

### DIFF
--- a/examples/13_gateway_intents/Cargo.toml
+++ b/examples/13_gateway_intents/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "13_gateway_intents"
+version = "0.1.0"
+authors = ["my name <my@email.address>"]
+edition = "2018"
+
+[dependencies]
+serenity = { path = "../../", default-features = true }

--- a/examples/13_gateway_intents/src/main.rs
+++ b/examples/13_gateway_intents/src/main.rs
@@ -1,0 +1,47 @@
+use std::env;
+
+use serenity::{
+    client::bridge::gateway::GatewayIntents,
+    model::{channel::Message, event::PresenceUpdateEvent, gateway::Ready},
+    prelude::*,
+};
+
+struct Handler;
+
+impl EventHandler for Handler {
+    // This event will be dispatched for guilds, but not for direct messages.
+    fn message(&self, _ctx: Context, msg: Message) {
+        println!("Received message: {}", msg.content);
+    }
+
+    // As the intents set in this example, this event shall never be dispatched.
+    // Try it by changing your status.
+    fn presence_update(&self, _ctx: Context, _new_data: PresenceUpdateEvent) {
+        println!("Presence Update");
+    }
+
+    fn ready(&self, _: Context, ready: Ready) {
+        println!("{} is connected!", ready.user.name);
+    }
+}
+
+fn main() {
+    // Configure the client with your Discord bot token in the environment.
+    let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
+
+    // Create a client with extras and then specify the intents you want to
+    // use.
+    // By default, Serenity sets no intents.
+    let mut client = Client::new_with_extras(&token, |f| {
+        f.intents(GatewayIntents::GUILDS).event_handler(Handler)
+    })
+    .expect("Err creating client");
+
+    // Finally, start a single shard, and start listening to events.
+    //
+    // Shards will automatically attempt to reconnect, and will perform
+    // exponential backoff until it reconnects.
+    if let Err(why) = client.start() {
+        println!("Client error: {:?}", why);
+    }
+}

--- a/src/client/bridge/gateway/intents.rs
+++ b/src/client/bridge/gateway/intents.rs
@@ -1,0 +1,133 @@
+use bitflags::__impl_bitflags;
+use serde::{
+    de::{Deserialize, Deserializer},
+    ser::{Serialize, Serializer},
+};
+
+#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
+/// [Gateway Intents] will limit the events your bot will receive via the gateway.
+/// By default, no intents are specified by Serenity.
+///
+/// [Gateway Intents]: https://discordapp.com/developers/docs/topics/gateway#gateway-intents
+pub struct GatewayIntents {
+    /// The flags composing gateway intents.
+    ///
+    /// # Note
+    /// Do not modify this yourself; use the provided methods.
+    /// Do the same when creating, unless you're absolutely certain that you're giving valid intents flags.
+    pub bits: u64
+}
+
+__impl_bitflags! {
+    GatewayIntents: u64 {
+        /// Enables following gateway events:
+        ///
+        /// - GUILD_CREATE
+        /// - GUILD_DELETE
+        /// - GUILD_ROLE_CREATE
+        /// - GUILD_ROLE_UPDATE
+        /// - GUILD_ROLE_DELETE
+        /// - CHANNEL_CREATE
+        /// - CHANNEL_UPDATE
+        /// - CHANNEL_DELETE
+        /// - CHANNEL_PINS_UPDATE
+        GUILDS = 1;
+        /// Enables following gateway events:
+        ///
+        /// - GUILD_MEMBER_ADD
+        /// - GUILD_MEMBER_UPDATE
+        /// - GUILD_MEMBER_REMOVE
+        ///
+        /// **Info**:
+        /// This intent is *privileged*.
+        /// In order to use it, you must head to your application in the
+        /// Developer Portal and enable the toggle for *Privileged Intents*.
+        GUILD_MEMBERS = 1 << 1;
+        /// Enables following gateway events:
+        ///
+        /// - GUILD_BAN_ADD
+        /// - GUILD_BAN_REMOVE
+        GUILD_BANS = 1 << 2;
+        /// Enables following gateway event:
+        ///
+        /// - GUILD_EMOJIS_UPDATE
+        GUILD_EMOJIS = 1 << 3;
+        /// Enables following gateway event:
+        ///
+        /// - GUILD_INTEGRATIONS_UPDATE
+        GUILD_INTEGRATIONS = 1 << 4;
+        /// Enables following gateway event:
+        ///
+        /// - WEBHOOKS_UPDATE
+        GUILD_WEBHOOKS = 1 << 5;
+        /// Enables following gateway events:
+        ///
+        /// - INVITE_CREATE
+        /// - INVITE_DELETE
+        GUILD_INVITES = 1 << 6;
+        /// Enables following gateway event:
+        ///
+        /// - VOICE_STATE_UPDATE
+        GUILD_VOICE_STATES = 1 << 7;
+        /// Enables following gateway event:
+        ///
+        /// - PRESENCE_UPDATE
+        ///
+        /// **Info**:
+        /// This intent is *privileged*.
+        /// In order to use it, you must head to your application in the
+        /// Developer Portal and enable the toggle for *Privileged Intents*.
+        GUILD_PRESENCES = 1 << 8;
+        /// Enables following gateway events:
+        ///
+        /// - MESSAGE_CREATE
+        /// - MESSAGE_UPDATE
+        /// - MESSAGE_DELETE
+        GUILD_MESSAGES = 1 << 9;
+        /// Enables following gateway events:
+        ///
+        /// - MESSAGE_REACTION_ADD
+        /// - MESSAGE_REACTION_REMOVE
+        /// - MESSAGE_REACTION_REMOVE_ALL
+        /// - MESSAGE_REACTION_REMOVE_EMOJI
+        GUILD_MESSAGE_REACTIONS = 1 << 10;
+        /// Enable following gateway event:
+        ///
+        /// - TYPING_START
+        GUILD_MESSAGE_TYPING = 1 << 11;
+        /// Enable following gateway events:
+        ///
+        /// - CHANNEL_CREATE
+        /// - MESSAGE_CREATE
+        /// - MESSAGE_UPDATE
+        /// - MESSAGE_DELETE
+        /// - CHANNEL_PINS_UPDATE
+        DIRECT_MESSAGES = 1 << 12;
+        /// Enable following gateway events:
+        ///
+        /// - MESSAGE_REACTION_ADD
+        /// - MESSAGE_REACTION_REMOVE
+        /// - MESSAGE_REACTION_REMOVE_ALL
+        /// - MESSAGE_REACTION_REMOVE_EMOJI
+        DIRECT_MESSAGE_REACTIONS = 1 << 13;
+        /// Enable following gateway event:
+        ///
+        /// - TYPING_START
+        DIRECT_MESSAGE_TYPING = 1 << 14;
+    }
+}
+
+impl<'de> Deserialize<'de> for GatewayIntents {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::from_bits_truncate(u64::deserialize(deserializer)?))
+    }
+}
+
+impl Serialize for GatewayIntents {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(self.bits())
+    }
+}

--- a/src/client/bridge/gateway/intents.rs
+++ b/src/client/bridge/gateway/intents.rs
@@ -117,6 +117,10 @@ __impl_bitflags! {
     }
 }
 
+impl Default for GatewayIntents {
+    fn default() -> Self { Self::empty() }
+}
+
 impl<'de> Deserialize<'de> for GatewayIntents {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(Self::from_bits_truncate(u64::deserialize(deserializer)?))
@@ -129,5 +133,120 @@ impl Serialize for GatewayIntents {
         S: Serializer,
     {
         serializer.serialize_u64(self.bits())
+    }
+}
+
+#[cfg(feature = "model")]
+impl GatewayIntents {
+     /// Shorthand for checking that the set of intents contains the
+    /// [GUILDS] intent.
+    ///
+    /// [GUILDS]: #associatedconstant.GUILDS
+    pub fn guilds(self) -> bool {
+        self.contains(Self::GUILDS)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_MEMBERS] intent.
+    ///
+    /// [GUILD_MEMBERS]: #associatedconstant.GUILD_MEMBERS
+    pub fn guild_members(self) -> bool {
+        self.contains(Self::GUILD_MEMBERS)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_BANS] intent.
+    ///
+    /// [GUILD_BANS]: #associatedconstant.GUILD_BANS
+    pub fn guild_bans(self) -> bool {
+        self.contains(Self::GUILD_BANS)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_EMOJIS] intent.
+    ///
+    /// [GUILD_EMOJIS]: #associatedconstant.GUILD_EMOJIS
+    pub fn guild_emojis(self) -> bool {
+        self.contains(Self::GUILD_EMOJIS)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_INTEGRATIONS] intent.
+    ///
+    /// [GUILD_INTEGRATIONS]: #associatedconstant.GUILD_INTEGRATIONS
+    pub fn guild_integrations(self) -> bool {
+        self.contains(Self::GUILD_INTEGRATIONS)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_WEBHOOKS] intent.
+    ///
+    /// [GUILD_WEBHOOKS]: #associatedconstant.GUILD_WEBHOOKS
+    pub fn guild_webhooks(self) -> bool {
+        self.contains(Self::GUILD_WEBHOOKS)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_INVITES] intent.
+    ///
+    /// [GUILD_INVITES]: #associatedconstant.GUILD_INVITES
+    pub fn guild_invites(self) -> bool {
+        self.contains(Self::GUILD_INVITES)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_VOICE_STATES] intent.
+    ///
+    /// [GUILD_VOICE_STATES]: #associatedconstant.GUILD_VOICE_STATES
+    pub fn guild_voice_states(self) -> bool {
+        self.contains(Self::GUILD_VOICE_STATES)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_PRESENCES] intent.
+    ///
+    /// [GUILD_PRESENCES]: #associatedconstant.GUILD_PRESENCES
+    pub fn guild_presences(self) -> bool {
+        self.contains(Self::GUILD_PRESENCES)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_MESSAGE_REACTIONS] intent.
+    ///
+    /// [GUILD_MESSAGE_REACTIONS]: #associatedconstant.GUILD_MESSAGE_REACTIONS
+    pub fn guild_message_reactions(self) -> bool {
+        self.contains(Self::GUILD_MESSAGE_REACTIONS)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [GUILD_MESSAGE_TYPING] intent.
+    ///
+    /// [GUILD_MESSAGE_TYPING]: #associatedconstant.GUILD_MESSAGE_TYPING
+    pub fn guild_message_typing(self) -> bool {
+        self.contains(Self::GUILD_MESSAGE_TYPING)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [DIRECT_MESSAGES] intent.
+    ///
+    /// [DIRECT_MESSAGES]: #associatedconstant.DIRECT_MESSAGES
+    pub fn direct_messages(self) -> bool {
+        self.contains(Self::DIRECT_MESSAGES)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [DIRECT_MESSAGE_REACTIONS] intent.
+    ///
+    /// [DIRECT_MESSAGE_REACTIONS]: #associatedconstant.DIRECT_MESSAGE_REACTIONS
+    pub fn direct_message_reactions(self) -> bool {
+        self.contains(Self::DIRECT_MESSAGE_REACTIONS)
+    }
+
+    /// Shorthand for checking that the set of intents contains the
+    /// [DIRECT_MESSAGE_TYPING] intent.
+    ///
+    /// [DIRECT_MESSAGE_TYPING]: #associatedconstant.DIRECT_MESSAGE_TYPING
+    pub fn direct_message_typing(self) -> bool {
+        self.contains(Self::DIRECT_MESSAGE_TYPING)
     }
 }

--- a/src/client/bridge/gateway/intents.rs
+++ b/src/client/bridge/gateway/intents.rs
@@ -4,11 +4,11 @@ use serde::{
     ser::{Serialize, Serializer},
 };
 
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 /// [Gateway Intents] will limit the events your bot will receive via the gateway.
 /// By default, no intents are specified by Serenity.
 ///
 /// [Gateway Intents]: https://discordapp.com/developers/docs/topics/gateway#gateway-intents
+#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct GatewayIntents {
     /// The flags composing gateway intents.
     ///

--- a/src/client/bridge/gateway/mod.rs
+++ b/src/client/bridge/gateway/mod.rs
@@ -56,6 +56,7 @@ mod shard_messenger;
 mod shard_queuer;
 mod shard_runner;
 mod shard_runner_message;
+mod intents;
 
 pub use self::shard_manager::{ShardManager, ShardManagerOptions};
 pub use self::shard_manager_monitor::ShardManagerMonitor;
@@ -63,6 +64,7 @@ pub use self::shard_messenger::ShardMessenger;
 pub use self::shard_queuer::ShardQueuer;
 pub use self::shard_runner::{ShardRunner, ShardRunnerOptions};
 pub use self::shard_runner_message::ShardRunnerMessage;
+pub use self::intents::GatewayIntents;
 
 use std::{
     fmt::{

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -14,6 +14,7 @@ use std::{
 };
 use super::super::super::{EventHandler, RawEventHandler};
 use super::{
+    GatewayIntents,
     ShardClientMessage,
     ShardId,
     ShardManagerMessage,
@@ -158,6 +159,7 @@ impl ShardManager {
             ws_url: Arc::clone(opt.ws_url),
             cache_and_http: Arc::clone(&opt.cache_and_http),
             guild_subscriptions: opt.guild_subscriptions,
+            intents: opt.intents,
         };
 
         thread::spawn(move || {
@@ -388,4 +390,5 @@ pub struct ShardManagerOptions<'a> {
     pub ws_url: &'a Arc<Mutex<String>>,
     pub cache_and_http: &'a Arc<CacheAndHttp>,
     pub guild_subscriptions: bool,
+    pub intents: Option<GatewayIntents>,
 }

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -99,6 +99,7 @@ use crate::client::bridge::voice::ClientVoiceManager;
 ///     ws_url: &gateway_url,
 ///     # cache_and_http: &cache_and_http,
 ///     guild_subscriptions: true,
+///     intents: None,
 /// });
 /// #     Ok(())
 /// # }

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -58,7 +58,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true)?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None)?;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -85,7 +85,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true)?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None)?;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -135,7 +135,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true)?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None)?;
     /// use serenity::model::gateway::Activity;
     ///
     /// shard.set_activity(Some(Activity::playing("Heroes of the Storm")));
@@ -169,7 +169,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true)?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None)?;
     /// #
     /// use serenity::model::{Activity, OnlineStatus};
     ///
@@ -209,7 +209,7 @@ impl ShardMessenger {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true)?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None)?;
     /// #
     /// use serenity::model::user::OnlineStatus;
     ///

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -17,6 +17,7 @@ use std::{
 };
 use super::super::super::{EventHandler, RawEventHandler};
 use super::{
+    GatewayIntents,
     ShardId,
     ShardManagerMessage,
     ShardQueuerMessage,
@@ -93,6 +94,7 @@ pub struct ShardQueuer {
     pub ws_url: Arc<Mutex<String>>,
     pub cache_and_http: Arc<CacheAndHttp>,
     pub guild_subscriptions: bool,
+    pub intents: Option<GatewayIntents>
 }
 
 impl ShardQueuer {
@@ -185,6 +187,7 @@ impl ShardQueuer {
             &self.cache_and_http.http.token,
             shard_info,
             self.guild_subscriptions,
+            self.intents,
         )?;
 
         let mut runner = ShardRunner::new(ShardRunnerOptions {

--- a/src/client/extras.rs
+++ b/src/client/extras.rs
@@ -1,4 +1,5 @@
 use super::{EventHandler, RawEventHandler};
+use crate::client::bridge::gateway::GatewayIntents;
 
 use std::fmt;
 use std::sync::Arc;
@@ -16,6 +17,7 @@ pub struct Extras {
     #[cfg(feature = "cache")]
     pub(crate) timeout: Option<Duration>,
     pub(crate) guild_subscriptions: bool,
+    pub(crate) intents: Option<GatewayIntents>,
 }
 
 impl Extras {
@@ -57,6 +59,14 @@ impl Extras {
         self.guild_subscriptions = guild_subscriptions;
         self
     }
+
+    /// Set what Discord gateway events shall be received.
+    ///
+    /// By default, no intents are being used and all events are received.
+    pub fn intents(&mut self, intents: GatewayIntents) -> &mut Self {
+        self.intents = Some(intents);
+        self
+    }
 }
 
 impl Default for Extras {
@@ -67,6 +77,7 @@ impl Default for Extras {
             #[cfg(feature = "cache")]
             timeout: None,
             guild_subscriptions: true,
+            intents: None,
         }
     }
 }
@@ -85,6 +96,7 @@ impl fmt::Debug for Extras {
         ds.field("raw_event_handler", &RawEventHandler);
         #[cfg(feature = "cache")]
         ds.field("cache_update_timeout", &self.timeout);
+        ds.field("intents", &self.intents);
 
         ds.finish()
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -400,6 +400,7 @@ impl Client {
             #[cfg(feature = "cache")]
             timeout,
             guild_subscriptions,
+            intents,
         } = extras;
 
         let http = Http::new_with_token(&token);
@@ -442,6 +443,7 @@ impl Client {
                 ws_url: &url,
                 cache_and_http: &cache_and_http,
                 guild_subscriptions,
+                intents,
             })
         };
 

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -99,7 +99,7 @@ pub struct Shard {
     pub started: Instant,
     pub token: String,
     ws_url: Arc<Mutex<String>>,
-    intents: Option<GatewayIntents>,
+    pub intents: Option<GatewayIntents>,
 }
 
 impl Shard {

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -125,7 +125,7 @@ impl Shard {
     /// let token = env::var("DISCORD_BOT_TOKEN")?;
     /// // retrieve the gateway response, which contains the URL to connect to
     /// let gateway = Arc::new(Mutex::new(http.get_gateway()?.url));
-    /// let shard = Shard::new(gateway, &token, [0, 1], true)?;
+    /// let shard = Shard::new(gateway, &token, [0, 1], true, None)?;
     ///
     /// // at this point, you can create a `loop`, and receive events and match
     /// // their variants
@@ -281,7 +281,7 @@ impl Shard {
     /// #
     /// # let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// # let mut shard = Shard::new(mutex.clone(), "", [0, 1], true).unwrap();
+    /// # let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None).unwrap();
     /// #
     /// use serenity::model::gateway::Activity;
     ///
@@ -332,7 +332,7 @@ impl Shard {
     /// #
     /// # let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// # let mut shard = Shard::new(mutex.clone(), "", [0, 1], true).unwrap();
+    /// # let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None).unwrap();
     /// #
     /// assert_eq!(shard.shard_info(), [1, 2]);
     /// # }
@@ -694,7 +694,7 @@ impl Shard {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true)?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None)?;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -721,7 +721,7 @@ impl Shard {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true)?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", [0, 1], true, None)?;
     /// #
     /// use serenity::model::id::GuildId;
     ///

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -2,7 +2,7 @@ use crate::constants::{self, close_codes};
 use crate::internal::prelude::*;
 use crate::model::{
     event::{Event, GatewayEvent},
-    gateway::{Activity},
+    gateway::Activity,
     id::GuildId,
     user::OnlineStatus
 };

--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use crate::constants::{self, OpCode};
 use crate::gateway::{CurrentPresence, WsClient};
+use crate::client::bridge::gateway::GatewayIntents;
 use crate::internal::prelude::*;
 use crate::internal::ws_impl::SenderExt;
 use crate::model::id::GuildId;
@@ -20,7 +21,7 @@ pub trait WebSocketGatewayClientExt {
     fn send_heartbeat(&mut self, shard_info: &[u64; 2], seq: Option<u64>)
         -> Result<()>;
 
-    fn send_identify(&mut self, shard_info: &[u64; 2], token: &str, guild_subscriptions: bool)
+    fn send_identify(&mut self, shard_info: &[u64; 2], token: &str, guild_subscriptions: bool, intents: Option<GatewayIntents>)
         -> Result<()>;
 
     fn send_presence_update(
@@ -68,7 +69,7 @@ impl WebSocketGatewayClientExt for WsClient {
         })).map_err(From::from)
     }
 
-    fn send_identify(&mut self, shard_info: &[u64; 2], token: &str, guild_subscriptions: bool)
+    fn send_identify(&mut self, shard_info: &[u64; 2], token: &str, guild_subscriptions: bool, intents: Option<GatewayIntents>)
         -> Result<()> {
         debug!("[Shard {:?}] Identifying", shard_info);
 
@@ -80,6 +81,7 @@ impl WebSocketGatewayClientExt for WsClient {
                 "guild_subscriptions": guild_subscriptions,
                 "shard": shard_info,
                 "token": token,
+                "intents": intents,
                 "v": constants::GATEWAY_VERSION,
                 "properties": {
                     "$browser": "serenity",


### PR DESCRIPTION
This adds support for gateway intents, you can specify these on the client via:

```rust
    let mut client = Client::new_with_extras(&token, |f| {
        f.intents(GatewayIntents::GUILDS).event_handler(Handler)
    })?;
```
By default, Serenity does not specify any intents.
Read more about gateway intents here: https://discordapp.com/developers/docs/topics/gateway#gateway-intents

Additionally, adds example 13 showcasing how to use gateway intents.

Closes: #815 