### PR TITLE
http error improvements

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -1,17 +1,7 @@
-use reqwest::{
-    Error as ReqwestError,
-    Response,
-    header::InvalidHeaderValue,
-    StatusCode,
-    Url,
-};
+use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, Response, StatusCode, Url};
 use std::{
     error::Error as StdError,
-    fmt::{
-        Display,
-        Formatter,
-        Result as FmtResult
-    }
+    fmt::{Display, Formatter, Result as FmtResult},
 };
 use url::ParseError as UrlError;
 
@@ -52,7 +42,6 @@ impl ErrorResponse {
     }
 }
 
-
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
@@ -76,9 +65,39 @@ impl Error {
     // We need a freestanding from-function since we cannot implement an async
     // From-trait.
     pub async fn from_response(r: Response) -> Self {
-        ErrorResponse::from_response(r)
-            .await
-            .into()
+        ErrorResponse::from_response(r).await.into()
+    }
+
+    /// Returns true when the error is caused by an unsuccessful request
+    pub fn is_unsuccessful_request(&self) -> bool {
+        match self {
+            Self::UnsuccessfulRequest(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true when the error is caused by the url containing invalid input
+    pub fn is_url_error(&self) -> bool {
+        match self {
+            Self::Url(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true when the error is caused by an invalid header
+    pub fn is_invalid_header(&self) -> bool {
+        match self {
+            Self::InvalidHeader(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the status code if the error is an unsuccessful request
+    pub fn status_code(&self) -> Option<StatusCode> {
+        match self {
+            Self::UnsuccessfulRequest(res) => Some(res.status_code),
+            _ => None,
+        }
     }
 }
 

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -1,7 +1,17 @@
-use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, Response, StatusCode, Url};
+use reqwest::{
+    header::InvalidHeaderValue,
+    Error as ReqwestError,
+    Response,
+    StatusCode,
+    Url
+};
 use std::{
     error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
+    fmt::{
+        Display,
+        Formatter,
+        Result as FmtResult
+    },
 };
 use url::ParseError as UrlError;
 
@@ -42,6 +52,7 @@ impl ErrorResponse {
     }
 }
 
+
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
@@ -65,7 +76,9 @@ impl Error {
     // We need a freestanding from-function since we cannot implement an async
     // From-trait.
     pub async fn from_response(r: Response) -> Self {
-        ErrorResponse::from_response(r).await.into()
+        ErrorResponse::from_response(r)
+            .await
+            .into()
     }
 
     /// Returns true when the error is caused by an unsuccessful request

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -3,14 +3,14 @@ use reqwest::{
     Error as ReqwestError,
     Response,
     StatusCode,
-    Url
+    Url,
 };
 use std::{
     error::Error as StdError,
     fmt::{
         Display,
         Formatter,
-        Result as FmtResult
+        Result as FmtResult,
     },
 };
 use url::ParseError as UrlError;
@@ -45,7 +45,7 @@ impl ErrorResponse {
             url: r.url().clone(),
             error: r.json().await.unwrap_or_else(|_| DiscordJsonError {
                 code: -1,
-                message: "[Serenity] No correct json was received!".to_string(),
+                message: "[Serenity] Could not decode json when receiving error response from discord!".to_string(),
                 non_exhaustive: (),
             }),
         }


### PR DESCRIPTION
This PR adds 3 methods to check for common error cases in the http::Error enum and one to get an Option back with the status code, it also changes the error message to be more descriptive.
I hope this closes #919 till work can be done on receiving and decoding the errors from the v8 api.
