### PR TITLE
member_permissions without cache

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -62,6 +62,7 @@ use super::{
 };
 #[cfg(all(feature = "cache", feature = "http"))]
 use crate::{
+    http::CacheHttp,
     cache::Cache,
     client::Context,
     framework::standard::CommonOptions,
@@ -273,15 +274,15 @@ pub(crate) fn levenshtein_distance(word_a: &str, word_b: &str) -> usize {
 /// and given the required permissions.
 #[cfg(feature = "cache")]
 pub async fn has_all_requirements(
-    cache: impl AsRef<Cache>,
+    cache_http: impl CacheHttp + AsRef<Cache>,
     cmd: &CommandOptions,
     msg: &Message,
 ) -> bool {
-    let cache = cache.as_ref();
+    let cache = cache_http.as_ref();
 
     if let Some(guild_id) = msg.guild_id {
         if let Some(member) = cache.member(guild_id, &msg.author.id).await {
-            if let Ok(permissions) = member.permissions(&cache).await {
+            if let Ok(permissions) = member.permissions(&cache_http).await {
                 return if cmd.allowed_roles.is_empty() {
                     permissions.administrator() || has_correct_permissions(&cache, &cmd, msg).await
                 } else if let Some(roles) = cache.guild_roles(guild_id).await {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -367,7 +367,7 @@ impl Member {
             None => return Err(From::from(ModelError::GuildNotFound)),
         };
 
-        Ok(guild.member_permissions(self.user.id))
+        Ok(guild.member_permissions_cached(self.user.id))
     }
 
     /// Removes a [`Role`] from the member, editing its roles in-place if the

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -305,7 +305,7 @@ impl Member {
                 if let Some(guild) = cache.guilds.read().await.get(&self.guild_id) {
                     let req = Permissions::KICK_MEMBERS;
 
-                    if !guild.has_perms(cache, req).await {
+                    if !guild.has_perms(&cache_http, req).await {
                         return Err(Error::Model(ModelError::InvalidPermissions(req)));
                     }
 
@@ -361,13 +361,13 @@ impl Member {
     /// [`ModelError::GuildNotFound`]: ../error/enum.Error.html#variant.GuildNotFound
     /// [`ModelError::ItemMissing`]: ../error/enum.Error.html#variant.ItemMissing
     #[cfg(feature = "cache")]
-    pub async fn permissions(&self, cache: impl AsRef<Cache>) -> Result<Permissions> {
-        let guild = match cache.as_ref().guild(self.guild_id).await {
+    pub async fn permissions(&self, cache_http: impl CacheHttp + AsRef<Cache>) -> Result<Permissions> {
+        let guild = match cache_http.as_ref().guild(self.guild_id).await {
             Some(guild) => guild,
             None => return Err(From::from(ModelError::GuildNotFound)),
         };
 
-        Ok(guild.member_permissions_cached(self.user.id))
+        guild.member_permissions(cache_http, self.user.id).await
     }
 
     /// Removes a [`Role`] from the member, editing its roles in-place if the

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1321,7 +1321,10 @@ impl Guild {
 
     /// Calculate a [`Member`]'s permissions in the guild.
     ///
+    /// This requires cache to be enabled. Otherwise, please use [`member_permissions`]
+    ///
     /// [`Member`]: struct.Member.html
+    /// [`member_permissions`]: #method.member_permissions
     #[inline]
     pub fn member_permissions_cached(&self, user_id: impl Into<UserId>) -> Permissions {
         self._member_permissions_cached(user_id.into())

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1271,15 +1271,19 @@ impl Guild {
 
     /// Calculate a [`Member`]'s permissions in the guild.
     ///
-    /// If the cache feature is enabled the cache will be checked
+    /// If member caching is enabled the cache will be checked
     /// first. If not found it will resort to an http request.
+    ///
+    /// Cache is still required to look up roles.
     ///
     /// [`Member`]: struct.Member.html
     #[inline]
+    #[cfg(feature = "cache")]
     pub async fn member_permissions(&self, cache_http: impl CacheHttp, user_id: impl Into<UserId>) -> Result<Permissions> {
         self._member_permissions(cache_http, user_id.into()).await
     }
 
+    #[cfg(feature = "cache")]
     async fn _member_permissions(&self, cache_http: impl CacheHttp, user_id: UserId) -> Result<Permissions> {
         if user_id == self.owner_id {
             return Ok(Permissions::all());


### PR DESCRIPTION
Still a bit of a work in progress. Changes here are:

* Member function `member_permissions_cache` which retains old behaviour
* `member_permissions` is now async with a Result<Permissions> return type
* `member_permissions` still only checks cache if cache is enabled; otherwise it checks on HTTP
* Functions such as `Guild::has_perms` and `Member::permissions` use the `member_permissions_cached` to retain old behaviour. 

It seems like it'll be a pain to blend this all under one since it requires changing a lot of arguments from `Cache` to `CacheHttp`, but this at least seems like a start. 