### PR TITLE
Add usable prefix to default configuration

### DIFF
--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -419,12 +419,11 @@ impl Configuration {
     ///     .prefix("!"));
     /// ```
     pub fn prefix(&mut self, prefix: &str) -> &mut Self {
-        self.prefixes =
-            if prefix.is_empty() {
-                vec![]
-            } else {
-                vec![prefix.to_string()]
-            };
+        self.prefixes = if prefix.is_empty() {
+            vec![]
+        } else {
+            vec![prefix.to_string()]
+        };
 
         self
     }

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -404,7 +404,9 @@ impl Configuration {
     /// Sets the prefix to respond to. A prefix can be a string slice of any
     /// non-zero length.
     ///
-    /// **Note**: Defaults to an empty vector.
+    /// **Note**: Defaults to "~".
+    ///
+    /// **Note**: Passing empty string `""` will set no prefix.
     ///
     /// # Examples
     ///
@@ -417,7 +419,12 @@ impl Configuration {
     ///     .prefix("!"));
     /// ```
     pub fn prefix(&mut self, prefix: &str) -> &mut Self {
-        self.prefixes = vec![prefix.to_string()];
+        self.prefixes =
+            if prefix.is_empty() {
+                vec![]
+            } else {
+                vec![prefix.to_string()]
+            };
 
         self
     }
@@ -551,7 +558,7 @@ impl Default for Configuration {
     /// - **no_dm_prefix** to `false`
     /// - **on_mention** to `false`
     /// - **owners** to an empty HashSet
-    /// - **prefix** to an empty vector
+    /// - **prefix** to "~"
     fn default() -> Configuration {
         Configuration {
             allow_dm: true,
@@ -569,7 +576,7 @@ impl Default for Configuration {
             no_dm_prefix: false,
             on_mention: None,
             owners: HashSet::default(),
-            prefixes: vec![],
+            prefixes: vec![String::from("~")],
         }
     }
 }


### PR DESCRIPTION
Not sure but for me it looks more consistent since there is default `Delimiter` and I was thinking that default configuration should be usable without changes, now it's not seems like because on_mention is disabled and prefix is not set.
I've picked ! because I think that it's widely used.