### PR TITLE
Add support for stickers

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -991,7 +991,9 @@ mod test {
                 application: None,
                 message_reference: None,
                 flags: None,
+                stickers: vec![],
                 referenced_message: None,
+                _nonexhaustive: (),
             },
         };
         // Check that the channel cache doesn't exist.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -993,7 +993,6 @@ mod test {
                 flags: None,
                 stickers: vec![],
                 referenced_message: None,
-                _nonexhaustive: (),
             },
         };
         // Check that the channel cache doesn't exist.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -111,8 +111,6 @@ pub struct Message {
     pub stickers: Vec<Sticker>,
     /// The message that was replied to using this message.
     pub referenced_message: Option<Box<Message>>, // Boxed to avoid recusion
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -106,8 +106,13 @@ pub struct Message {
     pub message_reference: Option<MessageReference>,
     /// Bit flags describing extra features of the message.
     pub flags: Option<MessageFlags>,
+    /// Array of stickers sent with the message.
+    #[serde(default)]
+    pub stickers: Vec<Sticker>,
     /// The message that was replied to using this message.
     pub referenced_message: Option<Box<Message>>, // Boxed to avoid recusion
+    #[serde(skip)]
+    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -8,6 +8,7 @@ mod message;
 mod private_channel;
 mod reaction;
 mod channel_category;
+mod sticker;
 
 pub use self::attachment::*;
 pub use self::channel_id::*;
@@ -17,6 +18,7 @@ pub use self::message::*;
 pub use self::private_channel::*;
 pub use self::reaction::*;
 pub use self::channel_category::*;
+pub use self::sticker::*;
 
 use crate::model::prelude::*;
 use serde::de::Error as DeError;

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -30,11 +30,11 @@ pub struct Sticker {
 #[non_exhaustive]
 pub enum StickerFormatType {
     /// A PNG format sticker.
-    PNG = 0,
+    PNG = 1,
     /// An APNG format animated sticker.
-    APNG = 1,
+    APNG = 2,
     /// A LOTTIE format animated sticker.
-    LOTTIE = 2,
+    LOTTIE = 3,
 }
 
 enum_number!(

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -1,8 +1,8 @@
 use crate::model::id::{StickerId, StickerPackId};
 
-/// A sticker sent with a message
+/// A sticker sent with a message.
 ///
-/// Bots currently can only receive messages with stickers, not send
+/// Bots currently can only receive messages with stickers, not send.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Sticker {
@@ -24,7 +24,7 @@ pub struct Sticker {
     pub format_type: StickerFormatType,
 }
 
-/// Differentiates between sticker formats
+/// Differentiates between sticker formats.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum StickerFormatType {

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -29,18 +29,18 @@ pub struct Sticker {
 #[non_exhaustive]
 pub enum StickerFormatType {
     /// A PNG format sticker.
-    PNG = 1,
+    Png = 1,
     /// An APNG format animated sticker.
-    APNG = 2,
+    Apng = 2,
     /// A LOTTIE format animated sticker.
-    LOTTIE = 3,
+    Lottie = 3,
 }
 
 enum_number!(
     StickerFormatType {
-        PNG,
-        APNG,
-        LOTTIE,
+        Png,
+        Apng,
+        Lottie,
     }
 );
 
@@ -49,9 +49,9 @@ impl StickerFormatType {
         use self::StickerFormatType::*;
 
         match self {
-            PNG => 1,
-            APNG => 2,
-            LOTTIE => 3,
+            Png => 1,
+            Apng => 2,
+            Lottie => 3,
         }
     }
 }

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -45,3 +45,14 @@ enum_number!(
     }
 );
 
+impl StickerFormatType {
+    pub fn num(self) -> u64 {
+        use self::StickerFormatType::*;
+
+        match self {
+            PNG => 1,
+            APNG => 2,
+            LOTTIE => 3,
+        }
+    }
+}

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -4,6 +4,7 @@ use crate::model::id::{StickerId, StickerPackId};
 ///
 /// Bots currently can only receive messages with stickers, not send
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Sticker {
     /// The unique ID given to this sticker.
     pub id: StickerId,
@@ -21,8 +22,6 @@ pub struct Sticker {
     pub preview_asset: Option<String>,
     /// The type of sticker format.
     pub format_type: StickerFormatType,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Differentiates between sticker formats

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -1,0 +1,47 @@
+use crate::model::id::{StickerId, StickerPackId};
+
+/// A sticker sent with a message
+///
+/// Bots currently can only receive messages with stickers, not send
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Sticker {
+    /// The unique ID given to this sticker.
+    pub id: StickerId,
+    /// The unique ID of the pack the sticker is from.
+    pub pack_id: StickerPackId,
+    /// The name of the sticker.
+    pub name: String,
+    /// Description of the sticker
+    pub description: String,
+    /// A comma-separated list of tags for the sticker.
+    pub tags: Option<String>,
+    /// The sticker asset hash.
+    pub asset: String,
+    /// The sticker preview asset hash.
+    pub preview_asset: Option<String>,
+    /// The type of sticker format.
+    pub format_type: StickerFormatType,
+    #[serde(skip)]
+    pub(crate) _nonexhaustive: (),
+}
+
+/// Differentiates between sticker formats
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum StickerFormatType {
+    /// A PNG format sticker.
+    PNG = 0,
+    /// An APNG format animated sticker.
+    APNG = 1,
+    /// A LOTTIE format animated sticker.
+    LOTTIE = 2,
+}
+
+enum_number!(
+    StickerFormatType {
+        PNG,
+        APNG,
+        LOTTIE,
+    }
+);
+

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -131,6 +131,14 @@ pub struct AuditLogEntryId(pub u64);
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct AttachmentId(u64);
 
+/// An identifier for a sticker.
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct StickerId(pub u64);
+
+/// An identifier for a sticker pack.
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct StickerPackId(pub u64);
+
 id_u64! {
     AttachmentId;
     ApplicationId;
@@ -140,6 +148,8 @@ id_u64! {
     IntegrationId;
     MessageId;
     RoleId;
+    StickerId;
+    StickerPackId;
     UserId;
     WebhookId;
     AuditLogEntryId;

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -267,6 +267,8 @@ fn dummy_message() -> Message {
         application: None,
         message_reference: None,
         flags: None,
+        stickers: Vec::new(),
         referenced_message: None,
+        _nonexhaustive: (),
     }
 }

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -269,6 +269,5 @@ fn dummy_message() -> Message {
         flags: None,
         stickers: Vec::new(),
         referenced_message: None,
-        _nonexhaustive: (),
     }
 }


### PR DESCRIPTION
For reference, discord/discord-api-docs#2155 has just been merged.

`cargo test --all-features` passes in addition to just logging messages of a user sending stickers to check if messages with stickers deserialize properly:

```rust
#[async_trait]
impl EventHandler for Handler {
    async fn message(&self, ctx: Context, msg: Message) {
        println!("{:#?}", msg);
    }
}
```

Example outputs (with the other fields truncated):

```text
Message {
    ...,
    stickers: [
        Sticker {
            id: StickerId(
                755244355563815073,
            ),
            pack_id: StickerPackId(
                755240383084232756,
            ),
            name: "No",
            description: "wumpus, no, not, no way, nope, nah, :no",
            tags: Some(
                "wumpus, no, not, no way, nope, nah, :no",
            ),
            asset: "d3bad2df3536a6eecb375769f9ac21c8",
            preview_asset: None,
            format_type: LOTTIE,
            _nonexhaustive: (),
        },
    ],
    _nonexhaustive: (),
}
```

```text
Message {
    ...,
    stickers: [
        Sticker {
            id: StickerId(
                755244598799892490,
            ),
            pack_id: StickerPackId(
                755240383084232756,
            ),
            name: "Eating",
            description: "wumpus, eating, 🤤, 😋, 🍕, 🍔, 🌮, :pizza, :burger, :hamburger, :taco, dinner time, lunch time, yum",
            tags: Some(
                "wumpus, eating, 🤤, 😋, 🍕, 🍔, 🌮, :pizza, :burger, :hamburger, :taco, dinner time, lunch time, yum",
            ),
            asset: "2bac02df5e2978c1e006ca33e61fcb60",
            preview_asset: None,
            format_type: LOTTIE,
            _nonexhaustive: (),
        },
    ],
    _nonexhaustive: (),
}