### PR TITLE
Change ChunkGuilds into ChunkGuild

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -218,7 +218,7 @@ impl Cache {
     /// _member_s that have not had data received. A single [`User`] may have
     /// multiple associated member objects that have not been received.
     ///
-    /// This can be used in combination with [`Shard::chunk_guilds`], and can be
+    /// This can be used in combination with [`Shard::chunk_guild`], and can be
     /// used to determine how many members have not yet been received.
     ///
     /// ```rust,no_run
@@ -258,7 +258,7 @@ impl Cache {
     /// ```
     ///
     /// [`Member`]: ../model/guild/struct.Member.html
-    /// [`Shard::chunk_guilds`]: ../gateway/struct.Shard.html#method.chunk_guilds
+    /// [`Shard::chunk_guild`]: ../gateway/struct.Shard.html#method.chunk_guild
     /// [`User`]: ../model/user/struct.User.html
     pub async fn unknown_members(&self) -> u64 {
         let mut total = 0;

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -64,9 +64,7 @@ impl ShardMessenger {
     /// #
     /// use serenity::model::id::GuildId;
     ///
-    /// let guild_ids = vec![GuildId(81384788765712384)];
-    ///
-    /// shard.chunk_guilds(guild_ids, Some(2000), ChunkGuildFilter::None, None);
+    /// shard.chunk_guild(GuildId(81384788765712384), Some(2000), ChunkGuildFilter::None, None);
     /// #     Ok(())
     /// # }
     /// ```
@@ -87,9 +85,7 @@ impl ShardMessenger {
     /// #
     /// use serenity::model::id::GuildId;
     ///
-    /// let guild_ids = vec![GuildId(81384788765712384)];
-    ///
-    /// shard.chunk_guilds(guild_ids, Some(20), ChunkGuildFilter::Query("do".to_owned()), Some("request"));
+    /// shard.chunk_guild(GuildId(81384788765712384), Some(20), ChunkGuildFilter::Query("do".to_owned()), Some("request"));
     /// #     Ok(())
     /// # }
     /// ```
@@ -97,17 +93,15 @@ impl ShardMessenger {
     /// [`Event::GuildMembersChunk`]: ../../../model/event/enum.Event.html#variant.GuildMembersChunk
     /// [`Guild`]: ../../../model/guild/struct.Guild.html
     /// [`Member`]: ../../../model/guild/struct.Member.html
-    pub fn chunk_guilds<It>(
+    pub fn chunk_guild(
         &self,
-        guild_ids: It,
+        guild_id: GuildId,
         limit: Option<u16>,
         filter: ChunkGuildFilter,
         nonce: Option<String>,
-    ) where It: IntoIterator<Item=GuildId> {
-        let guilds = guild_ids.into_iter().collect::<Vec<GuildId>>();
-
-        let _ = self.send_to_shard(ShardRunnerMessage::ChunkGuilds {
-            guild_ids: guilds,
+    ) {
+        let _ = self.send_to_shard(ShardRunnerMessage::ChunkGuild {
+            guild_id,
             limit,
             filter,
             nonce,

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -362,9 +362,9 @@ impl ShardRunner {
 
                         true
                     },
-                ShardClientMessage::Runner(ShardRunnerMessage::ChunkGuilds { guild_ids, limit, filter, nonce }) => {
-                    self.shard.chunk_guilds(
-                        guild_ids,
+                ShardClientMessage::Runner(ShardRunnerMessage::ChunkGuild { guild_id, limit, filter, nonce }) => {
+                    self.shard.chunk_guild(
+                        guild_id,
                         limit,
                         filter,
                         nonce.as_deref(),

--- a/src/client/bridge/gateway/shard_runner_message.rs
+++ b/src/client/bridge/gateway/shard_runner_message.rs
@@ -24,13 +24,11 @@ pub enum ChunkGuildFilter {
 #[derive(Clone, Debug)]
 pub enum ShardRunnerMessage {
     /// Indicates that the client is to send a member chunk message.
-    ChunkGuilds {
-        // FIXME: When intents are enabled, chunking guilds is limited to 1 guild per chunk
-        // request. Will be mandatory when using API v8.
-        /// The IDs of the [`Guild`]s to chunk.
+    ChunkGuild {
+        /// The IDs of the [`Guild`] to chunk.
         ///
         /// [`Guild`]: ../../../model/guild/struct.Guild.html
-        guild_ids: Vec<GuildId>,
+        guild_id: GuildId,
         /// The maximum number of members to receive [`GuildMembersChunkEvent`]s
         /// for.
         ///

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -696,9 +696,7 @@ impl Shard {
     /// #
     /// use serenity::model::id::GuildId;
     ///
-    /// let guild_ids = vec![GuildId(81384788765712384)];
-    ///
-    /// shard.chunk_guilds(guild_ids, Some(2000), ChunkGuildFilter::None, None).await?;
+    /// shard.chunk_guild(GuildId(81384788765712384), Some(2000), ChunkGuildFilter::None, None).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -720,9 +718,7 @@ impl Shard {
     /// #
     /// use serenity::model::id::GuildId;
     ///
-    /// let guild_ids = vec![GuildId(81384788765712384)];
-    ///
-    /// shard.chunk_guilds(guild_ids, Some(20), ChunkGuildFilter::Query("do".to_owned()), Some("request")).await?;
+    /// shard.chunk_guild(GuildId(81384788765712384), Some(20), ChunkGuildFilter::Query("do".to_owned()), Some("request")).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -730,18 +726,18 @@ impl Shard {
     /// [`Event::GuildMembersChunk`]: ../model/event/enum.Event.html#variant.GuildMembersChunk
     /// [`Guild`]: ../model/guild/struct.Guild.html
     /// [`Member`]: ../model/guild/struct.Member.html
-    #[instrument(skip(self, guild_ids))]
-    pub async fn chunk_guilds<It>(
+    #[instrument(skip(self))]
+    pub async fn chunk_guild(
         &mut self,
-        guild_ids: It,
+        guild_id: GuildId,
         limit: Option<u16>,
         filter: ChunkGuildFilter,
         nonce: Option<&str>,
-    ) -> Result<()> where It: IntoIterator<Item=GuildId> + Send {
+    ) -> Result<()> {
         debug!("[Shard {:?}] Requesting member chunks", self.shard_info);
 
-        self.client.send_chunk_guilds(
-            guild_ids,
+        self.client.send_chunk_guild(
+            guild_id,
             &self.shard_info,
             limit,
             filter,

--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -13,14 +13,14 @@ use tracing::{debug, trace};
 
 #[async_trait]
 pub trait WebSocketGatewayClientExt {
-    async fn send_chunk_guilds<It>(
+    async fn send_chunk_guild(
         &mut self,
-        guild_ids: It,
+        guild_id: GuildId,
         shard_info: &[u64; 2],
         limit: Option<u16>,
         filter: ChunkGuildFilter,
         nonce: Option<&str>,
-    ) -> Result<()> where It: IntoIterator<Item=GuildId> + Send;
+    ) -> Result<()>;
 
     async fn send_heartbeat(&mut self, shard_info: &[u64; 2], seq: Option<u64>)
         -> Result<()>;
@@ -45,21 +45,21 @@ pub trait WebSocketGatewayClientExt {
 
 #[async_trait]
 impl WebSocketGatewayClientExt for WsStream {
-    #[instrument(skip(self, guild_ids))]
-    async fn send_chunk_guilds<It>(
+    #[instrument(skip(self))]
+    async fn send_chunk_guild(
         &mut self,
-        guild_ids: It,
+        guild_id: GuildId,
         shard_info: &[u64; 2],
         limit: Option<u16>,
         filter: ChunkGuildFilter,
         nonce: Option<&str>,
-    ) -> Result<()> where It: IntoIterator<Item = GuildId> + Send, {
+    ) -> Result<()> {
         debug!("[Shard {:?}] Requesting member chunks", shard_info);
 
         let mut payload = json!({
             "op": OpCode::GetGuildMembers.num(),
             "d": {
-                "guild_id": guild_ids.into_iter().map(|x| x.as_ref().0).collect::<Vec<u64>>(),
+                "guild_id": [guild_id.as_ref().0],
                 "limit": limit.unwrap_or(0),
                 "nonce": nonce.unwrap_or(""),
             },


### PR DESCRIPTION
Followup to #1040, In v8 of the gateway, and with recent changes in v6, chunking cannot be performed on more than 1 guild at a time. To reflect this, the API has been changed to only allow one guild to be specified per request. APIs and types have also been renamed to use the singular form 'guild' over 'guilds'. This is a breaking change.