### PR TITLE
Implement endpoints for getting emojis of a guild

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1009,6 +1009,24 @@ impl Http {
         }).await
     }
 
+    /// Gets all emojis of a guild.
+    pub async fn get_emojis(&self, guild_id: u64) -> Result<Vec<Emoji>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetEmojis { guild_id },
+        }).await
+    }
+
+    /// Gets information about an emoji in a guild.
+    pub async fn get_emoji(&self, guild_id: u64, emoji_id: u64) -> Result<Emoji> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetEmoji { guild_id, emoji_id },
+        }).await
+    }
+
     /// Gets current gateway.
     pub async fn get_gateway(&self) -> Result<Gateway> {
         self.fire(Request {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -817,6 +817,13 @@ pub enum RouteInfo<'a> {
     },
     GetCurrentApplicationInfo,
     GetCurrentUser,
+    GetEmojis {
+        guild_id: u64,
+    },
+    GetEmoji {
+        guild_id: u64,
+        emoji_id: u64,
+    },
     GetGateway,
     GetGuild {
         guild_id: u64,
@@ -1250,6 +1257,16 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Get,
                 Route::UsersMe,
                 Cow::from(Route::user("@me")),
+            ),
+            RouteInfo::GetEmojis { guild_id } => (
+                LightMethod::Get,
+                Route::GuildsIdEmojis(guild_id),
+                Cow::from(Route::guild_emojis(guild_id)),
+            ),
+            RouteInfo::GetEmoji { guild_id, emoji_id } => (
+                LightMethod::Get,
+                Route::GuildsIdEmojisId(guild_id),
+                Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
             RouteInfo::GetGateway => (
                 LightMethod::Get,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -424,6 +424,22 @@ impl GuildId {
         http.as_ref().get_guild(self.0).await
     }
 
+    /// Gets all [`Emoji`]s of this guild via HTTP.
+    ///
+    /// [`Emoji`]: struct.Emoji.html
+    #[inline]
+    pub async fn emojis(&self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
+        http.as_ref().get_emojis(self.0).await
+    }
+
+    /// Gets an [`Emoji`] of this guild by its ID via HTTP.
+    ///
+    /// [`Emoji`]: struct.Emoji.html
+    #[inline]
+    pub async fn emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
+        http.as_ref().get_emoji(self.0, emoji_id.0).await
+    }
+
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -825,6 +825,22 @@ impl Guild {
             .map(|icon| format!(cdn!("/icons/{}/{}.webp"), self.id, icon))
     }
 
+    /// Gets all [`Emoji`]s of this guild via HTTP.
+    ///
+    /// [`Emoji`]: struct.Emoji.html
+    #[inline]
+    pub async fn emojis(&self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
+        self.id.emojis(http).await
+    }
+
+    /// Gets an [`Emoji`] of this guild by its ID via HTTP.
+    ///
+    /// [`Emoji`]: struct.Emoji.html
+    #[inline]
+    pub async fn emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
+        self.id.emoji(http, emoji_id).await
+    }
+
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -368,6 +368,22 @@ impl PartialGuild {
             .map(|icon| format!(cdn!("/icons/{}/{}.webp"), self.id, icon))
     }
 
+    /// Gets all [`Emoji`]s of this guild via HTTP.
+    ///
+    /// [`Emoji`]: struct.Emoji.html
+    #[inline]
+    pub async fn emojis(&self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
+        self.id.emojis(http).await
+    }
+
+    /// Gets an [`Emoji`] of this guild by its ID via HTTP.
+    ///
+    /// [`Emoji`]: struct.Emoji.html
+    #[inline]
+    pub async fn emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
+        self.id.emoji(http, emoji_id).await
+    }
+
     /// Gets all integration of the guild.
     ///
     /// This performs a request over the REST API.


### PR DESCRIPTION
This adds support for two endpoints, List Guild Emojis and Get Guild Emoji. Methods for both of these are added to the http client and to the guild models.