### PR TITLE
Fix Serenity feature dependencies in examples 2, 3, 4, 9, 11

### DIFF
--- a/examples/e02_transparent_guild_sharding/Cargo.toml
+++ b/examples/e02_transparent_guild_sharding/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-serenity = { path = "../../" }
+serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "0.2", features = ["macros"] }

--- a/examples/e03_struct_utilities/Cargo.toml
+++ b/examples/e03_struct_utilities/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-serenity = { path = "../../" }
+serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "0.2", features = ["macros"] }

--- a/examples/e04_message_builder/Cargo.toml
+++ b/examples/e04_message_builder/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-serenity = { path = "../../" }
+serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "0.2", features = ["macros"] }

--- a/examples/e09_shard_manager/Cargo.toml
+++ b/examples/e09_shard_manager/Cargo.toml
@@ -10,5 +10,6 @@ log = "0.4"
 tokio = { version = "0.2", features = ["macros", "rt-core", "time"] }
 
 [dependencies.serenity]
-features = ["client", "rustls_backend"]
+default-features = false
+features = ["client", "gateway", "rustls_backend", "model"]
 path = "../../"

--- a/examples/e11_create_message_builder/Cargo.toml
+++ b/examples/e11_create_message_builder/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-serenity = { path = "../../" }
+serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "0.2", features = ["macros"] }


### PR DESCRIPTION
Currently examples 2, 3, 4, 9 and 11 do not compile due to a mismatch with the defaultly-enabled features from the main Serenity crate. This PR fixes those examples' Cargo.toml files and all current examples now compile.