### PR TITLE
fix: strikethrough tip macro typo in examples

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -117,7 +117,7 @@ If you want more information about a specific command, just pass the command as 
 #[wrong_channel = "Strike"]
 // Serenity will automatically analyse and generate a hint/tip explaining the possible
 // cases of ~~strikethrough-commands~~, but only if
-// `strikethrough_commands_tip_{dm, guild}` aren't specified.
+// `strikethrough_commands_tip_in_{dm, guild}` aren't specified.
 // If you pass in a value, it will be displayed instead.
 async fn my_help(
     context: &Context,


### PR DESCRIPTION
Found a small documentation issue in the frameworks example
https://docs.rs/serenity/0.8.6/serenity/framework/standard/struct.HelpOptions.html#structfield.strikethrough_commands_tip_in_dm


There are also several other macros defined in https://docs.rs/serenity/0.8.6/serenity/framework/standard/macros/attr.help.html , I can also update the example to include those, let me know if I should include that too :)