### PR TITLE
Bump to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 This project mostly adheres to [Semantic Versioning][semver].
 
+## [0.9.0] - 2020-10-30
+
+Thanks to the following for their contributions:
+
+- [@james7132]
+- [@JellyWX]
+- [@nitsuga5124]
+- [@Qeenon]
+
+### Added
+
+- [client] Mention the required intents for certain events ([@nitsuga5124]) [c:c9971b6]
+- [gateway] Add support for filtering by user ids when requesting guild chunks ([@james7132]) [c:0d9b821]
+
+### Changed
+
+- [gateway] Change `Shard::chunk_guilds` to `chunk_guild` ([@james7132]) [c:50d9643]
+- [framework] Use `~` as a default command prefix ([@Qeenon]) [c:d9e9bf7]
+- [utils] Make `utils::shard_id` accept the guild id with `impl Into<u64>` ([@JellyWX]) [c:85b5489]
+
 ## [0.9.0-rc.4] - 2020-10-24
 
 Thanks to the following for their contributions:
@@ -3723,6 +3743,7 @@ rest::get_guilds(GuildPagination::After(GuildId(777)), 50);
 
 Initial commit.
 
+[0.9.0]: https://github.com/serenity-rs/serenity/compare/v0.9.0...v0.9.0-rc.4
 [0.9.0-rc.4]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.3...v0.9.0-rc.4
 [0.9.0-rc.3]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.2...v0.9.0-rc.3
 [0.9.0-rc.2]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.1...v0.9.0-rc.2
@@ -3842,6 +3863,7 @@ Initial commit.
 [@ijks]: https://github.com/ijks
 [@JellyWX]: https://github.com/JellyWX
 [@Jerald]: https://github.com/Jerald
+[@james7132]: https://github.com/james7132
 [@jhelwig]: https://github.com/jhelwig
 [@jkcclemens]: https://github.com/jkcclemens
 [@jmgao]: https://github.com/jmgao
@@ -3918,6 +3940,12 @@ Initial commit.
 [@zack37]: https://github.com/zack37
 [@zeyla]: https://github.com/zeyla
 
+
+[c:c9971b6]: https://github.com/serenity-rs/serenity/commit/c9971b6e60f3b5f5ac9c3e8931f6a7ecbf8194db
+[c:0d9b821]: https://github.com/serenity-rs/serenity/commit/0d9b821953268edeeea8b1c01fe0d33447ba08cb
+[c:50d9643]: https://github.com/serenity-rs/serenity/commit/50d96436612b18c5bb807287b10a68f62747b7e4
+[c:d9e9bf7]: https://github.com/serenity-rs/serenity/commit/d9e9bf77aff4770e22aacc5153947e1ecf1a9862
+[c:85b5489]: https://github.com/serenity-rs/serenity/commit/85b5489bc8f05a98ad8aeacc20e220ad08206ff8
 
 [c:7e55a0e]: https://github.com/serenity-rs/serenity/commit/7e55a0e6eec2106b0ca540822772706232aa2a1f
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3743,7 +3743,7 @@ rest::get_guilds(GuildPagination::After(GuildId(777)), 50);
 
 Initial commit.
 
-[0.9.0]: https://github.com/serenity-rs/serenity/compare/v0.9.0...v0.9.0-rc.4
+[0.9.0]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.4...v0.9.0
 [0.9.0-rc.4]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.3...v0.9.0-rc.4
 [0.9.0-rc.3]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.2...v0.9.0-rc.3
 [0.9.0-rc.2]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.1...v0.9.0-rc.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 name = "serenity"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/serenity.git"
-version = "0.9.0-rc.4"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]
@@ -28,7 +28,7 @@ version = "0.2"
 
 [dependencies.command_attr]
 path = "./command_attr"
