### PR TITLE
Add Sub-Command Support to Help

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -55,7 +55,7 @@ impl EventHandler for Handler {
 }
 
 #[group]
-#[commands(about, am_i_admin, say, commands, ping, latency, some_long_command)]
+#[commands(about, am_i_admin, say, commands, ping, latency, some_long_command, upper_command)]
 struct General;
 
 #[group]
@@ -522,6 +522,26 @@ async fn slow_mode(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
     };
 
     msg.channel_id.say(&ctx.http, say_content).await?;
+
+    Ok(())
+}
+
+// A command can have sub-commands, just like in command lines tools.
+// Imagine `cargo help` and `cargo help run`.
+#[command("upper")]
+#[sub_commands(sub)]
+async fn upper_command(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
+    msg.reply(&ctx.http, "This is the main function!").await?;
+
+    Ok(())
+}
+
+// This will only be called if preceded by the `upper`-command.
+#[command]
+#[aliases("sub-command", "secret")]
+#[description("This is `upper`'s sub-command.")]
+async fn sub(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
+    msg.reply(&ctx.http, "This is a sub function!").await?;
 
     Ok(())
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -474,7 +474,7 @@ async fn _nested_group_command_search<'rec, 'a: 'rec>(
                     }
 
                     // We check all sub-command names in order to see if one variant
-                    // has been issued to help-system.
+                    // has been issued to the help-system.
                     let name_str = name.as_str();
                     let sub_command_found = command
                         .options
@@ -484,7 +484,7 @@ async fn _nested_group_command_search<'rec, 'a: 'rec>(
                         .cloned();
 
                     // If we found a sub-command, we replace the parent with
-                    // it. This allows the help-systme to extract information
+                    // it. This allows the help-system to extract information
                     // from the sub-command.
                     if let Some(ref sub_command) = sub_command_found {
                         command = sub_command;

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -445,19 +445,54 @@ async fn _nested_group_command_search<'rec, 'a: 'rec>(
 
         let mut found_group_prefix: bool = false;
         for command in group.options.commands {
-            let command = *command;
+            let mut command = *command;
 
             let search_command_name_matched = if group.options.prefixes.is_empty() {
                 if starts_with_whole_word(&name, &group.name) {
                     name.drain(..=group.name.len());
                 }
 
-                command
+                let command_found = command
                     .options
                     .names
                     .iter()
                     .find(|n| **n == name)
-                    .cloned()
+                    .cloned();
+
+                if command_found.is_some() {
+                    command_found
+                } else {
+                    // Since the command could not be found in the group, we now will identify
+                    // if the command is actually using a sub-command.
+                    // We iterate all command names and check if one matches, if it does,
+                    // we potentially have a sub-command.
+                    for command_name in command.options.names {
+                        if starts_with_whole_word(&name, &command_name) {
+                            name.drain(..=command_name.len());
+                            break;
+                        }
+                    }
+
+                    // We check all sub-command names in order to see if one variant
+                    // has been issued to help-system.
+                    let name_str = name.as_str();
+                    let sub_command_found = command
+                        .options
+                        .sub_commands
+                        .iter()
+                        .find(|n| n.options.names.contains(&name_str))
+                        .cloned();
+
+                    // If we found a sub-command, we replace the parent with
+                    // it. This allows the help-systme to extract information
+                    // from the sub-command.
+                    if let Some(ref sub_command) = sub_command_found {
+                        command = sub_command;
+                        Some(sub_command.options.names[0])
+                    } else {
+                        None
+                    }
+                }
             } else {
                 find_any_command_matches(
                     &command,


### PR DESCRIPTION
Before, the help-system did list sub-commands but never considered them for dispatch or listing them.
This caused `help main-command sub-command` to fail.

This commit will inspect sub-commands for each mismatching command.

This addresses and fixes #970 .