### PR TITLE
Fix the struct for Voice Regions.

### DIFF
--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -21,11 +21,7 @@ pub struct VoiceRegion {
     /// A recognizable name of the location of the voice region.
     pub name: String,
     /// Whether the voice region is optimal for use by the current user.
-    pub optional: bool,
-    /// an example hostname.
-    pub sample_hostname: String,
-    /// An example port.
-    pub sample_port: u64,
+    pub optimal: bool,
     /// Indicator of whether the voice region is only for VIP guilds.
     pub vip: bool,
     #[serde(skip)]


### PR DESCRIPTION
Just another small Pull Request that fixes the broken Voice Region struct, required for using the HTTP method `get_voice_regions()`. The object no longer contains the `sample_hostname` or `sample_port` fields, and the `optional` field was renamed to `optimal` although I don't know for sure if it was always `optimal` and the author who created these structs just misspelled the field, but either way, the field has been fixed.