-version = "0.3.0-rc.4"
+version = "0.3"
 optional = true
 
 [dependencies.serde]

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-serenity = "0.9.0-rc.4"
+serenity = "0.9.0"
 ```
 
 Serenity supports a minimum of Rust 1.40.
@@ -115,7 +115,7 @@ Cargo.toml:
 [dependencies.serenity]
 default-features = false
 features = ["pick", "your", "feature", "names", "here"]
-version = "0.9.0-rc.4"
+version = "0.9.0"
 ```
 
 The default features are: `builder`, `cache`, `client`, `framework`, `gateway`,
@@ -175,7 +175,7 @@ features = [
     "utils",
     "rustls_backend",
 ]
-version = "0.9.0-rc.4"
+version = "0.9.0"
 ```
 
 # Dependencies

--- a/command_attr/Cargo.toml
+++ b/command_attr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command_attr"
-version = "0.3.0-rc.4"
+version = "0.3.0"
 authors = ["acdenisSK <acdenissk69@gmail.com>"]
 edition = "2018"
 description = "Procedural macros for command creation for the Serenity library."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serenity = "0.9.0-rc.4"
+//! serenity = "0.9.0"
 //! ```
 //!
 //! [`Cache`]: cache/struct.Cache.html


### PR DESCRIPTION
This prepares for the release of `0.9.0` by updating the `CHANGELOG.md` file and updating the version in relevant places.

This is a release to stabilize version 0.9.0.  It contains a few changes concerning the recent intents rollout, which include:
- Renaming of the `Shard::chunk_guilds` method to `chunk_guild`. No more than 1 guild can be chunked anymore.
- Addition of support for filtering by user ids when chunking a guild.
- Mentioning of privileged intents in certain events.

This release also includes a new default for the framework. The prefix will now be `~` if you do not specify one.

### Intents rollout
Discord has decided to disable privileged intents (`GUILD_MEMBERS` and `GUILD_PRESENCES`) by default. This has caused reports from bot developers across multiple libraries stating their bots have stopped working because they didn't receive member data anymore. If you are affected by this, make sure you enable [both privileged intents in your bot's application page](https://user-images.githubusercontent.com/16745149/97761061-05248d00-1b05-11eb-9a42-22c790b54184.png).

In response to v6 of the gateway being deprecated and in the soon future discontinued, 0.9.0 will immediately enter long-term support, alongside 0.8. Effort will move into working towards 0.10 that will support v8 of the gateway and other changes in the API.

The full, unsullied changelog for the release that will be put on Github's releases is:

---
Thanks to the following for their contributions:

- [@james7132]
- [@JellyWX]
- [@nitsuga5124]
- [@Qeenon]

### Added

- [client] Mention the required intents for certain events ([@nitsuga5124]) [c:c9971b6]
- [gateway] Add support for filtering by user ids when requesting guild chunks ([@james7132]) [c:0d9b821]

### Changed

- [gateway] Change `Shard::chunk_guilds` to `chunk_guild` ([@james7132]) [c:50d9643]
- [framework] Use `~` as a default command prefix ([@Qeenon]) [c:d9e9bf7]
- [utils] Make `utils::shard_id` accept the guild id with `impl Into<u64>` ([@JellyWX]) [c:85b5489]

[@james7132]: https://github.com/james7132
[@JellyWX]: https://github.com/JellyWX
[@nitsuga5124]: https://github.com/nitsuga5124
[@Qeenon]: https://github.com/Qeenon

[c:c9971b6]: https://github.com/serenity-rs/serenity/commit/c9971b6e60f3b5f5ac9c3e8931f6a7ecbf8194db
[c:0d9b821]: https://github.com/serenity-rs/serenity/commit/0d9b821953268edeeea8b1c01fe0d33447ba08cb
[c:50d9643]: https://github.com/serenity-rs/serenity/commit/50d96436612b18c5bb807287b10a68f62747b7e4
[c:d9e9bf7]: https://github.com/serenity-rs/serenity/commit/d9e9bf77aff4770e22aacc5153947e1ecf1a9862
[c:85b5489]: https://github.com/serenity-rs/serenity/commit/85b5489bc8f05a98ad8aeacc20e220ad08206ff8
