### PR TITLE
Update & reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ tracing = "0.1"
 tracing-futures = "0.2"
 serde_json = "1"
 async-trait = "0.1"
-futures = "0.3"
 
 [dependencies.static_assertions]
 optional = true
@@ -70,7 +69,7 @@ version = "0.7"
 default-features = false
 features = ["tokio-runtime"]
 optional = true
-version = "0.8"
+version = "0.9.2"
 
 [dependencies.typemap_rev]
 optional = true
@@ -92,6 +91,11 @@ version = "0.5"
 version = "0.2"
 default-features = false
 features = ["fs", "macros", "rt-core", "sync", "time"]
+
+[dependencies.futures]
+version = "0.3"
+default-features = false
+features = ["std"]
 
 [dev-dependencies.http_crate]
 version = "0.2"
@@ -139,7 +143,7 @@ gateway = [
 ]
 http = ["url", "bytes"]
 absolute_ratelimits = ["http"]
-rustls_backend = ["reqwest/rustls-tls", "async-tungstenite/async-tls"]
+rustls_backend = ["reqwest/rustls-tls", "async-tungstenite/tokio-rustls"]
 native_tls_backend = ["reqwest/native-tls", "async-tungstenite/tokio-native-tls"]
 model = ["builder", "http"]
 standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]


### PR DESCRIPTION
- Switch to async-tungstenite/tokio-rustls
- futures only with the `std` feature drops the futures-executor dep