### PR TITLE
Remove usages of `std::mem::replace` where its return value is unused

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -372,14 +372,9 @@ impl GuildChannel {
         f(&mut edit_channel);
         let edited = serenity_utils::hashmap_to_json_map(edit_channel.0);
 
-        match cache_http.http().edit_channel(self.id.0, &edited) {
-            Ok(channel) => {
-                std::mem::replace(self, channel);
+        *self = cache_http.http().edit_channel(self.id.0, &edited)?;
 
-                Ok(())
-            },
-            Err(why) => Err(why),
-        }
+        Ok(())
     }
 
     /// Edits a [`Message`] in the channel given its Id.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -27,7 +27,6 @@ use serde::{
 use super::utils::U64Visitor;
 #[cfg(feature = "model")]
 use std::{
-    mem,
     result::Result as StdResult,
 };
 #[cfg(feature = "model")]
@@ -280,14 +279,9 @@ impl Message {
 
         let map = serenity_utils::hashmap_to_json_map(builder.0);
 
-        match cache_http.http().edit_message(self.channel_id.0, self.id.0, &Value::Object(map)) {
-            Ok(edited) => {
-                mem::replace(self, edited);
+        *self = cache_http.http().edit_message(self.channel_id.0, self.id.0, &Value::Object(map))?;
 
-                Ok(())
-            },
-            Err(why) => Err(why),
-        }
+        Ok(())
     }
 
     pub(crate) fn transform_content(&mut self) {
@@ -580,14 +574,9 @@ impl Message {
 
         let map = serenity_utils::hashmap_to_json_map(suppress.0);
 
-        match cache_http.http().edit_message(self.channel_id.0, self.id.0, &Value::Object(map))
-        {
-            Ok(edited) => {
-                mem::replace(self, edited);
-                Ok(())
-            }
-            Err(why) => Err(why),
-        }
+        *self = cache_http.http().edit_message(self.channel_id.0, self.id.0, &Value::Object(map))?;
+
+        Ok(())
     }
 
     /// Checks whether the message mentions passed [`UserId`].

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -11,8 +11,6 @@ use serde_json::json;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
 #[cfg(all(feature = "cache", feature = "model"))]
-use std::mem;
-#[cfg(all(feature = "cache", feature = "model"))]
 use super::super::ModelError;
 #[cfg(all(feature = "cache", feature = "model"))]
 use super::super::id::GuildId;
@@ -119,14 +117,9 @@ impl Emoji {
                     "name": name,
                 });
 
-                match cache_http.http().edit_emoji(guild_id.0, self.id.0, &map) {
-                    Ok(emoji) => {
-                        mem::replace(self, emoji);
+                *self = cache_http.http().edit_emoji(guild_id.0, self.id.0, &map)?;
 
-                        Ok(())
-                    },
-                    Err(why) => Err(why),
-                }
+                Ok(())
             },
             None => Err(Error::Model(ModelError::ItemMissing)),
         }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -141,14 +141,9 @@ impl Webhook {
             map.insert("name".to_string(), Value::String(name.to_string()));
         }
 
-        match http.as_ref().edit_webhook_with_token(self.id.0, &self.token, &map) {
-            Ok(replacement) => {
-                mem::replace(self, replacement);
+        *self = http.as_ref().edit_webhook_with_token(self.id.0, &self.token, &map)?;
 
-                Ok(())
-            },
-            Err(why) => Err(why),
-        }
+        Ok(())
     }
 
     /// Executes a webhook with the fields set via the given builder.


### PR DESCRIPTION
Without caring for the return value it's the same as using the assign operator.