### PR TITLE
Update dependencies rustls, tungstenite, webpki-roots, parking_lot, and base64 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ version = "0.7"
 
 [dependencies.rustls]
 optional = true
-version = "0.16"
+version = "0.17"
 
 [dependencies.threadpool]
 optional = true
@@ -75,7 +75,7 @@ version = "1"
 [dependencies.tungstenite]
 default-features = false
 optional = true
-version = "0.9"
+version = "0.11"
 
 [dependencies.typemap]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 bitflags = "1"
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.11"
 serde_json = "1"
 
 [dependencies.static_assertions]
@@ -40,7 +40,7 @@ version = "0.6.0"
 
 [dependencies.base64]
 optional = true
-version = "0.11"
+version = "0.12"
 
 [dependencies.byteorder]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ version = "0.21"
 
 [dependencies.webpki-roots]
 optional = true
-version = "0.18"
+version = "0.19"
 
 [dependencies.xsalsa20poly1305]
 optional = true

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -30,9 +30,6 @@ use log::{error, debug, info, trace, warn};
 #[cfg(not(feature = "native_tls_backend"))]
 use crate::internal::ws_impl::create_rustls_client;
 
-#[cfg(feature = "native_tls_backend")]
-use tungstenite::handshake::client::Request;
-
 /// A Shard is a higher-level handler for a websocket connection to Discord's
 /// gateway. The shard allows for sending and receiving messages over the
 /// websocket, such as setting the active activity, reconnecting, syncing
@@ -843,7 +840,7 @@ fn connect(base_url: &str) -> Result<WsClient> {
 #[cfg(feature = "native_tls_backend")]
 fn connect(base_url: &str) -> Result<WsClient> {
     let url = build_gateway_url(base_url)?;
-    let client = tungstenite::connect(Request::from(url))?;
+    let client = tungstenite::connect(url)?;
 
     Ok(client.0)
 }

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -20,6 +20,8 @@ use std::{
     net::TcpStream,
     sync::Arc,
 };
+
+#[cfg(not(feature = "native_tls_backend"))]
 use url::Url;
 
 pub trait ReceiverExt {


### PR DESCRIPTION
## Motivation

Prevents depdenency on two different versions of rustls and http. Previously there were two versions of these crates when compiling this project when compiled/resolved today. Have attached some graphs generated with `cargo deps --all-deps | dot -Tpng > graph.png` before and after this change.

![deps_before](https://user-images.githubusercontent.com/32305209/85925818-f0a06180-b892-11ea-88a9-883f5da539e3.png)

![deps_after](https://user-images.githubusercontent.com/32305209/85925837-0f065d00-b893-11ea-93a3-1f6646fe1db1.png)

cargo build --all-features has 206 compilation units now vs 210 before this change.

## Notes

[`tungstenite::client::connect`](https://docs.rs/tungstenite/0.11.0/tungstenite/client/fn.connect.html) now uses a [`IntoClientRequest`](https://docs.rs/tungstenite/0.11.0/tungstenite/client/trait.IntoClientRequest.html), so the import of `tungstenite::handshake::client::Request` is no longer necessary.

The `url::Url` import in `src/internal/ws_impl.rs` was giving a warning, hence the addition of the extra configuration macro.