### PR TITLE
Use #[non_exhaustive] where applicable

### DIFF
--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -127,7 +127,6 @@ impl CreateChannel {
             let (id, kind) = match perm.kind {
                 PermissionOverwriteType::Member(id) => (id.0, "member"),
                 PermissionOverwriteType::Role(id) => (id.0, "role"),
-                PermissionOverwriteType::__Nonexhaustive => unreachable!(),
             };
 
             json!({

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -101,6 +101,7 @@ impl<F: FromStr> FromStrAndCache for F {
 /// [`Shard`]: ../gateway/struct.Shard.html
 /// [`http`]: ../http/index.html
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Cache {
     /// A map of channels in [`Guild`]s that the current user has received data
     /// for.
@@ -182,7 +183,6 @@ pub struct Cache {
     pub(crate) message_queue: RwLock<HashMap<ChannelId, VecDeque<MessageId>>>,
     /// The settings for the cache.
     settings: RwLock<Settings>,
-    __nonexhaustive: (),
 }
 
 impl Cache {
@@ -969,7 +969,6 @@ impl Default for Cache {
             user: RwLock::new(CurrentUser::default()),
             users: RwLock::new(HashMap::default()),
             message_queue: RwLock::new(HashMap::default()),
-            __nonexhaustive: (),
         }
     }
 }

--- a/src/cache/settings.rs
+++ b/src/cache/settings.rs
@@ -11,19 +11,18 @@
 /// settings.max_messages(10);
 /// ```
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Settings {
     /// The maximum number of messages to store in a channel's message cache.
     ///
     /// Defaults to 0.
     pub max_messages: usize,
-    __nonexhaustive: (),
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Settings {
             max_messages: usize::default(),
-            __nonexhaustive: (),
         }
     }
 }

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -242,10 +242,8 @@ impl ShardRunner {
         match *action {
             ShardAction::Reconnect(ReconnectType::Reidentify) => self.request_restart().await,
             ShardAction::Reconnect(ReconnectType::Resume) => self.shard.resume().await,
-            ShardAction::Reconnect(ReconnectType::__Nonexhaustive) => unreachable!(),
             ShardAction::Heartbeat => self.shard.heartbeat().await,
             ShardAction::Identify => self.shard.identify().await,
-            ShardAction::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -427,7 +425,6 @@ impl ShardRunner {
                 // Value must be forwarded over the websocket
                 self.shard.client.send_json(&value).await.is_ok()
             },
-            InterMessage::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -545,7 +542,6 @@ impl ShardRunner {
                             return Ok((None, None, false));
                         }
                     },
-                    ReconnectType::__Nonexhaustive => unreachable!(),
                 }
 
                 return Ok((None, None, true));

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -65,11 +65,10 @@ fn context(
 
 // Once we can use `Box` as part of a pattern, we will reconsider boxing.
 #[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
 pub(crate) enum DispatchEvent {
     Client(ClientEvent),
     Model(Event),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl DispatchEvent {
@@ -138,8 +137,6 @@ impl DispatchEvent {
             Self::Model(Event::VoiceStateUpdate(ref mut event)) => {
                 update(cache_and_http, event).await;
             },
-            Self::Model(Event::__Nonexhaustive) => unreachable!(),
-            Self::__Nonexhaustive => unreachable!(),
             _ => (),
         }
     }
@@ -361,7 +358,6 @@ async fn handle_event(
                         event_handler.category_create(context, &channel).await;
                     });
                 },
-                Channel::__Nonexhaustive => unreachable!(),
             }
         },
         DispatchEvent::Model(Event::ChannelDelete(mut event)) => {
@@ -383,7 +379,6 @@ async fn handle_event(
                         event_handler.category_delete(context, &channel).await;
                     });
                 },
-                Channel::__Nonexhaustive => unreachable!(),
             }
         },
         DispatchEvent::Model(Event::ChannelPinsUpdate(event)) => {
@@ -745,7 +740,5 @@ async fn handle_event(
                 event_handler.webhook_update(context, event.guild_id, event.channel_id).await;
             });
         },
