### PR TITLE
Fixed all clippy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Serenity is a Rust library for the Discord API.
 
 View the [examples] on how to make and structure a bot.
 
-Serenity supports bot login via the use of [`Client::new`].
+Serenity supports bot login via the use of [`Client::builder`].
 
 You may also check your tokens prior to login via the use of
 [`validate_token`].
@@ -70,7 +70,7 @@ async fn main() {
 
     // Login with a bot token from the environment
     let token = env::var("DISCORD_TOKEN").expect("token");
-    let mut client = Client::new(token)
+    let mut client = Client::builder(token)
         .event_handler(Handler)
         .framework(framework)
         .await
@@ -204,7 +204,7 @@ Voice + youtube-dl:
 - [lavalink-rs][project:lavalink-rs]: An interface to [Lavalink][repo:lavalink], an audio sending node based on [Lavaplayer][repo:lavaplayer]
 
 [`Cache`]: https://docs.rs/serenity/*/serenity/cache/struct.Cache.html
-[`Client::new`]: https://docs.rs/serenity/*/serenity/client/struct.Client.html#method.new
+[`Client::builder`]: https://docs.rs/serenity/*/serenity/client/struct.Client.html#method.builder
 [`EventHandler::message`]: https://docs.rs/serenity/*/serenity/client/trait.EventHandler.html#method.message
 [`Context`]: https://docs.rs/serenity/*/serenity/client/struct.Context.html
 [`Event`]: https://docs.rs/serenity/*/serenity/model/event/enum.Event.html

--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
     // Create a new instance of the Client, logging in as a bot. This will
     // automatically prepend your bot token with "Bot ", which is a requirement
     // by Discord for bot users.
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .await
         .expect("Err creating client");

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -48,7 +48,7 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN")
         .expect("Expected a token in the environment");
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .await
         .expect("Err creating client");

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -42,7 +42,7 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN")
         .expect("Expected a token in the environment");
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .await
         .expect("Err creating client");

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -50,7 +50,7 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN")
         .expect("Expected a token in the environment");
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .await
         .expect("Err creating client");

--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -262,7 +262,7 @@ async fn main() {
         .group(&MATH_GROUP)
         .group(&OWNER_GROUP);
 
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/examples/e06_voice/src/main.rs
+++ b/examples/e06_voice/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
                    .prefix("~"))
         .group(&GENERAL_GROUP);
 
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/examples/e07_sample_bot_structure/src/main.rs
+++ b/examples/e07_sample_bot_structure/src/main.rs
@@ -92,7 +92,7 @@ async fn main() {
                    .prefix("~"))
         .group(&GENERAL_GROUP);
 
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .framework(framework)
         .event_handler(Handler)
         .await

--- a/examples/e08_env_logging/src/main.rs
+++ b/examples/e08_env_logging/src/main.rs
@@ -76,7 +76,7 @@ async fn main() {
         .before(before)
         .group(&GENERAL_GROUP);
 
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/examples/e09_shard_manager/src/main.rs
+++ b/examples/e09_shard_manager/src/main.rs
@@ -56,7 +56,7 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN")
         .expect("Expected a token in the environment");
 
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .await
         .expect("Err creating client");

--- a/examples/e10_voice_receive/src/main.rs
+++ b/examples/e10_voice_receive/src/main.rs
@@ -105,7 +105,7 @@ async fn main() {
             .prefix("~"))
         .group(&GENERAL_GROUP);
 
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/examples/e11_create_message_builder/src/main.rs
+++ b/examples/e11_create_message_builder/src/main.rs
@@ -56,7 +56,7 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN")
         .expect("Expected a token in the environment");
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .await
         .expect("Err creating client");

--- a/examples/e12_collectors/src/main.rs
+++ b/examples/e12_collectors/src/main.rs
@@ -73,7 +73,7 @@ async fn main() {
         .help(&MY_HELP)
         .group(&COLLECTOR_GROUP);
 
-    let mut client = Client::new(&token)
+    let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/examples/e13_gateway_intents/src/main.rs
+++ b/examples/e13_gateway_intents/src/main.rs
@@ -33,7 +33,7 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
     // Build our client.
-    let mut client = Client::new(token)
+    let mut client = Client::builder(token)
         .event_handler(Handler)
         .add_intent(GatewayIntents::GUILDS)
         .add_intent(GatewayIntents::GUILD_MESSAGES)

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -242,7 +242,7 @@ impl CreateEmbed {
     ///     }
     /// }
     ///
-    /// let mut client = Client::new("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -296,7 +296,7 @@ impl CreateEmbed {
     ///     }
     /// }
     ///
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -58,7 +58,7 @@ use serde_json::Value;
 ///     }
 /// }
 ///
-/// let mut client =Client::new("token").event_handler(Handler).await?;
+/// let mut client =Client::builder("token").event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #     Ok(())

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -332,12 +332,13 @@ impl Cache {
     /// [`Guild`]: ../model/guild/struct.Guild.html
     /// [`Shard`]: ../gateway/struct.Shard.html
     pub async fn guilds(&self) -> Vec<GuildId> {
+        let chain = self.unavailable_guilds.read().await.clone().into_iter();
         self.guilds
             .read()
             .await
             .keys()
             .cloned()
-            .chain(self.unavailable_guilds.read().await.clone().into_iter())
+            .chain(chain)
             .collect()
     }
 
@@ -434,7 +435,7 @@ impl Cache {
     async fn _guild_field<Ret, Fun>(&self, id: GuildId, field_accessor: Fun) -> Option<Ret>
     where Fun: FnOnce(&Guild) -> Ret {
         let guilds = self.guilds.read().await;
-        let guild = guilds.get(&id.into())?;
+        let guild = guilds.get(&id)?;
 
         Some(field_accessor(guild))
     }
@@ -530,7 +531,7 @@ impl Cache {
         field_selector: Fun) -> Option<Ret>
     where Fun: FnOnce(&GuildChannel) -> Ret {
         let guild_channels = &self.channels.read().await;
-        let channel = guild_channels.get(&id.into())?;
+        let channel = guild_channels.get(&id)?;
 
         Some(field_selector(channel))
     }
@@ -678,7 +679,7 @@ impl Cache {
     /// Returns the number of shards.
     #[inline]
     pub async fn shard_count(&self) -> u64 {
-        self.shard_count.read().await.clone()
+        *self.shard_count.read().await
     }
 
     /// Retrieves a [`Channel`]'s message from the cache based on the channel's and
@@ -923,7 +924,7 @@ impl Cache {
     where Fun: FnOnce(&CurrentUser) -> Ret {
         let user = self.user.read().await;
 
-        field_selector(&user).clone()
+        field_selector(&user)
     }
 
     /// Updates the cache with the update implementation for an event or other

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -250,7 +250,7 @@ impl Cache {
     ///     }
     /// }
     ///
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -482,7 +482,7 @@ impl Cache {
     ///
     /// # #[cfg(feature = "client")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -234,7 +234,7 @@ impl ShardManager {
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// // restart shard ID 7
     /// client.shard_manager.lock().await.restart(ShardId(7)).await;

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -541,24 +541,24 @@ impl ShardRunner {
 
                 match why {
                     Error::Gateway(GatewayError::InvalidAuthentication) => {
-                        if let Err(_) = self.manager_tx.unbounded_send(
-                            ShardManagerMessage::ShardInvalidAuthentication) {
+                        if self.manager_tx.unbounded_send(
+                            ShardManagerMessage::ShardInvalidAuthentication).is_err() {
                             panic!("Failed sending InvalidAuthentication error to the shard manager.");
                         }
 
                         return Err(why);
                     },
                     Error::Gateway(GatewayError::InvalidGatewayIntents) => {
-                        if let Err(_) = self.manager_tx.unbounded_send(
-                            ShardManagerMessage::ShardInvalidGatewayIntents) {
+                        if self.manager_tx.unbounded_send(
+                            ShardManagerMessage::ShardInvalidGatewayIntents).is_err() {
                             panic!("Failed sending InvalidGatewayIntents error to the shard manager.");
                         }
 
                         return Err(why);
                     },
                     Error::Gateway(GatewayError::DisallowedGatewayIntents) => {
-                        if let Err(_) = self.manager_tx.unbounded_send(
-                            ShardManagerMessage::ShardDisallowedGatewayIntents) {
+                        if self.manager_tx.unbounded_send(
+                            ShardManagerMessage::ShardDisallowedGatewayIntents).is_err() {
                             panic!("Failed sending DisallowedGatewayIntents error to the shard manager.");
                         }
 

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -116,7 +116,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -153,7 +153,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -190,7 +190,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -226,7 +226,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -264,7 +264,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::new("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -307,7 +307,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -343,7 +343,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -373,7 +373,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -583,6 +583,7 @@ impl Client {
     ///
     /// [`Client`]: #struct.Client.html
     /// [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
+    #[allow(clippy::new_ret_no_self)] // Remnant of the async transition, but changing it would be breaking
     pub fn new<'a>(token: impl AsRef<str>) -> ClientBuilder<'a> {
         ClientBuilder::new(token)
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -378,7 +378,7 @@ impl<'a> Future for ClientBuilder<'a> {
 /// }
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut client = Client::new("my token here").event_handler(Handler).await?;
+/// let mut client = Client::builder("my token here").event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #   Ok(())
@@ -458,7 +458,7 @@ pub struct Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     /// {
     ///     let mut data = client.data.write().await;
     ///     data.insert::<MessageEventCounter>(HashMap::default());
@@ -505,7 +505,7 @@ pub struct Client {
     /// impl EventHandler for Handler { }
     ///
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// let shard_manager = client.shard_manager.clone();
     ///
@@ -534,7 +534,7 @@ pub struct Client {
     /// impl EventHandler for Handler { }
     ///
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// // Create a clone of the `Arc` containing the shard manager.
     /// let shard_manager = client.shard_manager.clone();
@@ -583,8 +583,13 @@ impl Client {
     ///
     /// [`Client`]: #struct.Client.html
     /// [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
-    #[allow(clippy::new_ret_no_self)] // Remnant of the async transition, but changing it would be breaking
+    #[deprecated(since="0.9.0", note="please use `builder` instead")]
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<'a>(token: impl AsRef<str>) -> ClientBuilder<'a> {
+        Self::builder(token)
+    }
+
+    pub fn builder<'a>(token: impl AsRef<str>) -> ClientBuilder<'a> {
         ClientBuilder::new(token)
     }
 
@@ -615,7 +620,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start().await {
     ///     println!("Err with client: {:?}", why);
@@ -658,7 +663,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_autosharded().await {
     ///     println!("Err with client: {:?}", why);
@@ -712,7 +717,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard(3, 5).await {
     ///     println!("Err with client: {:?}", why);
@@ -735,7 +740,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard(0, 1).await {
     ///     println!("Err with client: {:?}", why);
@@ -785,7 +790,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shards(8).await {
     ///     println!("Err with client: {:?}", why);
@@ -836,7 +841,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard_range([4, 7], 10).await {
     ///     println!("Err with client: {:?}", why);

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -70,7 +70,7 @@
 //!     // all-uppercased version of the `name` with a `_GROUP` suffix appended at the end.
 //!     .group(&GENERAL_GROUP);
 //!
-//! let mut client = Client::new(&token).event_handler(Handler).framework(framework).await?;
+//! let mut client = Client::builder(&token).event_handler(Handler).framework(framework).await?;
 //! #     Ok(())
 //! # }
 //! ```

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -86,7 +86,7 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 /// let framework = StandardFramework::new()
 ///     .configure(|c| c.on_mention(Some(UserId(5))).prefix("~"));
 ///
-/// let mut client = Client::new(&token).event_handler(Handler).framework(framework).await?;
+/// let mut client = Client::builder(&token).event_handler(Handler).framework(framework).await?;
 /// #     Ok(())
 /// # }
 /// ```

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -395,18 +395,16 @@ async fn check_command_behaviour(
 ) -> HelpBehaviour {
     let b = check_common_behaviour(&ctx, msg, &options, owners, help_options).await;
 
-    if b == HelpBehaviour::Nothing {
-        if !options.owner_privilege || !owners.contains(&msg.author.id) {
-            for check in group_checks.iter().chain(options.checks) {
-                if !check.check_in_help {
-                    continue;
-                }
+    if b == HelpBehaviour::Nothing && (!options.owner_privilege || !owners.contains(&msg.author.id)) {
+        for check in group_checks.iter().chain(options.checks) {
+            if !check.check_in_help {
+                continue;
+            }
 
-                let mut args = Args::new("", &[]);
+            let mut args = Args::new("", &[]);
 
-                if let CheckResult::Failure(_) = (check.function)(ctx, msg, &mut args, options).await {
-                    return help_options.lacking_conditions;
-                }
+            if let CheckResult::Failure(_) = (check.function)(ctx, msg, &mut args, options).await {
+                return help_options.lacking_conditions;
             }
         }
     }
@@ -1202,9 +1200,7 @@ async fn send_suggestion_embed(
     suggestions: &Suggestions,
     colour: Colour,
 ) -> Result<Message, Error> {
-    let text = help_description
-        .replace("{}", &suggestions.join("`, `"))
-        .to_string();
+    let text = help_description.replace("{}", &suggestions.join("`, `"));
 
     channel_id.send_message(&http, |m| {
         m.embed(|e| {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -150,7 +150,7 @@ impl StandardFramework {
     ///         .with_whitespace(true)
     ///         .prefix("~"));
     ///
-    /// let mut client = Client::new(&token).event_handler(Handler).framework(framework).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).framework(framework).await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -613,7 +613,7 @@ impl Framework for StandardFramework {
 
         stream.take_while_char(|c| c.is_whitespace());
 
-        let prefix = parse::prefix(&mut ctx, &msg, &mut stream, &self.config).await;
+        let prefix = parse::prefix(&ctx, &msg, &mut stream, &self.config).await;
 
         if prefix.is_some() && stream.rest().is_empty() {
             if let Some(prefix_only) = &self.prefix_only {
@@ -713,7 +713,7 @@ impl Framework for StandardFramework {
                 };
 
                 if let Some(error) =
-                    self.should_fail(&mut ctx, &msg, &mut args, &command.options, &group.options).await
+                    self.should_fail(&ctx, &msg, &mut args, &command.options, &group.options).await
                 {
                     if let Some(dispatch) = &self.dispatch {
                         dispatch(&mut ctx, &msg, error).await;
@@ -722,7 +722,7 @@ impl Framework for StandardFramework {
                     return;
                 }
 
-                let name = command.options.names[0].clone();
+                let name = command.options.names[0];
 
                 if let Some(before) = &self.before {
                     if !before(&mut ctx, &msg, name).await {
@@ -838,7 +838,7 @@ pub(crate) fn has_correct_roles(
     } else {
         options.allowed_roles()
             .iter()
-            .flat_map(|r| roles.values().find(|role| *r == &role.name))
+            .flat_map(|r| roles.values().find(|role| *r == role.name))
             .any(|g| member.roles.contains(&g.id))
     }
 }

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -162,6 +162,7 @@ pub fn mention<'a>(stream: &mut Stream<'a>, config: &Configuration) -> Option<&'
     }
 }
 
+#[allow(clippy::needless_lifetimes)] // Clippy and the compiler disagree
 async fn find_prefix<'a>(
     ctx: &Context,
     msg: &Message,
@@ -172,7 +173,7 @@ async fn find_prefix<'a>(
         let peeked = stream.peek_for_char(prefix.chars().count());
         let peeked = to_lowercase(config, peeked);
 
-        if prefix == &peeked {
+        if prefix == peeked {
             Some(peeked)
         } else {
             None
@@ -203,6 +204,7 @@ async fn find_prefix<'a>(
 ///
 /// [`Configuration::dynamic_prefix`]: ../struct.Configuration.html#method.dynamic_prefix
 /// [`Configuration::prefix`]: ../struct.Configuration.html#method.prefix
+#[allow(clippy::needless_lifetimes)] // Clippy and the compiler disagree
 pub async fn prefix<'a>(
     ctx: &Context,
     msg: &Message,
@@ -258,8 +260,8 @@ async fn check_discrepancy(
 
             let perms = permissions_in(ctx, &guild, msg.channel_id, msg.author.id).await;
 
-            if !perms.contains(*options.required_permissions())
-                && !(options.owner_privilege() && config.owners.contains(&msg.author.id))
+            if !(perms.contains(*options.required_permissions()) || options.owner_privilege()
+                && config.owners.contains(&msg.author.id))
             {
                 return Err(DispatchError::LackingPermissions(
                     *options.required_permissions(),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1563,7 +1563,7 @@ impl Http {
             .await?;
 
         if !response.status().is_success() {
-            return Err(HttpError::from_response(response).await)?;
+            return Err(HttpError::from_response(response).await.into());
         }
 
         response

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! View the [examples] on how to make and structure a bot.
 //!
-//! Serenity supports bot user authentication via the use of [`Client::new`].
+//! Serenity supports bot user authentication via the use of [`Client::builder`].
 //!
 //! Once logged in, you may add handlers to your client to dispatch [`Event`]s,
 //! such as [`Client::on_message`]. This will cause your handler to be called
@@ -40,7 +40,7 @@
 //! ```
 //!
 //! [`Cache`]: cache/struct.Cache.html
-//! [`Client::new`]: client/struct.Client.html#method.new
+//! [`Client::builder`]: client/struct.Client.html#method.builder
 //! [`Client::on_message`]: client/struct.Client.html#method.on_message
 //! [`Context`]: client/struct.Context.html
 //! [`Event`]: model/event/enum.Event.html

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -95,7 +95,7 @@ impl Attachment {
     ///     }
     /// }
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::new(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -504,7 +504,7 @@ impl GuildChannel {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -557,7 +557,7 @@ impl GuildChannel {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -21,7 +21,6 @@ pub use self::channel_category::*;
 use crate::model::prelude::*;
 use serde::de::Error as DeError;
 use serde::ser::{SerializeStruct, Serialize, Serializer};
-use serde_json;
 use super::utils::deserialize_u64;
 
 #[cfg(feature = "model")]

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -52,7 +52,7 @@ use super::Permissions;
 ///     }
 /// }
 /// let token = std::env::var("DISCORD_BOT_TOKEN")?;
-/// let mut client = Client::new(&token).event_handler(Handler).await?;
+/// let mut client = Client::builder(&token).event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #     Ok(())

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -2,7 +2,6 @@
 
 use serde::de::Error as DeError;
 use serde::ser::{SerializeStruct, Serialize, Serializer};
-use serde_json;
 use super::utils::*;
 use super::prelude::*;
 use bitflags::bitflags;

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -125,7 +125,7 @@ impl GuildId {
         // consider removing
         // `http.as_ref().get_channels(self.0)?()`:
         // `http.as_ref().get_channels(self.0)?`.
-        #[allow(clippy::identity_conversion)]
+        #[allow(clippy::useless_conversion)]
         for channel in http.as_ref().get_channels(self.0).await? {
             channels.insert(channel.id, channel);
         }
@@ -575,7 +575,7 @@ impl GuildId {
     #[cfg(feature = "cache")]
     pub async fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
         let guild = self.to_guild_cached(&cache).await?;
-        Some(guild.name.clone())
+        Some(guild.name)
     }
 
     /// Disconnects a member from a voice channel in the guild.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -1,5 +1,6 @@
 use crate::model::prelude::*;
 use chrono::{DateTime, Utc};
+use std::cmp::Reverse;
 use std::fmt::{
     Display,
     Formatter,
@@ -132,7 +133,7 @@ impl Member {
             .filter_map(|role_id| guild_roles.get(role_id))
             .collect::<Vec<&Role>>();
 
-        roles.sort_by(|a, b| b.cmp(a));
+        roles.sort_by_key(|&b| Reverse(b));
 
         let default = Colour::default();
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1727,7 +1727,7 @@ impl Guild {
     ///     }
     /// }
     ///
-    /// let mut client = Client::new("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #    Ok(())

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -192,7 +192,7 @@ impl Guild {
     /// Returns the "default" channel of the guild for the passed user id.
     /// (This returns the first channel that can be read by the user, if there isn't one,
     /// returns `None`)
-    pub async fn default_channel<'a>(&'a self, uid: UserId) -> Option<&'a GuildChannel> {
+    pub async fn default_channel(&self, uid: UserId) -> Option<&GuildChannel> {
         for (cid, channel) in &self.channels {
             if self.user_permissions_in(*cid, uid).read_messages() {
                 return Some(channel);
@@ -207,7 +207,7 @@ impl Guild {
     /// returns `None`)
     /// Note however that this is very costy if used in a server with lots of channels,
     /// members, or both.
-    pub async fn default_channel_guaranteed<'a>(&'a self) -> Option<&'a GuildChannel> {
+    pub async fn default_channel_guaranteed(&self) -> Option<&GuildChannel> {
         for (cid, channel) in &self.channels {
             for memid in self.members.keys() {
                 if self.user_permissions_in(*cid, *memid).read_messages() {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -586,7 +586,7 @@ impl PartialGuild {
     ///     }
     /// }
     ///
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #    Ok(())

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1,6 +1,5 @@
 //! User information-related models.
 
-use serde_json;
 use std::fmt;
 use super::utils::deserialize_u16;
 use super::prelude::*;
@@ -734,7 +733,7 @@ impl User {
             }
         }
 
-        guild_id.member(cache_http, &self.id).await.ok().and_then(|member| member.nick.clone())
+        guild_id.member(cache_http, &self.id).await.ok().and_then(|member| member.nick)
     }
 
     /// Returns a future that will await one message by this user.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -526,7 +526,7 @@ impl User {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     /// #     Ok(())
     /// # }
     /// # }
@@ -706,7 +706,7 @@ impl User {
     ///         }
     ///     }
     /// }
-    /// let mut client =Client::new("token").event_handler(Handler).await?;
+    /// let mut client =Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -157,7 +157,7 @@ impl MessageBuilder {
     /// # use serde_json::json;
     /// # use serenity::model::guild::Role;
     /// #
-    /// # fn main() {
+    /// # {
     /// #
     /// use serenity::model::guild::Emoji;
     /// use serenity::model::id::EmojiId;
@@ -920,9 +920,8 @@ impl Display for MessageBuilder {
 /// Make a named link to Rust's GitHub organization:
 ///
 /// ```rust
-/// # #[cfg(feature = "utils")]
-/// # fn main() {
-/// #
+/// #[cfg(feature = "utils")]
+/// {
 /// use serenity::utils::{EmbedMessageBuilding, MessageBuilder};
 ///
 /// let msg = MessageBuilder::new()
@@ -930,10 +929,10 @@ impl Display for MessageBuilder {
 ///     .build();
 ///
 /// assert_eq!(msg, "[Rust's GitHub](https://github.com/rust-lang)");
-/// # }
-/// #
-/// # #[cfg(not(feature = "utils"))]
-/// # fn main() { }
+/// }
+///
+/// #[cfg(not(feature = "utils"))]
+/// {}
 /// ```
 ///
 /// [`MessageBuilder`]: struct.MessageBuilder.html
@@ -947,9 +946,8 @@ pub trait EmbedMessageBuilding {
     /// Make a simple link to Rust's homepage for use in an embed:
     ///
     /// ```rust
-    /// # #[cfg(feature = "utils")]
-    /// # fn main() {
-    /// #
+    /// #[cfg(feature = "utils")]
+    /// {
     /// use serenity::utils::{EmbedMessageBuilding, MessageBuilder};
     ///
     /// let mut msg = MessageBuilder::new();
@@ -958,10 +956,10 @@ pub trait EmbedMessageBuilding {
     /// let content = msg.build();
     ///
     /// assert_eq!(content, "Rust's website: [Homepage](https://rust-lang.org)");
-    /// # }
-    /// #
-    /// # #[cfg(not(feature = "utils"))]
-    /// # fn main() { }
+    /// }
+    ///
+    /// #[cfg(not(feature = "utils"))]
+    /// {}
     /// ```
     fn push_named_link<T: I, U: I>(&mut self, name: T, url: U) -> &mut Self;
 
@@ -973,9 +971,8 @@ pub trait EmbedMessageBuilding {
     /// # Examples
     ///
     /// ```rust
-    /// # #[cfg(feature = "utils")]
-    /// # fn main() {
-    /// #
+    /// #[cfg(feature = "utils")]
+    /// {
     /// use serenity::utils::{EmbedMessageBuilding, MessageBuilder};
     ///
     /// let mut msg = MessageBuilder::new();
@@ -984,10 +981,10 @@ pub trait EmbedMessageBuilding {
     /// let content = msg.build();
     ///
     /// assert_eq!(content, "A weird website name: [Try to   break links ( (](https://rust-lang.org)");
-    /// # }
-    /// #
-    /// # #[cfg(not(feature = "utils"))]
-    /// # fn main() { }
+    /// }
+    ///
+    /// #[cfg(not(feature = "utils"))]
+    /// {}
     /// ```
     ///
     /// [`push_named_link`]: #tymethod.push_named_link
@@ -1134,6 +1131,7 @@ impl Content {
         }
     }
 
+    #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         trait UnwrapWith {
             fn unwrap_with(&self, n: usize) -> usize;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -17,7 +17,6 @@ pub use self::{
 };
 pub type Color = Colour;
 
-use base64;
 use crate::internal::prelude::*;
 use crate::model::{
     misc::EmojiIdentifier,


### PR DESCRIPTION
All of them. No more clippy warnings.
Had to #[allow] a few things, most notably things that would result in breaking API or clippy-compiler disagreements.