### PR TITLE
Change order rules of MessagesIter: from new to old

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -840,19 +840,12 @@ impl<H: AsRef<Http>> MessagesIter<H> {
 
         // If `self.before` is not set yet, we can use `.messages` to fetch
         // the last message after very first fetch from last.
-        self.buffer = 
+        self.buffer = self.channel_id.messages(&self.http, |b| {
             if let Some(before) = self.before {
-                self.channel_id
-                    .messages(&self.http, |b| 
-                        b.before(before)
-                         .limit(grab_size)
-                    ).await?
-            } else {
-                self.channel_id
-                    .messages(&self.http, |b| 
-                        b.limit(grab_size)
-                    ).await?
-            };
+                b.before(before);
+            }
+            b.limit(grab_size)
+        }).await?;
 
         self.before = self.buffer.get(0)
             .map(|message| message.id);


### PR DESCRIPTION
Default order behavior for `.messages(` method is from new to old https://docs.rs/serenity/0.9.0-rc.2/serenity/builder/struct.GetMessages.html

But if you switch to `MessageIter` way it's becoming from old to new which is not very consistent.

This pull request changes it to work alike GetMessages by default, I'd like it to be merged. However I'd like to discuss ability to use different ordering for `MessageIter`, maybe we should have two traits or maybe some options but from new to old should be default I think since it's generally more useful, imo.