### PR TITLE
Remove discord token from being logged

### DIFF
--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -75,7 +75,7 @@ impl WebSocketGatewayClientExt for WsStream {
         })).await.map_err(From::from)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, token))]
     async fn send_identify(&mut self, shard_info: &[u64; 2], token: &str, guild_subscriptions: bool, intents: Option<GatewayIntents>)
         -> Result<()> {
         debug!("[Shard {:?}] Identifying", shard_info);

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -27,6 +27,7 @@ use serde_json::json;
 use tracing::{debug, trace, instrument};
 use std::{
     collections::BTreeMap,
+    fmt,
     sync::Arc,
 };
 use tokio::{
@@ -34,11 +35,19 @@ use tokio::{
     fs::File,
 };
 
-#[derive(Debug)]
 pub struct Http {
     pub(crate) client: Arc<Client>,
     pub ratelimiter: Ratelimiter,
     pub token: String,
+}
+
+impl fmt::Debug for Http {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Http")
+            .field("client", &self.client)
+            .field("ratelimiter", &self.ratelimiter)
+            .finish()
+    }
 }
 
 impl Http {

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -47,6 +47,7 @@ use crate::internal::prelude::*;
 use tokio::sync::{Mutex, RwLock};
 use std::{
     collections::HashMap,
+    fmt,
     sync::Arc,
     str::{
         self,
@@ -79,7 +80,6 @@ use tracing::{debug, instrument};
 /// [`limit`]: struct.Ratelimit.html#method.limit
 /// [`remaining`]: struct.Ratelimit.html#method.remaining
 /// [`reset`]: struct.Ratelimit.html#method.reset
-#[derive(Debug)]
 pub struct Ratelimiter {
     client: Arc<Client>,
     global: Arc<Mutex<()>>,
@@ -87,6 +87,16 @@ pub struct Ratelimiter {
     // when the 'reset' passes.
     routes: Arc<RwLock<HashMap<Route, Arc<Mutex<Ratelimit>>>>>,
     token: String,
+}
+
+impl fmt::Debug for Ratelimiter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ratelimiter")
+            .field("client", &self.client)
+            .field("global", &self.global)
+            .field("routes", &self.routes)
+            .finish()
+    }
 }
 
 impl Ratelimiter {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -65,7 +65,7 @@ impl<'a> Request<'a> {
         Self { body, headers, route }
     }
 
-    #[instrument]
+    #[instrument(skip(token))]
     pub fn build(&'a self, client: &Client, token: &str) -> Result<ReqwestRequestBuilder, HttpError> {
         let Request {
             body,

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -5,10 +5,11 @@ use super::{
     user::User,
     utils::*,
 };
+use std::fmt;
 
 /// Information about a user's application. An application does not necessarily
 /// have an associated bot user.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ApplicationInfo {
     /// The bot user associated with the application. See [`BotApplication`] for
     /// more information.
@@ -52,8 +53,26 @@ pub struct ApplicationInfo {
     pub(crate) _nonexhaustive: (),
 }
 
+impl fmt::Debug for ApplicationInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApplicationInfo")
+            .field("bot", &self.bot)
+            .field("bot_public", &self.bot_public)
+            .field("bot_require_code_grant", &self.bot_require_code_grant)
+            .field("description", &self.description)
+            .field("flags", &self.flags)
+            .field("icon", &self.icon)
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("redirect_uris", &self.redirect_uris)
+            .field("rpc_origins", &self.rpc_origins)
+            .field("team", &self.team)
+            .finish()
+    }
+}
+
 /// Information about an application with an application's bot user.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct BotApplication {
     /// The unique Id of the bot user.
     pub id: UserId,
@@ -78,6 +97,19 @@ pub struct BotApplication {
     pub token: String,
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
+}
+
+
+impl fmt::Debug for BotApplication {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BotApplication")
+            .field("id", &self.id)
+            .field("avatar", &self.avatar)
+            .field("bot", &self.bot)
+            .field("discriminator", &self.discriminator)
+            .field("name", &self.name)
+            .finish()
+    }
 }
 
 /// Information about the current application and its owner.

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -7,7 +7,10 @@ use serde::ser::{
     SerializeSeq,
     Serializer
 };
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt
+};
 use super::utils::{deserialize_emojis, deserialize_u64};
 use super::prelude::*;
 use crate::constants::{OpCode, VoiceOpCode};
@@ -1312,7 +1315,7 @@ impl Serialize for UserUpdateEvent {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct VoiceServerUpdateEvent {
     pub channel_id: Option<ChannelId>,
     pub endpoint: Option<String>,
@@ -1320,6 +1323,16 @@ pub struct VoiceServerUpdateEvent {
     pub token: String,
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
+}
+
+impl fmt::Debug for VoiceServerUpdateEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VoiceServerUpdateEvent")
+            .field("channel_id", &self.channel_id)
+            .field("endpoint", &self.endpoint)
+            .field("guild_id", &self.guild_id)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -2079,13 +2092,22 @@ pub struct VoiceSpeaking {
     pub(crate) _nonexhaustive: (),
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct VoiceResume {
     pub server_id: String,
     pub session_id: String,
     pub token: String,
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
+}
+
+impl fmt::Debug for VoiceResume {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VoiceResume")
+            .field("server_id", &self.server_id)
+            .field("session_id", &self.session_id)
+            .finish()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -1,6 +1,7 @@
 //! Representations of voice information.
 
 use super::id::{ChannelId, UserId};
+use std::fmt;
 
 /// Information about an available voice region.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -26,7 +27,7 @@ pub struct VoiceRegion {
 }
 
 /// A user's state within a voice channel.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct VoiceState {
     pub channel_id: Option<ChannelId>,
     pub deaf: bool,
@@ -40,4 +41,21 @@ pub struct VoiceState {
     pub user_id: UserId,
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
+}
+
+
+impl fmt::Debug for VoiceState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VoiceState")
+            .field("channel_id", &self.channel_id)
+            .field("deaf", &self.deaf)
+            .field("mute", &self.mute)
+            .field("self_deaf", &self.self_deaf)
+            .field("self_mute", &self.self_mute)
+            .field("self_stream", &self.self_stream)
+            .field("session_id", &self.session_id)
+            .field("suppress", &self.suppress)
+            .field("user_id", &self.user_id)
+            .finish()
+    }
 }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -9,6 +9,8 @@ use super::{
     user::User
 };
 
+use std::fmt;
+
 #[cfg(feature = "model")]
 use crate::builder::ExecuteWebhook;
 #[cfg(feature = "model")]
@@ -25,7 +27,7 @@ use crate::http::Http;
 /// A representation of a webhook, which is a low-effort way to post messages to
 /// channels. They do not necessarily require a bot user or authentication to
 /// use.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Webhook {
     /// The unique Id.
     ///
@@ -55,6 +57,19 @@ pub struct Webhook {
     pub user: Option<User>,
     #[serde(skip)]
     pub(crate) _nonexhaustive: (),
+}
+
+impl fmt::Debug for Webhook {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Webhook")
+            .field("id", &self.id)
+            .field("avatar", &self.avatar)
+            .field("channel_id", &self.channel_id)
+            .field("guild_id", &self.guild_id)
+            .field("name", &self.name)
+            .field("user", &self.user)
+            .finish()
+    }
 }
 
 #[cfg(feature = "model")]

--- a/src/voice/connection_info.rs
+++ b/src/voice/connection_info.rs
@@ -1,10 +1,22 @@
 use crate::model::id::{GuildId, UserId};
+use std::fmt;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ConnectionInfo {
     pub endpoint: String,
     pub guild_id: GuildId,
     pub session_id: String,
     pub token: String,
     pub user_id: UserId,
+}
+
+impl fmt::Debug for ConnectionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectionInfo")
+            .field("endpoint", &self.endpoint)
+            .field("guild_id", &self.guild_id)
+            .field("session_id", &self.session_id)
+            .field("user_id", &self.user_id)
+            .finish()
+    }
 }

--- a/src/voice/handler.rs
+++ b/src/voice/handler.rs
@@ -355,7 +355,7 @@ impl Handler {
     ///
     /// [`connect`]: #method.connect
     /// [`standalone`]: #method.standalone
-    #[instrument(skip(self))]
+    #[instrument(skip(self, token))]
     pub fn update_server(&mut self, endpoint: &Option<String>, token: &str) {
         self.token = Some(token.to_string());
 


### PR DESCRIPTION
This was mainly done based on these two log lines (formatted them to make them easier to read): https://paste.gg/p/anonymous/9ae4e96480194dd2a85e4f34ebc5ad35

I've also proactively added custom `Debug` impls for every structure containing `token:` or `secret:` field. It is possible I missed something - would appreciate if someone would double-check.

Test results:
```sh
$ cargo test --all-features
# ...
test result: ok. 249 passed; 0 failed; 37 ignored; 0 measured; 0 filtered out
```