### PR TITLE
Fix parsing of commands that have requirements

### DIFF
--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -316,6 +316,10 @@ impl From<DispatchError> for ParseError {
     }
 }
 
+fn is_unrecognised<T>(res: &Result<T, ParseError>) -> bool {
+    matches!(res, Err(ParseError::UnrecognisedCommand(_)))
+}
+
 /// Parse a command from the message.
 ///
 /// The "command" may be:
@@ -357,7 +361,7 @@ pub async fn command(
             Map::WithPrefixes(map) => {
                 let res = handle_group(stream, ctx, msg, config, map).await;
 
-                if res.is_ok() {
+                if !is_unrecognised(&res) {
                     return res;
                 }
 
@@ -370,17 +374,13 @@ pub async fn command(
 
                 let res = handle_group(stream, ctx, msg, config, subgroups).await;
 
-                if res.is_ok() {
-                    check_discrepancy(ctx, msg, config, &group.options).await?;
-
+                if !is_unrecognised(&res) {
                     return res;
                 }
 
                 let res = handle_command(stream, ctx, msg, config, commands, group).await;
 
-                if res.is_ok() {
-                    check_discrepancy(ctx, msg, config, &group.options).await?;
-
+                if !is_unrecognised(&res) {
                     return res;
                 }
 


### PR DESCRIPTION
This fixes parsing behaviour of commands that have requirements. 

Under normal circumstances, if the requirements are not met, the framework should return a dispatch error. Of course, It does return a dispatch error, but only when there is a single group. Once there are several (at least two) groups, the dispatch error that is supposed to be returned gets replaced with the "UnrecognisedCommand" error. This is because we do not check that we had a dispatch error at all, so the framework does not have a problem replacing it with a useless error.

This also removes redundant discrepancy checks. Each valid group or command is already checked for discrepancies before they are returned from their parsing functions.