### PR TITLE
Add nonce field to guild members chunk

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -495,7 +495,7 @@ fn handle_event(
             let event_handler = Arc::clone(event_handler);
 
             threadpool.execute(move || {
-                event_handler.guild_members_chunk(context, event.guild_id, event.members);
+                event_handler.guild_members_chunk(context, event.guild_id, event.members, event.nonce);
             });
         },
         DispatchEvent::Model(Event::GuildRoleCreate(mut event)) => {

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -154,7 +154,7 @@ pub trait EventHandler: Send + Sync {
     /// Dispatched when the data for offline members was requested.
     ///
     /// Provides the guild's id and the data.
-    fn guild_members_chunk(&self, _ctx: Context, _guild_id: GuildId, _offline_members: HashMap<UserId, Member>) {}
+    fn guild_members_chunk(&self, _ctx: Context, _guild_id: GuildId, _offline_members: HashMap<UserId, Member>, _nonce: Option<String>) {}
 
     /// Dispatched when a role is created.
     ///

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -537,6 +537,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
 pub struct GuildMembersChunkEvent {
     pub guild_id: GuildId,
     pub members: HashMap<UserId, Member>,
+    pub nonce: Option<String>,
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
 }
@@ -592,9 +593,14 @@ impl<'de> Deserialize<'de> for GuildMembersChunkEvent {
                 }))
             .map_err(DeError::custom)?;
 
+        let nonce = map.get("nonce")
+            .and_then(|nonce| nonce.as_str())
+            .map(|nonce| nonce.to_string());
+
         Ok(GuildMembersChunkEvent {
             guild_id,
             members,
+            nonce,
             _nonexhaustive: (),
         })
     }


### PR DESCRIPTION
As per [the docs](https://discord.com/developers/docs/topics/gateway#guild-members-chunk) there is a nonce field in the `GuildMembersChunkEvent` object.

This PR is adding the ability to use it.

Pulled from [terminal-discord/serenity](https://github.com/terminal-discord/serenity), these changes are made to use serenity in [terminal-discord/weechat-discord](https://github.com/terminal-discord/weechat-discord)