### PR TITLE
Use the info level when notifying the user that a shard is running

### DIFF
--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -31,7 +31,7 @@ use tokio::sync::Mutex;
 #[cfg(feature = "collector")]
 use crate::collector::{MessageFilter, ReactionAction, ReactionFilter};
 
-use tracing::{trace, error, debug, warn, instrument};
+use tracing::{trace, error, debug, warn, info, instrument};
 
 /// A runner for managing a [`Shard`] and its respective WebSocket client.
 ///
@@ -110,7 +110,7 @@ impl ShardRunner {
     /// [`ShardRunnerMessage`]: enum.ShardRunnerMessage.html
     #[instrument(skip(self))]
     pub async fn run(&mut self) -> Result<()> {
-        warn!("[ShardRunner {:?}] Running", self.shard.shard_info());
+        info!("[ShardRunner {:?}] Running", self.shard.shard_info());
 
         loop {
             trace!("[ShardRunner {:?}] loop iteration started.", self.shard.shard_info());


### PR DESCRIPTION
I do not know of a reason why this is a warning, `info!` is more appropriate.

This is applied in 0.9. The commit will be cherry-picked onto `current` and `next` when it is merged.