### PR TITLE
Change doc attribute to doc comment

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2223,10 +2223,10 @@ impl Region {
     }
 }
 
-#[doc="The level to set as criteria prior to a user being able to send
-    messages in a [`Guild`].
-
-    [`Guild`]: struct.Guild.html"]
+/// The level to set as criteria prior to a user being able to send
+/// messages in a [`Guild`].
+///
+/// [`Guild`]: struct.Guild.html
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum VerificationLevel {


### PR DESCRIPTION
Current nightly fails to handle this doc attribute. 
I don't know if this a temporary nightly issue but this could prevent the build job on docs.rs.

see: https://github.com/serenity-rs/serenity/pull/1056/checks?check_run_id=1358558870