### PR TITLE
Replace `CheckResult` with a simple `Result<(), Reason>`

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -750,7 +750,7 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
     propagate_err!(create_declaration_validations(&mut fun, DeclarFor::Check));
 
-    let res = parse_quote!(serenity::framework::standard::CheckResult);
+    let res = parse_quote!(Result<(), serenity::framework::standard::Reason>);
     create_return_type_validation(&mut fun, res);
 
     let n = fun.name.clone();

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -750,7 +750,7 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
     propagate_err!(create_declaration_validations(&mut fun, DeclarFor::Check));
 
-    let res = parse_quote!(Result<(), serenity::framework::standard::Reason>);
+    let res = parse_quote!(std::result::Result<(), serenity::framework::standard::Reason>);
     create_return_type_validation(&mut fun, res);
 
     let n = fun.name.clone();

--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -13,8 +13,8 @@ use serenity::{
     async_trait,
     client::bridge::gateway::{ShardId, ShardManager},
     framework::standard::{
-        Args, CheckResult, CommandOptions, CommandResult, CommandGroup,
-        DispatchError, HelpOptions, help_commands, StandardFramework,
+        Args, CommandOptions, CommandResult, CommandGroup,
+        DispatchError, HelpOptions, help_commands, Reason, StandardFramework,
         macros::{command, group, help, check, hook},
     },
     http::Http,
@@ -335,22 +335,25 @@ async fn say(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
 // not called.
 #[check]
 #[name = "Owner"]
-async fn owner_check(_: &Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> CheckResult {
+async fn owner_check(_: &Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> Result<(), Reason> {
     // Replace 7 with your ID to make this check pass.
     //
-    // `true` will convert into `CheckResult::Success`,
+    // 1. If you want to pass a reason alongside failure you can do:
+    // `Reason::User("Lacked admin permission.".to_string())`,
     //
-    // `false` will convert into `CheckResult::Failure(Reason::Unknown)`,
+    // 2. If you want to mark it as something you want to log only:
+    // `Reason::Log("User lacked admin permission.".to_string())`,
     //
-    // and if you want to pass a reason alongside failure you can do:
-    // `CheckResult::new_user("Lacked admin permission.")`,
+    // 3. If the check's failure origin is unknown you can mark it as such:
+    // `Reason::Unknown`
     //
-    // if you want to mark it as something you want to log only:
-    // `CheckResult::new_log("User lacked admin permission.")`,
-    //
-    // and if the check's failure origin is unknown you can mark it as such (same as using `false.into`):
-    // `CheckResult::new_unknown()`
-    (msg.author.id == 7).into()
+    // 4. If you want log for your system and for the user, use:
+    // `Reason::UserAndLog { user, log }`
+    if msg.author.id == 7 {
+        return Err(Reason::User("Lacked owner permission".to_string()));
+    }
+
+    Ok(())
 }
 
 #[command]

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -56,7 +56,7 @@
 #[cfg(all(feature = "cache", feature = "http"))]
 use super::{
     Args, CommandGroup, CommandOptions, Check,
-    CheckResult, has_correct_roles, HelpBehaviour,
+    has_correct_roles, HelpBehaviour,
     HelpOptions, has_correct_permissions, OnlyIn,
     structures::Command as InternalCommand,
 };
@@ -404,7 +404,7 @@ async fn check_command_behaviour(
 
             let mut args = Args::new("", &[]);
 
-            if let CheckResult::Failure(_) = (check.function)(ctx, msg, &mut args, options).await {
+            if (check.function)(ctx, msg, &mut args, options).await.is_err() {
                 return help_options.lacking_conditions;
             }
         }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -310,8 +310,8 @@ impl StandardFramework {
         for check in group.checks.iter().chain(command.checks.iter()) {
             let res = (check.function)(ctx, msg, args, command).await;
 
-            if let CheckResult::Failure(r) = res {
-                return Some(DispatchError::CheckFailed(check.name, r));
+            if let Result::Err(reason) = res {
+                return Some(DispatchError::CheckFailed(check.name, reason));
             }
         }
 

--- a/src/framework/standard/structures/check.rs
+++ b/src/framework/standard/structures/check.rs
@@ -5,8 +5,7 @@ use crate::client::Context;
 use crate::framework::standard::{Args, CommandOptions};
 use futures::future::BoxFuture;
 
-/// This type describes why a check has failed and occurs on
-/// [`CheckResult::Failure`].
+/// This type describes why a check has failed.
 ///
 /// **Note**:
 /// The bot-developer is supposed to process this `enum` as the framework is not.
@@ -15,7 +14,6 @@ use futures::future::BoxFuture;
 /// occurring in [`Check`]s.
 ///
 /// [`Check`]: struct.Check.html
-/// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Reason {
@@ -29,94 +27,12 @@ pub enum Reason {
     UserAndLog { user: String, log: String },
 }
 
-/// Returned from [`Check`]s.
-/// If `Success`, the [`Check`] is considered as passed.
-/// If `Failure`, the [`Check`] is considered as failed and can return further
-/// information on the cause via [`Reason`].
-///
-/// [`Check`]: struct.Check.html
-/// [`Reason`]: enum.Reason.html
-#[derive(Clone, Debug)]
-pub enum CheckResult {
-   Success,
-   Failure(Reason),
-}
-
-impl CheckResult {
-    /// Creates a new [`CheckResult::Failure`] with [`Reason::User`].
-    ///
-    /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
-    /// [`Reason::User`]: enum.Reason.html#variant.User
-    pub fn new_user<D>(d: D) -> Self
-        where D: fmt::Display {
-        CheckResult::Failure(Reason::User(d.to_string()))
-    }
-
-    /// Creates a new [`CheckResult::Failure`] with [`Reason::Log`].
-    ///
-    /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
-    /// [`Reason::Log`]: enum.Reason.html#variant.Log
-    pub fn new_log<D>(d: D) -> Self
-        where D: fmt::Display {
-        CheckResult::Failure(Reason::Log(d.to_string()))
-    }
-
-    /// Creates a new [`CheckResult::Failure`] with [`Reason::Unknown`].
-    ///
-    /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
-    /// [`Reason::Unknown`]: enum.Reason.html#variant.Unknown
-    pub fn new_unknown() -> Self {
-        CheckResult::Failure(Reason::Unknown)
-    }
-
-    /// Creates a new [`CheckResult::Failure`] with [`Reason::UserAndLog`].
-    ///
-    /// [`CheckResult::Failure`]: enum.CheckResult.html#variant.Failure
-    /// [`Reason::UserAndLog`]: enum.Reason.html#variant.UserAndLog
-    pub fn new_user_and_log<D>(user: D, log: D) -> Self
-        where D: fmt::Display {
-        CheckResult::Failure(Reason::UserAndLog {
-            user: user.to_string(),
-            log: log.to_string(),
-        })
-    }
-
-    /// Returns `true` if [`CheckResult`] is [`CheckResult::Success`] and
-    /// `false` if not.
-    ///
-    /// [`CheckResult`]: enum.CheckResult.html
-    /// [`CheckResult::Success`]: enum.CheckResult.html#variant.Success
-    pub fn is_success(&self) -> bool {
-        if let CheckResult::Success = self {
-            return true;
-        }
-
-        false
-    }
-}
-
-impl From<bool> for CheckResult {
-    fn from(succeeded: bool) -> Self {
-        if succeeded {
-            CheckResult::Success
-        } else {
-            CheckResult::Failure(Reason::Unknown)
-        }
-    }
-}
-
-impl From<Reason> for CheckResult {
-    fn from(reason: Reason) -> Self {
-        CheckResult::Failure(reason)
-    }
-}
-
 pub type CheckFunction = for<'fut> fn(
     &'fut Context,
     &'fut Message,
     &'fut mut Args,
     &'fut CommandOptions,
-) -> BoxFuture<'fut, CheckResult>;
+) -> BoxFuture<'fut, Result<(), Reason>>;
 
 /// A check can be part of a command or group and will be executed to
 /// determine whether a user is permitted to use related item.


### PR DESCRIPTION
The goal is to simplify the API by using the standard library `Result`.
There is no reason to provide a different type for the check-system.