### PR TITLE
Avoid cloning the entire guild object upon a command invocation

### DIFF
--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -127,12 +127,12 @@ async fn permissions_in(
     // If the permission does not have the `READ_MESSAGES` permission, then
     // throw out actionable permissions.
     if !permissions.contains(Permissions::READ_MESSAGES) {
-        permissions &= Permissions::KICK_MEMBERS
+        permissions &= !(Permissions::KICK_MEMBERS
             | Permissions::BAN_MEMBERS
             | Permissions::ADMINISTRATOR
             | Permissions::MANAGE_GUILD
             | Permissions::CHANGE_NICKNAME
-            | Permissions::MANAGE_NICKNAMES;
+            | Permissions::MANAGE_NICKNAMES);
     }
 
     permissions

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -34,7 +34,7 @@ async fn permissions_in(
     member: &Member,
     roles: &HashMap<RoleId, Role>,
 ) -> Permissions {
-    if let Some(true) = ctx.cache.guild_field(guild_id, |guild| member.user.id == guild.owner_id).await {
+    if ctx.cache.guild_field(guild_id, |guild| member.user.id == guild.owner_id).await == Some(true) {
         return Permissions::all();
     }
 

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 // all members past 250, resulting in the problem to meet permissions of a command even if
 // the author does possess them. To avoid defaulting to permissions of everyone, we fetch
 // the member from HTTP if it is missing in the guild's members list.
+#[cfg(feature = "cache")]
 async fn permissions_in(
     ctx: &Context,
     guild_id: GuildId,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1542,12 +1542,12 @@ impl Guild {
         // If the permission does not have the `READ_MESSAGES` permission, then
         // throw out actionable permissions.
         if !permissions.contains(Permissions::READ_MESSAGES) {
-            *permissions &= Permissions::KICK_MEMBERS
+            *permissions &= !(Permissions::KICK_MEMBERS
                 | Permissions::BAN_MEMBERS
                 | Permissions::ADMINISTRATOR
                 | Permissions::MANAGE_GUILD
                 | Permissions::CHANGE_NICKNAME
-                | Permissions::MANAGE_NICKNAMES;
+                | Permissions::MANAGE_NICKNAMES);
         }
     }
 


### PR DESCRIPTION
This changes the discrepancy check code to avoid cloning the whole guild. Instead, it will only access and clone data it actually needs. Moreover, the code will also fetch the member data from http if it cannot be found in the cache.  

This is applied in 0.9. The commit will be cherry-picked onto `current` and `next` when it is merged.