### PR TITLE
Changed `utils::shard_id` to accept `Into<u64>`

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -451,7 +451,7 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
 /// assert_eq!(utils::shard_id(81384788765712384, 17), 7);
 /// ```
 #[inline]
-pub fn shard_id(guild_id: u64, shard_count: u64) -> u64 { (guild_id >> 22) % shard_count }
+pub fn shard_id(guild_id: impl Into<u64>, shard_count: u64) -> u64 { (guild_id.into() >> 22) % shard_count }
 
 /// Struct that allows to alter [`content_safe`]'s behaviour.
 ///

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -448,10 +448,10 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
 /// ```rust
 /// use serenity::utils;
 ///
-/// assert_eq!(utils::shard_id(81384788765712384, 17), 7);
+/// assert_eq!(utils::shard_id(81384788765712384 as u64, 17), 7);
 /// ```
 #[inline]
-pub fn shard_id(guild_id: u64, shard_count: u64) -> u64 { (guild_id >> 22) % shard_count }
+pub fn shard_id(guild_id: impl Into<u64>, shard_count: u64) -> u64 { (guild_id.into() >> 22) % shard_count }
 
 /// Struct that allows to alter [`content_safe`]'s behaviour.
 ///


### PR DESCRIPTION
This is beneficial as it allows you to pass GuildId objects into the shard_id function