### PR TITLE
Updated to tracing and dotenv

### DIFF
--- a/examples/e07_sample_bot_structure/Cargo.toml
+++ b/examples/e07_sample_bot_structure/Cargo.toml
@@ -5,10 +5,14 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-env_logger = "0.6"
-kankyo = "0.2"
-log = "0.4"
-tokio = { version = "0.2", features = ["macros"] }
+dotenv = "0.15"
+tracing = "0.1"
+tracing-subscriber = "0.2"
+tracing-futures = "0.2" # needed so intrument works with async functions.
+
+[dependencies.tokio]
+version = "0.2"
+features = ["macros"]
 
 [dependencies.serenity]
 features = ["cache", "framework", "standard_framework", "rustls_backend"]

--- a/examples/e07_sample_bot_structure/src/main.rs
+++ b/examples/e07_sample_bot_structure/src/main.rs
@@ -26,7 +26,13 @@ use serenity::{
     model::{event::ResumedEvent, gateway::Ready},
     prelude::*,
 };
-use log::{error, info};
+
+use tracing::{error, info};
+use tracing_subscriber::{
+    FmtSubscriber,
+    EnvFilter,
+};
+
 
 use commands::{
     math::*,
@@ -61,13 +67,18 @@ struct General;
 async fn main() {
     // This will load the environment variables located at `./.env`, relative to
     // the CWD. See `./.env.example` for an example on how to structure this.
-    kankyo::load().expect("Failed to load .env file");
+    dotenv::dotenv().expect("Failed to load .env file");
 
     // Initialize the logger to use environment variables.
     //
     // In this case, a good default is setting the environment variable
     // `RUST_LOG` to debug`.
-    env_logger::init();
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to start the logger");
+
 
     let token = env::var("DISCORD_TOKEN")
         .expect("Expected a token in the environment");


### PR DESCRIPTION
Replaced `kankyo` with `dotenv` due to being abandoned.
Replaced `log` with `tracing` to have better async support, and to follow example 8.

	modified:   Cargo.toml
	modified:   src/main.rs