### PR TITLE
Added support for displaying sub-commands in plaintext help.

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1453,11 +1453,20 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
         "**{}**: {}",
         help_options.grouped_label, command.group_name
     );
+
     let _ = writeln!(
         result,
         "**{}**: {}",
         help_options.available_text, command.availability
     );
+
+    if !command.sub_commands.is_empty() {
+        let _ = writeln!(
+            result,
+            "**{}**: {}",
+            help_options.sub_commands_label, format!("`{}`", command.sub_commands.join("`, `"))
+        );
+     }
 
     result
 }


### PR DESCRIPTION
Very small and simple Pull Request that adds support for displaying sub-commands in the plaintext help system for commands that have them, similar to the implementation that is implemented for the embed help system.