### PR TITLE
Correctly update the guild instance in the members chunk event

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -574,7 +574,7 @@ impl CacheUpdate for GuildMembersChunkEvent {
             cache.update_user_entry(&member.user).await;
         }
 
-        if let Some(mut g) = cache.guild(self.guild_id).await {
+        if let Some(g) = cache.guilds.write().await.get_mut(&self.guild_id) {
             g.members.extend(self.members.clone());
         }
 


### PR DESCRIPTION
The update method first cloned the guild, and then updated its members list. This is wrong, because as soon as the instance drops, we lose the members we received in the members chunk event. This fixes the behaviour by obtaining a mutable reference to the guild.