### PR TITLE
readme: Bump MSRV to 1.43.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ci-badge][]][ci] [![docs-badge][]][docs] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.40.0+ badge]][rust 1.40.0+ link]
+[![ci-badge][]][ci] [![docs-badge][]][docs] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.43.0+ badge]][rust 1.43.0+ link]
 
 # serenity
 
@@ -230,5 +230,5 @@ Voice + youtube-dl:
 [repo:lavalink]: https://github.com/Frederikam/Lavalink
 [repo:lavaplayer]: https://github.com/sedmelluq/lavaplayer
 [logo]: https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png
-[rust 1.40.0+ badge]: https://img.shields.io/badge/rust-1.40.0+-93450a.svg?style=flat-square
-[rust 1.40.0+ link]: https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html
+[rust 1.43.0+ badge]: https://img.shields.io/badge/rust-1.43.0+-93450a.svg?style=flat-square
+[rust 1.43.0+ link]: https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Add the following to your `Cargo.toml` file:
 serenity = "0.9.0"
 ```
 
-Serenity supports a minimum of Rust 1.40.
+Serenity supports a minimum of Rust 1.43.
 
 # Features
 


### PR DESCRIPTION
The current MSRV is `1.43.0`.

<details>
<summary>Build errors with 1.42.0</summary>

```
error: attributes are not yet allowed on `if` expressions
   --> src/client/bridge/gateway/shard_runner.rs:592:9
    |
592 |         #[cfg(feature = "voice")]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

error: attributes are not yet allowed on `if` expressions
   --> src/client/mod.rs:852:9
    |
852 |         #[cfg(feature = "voice")]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
```
```
error[E0425]: cannot find value `voice_manager` in this scope

error[E0560]: struct `client::bridge::gateway::shard_manager::ShardManagerOptions<'_>` has no field named `voice_manager`
  |
  = note: available fields are: `data`, `event_handler`, `raw_event_handler`, `framework`, `shard_index` ... and 5 others

error[E0560]: struct `client::Client` has no field named `voice_manager`
  |
  = note: available fields are: `data`, `shard_manager`, `shard_manager_worker`, `ws_uri`, `cache_and_http`

error[E0560]: struct `client::bridge::gateway::shard_runner::ShardRunnerOptions` has no field named `voice_manager`
   --> src/client/bridge/gateway/shard_queuer.rs:177:5
    |
177 |     #[instrument(skip(self))]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ `client::bridge::gateway::shard_runner::ShardRunnerOptions` does not have this field
    |
    = note: available fields are: `data`, `event_handler`, `raw_event_handler`, `framework`, `manager_tx` ... and 2 others

error[E0609]: no field `voice_manager` on type `&mut client::bridge::gateway::shard_queuer::ShardQueuer`
   --> src/client/bridge/gateway/shard_queuer.rs:177:5
    |
177 |     #[instrument(skip(self))]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
    |
    = note: available fields are: `data`, `event_handler`, `raw_event_handler`, `framework`, `last_start` ... and 7 others
```
</details>