### PR TITLE
Fix for #1088 - GuildId in message_delete handler

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -604,14 +604,14 @@ async fn handle_event(
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
-                event_handler.message_delete_bulk(context, event.channel_id, event.ids).await;
+                event_handler.message_delete_bulk(context, event.channel_id, event.ids, event.guild_id).await;
             });
         },
         DispatchEvent::Model(Event::MessageDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
-                event_handler.message_delete(context, event.channel_id, event.message_id).await;
+                event_handler.message_delete(context, event.channel_id, event.message_id, event.guild_id).await;
             });
         },
         DispatchEvent::Model(Event::MessageUpdate(mut event)) => {

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -235,12 +235,12 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when a message is deleted.
     ///
-    /// Provides the channel's id and the message's id.
+    /// Provides the guild's id, the channel's id and the message's id.
     async fn message_delete(&self, _ctx: Context, _channel_id: ChannelId, _deleted_message_id: MessageId, _guild_id: Option<GuildId>) {}
 
     /// Dispatched when multiple messages were deleted at once.
     ///
-    /// Provides the channel's id and the deleted messages' ids.
+    /// Provides the guild's id, channel's id and the deleted message's ids.
     async fn message_delete_bulk(&self, _ctx: Context, _channel_id: ChannelId, _multiple_deleted_messages_ids: Vec<MessageId>, _guild_id: Option<GuildId>) {}
 
     /// Dispatched when a message is updated.

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -235,7 +235,7 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when a message is deleted.
     ///
-    /// Provides the guild's id, the channel's id and the messages' id.
+    /// Provides the guild's id, the channel's id and the message's id.
     async fn message_delete(&self, _ctx: Context, _channel_id: ChannelId, _deleted_message_id: MessageId, _guild_id: Option<GuildId>) {}
 
     /// Dispatched when multiple messages were deleted at once.

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -236,12 +236,12 @@ pub trait EventHandler: Send + Sync {
     /// Dispatched when a message is deleted.
     ///
     /// Provides the channel's id and the message's id.
-    async fn message_delete(&self, _ctx: Context, _channel_id: ChannelId, _deleted_message_id: MessageId) {}
+    async fn message_delete(&self, _ctx: Context, _channel_id: ChannelId, _deleted_message_id: MessageId, _guild_id: Option<GuildId>) {}
 
     /// Dispatched when multiple messages were deleted at once.
     ///
     /// Provides the channel's id and the deleted messages' ids.
-    async fn message_delete_bulk(&self, _ctx: Context, _channel_id: ChannelId, _multiple_deleted_messages_ids: Vec<MessageId>) {}
+    async fn message_delete_bulk(&self, _ctx: Context, _channel_id: ChannelId, _multiple_deleted_messages_ids: Vec<MessageId>, _guild_id: Option<GuildId>) {}
 
     /// Dispatched when a message is updated.
     ///

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -235,12 +235,12 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when a message is deleted.
     ///
-    /// Provides the guild's id, the channel's id and the message's id.
+    /// Provides the guild's id, the channel's id and the messages' id.
     async fn message_delete(&self, _ctx: Context, _channel_id: ChannelId, _deleted_message_id: MessageId, _guild_id: Option<GuildId>) {}
 
     /// Dispatched when multiple messages were deleted at once.
     ///
-    /// Provides the guild's id, channel's id and the deleted message's ids.
+    /// Provides the guild's id, channel's id and the deleted messages' ids.
     async fn message_delete_bulk(&self, _ctx: Context, _channel_id: ChannelId, _multiple_deleted_messages_ids: Vec<MessageId>, _guild_id: Option<GuildId>) {}
 
     /// Dispatched when a message is updated.


### PR DESCRIPTION
The changes pass all the tests when using `cargo test --all-features`.
I also have tested this version on a real discord bot to ensure that it works (both in DMs and in a guild).