### PR TITLE
Add undocumented Watching activity type

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -208,6 +208,54 @@ impl Activity {
             _nonexhaustive: (),
         }
     }
+
+    /// Creates a `Game` struct that appears as a `Watching <name>` status.
+    ///
+    /// **Note**: Maximum `name` length is 128.
+    ///
+    /// **Caution**: This activity type is not documented by Discord.
+    ///
+    /// # Examples
+    ///
+    /// Create a command that sets the current watching status:
+    ///
+    /// ```rust,no_run
+    /// use serenity::model::gateway::Activity;
+    /// use serenity::model::channel::Message;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
+    /// # #[cfg(feature = "client")]
+    /// use serenity::client::Context;
+    ///
+    /// # #[cfg(feature = "framework")]
+    /// #[command]
+    /// fn watch(ctx: &Context, _msg: &Message, args: Args) -> CommandResult {
+    ///     let name = args.message();
+    ///     ctx.set_activity(Activity::watching(&name));
+    ///
+    ///     Ok(())
+    /// }
+    /// #
+    /// # fn main() {}
+    /// ```
+    pub fn watching(name: &str) -> Activity {
+        Activity {
+            application_id: None,
+            assets: None,
+            details: None,
+            flags: None,
+            instance: None,
+            kind: ActivityType::Watching,
+            name: name.to_string(),
+            party: None,
+            secrets: None,
+            state: None,
+            emoji: None,
+            timestamps: None,
+            url: None,
+            _nonexhaustive: (),
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for Activity {
@@ -362,6 +410,8 @@ pub enum ActivityType {
     Streaming = 1,
     /// An indicator that the user is listening to something.
     Listening = 2,
+    /// An indicator that the user is watching something.
+    Watching = 3,
     /// An indicator that the user uses custum statuses
     Custom = 4,
     #[doc(hidden)]
@@ -373,6 +423,7 @@ enum_number!(
         Playing,
         Streaming,
         Listening,
+        Watching,
         Custom,
     }
 );
@@ -385,6 +436,7 @@ impl ActivityType {
             Playing => 0,
             Streaming => 1,
             Listening => 2,
+            Watching => 3,
             Custom => 4,
             __Nonexhaustive => unreachable!(),
         }


### PR DESCRIPTION
This one isn't [documented by Discord](https://discord.com/developers/docs/topics/gateway#activity-object-activity-types), but I ran into it in [the Discord.js docs](https://discord.js.org/#/docs/main/stable/typedef/ActivityType) while googling (also in [discord.py](https://discordpy.readthedocs.io/en/latest/api.html#discord.ActivityType)) and it seems to work well.