### PR TITLE
Support for "Delete All Reactions for Emoji" endpoint

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -411,7 +411,7 @@ impl Http {
     }
 
     ///Deletes all the reactions for a given emoji on a message.
-    pub fn delete_message_reactions_emoji(&self,
+    pub fn delete_message_reaction_emoji(&self,
                                         channel_id: u64,
                                         message_id: u64,
                                         reaction_type: &ReactionType)

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -410,6 +410,23 @@ impl Http {
         })
     }
 
+    ///Deletes all the reactions for a given emoji on a message.
+    pub fn delete_message_reactions_emoji(&self,
+                                        channel_id: u64,
+                                        message_id: u64,
+                                        reaction_type: &ReactionType)
+                                        -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteMessageReactionEmoji {
+            reaction: &reaction_type.as_data(),
+            channel_id,
+            message_id,
+            },
+        })
+    }
+
     /// Deletes a permission override from a role or a member in a channel.
     pub fn delete_permission(&self, channel_id: u64, target_id: u64) -> Result<()> {
         self.wind(204, Request {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -420,9 +420,9 @@ impl Http {
             body: None,
             headers: None,
             route: RouteInfo::DeleteMessageReactionEmoji {
-            reaction: &reaction_type.as_data(),
-            channel_id,
-            message_id,
+                reaction: &reaction_type.as_data(),
+                channel_id,
+                message_id,
             },
         })
     }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -293,6 +293,19 @@ impl Route {
         )
     }
 
+    pub fn channel_message_reaction_emoji<T>(
+        channel_id: u64,
+        message_id: u64,
+        reaction_type: T
+    ) -> String where T: Display {
+        format!(
+            api!("/channels/{}/messages/{}/reactions/{}"),
+            channel_id,
+            message_id,
+            reaction_type,
+        )
+    }
+
     pub fn channel_message_reactions(
         channel_id: u64,
         message_id: u64,
@@ -705,6 +718,11 @@ pub enum RouteInfo<'a> {
         channel_id: u64,
         message_id: u64,
     },
+    DeleteMessageReactionEmoji {
+        channel_id: u64,
+        message_id: u64,
+        reaction: &'a str,
+    },
     DeletePermission {
         channel_id: u64,
         target_id: u64,
@@ -1041,6 +1059,15 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::channel_message_reactions(
                     channel_id,
                     message_id,
+                )),
+            ),
+            RouteInfo::DeleteMessageReactionEmoji { channel_id, message_id,  reaction} => (
+                LightMethod::Delete,
+                Route::ChannelsIdMessagesIdReactions(channel_id),
+                Cow::from(Route::channel_message_reaction_emoji(
+                    channel_id,
+                    message_id,
+                    reaction,
                 )),
             ),
             RouteInfo::DeleteMessage { channel_id, message_id } => (

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -219,7 +219,7 @@ impl ChannelId {
             &reaction_type.into(),
         )
     }
-
+ 
     #[cfg(feature = "http")]
     fn _delete_reaction(
         self,
@@ -235,6 +235,43 @@ impl ChannelId {
             reaction_type,
         )
     }
+
+
+    /// Deletes all [`Reaction`]s of the given emoji to a message within the channel.
+    /// 
+    /// **Note**: Requires the [Manage Messages] permission.
+    /// 
+    /// [`Reaction`]: ../channel/struct.Reaction.html
+    /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
+    #[cfg(feature = "http")]
+    #[inline]
+    pub fn delete_reaction_emoji<M, R>(self,
+                                http: impl AsRef<Http>,
+                                message_id: M,
+                                reaction_type: R)
+                                -> Result<()>
+        where M: Into<MessageId>, R: Into<ReactionType> {
+            self._delete_reaction_emoji(
+                &http,
+                message_id.into(),
+                &reaction_type.into()
+            )
+    }
+
+    #[cfg(feature = "http")]
+    fn _delete_reaction_emoji(
+        self,
+        http: impl AsRef<Http>,
+        message_id: MessageId,
+        reaction_type: &ReactionType,
+    ) -> Result<()> {
+        http.as_ref().delete_message_reaction_emoji(
+            self.0,
+            message_id.0,
+            reaction_type
+        )
+    }
+
 
 
     /// Edits the settings of a [`Channel`], optionally setting new values.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -218,7 +218,7 @@ impl Message {
             }
         }
 
-        cache_http.http().as_ref().delete_message_reactions_emoji(self.channel_id.0, self.id.0, &reaction_type.into())
+        cache_http.http().as_ref().delete_message_reaction_emoji(self.channel_id.0, self.id.0, &reaction_type.into())
     }
 
     /// Edits this message, replacing the original content with new content.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -192,6 +192,35 @@ impl Message {
         cache_http.http().as_ref().delete_message_reactions(self.channel_id.0, self.id.0)
     }
 
+    /// Deletes all of the [`Reaction`]s of a given emoji associated with the message.
+    ///
+    /// **Note**: Requires the [Manage Messages] permission.
+    ///
+    /// # Errors
+    ///
+    /// If the `cache` feature is enabled, then returns a
+    /// [`ModelError::InvalidPermissions`] if the current user does not have
+    /// the required permissions.
+    ///
+    /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
+    /// [`Reaction`]: struct.Reaction.html
+    /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
+    #[cfg(feature = "http")]
+    pub fn delete_reaction_emoji<R: Into<ReactionType>>(&self, cache_http: impl CacheHttp, reaction_type: R) -> Result<()> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::MANAGE_MESSAGES;
+
+                if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req)? {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
+            }
+        }
+
+        cache_http.http().as_ref().delete_message_reactions_emoji(self.channel_id.0, self.id.0, &reaction_type.into())
+    }
+
     /// Edits this message, replacing the original content with new content.
     ///
     /// Message editing preserves all unchanged message data.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -107,6 +107,34 @@ impl Reaction {
         cache_http.http().delete_reaction(self.channel_id.0, self.message_id.0, user_id, &self.emoji)
     }
 
+    /// Deletes all reactions from the message with this emoji.
+    ///
+    /// Requires the [Manage Messages] permission
+    ///
+    /// # Errors
+    ///
+    /// If the `cache` is enabled, then returns a
+    /// [`ModelError::InvalidPermissions`] if the current user does not have
+    /// the required [permissions].
+    ///
+    /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
+    /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
+    /// [permissions]: ../permissions/index.html
+    #[cfg(feature = "http")]
+    pub fn delete_all(&self, cache_http: impl CacheHttp) -> Result<()> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(cache) = cache_http.cache() {
+                let req = Permissions::MANAGE_MESSAGES;
+
+                if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req)? {
+                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                }
+            }
+        }
+        cache_http.http().as_ref().delete_message_reaction_emoji(self.channel_id.0, self.message_id.0, &self.emoji)
+    }
+
     /// Retrieves the [`Message`] associated with this reaction.
     ///
     /// Requires the [Read Message History] permission.


### PR DESCRIPTION
This adds support for the aforementioned endpoint to the http module, and adds methods for deleting them from a Message, a Reaction, and a ChannelId.

 Resolves #813