### PR TITLE
Include only necessary files in the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 repository = "https://github.com/serenity-rs/serenity.git"
 version = "0.9.0"
 edition = "2018"
+include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 
 [dependencies]
 bitflags = "1"


### PR DESCRIPTION
cargo-diet: Saved 64% or 2.9 MB in 60 files (of 4.5 MB and 167 files in entire crate)

This excludes the tests & bench folders which are not necessary to use serenity.

Before: `1.1M` serenity-0.9.0.crate
After: `365K` serenity-0.9.0.crate