### PR TITLE
Fix check behaviour in the help command

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -395,15 +395,17 @@ fn check_command_behaviour(
     let b = check_common_behaviour(&ctx, msg, &options, owners, help_options);
 
     if b == HelpBehaviour::Nothing {
-       for check in options.checks {
-           if !check.check_in_help {
-               break;
-           }
+       if !options.owner_privilege || !owners.contains(&msg.author.id) {
+           for check in options.checks {
+               if !check.check_in_help {
+                   continue;
+               }
 
-           let mut args = Args::new("", &[]);
+               let mut args = Args::new("", &[]);
 
-           if let CheckResult::Failure(_) = (check.function)(ctx, msg, &mut args, options) {
-               return help_options.lacking_conditions;
+               if let CheckResult::Failure(_) = (check.function)(ctx, msg, &mut args, options) {
+                   return help_options.lacking_conditions;
+               }
            }
        }
     }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -897,9 +897,9 @@ pub fn create_customised_help_data<'a>(
     }
 
     let strikethrough_command_tip = if msg.is_private() {
-        &help_options.strikethrough_commands_tip_in_guild
-    } else {
         &help_options.strikethrough_commands_tip_in_dm
+    } else {
+        &help_options.strikethrough_commands_tip_in_guild
     };
 
     let description = if let Some(ref strikethrough_command_text) = strikethrough_command_tip {


### PR DESCRIPTION
Four vaguely related commits in one pull request:

* Fix reversed strikethrough_commands_tip_in_{dm,guild}.
* Respect owner_privilege in help.
* ~Expose CustomisedHelpData fields.~
* ~Allow deletion of help command strikethrough text.~

I think the first three should be mostly uncontroversial, but the last one changes behavior, so maybe it'd need to go into `next`? Let me know if you want me to move commits around.