### PR TITLE
Update Example 6

### DIFF
--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -40,7 +40,7 @@ use commands::{
     owner::*,
 };
 
-struct ShardManagerContainer;
+pub struct ShardManagerContainer;
 
 impl TypeMapKey for ShardManagerContainer {
     type Value = Arc<Mutex<ShardManager>>;


### PR DESCRIPTION
Example 6 involved importing the struct `ShardManagerContainer` into another file. Because it is not declared as `pub` it isn't accesible and leads to errors on runtime.

This Pr makes the struct public!