### PR TITLE
Removed unnecessary Option on Message::channel_mentions

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1018,7 +1018,7 @@ mod test {
                 member: None,
                 mention_everyone: false,
                 mention_roles: vec![],
-                mention_channels: None,
+                mention_channels: vec![],
                 mentions: vec![],
                 nonce: Value::Number(Number::from(1)),
                 pinned: false,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -84,7 +84,8 @@ pub struct Message {
     /// [`Role`]: ../guild/struct.Role.html
     pub mention_roles: Vec<RoleId>,
     /// Channels specifically mentioned in this message.
-    pub mention_channels: Option<Vec<ChannelMention>>,
+    #[serde(default = "Vec::new")]
+    pub mention_channels: Vec<ChannelMention>,
     /// Array of users mentioned in the message.
     pub mentions: Vec<User>,
     /// Non-repeating number used for ensuring message order.

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -261,7 +261,7 @@ fn dummy_message() -> Message {
         member: None,
         mention_everyone: false,
         mention_roles: Vec::new(),
-        mention_channels: None,
+        mention_channels: Vec::new(),
         mentions: Vec::new(),
         nonce: Value::Null,
         pinned: false,


### PR DESCRIPTION
For consistency sake

	modified:   src/cache/mod.rs
	modified:   src/model/channel/message.rs
	modified:   src/utils/custom_message.rs