### PR TITLE
Switched from u64 to usize to represent overflow (#1092)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,14 +1,14 @@
 //! A set of constants used by the library.
 
 /// The maximum length of the textual size of an embed.
-pub const EMBED_MAX_LENGTH: u16 = 6000;
+pub const EMBED_MAX_LENGTH: usize = 6000;
 /// The gateway version used by the library. The gateway URI is retrieved via
 /// the REST API.
 pub const GATEWAY_VERSION: u8 = 8;
 /// The large threshold to send on identify.
 pub const LARGE_THRESHOLD: u8 = 250;
 /// The maximum unicode code points allowed within a message by Discord.
-pub const MESSAGE_CODE_LIMIT: u16 = 2000;
+pub const MESSAGE_CODE_LIMIT: usize = 2000;
 /// The [UserAgent] sent along with every request.
 ///
 /// [UserAgent]: ../../reqwest/header/constant.USER_AGENT.html

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -461,14 +461,13 @@ impl Message {
     /// Returns `None` if the message is within the limit, otherwise returns
     /// `Some` with an inner value of how many unicode code points the message
     /// is over.
-    pub fn overflow_length(content: &str) -> Option<u64> {
+    pub fn overflow_length(content: &str) -> Option<usize> {
         // Check if the content is over the maximum number of unicode code
         // points.
-        let count = content.chars().count() as i64;
-        let diff = count - i64::from(constants::MESSAGE_CODE_LIMIT);
+        let count = content.chars().count();
 
-        if diff > 0 {
-            Some(diff as u64)
+        if count > constants::MESSAGE_CODE_LIMIT {
+            Some(count - constants::MESSAGE_CODE_LIMIT)
         } else {
             None
         }
@@ -842,11 +841,10 @@ impl Message {
             total += title.len();
         }
 
-        if total <= constants::EMBED_MAX_LENGTH as usize {
+        if total <= constants::EMBED_MAX_LENGTH {
             Ok(())
         } else {
-            let overflow = total as u64 - u64::from(constants::EMBED_MAX_LENGTH);
-
+            let overflow = total - constants::EMBED_MAX_LENGTH;
             Err(Error::Model(ModelError::EmbedTooLarge(overflow)))
         }
     }

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -74,7 +74,7 @@ pub enum Error {
     DeleteMessageDaysAmount(u8),
     /// Indicates that the textual content of an embed exceeds the maximum
     /// length.
-    EmbedTooLarge(u64),
+    EmbedTooLarge(usize),
     /// An indication that a [guild][`Guild`] could not be found by
     /// [Id][`GuildId`] in the [`Cache`].
     ///
@@ -115,12 +115,12 @@ pub enum Error {
     /// [`Cache`]: ../../cache/struct.Cache.html
     ItemMissing,
     /// Indicates that a [`Message`]s content was too long and will not
-    /// successfully send, as the length is over 2000 codepoints, or 4000 bytes.
+    /// successfully send, as the length is over 2000 codepoints.
     ///
-    /// The number of bytes larger than the limit is provided.
+    /// The number of characters larger than the limit is provided.
     ///
     /// [`Message`]: ../channel/struct.Message.html
-    MessageTooLong(u64),
+    MessageTooLong(usize),
     /// Indicates that the current user is attempting to Direct Message another
     /// bot user, which is disallowed by the API.
     MessagingBot,

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -117,7 +117,7 @@ pub enum Error {
     /// Indicates that a [`Message`]s content was too long and will not
     /// successfully send, as the length is over 2000 codepoints.
     ///
-    /// The number of characters larger than the limit is provided.
+    /// The number of code points larger than the limit is provided.
     ///
     /// [`Message`]: ../channel/struct.Message.html
     MessageTooLong(usize),


### PR DESCRIPTION
This PR is a breaking change as it changes the inner type of two Errors (EmbedTooLarge and MessageTooLong) from u64 to usize.

I think a test target should be added to ensure that the `overflow_length` function remains correct but there is nothing about adding unit tests in `contribute.md`.
