### PR TITLE
Songbird driver configuration implemented

### DIFF
--- a/songbird/src/driver/config.rs
+++ b/songbird/src/driver/config.rs
@@ -44,38 +44,38 @@ pub struct Config {
 }
 
 impl Default for Config {
-	fn default() -> Self {
-		Self {
-			crypto_mode: CryptoMode::Normal,
-			decode_mode: DecodeMode::Decrypt,
-			preallocated_tracks: 1,
-		}
-	}
+    fn default() -> Self {
+        Self {
+            crypto_mode: CryptoMode::Normal,
+            decode_mode: DecodeMode::Decrypt,
+            preallocated_tracks: 1,
+        }
+    }
 }
 
 impl Config {
-	/// Sets this `Config`'s chosen cryptographic tagging scheme.
-	pub fn crypto_mode(mut self, crypto_mode: CryptoMode) -> Self {
-		self.crypto_mode = crypto_mode;
-		self
-	}
+    /// Sets this `Config`'s chosen cryptographic tagging scheme.
+    pub fn crypto_mode(mut self, crypto_mode: CryptoMode) -> Self {
+        self.crypto_mode = crypto_mode;
+        self
+    }
 
-	/// Sets this `Config`'s received packet decryption/decoding behaviour.
-	pub fn decode_mode(mut self, decode_mode: DecodeMode) -> Self {
-		self.decode_mode = decode_mode;
-		self
-	}
+    /// Sets this `Config`'s received packet decryption/decoding behaviour.
+    pub fn decode_mode(mut self, decode_mode: DecodeMode) -> Self {
+        self.decode_mode = decode_mode;
+        self
+    }
 
-	/// Sets this `Config`'s number of tracks to preallocate.
-	pub fn preallocated_tracks(mut self, preallocated_tracks: usize) -> Self {
-		self.preallocated_tracks = preallocated_tracks;
-		self
-	}
+    /// Sets this `Config`'s number of tracks to preallocate.
+    pub fn preallocated_tracks(mut self, preallocated_tracks: usize) -> Self {
+        self.preallocated_tracks = preallocated_tracks;
+        self
+    }
 
-	/// This is used to prevent changes which would invalidate the current session.
-	pub(crate) fn make_safe(&mut self, previous: &Config, connected: bool) {
-		if connected {
-			self.crypto_mode = previous.crypto_mode;
-		}
-	}
+    /// This is used to prevent changes which would invalidate the current session.
+    pub(crate) fn make_safe(&mut self, previous: &Config, connected: bool) {
+        if connected {
+            self.crypto_mode = previous.crypto_mode;
+        }
+    }
 }

--- a/songbird/src/driver/config.rs
+++ b/songbird/src/driver/config.rs
@@ -2,7 +2,6 @@ use super::{CryptoMode, DecodeMode};
 
 /// Configuration for the inner Driver.
 ///
-/// At present, this cannot be changed.
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Selected tagging mode for voice packet encryption.

