### PR TITLE
Fixed unrecognised_command() not working if the last group added has prefixes.

### DIFF
--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -373,8 +373,8 @@ pub fn command(
                 if res.is_ok() {
                     check_discrepancy(ctx, msg, config, &group.options)?;
 
-                    return res;
                     is_prefixless = true;
+                    return res;
                 }
 
                 last = res;

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -343,6 +343,7 @@ pub fn command(
     }
 
     let mut last = Err(ParseError::UnrecognisedCommand(None));
+    let mut is_prefixless = false;
 
     for (group, map) in groups {
         match map {
@@ -354,7 +355,9 @@ pub fn command(
                     return res;
                 }
 
-                last = res;
+                if !is_prefixless {
+                    last = res;
+                }
             }
             Map::Prefixless(subgroups, commands) => {
                 let res = handle_group(stream, ctx, msg, config, subgroups);
@@ -371,6 +374,7 @@ pub fn command(
                     check_discrepancy(ctx, msg, config, &group.options)?;
 
                     return res;
+                    is_prefixless = true;
                 }
 
                 last = res;


### PR DESCRIPTION
```
Fixed unrecognised_command() not triggering when the last group in the standard framework has a prefix.

	modified:   src/framework/standard/parse/mod.rs
```