### PR TITLE
Add secrecy to wrap tokens to avoid accidental leaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tracing-futures = "0.2"
 serde_json = "1"
 async-trait = "0.1"
 futures = "0.3"
+secrecy = "0.7"
 
 [dependencies.static_assertions]
 optional = true

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -27,6 +27,7 @@ use async_tungstenite::tungstenite::{
 };
 use url::Url;
 use tracing::{error, debug, info, trace, warn, instrument};
+use secrecy::SecretString;
 
 #[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 use crate::internal::ws_impl::create_rustls_client;
@@ -97,7 +98,7 @@ pub struct Shard {
     // This acts as a timeout to determine if the shard has - for some reason -
     // not started within a decent amount of time.
     pub started: Instant,
-    pub token: String,
+    pub token: SecretString,
     ws_url: Arc<Mutex<String>>,
     pub intents: Option<GatewayIntents>,
 }
@@ -133,7 +134,7 @@ impl Shard {
     /// ```
     pub async fn new(
         ws_url: Arc<Mutex<String>>,
-        token: &str,
+        token: &SecretString,
         shard_info: [u64; 2],
         guild_subscriptions: bool,
         intents: Option<GatewayIntents>,
@@ -159,7 +160,7 @@ impl Shard {
             seq,
             stage,
             started: Instant::now(),
-            token: token.to_string(),
+            token: token.clone(),
             session_id,
             shard_info,
             guild_subscriptions,

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -59,6 +59,7 @@ use std::{
 use tokio::time::{delay_for, Duration};
 use super::{HttpError, Request};
 use tracing::{debug, instrument};
+use secrecy::SecretString;
 
 /// Ratelimiter for requests to the Discord API.
 ///
@@ -86,7 +87,7 @@ pub struct Ratelimiter {
     // When futures is implemented, make tasks clear out their respective entry
     // when the 'reset' passes.
     routes: Arc<RwLock<HashMap<Route, Arc<Mutex<Ratelimit>>>>>,
-    token: String,
+    token: SecretString,
 }
 
 impl Ratelimiter {
@@ -95,11 +96,11 @@ impl Ratelimiter {
     ///
     /// The bot token must be prefixed with `"Bot "`. The ratelimiter does not
     /// prefix it.
-    pub fn new(client: Arc<Client>, token: impl Into<String>) -> Self {
-        Self::_new(client, token.into())
+    pub fn new(client: Arc<Client>, token: SecretString) -> Self {
+        Self::_new(client, token)
     }
 
-    fn _new(client: Arc<Client>, token: String) -> Self {
+    fn _new(client: Arc<Client>, token: SecretString) -> Self {
         Self {
             client,
             global: Default::default(),

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -12,6 +12,7 @@ use super::{
     HttpError,
     routing::RouteInfo,
 };
+use secrecy::{SecretString, ExposeSecret};
 
 pub struct RequestBuilder<'a> {
     body: Option<&'a [u8]>,
@@ -66,7 +67,7 @@ impl<'a> Request<'a> {
     }
 
     #[instrument]
-    pub fn build(&'a self, client: &Client, token: &str) -> Result<ReqwestRequestBuilder, HttpError> {
+    pub fn build(&'a self, client: &Client, token: &SecretString) -> Result<ReqwestRequestBuilder, HttpError> {
         let Request {
             body,
             headers: ref request_headers,
@@ -87,7 +88,7 @@ impl<'a> Request<'a> {
         let mut headers = Headers::with_capacity(4);
         headers.insert(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT));
         headers.insert(AUTHORIZATION,
-            HeaderValue::from_str(&token).map_err(HttpError::InvalidHeader)?);
+            HeaderValue::from_str(token.expose_secret()).map_err(HttpError::InvalidHeader)?);
 
         // Discord will return a 400: Bad Request response if we set the content type header,
         // but don't give a body.


### PR DESCRIPTION
The new tracing logging has exposed some ways through which the token could be leaking with instrumentation. With this PR we're adding the secrecy crate and ensuring there's no accidental token leaks through derived Debug impls.