### PR TITLE
Resume Instead of Reidentify on Reconnect Events

### DIFF
--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -138,7 +138,7 @@ impl ShardRunner {
             }
 
             match action {
-                Some(ShardAction::Reconnect(ReconnectType::Resume)) => {
+                Some(ShardAction::Reconnect(ReconnectType::Reidentify)) => {
                     let _ = self.request_restart();
                     continue;
                 },

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -554,7 +554,7 @@ impl Shard {
                 }))
             },
             Ok(GatewayEvent::Reconnect) => {
-                Ok(Some(ShardAction::Reconnect(ReconnectType::Reidentify)))
+                Ok(Some(ShardAction::Reconnect(ReconnectType::Resume)))
             },
             Err(Error::Gateway(GatewayError::Closed(ref data))) => self.handle_gateway_closed(&data),
             Err(Error::Tungstenite(ref why)) => {


### PR DESCRIPTION
There was a small oversight when porting the rebalance handling from the `await` pull request to the threadpool'ed `next` (which then got selected into `current`).

This pull request evens out these dissimilarities.