### PR TITLE
Remove the `matches` developmental dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,9 +99,6 @@ version = "0.18"
 version = "0.2"
 package = "http"
 
-[dev-dependencies.matches]
-version = "0.1"
-
 [features]
 default = [
     "builder",


### PR DESCRIPTION
This removes the `matches` dependency that had been previously used in tests for `Args`. [These tests were later removed][tests], thus this dependency no longer has a purpose in the library.

Furthermore, a [`matches!`][matches] macro was added into the standard library in Rust 1.42. This macro achieves the same goal as the dependency, minus the `assert_matches!` macro. If the need arises again, we can just use the macro from the standard library.

[tests]: https://github.com/serenity-rs/serenity/commit/c472ddd8aad713c0a378af3d7740c799f36d95ab#diff-afe9a5d56371cb67f4427d4a16ccf38cL1051
[matches]: https://doc.rust-lang.org/nightly/std/macro.matches.html