--- a/songbird/src/driver/config.rs
+++ b/songbird/src/driver/config.rs
@@ -18,16 +18,17 @@ pub struct Config {
     /// Configures whether decoding and decryption occur for all received packets.
     ///
     /// If voice receiving voice packets, generally you should choose [`DecodeMode::Decode`].
-    /// [`DecodeMode::Decrypt`] is intended for users running their own selective decoding
-    /// or who need to inspect Opus packets. If you're certain you will never need any RT(C)P
-    /// events, then consider [`DecodeMode::Pass`].
+    /// [`DecodeMode::Decrypt`] is intended for users running their own selective decoding,
+    /// who rely upon [user speaking events], or who need to inspect Opus packets.
+    /// If you're certain you will never need any RT(C)P events, then consider [`DecodeMode::Pass`].
     ///
     /// Defaults to [`DecodeMode::Decrypt`]. This is due to per-packet decoding costs,
-    /// which most users will not want to pay.
+    /// which most users will not want to pay, but allowing speaking events which are commonly used.
     ///
     /// [`DecodeMode::Decode`]: enum.DecodeMode.html#variant.Decode
     /// [`DecodeMode::Decrypt`]: enum.DecodeMode.html#variant.Decrypt
     /// [`DecodeMode::Pass`]: enum.DecodeMode.html#variant.Pass
+    /// [user speaking events]: ../events/enum.CoreEvent.html#variant.SpeakingUpdate
     pub decode_mode: DecodeMode,
     /// Number of concurrently active tracks to allocate memory for.
     ///

--- a/songbird/src/driver/config.rs
+++ b/songbird/src/driver/config.rs
@@ -1,10 +1,81 @@
-use super::CryptoMode;
+use super::{CryptoMode, DecodeMode};
 
 /// Configuration for the inner Driver.
 ///
 /// At present, this cannot be changed.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Config {
     /// Selected tagging mode for voice packet encryption.
-    pub crypto_mode: Option<CryptoMode>,
+    ///
+    /// Defaults to [`CryptoMode::Normal`].
+    ///
+    /// Changes to this field will not immediately apply if the
+    /// driver is actively connected, but will apply to subsequent
+    /// sessions.
+    ///
+    /// [`CryptoMode::Normal`]: enum.CryptoMode.html#variant.Normal
+    pub crypto_mode: CryptoMode,
+    /// Configures whether decoding and decryption occur for all received packets.
+    ///
+    /// If voice receiving voice packets, generally you should choose [`DecodeMode::Decode`].
+    /// [`DecodeMode::Decrypt`] is intended for users running their own selective decoding
+    /// or who need to inspect Opus packets. If you're certain you will never need any RT(C)P
+    /// events, then consider [`DecodeMode::Pass`].
+    ///
+    /// Defaults to [`DecodeMode::Decrypt`]. This is due to per-packet decoding costs,
+    /// which most users will not want to pay.
+    ///
+    /// [`DecodeMode::Decode`]: enum.DecodeMode.html#variant.Decode
+    /// [`DecodeMode::Decrypt`]: enum.DecodeMode.html#variant.Decrypt
+    /// [`DecodeMode::Pass`]: enum.DecodeMode.html#variant.Pass
+    pub decode_mode: DecodeMode,
+    /// Number of concurrently active tracks to allocate memory for.
+    ///
+    /// This should be set at, or just above, the maximum number of tracks
+    /// you expect your bot will play at the same time. Exceeding the size of
+    /// the internal queue will trigger a larger memory allocation and copy,
+    /// possibly causing the mixer thread to miss a packet deadline.
+    ///
+    /// Defaults to `1`.
+    ///
+    /// Changes to this field in a running driver will only ever increase
+    /// the capacity of the track store.
+    pub preallocated_tracks: usize,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			crypto_mode: CryptoMode::Normal,
+			decode_mode: DecodeMode::Decrypt,
+			preallocated_tracks: 1,
+		}
+	}
+}
+
+impl Config {
+	/// Sets this `Config`'s chosen cryptographic tagging scheme.
+	pub fn crypto_mode(mut self, crypto_mode: CryptoMode) -> Self {
+		self.crypto_mode = crypto_mode;
+		self
+	}
+
+	/// Sets this `Config`'s received packet decryption/decoding behaviour.
+	pub fn decode_mode(mut self, decode_mode: DecodeMode) -> Self {
+		self.decode_mode = decode_mode;
+		self
+	}
+
+	/// Sets this `Config`'s number of tracks to preallocate.
+	pub fn preallocated_tracks(mut self, preallocated_tracks: usize) -> Self {
+		self.preallocated_tracks = preallocated_tracks;
+		self
+	}
+
+	/// This is used to prevent changes which would invalidate the current session.
+	pub(crate) fn make_safe(&mut self, previous: &Config, connected: bool) {
+		if connected {
+			self.crypto_mode = previous.crypto_mode;
+		}
+	}
 }

--- a/songbird/src/driver/crypto.rs
+++ b/songbird/src/driver/crypto.rs
@@ -13,8 +13,6 @@ use xsalsa20poly1305::{
 };
 
 /// Variants of the XSalsa20Poly1305 encryption scheme.
-///
-/// At present, only `Normal` is supported or selectable.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CryptoMode {

--- a/songbird/src/driver/crypto.rs
+++ b/songbird/src/driver/crypto.rs
@@ -1,38 +1,210 @@
 //! Encryption schemes supported by Discord's secure RTP negotiation.
+use byteorder::{NetworkEndian, WriteBytesExt};
+use discortp::{
+    rtp::RtpPacket,
+    MutablePacket,
+};
+use rand::Rng;
+use std::num::Wrapping;
+use xsalsa20poly1305::{aead::{AeadInPlace, Error as CryptoError}, Nonce, Tag, XSalsa20Poly1305 as Cipher, NONCE_SIZE, TAG_SIZE};
 
 /// Variants of the XSalsa20Poly1305 encryption scheme.
 ///
 /// At present, only `Normal` is supported or selectable.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum Mode {
