### PR TITLE
refixed framework::unrecognised_command not working [867]

### DIFF
--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -374,7 +374,6 @@ pub fn command(
                     check_discrepancy(ctx, msg, config, &group.options)?;
 
                     is_prefixless = true;
-                    return res;
                 }
 
                 last = res;


### PR DESCRIPTION
	modified:   src/framework/standard/parse/mod.rs