### PR TITLE
Update owner.rs in sample bot structure

### DIFF
--- a/examples/e07_sample_bot_structure/src/commands/owner.rs
+++ b/examples/e07_sample_bot_structure/src/commands/owner.rs
@@ -12,6 +12,7 @@ async fn quit(ctx: &Context, msg: &Message) -> CommandResult {
     let data = ctx.data.read().await;
 
     if let Some(manager) = data.get::<ShardManagerContainer>() {
+        msg.reply(ctx, "Shutting down!").await?;
         manager.lock().await.shutdown_all().await;
     } else {
         msg.reply(ctx, "There was a problem getting the shard manager").await?;
@@ -19,7 +20,7 @@ async fn quit(ctx: &Context, msg: &Message) -> CommandResult {
         return Ok(());
     }
 
-    msg.reply(ctx, "Shutting down!").await?;
+
 
     Ok(())
 }


### PR DESCRIPTION
This should allow the shutdown notice to actually make it to discord before the instance halts. Prior to this it never made it out...