### PR TITLE
Bump to 0.9.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project mostly adheres to [Semantic Versioning][semver].
 
+## [0.9.0-rc.4] - 2020-10-24
+
+Thanks to the following for their contributions:
+
+- [@acdenisSK]
+
+### Changed
+
+- [misc] Increase the type length limit ([@acdenisSK]) [c:7e55a0e]
+
 ## [0.9.0-rc.3] - 2020-10-23
 
 Thanks to the following for their contributions:
@@ -3713,6 +3723,7 @@ rest::get_guilds(GuildPagination::After(GuildId(777)), 50);
 
 Initial commit.
 
+[0.9.0-rc.4]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.3...v0.9.0-rc.4
 [0.9.0-rc.3]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.2...v0.9.0-rc.3
 [0.9.0-rc.2]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.1...v0.9.0-rc.2
 [0.9.0-rc.1]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.0...v0.9.0-rc.1
@@ -3907,6 +3918,8 @@ Initial commit.
 [@zack37]: https://github.com/zack37
 [@zeyla]: https://github.com/zeyla
 
+
+[c:7e55a0e]: https://github.com/serenity-rs/serenity/commit/7e55a0e6eec2106b0ca540822772706232aa2a1f
 
 [c:5bb8342]: https://github.com/serenity-rs/serenity/commit/5bb8342b018bc60def13f36218fd9ee31ce18c0d
 [c:a1b3c8d]: https://github.com/serenity-rs/serenity/commit/a1b3c8ddbfde9fdcd6484d99a6f4ad6bc25a742c

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 name = "serenity"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/serenity.git"
-version = "0.9.0-rc.3"
+version = "0.9.0-rc.4"
 edition = "2018"
 
 [dependencies]
@@ -28,7 +28,7 @@ version = "0.2"
 
 [dependencies.command_attr]
 path = "./command_attr"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.4"
 optional = true
 
 [dependencies.serde]

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-serenity = "0.9.0-rc.3"
+serenity = "0.9.0-rc.4"
 ```
 
 Serenity supports a minimum of Rust 1.40.
@@ -115,7 +115,7 @@ Cargo.toml:
 [dependencies.serenity]
 default-features = false
 features = ["pick", "your", "feature", "names", "here"]
-version = "0.9.0-rc.3"
+version = "0.9.0-rc.4"
 ```
 
 The default features are: `builder`, `cache`, `client`, `framework`, `gateway`,
@@ -175,7 +175,7 @@ features = [
     "utils",
     "rustls_backend",
 ]
-version = "0.9.0-rc.3"
+version = "0.9.0-rc.4"
 ```
 
 # Dependencies

--- a/command_attr/Cargo.toml
+++ b/command_attr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command_attr"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 authors = ["acdenisSK <acdenissk69@gmail.com>"]
 edition = "2018"
 description = "Procedural macros for command creation for the Serenity library."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serenity = "0.9.0-rc.3"
+//! serenity = "0.9.0-rc.4"
 //! ```
 //!
 //! [`Cache`]: cache/struct.Cache.html


### PR DESCRIPTION
This prepares for the release of `0.9.0-rc.4` by updating the `CHANGELOG.md` file and updating the version in relevant places.

This is an emergency release to fix compilation of the library on Windows computers.

The full, unsullied changelog for the release that will be put on Github's releases is:

---
Thanks to the following for their contributions:

- [@acdenisSK]

### Changed

- [misc] Increase the type length limit ([@acdenisSK]) [c:7e55a0e]

[@acdenisSK]: https://github.com/acdenisSK

[c:7e55a0e]: https://github.com/serenity-rs/serenity/commit/7e55a0e6eec2106b0ca540822772706232aa2a1f
