### PR TITLE
Increase the type length limit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! [gateway docs]: gateway/index.html
 #![doc(html_root_url = "https://docs.rs/serenity/*")]
 #![deny(rust_2018_idioms)]
-#![type_length_limit="2504639"] // needed so ShardRunner::run compiles with instrument.
+#![type_length_limit="3294819"] // needed so ShardRunner::run compiles with instrument.
 
 #[macro_use]
 extern crate serde;


### PR DESCRIPTION
The current limit is insufficient for Windows, preventing the compilation of Serenity. This increases the limit to avoid hitting the issue.

Barely any thought went into the new number; I only ensured it has the same number of digits and is higher than the current one.