+pub enum CryptoMode {
     /// The RTP header is used as the source of nonce bytes for the packet.
     ///
     /// Equivalent to a nonce of at most 48b (6B) at no extra packet overhead:
     /// the RTP sequence number and timestamp are the varying quantities.
     Normal,
     /// An additional random 24B suffix is used as the source of nonce bytes for the packet.
+    /// This is regenerated randomly for each packet.
     ///
     /// Full nonce width of 24B (192b), at an extra 24B per packet (~1.2 kB/s).
     Suffix,
-    /// An additional random 24B suffix is used as the source of nonce bytes for the packet.
+    /// An additional random 4B suffix is used as the source of nonce bytes for the packet.
+    /// This nonce value increments by `1` with each packet.
     ///
     /// Nonce width of 4B (32b), at an extra 4B per packet (~0.2 kB/s).
     Lite,
 }
 
-impl Mode {
+impl From<CryptoState> for CryptoMode {
+    fn from(val: CryptoState) -> Self {
+        use CryptoState::*;
+        match val {
+            Normal => CryptoMode::Normal,
+            Suffix => CryptoMode::Suffix,
+            Lite(_) => CryptoMode::Lite,
+        }
+    }
+}
+
+impl CryptoMode {
     /// Returns the name of a mode as it will appear during negotiation.
     pub fn to_request_str(self) -> &'static str {
-        use Mode::*;
+        use CryptoMode::*;
         match self {
             Normal => "xsalsa20_poly1305",
             Suffix => "xsalsa20_poly1305_suffix",
             Lite => "xsalsa20_poly1305_lite",
         }
     }
+
+    /// Returns the number of bytes each nonce is stored as within
+    /// a packet.
+    pub fn nonce_size(self) -> usize {
+        use CryptoMode::*;
+        match self {
+            Normal => RtpPacket::minimum_packet_size(),
+            Suffix => NONCE_SIZE,
+            Lite => 4,
+        }
+    }
+
+    /// Returns the number of bytes occupied by the encryption scheme
+    /// which fall before the payload.
+    pub fn payload_prefix_len(self) -> usize {
+        TAG_SIZE
+    }
+
+    /// Returns the number of bytes occupied by the encryption scheme
+    /// which fall after the payload.
+    pub fn payload_suffix_len(self) -> usize {
+        use CryptoMode::*;
+        match self {
+            Normal => 0,
+            Suffix | Lite => self.nonce_size(),
+        }
+    }
+
+    /// Calculates the number of additional bytes required compared
+    /// to an unencrypted payload.
+    pub fn payload_overhead(self) -> usize {
+        self.payload_prefix_len() + self.payload_suffix_len()
+    }
+
+    /// Extracts the byte slice in a packet used as the nonce, and the remaining mutable
+    /// portion of the packet.
+    fn nonce_slice<'a>(self, header: &'a [u8], body: &'a mut [u8]) -> (&'a[u8], &'a mut [u8]) {
+        use CryptoMode::*;
+        match self {
+            Normal => (header, body),
+            Suffix | Lite => {
+                let len = body.len();
+                let (body_left, nonce_loc) = body.split_at_mut(len-self.payload_suffix_len());
+                (&nonce_loc[..self.nonce_size()], body_left)
+            }
+        }
+    }
+
+    /// Decrypts a Discord RT(C)P packet using the given key.
+    ///
+    /// If successful, this returns the number of bytes to be ignored from the
+    /// start and end of the packet payload.
+    #[inline]
+    pub(crate) fn decrypt_in_place(self, packet: &mut impl MutablePacket, cipher: &Cipher) -> Result<(usize, usize), CryptoError> {
+        let header_len = packet.packet().len() - packet.payload().len();
+        let (header, body) = packet.packet_mut().split_at_mut(header_len);
+        let (slice_to_use, body_remaining) = self.nonce_slice(header, body);
+
+        let mut nonce = Nonce::default();
+        let nonce_slice = if slice_to_use.len() == NONCE_SIZE {
+            Nonce::from_slice(&slice_to_use[..NONCE_SIZE])
+        } else {
+            let max_bytes_avail = slice_to_use.len();
+            nonce[..self.nonce_size().min(max_bytes_avail)].copy_from_slice(slice_to_use);
+            &nonce
+        };
+
+        let body_start = self.payload_prefix_len();
+        let body_tail = self.payload_suffix_len();
+
+        let (tag_bytes, data_bytes) = body_remaining.split_at_mut(body_start);
+        let tag = Tag::from_slice(tag_bytes);
+
+        Ok(cipher
+            .decrypt_in_place_detached(nonce_slice, b"", data_bytes, tag)
+            .map(|_| (body_start, body_tail))?)
+    }
+
+    /// Encrypts a Discord RT(C)P packet using the given key.
+    ///
+    /// Use of this requires that the input packet has had a nonce generated in the correct location,
+    /// and `payload_len` specifies the number of bytes after the header including this nonce.
+    #[inline]
+    pub fn encrypt_in_place(self, packet: &mut impl MutablePacket, cipher: &Cipher, payload_len: usize) -> Result<(), CryptoError> {
+        let header_len = packet.packet().len() - packet.payload().len();
+        let (header, body) = packet.packet_mut().split_at_mut(header_len);
+        let (slice_to_use, body_remaining) = self.nonce_slice(header, &mut body[..payload_len]);
+
+        let mut nonce = Nonce::default();
+        let nonce_slice = if slice_to_use.len() == NONCE_SIZE {
+            Nonce::from_slice(&slice_to_use[..NONCE_SIZE])
+        } else {
+            nonce[..self.nonce_size()].copy_from_slice(slice_to_use);
+            &nonce
+        };
+
+        // body_remaining is now correctly truncated by this point.
+        // the true_payload to encrypt follows after the first TAG_LEN bytes.
+        let tag = cipher.encrypt_in_place_detached(
+            nonce_slice,
+            b"",
+            &mut body_remaining[TAG_SIZE..],
+        )?;
+        body_remaining[..TAG_SIZE].copy_from_slice(&tag[..]);
+
+        Ok(())
+    }
 }
 
