### PR TITLE
Ignore empty arguments

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -312,6 +312,11 @@ impl Args {
             let mut stream = Stream::new(message);
 
             while let Some(token) = lex(&mut stream, &delims) {
+                // Ignore empty arguments.
+                if message[token.span.0..token.span.1].is_empty() {
+                    continue;
+                }
+
                 args.push(token);
             }
 


### PR DESCRIPTION
This changes `Args` to avoid storing arguments that are empty. These may happen in the case where one of the delimiters is a space (which is by default) and the arguments of a command are filled with several spaces in a row.

E.g.:
```
!ping 1      2                3
```
There are many "arguments" between the spaces that are empty, while intuition says that there should be just three arguments: `1`, `2`, and `3`. This fixes the behaviour to be of the latter.