### PR TITLE
Bump to 0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project mostly adheres to [Semantic Versioning][semver].
 
+## [0.8.8] - 2020-11-28
+
+Thanks to the following for their contributions:
+
+- [@acdenisSK]
+
+### Changed
+
+- [framework] Backport changes in the framework discrepancy check from 0.9.x ([@acdenisSK]) [c:72f287c]
+
 ## [0.8.7] - 2020-08-11
 
 This is a small release to publish a bunch of fixes the `current` branch has accumulated.
@@ -3494,6 +3504,7 @@ rest::get_guilds(GuildPagination::After(GuildId(777)), 50);
 
 Initial commit.
 
+[0.8.8]: https://github.com/serenity-rs/serenity/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/serenity-rs/serenity/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/serenity-rs/serenity/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/serenity-rs/serenity/compare/v0.8.4...v0.8.5
@@ -3661,6 +3672,8 @@ Initial commit.
 [@zack37]: https://github.com/zack37
 [@zeyla]: https://github.com/zeyla
 
+
+[c:72f287c]: https://github.com/serenity-rs/serenity/commit/72f287c5b4ebbd9e9fbaae9afec99187387db0dd
 
 [c:6b1021f]: https://github.com/acdenisSK/serenity/commit/6b1021f85ea8590b2aa50e4ea986b598575c6abb
 [c:9f848af]: https://github.com/acdenisSK/serenity/commit/9f848aff0fda841d7ca827447ac115bcb0d18d1a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 name = "serenity"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/serenity.git"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This prepares for the release of `0.8.8` by updating the `CHANGELOG.md` file and updating the version in relevant places.

This is a quick release to publish a backported fix from 0.9.x for the framework's discrepancy check, which fixes the `#[required_permissions(...)]` and `#[allowed_roles(...)]` attributes.

The full, unsullied changelog for the release that will be put on Github's releases is:

---
Thanks to the following for their contributions:

- [@acdenisSK]

### Changed

- [framework] Backport changes in the framework discrepancy check from 0.9.x ([@acdenisSK]) [c:72f287c]

[@acdenisSK]: https://github.com/acdenisSK

[c:72f287c]: https://github.com/serenity-rs/serenity/commit/72f287c5b4ebbd9e9fbaae9afec99187387db0dd
