### PR TITLE
Allow setting builders directly

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -43,7 +43,7 @@ use crate::utils::Colour;
 pub struct CreateEmbed(pub HashMap<&'static str, Value>);
 
 impl CreateEmbed {
-    /// Set the author of the embed.
+    /// Build the author of the embed.
     ///
     /// Refer to the documentation for [`CreateEmbedAuthor`] for more
     /// information.
@@ -53,7 +53,11 @@ impl CreateEmbed {
         where F: FnOnce(&mut CreateEmbedAuthor) -> &mut CreateEmbedAuthor {
         let mut author = CreateEmbedAuthor::default();
         f(&mut author);
+        self.set_author(author)
+    }
 
+    /// Set the author of the embed.
+    pub fn set_author(&mut self, author: CreateEmbedAuthor) -> &mut Self {
         let map = utils::hashmap_to_json_map(author.0);
 
         self.0.insert("author", Value::Object(map));
@@ -160,7 +164,7 @@ impl CreateEmbed {
         self
     }
 
-    /// Set the footer of the embed.
+    /// Build the footer of the embed.
     ///
     /// Refer to the documentation for [`CreateEmbedFooter`] for more
     /// information.
@@ -170,6 +174,11 @@ impl CreateEmbed {
         where F: FnOnce(&mut CreateEmbedFooter) -> &mut CreateEmbedFooter {
         let mut create_embed_footer = CreateEmbedFooter::default();
         f(&mut create_embed_footer);
+        self.set_footer(create_embed_footer)
+    }
+
+    /// Set the footer of the embed.
+    pub fn set_footer(&mut self, create_embed_footer: CreateEmbedFooter) -> &mut Self {
         let footer = create_embed_footer.0;
         let map = utils::hashmap_to_json_map(footer);
 

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -70,11 +70,16 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    /// Set an embed for the message.
+    /// Create an embed for the message.
     pub fn embed<F>(&mut self, f: F) -> &mut Self
     where F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed {
         let mut embed = CreateEmbed::default();
         f(&mut embed);
+        self.set_embed(embed)
+    }
+
+    /// Set an embed for the message.
+    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 


### PR DESCRIPTION
A backwards-compatible change that allows directly setting the embed for the message, without the closure. The same for setting embed author/footer.

This allows for having those values calculated beforehand - either for reusing them or, as in my case, allow for easier creation of CreateMessage instance when doing so based on mappings.

Not sold on the naming scheme, but it's late and can't come up with anything better.

Test results:
> test result: ok. 243 passed; 0 failed; 37 ignored; 0 measured; 0 filtered out