### PR TITLE
Return Instantly When Requesting Restart

### DIFF
--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -296,7 +296,7 @@ impl ShardManager {
 
             if let Err(why) = runner.runner_tx.send(msg) {
                 warn!(
-                    "Failed to cleanly shutdown shard {}: {:?}",
+                    "Failed to send shutdown shard {}: {:?}",
                     shard_id,
                     why,
                 );
@@ -310,7 +310,7 @@ impl ShardManager {
                         );
                     },
                 Err(why) => warn!(
-                    "Failed to cleanly shutdown shard {}: {:?}",
+                    "Failed to cleanly shutdown shard {} due to timeout: {:?}",
                     shard_id,
                     why,
                 )

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -139,8 +139,7 @@ impl ShardRunner {
 
             match action {
                 Some(ShardAction::Reconnect(ReconnectType::Reidentify)) => {
-                    let _ = self.request_restart();
-                    continue;
+                    return self.request_restart();
                 },
                 Some(other) => {
                     let _ = self.action(&other);

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -616,7 +616,7 @@ impl Shard {
 
             false
         } else {
-            trace!("[Shard {:?}] Heartbeated", self.shard_info);
+            trace!("[Shard {:?}] Heartbeat", self.shard_info);
 
             true
         }
@@ -799,7 +799,7 @@ impl Shard {
     }
 
     pub fn resume(&mut self) -> Result<()> {
-        debug!("Shard {:?}] Attempting to resume", self.shard_info);
+        debug!("[Shard {:?}] Attempting to resume", self.shard_info);
 
         self.client = self.initialize()?;
         self.stage = ConnectionStage::Resuming;


### PR DESCRIPTION
This backports changes on Serenity.await to `current` - including renaming of log messages - fixing a logic error when a restart is requested, causing a problematic loop and preventing the shard to finish.