### PR TITLE
Only add roles that the member does not have

### DIFF
--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -82,7 +82,11 @@ impl Member {
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     pub async fn add_roles(&mut self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
-        self.roles.extend_from_slice(role_ids);
+        for id in role_ids {
+            if !self.roles.contains(id) {
+                self.roles.push(*id);
+            }
+        }
 
         let mut builder = EditMember::default();
         builder.roles(&self.roles);

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -82,7 +82,12 @@ impl Member {
     /// [`Role`]: struct.Role.html
     /// [Manage Roles]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_ROLES
     pub async fn add_roles(&mut self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
-        let mut roles = self.roles.to_vec();
+        if role_ids.is_empty() {
+            return Ok(());
+        }
+
+        let mut roles = Vec::with_capacity(self.roles.len() + role_ids.len());
+        roles.extend_from_slice(&self.roles);
 
         for id in role_ids {
             if !roles.contains(id) {


### PR DESCRIPTION
Should fix #1046.

This is applied in 0.9. The commit will be cherry-picked onto `current` and `next` when it is merged.