### PR TITLE
Feature: Add support for user_id ChunkGuild gateway requests

### DIFF
--- a/src/client/bridge/gateway/mod.rs
+++ b/src/client/bridge/gateway/mod.rs
@@ -63,7 +63,7 @@ pub use self::shard_manager_monitor::{ShardManagerMonitor, ShardManagerError};
 pub use self::shard_messenger::ShardMessenger;
 pub use self::shard_queuer::ShardQueuer;
 pub use self::shard_runner::{ShardRunner, ShardRunnerOptions};
-pub use self::shard_runner_message::ShardRunnerMessage;
+pub use self::shard_runner_message::{ShardRunnerMessage, ChunkGuildFilter};
 pub use self::intents::GatewayIntents;
 
 use std::{

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -1,6 +1,6 @@
 use crate::gateway::InterMessage;
 use crate::model::prelude::*;
-use super::{ShardClientMessage, ShardRunnerMessage};
+use super::{ShardClientMessage, ShardRunnerMessage, ChunkGuildFilter};
 use futures::channel::mpsc::{UnboundedSender as Sender, TrySendError};
 use async_tungstenite::tungstenite::Message;
 #[cfg(feature = "collector")]
@@ -99,7 +99,7 @@ impl ShardMessenger {
         &self,
         guild_ids: It,
         limit: Option<u16>,
-        query: Option<String>,
+        filter: ChunkGuildFilter,
         nonce: Option<String>,
     ) where It: IntoIterator<Item=GuildId> {
         let guilds = guild_ids.into_iter().collect::<Vec<GuildId>>();
@@ -107,7 +107,7 @@ impl ShardMessenger {
         let _ = self.send_to_shard(ShardRunnerMessage::ChunkGuilds {
             guild_ids: guilds,
             limit,
-            query,
+            filter,
             nonce,
         });
     }

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -53,6 +53,7 @@ impl ShardMessenger {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
+    /// # use serenity::client::bridge::gateway::ChunkGuildFilter;
     /// # use serenity::gateway::Shard;
     /// # use std::sync::Arc;
     /// #
@@ -65,7 +66,7 @@ impl ShardMessenger {
     ///
     /// let guild_ids = vec![GuildId(81384788765712384)];
     ///
-    /// shard.chunk_guilds(guild_ids, Some(2000), None, None);
+    /// shard.chunk_guilds(guild_ids, Some(2000), ChunkGuildFilter::None, None);
     /// #     Ok(())
     /// # }
     /// ```
@@ -75,6 +76,7 @@ impl ShardMessenger {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
+    /// # use serenity::client::bridge::gateway::ChunkGuildFilter;
     /// # use serenity::gateway::Shard;
     /// # use std::sync::Arc;
     /// #
@@ -87,7 +89,7 @@ impl ShardMessenger {
     ///
     /// let guild_ids = vec![GuildId(81384788765712384)];
     ///
-    /// shard.chunk_guilds(guild_ids, Some(20), Some("do"), Some("request"));
+    /// shard.chunk_guilds(guild_ids, Some(20), ChunkGuildFilter::Query("do".to_owned()), Some("request"));
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -362,11 +362,11 @@ impl ShardRunner {
 
                         true
                     },
-                ShardClientMessage::Runner(ShardRunnerMessage::ChunkGuilds { guild_ids, limit, query, nonce }) => {
+                ShardClientMessage::Runner(ShardRunnerMessage::ChunkGuilds { guild_ids, limit, filter, nonce }) => {
                     self.shard.chunk_guilds(
                         guild_ids,
                         limit,
-                        query.as_deref(),
+                        filter,
                         nonce.as_deref(),
                     ).await.is_ok()
                 },

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -7,7 +7,7 @@ use crate::model::{
     user::OnlineStatus
 };
 use tokio::sync::Mutex;
-use crate::client::bridge::gateway::GatewayIntents;
+use crate::client::bridge::gateway::{GatewayIntents, ChunkGuildFilter};
 use std::{
     sync::Arc,
     time::{Duration as StdDuration, Instant}
@@ -733,7 +733,7 @@ impl Shard {
         &mut self,
         guild_ids: It,
         limit: Option<u16>,
-        query: Option<&str>,
+        filter: ChunkGuildFilter,
         nonce: Option<&str>,
     ) -> Result<()> where It: IntoIterator<Item=GuildId> + Send {
         debug!("[Shard {:?}] Requesting member chunks", self.shard_info);
@@ -742,7 +742,7 @@ impl Shard {
             guild_ids,
             &self.shard_info,
             limit,
-            query,
+            filter,
             nonce,
         ).await
     }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -685,6 +685,7 @@ impl Shard {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
+    /// # use serenity::client::bridge::gateway::ChunkGuildFilter;
     /// # use serenity::gateway::Shard;
     /// # use std::sync::Arc;
     /// #
@@ -697,7 +698,7 @@ impl Shard {
     ///
     /// let guild_ids = vec![GuildId(81384788765712384)];
     ///
-    /// shard.chunk_guilds(guild_ids, Some(2000), None, None).await?;
+    /// shard.chunk_guilds(guild_ids, Some(2000), ChunkGuildFilter::None, None).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -708,6 +709,7 @@ impl Shard {
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
     /// # use serenity::gateway::Shard;
+    /// # use serenity::client::bridge::gateway::ChunkGuildFilter;
     /// # use std::error::Error;
     /// # use std::sync::Arc;
     /// #
@@ -720,7 +722,7 @@ impl Shard {
     ///
     /// let guild_ids = vec![GuildId(81384788765712384)];
     ///
-    /// shard.chunk_guilds(guild_ids, Some(20), Some("do"), Some("request")).await?;
+    /// shard.chunk_guilds(guild_ids, Some(20), ChunkGuildFilter::Query("do".to_owned()), Some("request")).await?;
     /// #     Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
**What**
- Added new type ChunkGuildFilter. Use of a query or user IDs is mutually exclusive, makes more sense to avoid passing two Option<T> arguments.
- Replaced the query parameter on the existing API with the new ChunkGuildFilter enum.
- Documented the expected behavior and intent requirements.
- Left a FIXME to address changes when intents are used (will be mandatory for supporting v8).

**Why**
Provides a way to make targeted queries for member data using available IDs or usernames easier for cache-less bots. 

**Non-Goals**
 - Currently unwieldy to read results from the chunk request. Needs a separate listener on GuildMembersChunkEvent. Other libraries (i.e. discord.py) support using async streams for consuming the chunks. Perhaps a `request_members` function on both Guild and GuildId that returns a Stream?
 - When using intents, these requests have a hard 1 guild per chunk request and 100 members when making filtered requests (both by query and user IDs). 