### PR TITLE
Abstract CommandResult type

### DIFF
--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -70,7 +70,7 @@ pub struct CommandOptions {
 }
 
 pub type CommandError = Box<dyn StdError + Send + Sync>;
-pub type CommandResult = std::result::Result<(), CommandError>;
+pub type CommandResult<T = ()> = std::result::Result<T, CommandError>;
 pub type CommandFn = for<'fut> fn(&'fut Context, &'fut Message, Args) -> BoxFuture<'fut, CommandResult>;
 
 pub struct Command {


### PR DESCRIPTION
As discussed in Discord, this allows users to provide an optional type to return on success for CommandResult.