### PR TITLE
Derive `Clone` for `CacheAndHttp`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ use crate::http::Http;
 
 
 #[cfg(feature = "client")]
-#[derive(Default)]
+#[derive(Clone, Default)]
 #[non_exhaustive]
 pub struct CacheAndHttp {
     #[cfg(feature = "cache")]


### PR DESCRIPTION
All of its fields implement `Clone`, and there is no concrete reason why `CacheAndHttp` cannot as well.