### PR TITLE
Add Gateway Intents Example to Azure Pipelines

### DIFF
--- a/azure-build-examples.yml
+++ b/azure-build-examples.yml
@@ -98,3 +98,10 @@ jobs:
       CARGO_TARGET_DIR='..' cd examples/12_timing_and_events
       cargo build
     displayName: 'Build example 12'
+
+  - bash: |
+      source $HOME/.cargo/env
+      CARGO_TARGET_DIR='..' cd examples/13_gateway_intents
+      cargo build
+    displayName: 'Build example 13'
+    


### PR DESCRIPTION
We are not building example 13 in our CI test suite right now. This pull request adds it to the CI build file.