### PR TITLE
Provide youtube-dlc as an alternative to youtube-dl 

### DIFF
--- a/songbird/Cargo.toml
+++ b/songbird/Cargo.toml
@@ -107,6 +107,7 @@ default = [
     "serenity-rustls",
     "driver",
     "gateway",
+    "youtube-dlc"
 ]
 gateway = [
     "flume",
@@ -135,6 +136,8 @@ driver = [
     "url",
     "xsalsa20poly1305",
 ]
+youtube-dl = []
+youtube-dlc = []
 rustls = ["async-tungstenite/tokio-rustls"]
 native = ["async-tungstenite/tokio-native-tls"]
 serenity-rustls = ["serenity/rustls_backend", "rustls", "gateway", "serenity-deps"]

--- a/songbird/Cargo.toml
+++ b/songbird/Cargo.toml
@@ -107,7 +107,7 @@ default = [
     "serenity-rustls",
     "driver",
     "gateway",
-    "youtube-dlc"
+    "youtube-dl"
 ]
 gateway = [
     "flume",

--- a/songbird/build.rs
+++ b/songbird/build.rs
@@ -23,9 +23,10 @@ compile_error!(
 #[cfg(all(feature = "youtube-dl", feature = "youtube-dlc"))]
 compile_error!(
     "Only youtube-dl or youtube-dlc can be selected \
-    - `youtube-dl` is readily availible on most linux package managers however is error prone \
-    - `youtube-dlc` is a more maintained fork of youtube-dl \
-    If you are unsure, go with `youtube-dlc`."
+    - `youtube-dl` is the standard downloading tool of youtube videos \
+    - `youtube-dlc` is a fork of youtube-dl that aims to solve bugs with youtube-dl \
+    If you are unsure, go with `youtube-dl`, however, if you encounter any errors with `youtube-dl`,
+    such as songs ending immedietly when they are queued/played, try 'youtube-dlc'."
 );
 
 fn main() {}

--- a/songbird/build.rs
+++ b/songbird/build.rs
@@ -20,4 +20,12 @@ compile_error!(
     If you are unsure, go with `stock-zlib`."
 );
 
+#[cfg(all(feature = "youtube-dl", feature = "youtube-dlc"))]
+compile_error!(
+    "Only youtube-dl or youtube-dlc can be selected \
+    - `youtube-dl` is readily availible on most linux package managers however is error prone \
+    - `youtube-dlc` is a more maintained fork of youtube-dl \
+    If you are unsure, go with `youtube-dlc`."
+);
+
 fn main() {}

--- a/songbird/src/input/ytdl_src.rs
+++ b/songbird/src/input/ytdl_src.rs
@@ -45,7 +45,7 @@ pub(crate) async fn _ytdl(uri: &str, pre_args: &[&str]) -> Result<Input> {
         "-",
     ];
 
-    let mut youtube_dl = Command::new("youtube-dl")
+    let mut youtube_dl = Command::new("youtube-dlc")
         .args(&ytdl_args)
         .stdin(Stdio::null())
         .stderr(Stdio::piped())

--- a/songbird/src/input/ytdl_src.rs
+++ b/songbird/src/input/ytdl_src.rs
@@ -14,7 +14,13 @@ use std::{
 use tokio::task;
 use tracing::trace;
 
+#[cfg(feature = "youtube-dl")]
+const YOUTUBE_DL_COMMAND: &str = "youtube-dl";
+#[cfg(feature = "youtube-dlc")]
+const YOUTUBE_DL_COMMAND: &str = "youtube-dlc";
+
 /// Creates a streamed audio source with `youtube-dl` and `ffmpeg`.
+#[cfg(any(feature = "youtube-dl", feature = "youtube-dlc"))]
 pub async fn ytdl(uri: &str) -> Result<Input> {
     _ytdl(uri, &[]).await
 }
@@ -45,7 +51,7 @@ pub(crate) async fn _ytdl(uri: &str, pre_args: &[&str]) -> Result<Input> {
         "-",
     ];
 
-    let mut youtube_dl = Command::new("youtube-dlc")
+    let mut youtube_dl = Command::new(YOUTUBE_DL_COMMAND)
         .args(&ytdl_args)
         .stdin(Stdio::null())
         .stderr(Stdio::piped())
@@ -102,6 +108,7 @@ pub(crate) async fn _ytdl(uri: &str, pre_args: &[&str]) -> Result<Input> {
 
 /// Creates a streamed audio source from YouTube search results with `youtube-dl`,`ffmpeg`, and `ytsearch`.
 /// Takes the first video listed from the YouTube search.
+#[cfg(any(feature = "youtube-dl", feature = "youtube-dlc"))]
 pub async fn ytdl_search(name: &str) -> Result<Input> {
     ytdl(&format!("ytsearch1:{}", name)).await
 }


### PR DESCRIPTION
youtube-dl's progress has slowed down and will very often error with `ERROR: Unable to extract JS player URL`.  youtube-dlc is a drop-in replacement for youtube-dl that is being updated and does not have that error https://github.com/blackjack4494/yt-dlc