### PR TITLE
Update async-tungstenite to 0.9.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,16 +69,7 @@ version = "0.7"
 default-features = false
 features = ["tokio-runtime"]
 optional = true
-version = "0.9.2"
-
-[dependencies.rustls]
-default-features = false
-optional = true
-version = "0.18" # keep in sync with reqwest's rustls version
-
-[dependencies.webpki-roots]
-optional = true
-version = "0.19" # keep in sync with reqwest's webpki-roots version
+version = "0.9.3"
 
 [dependencies.typemap_rev]
 optional = true
@@ -152,7 +143,7 @@ gateway = [
 ]
 http = ["url", "bytes"]
 absolute_ratelimits = ["http"]
-rustls_backend = ["reqwest/rustls-tls", "async-tungstenite/tokio-rustls", "rustls", "webpki-roots"]
+rustls_backend = ["reqwest/rustls-tls", "async-tungstenite/tokio-rustls"]
 native_tls_backend = ["reqwest/native-tls", "async-tungstenite/tokio-native-tls"]
 model = ["builder", "http"]
 standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -147,12 +147,8 @@ impl StdError for RustlsError {
 #[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 #[instrument]
 pub(crate) async fn create_rustls_client(url: Url) -> Result<WsStream> {
-    let mut config = rustls::ClientConfig::new();
-    config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let connector = std::sync::Arc::new(config).into();
-    let (stream, _) = async_tungstenite::tokio::connect_async_with_tls_connector_and_config::<Url>(
+    let (stream, _) = async_tungstenite::tokio::connect_async_with_config::<Url>(
         url,
-        Some(connector),
         Some(async_tungstenite::tungstenite::protocol::WebSocketConfig {
             max_message_size: None,
             max_frame_size: None,


### PR DESCRIPTION
The new version already comes with a configured TLS connector

see: sdroege/async-tungstenite#61