-// TODO: implement encrypt + decrypt + nonce selection for each.
-// This will probably need some research into correct handling of
-// padding, reported length, SRTP profiles, and so on.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub(crate) enum CryptoState {
+    Normal,
+    Suffix,
+    Lite(Wrapping<u32>),
+}
+
+impl From<CryptoMode> for CryptoState {
+    fn from(val: CryptoMode) -> Self {
+        use CryptoMode::*;
+        match val {
+            Normal => CryptoState::Normal,
+            Suffix => CryptoState::Suffix,
+            Lite => CryptoState::Lite(Wrapping(rand::random::<u32>())),
+        }
+    }
+}
+
+impl CryptoState {
+    /// Writes packet nonce into the body, if required, returning the new length.
+    pub fn write_packet_nonce(&mut self, packet: &mut impl MutablePacket, payload_end: usize) -> usize {
+        let mode = self.kind();
+        let endpoint = payload_end + mode.payload_suffix_len();
+
+        use CryptoState::*;
+        match self {
+            Suffix => {
+                rand::thread_rng()
+                    .fill(&mut packet.payload_mut()[payload_end..endpoint]);
+            },
+            Lite(mut i) => {
+                (&mut packet.payload_mut()[payload_end..endpoint])
+                    .write_u32::<NetworkEndian>(i.0)
+                    .expect("Nonce size is guaranteed to be sufficient to write u32 for lite tagging.");
+                i += Wrapping(1);
+            },
+            _ => {},
+        }
+
+        endpoint
+    }
+
+    pub fn kind(&self) -> CryptoMode {
+        CryptoMode::from(*self)
+    }
+}

--- a/songbird/src/driver/decode_mode.rs
+++ b/songbird/src/driver/decode_mode.rs
@@ -2,24 +2,24 @@
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum DecodeMode {
-	/// Packets received from Discord are handed over to events without any
-	/// changes applied.
-	///
-	/// No CPU work involved.
-	Pass,
-	/// Decrypts the body of each received packet.
-	///
-	/// Small per-packet CPU use.
-	Decrypt,
-	/// Decrypts and decodes each received packet, correctly accounting for losses.
-	///
-	/// Larger per-packet CPU use.
-	Decode,
+    /// Packets received from Discord are handed over to events without any
+    /// changes applied.
+    ///
+    /// No CPU work involved.
+    Pass,
+    /// Decrypts the body of each received packet.
+    ///
+    /// Small per-packet CPU use.
+    Decrypt,
+    /// Decrypts and decodes each received packet, correctly accounting for losses.
+    ///
+    /// Larger per-packet CPU use.
+    Decode,
 }
 
 impl DecodeMode {
-	/// Returns whether this mode will decrypt received packets.
-	pub fn should_decrypt(self) -> bool {
-		self != DecodeMode::Pass
-	}
+    /// Returns whether this mode will decrypt received packets.
+    pub fn should_decrypt(self) -> bool {
+        self != DecodeMode::Pass
+    }
 }

