### PR TITLE
Fix serialization of `PermissionOverwrite`s

### DIFF
--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -377,8 +377,8 @@ impl<'de> Deserialize<'de> for PermissionOverwrite {
         let data = PermissionOverwriteData::deserialize(deserializer)?;
 
         let kind = match &data.kind {
-            1 => PermissionOverwriteType::Member(UserId(data.id)),
             0 => PermissionOverwriteType::Role(RoleId(data.id)),
+            1 => PermissionOverwriteType::Member(UserId(data.id)),
             _ => return Err(DeError::custom("Unknown PermissionOverwriteType")),
         };
 
@@ -394,8 +394,8 @@ impl Serialize for PermissionOverwrite {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
         where S: Serializer {
         let (id, kind) = match self.kind {
-            PermissionOverwriteType::Member(id) => (id.0, 0),
             PermissionOverwriteType::Role(id) => (id.0, 0),
+            PermissionOverwriteType::Member(id) => (id.0, 1),
         };
 
         let mut state = serializer.serialize_struct("PermissionOverwrite", 4)?;


### PR DESCRIPTION
~~Despite [Discord claiming that the type of `PermissionOverwrites` is an integer](https://discord.com/developers/docs/resources/channel#overwrite-object-overwrite-structure) in v8, it is still a string like before. This reverses the change made in https://github.com/serenity-rs/serenity/pull/1043 to deserialize strings again. It also adds a visitor to future-proof the code once Discord decides to actually update the data type.~~ #1064 actually fixed the issue. This pull request has been repurposed to fix serialization of `PermissionOverwrite`s instead.