### PR TITLE
Implement AsRef<ShardMessenger> for ShardMessenger

### DIFF
--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -251,3 +251,9 @@ impl ShardMessenger {
         let _ = self.send_to_shard(ShardRunnerMessage::SetReactionFilter(collector));
     }
 }
+
+impl AsRef<ShardMessenger> for ShardMessenger {
+    fn as_ref(&self) -> &ShardMessenger {
+        self
+    }
+}


### PR DESCRIPTION
This implementation is necessary for some use-cases where an argument has the type `&impl AsRef<ShardMessenger>`, e.g. `ChannelId::await_reply`. In this case, without this implementation, it's not possible to pass a `&ShardMessenger`.