--- a/songbird/src/driver/decode_mode.rs
+++ b/songbird/src/driver/decode_mode.rs
@@ -6,6 +6,13 @@ pub enum DecodeMode {
     /// changes applied.
     ///
     /// No CPU work involved.
+    ///
+    /// *BEWARE: this will almost certainly break [user speaking events].
+    /// Silent frame detection only works if extensions can be parsed or
+    /// are not present, as they are encrypted.
+    /// This event requires such functionality.*
+    ///
+    /// [user speaking events]: ../events/enum.CoreEvent.html#variant.SpeakingUpdate
     Pass,
     /// Decrypts the body of each received packet.
     ///

--- a/songbird/src/driver/decode_mode.rs
+++ b/songbird/src/driver/decode_mode.rs
@@ -1,0 +1,25 @@
+/// Decode behaviour for received RTP packets within the driver.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum DecodeMode {
+	/// Packets received from Discord are handed over to events without any
+	/// changes applied.
+	///
+	/// No CPU work involved.
+	Pass,
+	/// Decrypts the body of each received packet.
+	///
+	/// Small per-packet CPU use.
+	Decrypt,
+	/// Decrypts and decodes each received packet, correctly accounting for losses.
+	///
+	/// Larger per-packet CPU use.
+	Decode,
+}
+
+impl DecodeMode {
+	/// Returns whether this mode will decrypt received packets.
+	pub fn should_decrypt(self) -> bool {
+		self != DecodeMode::Pass
+	}
+}

--- a/songbird/src/driver/mod.rs
+++ b/songbird/src/driver/mod.rs
@@ -189,6 +189,13 @@ impl Driver {
         self.send(CoreMessage::SetTrack(None))
     }
 
+    /// Sets the configuration for this driver.
+    #[instrument(skip(self))]
+    pub fn set_config(&mut self, config: Config) {
+        self.config = config.clone();
+        self.send(CoreMessage::SetConfig(config))
+    }
+
     /// Attach a global event handler to an audio context. Global events may receive
     /// any [`EventContext`].
     ///

--- a/songbird/src/driver/mod.rs
+++ b/songbird/src/driver/mod.rs
@@ -11,11 +11,13 @@
 mod config;
 pub(crate) mod connection;
 mod crypto;
+mod decode_mode;
 pub(crate) mod tasks;
 
 pub use config::Config;
 use connection::error::Result;
