### PR TITLE
Change the default help text to use the word 'server'

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -404,7 +404,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     if options.strikethrough_commands_tip_in_guild == None {
         options.strikethrough_commands_tip_in_guild =
-            produce_strike_text(&options, "guild messages");
+            produce_strike_text(&options, "server messages");
     }
 
     let HelpOptions {

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -550,11 +550,11 @@ impl Default for HelpOptions {
             grouped_label: "Group".to_string(),
             aliases_label: "Aliases".to_string(),
             description_label: "Description".to_string(),
-            guild_only_text: "Only in guilds".to_string(),
+            guild_only_text: "Only in servers".to_string(),
             checks_label: "Checks".to_string(),
             sub_commands_label: "Sub Commands".to_string(),
             dm_only_text: "Only in DM".to_string(),
-            dm_and_guild_text: "In DM and guilds".to_string(),
+            dm_and_guild_text: "In DM and servers".to_string(),
             available_text: "Available".to_string(),
             command_not_found_text: "**Error**: Command `{}` not found.".to_string(),
             individual_command_tip: "To get help with an individual command, pass its \


### PR DESCRIPTION
Fixes #980.

This changes the terminology used in text for the help command to *server* rather than *guild*. Discord uses the two interchangeably to mean the same thing, but in different contexts to avoid confusion. *Servers* are used in the app because Discord used to be advertised to gamers, and the concept of guilds has already existed in games. However, on the other side of the spectrum, the *servers* providing services for Discord and bots on the platform exist, so *guilds* are used in the API instead.    