### PR TITLE
Fix ReactionType::Unicode() to only accept valid emojis as types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bitflags = "1"
 log = "0.4"
 serde_json = "1"
 async-trait = "0.1"
+unic-emoji-char = "0.9.0"
 
 [dependencies.static_assertions]
 optional = true


### PR DESCRIPTION
Previously, to parse String into ReactionType, as long as the string wasn't empty and didn't start with '<', it was assumed to be valid ReactionType::Unicode emoji

Please note that I'm relatively new to Rust, so possible that I did it completely wrong. Feedback would be greatly appreciated.

I didn't want to break the API, but from my knowledge it's not possible to keep it as it was. Would love to be proved wrong.

TODO:
- Fix tests
- Add tests
- Check formatting
- Rebase onto `next` branch?