### PR TITLE
Correct privileged intents.

### DIFF
--- a/src/client/bridge/gateway/intents.rs
+++ b/src/client/bridge/gateway/intents.rs
@@ -154,7 +154,7 @@ impl GatewayIntents {
     pub const fn privileged() -> GatewayIntents {
         // bitflags don't support const evaluation. Workaround.
         // See: https://github.com/bitflags/bitflags/issues/180
-        Self::from_bits_truncate(Self::GUILD_MEMBERS.bits() & Self::GUILD_PRESENCES.bits())
+        Self::from_bits_truncate(Self::GUILD_MEMBERS.bits() | Self::GUILD_PRESENCES.bits())
     }
 
     /// Checks if any of the included intents are privileged


### PR DESCRIPTION
|, not &. Should also fix the default intents. Before, default (and `::non_privileged()`) gave a mask still containing the privileged intents (as `privileged()` == 0).