### PR TITLE
Last fix to unrecognised_command.

### DIFF
--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -360,6 +360,8 @@ pub fn command(
                 }
             }
             Map::Prefixless(subgroups, commands) => {
+                is_prefixless = true;
+
                 let res = handle_group(stream, ctx, msg, config, subgroups);
 
                 if res.is_ok() {
@@ -372,8 +374,8 @@ pub fn command(
 
                 if res.is_ok() {
                     check_discrepancy(ctx, msg, config, &group.options)?;
-
-                    is_prefixless = true;
+                    
+                    return res;
                 }
 
                 last = res;


### PR DESCRIPTION
Turns out the return is necessary, it just needed to be in a different order.
This fixes normal commands not working at all.
upz :P 