### PR TITLE
Use a cargo workspace to compile the examples efficiently

### DIFF
--- a/azure-build-examples.yml
+++ b/azure-build-examples.yml
@@ -90,7 +90,7 @@ jobs:
   - bash: |
       source $HOME/.cargo/env
       cd examples/
-      cargo build -p e11_crate_message_builder
+      cargo build -p e11_create_message_builder
     displayName: 'Build example 11'
 
   - bash: |

--- a/azure-build-examples.yml
+++ b/azure-build-examples.yml
@@ -29,79 +29,79 @@ jobs:
 
   - bash: |
       source $HOME/.cargo/env
-      cd examples/e01_basic_ping_bot
-      CARGO_TARGET_DIR='..' cargo build
+      cd examples/
+      cargo build -p e01_basic_ping_bot
     displayName: 'Build example 1'
 
   - bash: |
       source $HOME/.cargo/env
-      cd examples/e02_transparent_guild_sharding
-      CARGO_TARGET_DIR='..' cargo build
+      cd examples/
+      cargo build -p e02_transparent_guild_sharding
     displayName: 'Build example 2'
 
   - bash: |
       source $HOME/.cargo/env
-      cd examples/e03_struct_utilities
-      CARGO_TARGET_DIR='..' cargo build
+      cd examples/
+      cargo build -p e03_struct_utilities
     displayName: 'Build example 3'
 
   - bash: |
       source $HOME/.cargo/env
-      cd examples/e04_message_builder
-      CARGO_TARGET_DIR='..' cargo build
+      cd examples/
+      cargo build -p e04_message_builder
     displayName: 'Build example 4'
 
   - bash: |
       source $HOME/.cargo/env
-      cd examples/e05_command_framework
-      CARGO_TARGET_DIR='..' cargo build
+      cd examples/
+      cargo build -p e05_command_framework
     displayName: 'Build example 5'
 
   - bash: |
       source $HOME/.cargo/env
-      cd examples/e06_voice
-      CARGO_TARGET_DIR='..' cargo build
+      cd examples/
+      cargo build -p e06_voice
     displayName: 'Build example 6'
 
   - bash: |
       source $HOME/.cargo/env
-      cd examples/e07_sample_bot_structure
-      CARGO_TARGET_DIR='..' cargo build
+      cd examples/
+      cargo build -p e07_sample_bot_structure
     displayName: 'Build example 7'
 
   - bash: |
       source $HOME/.cargo/env
-      CARGO_TARGET_DIR='..' cd examples/e08_env_logging
-      cargo build
+      cd examples/
+      cargo build -p e08_env_logging
     displayName: 'Build example 8'
 
   - bash: |
       source $HOME/.cargo/env
-      CARGO_TARGET_DIR='..' cd examples/e09_shard_manager
-      cargo build
+      cd examples/
+      cargo build -p e09_shard_manager
     displayName: 'Build example 9'
 
   - bash: |
       source $HOME/.cargo/env
-      CARGO_TARGET_DIR='..' cd examples/e10_voice_receive
-      cargo build
+      cd examples/
+      cargo build -p e10_voice_receive
     displayName: 'Build example 10'
 
   - bash: |
       source $HOME/.cargo/env
-      CARGO_TARGET_DIR='..' cd examples/e11_crate_message_builder
-      cargo build
+      cd examples/
+      cargo build -p e11_crate_message_builder
     displayName: 'Build example 11'
 
   - bash: |
       source $HOME/.cargo/env
-      CARGO_TARGET_DIR='..' cd examples/e12_timing_and_events
-      cargo build
+      cd examples/
+      cargo build -p e12_timing_and_events
     displayName: 'Build example 12'
 
   - bash: |
       source $HOME/.cargo/env
-      CARGO_TARGET_DIR='..' cd examples/e13_gateway_intents
-      cargo build
+      cd examples/
+      cargo build -p e13_gateway_intents
     displayName: 'Build example 13'
-    
+

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+members = [
+    "e01_basic_ping_bot",
+    "e02_transparent_guild_sharding",
+    "e03_struct_utilities",
+    "e04_message_builder",
+    "e05_command_framework",
+    "e06_voice",
+    "e07_sample_bot_structure",
+    "e08_env_logging",
+    "e09_shard_manager",
+    "e10_voice_receive",
+    "e11_create_message_builder",
+    "e12_timing_and_events",
+    "e13_gateway_intents",
+]


### PR DESCRIPTION
This changes the examples to compile under a workspace, thereby sharing a singular `Cargo.lock` file and `target/` directory. Prior to this we have been using a hack by abusing the `CARGO_TARGET_DIR` environment variable to reuse the target directory. Though  as I was making this I found out we aren't even using the hack properly after the 7th example!