### PR TITLE
Perform an audit on all feature gates in the repository

### DIFF
--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 /// # #[cfg(feature = "framework")]
 /// # use serenity::framework::standard::{CommandResult, macros::command};
 /// #
-/// # #[cfg(all(feature = "http", feature = "framework"))]
+/// # #[cfg(all(feature = "model", feature = "utils", feature = "framework"))]
 /// # #[command]
 /// # fn example(ctx: &Context) -> CommandResult {
 /// # let mut message = ChannelId(7).message(&ctx.http, MessageId(8)).unwrap();

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -21,7 +21,7 @@ use parse::map::{CommandMap, GroupMap, Map};
 use super::Framework;
 use crate::client::Context;
 use crate::model::{
-    channel::{Channel, Message},
+    channel::Message,
     permissions::Permissions,
 };
 
@@ -31,6 +31,8 @@ use std::sync::Arc;
 use threadpool::ThreadPool;
 use uwl::Stream;
 
+#[cfg(feature = "cache")]
+use crate::model::channel::Channel;
 #[cfg(feature = "cache")]
 use crate::cache::CacheRwLock;
 #[cfg(feature = "cache")]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1196,9 +1196,9 @@ impl Http {
     /// Gets information about a specific invite.
     pub fn get_invite(&self, mut code: &str, stats: bool) -> Result<Invite> {
         #[cfg(feature = "utils")]
-            {
-                code = crate::utils::parse_invite(code);
-            }
+        {
+            code = crate::utils::parse_invite(code);
+        }
 
         self.fire(Request {
             body: None,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -40,10 +40,8 @@ use std::{
     borrow::Cow,
     fs::File,
     path::{Path, PathBuf},
+    sync::Arc,
 };
-
-#[cfg(any(feature = "client", feature = "http"))]
-use std::sync::Arc;
 
 #[cfg(feature = "cache")]
 use crate::cache::CacheRwLock;
@@ -51,7 +49,6 @@ use crate::cache::CacheRwLock;
 use crate::client::Context;
 #[cfg(feature = "client")]
 use crate::CacheAndHttp;
-
 
 /// This trait will be required by functions that need [`Http`] and can
 /// optionally use a [`CacheRwLock`] to potentially avoid REST-requests.
@@ -70,7 +67,6 @@ use crate::CacheAndHttp;
 /// [`Http`]: client/struct.Http.html
 /// [`Context`]: ../client/struct.Context.html
 pub trait CacheHttp {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http;
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&CacheRwLock> { None }
@@ -78,7 +74,6 @@ pub trait CacheHttp {
 
 #[cfg(feature = "client")]
 impl CacheHttp for Context {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http { &self.http }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
@@ -86,7 +81,6 @@ impl CacheHttp for Context {
 
 #[cfg(feature = "client")]
 impl CacheHttp for &Context {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http { &self.http }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
@@ -94,7 +88,6 @@ impl CacheHttp for &Context {
 
 #[cfg(feature = "client")]
 impl CacheHttp for CacheAndHttp {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http { &self.http }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
@@ -102,7 +95,6 @@ impl CacheHttp for CacheAndHttp {
 
 #[cfg(feature = "client")]
 impl CacheHttp for &CacheAndHttp {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http { &self.http }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
@@ -110,7 +102,6 @@ impl CacheHttp for &CacheAndHttp {
 
 #[cfg(feature = "client")]
 impl CacheHttp for Arc<CacheAndHttp> {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http { &self.http }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
@@ -118,34 +109,30 @@ impl CacheHttp for Arc<CacheAndHttp> {
 
 #[cfg(feature = "client")]
 impl CacheHttp for &Arc<CacheAndHttp> {
-    #[cfg(feature = "http")]
     fn http(&self) -> &Http { &self.http }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.cache) }
 }
 
-#[cfg(all(feature = "cache", feature = "http"))]
+#[cfg(feature = "cache")]
 impl CacheHttp for (&CacheRwLock, &Http) {
     fn cache(&self) -> Option<&CacheRwLock> { Some(&self.0) }
     fn http(&self) -> &Http { &self.1 }
 }
 
-#[cfg(feature = "http")]
 impl CacheHttp for &Http {
     fn http(&self) -> &Http { *self }
 }
 
-#[cfg(feature = "http")]
 impl CacheHttp for Arc<Http> {
     fn http(&self) -> &Http { &*self }
 }
 
-#[cfg(feature = "http")]
 impl CacheHttp for &Arc<Http> {
     fn http(&self) -> &Http { &*self }
 }
 
-#[cfg(all(feature = "cache", feature = "http"))]
+#[cfg(feature = "cache")]
 impl AsRef<CacheRwLock> for (&CacheRwLock, &Http) {
     fn as_ref(&self) -> &CacheRwLock {
         self.0

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -20,6 +20,7 @@ use std::{
     net::TcpStream,
     sync::Arc,
 };
+#[cfg(not(feature = "native_tls_backend"))]
 use url::Url;
 
 pub trait ReceiverExt {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,9 +89,9 @@ pub use crate::error::{Error, Result};
 #[cfg(feature = "client")]
 pub use crate::client::Client;
 
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "client", feature = "cache"))]
 use crate::cache::CacheRwLock;
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "client", feature = "cache"))]
 use std::time::Duration;
 #[cfg(feature = "client")]
 use std::sync::Arc;

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -1,13 +1,11 @@
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
 use crate::model::prelude::*;
 
-#[cfg(all(feature = "builder", feature = "model"))]
+#[cfg(feature = "model")]
 use crate::builder::EditChannel;
 #[cfg(all(feature = "model", feature = "utils"))]
 use crate::utils as serenity_utils;
-#[cfg(feature = "http")]
-use crate::http::Http;
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
 
 /// A category of [`GuildChannel`]s.
 ///
@@ -46,7 +44,6 @@ pub struct ChannelCategory {
 #[cfg(feature = "model")]
 impl ChannelCategory {
     /// Adds a permission overwrite to the category's channels.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_permission(&self, http: impl AsRef<Http>, target: &PermissionOverwrite) -> Result<()> {
         self.id.create_permission(&http, target)
@@ -57,7 +54,6 @@ impl ChannelCategory {
     /// **Note**: Requires the [Manage Channel] permission.
     ///
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         self.id.delete_permission(&http, permission_type)
@@ -66,7 +62,6 @@ impl ChannelCategory {
 
     /// Deletes this category if required permissions are met.
     #[inline]
-    #[cfg(feature = "http")]
     pub fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
         self.id.delete(&cache_http.http()).map(|_| ())
     }
@@ -82,14 +77,13 @@ impl ChannelCategory {
     /// ```rust,ignore
     /// category.edit(&context, |c| c.name("test").bitrate(86400));
     /// ```
-    #[cfg(all(feature = "builder", feature = "model", feature = "utils", feature = "client"))]
+    #[cfg(feature = "utils")]
     pub fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
         where F: FnOnce(&mut EditChannel) -> &mut EditChannel
     {
         let mut map = HashMap::new();
         map.insert("name", Value::String(self.name.clone()));
         map.insert("position", Value::Number(Number::from(self.position)));
-
 
         let mut edit_channel = EditChannel::default();
         f(&mut edit_channel);

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
 use crate::{internal::RwLockExt, model::prelude::*};
 
 #[cfg(feature = "model")]
@@ -12,16 +10,16 @@ use crate::builder::{
     GetMessages
 };
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache:: {Cache, CacheRwLock};
+use crate::cache::{Cache, CacheRwLock};
 #[cfg(all(feature = "cache", feature = "model"))]
 use parking_lot::RwLock;
 #[cfg(feature = "model")]
 use crate::http::AttachmentType;
 #[cfg(feature = "model")]
 use crate::utils;
-#[cfg(feature = "http")]
-use crate::http::Http;
-#[cfg(all(feature = "http", feature = "model"))]
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
+#[cfg(feature = "model")]
 use serde_json::json;
 
 #[cfg(feature = "model")]
@@ -46,7 +44,6 @@ impl ChannelId {
     /// ```
     ///
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn broadcast_typing(self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().broadcast_typing(self.0) }
 
@@ -63,7 +60,6 @@ impl ChannelId {
     /// [`PermissionOverwrite`]: ../channel/struct.PermissionOverwrite.html
     /// [`Role`]: ../guild/struct.Role.html
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_permission(self, http: impl AsRef<Http>, target: &PermissionOverwrite) -> Result<()> {
         let (id, kind) = match target.kind {
@@ -94,7 +90,6 @@ impl ChannelId {
     /// [`Message`]: ../channel/struct.Message.html
     /// [`Message::react`]: ../channel/struct.Message.html#method.react
     /// [Add Reactions]: ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_reaction<M, R>(self, http: impl AsRef<Http>, message_id: M, reaction_type: R) -> Result<()>
         where M: Into<MessageId>, R: Into<ReactionType> {
@@ -111,7 +106,6 @@ impl ChannelId {
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete(self, http: impl AsRef<Http>) -> Result<Channel> { http.as_ref().delete_channel(self.0) }
 
@@ -125,13 +119,11 @@ impl ChannelId {
     /// [`Message`]: ../channel/struct.Message.html
     /// [`Message::delete`]: ../channel/struct.Message.html#method.delete
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_message<M: Into<MessageId>>(self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self._delete_message(&http, message_id.into())
     }
 
-    #[cfg(feature = "http")]
     fn _delete_message(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
         http.as_ref().delete_message(self.0, message_id.0)
     }
@@ -154,7 +146,6 @@ impl ChannelId {
     /// [`Channel::delete_messages`]: ../channel/enum.Channel.html#method.delete_messages
     /// [`ModelError::BulkDeleteAmount`]: ../error/enum.Error.html#variant.BulkDeleteAmount
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(self, http: impl AsRef<Http>, message_ids: It) -> Result<()> {
         let ids = message_ids
             .into_iter()
@@ -164,7 +155,6 @@ impl ChannelId {
         self._delete_messages(&http, &ids)
     }
 
-    #[cfg(feature = "http")]
     fn _delete_messages(self, http: impl AsRef<Http>, ids: &[u64]) -> Result<()> {
         let len = ids.len();
 
@@ -184,7 +174,6 @@ impl ChannelId {
     /// **Note**: Requires the [Manage Channel] permission.
     ///
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     pub fn delete_permission(self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         http.as_ref().delete_permission(
             self.0,
@@ -203,7 +192,6 @@ impl ChannelId {
     ///
     /// [`Reaction`]: ../channel/struct.Reaction.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction<M, R>(self,
                                  http: impl AsRef<Http>,
@@ -219,8 +207,7 @@ impl ChannelId {
             &reaction_type.into(),
         )
     }
- 
-    #[cfg(feature = "http")]
+
     fn _delete_reaction(
         self,
         http: impl AsRef<Http>,
@@ -238,12 +225,11 @@ impl ChannelId {
 
 
     /// Deletes all [`Reaction`]s of the given emoji to a message within the channel.
-    /// 
+    ///
     /// **Note**: Requires the [Manage Messages] permission.
-    /// 
+    ///
     /// [`Reaction`]: ../channel/struct.Reaction.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction_emoji<M, R>(self,
                                 http: impl AsRef<Http>,
@@ -258,7 +244,6 @@ impl ChannelId {
             )
     }
 
-    #[cfg(feature = "http")]
     fn _delete_reaction_emoji(
         self,
         http: impl AsRef<Http>,
@@ -292,7 +277,7 @@ impl ChannelId {
     ///
     /// [`Channel`]: ../channel/enum.Channel.html
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(all(feature = "utils", feature = "http"))]
+    #[cfg(feature = "utils")]
     #[inline]
     pub fn edit<F: FnOnce(&mut EditChannel) -> &mut EditChannel>(self, http: impl AsRef<Http>, f: F) -> Result<GuildChannel> {
         let mut channel = EditChannel::default();
@@ -322,13 +307,14 @@ impl ChannelId {
     /// [`EditMessage`]: ../../builder/struct.EditMessage.html
     /// [`Message`]: ../channel/struct.Message.html
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
-    #[cfg(all(feature = "utils", feature = "http"))]
+    #[cfg(feature = "utils")]
     #[inline]
     pub fn edit_message<F, M>(self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
         self._edit_message(&http, message_id.into(), f)
     }
 
+    #[cfg(feature = "utils")]
     fn _edit_message<F>(self, http: impl AsRef<Http>, message_id: MessageId, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage {
         let mut msg = EditMessage::default();
@@ -370,7 +356,6 @@ impl ChannelId {
     /// owning the required permissions the HTTP-request will be issued.
     ///
     /// [`Channel`]: ../channel/enum.Channel.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn to_channel(self, cache_http: impl CacheHttp) -> Result<Channel> {
         #[cfg(feature = "cache")]
@@ -391,7 +376,6 @@ impl ChannelId {
     /// Requires the [Manage Channels] permission.
     ///
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {http.as_ref().get_channel_invites(self.0) }
 
@@ -400,13 +384,11 @@ impl ChannelId {
     /// Requires the [Read Message History] permission.
     ///
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "http")]
     #[inline]
     pub fn message<M: Into<MessageId>>(self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
         self._message(&http, message_id.into())
     }
 
-    #[cfg(feature = "http")]
     fn _message(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<Message> {
         http.as_ref().get_message(self.0, message_id.0).map(|mut msg| {
             msg.transform_content();
@@ -423,7 +405,6 @@ impl ChannelId {
     ///
     /// [`GetMessages`]: ../../builder/struct.GetMessages.html
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "http")]
     pub fn messages<F>(self, http: impl AsRef<Http>, builder: F) -> Result<Vec<Message>>
         where F: FnOnce(&mut GetMessages) -> &mut GetMessages {
         let mut get_messages = GetMessages::default();
@@ -451,7 +432,7 @@ impl ChannelId {
     }
 
     /// Returns the name of whatever channel this id holds.
-    #[cfg(all(feature = "model", feature = "cache"))]
+    #[cfg(feature = "cache")]
     pub fn name(self, cache: impl AsRef<CacheRwLock>) -> Option<String> {
         let channel = if let Some(c) = self.to_channel_cached(&cache) {
             c
@@ -624,7 +605,7 @@ impl ChannelId {
     /// [`GuildChannel`]: struct.GuildChannel.html
     /// [Attach Files]: ../permissions/struct.Permissions.html#associatedconstant.ATTACH_FILES
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(all(feature = "utils", feature = "http"))]
+    #[cfg(feature = "utils")]
     pub fn send_files<'a, F, T, It>(self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
               T: Into<AttachmentType<'a>>, It: IntoIterator<Item=T> {
@@ -667,7 +648,7 @@ impl ChannelId {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     /// [`CreateMessage`]: ../../builder/struct.CreateMessage.html
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(all(feature = "utils", feature = "http"))]
+    #[cfg(feature = "utils")]
     pub fn send_message<'a, F>(self, http: impl AsRef<Http>, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a> {
         let mut create_message = CreateMessage::default();
@@ -709,13 +690,12 @@ impl ChannelId {
     ///
     /// [`Message`]: ../channel/struct.Message.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn unpin<M: Into<MessageId>>(self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self._unpin(&http, message_id.into())
     }
 
-    #[cfg(feature = "http")]
+    #[inline]
     fn _unpin(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
         http.as_ref().unpin_message(self.0, message_id.0)
     }
@@ -725,9 +705,8 @@ impl ChannelId {
     /// **Note**: Requires the [Manage Webhooks] permission.
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
-    #[cfg(feature = "http")]
     #[inline]
-    pub fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {http.as_ref().get_channel_webhooks(self.0) }
+    pub fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> { http.as_ref().get_channel_webhooks(self.0) }
 }
 
 impl From<Channel> for ChannelId {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1,13 +1,11 @@
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
 use chrono::{DateTime, FixedOffset};
 use crate::model::prelude::*;
 
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::CacheRwLock;
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "cache", feature = "model"))]
 use parking_lot::RwLock;
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "cache", feature = "model"))]
 use std::sync::Arc;
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -28,10 +26,10 @@ use std::fmt::{
 };
 #[cfg(all(feature = "model", feature = "utils"))]
 use crate::utils as serenity_utils;
-#[cfg(all(feature = "model", feature = "builder"))]
+#[cfg(feature = "model")]
 use crate::builder::EditChannel;
-#[cfg(feature = "http")]
-use crate::http::Http;
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
 
 /// Represents a guild's text, news, or voice channel. Some methods are available
 /// only for voice channels and some are only available for text channels.
@@ -121,7 +119,7 @@ impl GuildChannel {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(feature = "http")]
+    #[inline]
     pub fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> { self.id.broadcast_typing(&http) }
 
     /// Creates an invite leading to the given channel.
@@ -133,7 +131,7 @@ impl GuildChannel {
     /// ```rust,ignore
     /// let invite = channel.create_invite(&context, |i| i.max_uses(5));
     /// ```
-    #[cfg(all(feature = "utils", feature = "client"))]
+    #[cfg(feature = "utils")]
     pub fn create_invite<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<RichInvite>
         where F: FnOnce(&mut CreateInvite) -> &mut CreateInvite {
         #[cfg(feature = "cache")]
@@ -266,7 +264,6 @@ impl GuildChannel {
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
     /// [Send TTS Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_TTS_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_permission(&self, http: impl AsRef<Http>, target: &PermissionOverwrite) -> Result<()> {
         self.id.create_permission(&http, target)
@@ -276,7 +273,6 @@ impl GuildChannel {
     ///
     /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon
     /// owning the required permissions the HTTP-request will be issued.
-    #[cfg(feature = "http")]
     pub fn delete(&self, cache_http: impl CacheHttp) -> Result<Channel> {
         #[cfg(feature = "cache")]
         {
@@ -309,7 +305,6 @@ impl GuildChannel {
     /// [`Channel::delete_messages`]: enum.Channel.html#method.delete_messages
     /// [`ModelError::BulkDeleteAmount`]: ../error/enum.Error.html#variant.BulkDeleteAmount
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: impl AsRef<Http>, message_ids: It) -> Result<()> {
         self.id.delete_messages(&http, message_ids)
@@ -321,7 +316,6 @@ impl GuildChannel {
     /// **Note**: Requires the [Manage Channel] permission.
     ///
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         self.id.delete_permission(&http, permission_type)
@@ -334,7 +328,6 @@ impl GuildChannel {
     ///
     /// [`Reaction`]: struct.Reaction.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction<M, R>(&self,
                                  http: impl AsRef<Http>,
@@ -357,7 +350,7 @@ impl GuildChannel {
     /// ```rust,ignore
     /// channel.edit(&context, |c| c.name("test").bitrate(86400));
     /// ```
-    #[cfg(all(feature = "utils", feature = "client", feature = "builder"))]
+    #[cfg(feature = "utils")]
     pub fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
         where F: FnOnce(&mut EditChannel) -> &mut EditChannel {
         #[cfg(feature = "cache")]
@@ -408,7 +401,6 @@ impl GuildChannel {
     /// [`EditMessage`]: ../../builder/struct.EditMessage.html
     /// [`Message`]: struct.Message.html
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_message<F, M>(&self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
@@ -420,13 +412,13 @@ impl GuildChannel {
     /// **Note**: Right now this performs a clone of the guild. This will be
     /// optimized in the future.
     #[cfg(feature = "cache")]
+    #[inline]
     pub fn guild(&self, cache: impl AsRef<CacheRwLock>) -> Option<Arc<RwLock<Guild>>> { cache.as_ref().read().guild(self.guild_id) }
 
     /// Gets all of the channel's invites.
     ///
     /// Requires the [Manage Channels] permission.
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> { self.id.invites(&http) }
 
@@ -447,7 +439,6 @@ impl GuildChannel {
     /// Requires the [Read Message History] permission.
     ///
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "http")]
     #[inline]
     pub fn message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
         self.id.message(&http, message_id)
@@ -714,12 +705,10 @@ impl GuildChannel {
     /// Pins a [`Message`] to the channel.
     ///
     /// [`Message`]: struct.Message.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn pin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> { self.id.pin(&http, message_id) }
 
     /// Gets all channel's pins.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> { self.id.pins(&http) }
 
@@ -735,7 +724,6 @@ impl GuildChannel {
     /// [`Message`]: struct.Message.html
     /// [`User`]: ../user/struct.User.html
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "http")]
     pub fn reaction_users<M, R, U>(
         &self,
         http: impl AsRef<Http>,
@@ -759,7 +747,6 @@ impl GuildChannel {
     ///
     /// [`ChannelId`]: ../id/struct.ChannelId.html
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
-    #[cfg(feature = "http")]
     #[inline]
     pub fn say(&self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> { self.id.say(&http, content) }
 
@@ -781,7 +768,6 @@ impl GuildChannel {
     /// [`ClientError::MessageTooLong`]: ../../client/enum.ClientError.html#variant.MessageTooLong
     /// [Attach Files]: ../permissions/struct.Permissions.html#associatedconstant.ATTACH_FILES
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn send_files<'a, F, T, It>(&self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
@@ -808,7 +794,6 @@ impl GuildChannel {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     /// [`Message`]: struct.Message.html
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(feature = "client")]
     pub fn send_message<'a, F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Message>
     where for <'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a> {
         #[cfg(feature = "cache")]
@@ -831,7 +816,6 @@ impl GuildChannel {
     ///
     /// [`Message`]: struct.Message.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn unpin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self.id.unpin(&http, message_id)
@@ -842,7 +826,6 @@ impl GuildChannel {
     /// **Note**: Requires the [Manage Webhooks] permission.
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
 
@@ -900,7 +883,6 @@ impl GuildChannel {
     }
 }
 
-#[cfg(feature = "model")]
 impl Display for GuildChannel {
     /// Formats the channel, creating a mention of it.
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult { Display::fmt(&self.id.mention(), f) }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1,18 +1,16 @@
 //! Models relating to Discord channels.
 
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
 use chrono::{DateTime, FixedOffset};
-use crate::{model::prelude::*};
+use crate::model::prelude::*;
 use serde_json::Value;
 
-#[cfg(feature = "model")]
+#[cfg(all(feature = "model", feature = "utils"))]
 use crate::builder::{CreateEmbed, EditMessage};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::CacheRwLock;
 #[cfg(all(feature = "cache", feature = "model"))]
 use parking_lot::RwLock;
-#[cfg(all(feature = "client", feature = "model"))]
+#[cfg(feature = "model")]
 use serde_json::json;
 #[cfg(all(feature = "cache", feature = "model"))]
 use std::sync::Arc;
@@ -35,15 +33,16 @@ use std::{
 #[cfg(feature = "model")]
 use crate::{
     constants,
-    utils as serenity_utils,
     model::id::{
         MessageId,
         GuildId,
         ChannelId,
     },
 };
-#[cfg(feature = "http")]
-use crate::http::Http;
+#[cfg(all(feature = "model", feature = "utils"))]
+use crate::utils as serenity_utils;
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
 
 /// A representation of a message over a guild's text channel, a group, or a
 /// private channel.
@@ -145,7 +144,6 @@ impl Message {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`ModelError::InvalidUser`]: ../error/enum.Error.html#variant.InvalidUser
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     pub fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -176,7 +174,6 @@ impl Message {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`Reaction`]: struct.Reaction.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     pub fn delete_reactions(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -205,7 +202,6 @@ impl Message {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`Reaction`]: struct.Reaction.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     pub fn delete_reaction_emoji<R: Into<ReactionType>>(&self, cache_http: impl CacheHttp, reaction_type: R) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -253,7 +249,7 @@ impl Message {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     /// [`EditMessage`]: ../../builder/struct.EditMessage.html
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
-    #[cfg(feature = "client")]
+    #[cfg(feature = "utils")]
     pub fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage {
         #[cfg(feature = "cache")]
@@ -365,7 +361,6 @@ impl Message {
     /// [`Message`]: struct.Message.html
     /// [`User`]: ../user/struct.User.html
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "http")]
     #[inline]
     pub fn reaction_users<R, U>(
         &self,
@@ -392,6 +387,7 @@ impl Message {
     }
 
     /// True if message was sent using direct messages.
+    #[inline]
     pub fn is_private(&self) -> bool {
         self.guild_id.is_none()
     }
@@ -440,7 +436,6 @@ impl Message {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES.html
-    #[cfg(feature = "http")]
     pub fn pin(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -475,12 +470,10 @@ impl Message {
     /// ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
     /// [permissions]: ../permissions/index.html
     #[inline]
-    #[cfg(feature = "client")]
     pub fn react<R: Into<ReactionType>>(&self, cache_http: impl CacheHttp, reaction_type: R) -> Result<()> {
         self._react(cache_http, &reaction_type.into())
     }
 
-    #[cfg(feature = "client")]
     fn _react(&self, cache_http: impl CacheHttp, reaction_type: &ReactionType) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -521,7 +514,6 @@ impl Message {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(feature = "client")]
     pub fn reply(&self, cache_http: impl CacheHttp, content: impl AsRef<str>) -> Result<Message> {
         let content = content.as_ref();
 
@@ -568,7 +560,7 @@ impl Message {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`ModelError::InvalidUser`]: ../error/enum.Error.html#variant.InvalidUser
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "client")]
+    #[cfg(feature = "utils")]
     pub fn suppress_embeds(&mut self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -606,6 +598,7 @@ impl Message {
         self._mentions_user_id(id.into())
     }
 
+    #[inline]
     fn _mentions_user_id(&self, id: UserId) -> bool {
         self.mentions.iter().any(|mentioned_user| mentioned_user.id.0 == id.0)
     }
@@ -613,6 +606,7 @@ impl Message {
     /// Checks whether the message mentions passed [`User`].
     ///
     /// [`User`]: ../user/struct.User.html
+    #[inline]
     pub fn mentions_user(&self, user: &User) -> bool {
         self.mentions_user_id(user.id)
     }
@@ -629,7 +623,6 @@ impl Message {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     pub fn unpin(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -653,7 +646,7 @@ impl Message {
     /// **Note**:
     /// If message was sent in a private channel, then the function will return
     /// `None`.
-    #[cfg(feature = "http")]
+    #[inline]
     pub fn author_nick(&self, cache_http: impl CacheHttp) -> Option<String> {
         self.guild_id.as_ref().and_then(|guild_id| self.author.nick_in(cache_http, *guild_id))
     }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -17,7 +17,7 @@ use crate::builder::{
 use crate::http::AttachmentType;
 #[cfg(feature = "model")]
 use crate::internal::RwLockExt;
-#[cfg(feature = "http")]
+#[cfg(feature = "model")]
 use crate::http::Http;
 
 /// A Direct Message text channel with another user.
@@ -52,7 +52,7 @@ pub struct PrivateChannel {
 #[cfg(feature = "model")]
 impl PrivateChannel {
     /// Broadcasts that the current user is typing to the recipient.
-    #[cfg(feature = "http")]
+    #[inline]
     pub fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> { self.id.broadcast_typing(&http) }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
@@ -67,7 +67,7 @@ impl PrivateChannel {
     /// [`Message`]: struct.Message.html
     /// [`Message::react`]: struct.Message.html#method.react
     /// [Add Reactions]: ../permissions/struct.Permissions.html#associatedconstant.ADD_REACTIONS
-    #[cfg(feature = "http")]
+    #[inline]
     pub fn create_reaction<M, R>(&self, http: impl AsRef<Http>, message_id: M, reaction_type: R) -> Result<()>
         where M: Into<MessageId>, R: Into<ReactionType> {
         self.id.create_reaction(&http, message_id, reaction_type)
@@ -76,7 +76,6 @@ impl PrivateChannel {
     /// Deletes the channel. This does not delete the contents of the channel,
     /// and is equivalent to closing a private channel on the client, which can
     /// be re-opened.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete(&self, http: impl AsRef<Http>) -> Result<Channel> { self.id.delete(&http) }
 
@@ -97,7 +96,6 @@ impl PrivateChannel {
     /// [`Channel::delete_messages`]: enum.Channel.html#method.delete_messages
     /// [`ModelError::BulkDeleteAmount`]: ../error/enum.Error.html#variant.BulkDeleteAmount
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item=T>>(&self, http: impl AsRef<Http>, message_ids: It) -> Result<()> {
         self.id.delete_messages(&http, message_ids)
@@ -109,7 +107,6 @@ impl PrivateChannel {
     /// **Note**: Requires the [Manage Channel] permission.
     ///
     /// [Manage Channel]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_permission(&self, http: impl AsRef<Http>, permission_type: PermissionOverwriteType) -> Result<()> {
         self.id.delete_permission(&http, permission_type)
@@ -122,7 +119,6 @@ impl PrivateChannel {
     ///
     /// [`Reaction`]: struct.Reaction.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_reaction<M, R>(&self,
                                  http: impl AsRef<Http>,
@@ -153,7 +149,6 @@ impl PrivateChannel {
     /// [`EditMessage`]: ../../builder/struct.EditMessage.html
     /// [`Message`]: struct.Message.html
     /// [`the limit`]: ../../builder/struct.EditMessage.html#method.content
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_message<F, M>(&self, http: impl AsRef<Http>, message_id: M, f: F) -> Result<Message>
         where F: FnOnce(&mut EditMessage) -> &mut EditMessage, M: Into<MessageId> {
@@ -172,7 +167,6 @@ impl PrivateChannel {
     /// Requires the [Read Message History] permission.
     ///
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "http")]
     #[inline]
     pub fn message<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<Message> {
         self.id.message(&http, message_id)
@@ -186,7 +180,6 @@ impl PrivateChannel {
     ///
     /// [`GetMessages`]: ../../builder/struct.GetMessages.html
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "http")]
     #[inline]
     pub fn messages<F>(&self, http: impl AsRef<Http>, builder: F) -> Result<Vec<Message>>
         where F: FnOnce(&mut GetMessages) -> &mut GetMessages {
@@ -208,7 +201,6 @@ impl PrivateChannel {
     /// [`Message`]: struct.Message.html
     /// [`User`]: ../user/struct.User.html
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
-    #[cfg(feature = "http")]
     #[inline]
     pub fn reaction_users<M, R, U>(&self,
         http: impl AsRef<Http>,
@@ -225,13 +217,11 @@ impl PrivateChannel {
     /// Pins a [`Message`] to the channel.
     ///
     /// [`Message`]: struct.Message.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn pin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> { self.id.pin(&http, message_id) }
 
     /// Retrieves the list of messages that have been pinned in the private
     /// channel.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> { self.id.pins(&http) }
 
@@ -245,7 +235,6 @@ impl PrivateChannel {
     ///
     /// [`ChannelId`]: ../id/struct.ChannelId.html
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
-    #[cfg(feature = "http")]
     #[inline]
     pub fn say(&self, http: impl AsRef<Http>, content: impl std::fmt::Display) -> Result<Message> { self.id.say(&http, content) }
 
@@ -267,7 +256,6 @@ impl PrivateChannel {
     /// [`ClientError::MessageTooLong`]: ../../client/enum.ClientError.html#variant.MessageTooLong
     /// [Attach Files]: ../permissions/struct.Permissions.html#associatedconstant.ATTACH_FILES
     /// [Send Messages]: ../permissions/struct.Permissions.html#associatedconstant.SEND_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn send_files<'a, F, T, It>(&self, http: impl AsRef<Http>, files: It, f: F) -> Result<Message>
         where for <'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
@@ -289,7 +277,6 @@ impl PrivateChannel {
     /// [`ModelError::MessageTooLong`]: ../error/enum.Error.html#variant.MessageTooLong
     /// [`CreateMessage`]: ../../builder/struct.CreateMessage.html
     /// [`Message`]: struct.Message.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn send_message<'a, F>(&self, http: impl AsRef<Http>, f: F) -> Result<Message>
     where for <'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a> {
@@ -302,7 +289,6 @@ impl PrivateChannel {
     ///
     /// [`Message`]: struct.Message.html
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn unpin<M: Into<MessageId>>(&self, http: impl AsRef<Http>, message_id: M) -> Result<()> {
         self.id.unpin(&http, message_id)

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-use crate::{model::prelude::*};
+use crate::model::prelude::*;
 use serde::de::{Deserialize, Error as DeError, MapAccess, Visitor};
 use serde::ser::{SerializeMap, Serialize, Serializer};
 use std::{
@@ -16,9 +14,9 @@ use std::{
 
 use crate::internal::prelude::*;
 
-#[cfg(feature = "http")]
-use crate::http::Http;
-#[cfg(all(feature = "http", feature = "model"))]
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
+#[cfg(feature = "model")]
 use log::warn;
 use std::convert::TryFrom;
 use std::str::FromStr;
@@ -61,7 +59,6 @@ impl Reaction {
     ///
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     #[inline]
-    #[cfg(feature = "http")]
     pub fn channel(&self, cache_http: impl CacheHttp) -> Result<Channel> {
         self.channel_id.to_channel(cache_http)
     }
@@ -81,9 +78,9 @@ impl Reaction {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     /// [permissions]: ../permissions/index.html
-    #[cfg(feature = "http")]
     pub fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
-
+        // Silences a warning when compiling without the `cache` feature.
+        #[allow(unused_mut)]
         let mut user_id = Some(self.user_id.0);
 
         #[cfg(feature = "cache")]
@@ -120,7 +117,6 @@ impl Reaction {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Messages]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_MESSAGES
     /// [permissions]: ../permissions/index.html
-    #[cfg(feature = "http")]
     pub fn delete_all(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -145,7 +141,6 @@ impl Reaction {
     ///
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     /// [`Message`]: struct.Message.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn message(&self, http: impl AsRef<Http>) -> Result<Message> {
         self.channel_id.message(&http, self.message_id)
@@ -157,7 +152,6 @@ impl Reaction {
     /// If not - or the user was not found - this will perform a request over
     /// the REST API for the user.
     #[inline]
-    #[cfg(feature = "http")]
     pub fn user(&self, cache_http: impl CacheHttp) -> Result<User> {
         self.user_id.to_user(cache_http)
     }
@@ -187,7 +181,6 @@ impl Reaction {
     /// [`User`]: ../user/struct.User.html
     /// [Read Message History]: ../permissions/struct.Permissions.html#associatedconstant.READ_MESSAGE_HISTORY
     /// [permissions]: ../permissions/index.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn users<R, U>(&self,
                        http: impl AsRef<Http>,
@@ -199,7 +192,6 @@ impl Reaction {
         self._users(&http, &reaction_type.into(), limit, after.map(Into::into))
     }
 
-    #[cfg(feature = "http")]
     fn _users(
         &self,
         http: impl AsRef<Http>,
@@ -347,7 +339,7 @@ impl Serialize for ReactionType {
     }
 }
 
-#[cfg(any(feature = "model", feature = "http"))]
+#[cfg(feature = "model")]
 impl ReactionType {
     /// Creates a data-esque display of the type. This is not very useful for
     /// displaying, as the primary client can not render it, but can be useful
@@ -355,6 +347,7 @@ impl ReactionType {
     ///
     /// **Note**: This is mainly for use internally. There is otherwise most
     /// likely little use for it.
+    #[inline]
     pub fn as_data(&self) -> String {
         match *self {
             ReactionType::Custom {
@@ -368,7 +361,6 @@ impl ReactionType {
     }
 }
 
-#[cfg(feature = "model")]
 impl From<char> for ReactionType {
     /// Creates a `ReactionType` from a `char`.
     ///

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -110,7 +110,7 @@ pub struct ChannelDeleteEvent {
     pub(crate) _nonexhaustive: (),
 }
 
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "cache", feature = "model"))]
 impl CacheUpdate for ChannelDeleteEvent {
     type Output = ();
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -478,7 +478,7 @@ impl<'de> Deserialize<'de> for Presence {
             }
             None => None,
         };
-        
+
         let last_modified = match map.remove("last_modified") {
             Some(v) => serde_json::from_value::<Option<u64>>(v)
                 .map_err(DeError::custom)?,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-use crate::{model::prelude::*};
+use crate::model::prelude::*;
 
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::CacheRwLock;
@@ -10,12 +8,12 @@ use crate::builder::{EditGuild, EditMember, EditRole};
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::utils;
-#[cfg(feature = "http")]
-use crate::http::Http;
 #[cfg(feature = "model")]
 use crate::builder::CreateChannel;
 #[cfg(feature = "model")]
 use serde_json::json;
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
 
 #[cfg(feature = "model")]
 impl GuildId {
@@ -46,7 +44,6 @@ impl GuildId {
     /// [`Guild::ban`]: ../guild/struct.Guild.html#method.ban
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn ban(self, http: impl AsRef<Http>, user: impl Into<UserId>, dmd: u8) -> Result<()> {
         self._ban_with_reason(http, user.into(), dmd, "")
@@ -56,7 +53,6 @@ impl GuildId {
     ///
     /// [`User`]: ../user/struct.User.html
     /// [`ban`]: #method.ban
-    #[cfg(feature = "http")]
     #[inline]
     pub fn ban_with_reason(self, http: impl AsRef<Http>,
                                  user: impl Into<UserId>,
@@ -65,7 +61,6 @@ impl GuildId {
         self._ban_with_reason(http, user.into(), dmd, reason.as_ref())
     }
 
-    #[cfg(feature = "http")]
     fn _ban_with_reason(self, http: impl AsRef<Http>, user: UserId, dmd: u8, reason: &str) -> Result<()> {
         if dmd > 7 {
             return Err(Error::Model(ModelError::DeleteMessageDaysAmount(dmd)));
@@ -83,12 +78,10 @@ impl GuildId {
     /// Requires the [Ban Members] permission.
     ///
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn bans(self, http: impl AsRef<Http>) -> Result<Vec<Ban>> { http.as_ref().get_bans(self.0) }
 
     /// Gets a list of the guild's audit log entries
-    #[cfg(feature = "http")]
     #[inline]
     pub fn audit_logs(self, http: impl AsRef<Http>,
                             action_type: Option<u8>,
@@ -101,7 +94,6 @@ impl GuildId {
     /// Gets all of the guild's channels over the REST API.
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
-    #[cfg(feature = "http")]
     pub fn channels(self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> {
         let mut channels = HashMap::new();
 
@@ -137,7 +129,6 @@ impl GuildId {
     /// [`GuildChannel`]: ../channel/struct.GuildChannel.html
     /// [`http::create_channel`]: ../../http/fn.create_channel.html
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_channel(self, http: impl AsRef<Http>, f: impl FnOnce(&mut CreateChannel) -> &mut CreateChannel) -> Result<GuildChannel> {
         let mut builder = CreateChannel::default();
@@ -165,7 +156,6 @@ impl GuildId {
     /// [`Guild::create_emoji`]: ../guild/struct.Guild.html#method.create_emoji
     /// [`utils::read_image`]: ../../utils/fn.read_image.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_emoji(self, http: impl AsRef<Http>, name: &str, image: &str) -> Result<Emoji> {
         let map = json!({
@@ -181,14 +171,12 @@ impl GuildId {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_integration<I>(self, http: impl AsRef<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
         self._create_integration(&http, integration_id.into(), kind)
     }
 
-    #[cfg(feature = "http")]
     fn _create_integration(
         self,
         http: impl AsRef<Http>,
@@ -211,7 +199,6 @@ impl GuildId {
     ///
     /// [`Guild::create_role`]: ../guild/struct.Guild.html#method.create_role
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_role<F>(self, http: impl AsRef<Http>, f: F) -> Result<Role>
     where F: FnOnce(&mut EditRole) -> &mut EditRole {
@@ -236,7 +223,6 @@ impl GuildId {
     /// **Note**: Requires the current user to be the owner of the guild.
     ///
     /// [`Guild::delete`]: ../guild/struct.Guild.html#method.delete
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete(self, http: impl AsRef<Http>) -> Result<PartialGuild> { http.as_ref().delete_guild(self.0) }
 
@@ -246,13 +232,12 @@ impl GuildId {
     ///
     /// [`Emoji`]: ../guild/struct.Emoji.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_emoji<E: Into<EmojiId>>(self, http: impl AsRef<Http>, emoji_id: E) -> Result<()> {
         self._delete_emoji(&http, emoji_id.into())
     }
 
-    #[cfg(feature = "http")]
+    #[inline]
     fn _delete_emoji(self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<()> {
         http.as_ref().delete_emoji(self.0, emoji_id.0)
     }
@@ -262,7 +247,6 @@ impl GuildId {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_integration<I: Into<IntegrationId>>(self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self._delete_integration(&http, integration_id.into())
@@ -282,13 +266,12 @@ impl GuildId {
     /// [`Role`]: ../guild/struct.Role.html
     /// [`Role::delete`]: ../guild/struct.Role.html#method.delete
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_role<R: Into<RoleId>>(self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
         self._delete_role(&http, role_id.into())
     }
 
-    #[cfg(feature = "http")]
+    #[inline]
     fn _delete_role(self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
         http.as_ref().delete_role(self.0, role_id.0)
     }
@@ -302,10 +285,10 @@ impl GuildId {
     ///
     /// [`Guild::edit`]: ../guild/struct.Guild.html#method.edit
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<PartialGuild>
-    where F: FnOnce(&mut EditGuild) -> &mut EditGuild{
+        where F: FnOnce(&mut EditGuild) -> &mut EditGuild
+    {
         let mut edit_guild = EditGuild::default();
         f(&mut edit_guild);
         let map = utils::hashmap_to_json_map(edit_guild.0);
@@ -323,7 +306,6 @@ impl GuildId {
     /// [`Emoji`]: ../guild/struct.Emoji.html
     /// [`Emoji::edit`]: ../guild/struct.Emoji.html#method.edit
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_emoji<E: Into<EmojiId>>(self, http: impl AsRef<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
         self._edit_emoji(&http, emoji_id.into(), name)
@@ -350,14 +332,12 @@ impl GuildId {
     /// ```rust,ignore
     /// guild.edit_member(&context, user_id, |m| m.mute(true).roles(&vec![role_id]));
     /// ```
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_member<F, U>(self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(&mut EditMember) -> &mut EditMember, U: Into<UserId> {
         self._edit_member(&http, user_id.into(), f)
     }
 
-    #[cfg(feature = "http")]
     fn _edit_member<F>(self, http: impl AsRef<Http>, user_id: UserId, f: F) -> Result<()>
         where F: FnOnce(&mut EditMember) -> &mut EditMember {
         let mut edit_member = EditMember::default();
@@ -374,7 +354,6 @@ impl GuildId {
     /// Requires the [Change Nickname] permission.
     ///
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_nickname(self, http: impl AsRef<Http>, new_nickname: Option<&str>) -> Result<()> {
         http.as_ref().edit_nickname(self.0, new_nickname)
@@ -396,14 +375,12 @@ impl GuildId {
     ///
     /// [`Role`]: ../guild/struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_role<F, R>(self, http: impl AsRef<Http>, role_id: R, f: F) -> Result<Role>
         where F: FnOnce(&mut EditRole) -> &mut EditRole, R: Into<RoleId> {
         self._edit_role(&http, role_id.into(), f)
     }
 
-    #[cfg(feature = "http")]
     fn _edit_role<F>(self, http: impl AsRef<Http>, role_id: RoleId, f: F) -> Result<Role>
         where F: FnOnce(&mut EditRole) -> &mut EditRole {
         let mut edit_role = EditRole::default();
@@ -427,14 +404,13 @@ impl GuildId {
     ///
     /// [`Role`]: ../guild/struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_role_position<R>(self, http: impl AsRef<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
         where R: Into<RoleId> {
         self._edit_role_position(&http, role_id.into(), position)
     }
 
-    #[cfg(feature = "http")]
+    #[inline]
     fn _edit_role_position(
         self,
         http: impl AsRef<Http>,
@@ -458,14 +434,12 @@ impl GuildId {
     ///
     /// [`PartialGuild`]: ../guild/struct.PartialGuild.html
     /// [`Guild`]: ../guild/struct.Guild.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn to_partial_guild(self, http: impl AsRef<Http>) -> Result<PartialGuild> {http.as_ref().get_guild(self.0) }
 
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn integrations(self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {http.as_ref().get_guild_integrations(self.0) }
 
@@ -474,7 +448,6 @@ impl GuildId {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {http.as_ref().get_guild_invites(self.0) }
 
@@ -484,20 +457,17 @@ impl GuildId {
     ///
     /// [`Member`]: ../guild/struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn kick<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
         http.as_ref().kick_member(self.0, user_id.into().0)
     }
 
-    #[cfg(feature = "http")]
     #[inline]
     pub fn kick_with_reason<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> {
         http.as_ref().kick_member_with_reason(self.0, user_id.into().0, reason)
     }
 
     /// Leaves the guild.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn leave(self, http: impl AsRef<Http>) -> Result<()> { http.as_ref().leave_guild(self.0) }
 
@@ -508,13 +478,11 @@ impl GuildId {
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     /// [`Member`]: ../guild/struct.Member.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn member<U: Into<UserId>>(self, cache_http: impl CacheHttp, user_id: U) -> Result<Member> {
         self._member(cache_http, user_id.into())
     }
 
-    #[cfg(feature = "http")]
     fn _member(self, cache_http: impl CacheHttp, user_id: UserId) -> Result<Member> {
         #[cfg(feature = "cache")]
         {
@@ -536,14 +504,13 @@ impl GuildId {
     /// [`User`]'s Id.
     ///
     /// [`User`]: ../user/struct.User.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn members<U>(self, http: impl AsRef<Http>, limit: Option<u64>, after: U) -> Result<Vec<Member>>
         where U: Into<Option<UserId>> {
         self._members(&http, limit, after.into())
     }
 
-    #[cfg(feature = "http")]
+    #[inline]
     fn _members(self, http: impl AsRef<Http>, limit: Option<u64>, after: Option<UserId>) -> Result<Vec<Member>> {
         http.as_ref().get_guild_members(self.0, limit, after.map(|x| x.0))
     }
@@ -570,7 +537,7 @@ impl GuildId {
     ///         Err(error) => eprintln!("Uh oh!  Error: {}", error),
     ///     }
     /// }
-    #[cfg(all(feature = "http", feature = "cache"))]
+    #[cfg(feature = "cache")]
     pub fn members_iter<H: AsRef<Http>>(self, http: H) -> MembersIter<H> {
         MembersIter::new(self, http)
     }
@@ -580,14 +547,12 @@ impl GuildId {
     /// Requires the [Move Members] permission.
     ///
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn move_member<C, U>(self, http: impl AsRef<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
         self._move_member(&http, user_id.into(), channel_id.into())
     }
 
-    #[cfg(feature = "http")]
     fn _move_member(
         self,
         http: impl AsRef<Http>,
@@ -610,7 +575,7 @@ impl GuildId {
     ///
     /// [`Member`]: ../guild/struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
-    #[cfg(feature = "http")]
+    #[inline]
     pub fn prune_count(self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
         let map = json!({
             "days": days,
@@ -688,13 +653,12 @@ impl GuildId {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn start_integration_sync<I: Into<IntegrationId>>(self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self._start_integration_sync(&http, integration_id.into())
     }
 
-    #[cfg(feature = "http")]
+    #[inline]
     fn _start_integration_sync(
         self,
         http: impl AsRef<Http>,
@@ -712,7 +676,6 @@ impl GuildId {
     /// [`GuildPrune`]: ../guild/struct.GuildPrune.html
     /// [`Member`]: ../guild/struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn start_prune(self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
         let map = json!({
@@ -728,13 +691,12 @@ impl GuildId {
     ///
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn unban<U: Into<UserId>>(self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
         self._unban(&http, user_id.into())
     }
 
-    #[cfg(feature = "http")]
+    #[inline]
     fn _unban(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
         http.as_ref().remove_ban(self.0, user_id.0)
     }
@@ -744,7 +706,6 @@ impl GuildId {
     /// **Note**: Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn vanity_url(self, http: impl AsRef<Http>) -> Result<String> {
         http.as_ref().get_guild_vanity_url(self.0)
@@ -803,7 +764,7 @@ impl<'a> From<&'a Guild> for GuildId {
 ///
 /// [`GuildId.members_iter()`]: #method.members_iter
 #[derive(Clone, Debug)]
-#[cfg(all(feature = "http", feature = "cache"))]
+#[cfg(all(feature = "model", feature = "cache"))]
 pub struct MembersIter<H: AsRef<Http>> {
     guild_id: GuildId,
     http: H,
@@ -812,7 +773,7 @@ pub struct MembersIter<H: AsRef<Http>> {
     tried_fetch: bool,
 }
 
-#[cfg(all(feature = "http", feature = "cache"))]
+#[cfg(all(feature = "model", feature = "cache"))]
 impl<H: AsRef<Http>> MembersIter<H> {
     fn new(guild_id: GuildId, http: H) -> MembersIter<H> {
         MembersIter {
@@ -852,7 +813,7 @@ impl<H: AsRef<Http>> MembersIter<H> {
     }
 }
 
-#[cfg(all(feature = "http", feature = "cache"))]
+#[cfg(all(feature = "model", feature = "cache"))]
 impl<H: AsRef<Http>> Iterator for MembersIter<H> {
     type Item = Result<Member>;
 
@@ -876,5 +837,5 @@ impl<H: AsRef<Http>> Iterator for MembersIter<H> {
     }
 }
 
-#[cfg(all(feature = "http", feature = "cache"))]
+#[cfg(all(feature = "model", feature = "cache"))]
 impl<H: AsRef<Http>> std::iter::FusedIterator for MembersIter<H> {}

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -9,8 +9,6 @@ mod role;
 mod audit_log;
 mod premium_tier;
 
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
 pub use self::emoji::*;
 pub use self::guild_id::*;
 pub use self::integration::*;
@@ -41,8 +39,8 @@ use crate::constants::LARGE_THRESHOLD;
 use log::{error, warn};
 #[cfg(feature = "model")]
 use std::borrow::Cow;
-#[cfg(feature = "http")]
-use crate::http::Http;
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
 
 /// A representation of a banning of a user.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize)]
@@ -187,7 +185,6 @@ impl Guild {
     /// Returns the "default" channel of the guild for the passed user id.
     /// (This returns the first channel that can be read by the user, if there isn't one,
     /// returns `None`)
-    #[cfg(feature = "http")]
     pub fn default_channel(&self, uid: UserId) -> Option<Arc<RwLock<GuildChannel>>> {
         for (cid, channel) in &self.channels {
             if self.user_permissions_in(*cid, uid).read_messages() {
@@ -271,7 +268,6 @@ impl Guild {
     /// [`Guild::ban`]: ../guild/struct.Guild.html#method.ban
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "client")]
     #[inline]
     pub fn ban(&self, cache_http: impl CacheHttp, user: impl Into<UserId>, dmd: u8) -> Result<()> {
         self._ban_with_reason(cache_http, user.into(), dmd, "")
@@ -281,7 +277,6 @@ impl Guild {
     ///
     /// [`User`]: ../user/struct.User.html
     /// [`ban`]: #method.ban
-    #[cfg(feature = "client")]
     #[inline]
     pub fn ban_with_reason(&self, cache_http: impl CacheHttp,
                                   user: impl Into<UserId>,
@@ -290,7 +285,6 @@ impl Guild {
         self._ban_with_reason(cache_http, user.into(), dmd, reason.as_ref())
     }
 
-    #[cfg(feature = "client")]
     fn _ban_with_reason(&self, cache_http: impl CacheHttp, user: UserId, dmd: u8, reason: &str) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -320,7 +314,6 @@ impl Guild {
     /// [`Ban`]: struct.Ban.html
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "http")]
     pub fn bans(&self, cache_http: impl CacheHttp) -> Result<Vec<Ban>> {
         #[cfg(feature = "cache")]
         {
@@ -339,7 +332,6 @@ impl Guild {
     /// Retrieves a list of [`AuditLogs`] for the guild.
     ///
     /// [`AuditLogs`]: audit_log/struct.AuditLogs.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn audit_logs(&self, http: impl AsRef<Http>,
                              action_type: Option<u8>,
@@ -352,7 +344,6 @@ impl Guild {
     /// Gets all of the guild's channels over the REST API.
     ///
     /// [`Guild`]: struct.Guild.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn channels(&self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> { self.id.channels(&http) }
 
@@ -381,7 +372,6 @@ impl Guild {
     /// [`Shard`]: ../../gateway/struct.Shard.html
     /// [US West region]: enum.Region.html#variant.UsWest
     /// [whitelist]: https://discordapp.com/developers/docs/resources/guild#create-guild
-    #[cfg(feature = "http")]
     pub fn create(http: impl AsRef<Http>, name: &str, region: Region, icon: Option<&str>) -> Result<PartialGuild> {
         let map = json!({
             "icon": icon,
@@ -414,7 +404,6 @@ impl Guild {
     /// [`Channel`]: ../channel/enum.Channel.html
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "client")]
     pub fn create_channel(&self, cache_http: impl CacheHttp, f: impl FnOnce(&mut CreateChannel) -> &mut CreateChannel) -> Result<GuildChannel> {
         #[cfg(feature = "cache")]
         {
@@ -449,7 +438,6 @@ impl Guild {
     /// [`EditProfile::avatar`]: ../../builder/struct.EditProfile.html#method.avatar
     /// [`utils::read_image`]: ../../utils/fn.read_image.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_emoji(&self, http: impl AsRef<Http>, name: &str, image: &str) -> Result<Emoji> {
         self.id.create_emoji(&http, name, image)
@@ -460,7 +448,6 @@ impl Guild {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_integration<I>(&self, http: impl AsRef<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
@@ -489,7 +476,6 @@ impl Guild {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "client")]
     pub fn create_role<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Role>
         where F: FnOnce(&mut EditRole) -> &mut EditRole {
         #[cfg(feature = "cache")]
@@ -517,7 +503,6 @@ impl Guild {
     /// if the current user is not the guild owner.
     ///
     /// [`ModelError::InvalidUser`]: ../error/enum.Error.html#variant.InvalidUser
-    #[cfg(feature = "http")]
     pub fn delete(&self, cache_http: impl CacheHttp) -> Result<PartialGuild> {
         #[cfg(feature = "cache")]
         {
@@ -540,7 +525,6 @@ impl Guild {
     ///
     /// [`Emoji`]: struct.Emoji.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E) -> Result<()> {
         self.id.delete_emoji(&http, emoji_id)
@@ -551,7 +535,6 @@ impl Guild {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_integration<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self.id.delete_integration(&http, integration_id)
@@ -567,7 +550,6 @@ impl Guild {
     /// [`Role`]: struct.Role.html
     /// [`Role::delete`]: struct.Role.html#method.delete
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_role<R: Into<RoleId>>(&self, http: impl AsRef<Http>, role_id: R) -> Result<()> {
         self.id.delete_role(&http, role_id)
@@ -601,7 +583,6 @@ impl Guild {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "client")]
     pub fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
         where F: FnOnce(&mut EditGuild) -> &mut EditGuild {
         #[cfg(feature = "cache")]
@@ -647,7 +628,6 @@ impl Guild {
     /// [`Emoji`]: struct.Emoji.html
     /// [`Emoji::edit`]: struct.Emoji.html#method.edit
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
         self.id.edit_emoji(&http, emoji_id, name)
@@ -666,7 +646,6 @@ impl Guild {
     /// ```rust,ignore
     /// guild.edit_member(user_id, |m| m.mute(true).roles(&vec![role_id]));
     /// ```
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_member<F, U>(&self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(&mut EditMember) -> &mut EditMember, U: Into<UserId> {
@@ -687,7 +666,6 @@ impl Guild {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
-    #[cfg(feature = "client")]
     pub fn edit_nickname(&self, cache_http: impl CacheHttp, new_nickname: Option<&str>) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -716,7 +694,6 @@ impl Guild {
     /// ```
     ///
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_role<F, R>(&self, http: impl AsRef<Http>, role_id: R, f: F) -> Result<Role>
         where F: FnOnce(&mut EditRole) -> &mut EditRole, R: Into<RoleId> {
@@ -737,7 +714,6 @@ impl Guild {
     ///
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_role_position<R>(&self, http: impl AsRef<Http>, role_id: R, position: u64) -> Result<Vec<Role>>
         where R: Into<RoleId> {
@@ -747,7 +723,6 @@ impl Guild {
     /// Gets a partial amount of guild data by its Id.
     ///
     /// Requires that the current user be in the guild.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn get<G: Into<GuildId>>(http: impl AsRef<Http>, guild_id: G) -> Result<PartialGuild> { guild_id.into().to_partial_guild(&http) }
 
@@ -834,7 +809,6 @@ impl Guild {
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> { self.id.integrations(&http) }
 
@@ -849,7 +823,6 @@ impl Guild {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     pub fn invites(&self, cache_http: impl CacheHttp) -> Result<Vec<RichInvite>> {
         #[cfg(feature = "cache")]
         {
@@ -876,13 +849,11 @@ impl Guild {
     ///
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
         self.id.kick(&http, user_id)
     }
 
-    #[cfg(feature = "http")]
     #[inline]
     pub fn kick_with_reason<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> {
         self.id.kick_with_reason(&http, user_id, reason)
@@ -897,7 +868,6 @@ impl Guild {
     /// [`Guild`]: ../guild/struct.Guild.html
     /// [`Member`]: struct.Member.html
     #[inline]
-    #[cfg(feature = "client")]
     pub fn member<U: Into<UserId>>(&self, cache_http: impl CacheHttp, user_id: U) -> Result<Member> {
         self.id.member(cache_http, user_id)
     }
@@ -909,7 +879,6 @@ impl Guild {
     /// [`User`]'s Id.
     ///
     /// [`User`]: ../user/struct.User.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn members<U>(&self, http: impl AsRef<Http>, limit: Option<u64>, after: U) -> Result<Vec<Member>>
         where U: Into<Option<UserId>> {
@@ -1283,7 +1252,6 @@ impl Guild {
     /// Requires the [Move Members] permission.
     ///
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn move_member<C, U>(&self, http: impl AsRef<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
@@ -1496,7 +1464,6 @@ impl Guild {
     /// [`GuildPrune`]: struct.GuildPrune.html
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
-    #[cfg(feature = "client")]
     pub fn prune_count(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
@@ -1540,7 +1507,7 @@ impl Guild {
     /// Although not required, you should specify all channels' positions,
     /// regardless of whether they were updated. Otherwise, positioning can
     /// sometimes get weird.
-    #[cfg(feature = "http")]
+    #[inline]
     pub fn reorder_channels<It>(&self, http: impl AsRef<Http>, channels: It) -> Result<()>
         where It: IntoIterator<Item = (ChannelId, u64)> {
         self.id.reorder_channels(&http, channels)
@@ -1596,7 +1563,6 @@ impl Guild {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self.id.start_integration_sync(&http, integration_id)
@@ -1617,7 +1583,6 @@ impl Guild {
     /// [`GuildPrune`]: struct.GuildPrune.html
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
-    #[cfg(feature = "client")]
     pub fn start_prune(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
@@ -1645,7 +1610,6 @@ impl Guild {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "client")]
     pub fn unban<U: Into<UserId>>(&self, cache_http: impl CacheHttp, user_id: U) -> Result<()> {
         #[cfg(feature = "cache")]
         {
@@ -1666,7 +1630,6 @@ impl Guild {
     /// **Note**: Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
         self.id.vanity_url(&http)
@@ -1677,7 +1640,6 @@ impl Guild {
     /// **Note**: Requires the [Manage Webhooks] permission.
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,14 +1,12 @@
 use serde::de::Error as DeError;
 
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-use crate::{model::prelude::*};
+use crate::model::prelude::*;
 use super::super::utils::{deserialize_emojis, deserialize_roles};
 
 #[cfg(feature = "model")]
 use crate::builder::{CreateChannel, EditGuild, EditMember, EditRole};
-#[cfg(feature = "http")]
-use crate::http::Http;
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
 #[cfg(all(feature = "cache", feature = "utils", feature = "client"))]
 use crate::cache::CacheRwLock;
 
@@ -74,7 +72,6 @@ impl PartialGuild {
     /// [`ModelError::DeleteMessageDaysAmount`]: ../error/enum.Error.html#variant.DeleteMessageDaysAmount
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn ban(&self, http: impl AsRef<Http>, user: impl Into<UserId>, dmd: u8) -> Result<()> {
         self.ban_with_reason(&http, user, dmd, "")
@@ -84,7 +81,6 @@ impl PartialGuild {
     ///
     /// [`User`]: ../user/struct.User.html
     /// [`ban`]: #method.ban
-    #[cfg(feature = "http")]
     #[inline]
     pub fn ban_with_reason(&self, http: impl AsRef<Http>,
                                   user: impl Into<UserId>,
@@ -98,14 +94,12 @@ impl PartialGuild {
     /// Requires the [Ban Members] permission.
     ///
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn bans(&self, http: impl AsRef<Http>) -> Result<Vec<Ban>> { self.id.bans(&http) }
 
     /// Gets all of the guild's channels over the REST API.
     ///
     /// [`Guild`]: struct.Guild.html
-    #[cfg(feature = "http")]
     #[inline]
     pub fn channels(&self, http: impl AsRef<Http>) -> Result<HashMap<ChannelId, GuildChannel>> { self.id.channels(&http) }
 
@@ -128,7 +122,6 @@ impl PartialGuild {
     /// [`GuildChannel`]: ../channel/struct.GuildChannel.html
     /// [`http::create_channel`]: ../../http/fn.create_channel.html
     /// [Manage Channels]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_CHANNELS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_channel(&self, http: impl AsRef<Http>, f: impl FnOnce(&mut CreateChannel) -> &mut CreateChannel) -> Result<GuildChannel> {
         self.id.create_channel(&http, f)
@@ -151,7 +144,6 @@ impl PartialGuild {
     /// [`Guild::create_emoji`]: struct.Guild.html#method.create_emoji
     /// [`utils::read_image`]: ../../utils/fn.read_image.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_emoji(&self, http: impl AsRef<Http>, name: &str, image: &str) -> Result<Emoji> {
         self.id.create_emoji(&http, name, image)
@@ -162,7 +154,6 @@ impl PartialGuild {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_integration<I>(&self, http: impl AsRef<Http>, integration_id: I, kind: &str) -> Result<()>
         where I: Into<IntegrationId> {
@@ -183,7 +174,6 @@ impl PartialGuild {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [`Guild::create_role`]: struct.Guild.html#method.create_role
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
-    #[cfg(feature = "http")]
     #[inline]
     pub fn create_role<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Role>
     where F: FnOnce(&mut EditRole) -> &mut EditRole {
@@ -194,7 +184,6 @@ impl PartialGuild {
     /// guild.
     ///
     /// **Note**: Requires the current user to be the owner of the guild.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete(&self, http: impl AsRef<Http>) -> Result<PartialGuild> { self.id.delete(&http) }
 
@@ -204,7 +193,6 @@ impl PartialGuild {
     ///
     /// [`Emoji`]: struct.Emoji.html
     /// [Manage Emojis]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn delete_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E) -> Result<()> {
         self.id.delete_emoji(&http, emoji_id)
@@ -241,7 +229,6 @@ impl PartialGuild {
     /// permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     pub fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<()>
         where F: FnOnce(&mut EditGuild) -> &mut EditGuild {
         match self.id.edit(&http, f) {
@@ -277,7 +264,6 @@ impl PartialGuild {
     /// [`Emoji::edit`]: struct.Emoji.html#method.edit
     /// [Manage Emojis]:
     /// ../permissions/struct.Permissions.html#associatedconstant.MANAGE_EMOJIS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_emoji<E: Into<EmojiId>>(&self, http: impl AsRef<Http>, emoji_id: E, name: &str) -> Result<Emoji> {
         self.id.edit_emoji(&http, emoji_id, name)
@@ -298,7 +284,6 @@ impl PartialGuild {
     ///
     /// GuildId(7).edit_member(user_id, |m| m.mute(true).roles(&vec![role_id]));
     /// ```
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_member<F, U>(&self, http: impl AsRef<Http>, user_id: U, f: F) -> Result<()>
         where F: FnOnce(&mut EditMember) -> &mut EditMember, U: Into<UserId> {
@@ -319,7 +304,6 @@ impl PartialGuild {
     ///
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Change Nickname]: ../permissions/struct.Permissions.html#associatedconstant.CHANGE_NICKNAME
-    #[cfg(feature = "http")]
     #[inline]
     pub fn edit_nickname(&self, http: impl AsRef<Http>, new_nickname: Option<&str>) -> Result<()> {
         self.id.edit_nickname(&http, new_nickname)
@@ -328,7 +312,6 @@ impl PartialGuild {
     /// Gets a partial amount of guild data by its Id.
     ///
     /// Requires that the current user be in the guild.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn get<G: Into<GuildId>>(http: impl AsRef<Http>, guild_id: G) -> Result<PartialGuild> {
         guild_id.into().to_partial_guild(&http)
@@ -340,13 +323,11 @@ impl PartialGuild {
     ///
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn kick<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> {
         self.id.kick(&http, user_id)
     }
 
-    #[cfg(feature = "http")]
     #[inline]
     pub fn kick_with_reason<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U, reason: &str) -> Result<()> {
         self.id.kick_with_reason(&http, user_id, reason)
@@ -362,7 +343,6 @@ impl PartialGuild {
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> { self.id.integrations(&http) }
 
@@ -371,12 +351,10 @@ impl PartialGuild {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> { self.id.invites(&http) }
 
     /// Leaves the guild.
-    #[cfg(feature = "http")]
     #[inline]
     pub fn leave(&self, http: impl AsRef<Http>) -> Result<()> { self.id.leave(&http) }
 
@@ -384,7 +362,7 @@ impl PartialGuild {
     ///
     /// [`Guild`]: struct.Guild.html
     /// [`Member`]: struct.Member.html
-    #[cfg(feature = "client")]
+    #[inline]
     pub fn member<U: Into<UserId>>(&self, cache_http: impl CacheHttp, user_id: U) -> Result<Member> {
         self.id.member(cache_http, user_id)
     }
@@ -396,7 +374,7 @@ impl PartialGuild {
     /// [`User`]'s Id.
     ///
     /// [`User`]: ../user/struct.User.html
-    #[cfg(feature = "http")]
+    #[inline]
     pub fn members<U>(&self, http: impl AsRef<Http>, limit: Option<u64>, after: U) -> Result<Vec<Member>>
         where U: Into<Option<UserId>> {
         self.id.members(&http, limit, after)
@@ -408,7 +386,6 @@ impl PartialGuild {
     ///
     /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
     #[inline]
-    #[cfg(feature = "http")]
     pub fn move_member<C, U>(&self, http: impl AsRef<Http>, user_id: U, channel_id: C) -> Result<()>
         where C: Into<ChannelId>, U: Into<UserId> {
         self.id.move_member(&http, user_id, channel_id)
@@ -422,7 +399,6 @@ impl PartialGuild {
     /// [`Member`]: struct.Member.html
     /// [Kick Members]: ../permissions/struct.Permissions.html#associatedconstant.KICK_MEMBERS
     #[inline]
-    #[cfg(feature = "http")]
     pub fn prune_count(&self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> { self.id.prune_count(&http, days) }
 
     /// Returns the Id of the shard associated with the guild.
@@ -435,7 +411,7 @@ impl PartialGuild {
     /// total, consider using [`utils::shard_id`].
     ///
     /// [`utils::shard_id`]: ../../utils/fn.shard_id.html
-    #[cfg(all(feature = "cache", feature = "utils", feature = "client"))]
+    #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
     pub fn shard_id(&self, cache: impl AsRef<CacheRwLock>) -> u64 { self.id.shard_id(cache) }
 
@@ -464,6 +440,7 @@ impl PartialGuild {
     pub fn shard_id(&self, shard_count: u64) -> u64 { self.id.shard_id(shard_count) }
 
     /// Returns the formatted URL of the guild's splash image, if one exists.
+    #[inline]
     pub fn splash_url(&self) -> Option<String> {
         self.icon
             .as_ref()
@@ -475,7 +452,6 @@ impl PartialGuild {
     /// Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn start_integration_sync<I: Into<IntegrationId>>(&self, http: impl AsRef<Http>, integration_id: I) -> Result<()> {
         self.id.start_integration_sync(&http, integration_id)
@@ -487,7 +463,6 @@ impl PartialGuild {
     ///
     /// [`User`]: ../user/struct.User.html
     /// [Ban Members]: ../permissions/struct.Permissions.html#associatedconstant.BAN_MEMBERS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn unban<U: Into<UserId>>(&self, http: impl AsRef<Http>, user_id: U) -> Result<()> { self.id.unban(&http, user_id) }
 
@@ -496,7 +471,6 @@ impl PartialGuild {
     /// **Note**: Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
-    #[cfg(feature = "http")]
     #[inline]
     pub fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
         self.id.vanity_url(&http)
@@ -507,7 +481,6 @@ impl PartialGuild {
     /// **Note**: Requires the [Manage Webhooks] permission.
     ///
     /// [Manage Webhooks]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_WEBHOOKS
-    #[cfg(feature = "http")]
     #[inline]
     pub fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> { self.id.webhooks(&http) }
 
@@ -549,6 +522,7 @@ impl PartialGuild {
     /// ```
     ///
     /// [`Role`]: ../guild/struct.Role.html
+    #[inline]
     pub fn role_by_name(&self, role_name: &str) -> Option<&Role> {
         self.roles.values().find(|role| role_name == role.name)
     }

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -1,8 +1,9 @@
 //! Models for server and channel invites.
 
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use std::ops::Deref;
+
 use chrono::{DateTime, FixedOffset};
+
 use super::prelude::*;
 
 #[cfg(feature = "model")]
@@ -13,11 +14,10 @@ use crate::internal::prelude::*;
 use super::{Permissions, utils as model_utils};
 #[cfg(feature = "model")]
 use crate::utils;
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::CacheRwLock;
-#[cfg(feature = "http")]
-use crate::http::Http;
-use std::ops::Deref;
+#[cfg(feature = "model")]
+use crate::http::{Http, CacheHttp};
 
 /// Information about an invite code.
 ///
@@ -83,13 +83,12 @@ impl Invite {
     /// [`GuildChannel`]: ../channel/struct.GuildChannel.html
     /// [Create Invite]: ../permissions/struct.Permissions.html#associatedconstant.CREATE_INVITE
     /// [permission]: ../permissions/index.html
-    #[cfg(feature = "client")]
+    #[inline]
     pub fn create<C, F>(cache_http: impl CacheHttp, channel_id: C, f: F) -> Result<RichInvite>
         where C: Into<ChannelId>, F: FnOnce(CreateInvite) -> CreateInvite {
         Self::_create(cache_http, channel_id.into(), f)
     }
 
-    #[cfg(feature = "client")]
     fn _create<F>(cache_http: impl CacheHttp, channel_id: ChannelId, f: F) -> Result<RichInvite>
         where F: FnOnce(CreateInvite) -> CreateInvite {
         #[cfg(feature = "cache")]
@@ -120,7 +119,6 @@ impl Invite {
     /// [`ModelError::InvalidPermissions`]: ../error/enum.Error.html#variant.InvalidPermissions
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
     /// [permission]: ../permissions/index.html
-    #[cfg(feature = "http")]
     pub fn delete(&self, cache_http: impl CacheHttp) -> Result<Invite> {
         #[cfg(feature = "cache")]
         {
@@ -138,7 +136,6 @@ impl Invite {
     }
 
     /// Gets the information about an invite.
-    #[cfg(feature = "http")]
     pub fn get(http: impl AsRef<Http>, code: &str, stats: bool) -> Result<Invite> {
         let mut invite = code;
 
@@ -346,7 +343,6 @@ impl RichInvite {
     /// [`http::delete_invite`]: ../../http/fn.delete_invite.html
     /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD.html
     /// [permission]: ../permissions/index.html
-    #[cfg(feature = "http")]
     pub fn delete(&self, cache_http: impl CacheHttp) -> Result<Invite> {
         #[cfg(feature = "cache")]
         {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -19,7 +19,7 @@ use std::mem;
 use super::channel::Message;
 #[cfg(feature = "model")]
 use crate::utils;
-#[cfg(feature = "http")]
+#[cfg(feature = "model")]
 use crate::http::Http;
 
 /// A representation of a webhook, which is a low-effort way to post messages to

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,13 +26,11 @@ use crate::model::{
     id::EmojiId,
 };
 #[cfg(feature = "cache")]
-use crate::model::{
-    id::{
-        ChannelId,
-        GuildId,
-        RoleId,
-        UserId,
-    },
+use crate::model::id::{
+    ChannelId,
+    GuildId,
+    RoleId,
+    UserId,
 };
 use std::{
     collections::HashMap,


### PR DESCRIPTION
Many feature gates in the model module are unnecessary, as they're already implied by the `model` feature (it depends on the `http` and `builder` features). Some were entirely redundant. I've removed some of the feature gates for the http module as well. In what world is the `http` feature not enabled in the http module?

I've fixed some of the function declarations. I also noticed that a few methods on `Role` no longer need to depend on the `cache` feature due to the addition of `Role::guild_id`. They've been fixed too, and a method that was used to find the `GuildId` the role belonged to has been deprecated.

This depends on #852 to be merged first.