### PR TITLE
Add GuildId::disconnect_member

### DIFF
--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -77,4 +77,15 @@ impl EditMember {
         let num = Value::Number(Number::from(channel_id.0));
         self.0.insert("channel_id", num);
     }
+
+    /// Disconnects the user from their voice channel if any
+    ///
+    /// Requires the [Move Members] permission.
+    ///
+    /// [Move Members]: ../model/permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
+    pub fn disconnect_member(&mut self) -> &mut Self {
+        self.0.insert("channel_id", Value::Null);
+
+        self
+    }
 }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -595,6 +595,32 @@ impl GuildId {
         http.as_ref().edit_member(self.0, user_id.0, &map)
     }
 
+    /// Disconnects a member from a voice channel in a guild.
+    ///
+    /// Requires the [Move Members] permission.
+    ///
+    /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
+    #[cfg(feature = "http")]
+    #[inline]
+    pub fn disconnect_member<U>(self, http: impl AsRef<Http>, user_id: U) -> Result<()>
+        where U: Into<UserId> {
+        self._disconnect_member(&http, user_id.into())
+    }
+
+    #[cfg(feature = "http")]
+    fn _disconnect_member(
+        self,
+        http: impl AsRef<Http>,
+        user_id: UserId,
+    ) -> Result<()> {
+        let mut map = Map::new();
+        map.insert(
+            "channel_id".to_string(),
+            Value::Null
+        );
+        http.as_ref().edit_member(self.0, user_id.0, &map)
+    }
+
     /// Gets the number of [`Member`]s that would be pruned with the given
     /// number of days.
     ///

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
-use crate::{model::prelude::*};
+use crate::model::prelude::*;
 use chrono::{DateTime, FixedOffset};
 use std::fmt::{
     Display,
@@ -375,6 +375,35 @@ impl Member {
         }
 
         self.guild_id.kick_with_reason(cache_http.http(), self.user.read().id, reason)
+    }
+
+    /// Moves the member to a voice channel.
+    ///
+    /// Requires the [Move Members] permission.
+    ///
+    /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
+    pub fn move_to_voice_channel<C, H>(&self, http: H, c: C) -> Result<()>
+    where
+        C: Into<ChannelId>,
+        H: AsRef<Http>,
+    {
+        self._move_to_voice_channel(http, c.into())
+    }
+
+    fn _move_to_voice_channel<H>(&self, http: H, c: ChannelId) -> Result<()>
+    where
+        H: AsRef<Http>
+    {
+        self.guild_id.move_member(http, self.user.read().id, c)
+    }
+
+    /// Disconnects the member their voice channel if any.
+    ///
+    /// Requires the [Move Members] permission.
+    ///
+    /// [Move Members]: ../permissions/struct.Permissions.html#associatedconstant.MOVE_MEMBERS
+    pub fn disconnect_from_voice(&self, http: impl AsRef<Http>) -> Result<()> {
+        self.guild_id.disconnect_member(http, self.user.read().id)
     }
 
 


### PR DESCRIPTION
Adds the ability to disconnect a member from a voice channel in the guild.

This implementation was based on [this discussion](https://discordapp.com/channels/381880193251409931/381912587505500160/707567000460853339) in the serenity discord.

This was thrown together without much thought so feedback is welcome