### PR TITLE
Replace `CommandError` with an alias to `Box<dyn Error>`

### DIFF
--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashSet,
     fmt,
+    error::Error as StdError,
 };
 use crate::client::Context;
 use crate::model::{
@@ -67,16 +68,7 @@ pub struct CommandOptions {
     pub sub_commands: &'static [&'static Command],
 }
 
-#[derive(Debug, Clone)]
-pub struct CommandError(pub String);
-
-impl<T: fmt::Display> From<T> for CommandError {
-    #[inline]
-    fn from(d: T) -> Self {
-        CommandError(d.to_string())
-    }
-}
-
+pub type CommandError = Box<dyn StdError>;
 pub type CommandResult = ::std::result::Result<(), CommandError>;
 
 pub type CommandFn = fn(&Context, &Message, Args) -> CommandResult;


### PR DESCRIPTION
I propose this change because it removes a small newtype that is outside of the context of the framework useless, and accomplishes the same goal as the newtype. It may break code that relies on the `From<T> where T: Display` property of the from impl, but I doubt anyone actually depends on that, as in practice I see people either using `?` on `Result`s whose error types implement `std::error::Error`, or are manually handling the results with `match`es and `if let`s.

I made this newtype a long time ago to support returning strings as errors from a command, but have recently discovered that there are `From<[string type here]>` impls for `Box<dyn Error>`. For instance, [`From<&str> for Box<dyn Error>`](https://doc.rust-lang.org/nightly/std/boxed/struct.Box.html#impl-From%3C%26%27_%20str%3E-2).