### PR TITLE
Mention projects that extend the functionality of the library instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Voice + youtube-dl:
 
 # Projects extending Serenity
 
-- [serenity-lavalink][project:serenity-lavalink] - A wrapper around [Lavalink][repo:lavalink], an audio sending node based on [Lavaplayer][repo:lavaplayer]
+- [serenity-lavalink][project:serenity-lavalink] - An interface to [Lavalink][repo:lavalink], an audio sending node based on [Lavaplayer][repo:lavaplayer]
 
 [`Cache`]: https://docs.rs/serenity/*/serenity/cache/struct.Cache.html
 [`Client::new`]: https://docs.rs/serenity/*/serenity/client/struct.Client.html#method.new

--- a/README.md
+++ b/README.md
@@ -192,14 +192,9 @@ Voice + youtube-dl:
 
 - youtube-dl (Arch: `community/youtube-dl`)
 
-# Related Projects
+# Projects extending Serenity
 
-- [Discord.net][library:Discord.net]
-- [JDA][library:JDA]
-- [disco][library:disco]
-- [discordrb][library:discordrb]
-- [discord.js][library:discord.js]
-- [discord.py][library:discord.py]
+- [serenity-lavalink][project:serenity-lavalink]
 
 [`Cache`]: https://docs.rs/serenity/*/serenity/cache/struct.Cache.html
 [`Client::new`]: https://docs.rs/serenity/*/serenity/client/struct.Client.html#method.new
@@ -224,12 +219,7 @@ Voice + youtube-dl:
 [gateway docs]: https://docs.rs/serenity/*/serenity/gateway/index.html
 [guild]: https://discord.gg/WBdGJCc
 [guild-badge]: https://img.shields.io/discord/381880193251409931.svg?style=flat-square&colorB=7289DA
-[library:Discord.net]: https://github.com/discord-net/Discord.Net
-[library:JDA]: https://github.com/DV8FromTheWorld/JDA
-[library:disco]: https://github.com/b1naryth1ef/disco
-[library:discordrb]: https://github.com/meew0/discordrb
-[library:discord.js]: https://github.com/discordjs/discord.js
-[library:discord.py]: https://github.com/Rapptz/discord.py
+[project:serenity-lavalink]: https://gitlab.com/nitsuga5124/serenity-lavalink/
 [logo]: https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png
 [rust 1.39.0+ badge]: https://img.shields.io/badge/rust-1.39.0+-93450a.svg?style=flat-square
 [rust 1.39.0+ link]: https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Voice + youtube-dl:
 
 # Projects extending Serenity
 
-- [serenity-lavalink][project:serenity-lavalink]
+- [serenity-lavalink][project:serenity-lavalink] - A wrapper around [Lavalink][repo:lavalink], an audio sending node based on [Lavaplayer][repo:lavaplayer]
 
 [`Cache`]: https://docs.rs/serenity/*/serenity/cache/struct.Cache.html
 [`Client::new`]: https://docs.rs/serenity/*/serenity/client/struct.Client.html#method.new
@@ -220,6 +220,8 @@ Voice + youtube-dl:
 [guild]: https://discord.gg/WBdGJCc
 [guild-badge]: https://img.shields.io/discord/381880193251409931.svg?style=flat-square&colorB=7289DA
 [project:serenity-lavalink]: https://gitlab.com/nitsuga5124/serenity-lavalink/
+[repo:lavalink]: https://github.com/Frederikam/Lavalink
+[repo:lavaplayer]: https://github.com/sedmelluq/lavaplayer
 [logo]: https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png
 [rust 1.39.0+ badge]: https://img.shields.io/badge/rust-1.39.0+-93450a.svg?style=flat-square
 [rust 1.39.0+ link]: https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Voice + youtube-dl:
 
 # Projects extending Serenity
 
-- [serenity-lavalink][project:serenity-lavalink] - An interface to [Lavalink][repo:lavalink], an audio sending node based on [Lavaplayer][repo:lavaplayer]
+- [serenity-lavalink][project:serenity-lavalink]: An interface to [Lavalink][repo:lavalink], an audio sending node based on [Lavaplayer][repo:lavaplayer]
 
 [`Cache`]: https://docs.rs/serenity/*/serenity/cache/struct.Cache.html
 [`Client::new`]: https://docs.rs/serenity/*/serenity/client/struct.Client.html#method.new


### PR DESCRIPTION
The only relation we have with the "related projects" is that they also wrap the Discord API in their target languages. This section really only serves one purpose: to acknowledge the existence of these wrappers for other languages. Sure, we raise awareness of them but it doesn't help the consumers of Serenity. Hence, we have decided to replace with another section that might be of use to them.

For now, we're only mentioning the `serenity-lavalink` project, which may be particularly useful to users playing audio/music with Serenity.