### PR TITLE
Fix animated emoji url for EmojiIdentifier

### DIFF
--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -193,8 +193,12 @@ pub struct EmojiIdentifier {
 #[cfg(all(feature = "model", feature = "utils"))]
 impl EmojiIdentifier {
     /// Generates a URL to the emoji's image.
-    #[inline]
-    pub fn url(&self) -> String { format!(cdn!("/emojis/{}.png"), self.id) }
+    pub fn url(&self) -> String {
+        match self.animated {
+            true => format!(cdn!("/emojis/{}.gif"), self.id),
+            false => format!(cdn!("/emojis/{}.png"), self.id),
+        }
+    }
 }
 
 #[cfg(all(feature = "model", feature = "utils"))]


### PR DESCRIPTION
Currently, calling `.url()` on an animated emoji returns only the first frame. This should fix it by changing the file extension to `.gif` whenever appropriate.