### PR TITLE
Fix `.mute(...)` not causing bot to stop frames.

### DIFF
--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -466,7 +466,8 @@ impl Connection {
                 mut sources: &mut Vec<LockedAudio>,
                 mut receiver: &mut Option<Box<dyn AudioReceiver>>,
                 audio_timer: &mut Timer,
-                bitrate: Bitrate)
+                bitrate: Bitrate,
+                muted: bool)
                  -> Result<()> {
         // We need to actually reserve enough space for the desired bitrate.
         let size = match bitrate {
@@ -535,9 +536,13 @@ impl Connection {
 
         // Walk over all the audio files, removing those which have finished.
         // For this purpose, we need a while loop in Rust.
-        let len = self.remove_unfinished_files(&mut sources, &opus_frame, &mut buffer,&mut mix_buffer)?;
+        let mut len = self.remove_unfinished_files(&mut sources, &opus_frame, &mut buffer, &mut mix_buffer)?;
 
         self.soft_clip.apply(&mut mix_buffer[..])?;
+
+        if muted {
+            len = 0;
+        }
 
         if len == 0 {
             if self.silence_frames > 0 {

--- a/src/voice/handler.rs
+++ b/src/voice/handler.rs
@@ -244,6 +244,7 @@ impl Handler {
 
         if self.channel_id.is_some() {
             self.update();
+            self.send(VoiceStatus::Mute(mute));
         }
     }
 

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -40,4 +40,5 @@ pub(crate) enum Status {
     SetSender(Option<LockedAudio>),
     AddSender(LockedAudio),
     SetBitrate(Bitrate),
+    Mute(bool),
 }

--- a/src/voice/threading.rs
+++ b/src/voice/threading.rs
@@ -26,6 +26,7 @@ fn runner(rx: &MpscReceiver<Status>) {
     let mut connection = None;
     let mut timer = Timer::new(20);
     let mut bitrate = audio::DEFAULT_BITRATE;
+    let mut mute = false;
 
     'runner: loop {
         loop {
@@ -59,6 +60,9 @@ fn runner(rx: &MpscReceiver<Status>) {
                 Ok(Status::SetBitrate(b)) => {
                     bitrate = b;
                 },
+                Ok(Status::Mute(m)) => {
+                    mute = m;
+                },
                 Err(TryRecvError::Empty) => {
                     // If we received nothing, then we can perform an update.
                     break;
@@ -79,7 +83,7 @@ fn runner(rx: &MpscReceiver<Status>) {
         // another event.
         let error = match connection.as_mut() {
             Some(connection) => {
-                let cycle = connection.cycle(&mut senders, &mut receiver, &mut timer, bitrate);
+                let cycle = connection.cycle(&mut senders, &mut receiver, &mut timer, bitrate, mute);
 
                 match cycle {
                     Ok(()) => false,


### PR DESCRIPTION
It seems we expected Discord to take responsibility for not forwarding traffic of muted participants... Instead, Discord will keep reflecting RTP traffic over the allocated TURN server. Whoops.

Fixes #917.