### PR TITLE
Initial implementation for inline replies

### DIFF
--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -1,6 +1,6 @@
 use crate::internal::prelude::*;
 use crate::http::AttachmentType;
-use crate::model::channel::ReactionType;
+use crate::model::channel::{ReactionType, MessageReference};
 use super::CreateEmbed;
 use super::CreateAllowedMentions;
 use crate::utils;
@@ -133,6 +133,12 @@ impl<'a> CreateMessage<'a> {
         let allowed_mentions = Value::Object(map);
 
         self.0.insert("allowed_mentions", allowed_mentions);
+        self
+    }
+
+    /// Set the reference message this message is a reply to.
+    pub fn reference_message(&mut self, reference: impl Into<MessageReference>) -> &mut Self {
+        self.0.insert("message_reference", serde_json::to_value(reference.into()).unwrap());
         self
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1030,6 +1030,7 @@ mod test {
                 application: None,
                 message_reference: None,
                 flags: None,
+                referenced_message: None,
                 _nonexhaustive: (),
             },
             _nonexhaustive: (),

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -112,6 +112,8 @@ pub struct Message {
     pub message_reference: Option<MessageReference>,
     /// Bit flags describing extra features of the message.
     pub flags: Option<MessageFlags>,
+    /// The message that was replied to using this message.
+    pub referenced_message: Option<Box<Message>>, // Boxed to avoid recusion
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
 }
@@ -863,6 +865,8 @@ pub enum MessageType {
     NitroTier2 = 10,
     /// An indicator that the guild has reached nitro tier 3
     NitroTier3 = 11,
+    // /// An message reply.
+    // InlineReply = 19, // TODO Enable this when v8 hits.
 }
 
 enum_number!(
@@ -879,6 +883,7 @@ enum_number!(
         NitroTier1,
         NitroTier2,
         NitroTier3,
+        // InlineReply, // TODO Enable this when v8 hits
     }
 );
 
@@ -975,6 +980,28 @@ pub struct MessageReference {
     pub guild_id: Option<GuildId>,
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
+}
+
+impl From<&Message> for MessageReference {
+    fn from(m: &Message) -> Self {
+        Self {
+            message_id: Some(m.id),
+            channel_id: m.channel_id,
+            guild_id: m.guild_id,
+            _nonexhaustive: ()
+        }
+    }
+}
+
+impl From<(ChannelId, MessageId)> for MessageReference {
+    fn from(pair: (ChannelId, MessageId)) -> Self {
+        Self {
+            message_id: Some(pair.1),
+            channel_id: pair.0,
+            guild_id: None,
+            _nonexhaustive: ()
+        }
+    }
 }
 
 /// Channel Mention Object

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -904,6 +904,7 @@ impl MessageType {
             NitroTier1 => 9,
             NitroTier2 => 10,
             NitroTier3 => 11,
+            InlineReply => 19,
         }
     }
 }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -866,7 +866,7 @@ pub enum MessageType {
     /// An indicator that the guild has reached nitro tier 3
     NitroTier3 = 11,
     // /// An message reply.
-    // InlineReply = 19, // TODO Enable this when v8 hits.
+    InlineReply = 19,
 }
 
 enum_number!(
@@ -883,7 +883,7 @@ enum_number!(
         NitroTier1,
         NitroTier2,
         NitroTier3,
-        // InlineReply, // TODO Enable this when v8 hits
+        InlineReply,
     }
 );
 

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -273,6 +273,7 @@ fn dummy_message() -> Message {
         application: None,
         message_reference: None,
         flags: None,
+        referenced_message: None,
         _nonexhaustive: (),
     }
 }


### PR DESCRIPTION
Initial implementation for https://github.com/discord/discord-api-docs/pull/2118

I also added in the support for v8, which will need to be uncommented when that gets implemented. Do you guys keep track of a v8 TODO list somewhere?

Full disclaimer though, I have no idea if this works as it is untested vs the Discord API (~~they haven't implemented this yet, so don't merge until they have~~).