-pub use crypto::Mode as CryptoMode;
+pub use crypto::*;
+pub use decode_mode::DecodeMode;
 
 use crate::{
     events::EventData,

--- a/songbird/src/driver/tasks/message/core.rs
+++ b/songbird/src/driver/tasks/message/core.rs
@@ -1,5 +1,5 @@
 use crate::{
-    driver::connection::error::Error,
+    driver::{connection::error::Error, Config},
     events::EventData,
     tracks::Track,
     Bitrate,
@@ -16,6 +16,7 @@ pub enum CoreMessage {
     AddTrack(Track),
     SetBitrate(Bitrate),
     AddEvent(EventData),
+    SetConfig(Config),
     Mute(bool),
     Reconnect,
     FullReconnect,

--- a/songbird/src/driver/tasks/message/mixer.rs
+++ b/songbird/src/driver/tasks/message/mixer.rs
@@ -1,6 +1,10 @@
 use super::{Interconnect, UdpRxMessage, UdpTxMessage, WsMessage};
 
-use crate::{driver::{Config, CryptoState}, tracks::Track, Bitrate};
+use crate::{
+    driver::{Config, CryptoState},
+    tracks::Track,
+    Bitrate,
+};
 use flume::Sender;
 use xsalsa20poly1305::XSalsa20Poly1305 as Cipher;
 

--- a/songbird/src/driver/tasks/message/mixer.rs
+++ b/songbird/src/driver/tasks/message/mixer.rs
@@ -1,11 +1,12 @@
 use super::{Interconnect, UdpRxMessage, UdpTxMessage, WsMessage};
 
-use crate::{tracks::Track, Bitrate};
+use crate::{driver::{Config, CryptoState}, tracks::Track, Bitrate};
 use flume::Sender;
 use xsalsa20poly1305::XSalsa20Poly1305 as Cipher;
 
 pub(crate) struct MixerConnection {
     pub cipher: Cipher,
+    pub crypto_state: CryptoState,
     pub udp_rx: Sender<UdpRxMessage>,
     pub udp_tx: Sender<UdpTxMessage>,
 }
@@ -20,13 +21,17 @@ impl Drop for MixerConnection {
 pub(crate) enum MixerMessage {
     AddTrack(Track),
     SetTrack(Option<Track>),
+
     SetBitrate(Bitrate),
+    SetConfig(Config),
     SetMute(bool),
+
     SetConn(MixerConnection, u32),
+    Ws(Option<Sender<WsMessage>>),
     DropConn,
+
     ReplaceInterconnect(Interconnect),
     RebuildEncoder,
 
-    Ws(Option<Sender<WsMessage>>),
     Poison,
 }

--- a/songbird/src/driver/tasks/message/udp_rx.rs
+++ b/songbird/src/driver/tasks/message/udp_rx.rs
@@ -2,7 +2,7 @@ use super::Interconnect;
 use crate::driver::Config;
 
 pub(crate) enum UdpRxMessage {
-	SetConfig(Config),
+    SetConfig(Config),
     ReplaceInterconnect(Interconnect),
 
     Poison,

--- a/songbird/src/driver/tasks/message/udp_rx.rs
+++ b/songbird/src/driver/tasks/message/udp_rx.rs
@@ -1,6 +1,8 @@
 use super::Interconnect;
+use crate::driver::Config;
 
 pub(crate) enum UdpRxMessage {
+	SetConfig(Config),
     ReplaceInterconnect(Interconnect),
 
     Poison,

--- a/songbird/src/driver/tasks/mixer.rs
+++ b/songbird/src/driver/tasks/mixer.rs
@@ -170,7 +170,8 @@ impl Mixer {
                         self.config = new_config.clone();
 
                         if self.tracks.capacity() < self.config.preallocated_tracks {
-                            self.tracks.reserve(self.config.preallocated_tracks - self.tracks.len());
+                            self.tracks
+                                .reserve(self.config.preallocated_tracks - self.tracks.len());
                         }
 
                         if let Some(conn) = &self.conn_active {
@@ -482,19 +483,25 @@ impl Mixer {
 
             let payload_len = if opus_frame.is_empty() {
                 let total_payload_space = payload.len() - crypto_mode.payload_suffix_len();
-                self.encoder
-                    .encode_float(&buffer[..STEREO_FRAME_SIZE], &mut payload[TAG_SIZE..total_payload_space])?
+                self.encoder.encode_float(
+                    &buffer[..STEREO_FRAME_SIZE],
+                    &mut payload[TAG_SIZE..total_payload_space],
+                )?
             } else {
                 let len = opus_frame.len();
                 payload[TAG_SIZE..TAG_SIZE + len].clone_from_slice(opus_frame);
                 len
             };
 
-            let final_payload_size = conn.crypto_state.write_packet_nonce(&mut rtp, TAG_SIZE + payload_len);
+            let final_payload_size = conn
+                .crypto_state
+                .write_packet_nonce(&mut rtp, TAG_SIZE + payload_len);
 
-            conn.crypto_state
-                .kind()
-                .encrypt_in_place(&mut rtp, &conn.cipher, final_payload_size)?;
+            conn.crypto_state.kind().encrypt_in_place(
+                &mut rtp,
+                &conn.cipher,
+                final_payload_size,
+            )?;
 
             RtpPacket::minimum_packet_size() + final_payload_size
         };

--- a/songbird/src/driver/tasks/mixer.rs
+++ b/songbird/src/driver/tasks/mixer.rs
@@ -1,4 +1,4 @@
-use super::{error::Result, message::*};
+use super::{error::Result, message::*, Config};
 use crate::{
     constants::*,
     tracks::{PlayMode, Track},
@@ -13,7 +13,6 @@ use audiopus::{
 use discortp::{
     rtp::{MutableRtpPacket, RtpPacket},
     MutablePacket,
-    Packet,
 };
 use flume::{Receiver, Sender, TryRecvError};
 use rand::random;
@@ -21,11 +20,12 @@ use spin_sleep::SpinSleeper;
 use std::time::Instant;
 use tokio::runtime::Handle;
 use tracing::{error, instrument};
-use xsalsa20poly1305::{aead::AeadInPlace, Nonce, TAG_SIZE};
+use xsalsa20poly1305::TAG_SIZE;
 
 struct Mixer {
     async_handle: Handle,
     bitrate: Bitrate,
+    config: Config,
     conn_active: Option<MixerConnection>,
     deadline: Instant,
     encoder: OpusEncoder,
@@ -53,6 +53,7 @@ impl Mixer {
         mix_rx: Receiver<MixerMessage>,
         async_handle: Handle,
         interconnect: Interconnect,
+        config: Config,
     ) -> Self {
         let bitrate = DEFAULT_BITRATE;
         let encoder = new_encoder(bitrate)
@@ -70,9 +71,12 @@ impl Mixer {
         rtp.set_sequence(random::<u16>().into());
         rtp.set_timestamp(random::<u32>().into());
 
+        let tracks = Vec::with_capacity(1.max(config.preallocated_tracks));
+
         Self {
             async_handle,
             bitrate,
+            config,
             conn_active: None,
             deadline: Instant::now(),
             encoder,
@@ -84,7 +88,7 @@ impl Mixer {
             silence_frames: 0,
             sleeper: Default::default(),
             soft_clip,
-            tracks: vec![],
+            tracks,
             ws: None,
         }
     }
@@ -137,6 +141,8 @@ impl Mixer {
                                 (Blame: VOICE_PACKET_MAX?)",
                         );
                         rtp.set_ssrc(ssrc);
+                        rtp.set_sequence(random::<u16>().into());
+                        rtp.set_timestamp(random::<u32>().into());
                         self.deadline = Instant::now();
                         Ok(())
                     },
@@ -159,6 +165,22 @@ impl Mixer {
                         self.interconnect = i;
 
                         self.rebuild_tracks()
+                    },
+                    Ok(SetConfig(new_config)) => {
+                        self.config = new_config.clone();
+
+                        if self.tracks.capacity() < self.config.preallocated_tracks {
+                            self.tracks.reserve(self.config.preallocated_tracks - self.tracks.len());
+                        }
+
+                        if let Some(conn) = &self.conn_active {
+                            conn_failure |= conn
+                                .udp_rx
+                                .send(UdpRxMessage::SetConfig(new_config))
+                                .is_err();
+                        }
+
+                        Ok(())
                     },
                     Ok(RebuildEncoder) => match new_encoder(self.bitrate) {
                         Ok(encoder) => {
@@ -449,38 +471,32 @@ impl Mixer {
             .as_mut()
             .expect("Shouldn't be mixing packets without access to a cipher + UDP dest.");
 
-        let mut nonce = Nonce::default();
         let index = {
             let mut rtp = MutableRtpPacket::new(&mut self.packet[..]).expect(
                 "FATAL: Too few bytes in self.packet for RTP header.\
                     (Blame: VOICE_PACKET_MAX?)",
             );
 
-            let pkt = rtp.packet();
-            let rtp_len = RtpPacket::minimum_packet_size();
-            nonce[..rtp_len].copy_from_slice(&pkt[..rtp_len]);
-
             let payload = rtp.payload_mut();
+            let crypto_mode = conn.crypto_state.kind();
 
             let payload_len = if opus_frame.is_empty() {
+                let total_payload_space = payload.len() - crypto_mode.payload_suffix_len();
                 self.encoder
-                    .encode_float(&buffer[..STEREO_FRAME_SIZE], &mut payload[TAG_SIZE..])?
+                    .encode_float(&buffer[..STEREO_FRAME_SIZE], &mut payload[TAG_SIZE..total_payload_space])?
             } else {
                 let len = opus_frame.len();
                 payload[TAG_SIZE..TAG_SIZE + len].clone_from_slice(opus_frame);
                 len
             };
 
-            let final_payload_size = TAG_SIZE + payload_len;
+            let final_payload_size = conn.crypto_state.write_packet_nonce(&mut rtp, TAG_SIZE + payload_len);
 
-            let tag = conn.cipher.encrypt_in_place_detached(
-                &nonce,
-                b"",
-                &mut payload[TAG_SIZE..final_payload_size],
-            )?;
-            payload[..TAG_SIZE].copy_from_slice(&tag[..]);
+            conn.crypto_state
+                .kind()
+                .encrypt_in_place(&mut rtp, &conn.cipher, final_payload_size)?;
 
-            rtp_len + final_payload_size
+            RtpPacket::minimum_packet_size() + final_payload_size
         };
 
         // TODO: This is dog slow, don't do this.
@@ -509,8 +525,9 @@ pub(crate) fn runner(
     interconnect: Interconnect,
     mix_rx: Receiver<MixerMessage>,
     async_handle: Handle,
+    config: Config,
 ) {
-    let mut mixer = Mixer::new(mix_rx, async_handle, interconnect);
+    let mut mixer = Mixer::new(mix_rx, async_handle, interconnect, config);
 
     mixer.run();
 }

--- a/songbird/src/driver/tasks/mod.rs
+++ b/songbird/src/driver/tasks/mod.rs
@@ -61,7 +61,9 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
         match rx.recv_async().await {
             Ok(CoreMessage::ConnectWithResult(info, tx)) => {
                 config = if let Some(new_config) = next_config.take() {
-                    let _ = interconnect.mixer.send(MixerMessage::SetConfig(new_config.clone()));
+                    let _ = interconnect
+                        .mixer
+                        .send(MixerMessage::SetConfig(new_config.clone()));
                     new_config
                 } else {
                     config

--- a/songbird/src/driver/tasks/mod.rs
+++ b/songbird/src/driver/tasks/mod.rs
@@ -23,7 +23,7 @@ pub(crate) fn start(config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
     });
 }
 
-fn start_internals(core: Sender<CoreMessage>) -> Interconnect {
+fn start_internals(core: Sender<CoreMessage>, config: Config) -> Interconnect {
     let (evt_tx, evt_rx) = flume::unbounded();
     let (mix_tx, mix_rx) = flume::unbounded();
 
@@ -44,7 +44,7 @@ fn start_internals(core: Sender<CoreMessage>) -> Interconnect {
     let handle = Handle::current();
     std::thread::spawn(move || {
         info!("Mixer started.");
-        mixer::runner(ic, mix_rx, handle);
+        mixer::runner(ic, mix_rx, handle, config);
         info!("Mixer finished.");
     });
 
@@ -52,13 +52,21 @@ fn start_internals(core: Sender<CoreMessage>) -> Interconnect {
 }
 
 #[instrument(skip(rx, tx))]
-async fn runner(config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMessage>) {
+async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMessage>) {
+    let mut next_config: Option<Config> = None;
     let mut connection = None;
-    let mut interconnect = start_internals(tx);
+    let mut interconnect = start_internals(tx, config.clone());
 
     loop {
         match rx.recv_async().await {
             Ok(CoreMessage::ConnectWithResult(info, tx)) => {
+                config = if let Some(new_config) = next_config.take() {
+                    let _ = interconnect.mixer.send(MixerMessage::SetConfig(new_config.clone()));
+                    new_config
+                } else {
+                    config
+                };
+
                 connection = match Connection::new(info, &interconnect, &config).await {
                     Ok(connection) => {
                         // Other side may not be listening: this is fine.
@@ -86,6 +94,13 @@ async fn runner(config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMessag
             },
             Ok(CoreMessage::SetBitrate(b)) => {
                 let _ = interconnect.mixer.send(MixerMessage::SetBitrate(b));
+            },
+            Ok(CoreMessage::SetConfig(mut new_config)) => {
+                next_config = Some(new_config.clone());
+
+                new_config.make_safe(&config, connection.is_some());
+
+                let _ = interconnect.mixer.send(MixerMessage::SetConfig(new_config));
             },
             Ok(CoreMessage::AddEvent(evt)) => {
                 let _ = interconnect.events.send(EventMessage::AddGlobalEvent(evt));


### PR DESCRIPTION
This adds user control over the encryption scheme negotiated between the driver and discord (and implements the remaining variants, `xsalsa20_poly1305_suffix` and `xsalsa20_poly1305_lite`), the number of tracks to preallocate, and whether any decoding/decryption work is performed on received packets. These can be set for all `Call`s, or on a per-`Call`/`Driver` basis.

This causes breaking changes on RTP and RTCP packet events, as there may be no decoded packet (-> `Option<...>`) and that received packets may have a trailing encryption nonce (`packet_end_pad`).