### PR TITLE
Added cargo-make support for building the examples.

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,285 @@
+[env]
+EXAMPLES_PATH = { value = "./examples", condition = { env_not_set = ["EXAMPLES_PATH"] } }
+
+[tasks.build]
+command = "cargo"
+args = ["build"]
+
+[tasks.build_release]
+extend = "build"
+args = ["build", "--release"]
+
+[tasks.build_example]
+command = "cargo"
+args = ["make", "--cwd", "${EXAMPLES_PATH}/${@}", "examples_build"]
+dependencies = ["build"]
+
+[tasks.build_example_release]
+command = "cargo"
+args = ["make", "--cwd", "${EXAMPLES_PATH}/${@}", "examples_build_release"]
+dependencies = ["build_release"]
+
+[tasks.run]
+command = "cargo"
+args = ["run"]
+
+[tasks.run_release]
+extend = "run"
+args = ["run", "--release"]
+dependencies = ["build"]
+
+[tasks.run_example]
+command = "cargo"
+args = ["make", "--cwd", "${EXAMPLES_PATH}/${@}", "examples_run"]
+dependencies = ["build_release"]
+
+[tasks.run_example_release]
+command = "cargo"
+args = ["make", "--cwd", "${EXAMPLES_PATH}/${@}", "examples_run_release"]
+
+[tasks.1]
+alias = "run_1"
+
+[tasks.run_1]
+command = "cargo"
+args = ["make", "run_example_release", "e01_basic_ping_bot"]
+
+[tasks.build_1]
+command = "cargo"
+args = ["make", "run_example_release", "e01_basic_ping_bot"]
+
+[tasks.dev_run_1]
+command = "cargo"
+args = ["make", "run_example_release", "e01_basic_ping_bot"]
+
+[tasks.dev_build_1]
+command = "cargo"
+args = ["make", "run_example_release", "e01_basic_ping_bot"]
+
+[tasks.2]
+alias = "run_2"
+
+[tasks.run_2]
+command = "cargo"
+args = ["make", "run_example_release", "e02_transparent_guild_sharding"]
+
+[tasks.build_2]
+command = "cargo"
+args = ["make", "run_example_release", "e02_transparent_guild_sharding"]
+
+[tasks.dev_run_2]
+command = "cargo"
+args = ["make", "run_example_release", "e02_transparent_guild_sharding"]
+
+[tasks.dev_build_2]
+command = "cargo"
+args = ["make", "run_example_release", "e02_transparent_guild_sharding"]
+
+[tasks.3]
+alias = "run_3"
+
+[tasks.run_3]
+command = "cargo"
+args = ["make", "run_example_release", "e03_struct_utilities"]
+
+[tasks.build_3]
+command = "cargo"
+args = ["make", "run_example_release", "e03_struct_utilities"]
+
+[tasks.dev_run_3]
+command = "cargo"
+args = ["make", "run_example_release", "e03_struct_utilities"]
+
+[tasks.dev_build_3]
+command = "cargo"
+args = ["make", "run_example_release", "e03_struct_utilities"]
+
+[tasks.4]
+alias = "run_4"
+
+[tasks.run_4]
+command = "cargo"
+args = ["make", "run_example_release", "e04_message_builder"]
+
+[tasks.build_4]
+command = "cargo"
+args = ["make", "run_example_release", "e04_message_builder"]
+
+[tasks.dev_run_4]
+command = "cargo"
+args = ["make", "run_example_release", "e04_message_builder"]
+
+[tasks.dev_build_4]
+command = "cargo"
+args = ["make", "run_example_release", "e04_message_builder"]
+
+[tasks.5]
+alias = "run_5"
+
+[tasks.run_5]
+command = "cargo"
+args = ["make", "run_example_release", "e05_command_framework"]
+
+[tasks.build_5]
+command = "cargo"
+args = ["make", "run_example_release", "e05_command_framework"]
+
+[tasks.dev_run_5]
+command = "cargo"
+args = ["make", "run_example_release", "e05_command_framework"]
+
+[tasks.dev_build_5]
+command = "cargo"
+args = ["make", "run_example_release", "e05_command_framework"]
+
+[tasks.6]
+alias = "run_6"
+
+[tasks.run_6]
+command = "cargo"
+args = ["make", "run_example_release", "e06_voice"]
+
+[tasks.build_6]
+command = "cargo"
+args = ["make", "run_example_release", "e06_voice"]
+
+[tasks.dev_run_6]
+command = "cargo"
+args = ["make", "run_example_release", "e06_voice"]
+
+[tasks.dev_build_6]
+command = "cargo"
+args = ["make", "run_example_release", "e06_voice"]
+
+[tasks.7]
+alias = "run_7"
+
+[tasks.run_7]
+command = "cargo"
+args = ["make", "run_example_release", "e07_sample_bot_structure"]
+
+[tasks.build_7]
+command = "cargo"
+args = ["make", "run_example_release", "e07_sample_bot_structure"]
+
+[tasks.dev_run_7]
+command = "cargo"
+args = ["make", "run_example_release", "e07_sample_bot_structure"]
+
+[tasks.dev_build_7]
+command = "cargo"
+args = ["make", "run_example_release", "e07_sample_bot_structure"]
+
+[tasks.8]
+alias = "run_8"
+
+[tasks.run_8]
+command = "cargo"
+args = ["make", "run_example_release", "e08_env_logging"]
+
+[tasks.build_8]
+command = "cargo"
+args = ["make", "run_example_release", "e08_env_logging"]
+
+[tasks.dev_run_8]
+command = "cargo"
+args = ["make", "run_example_release", "e08_env_logging"]
+
+[tasks.dev_build_8]
+command = "cargo"
+args = ["make", "run_example_release", "e08_env_logging"]
+
+[tasks.9]
+alias = "run_9"
+
+[tasks.run_9]
+command = "cargo"
+args = ["make", "run_example_release", "e09_shard_manager"]
+
+[tasks.build_9]
+command = "cargo"
+args = ["make", "run_example_release", "e09_shard_manager"]
+
+[tasks.dev_run_9]
+command = "cargo"
+args = ["make", "run_example_release", "e09_shard_manager"]
+
+[tasks.dev_build_9]
+command = "cargo"
+args = ["make", "run_example_release", "e09_shard_manager"]
+
+[tasks.10]
+alias = "run_10"
+
+[tasks.run_10]
+command = "cargo"
+args = ["make", "run_example_release", "e10_voice_receive"]
+
+[tasks.build_10]
+command = "cargo"
+args = ["make", "run_example_release", "e10_voice_receive"]
+
+[tasks.dev_run_10]
+command = "cargo"
+args = ["make", "run_example_release", "e10_voice_receive"]
+
+[tasks.dev_build_10]
+command = "cargo"
+args = ["make", "run_example_release", "e10_voice_receive"]
+
+[tasks.11]
+alias = "run_11"
+
+[tasks.run_11]
+command = "cargo"
+args = ["make", "run_example_release", "e11_create_message_builder"]
+
+[tasks.build_11]
+command = "cargo"
+args = ["make", "run_example_release", "e11_create_message_builder"]
+
+[tasks.dev_run_11]
+command = "cargo"
+args = ["make", "run_example_release", "e11_create_message_builder"]
+
+[tasks.dev_build_11]
+command = "cargo"
+args = ["make", "run_example_release", "e11_create_message_builder"]
+
+[tasks.12]
+alias = "run_12"
+
+[tasks.run_12]
+command = "cargo"
+args = ["make", "run_example_release", "e12_collectors"]
+
+[tasks.build_12]
+command = "cargo"
+args = ["make", "run_example_release", "e12_collectors"]
+
+[tasks.dev_run_12]
+command = "cargo"
+args = ["make", "run_example_release", "e12_collectors"]
+
+[tasks.dev_build_12]
+command = "cargo"
+args = ["make", "run_example_release", "e12_collectors"]
+
+[tasks.13]
+alias = "run_13"
+
+[tasks.run_13]
+command = "cargo"
+args = ["make", "run_example_release", "e13_gateway_intents"]
+
+[tasks.build_13]
+command = "cargo"
+args = ["make", "run_example_release", "e13_gateway_intents"]
+
+[tasks.dev_run_13]
+command = "cargo"
+args = ["make", "run_example_release", "e13_gateway_intents"]
+
+[tasks.dev_build_13]
+command = "cargo"
+args = ["make", "run_example_release", "e13_gateway_intents"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -46,15 +46,15 @@ args = ["make", "run_example_release", "e01_basic_ping_bot"]
 
 [tasks.build_1]
 command = "cargo"
-args = ["make", "run_example_release", "e01_basic_ping_bot"]
+args = ["make", "build_example_release", "e01_basic_ping_bot"]
 
 [tasks.dev_run_1]
 command = "cargo"
-args = ["make", "run_example_release", "e01_basic_ping_bot"]
+args = ["make", "run_example", "e01_basic_ping_bot"]
 
 [tasks.dev_build_1]
 command = "cargo"
-args = ["make", "run_example_release", "e01_basic_ping_bot"]
+args = ["make", "build_example", "e01_basic_ping_bot"]
 
 [tasks.2]
 alias = "run_2"
@@ -65,15 +65,15 @@ args = ["make", "run_example_release", "e02_transparent_guild_sharding"]
 
 [tasks.build_2]
 command = "cargo"
-args = ["make", "run_example_release", "e02_transparent_guild_sharding"]
+args = ["make", "build_example_release", "e02_transparent_guild_sharding"]
 
 [tasks.dev_run_2]
 command = "cargo"
-args = ["make", "run_example_release", "e02_transparent_guild_sharding"]
+args = ["make", "run_example", "e02_transparent_guild_sharding"]
 
 [tasks.dev_build_2]
 command = "cargo"
-args = ["make", "run_example_release", "e02_transparent_guild_sharding"]
+args = ["make", "build_example", "e02_transparent_guild_sharding"]
 
 [tasks.3]
 alias = "run_3"
@@ -84,15 +84,15 @@ args = ["make", "run_example_release", "e03_struct_utilities"]
 
 [tasks.build_3]
 command = "cargo"
-args = ["make", "run_example_release", "e03_struct_utilities"]
+args = ["make", "build_example_release", "e03_struct_utilities"]
 
 [tasks.dev_run_3]
 command = "cargo"
-args = ["make", "run_example_release", "e03_struct_utilities"]
+args = ["make", "run_example", "e03_struct_utilities"]
 
 [tasks.dev_build_3]
 command = "cargo"
-args = ["make", "run_example_release", "e03_struct_utilities"]
+args = ["make", "build_example", "e03_struct_utilities"]
 
 [tasks.4]
 alias = "run_4"
@@ -103,15 +103,15 @@ args = ["make", "run_example_release", "e04_message_builder"]
 
 [tasks.build_4]
 command = "cargo"
-args = ["make", "run_example_release", "e04_message_builder"]
+args = ["make", "build_example_release", "e04_message_builder"]
 
 [tasks.dev_run_4]
 command = "cargo"
-args = ["make", "run_example_release", "e04_message_builder"]
+args = ["make", "run_example", "e04_message_builder"]
 
 [tasks.dev_build_4]
 command = "cargo"
-args = ["make", "run_example_release", "e04_message_builder"]
+args = ["make", "build_example", "e04_message_builder"]
 
 [tasks.5]
 alias = "run_5"
@@ -122,15 +122,15 @@ args = ["make", "run_example_release", "e05_command_framework"]
 
 [tasks.build_5]
 command = "cargo"
-args = ["make", "run_example_release", "e05_command_framework"]
+args = ["make", "build_example_release", "e05_command_framework"]
 
 [tasks.dev_run_5]
 command = "cargo"
-args = ["make", "run_example_release", "e05_command_framework"]
+args = ["make", "run_example", "e05_command_framework"]
 
 [tasks.dev_build_5]
 command = "cargo"
-args = ["make", "run_example_release", "e05_command_framework"]
+args = ["make", "build_example", "e05_command_framework"]
 
 [tasks.6]
 alias = "run_6"
@@ -141,15 +141,15 @@ args = ["make", "run_example_release", "e06_voice"]
 
 [tasks.build_6]
 command = "cargo"
-args = ["make", "run_example_release", "e06_voice"]
+args = ["make", "build_example_release", "e06_voice"]
 
 [tasks.dev_run_6]
 command = "cargo"
-args = ["make", "run_example_release", "e06_voice"]
+args = ["make", "run_example", "e06_voice"]
 
 [tasks.dev_build_6]
 command = "cargo"
-args = ["make", "run_example_release", "e06_voice"]
+args = ["make", "build_example", "e06_voice"]
 
 [tasks.7]
 alias = "run_7"
@@ -160,15 +160,15 @@ args = ["make", "run_example_release", "e07_sample_bot_structure"]
 
 [tasks.build_7]
 command = "cargo"
-args = ["make", "run_example_release", "e07_sample_bot_structure"]
+args = ["make", "build_example_release", "e07_sample_bot_structure"]
 
 [tasks.dev_run_7]
 command = "cargo"
-args = ["make", "run_example_release", "e07_sample_bot_structure"]
+args = ["make", "run_example", "e07_sample_bot_structure"]
 
 [tasks.dev_build_7]
 command = "cargo"
-args = ["make", "run_example_release", "e07_sample_bot_structure"]
+args = ["make", "build_example", "e07_sample_bot_structure"]
 
 [tasks.8]
 alias = "run_8"
@@ -179,15 +179,15 @@ args = ["make", "run_example_release", "e08_env_logging"]
 
 [tasks.build_8]
 command = "cargo"
-args = ["make", "run_example_release", "e08_env_logging"]
+args = ["make", "build_example_release", "e08_env_logging"]
 
 [tasks.dev_run_8]
 command = "cargo"
-args = ["make", "run_example_release", "e08_env_logging"]
+args = ["make", "run_example", "e08_env_logging"]
 
 [tasks.dev_build_8]
 command = "cargo"
-args = ["make", "run_example_release", "e08_env_logging"]
+args = ["make", "build_example", "e08_env_logging"]
 
 [tasks.9]
 alias = "run_9"
@@ -198,15 +198,15 @@ args = ["make", "run_example_release", "e09_shard_manager"]
 
 [tasks.build_9]
 command = "cargo"
-args = ["make", "run_example_release", "e09_shard_manager"]
+args = ["make", "build_example_release", "e09_shard_manager"]
 
 [tasks.dev_run_9]
 command = "cargo"
-args = ["make", "run_example_release", "e09_shard_manager"]
+args = ["make", "run_example", "e09_shard_manager"]
 
 [tasks.dev_build_9]
 command = "cargo"
-args = ["make", "run_example_release", "e09_shard_manager"]
+args = ["make", "build_example", "e09_shard_manager"]
 
 [tasks.10]
 alias = "run_10"
@@ -217,15 +217,15 @@ args = ["make", "run_example_release", "e10_voice_receive"]
 
 [tasks.build_10]
 command = "cargo"
-args = ["make", "run_example_release", "e10_voice_receive"]
+args = ["make", "build_example_release", "e10_voice_receive"]
 
 [tasks.dev_run_10]
 command = "cargo"
-args = ["make", "run_example_release", "e10_voice_receive"]
+args = ["make", "run_example", "e10_voice_receive"]
 
 [tasks.dev_build_10]
 command = "cargo"
-args = ["make", "run_example_release", "e10_voice_receive"]
+args = ["make", "build_example", "e10_voice_receive"]
 
 [tasks.11]
 alias = "run_11"
@@ -236,15 +236,15 @@ args = ["make", "run_example_release", "e11_create_message_builder"]
 
 [tasks.build_11]
 command = "cargo"
-args = ["make", "run_example_release", "e11_create_message_builder"]
+args = ["make", "build_example_release", "e11_create_message_builder"]
 
 [tasks.dev_run_11]
 command = "cargo"
-args = ["make", "run_example_release", "e11_create_message_builder"]
+args = ["make", "run_example", "e11_create_message_builder"]
 
 [tasks.dev_build_11]
 command = "cargo"
-args = ["make", "run_example_release", "e11_create_message_builder"]
+args = ["make", "build_example", "e11_create_message_builder"]
 
 [tasks.12]
 alias = "run_12"
@@ -255,15 +255,15 @@ args = ["make", "run_example_release", "e12_collectors"]
 
 [tasks.build_12]
 command = "cargo"
-args = ["make", "run_example_release", "e12_collectors"]
+args = ["make", "build_example_release", "e12_collectors"]
 
 [tasks.dev_run_12]
 command = "cargo"
-args = ["make", "run_example_release", "e12_collectors"]
+args = ["make", "run_example", "e12_collectors"]
 
 [tasks.dev_build_12]
 command = "cargo"
-args = ["make", "run_example_release", "e12_collectors"]
+args = ["make", "build_example", "e12_collectors"]
 
 [tasks.13]
 alias = "run_13"
@@ -274,12 +274,12 @@ args = ["make", "run_example_release", "e13_gateway_intents"]
 
 [tasks.build_13]
 command = "cargo"
-args = ["make", "run_example_release", "e13_gateway_intents"]
+args = ["make", "build_example_release", "e13_gateway_intents"]
 
 [tasks.dev_run_13]
 command = "cargo"
-args = ["make", "run_example_release", "e13_gateway_intents"]
+args = ["make", "run_example", "e13_gateway_intents"]
 
 [tasks.dev_build_13]
 command = "cargo"
-args = ["make", "run_example_release", "e13_gateway_intents"]
+args = ["make", "build_example", "e13_gateway_intents"]

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-serenity = "0.9.0-rc.0"
+serenity = "0.9.0-rc.1"
 ```
 
 Serenity supports a minimum of Rust 1.39.
@@ -115,7 +115,7 @@ Cargo.toml:
 [dependencies.serenity]
 default-features = false
 features = ["pick", "your", "feature", "names", "here"]
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 ```
 
 The default features are: `builder`, `cache`, `client`, `framework`, `gateway`,
@@ -175,7 +175,7 @@ features = [
     "utils",
     "rustls_backend",
 ]
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 ```
 
 # Dependencies

--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -1,0 +1,24 @@
+extend = "../Makefile.toml"
+
+[env]
+EXAMPLES_PATH = "../../examples"
+
+[tasks.build_example]
+command = "cargo"
+args = ["make", "--cwd", "./${@}", "examples_build"]
+dependencies = ["build"]
+
+[tasks.build_example_release]
+command = "cargo"
+args = ["make", "--cwd", "./${@}", "examples_build_release"]
+dependencies = ["build_release"]
+
+[tasks.run_example]
+command = "cargo"
+args = ["make", "--cwd", "./${@}", "examples_run"]
+dependencies = ["build"]
+
+[tasks.run_example_release]
+command = "cargo"
+args = ["make", "--cwd", "./${@}", "examples_run_release"]
+dependencies = ["build_release"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ WARNING: This *may* not work, PR #806 is aiming to fix this.
 - CD into the example of choice: `cd e01_basic_ping_bot`
 - Run the example: `cargo run --release`
 
-3: Copy Paste:
+3. Copy Paste:
 - Copy the contents of the example into your local binary project\
 (created via `cargo new test-project --bin`)\
 and ensuring that the contents of the `Cargo.toml` file contains that

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ documentation.
 
 To provide a token for them to use, you need to set the `DISCORD_TOKEN`
 environmental variable to the Bot token.\
+If you don't like environment tokens, you can hardcode your token in instead.\
 TIP: A valid token starts with M, N or O and has 2 dots.
 
 ### Running Examples
@@ -47,12 +48,9 @@ To run an example, you have various options:
 3. Copy Paste:
 - Copy the contents of the example into your local binary project\
 (created via `cargo new test-project --bin`)\
-and ensuring that the contents of the `Cargo.toml` file contains that
-of the example's `[dependencies]` section, and _then_ executing `cargo run`.
-
-Note that all examples - by default - require an environment token of
-`DISCORD_TOKEN` to be set. If you don't like environment tokens, you can
-hardcode your token in.
+and ensuring that the contents of the `Cargo.toml` file
+contains that of the example's `[dependencies]` section,\
+and _then_ executing `cargo run`.
 
 ### Questions
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ concepts. Examples should be completed in order, so as not to miss any
 documentation.
 
 To provide a token for them to use, you need to set the `DISCORD_TOKEN`
-environmental variable to the Bot token.
+environmental variable to the Bot token.\
 TIP: A valid token starts with M, N or O and has 2 dots.
 
 ### Running Examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ To run an example, you have various options:
  3 => Structure Utilities: Simple usage of the utils feature flag.
  4 => Message Builder: A demonstration of the message builder utility, to generate messages safely.
  5 => Command Framework: The main example, where it's demonstrated how to use serenity's command framework,
- along with mosts of it's utilities.
+      along with mosts of it's utilities.
       This example also shows how to share data between events and commands with `Context.data`
  6 => Voice: Simple example on playing back audio with serenity along with FFMPEG and Youtube-DL.
  7 => Simple Bot Stucture: An example showing the recommended file structure.

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,16 +7,47 @@ All examples have documentation for new concepts, and try to explain any new
 concepts. Examples should be completed in order, so as not to miss any
 documentation.
 
+To provide a token for them to use, you need to set the `DISCORD_TOKEN`
+environmental variable to the Bot token.
+TIP: A valid token starts with M, N or O and has 2 dots.
+
 ### Running Examples
 
-To run an example, you have the option of either:
+To run an example, you have various options:
 
-1. cloning this repository, `cd`ing into the example's directory, and then
-running `cargo run` to run the example; or
-2. copying the contents of the example into your local binary project
-(created via `cargo new test-project --bin`) and ensuring that the contents of
-the `Cargo.toml` file contains that of the example's `[dependencies]` section,
-and _then_ executing `cargo run`.
+1. [cargo-make](https://lib.rs/crates/cargo-make)
+- Clone the repository: `git clone https://github.com/serenity-rs/serenity.git`
+- CD into the serenity folder: `cd serenity`
+- Run `cargo make 1`, where 1 is the number of the example you wish to run; these are:
+```
+ 1 => Basing Ping Bot: A bare minimum serenity application.
+ 2 => Transparent Guild Sharding: How to use sharding and shared cache.
+ 3 => Structure Utilities: Simple usage of the utils feature flag.
+ 4 => Message Builder: A demonstration of the message builder utility, to generate messages safely.
+ 5 => Command Framework: The main example, where it's demonstrated how to use serenity's command framework, along with mosts of it's utilities.
+      This example also shows how to share data between events and commands with `Context.data`
+ 6 => Voice: Simple example on playing back audio with serenity along with FFMPEG and Youtube-DL.
+ 7 => Simple Bot Stucture: An example showing the recommended file structure.
+ 8 => Env Logging: How to use the log crate along with serenity.
+ 9 => Shard Manager: How to get started with using the shard manager.
+10 => Voice Recieve: How to recieve voice audio packets.
+WARNING: This *may* not work, PR #806 is aiming to fix this.
+11 => Create Message Builder: How to send embeds and files.
+12 => Collectors: How to use the collectors feature to wait for messages and reactions.
+13 => Gateway Intents: How to use intents to limit the events the bot will recieve.
+```
+
+2. Manualy running:
+- Clone the repository: `git clone https://github.com/serenity-rs/serenity.git`
+- CD into the examples folder: `cd serenity/examples`
+- CD into the example of choice: `cd e01_basic_ping_bot`
+- Run the example: `cargo run --release`
+
+3: Copy Paste:
+- Copy the contents of the example into your local binary project\
+(created via `cargo new test-project --bin`)\
+and ensuring that the contents of the `Cargo.toml` file contains that
+of the example's `[dependencies]` section, and _then_ executing `cargo run`.
 
 Note that all examples - by default - require an environment token of
 `DISCORD_TOKEN` to be set. If you don't like environment tokens, you can
@@ -29,4 +60,7 @@ clarified.
 
 ### Contributing
 
-If you add a new example also add it to the file `azure-build-examples.yml`.
+If you add a new example also add it to the following files:
+- `azure-build-examples.yml`
+- `Makefile.toml`
+- `examples/README.md`

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,14 +24,15 @@ To run an example, you have various options:
  2 => Transparent Guild Sharding: How to use sharding and shared cache.
  3 => Structure Utilities: Simple usage of the utils feature flag.
  4 => Message Builder: A demonstration of the message builder utility, to generate messages safely.
- 5 => Command Framework: The main example, where it's demonstrated how to use serenity's command framework, along with mosts of it's utilities.
+ 5 => Command Framework: The main example, where it's demonstrated how to use serenity's command framework,
+ along with mosts of it's utilities.
       This example also shows how to share data between events and commands with `Context.data`
  6 => Voice: Simple example on playing back audio with serenity along with FFMPEG and Youtube-DL.
  7 => Simple Bot Stucture: An example showing the recommended file structure.
  8 => Env Logging: How to use the log crate along with serenity.
  9 => Shard Manager: How to get started with using the shard manager.
 10 => Voice Recieve: How to recieve voice audio packets.
-WARNING: This *may* not work, PR #806 is aiming to fix this.
+      WARNING: This example *may* not work, PR #806 is aiming to fix this.
 11 => Create Message Builder: How to send embeds and files.
 12 => Collectors: How to use the collectors feature to wait for messages and reactions.
 13 => Gateway Intents: How to use intents to limit the events the bot will recieve.

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,15 +21,15 @@ To run an example, you have various options:
 - CD into the serenity folder: `cd serenity`
 - Run `cargo make 1`, where 1 is the number of the example you wish to run; these are:
 ```
- 1 => Basing Ping Bot: A bare minimum serenity application.
+ 1 => Basic Ping Bot: A bare minimum serenity application.
  2 => Transparent Guild Sharding: How to use sharding and shared cache.
- 3 => Structure Utilities: Simple usage of the utils feature flag.
+ 3 => Structure Utilities: Simple usage of the utils feature.
  4 => Message Builder: A demonstration of the message builder utility, to generate messages safely.
  5 => Command Framework: The main example, where it's demonstrated how to use serenity's command framework,
       along with mosts of it's utilities.
-      This example also shows how to share data between events and commands with `Context.data`
- 6 => Voice: Simple example on playing back audio with serenity along with FFMPEG and Youtube-DL.
- 7 => Simple Bot Stucture: An example showing the recommended file structure.
+      This example also shows how to share data between events and commands, using `Context.data`
+ 6 => Voice: Simple example on playing back audio with serenity, along with FFMPEG and Youtube-DL.
+ 7 => Simple Bot Stucture: An example showing the recommended file structure to use.
  8 => Env Logging: How to use the log crate along with serenity.
  9 => Shard Manager: How to get started with using the shard manager.
 10 => Voice Recieve: How to recieve voice audio packets.

--- a/examples/e01_basic_ping_bot/Makefile.toml
+++ b/examples/e01_basic_ping_bot/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e02_transparent_guild_sharding/Makefile.toml
+++ b/examples/e02_transparent_guild_sharding/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e03_struct_utilities/Makefile.toml
+++ b/examples/e03_struct_utilities/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e04_message_builder/Makefile.toml
+++ b/examples/e04_message_builder/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e05_command_framework/Makefile.toml
+++ b/examples/e05_command_framework/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e06_voice/Makefile.toml
+++ b/examples/e06_voice/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e07_sample_bot_structure/Makefile.toml
+++ b/examples/e07_sample_bot_structure/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e08_env_logging/Makefile.toml
+++ b/examples/e08_env_logging/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e09_shard_manager/Makefile.toml
+++ b/examples/e09_shard_manager/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e10_voice_receive/Makefile.toml
+++ b/examples/e10_voice_receive/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e11_create_message_builder/Makefile.toml
+++ b/examples/e11_create_message_builder/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e12_collectors/Makefile.toml
+++ b/examples/e12_collectors/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e13_gateway_intents/Makefile.toml
+++ b/examples/e13_gateway_intents/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serenity = "0.9.0-rc.0"
+//! serenity = "0.9.0-rc.1"
 //! ```
 //!
 //! [`Cache`]: cache/struct.Cache.html


### PR DESCRIPTION
Additionally, information about what each example does was added.
	
	new file:   Makefile.toml
	modified:   README.md
	new file:   examples/Makefile.toml
	modified:   examples/README.md
	new file:   examples/e01_basic_ping_bot/Makefile.toml
	new file:   examples/e02_transparent_guild_sharding/Makefile.toml
	new file:   examples/e03_struct_utilities/Makefile.toml
	new file:   examples/e04_message_builder/Makefile.toml
	new file:   examples/e05_command_framework/Makefile.toml
	new file:   examples/e06_voice/Makefile.toml
	new file:   examples/e07_sample_bot_structure/Makefile.toml
	new file:   examples/e08_env_logging/Makefile.toml
	new file:   examples/e09_shard_manager/Makefile.toml
	new file:   examples/e10_voice_receive/Makefile.toml
	new file:   examples/e11_create_message_builder/Makefile.toml
	new file:   examples/e12_collectors/Makefile.toml
	new file:   examples/e13_gateway_intents/Makefile.toml