### PR TITLE
voice: use `xsalsa20poly1305` crate for encryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,12 +68,6 @@ version = "0.7"
 optional = true
 version = "0.16"
 
-[dependencies.sodiumoxide]
-default-features = false
-features = ["std"]
-optional = true
-version = "0.2"
-
 [dependencies.threadpool]
 optional = true
 version = "1"
@@ -98,6 +92,10 @@ version = "0.21"
 [dependencies.webpki-roots]
 optional = true
 version = "0.18"
+
+[dependencies.xsalsa20poly1305]
+optional = true
+version = "0.4.2"
 
 [dev-dependencies.http_crate]
 version = "0.2"
@@ -154,7 +152,7 @@ native_tls_backend = ["reqwest/native-tls", "tungstenite/tls"]
 model = ["builder", "http"]
 standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]
 utils = ["base64"]
-voice = ["byteorder", "gateway", "audiopus", "rand", "sodiumoxide"]
+voice = ["byteorder", "gateway", "audiopus", "rand", "xsalsa20poly1305"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This commit replaces the `sodiumoxide` crate, a wrapper for the libsodium C library, with the pure Rust `xsalsa20poly1305` crate from the RustCrypto project:

https://github.com/RustCrypto/AEADs/tree/master/xsalsa20poly1305

This should reduce compile times as `libsodium` is a somewhat large C library and you are only using one algorithm from it. The `xsalsa20poly1305` crate, on the other hand, is a lightweight pure Rust dependency that implements only the algorithm you are using.

Note that the advertised MSRV of this crate is 1.41+, however earlier today new release of the dependency causing that, `generic-array`, reduced the MSRV to 1.36.0:

https://github.com/fizyk20/generic-array/pull/102

You can read more about RustCrypto and our recent releases in this post:

https://www.reddit.com/r/rust/comments/h0em5n/ann_new_rustcrypto_releases_aead_blockcipher/