-        DispatchEvent::Model(Event::__Nonexhaustive) => unreachable!(),
-        DispatchEvent::__Nonexhaustive => unreachable!(),
     }
 }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -18,6 +18,7 @@ use std::{
 /// [`GuildId::ban`]: ../model/id/struct.GuildId.html#method.ban
 #[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// When the token provided is invalid. This is returned when validating a
     /// token through the [`validate_token`] function.
@@ -30,8 +31,6 @@ pub enum Error {
     /// When all shards that the client is responsible for have shutdown with an
     /// error.
     Shutdown,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Display for Error {
@@ -40,7 +39,6 @@ impl Display for Error {
             Error::InvalidToken => f.write_str("The provided token was invalid"),
             Error::ShardBootFailure => f.write_str("Failed to (re-)boot a shard"),
             Error::Shutdown => f.write_str("The clients shards shutdown"),
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -51,7 +49,6 @@ impl StdError for Error {
             Error::InvalidToken => "The provided token was invalid",
             Error::ShardBootFailure => "Failed to (re-)boot a shard",
             Error::Shutdown => "The clients shards shutdown",
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -302,7 +302,6 @@ impl<'a> Future for ClientBuilder<'a> {
                 #[cfg(feature = "cache")]
                 update_cache_timeout: self.timeout.take(),
                 http: Arc::clone(&http),
-                __nonexhaustive: (),
             });
 
             self.fut = Some(Box::pin(async move {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -65,6 +65,7 @@ pub static JOIN_MESSAGES: &[&str] = &[
 
 /// Enum to map gateway opcodes.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum OpCode {
     /// Dispatches an event.
     Event = 0,
@@ -90,8 +91,6 @@ pub enum OpCode {
     Hello = 10,
     /// Sent immediately following a client heartbeat that was received.
     HeartbeatAck = 11,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -126,13 +125,13 @@ impl OpCode {
             OpCode::InvalidSession => 9,
             OpCode::Hello => 10,
             OpCode::HeartbeatAck => 11,
-            OpCode::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 /// Enum to map voice opcodes.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum VoiceOpCode {
     /// Used to begin a voice websocket connection.
     Identify = 0,
@@ -158,8 +157,6 @@ pub enum VoiceOpCode {
     ClientConnect = 12,
     /// Message indicating that another user has disconnected from the voice channel.
     ClientDisconnect = 13,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -194,7 +191,6 @@ impl VoiceOpCode {
             VoiceOpCode::Resumed => 9,
             VoiceOpCode::ClientConnect => 12,
             VoiceOpCode::ClientDisconnect => 13,
-            VoiceOpCode::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,7 @@ pub type Result<T> = StdResult<T, Error>;
 /// [`GatewayError`]: gateway/enum.GatewayError.html
 /// [`Result`]: type.Result.html
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// An error while decoding a payload.
     Decode(&'static str, Value),
@@ -109,8 +110,6 @@ pub enum Error {
     /// [voice module]: voice/index.html
     #[cfg(feature = "voice")]
     Voice(VoiceError),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl From<FormatError> for Error {
@@ -198,7 +197,6 @@ impl Display for Error {
             Error::Tungstenite(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "voice")]
             Error::Voice(_) => f.write_str("Voice error"),
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -7,13 +7,12 @@ use std::borrow::Cow;
 
 /// Defines how an operation on an `Args` method failed.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error<E> {
     /// "END-OF-STRING". We reached the end. There's nothing to parse anymore.
     Eos,
     /// Parsing operation failed. Contains how it did.
     Parse(E),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<E> From<E> for Error<E> {
@@ -29,7 +28,6 @@ impl<E: fmt::Display> fmt::Display for Error<E> {
         match *self {
             Eos => write!(f, "ArgError(\"end of string\")"),
             Parse(ref e) => write!(f, "ArgError(\"{}\")", e),
-            __Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -92,7 +92,6 @@ macro_rules! format_command_name {
             HelpBehaviour::Strike => format!("~~`{}`~~", $command_name),
             HelpBehaviour::Nothing => format!("`{}`", $command_name),
             HelpBehaviour::Hide => continue,
-            HelpBehaviour::__Nonexhaustive => unreachable!(),
         }
     };
 }
@@ -183,6 +182,7 @@ impl Suggestions {
 /// yields relevant data in customised textual
 /// representation.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum CustomisedHelpData<'a> {
     /// To display suggested commands.
     SuggestedCommands {
@@ -198,8 +198,6 @@ pub enum CustomisedHelpData<'a> {
     SingleCommand { command: Command<'a> },
     /// To display failure in finding a fitting command.
     NoCommandFound { help_error_message: &'a str },
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Wraps around a `Vec<Vec<T>>` and provides access
@@ -1316,7 +1314,6 @@ pub async fn with_embeds(
             &command,
             help_options.embed_success_colour,
         ).await,
-        CustomisedHelpData::__Nonexhaustive => unreachable!(),
     };
 
     match response_result {
@@ -1491,7 +1488,6 @@ pub async fn plain(
         CustomisedHelpData::SingleCommand { ref command } => {
             single_command_to_plain_string(&help_options, &command)
         },
-        CustomisedHelpData::__Nonexhaustive => unreachable!(),
     };
 
     match msg.channel_id.say(&ctx, result).await {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -47,6 +47,7 @@ use crate::model::{guild::Role, id::RoleId};
 /// An enum representing all possible fail conditions under which a command won't
 /// be executed.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DispatchError {
     /// When a custom function check has failed.
     CheckFailed(&'static str, Reason),
@@ -82,8 +83,6 @@ pub enum DispatchError {
     IgnoredBot,
     /// When the bot ignores webhooks and a command was issued by one.
     WebhookAuthor,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 type DispatchHook = for<'fut> fn(&'fut Context, &'fut Message, DispatchError) -> BoxFuture<'fut , ()>;

--- a/src/framework/standard/structures/check.rs
+++ b/src/framework/standard/structures/check.rs
@@ -17,6 +17,7 @@ use futures::future::BoxFuture;
 /// [`Check`]: struct.Check.html
 /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Reason {
     /// No information on the failure.
     Unknown,
@@ -26,8 +27,6 @@ pub enum Reason {
     Log(String),
     /// Information for the user but also for logging purposes.
     UserAndLog { user: String, log: String },
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Returned from [`Check`]s.

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -19,12 +19,11 @@ pub mod buckets;
 pub use self::check::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum OnlyIn {
     Dm,
     Guild,
     None,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Default for OnlyIn {
@@ -129,6 +128,7 @@ impl PartialEq for HelpCommand {
 /// Lacking required roles to execute the command.
 /// The command can't be used in the current channel (as in `DM only` or `guild only`).
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum HelpBehaviour {
     /// The command will be displayed, hence nothing will be done.
     Nothing,
@@ -136,8 +136,6 @@ pub enum HelpBehaviour {
     Strike,
     /// Does not list a command in the help-menu.
     Hide,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -13,6 +13,7 @@ use async_tungstenite::tungstenite::protocol::CloseFrame;
 /// Note that - from a user standpoint - there should be no situation in which
 /// you manually handle these.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// There was an error building a URL.
     BuildingUrl,
@@ -57,8 +58,6 @@ pub enum Error {
     /// If an connection has been established but priviliged gateway intents
     /// were provided without enabling them prior.
     DisallowedGatewayIntents,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Display for Error {
@@ -78,7 +77,6 @@ impl Display for Error {
             Error::ReconnectFailure => f.write_str("Failed to Reconnect"),
             Error::InvalidGatewayIntents => f.write_str("Invalid gateway intents were provided"),
             Error::DisallowedGatewayIntents => f.write_str("Disallowed gateway intents were provided"),
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -78,6 +78,7 @@ pub type WsStream = WebSocketStream<ConnectStream>;
 ///
 /// [`Shard`]: struct.Shard.html
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum ConnectionStage {
     /// Indicator that the [`Shard`] is normally connected and is not in, e.g.,
     /// a resume phase.
@@ -108,8 +109,6 @@ pub enum ConnectionStage {
     ///
     /// [`Shard`]: struct.Shard.html
     Resuming,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ConnectionStage {
@@ -152,7 +151,6 @@ impl ConnectionStage {
         match self {
             Connecting | Handshake | Identifying | Resuming => true,
             Connected | Disconnected => false,
-            __Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -168,7 +166,6 @@ impl Display for ConnectionStage {
             Handshake => "handshaking",
             Identifying => "identifying",
             Resuming => "resuming",
-            __Nonexhaustive => unreachable!(),
         })
     }
 }
@@ -179,28 +176,25 @@ impl Display for ConnectionStage {
 /// the lower-level internals of the `client`, `gateway, and `voice` modules it
 /// may be necessary.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum InterMessage {
     #[cfg(feature = "client")]
     Client(Box<ShardClientMessage>),
     Json(Value),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
+#[non_exhaustive]
 pub enum ShardAction {
     Heartbeat,
     Identify,
     Reconnect(ReconnectType),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// The type of reconnection that should be performed.
+#[non_exhaustive]
 pub enum ReconnectType {
     /// Indicator that a new connection should be made by sending an IDENTIFY.
     Reidentify,
     /// Indicator that a new connection should be made by sending a RESUME.
     Resume,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1228,7 +1228,6 @@ impl Http {
         let (after, before) = match *target {
             GuildPagination::After(id) => (Some(id.0), None),
             GuildPagination::Before(id) => (None, Some(id.0)),
-            GuildPagination::__Nonexhaustive => unreachable!(),
         };
 
         self.fire(Request {
@@ -1535,7 +1534,6 @@ impl Http {
                         .part(file_num.to_string(), Part::bytes(picture)
                             .file_name(filename.to_string()));
                 },
-                AttachmentType::__Nonexhaustive => unreachable!(),
             }
 
             unsafe {

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -54,6 +54,7 @@ impl ErrorResponse {
 
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// When a non-successful status code was received for a request.
     UnsuccessfulRequest(ErrorResponse),
@@ -69,8 +70,6 @@ pub enum Error {
     InvalidHeader(InvalidHeaderValue),
     /// Reqwest's Error contain information on why sending a request failed.
     Request(ReqwestError),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Error {
@@ -116,7 +115,6 @@ impl Display for Error {
             Error::Url(_) => f.write_str("Provided URL is incorrect."),
             Error::InvalidHeader(_) => f.write_str("Provided value is an invalid header value."),
             Error::Request(_) => f.write_str("Error while sending HTTP request."),
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -156,6 +156,7 @@ impl LightMethod {
 
 /// Enum that allows a user to pass a `Path` or a `File` type to `send_files`
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum AttachmentType<'a> {
     /// Indicates that the `AttachmentType` is a byte slice with a filename.
     Bytes{ data: Cow<'a, [u8]>, filename: String } ,
@@ -165,8 +166,6 @@ pub enum AttachmentType<'a> {
     Path(&'a Path),
     /// Indicates that the `AttachmentType` is an image URL.
     Image(&'a str),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<'a> From<(&'a [u8], &str)> for AttachmentType<'a> {
@@ -203,13 +202,12 @@ impl<'a> From<(&'a File, &str)> for AttachmentType<'a> {
 /// function.
 ///
 /// [`get_guilds`]: fn.get_guilds.html
+#[non_exhaustive]
 pub enum GuildPagination {
     /// The Id to get the guilds after.
     After(GuildId),
     /// The Id to get the guilds before.
     Before(GuildId),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[cfg(test)]

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -10,6 +10,7 @@ use super::LightMethod;
 ///
 /// [`http`]: ../index.html
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum Route {
     /// Route for the `/channels/:channel_id` path.
     ///
@@ -261,8 +262,6 @@ pub enum Route {
     /// This is a special case, in that if the route is `None` then pre- and
     /// post-hooks are not executed.
     None,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Route {
@@ -642,6 +641,7 @@ impl Route {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum RouteInfo<'a> {
     AddMemberRole {
         guild_id: u64,
@@ -942,8 +942,6 @@ pub enum RouteInfo<'a> {
         channel_id: u64,
         message_id: u64,
     },
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<'a> RouteInfo<'a> {
@@ -1480,7 +1478,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ChannelsIdPinsMessageId(channel_id),
                 Cow::from(Route::channel_pin(channel_id, message_id)),
             ),
-            RouteInfo::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -109,6 +109,7 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Valu
 
 /// An error that occured while connecting over rustls
 #[derive(Debug)]
+#[non_exhaustive]
 #[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 pub enum RustlsError {
     /// WebPKI X.509 Certificate Validation Error.
@@ -117,8 +118,6 @@ pub enum RustlsError {
     HandshakeError,
     /// Standard IO error happening while creating the tcp stream
     Io(IoError),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
@@ -135,7 +134,6 @@ impl Display for RustlsError {
             RustlsError::WebPKI => f.write_str("Failed to validate X.509 certificate"),
             RustlsError::HandshakeError => f.write_str("TLS handshake failed when making the websocket connection"),
             RustlsError::Io(inner) => Display::fmt(&inner, f),
-            RustlsError::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,13 +104,13 @@ use crate::http::Http;
 
 #[cfg(feature = "client")]
 #[derive(Default)]
+#[non_exhaustive]
 pub struct CacheAndHttp {
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,
     #[cfg(feature = "cache")]
     pub update_cache_timeout: Option<Duration>,
     pub http: Arc<Http>,
-    __nonexhaustive: (),
 }
 
 // For the procedural macros in `command_attr`.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -75,7 +75,6 @@ impl ChannelId {
         let (id, kind) = match target.kind {
             PermissionOverwriteType::Member(id) => (id.0, "member"),
             PermissionOverwriteType::Role(id) => (id.0, "role"),
-            PermissionOverwriteType::__Nonexhaustive => unreachable!(),
         };
 
         let map = json!({
@@ -187,7 +186,6 @@ impl ChannelId {
             match permission_type {
                 PermissionOverwriteType::Member(id) => id.0,
                 PermissionOverwriteType::Role(id) => id.0,
-                PermissionOverwriteType::__Nonexhaustive => unreachable!(),
             },
         ).await
     }
@@ -458,7 +456,6 @@ impl ChannelId {
             Channel::Guild(channel) => channel.name().to_string(),
             Channel::Category(category) => category.name().to_string(),
             Channel::Private(channel) => channel.name(),
-            Channel::__Nonexhaustive => unreachable!(),
         })
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -895,7 +895,6 @@ impl GuildChannel {
 
                 "data:image/png;base64,".to_string() + &base64::encode(&picture)
             },
-            AttachmentType::__Nonexhaustive => unreachable!(),
         };
         
         let map = serde_json::json!({

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -820,6 +820,7 @@ pub struct MessageReaction {
 
 /// Differentiates between regular and different types of system messages.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum MessageType {
     /// A regular message.
     Regular = 0,
@@ -845,8 +846,6 @@ pub enum MessageType {
     NitroTier2 = 10,
     /// An indicator that the guild has reached nitro tier 3
     NitroTier3 = 11,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -883,20 +882,18 @@ impl MessageType {
             NitroTier1 => 9,
             NitroTier2 => 10,
             NitroTier3 => 11,
-            __Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum MessageActivityKind {
     JOIN = 1,
     SPECTATE = 2,
     LISTEN = 3,
     #[allow(non_camel_case_types)]
     JOIN_REQUEST = 5,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -917,7 +914,6 @@ impl MessageActivityKind {
             SPECTATE => 2,
             LISTEN => 3,
             JOIN_REQUEST => 5,
-            __Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -42,6 +42,7 @@ use crate::http::CacheHttp;
 
 /// A container for any channel.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Channel {
     /// A [text] or [voice] channel within a [`Guild`].
     ///
@@ -58,8 +59,6 @@ pub enum Channel {
     ///
     /// [`GuildChannel`]: struct.GuildChannel.html
     Category(ChannelCategory),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[cfg(feature = "model")]
@@ -185,7 +184,6 @@ impl Channel {
             Channel::Category(category) => {
                 category.delete(cache_http).await?;
             },
-            Channel::__Nonexhaustive => unreachable!(),
         }
 
         Ok(())
@@ -198,7 +196,6 @@ impl Channel {
             Channel::Guild(channel) => channel.is_nsfw(),
             Channel::Category(category) => category.is_nsfw(),
             Channel::Private(_) => false,
-            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -213,7 +210,6 @@ impl Channel {
             Channel::Guild(ch) => ch.id,
             Channel::Private(ch) => ch.id,
             Channel::Category(ch) => ch.id,
-            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -265,7 +261,6 @@ impl Serialize for Channel {
             Channel::Category(c) => ChannelCategory::serialize(c, serializer),
             Channel::Guild(c) => GuildChannel::serialize(c, serializer),
             Channel::Private(c) => PrivateChannel::serialize(c, serializer),
-            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -286,13 +281,13 @@ impl Display for Channel {
             Channel::Guild(ch) => Display::fmt(&ch.id.mention(), f),
             Channel::Private(ch) => Display::fmt(&ch.recipient.name, f),
             Channel::Category(ch) => Display::fmt(&ch.name, f),
-            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 /// A representation of a type of channel.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum ChannelType {
     /// An indicator that the channel is a text [`GuildChannel`].
     ///
@@ -322,8 +317,6 @@ pub enum ChannelType {
     ///
     /// [`GuildChannel`]: struct.GuildChannel.html
     Store = 6,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -347,7 +340,6 @@ impl ChannelType {
             ChannelType::Category => "category",
             ChannelType::News => "news",
             ChannelType::Store => "store",
-            ChannelType::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -360,7 +352,6 @@ impl ChannelType {
             ChannelType::Category => 4,
             ChannelType::News => 5,
             ChannelType::Store => 6,
-            ChannelType::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -406,7 +397,6 @@ impl Serialize for PermissionOverwrite {
         let (id, kind) = match self.kind {
             PermissionOverwriteType::Member(id) => (id.0, "member"),
             PermissionOverwriteType::Role(id) => (id.0, "role"),
-            PermissionOverwriteType::__Nonexhaustive => unreachable!(),
         };
 
         let mut state = serializer.serialize_struct("PermissionOverwrite", 4)?;
@@ -425,13 +415,12 @@ impl Serialize for PermissionOverwrite {
 ///
 /// [`GuildChannel::create_permission`]: struct.GuildChannel.html#method.create_permission
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum PermissionOverwriteType {
     /// A member which is having its permission overwrites edited.
     Member(UserId),
     /// A role which is having its permission overwrites edited.
     Role(RoleId),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[cfg(test)]

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -242,6 +242,7 @@ impl Reaction {
 ///
 /// [`Reaction`]: struct.Reaction.html
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub enum ReactionType {
     /// A reaction with a [`Guild`]s custom [`Emoji`], which is unique to the
     /// guild.
@@ -261,8 +262,6 @@ pub enum ReactionType {
     },
     /// A reaction with a twemoji.
     Unicode(String),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<'de> Deserialize<'de> for ReactionType {
@@ -356,7 +355,6 @@ impl Serialize for ReactionType {
 
                 map.end()
             },
-            ReactionType::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -378,7 +376,6 @@ impl ReactionType {
                 ..
             } => format!("{}:{}", name.as_ref().map_or("", |s| s.as_str()), id),
             ReactionType::Unicode(ref unicode) => unicode.clone(),
-            ReactionType::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -599,7 +596,6 @@ impl Display for ReactionType {
                 f.write_char('>')
             },
             ReactionType::Unicode(ref unicode) => f.write_str(unicode),
-            ReactionType::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -64,6 +64,7 @@ use super::Permissions;
 /// [`GuildId::ban`]: ../id/struct.GuildId.html#method.ban
 /// [`model`]: ../index.html
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// When attempting to delete below or above the minimum and maximum allowed
     /// number of messages.
@@ -127,8 +128,6 @@ pub enum Error {
     ///
     /// [`ChannelType`]: ../channel/enum.ChannelType.html
     InvalidChannelType,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Display for Error {
@@ -146,7 +145,6 @@ impl Display for Error {
             Error::ItemMissing => f.write_str("The required item is missing from the cache."),
             Error::MessageTooLong(_) => f.write_str("Message too large."),
             Error::MessagingBot => f.write_str("Attempted to message another bot user."),
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -115,7 +115,6 @@ impl CacheUpdate for ChannelCreateEvent {
                     .insert(category.id, category.clone())
                     .map(Channel::Category)
             },
-            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -161,7 +160,6 @@ impl CacheUpdate for ChannelDeleteEvent {
 
                 cache.private_channels.write().await.remove(&id);
             },
-            Channel::__Nonexhaustive => unreachable!(),
         };
 
         // Remove the cached messages for the channel.
@@ -259,7 +257,6 @@ impl CacheUpdate for ChannelUpdateEvent {
                     .get_mut(&category.id)
                     .map(|c| c.clone_from(category));
             },
-            Channel::__Nonexhaustive => unreachable!(),
         }
 
         None
@@ -1221,7 +1218,6 @@ impl CacheUpdate for ReadyEvent {
                     cache.guilds.write().await.insert(guild.id, guild);
                 },
                 GuildStatus::OnlinePartialGuild(_) => {},
-                GuildStatus::__Nonexhaustive => unreachable!(),
             }
         }
 
@@ -1412,6 +1408,7 @@ pub struct WebhookUpdateEvent {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum GatewayEvent {
     Dispatch(u64, Event),
@@ -1421,8 +1418,6 @@ pub enum GatewayEvent {
     InvalidateSession(bool),
     Hello(u64),
     HeartbeatAck,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<'de> Deserialize<'de> for GatewayEvent {
@@ -1494,6 +1489,7 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 /// Event received over a websocket connection
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum Event {
     /// A [`Channel`] was created.
@@ -1607,8 +1603,6 @@ pub enum Event {
     WebhookUpdate(WebhookUpdateEvent),
     /// An event type not covered by the above
     Unknown(UnknownEvent),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Deserializes a `serde_json::Value` into an `Event`.
@@ -1730,7 +1724,6 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
             value: v,
             _nonexhaustive: (),
         }),
-        EventType::__Nonexhaustive => unreachable!(),
     })
 }
 
@@ -1744,6 +1737,7 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
 ///
 /// [`EventType::ChannelCreate`]: enum.EventType.html#variant.ChannelCreate
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum EventType {
     /// Indicator that a channel create payload was received.
     ///
@@ -1972,8 +1966,6 @@ pub enum EventType {
     /// This should be logged so that support for it can be added in the
     /// library.
     Other(String),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<'de> Deserialize<'de> for EventType {
@@ -2121,6 +2113,7 @@ pub struct VoiceClientDisconnect {
 ///
 /// [`voice`]: ../../voice/index.html
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum VoiceEvent {
     /// Server's response to the client's Identify operation.
@@ -2150,8 +2143,6 @@ pub enum VoiceEvent {
     ClientDisconnect(VoiceClientDisconnect),
     /// An unknown voice event not registered.
     Unknown(VoiceOpCode, Value),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<'de> Deserialize<'de> for VoiceEvent {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -347,6 +347,7 @@ pub struct ActivityEmoji {
 
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ActivityType {
     /// An indicator that the user is playing a game.
     Playing = 0,
@@ -356,8 +357,6 @@ pub enum ActivityType {
     Listening = 2,
     /// An indicator that the user uses custum statuses
     Custom = 4,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -378,7 +377,6 @@ impl ActivityType {
             Streaming => 1,
             Listening => 2,
             Custom => 4,
-            __Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -16,6 +16,7 @@ use std::{
 
 /// Determines to what entity an action was used on.
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum Target {
     Guild = 10,
@@ -26,12 +27,11 @@ pub enum Target {
     Webhook = 60,
     Emoji = 70,
     Integration = 80,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Determines the action that was done on a target.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Action {
     GuildUpdate,
     Channel(ActionChannel),
@@ -43,8 +43,6 @@ pub enum Action {
     Emoji(ActionEmoji),
     Message(ActionMessage),
     Integration(ActionIntegration),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Action {
@@ -62,19 +60,17 @@ impl Action {
             Action::Emoji(ref x) => x.num(),
             Action::Message(ref x) => x.num(),
             Action::Integration(ref x) => x.num(),
-            Action::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionChannel {
     Create = 10,
     Update = 11,
     Delete = 12,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionChannel {
@@ -83,19 +79,17 @@ impl ActionChannel {
             ActionChannel::Create => 10,
             ActionChannel::Update => 11,
             ActionChannel::Delete => 12,
-            ActionChannel::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionChannelOverwrite {
     Create = 13,
     Update = 14,
     Delete = 15,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionChannelOverwrite {
@@ -104,12 +98,12 @@ impl ActionChannelOverwrite {
             ActionChannelOverwrite::Create => 13,
             ActionChannelOverwrite::Update => 14,
             ActionChannelOverwrite::Delete => 15,
-            ActionChannelOverwrite::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionMember {
     Kick = 20,
@@ -121,8 +115,6 @@ pub enum ActionMember {
     MemberMove = 26,
     MemberDisconnect = 27,
     BotAdd = 28,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionMember {
@@ -137,19 +129,17 @@ impl ActionMember {
             ActionMember::MemberMove => 26,
             ActionMember::MemberDisconnect => 27,
             ActionMember::BotAdd => 28,
-            ActionMember::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionRole {
     Create = 30,
     Update = 31,
     Delete = 32,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionRole {
@@ -158,19 +148,17 @@ impl ActionRole {
             ActionRole::Create => 30,
             ActionRole::Update => 31,
             ActionRole::Delete => 32,
-            ActionRole::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionInvite {
     Create = 40,
     Update = 41,
     Delete = 42,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionInvite {
@@ -179,19 +167,17 @@ impl ActionInvite {
             ActionInvite::Create => 40,
             ActionInvite::Update => 41,
             ActionInvite::Delete => 42,
-            ActionInvite::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionWebhook {
     Create = 50,
     Update = 51,
     Delete = 52,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionWebhook {
@@ -200,19 +186,17 @@ impl ActionWebhook {
             ActionWebhook::Create => 50,
             ActionWebhook::Update => 51,
             ActionWebhook::Delete => 52,
-            ActionWebhook::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionEmoji {
     Create = 60,
     Delete = 61,
     Update = 62,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionEmoji {
@@ -221,20 +205,18 @@ impl ActionEmoji {
             ActionEmoji::Create => 60,
             ActionEmoji::Update => 61,
             ActionEmoji::Delete => 62,
-            ActionEmoji::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionMessage {
     Delete = 72,
     BulkDelete = 73,
     Pin = 74,
     Unpin = 75,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionMessage {
@@ -244,20 +226,18 @@ impl ActionMessage {
             ActionMessage::BulkDelete => 73,
             ActionMessage::Pin => 74,
             ActionMessage::Unpin => 75,
-            ActionMessage::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 
 #[derive(Debug)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActionIntegration {
     Create = 80,
     Update = 81,
     Delete = 82,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ActionIntegration {
@@ -266,7 +246,6 @@ impl ActionIntegration {
             ActionIntegration::Create => 80,
             ActionIntegration::Update => 81,
             ActionIntegration::Delete => 82,
-            ActionIntegration::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1980,13 +1980,12 @@ fn closest_to_origin(origin: &str, word_a: &str, word_b: &str) -> std::cmp::Orde
 /// a guild needs to be retrieved from the cache.
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum GuildContainer {
     /// A guild which can have its contents directly searched.
     Guild(PartialGuild),
     /// A guild's id, which can be used to search the cache for a guild.
     Id(GuildId),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Information relating to a guild's widget embed.
@@ -2072,13 +2071,12 @@ pub struct GuildUnavailable {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum GuildStatus {
     OnlinePartialGuild(PartialGuild),
     OnlineGuild(Guild),
     Offline(GuildUnavailable),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[cfg(feature = "model")]
@@ -2091,20 +2089,18 @@ impl GuildStatus {
             GuildStatus::Offline(offline) => offline.id,
             GuildStatus::OnlineGuild(ref guild) => guild.id,
             GuildStatus::OnlinePartialGuild(ref partial_guild) => partial_guild.id,
-            GuildStatus::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 /// Default message notification level for a guild.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum DefaultMessageNotificationLevel {
     /// Receive notifications for everything.
     All = 0,
     /// Receive only mentions.
     Mentions = 1,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -2119,13 +2115,13 @@ impl DefaultMessageNotificationLevel {
         match self {
             DefaultMessageNotificationLevel::All => 0,
             DefaultMessageNotificationLevel::Mentions => 1,
-            DefaultMessageNotificationLevel::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 /// Setting used to filter explicit messages from members.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum ExplicitContentFilter {
     /// Don't scan any messages.
     None = 0,
@@ -2133,8 +2129,6 @@ pub enum ExplicitContentFilter {
     WithoutRole = 1,
     /// Scan messages sent by all members.
     All = 2,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -2151,20 +2145,18 @@ impl ExplicitContentFilter {
             ExplicitContentFilter::None => 0,
             ExplicitContentFilter::WithoutRole => 1,
             ExplicitContentFilter::All => 2,
-            ExplicitContentFilter::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 /// Multi-Factor Authentication level for guild moderators.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum MfaLevel {
     /// MFA is disabled.
     None = 0,
     /// MFA is enabled.
     Elevated = 1,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -2179,13 +2171,13 @@ impl MfaLevel {
         match self {
             MfaLevel::None => 0,
             MfaLevel::Elevated => 1,
-            MfaLevel::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 /// The name of a region that a voice server can be located in.
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+#[non_exhaustive]
 pub enum Region {
     #[serde(rename = "amsterdam")] Amsterdam,
     #[serde(rename = "brazil")] Brazil,
@@ -2205,8 +2197,6 @@ pub enum Region {
     #[serde(rename = "vip-amsterdam")] VipAmsterdam,
     #[serde(rename = "vip-us-east")] VipUsEast,
     #[serde(rename = "vip-us-west")] VipUsWest,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Region {
@@ -2230,7 +2220,6 @@ impl Region {
             Region::VipAmsterdam => "vip-amsterdam",
             Region::VipUsEast => "vip-us-east",
             Region::VipUsWest => "vip-us-west",
-            Region::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -2240,6 +2229,7 @@ impl Region {
 
     [`Guild`]: struct.Guild.html"]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum VerificationLevel {
     /// Does not require any verification.
     None = 0,
@@ -2251,8 +2241,6 @@ pub enum VerificationLevel {
     High = 3,
     /// Must have a verified phone on the user's Discord account.
     Higher = 4,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -2273,7 +2261,6 @@ impl VerificationLevel {
             VerificationLevel::Medium => 2,
             VerificationLevel::High => 3,
             VerificationLevel::Higher => 4,
-            VerificationLevel::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -1,13 +1,12 @@
 /// The guild's premium tier, depends on the amount of users boosting the guild currently
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
 pub enum PremiumTier {
     /// No tier, considered None
     Tier0,
     Tier1,
     Tier2,
     Tier3,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 enum_number!(
@@ -16,7 +15,6 @@ enum_number!(
         Tier1,
         Tier2,
         Tier3,
-        __Nonexhaustive,
     }
 );
 
@@ -27,7 +25,6 @@ impl PremiumTier {
             PremiumTier::Tier1 => 1,
             PremiumTier::Tier2 => 2,
             PremiumTier::Tier3 => 3,
-            PremiumTier::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -30,7 +30,6 @@ impl Mentionable for Channel {
             Channel::Guild(channel) => channel.mention(),
             Channel::Private(channel) => channel.mention(),
             Channel::Category(channel) => channel.mention(),
-            Channel::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -87,11 +86,10 @@ impl Mentionable for GuildChannel {
 
 #[cfg(all(feature = "model", feature = "utils"))]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum UserParseError {
     InvalidUsername,
     Rest(Box<Error>),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[cfg(all(feature = "model", feature = "utils"))]
@@ -100,7 +98,6 @@ impl fmt::Display for UserParseError {
         match self {
             UserParseError::InvalidUsername => f.write_str("invalid username"),
             UserParseError::Rest(_) => f.write_str("could not fetch"),
-            UserParseError::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -258,6 +255,7 @@ pub struct IncidentUpdate {
 
 /// The type of status update during a service incident.
 #[derive(Copy, Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum IncidentStatus {
     Identified,
@@ -265,8 +263,6 @@ pub enum IncidentStatus {
     Monitoring,
     Postmortem,
     Resolved,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// A Discord status maintenance message. This can be either for active

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -319,6 +319,7 @@ impl CurrentUser {
 ///
 /// [`name`]: #method.name
 #[derive(Copy, Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+#[non_exhaustive]
 pub enum DefaultAvatar {
     /// The avatar when the result is `0`.
     #[serde(rename = "6debd47ed13483642cf09e832ed0bc1b")]
@@ -335,8 +336,6 @@ pub enum DefaultAvatar {
     /// The avatar when the result is `4`.
     #[serde(rename = "1cbd08c76f8af6dddce02c5138971129")]
     Red,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl DefaultAvatar {
@@ -354,14 +353,13 @@ impl DefaultAvatar {
 /// [`DoNotDisturb`]: #variant.DoNotDisturb
 /// [`Invisible`]: #variant.Invisible
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+#[non_exhaustive]
 pub enum OnlineStatus {
     #[serde(rename = "dnd")] DoNotDisturb,
     #[serde(rename = "idle")] Idle,
     #[serde(rename = "invisible")] Invisible,
     #[serde(rename = "offline")] Offline,
     #[serde(rename = "online")] Online,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl OnlineStatus {
@@ -372,7 +370,6 @@ impl OnlineStatus {
             OnlineStatus::Invisible => "invisible",
             OnlineStatus::Offline => "offline",
             OnlineStatus::Online => "online",
-            OnlineStatus::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -656,7 +653,6 @@ impl User {
                             .map(|m| m.roles.contains(&role))
                     }
                 },
-                GuildContainer::__Nonexhaustive => unreachable!(),
             }
         }.boxed()
     }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -110,7 +110,6 @@ pub fn deserialize_private_channels<'de, D: Deserializer<'de>>(
             Channel::Private(ref channel) => channel.id,
             Channel::Guild(_) => unreachable!("Guild private channel decode"),
             Channel::Category(_) => unreachable!("Channel category private channel decode"),
-            Channel::__Nonexhaustive => unreachable!(),
         };
 
         private_channels.insert(id, private_channel);
@@ -252,7 +251,6 @@ pub async fn user_has_perms(
                     // just assume that all permissions are granted and return `true`.
                     return Ok(true);
                 },
-                Channel::__Nonexhaustive => unreachable!(),
             }
         }
     };

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1037,6 +1037,7 @@ impl EmbedMessageBuilding for MessageBuilder {
 /// use serenity::utils::Content;
 /// let content: Content = Bold + Italic + "text";
 /// ```
+#[non_exhaustive]
 pub enum ContentModifier {
     Italic,
     Bold,
@@ -1044,8 +1045,6 @@ pub enum ContentModifier {
     Code,
     Underline,
     Spoiler,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Describes formatting on string content
@@ -1132,7 +1131,6 @@ impl Content {
             ContentModifier::Spoiler => {
                 self.spoiler = true;
             },
-            ContentModifier::__Nonexhaustive => unreachable!(),
         }
     }
 

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -44,11 +44,10 @@ pub trait AudioReceiver: Send + Sync {
 }
 
 #[derive(Clone, Copy)]
+#[non_exhaustive]
 pub enum AudioType {
     Opus,
     Pcm,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Control object for audio playback.

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -450,7 +450,6 @@ impl Connection {
                             None => 0,
                         }
                     },
-                    AudioType::__Nonexhaustive => unreachable!(),
                 };
 
                 // May need to force interleave/copy.

--- a/src/voice/error.rs
+++ b/src/voice/error.rs
@@ -7,6 +7,7 @@ use std::{
 /// An error returned from the voice module.
 // Errors which are not visible to the end user are hidden.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum VoiceError {
     /// An indicator that an endpoint URL was invalid.
     EndpointUrl,
@@ -28,17 +29,14 @@ pub enum VoiceError {
     ///
     /// The JSON output is given.
     YouTubeDLUrl(Value),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// An error returned from the dca method.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DcaError {
     IoError(IoError),
     InvalidHeader,
     InvalidMetadata(JsonError),
     InvalidSize(i32),
-    #[doc(hidden)]
-    __Nonexhaustive,
 }


### PR DESCRIPTION
Hi there! This changes all of those odd `__Nonexhaustive` enum cases, so that they instead use [the `#[non_exhaustive]` attribute](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute).



~~However, I opted not to add the `#[non_exhaustive]` attribute to any structs where it could apply (that is, those who had a `__nonexhaustive: ()` field), since I'm unsure if the effects would be acceptable:~~

> ~~Non-exhaustive structs could have additional fields added in future. Therefore, non-exhaustive structs cannot be constructed in external crates using the traditional `Struct { .. }` syntax; cannot be matched against without a wildcard `..`; and struct update syntax will not work.~~

~~That said, if it's desired that I add it to any applicable structs, I can do so.~~



Side note: I did notice #752 while searching to see if there was an existing PR that made this change -- but being that the PR is from December 2019, I imagine there would be lots of merge conflicts and other misc issues that would make it hard to merge that. So I decided to make my own PR.

