### PR TITLE
Deserialize the correct data from the `GUILD_DELETE` event

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -983,7 +983,6 @@ mod test {
         cache::{Cache, CacheUpdate, Settings},
         model::prelude::*,
     };
-    use crate::model::guild::PremiumTier::Tier2;
 
     #[tokio::test]
     async fn test_cache_messages() {
@@ -1135,29 +1134,9 @@ mod test {
         assert!(cache.update(&mut event).await.is_none());
 
         let mut guild_delete = GuildDeleteEvent {
-            guild: PartialGuild {
+            guild: GuildUnavailable {
                 id: GuildId(1),
-                afk_channel_id: None,
-                afk_timeout: 0,
-                default_message_notifications: DefaultMessageNotificationLevel::All,
-                embed_channel_id: None,
-                embed_enabled: false,
-                emojis: HashMap::new(),
-                features: vec![],
-                icon: None,
-                mfa_level: MfaLevel::None,
-                name: String::new(),
-                owner_id: UserId(3),
-                region: String::new(),
-                roles: HashMap::new(),
-                splash: None,
-                verification_level: VerificationLevel::Low,
-                description: None,
-                premium_tier: Tier2,
-                premium_subscription_count: 12,
-                banner: None,
-                vanity_url_code: Some("bruhmoment".to_string()),
-                _nonexhaustive: (),
+                unavailable: false,
             },
             _nonexhaustive: (),
         };

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -99,14 +99,22 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Provides the partial data of the guild sent by discord,
     /// and the full data from the cache, if available.
+    ///
+    /// The `unavailable` flag in the partial data determines the status of the guild.
+    /// If the flag is false, the bot was removed from the guild, either by being
+    /// kicked or banned. If the flag is true, the guild went offline.
     #[cfg(feature = "cache")]
-    async fn guild_delete(&self, _ctx: Context, _incomplete: PartialGuild, _full: Option<Guild>) {}
+    async fn guild_delete(&self, _ctx: Context, _incomplete: GuildUnavailable, _full: Option<Guild>) {}
 
     /// Dispatched when a guild is deleted.
     ///
     /// Provides the partial data of the guild sent by discord.
+    ///
+    /// The `unavailable` flag in the partial data determines the status of the guild.
+    /// If the flag is false, the bot was removed from the guild, either by being
+    /// kicked or banned. If the flag is true, the guild went offline.
     #[cfg(not(feature = "cache"))]
-    async fn guild_delete(&self, _ctx: Context, _incomplete: PartialGuild) {}
+    async fn guild_delete(&self, _ctx: Context, _incomplete: GuildUnavailable) {}
 
     /* the emojis were updated. */
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -339,7 +339,7 @@ impl Serialize for GuildCreateEvent {
 
 #[derive(Clone, Debug)]
 pub struct GuildDeleteEvent {
-    pub guild: PartialGuild,
+    pub guild: GuildUnavailable,
     pub(crate) _nonexhaustive: (),
 }
 
@@ -369,7 +369,7 @@ impl CacheUpdate for GuildDeleteEvent {
 impl<'de> Deserialize<'de> for GuildDeleteEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
-            guild: PartialGuild::deserialize(deserializer)?,
+            guild: GuildUnavailable::deserialize(deserializer)?,
             _nonexhaustive: (),
         })
     }
@@ -378,7 +378,7 @@ impl<'de> Deserialize<'de> for GuildDeleteEvent {
 impl Serialize for GuildDeleteEvent {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
         where S: Serializer {
-        PartialGuild::serialize(&self.guild, serializer)
+        GuildUnavailable::serialize(&self.guild, serializer)
     }
 }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2059,13 +2059,12 @@ impl InviteGuild {
 /// Data for an unavailable guild.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct GuildUnavailable {
-    /// The Id of the [`Guild`] that is unavailable.
+    /// The Id of the [`Guild`] that may be unavailable.
     ///
     /// [`Guild`]: struct.Guild.html
     pub id: GuildId,
     /// Indicator of whether the guild is unavailable.
-    ///
-    /// This should always be `true`.
+    #[serde(default)]
     pub unavailable: bool,
 }
 


### PR DESCRIPTION
Fixes #1023.

[As explained in my comment](https://github.com/serenity-rs/serenity/issues/1023#issuecomment-711952634), we expect to receive data from Discord that is a `PartialGuild`, while in truth, Discord sends us `GuildUnavailable` on the `GUILD_DELETE` event. 