### PR TITLE
Update example 05 to specifically get the current bot_id

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -206,8 +206,10 @@ async fn main() {
             } else {
                 owners.insert(info.owner.id);
             }
-
-            (owners, info.id)
+            match http.get_current_user().await {
+                Ok(bot_id) => (owners, bot_id.id),
+                Err(why) => panic!("Could not access the bot id: {:?}", why),
+            }
         },
         Err(why) => panic!("Could not access application info: {:?}", why),
     };


### PR DESCRIPTION
This closes #899 by specifically getting the current user id (bot id) as the CurrentApplicationInfo does not provide this. The downside is two http requests are needed.