### PR TITLE
Fix Tungstenite IO error being discarded in ws_impl

### DIFF
--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -509,28 +509,6 @@ impl ShardRunner {
             },
             Ok(None) => Ok(None),
             Err(Error::Tungstenite(TungsteniteError::Io(_))) => {
-                // Check that an amount of time at least double the
-                // heartbeat_interval has passed.
-                //
-                // If not, continue on trying to receive messages.
-                //
-                // If it has, attempt to auto-reconnect.
-                {
-                    let last = self.shard.last_heartbeat_ack();
-                    let interval = self.shard.heartbeat_interval();
-
-                    if let (Some(last_heartbeat_ack), Some(interval)) = (last, interval) {
-                        let seconds_passed = last_heartbeat_ack.elapsed().as_secs();
-                        let interval_in_secs = interval / 1000;
-
-                        if seconds_passed <= interval_in_secs * 2 {
-                            return Ok((None, None, true));
-                        }
-                    } else {
-                        return Ok((None, None, true));
-                    }
-                }
-
                 debug!("Attempting to auto-reconnect");
 
                 match self.shard.reconnection_type() {

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -38,8 +38,9 @@ impl ReceiverExt for WsStream {
         const TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_millis(500);
 
         let ws_message = match timeout(TIMEOUT, self.next()).await {
-            Ok(v) => v.map(|v| v.ok()).flatten(),
-            Err(_) => None,
+            Ok(Some(Ok(v))) => Some(v),
+            Ok(Some(Err(e))) => return Err(e.into()),
+            Ok(None) | Err(_) => None,
         };
 
         convert_ws_message(ws_message)


### PR DESCRIPTION
This PR fixes the issue where the recv_json() impl in ws_impl was discarding tungstenite errors, so that any matches later in the error propagation chain can properly handle this event.

This PR also removes the (imho, nonsensical) IO error discarding until the next heartbeat fails. An IO error on a connection is, in most cases, unrecoverable. So it's often faster and more reliable to just discard the connection and retry.

This is a fix for (at least one) CPU and memory spike happening. Further testing will have to prove whether this also fixes the OOM issue as described in #974 and #955.