### PR TITLE
Get guilds limit optional

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1175,7 +1175,7 @@ impl Http {
     ///
     /// let guild_id = GuildId(81384788765712384);
     ///
-    /// let guilds = http.as_ref().get_guilds(&GuildPagination::After(guild_id), 10).unwrap();
+    /// let guilds = http.as_ref().get_guilds(&GuildPagination::After(guild_id), Some(10)).unwrap();
     /// ```
     ///
     /// [docs]: https://discord.com/developers/docs/resources/user#get-current-user-guilds

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1179,7 +1179,7 @@ impl Http {
     /// ```
     ///
     /// [docs]: https://discord.com/developers/docs/resources/user#get-current-user-guilds
-    pub fn get_guilds(&self, target: &GuildPagination, limit: u64) -> Result<Vec<GuildInfo>> {
+    pub fn get_guilds(&self, target: &GuildPagination, limit: Option<u64>) -> Result<Vec<GuildInfo>> {
         let (after, before) = match *target {
             GuildPagination::After(id) => (Some(id.0), None),
             GuildPagination::Before(id) => (None, Some(id.0)),

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -607,9 +607,13 @@ impl Route {
         target: D,
         after: Option<u64>,
         before: Option<u64>,
-        limit: u64,
+        limit: Option<u64>,
     ) -> String {
-        let mut s = format!(api!("/users/{}/guilds?limit={}&"), target, limit);
+        let mut s = format!(api!("/users/{}/guilds?"), target);
+
+        if let Some(limit) = limit {
+            let _ = write!(s, "&limit={}", limit);
+        }
 
         if let Some(after) = after {
             let _ = write!(s, "&after={}", after);
@@ -854,7 +858,7 @@ pub enum RouteInfo<'a> {
     GetGuilds {
         after: Option<u64>,
         before: Option<u64>,
-        limit: u64,
+        limit: Option<u64>,
     },
     GetInvite {
         code: &'a str,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -166,7 +166,19 @@ impl CurrentUser {
     /// ```
     #[inline]
     pub fn guilds(&self, http: impl AsRef<Http>) -> Result<Vec<GuildInfo>> {
-        http.as_ref().get_guilds(&GuildPagination::After(GuildId(1)), 100)
+        let mut guilds = Vec::new();
+        loop {
+            let mut pagination = http.as_ref().get_guilds(
+                &GuildPagination::After(guilds.last().map_or(GuildId(1), |g: &GuildInfo| g.id)),
+                100,
+            )?;
+            let len = pagination.len();
+            guilds.append(&mut pagination);
+            if len != 100 {
+                break;
+            }
+        }
+        Ok(guilds)
     }
 
     /// Returns the invite url for the bot with the given permissions.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -170,7 +170,7 @@ impl CurrentUser {
         loop {
             let mut pagination = http.as_ref().get_guilds(
                 &GuildPagination::After(guilds.last().map_or(GuildId(1), |g: &GuildInfo| g.id)),
-                100,
+                Some(100),
             )?;
             let len = pagination.len();
             guilds.append(&mut pagination);


### PR DESCRIPTION
Depends on #877 

Reflects the optional nature of the parameter in the discord API: https://discord.com/developers/docs/resources/user#get-current-user-guilds

This is more of an "RFC" than anything. Maybe it would be preferable to have a different API. e.g., Have `get_guilds` and `get_guilds_with_limit` etc...