### PR TITLE
The great removal of _nonexhaustive().

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -534,27 +534,23 @@ mod test {
                     inline: false,
                     name: "a".to_string(),
                     value: "b".to_string(),
-                    _nonexhaustive: (),
                 },
                 EmbedField {
                     inline: true,
                     name: "c".to_string(),
                     value: "z".to_string(),
-                    _nonexhaustive: (),
                 },
             ],
             footer: Some(EmbedFooter {
                 icon_url: Some("https://i.imgur.com/XfWpfCV.gif".to_string()),
                 proxy_icon_url: None,
                 text: "This is a hakase footer".to_string(),
-                _nonexhaustive: (),
             }),
             image: Some(EmbedImage {
                 height: 213,
                 proxy_url: "a".to_string(),
                 url: "https://i.imgur.com/XfWpfCV.gif".to_string(),
                 width: 224,
-                _nonexhaustive: (),
             }),
             kind: "rich".to_string(),
             provider: None,
@@ -566,9 +562,7 @@ mod test {
                 height: 213,
                 url: "https://i.imgur.com/XfWpfCV.mp4".to_string(),
                 width: 224,
-                _nonexhaustive: (),
             }),
-            _nonexhaustive: (),
         };
 
         let mut builder = CreateEmbed::from(embed);

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1006,7 +1006,6 @@ mod test {
                     bot: false,
                     discriminator: 1,
                     name: "user 1".to_owned(),
-                    _nonexhaustive: (),
                 },
                 channel_id: ChannelId(2),
                 guild_id: Some(GuildId(1)),
@@ -1030,9 +1029,7 @@ mod test {
                 message_reference: None,
                 flags: None,
                 referenced_message: None,
-                _nonexhaustive: (),
             },
-            _nonexhaustive: (),
         };
         // Check that the channel cache doesn't exist.
         assert!(!cache.messages.read().await.contains_key(&event.message.channel_id));
@@ -1076,14 +1073,12 @@ mod test {
             user_limit: None,
             nsfw: false,
             slow_mode_rate: Some(0),
-            _nonexhaustive: (),
         };
 
         // Add a channel delete event to the cache, the cached messages for that
         // channel should now be gone.
         let mut delete = ChannelDeleteEvent {
             channel: Channel::Guild(guild_channel.clone()),
-            _nonexhaustive: (),
         };
         assert!(cache.update(&mut delete).await.is_none());
         assert!(!cache.messages.read().await.contains_key(&delete.channel.id()));
@@ -1126,9 +1121,7 @@ mod test {
                     banner: None,
                     vanity_url_code: Some("bruhmoment".to_string()),
                     preferred_locale: "en-US".to_string(),
-                    _nonexhaustive: (),
                 },
-                _nonexhaustive: (),
             }
         };
         assert!(cache.update(&mut guild_create).await.is_none());
@@ -1139,7 +1132,6 @@ mod test {
                 id: GuildId(1),
                 unavailable: false,
             },
-            _nonexhaustive: (),
         };
 
         // The guild existed in the cache, so the cache's guild is returned by the

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -126,6 +126,7 @@ pub struct SuggestedCommandName {
 
 /// A single command containing all related pieces of information.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Command<'a> {
     pub name: &'static str,
     pub group_name: &'static str,
@@ -137,7 +138,6 @@ pub struct Command<'a> {
     pub usage: Option<&'static str>,
     pub usage_sample: Vec<&'static str>,
     pub checks: Vec<String>,
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Contains possible suggestions in case a command could not be found
@@ -600,7 +600,6 @@ async fn _nested_group_command_search<'rec, 'a: 'rec>(
                     usage: options.usage,
                     usage_sample: options.examples.to_vec(),
                     sub_commands: sub_command_names,
-                    _nonexhaustive: (),
                 },
             });
         }

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -10,6 +10,7 @@ use std::fmt;
 /// Information about a user's application. An application does not necessarily
 /// have an associated bot user.
 #[derive(Clone, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ApplicationInfo {
     /// The bot user associated with the application. See [`BotApplication`] for
     /// more information.
@@ -49,8 +50,6 @@ pub struct ApplicationInfo {
     ///
     /// This is not equivalent to the application's bot user's token.
     pub secret: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 impl fmt::Debug for ApplicationInfo {
@@ -73,6 +72,7 @@ impl fmt::Debug for ApplicationInfo {
 
 /// Information about an application with an application's bot user.
 #[derive(Clone, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct BotApplication {
     /// The unique Id of the bot user.
     pub id: UserId,
@@ -95,8 +95,6 @@ pub struct BotApplication {
     /// **Note**: Keep this information private, as untrusted sources can use it
     /// to perform any action with a bot user.
     pub token: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 
@@ -114,6 +112,7 @@ impl fmt::Debug for BotApplication {
 
 /// Information about the current application and its owner.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct CurrentApplicationInfo {
     pub description: String,
     pub icon: Option<String>,
@@ -124,8 +123,6 @@ pub struct CurrentApplicationInfo {
     pub bot_public: bool,
     pub bot_require_code_grant: bool,
     pub team: Option<Team>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Information about the Team group of the application.

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -9,6 +9,7 @@ use crate::internal::prelude::*;
 ///
 /// [`Embed`]: struct.Embed.html
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Attachment {
     /// The unique ID given to this attachment.
     pub id: AttachmentId,
@@ -25,8 +26,6 @@ pub struct Attachment {
     pub url: String,
     /// If the attachment is an image, then the width of the image is provided.
     pub width: Option<u64>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -11,6 +11,7 @@ use crate::http::{Http, CacheHttp};
 ///
 /// [`GuildChannel`]: struct.GuildChannel.html
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ChannelCategory {
     /// Id of this category.
     pub id: ChannelId,
@@ -37,8 +38,6 @@ pub struct ChannelCategory {
     ///
     /// [`GuildChannel`]: struct.GuildChannel.html
     pub permission_overwrites: Vec<PermissionOverwrite>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -117,7 +116,6 @@ impl ChannelCategory {
                 name,
                 position,
                 kind,
-                _nonexhaustive: (),
             };
         })
     }

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -18,6 +18,7 @@ use crate::utils;
 ///
 /// [slack's attachments]: https://api.slack.com/docs/message-attachments
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Embed {
     /// Information about the author of the embed.
     pub author: Option<EmbedAuthor>,
@@ -67,8 +68,6 @@ pub struct Embed {
     ///
     /// [`kind`]: #structfield.kind
     pub video: Option<EmbedVideo>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -105,6 +104,7 @@ impl Embed {
 
 /// An author object in an embed.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct EmbedAuthor {
     /// The URL of the author icon.
     ///
@@ -116,12 +116,11 @@ pub struct EmbedAuthor {
     pub proxy_icon_url: Option<String>,
     /// The URL of the author.
     pub url: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// A field object in an embed.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct EmbedField {
     /// Indicator of whether the field should display as inline.
     pub inline: bool,
@@ -133,8 +132,6 @@ pub struct EmbedField {
     ///
     /// The maxiumum length of this field is 1024 unicode codepoints.
     pub value: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 impl EmbedField {
@@ -155,13 +152,13 @@ impl EmbedField {
             name,
             value,
             inline,
-            _nonexhaustive: (),
         }
     }
 }
 
 /// Footer information for an embed.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct EmbedFooter {
     /// The URL of the footer icon.
     ///
@@ -171,12 +168,11 @@ pub struct EmbedFooter {
     pub proxy_icon_url: Option<String>,
     /// The associated text with the footer.
     pub text: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// An image object in an embed.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct EmbedImage {
     /// The height of the image.
     pub height: u64,
@@ -188,23 +184,21 @@ pub struct EmbedImage {
     pub url: String,
     /// The width of the image.
     pub width: u64,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// The provider of an embed.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct EmbedProvider {
     /// The name of the provider.
     pub name: String,
     /// The URL of the provider.
     pub url: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// The dimensions and URL of an embed thumbnail.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct EmbedThumbnail {
     /// The height of the thumbnail in pixels.
     pub height: u64,
@@ -216,12 +210,11 @@ pub struct EmbedThumbnail {
     pub url: String,
     /// The width of the thumbnail in pixels.
     pub width: u64,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Video information for an embed.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct EmbedVideo {
     /// The height of the video in pixels.
     pub height: u64,
@@ -229,6 +222,4 @@ pub struct EmbedVideo {
     pub url: String,
     /// The width of the video in pixels.
     pub width: u64,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 /// News channels are a subset of text channels and lack slow mode hence
 /// `slow_mode_rate` will be `None`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildChannel {
     /// The unique Id of the channel.
     ///
@@ -114,8 +115,6 @@ pub struct GuildChannel {
     /// channels.
     #[serde(default, rename = "rate_limit_per_user")]
     pub slow_mode_rate: Option<u64>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -45,6 +45,7 @@ use crate::client::bridge::gateway::ShardMessenger;
 /// A representation of a message over a guild's text channel, a group, or a
 /// private channel.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Message {
     /// The unique Id of the message. Can be used to calculate the creation date
     /// of the message.
@@ -113,8 +114,6 @@ pub struct Message {
     pub flags: Option<MessageFlags>,
     /// The message that was replied to using this message.
     pub referenced_message: Option<Box<Message>>, // Boxed to avoid recusion
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -550,7 +549,6 @@ impl Message {
             message_id: self.id,
             user_id,
             guild_id: self.guild_id,
-            _nonexhaustive: (),
         })
     }
 
@@ -874,6 +872,7 @@ impl<'a> From<&'a Message> for MessageId {
 /// [`count`]: #structfield.count
 /// [reaction type]: enum.ReactionType.html
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct MessageReaction {
     /// The amount of the type of reaction that have been sent for the
     /// associated message.
@@ -883,8 +882,6 @@ pub struct MessageReaction {
     /// The type of reaction.
     #[serde(rename = "emoji")]
     pub reaction_type: ReactionType,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Differentiates between regular and different types of system messages.
@@ -993,6 +990,7 @@ impl MessageActivityKind {
 
 /// Rich Presence application information.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct MessageApplication {
     /// ID of the application.
     pub id: u64,
@@ -1004,24 +1002,22 @@ pub struct MessageApplication {
     pub icon: Option<String>,
     /// Name of the application.
     pub name: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Rich Presence activity information.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct MessageActivity {
     /// Kind of message activity.
     #[serde(rename = "type")]
     pub kind: MessageActivityKind,
     /// `party_id` from a Rich Presence event.
     pub party_id: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Reference data sent with crossposted messages.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct MessageReference {
     /// ID of the originating message.
     pub message_id: Option<MessageId>,
@@ -1029,8 +1025,6 @@ pub struct MessageReference {
     pub channel_id: ChannelId,
     /// ID of the originating message's guild.
     pub guild_id: Option<GuildId>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 impl From<&Message> for MessageReference {
@@ -1039,7 +1033,6 @@ impl From<&Message> for MessageReference {
             message_id: Some(m.id),
             channel_id: m.channel_id,
             guild_id: m.guild_id,
-            _nonexhaustive: ()
         }
     }
 }
@@ -1050,7 +1043,6 @@ impl From<(ChannelId, MessageId)> for MessageReference {
             message_id: Some(pair.1),
             channel_id: pair.0,
             guild_id: None,
-            _nonexhaustive: ()
         }
     }
 }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -444,7 +444,6 @@ mod test {
                 user_limit: None,
                 nsfw: false,
                 slow_mode_rate: Some(0),
-                _nonexhaustive: (),
             }
         }
 
@@ -460,9 +459,7 @@ mod test {
                     bot: false,
                     discriminator: 1,
                     name: "ab".to_string(),
-                    _nonexhaustive: (),
                 },
-                _nonexhaustive: (),
             }
         }
 

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 
 /// A Direct Message text channel with another user.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct PrivateChannel {
     /// The unique Id of the private channel.
     ///
@@ -44,8 +45,6 @@ pub struct PrivateChannel {
             serialize_with = "serialize_single_recipient",
             rename = "recipients")]
     pub recipient: User,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -23,6 +23,7 @@ use std::str::FromStr;
 
 /// An emoji reaction to a message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Reaction {
     /// The [`Channel`] of the associated [`Message`].
     ///
@@ -46,8 +47,6 @@ pub struct Reaction {
     ///
     /// [`Guild`]: ../guild/struct.Guild.html
     pub guild_id: Option<GuildId>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -383,7 +382,7 @@ impl ReactionType {
     /// perform any allocation. Will always return false if the reaction was
     /// not a unicode reaction.
     pub fn unicode_eq(&self, other: &str) -> bool {
-        
+
         if let ReactionType::Unicode(unicode) = &self {
             unicode == other
         } else {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -33,17 +33,16 @@ use async_trait::async_trait;
 /// [`Guild`]: ../guild/struct.Guild.html
 /// [`PrivateChannel`]: ../channel/struct.PrivateChannel.html
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ChannelCreateEvent {
     /// The channel that was created.
     pub channel: Channel,
-    pub(crate) _nonexhaustive: (),
 }
 
 impl<'de> Deserialize<'de> for ChannelCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             channel: Channel::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -118,9 +117,9 @@ impl CacheUpdate for ChannelCreateEvent {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ChannelDeleteEvent {
     pub channel: Channel,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
@@ -171,7 +170,6 @@ impl<'de> Deserialize<'de> for ChannelDeleteEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             channel: Channel::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -184,12 +182,11 @@ impl Serialize for ChannelDeleteEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ChannelPinsUpdateEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub last_pin_timestamp: Option<DateTime<Utc>>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -215,9 +212,9 @@ impl CacheUpdate for ChannelPinsUpdateEvent {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ChannelUpdateEvent {
     pub channel: Channel,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -259,7 +256,6 @@ impl<'de> Deserialize<'de> for ChannelUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             channel: Channel::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -272,25 +268,23 @@ impl Serialize for ChannelUpdateEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildBanAddEvent {
     pub guild_id: GuildId,
     pub user: User,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildBanRemoveEvent {
     pub guild_id: GuildId,
     pub user: User,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct GuildCreateEvent {
     pub guild: Guild,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -324,7 +318,6 @@ impl<'de> Deserialize<'de> for GuildCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             guild: Guild::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -337,9 +330,9 @@ impl Serialize for GuildCreateEvent {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct GuildDeleteEvent {
     pub guild: GuildUnavailable,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -369,7 +362,6 @@ impl<'de> Deserialize<'de> for GuildDeleteEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             guild: GuildUnavailable::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -382,11 +374,10 @@ impl Serialize for GuildDeleteEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildEmojisUpdateEvent {
     #[serde(serialize_with = "serialize_emojis", deserialize_with = "deserialize_emojis")] pub emojis: HashMap<EmojiId, Emoji>,
     pub guild_id: GuildId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -404,17 +395,16 @@ impl CacheUpdate for GuildEmojisUpdateEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildIntegrationsUpdateEvent {
     pub guild_id: GuildId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct GuildMemberAddEvent {
     pub guild_id: GuildId,
     pub member: Member,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -451,7 +441,6 @@ impl<'de> Deserialize<'de> for GuildMemberAddEvent {
             guild_id,
             member: Member::deserialize(Value::Object(map))
                 .map_err(DeError::custom)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -472,11 +461,10 @@ impl Serialize for GuildMemberAddEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildMemberRemoveEvent {
     pub guild_id: GuildId,
     pub user: User,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -495,13 +483,12 @@ impl CacheUpdate for GuildMemberRemoveEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildMemberUpdateEvent {
     pub guild_id: GuildId,
     pub nick: Option<String>,
     pub roles: Vec<RoleId>,
     pub user: User,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -540,7 +527,6 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                         nick: self.nick.clone(),
                         roles: self.roles.clone(),
                         user: self.user.clone(),
-                        _nonexhaustive: (),
                     },
                 );
             }
@@ -553,14 +539,13 @@ impl CacheUpdate for GuildMemberUpdateEvent {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub struct GuildMembersChunkEvent {
     pub guild_id: GuildId,
     pub members: HashMap<UserId, Member>,
     pub chunk_index: u32,
     pub chunk_count: u32,
     pub nonce: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -635,17 +620,15 @@ impl<'de> Deserialize<'de> for GuildMembersChunkEvent {
             chunk_index,
             chunk_count,
             nonce,
-            _nonexhaustive: (),
         })
     }
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub struct GuildRoleCreateEvent {
     pub guild_id: GuildId,
     pub role: Role,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -690,17 +673,15 @@ impl<'de> Deserialize<'de> for GuildRoleCreateEvent {
         Ok(Self {
             guild_id,
             role,
-            _nonexhaustive: (),
         })
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildRoleDeleteEvent {
     pub guild_id: GuildId,
     pub role_id: RoleId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -719,11 +700,10 @@ impl CacheUpdate for GuildRoleDeleteEvent {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub struct GuildRoleUpdateEvent {
     pub guild_id: GuildId,
     pub role: Role,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -768,12 +748,12 @@ impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
         Ok(Self {
             guild_id,
             role,
-            _nonexhaustive: (),
         })
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct InviteCreateEvent {
     pub channel_id: ChannelId,
     pub code: String,
@@ -782,24 +762,20 @@ pub struct InviteCreateEvent {
     pub max_age: u64,
     pub max_uses: u64,
     pub temporary: bool,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct InviteDeleteEvent {
     pub channel_id: ChannelId,
     pub guild_id: Option<GuildId>,
     pub code: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildUnavailableEvent {
     #[serde(rename = "id")] pub guild_id: GuildId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -816,9 +792,9 @@ impl CacheUpdate for GuildUnavailableEvent {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct GuildUpdateEvent {
     pub guild: PartialGuild,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -846,7 +822,6 @@ impl<'de> Deserialize<'de> for GuildUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             guild: PartialGuild::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -859,9 +834,9 @@ impl Serialize for GuildUpdateEvent {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct MessageCreateEvent {
     pub message: Message,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -906,7 +881,6 @@ impl<'de> Deserialize<'de> for MessageCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             message: Message::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -919,24 +893,23 @@ impl Serialize for MessageCreateEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct MessageDeleteBulkEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub ids: Vec<MessageId>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct MessageDeleteEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     #[serde(rename = "id")] pub message_id: MessageId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct MessageUpdateEvent {
     pub id: MessageId,
     pub guild_id: Option<GuildId>,
@@ -954,8 +927,6 @@ pub struct MessageUpdateEvent {
     pub mention_roles: Option<Vec<RoleId>>,
     pub attachments: Option<Vec<Attachment>>,
     pub embeds: Option<Vec<Value>>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -1006,11 +977,10 @@ impl CacheUpdate for MessageUpdateEvent {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub struct PresenceUpdateEvent {
     pub guild_id: Option<GuildId>,
     pub presence: Presence,
-    #[serde(skip_serializing)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -1051,7 +1021,6 @@ impl CacheUpdate for PresenceUpdateEvent {
                             nick: None,
                             user: user.clone(),
                             roles: vec![],
-                            _nonexhaustive: (),
                         });
                     }
                 }
@@ -1085,15 +1054,14 @@ impl<'de> Deserialize<'de> for PresenceUpdateEvent {
         Ok(Self {
             guild_id,
             presence,
-            _nonexhaustive: (),
         })
     }
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct PresencesReplaceEvent {
     pub presences: Vec<Presence>,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -1122,7 +1090,6 @@ impl<'de> Deserialize<'de> for PresencesReplaceEvent {
 
         Ok(Self {
             presences,
-            _nonexhaustive: (),
         })
     }
 }
@@ -1141,16 +1108,15 @@ impl Serialize for PresencesReplaceEvent {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ReactionAddEvent {
     pub reaction: Reaction,
-    pub(crate) _nonexhaustive: (),
 }
 
 impl<'de> Deserialize<'de> for ReactionAddEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             reaction: Reaction::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -1163,16 +1129,15 @@ impl Serialize for ReactionAddEvent {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ReactionRemoveEvent {
     pub reaction: Reaction,
-    pub(crate) _nonexhaustive: (),
 }
 
 impl<'de> Deserialize<'de> for ReactionRemoveEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             reaction: Reaction::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -1185,19 +1150,18 @@ impl Serialize for ReactionRemoveEvent {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ReactionRemoveAllEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub message_id: MessageId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// The "Ready" event, containing initial ready cache
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ReadyEvent {
     pub ready: Ready,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -1248,7 +1212,6 @@ impl<'de> Deserialize<'de> for ReadyEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             ready: Ready::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -1261,34 +1224,31 @@ impl Serialize for ReadyEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ResumedEvent {
     #[serde(rename = "_trace")] pub trace: Vec<Option<String>>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct TypingStartEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
     pub timestamp: u64,
     pub user_id: UserId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct UnknownEvent {
     pub kind: String,
     pub value: Value,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct UserUpdateEvent {
     pub current_user: CurrentUser,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -1306,7 +1266,6 @@ impl<'de> Deserialize<'de> for UserUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
             current_user: CurrentUser::deserialize(deserializer)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -1319,13 +1278,12 @@ impl Serialize for UserUpdateEvent {
 }
 
 #[derive(Clone, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct VoiceServerUpdateEvent {
     pub channel_id: Option<ChannelId>,
     pub endpoint: Option<String>,
     pub guild_id: Option<GuildId>,
     pub token: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 impl fmt::Debug for VoiceServerUpdateEvent {
@@ -1339,10 +1297,10 @@ impl fmt::Debug for VoiceServerUpdateEvent {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct VoiceStateUpdateEvent {
     pub guild_id: Option<GuildId>,
     pub voice_state: VoiceState,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "cache")]
@@ -1391,7 +1349,6 @@ impl<'de> Deserialize<'de> for VoiceStateUpdateEvent {
             guild_id,
             voice_state: VoiceState::deserialize(Value::Object(map))
                 .map_err(DeError::custom)?,
-            _nonexhaustive: (),
         })
     }
 }
@@ -1414,11 +1371,10 @@ impl Serialize for VoiceStateUpdateEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct WebhookUpdateEvent {
     pub channel_id: ChannelId,
     pub guild_id: GuildId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -1783,7 +1739,6 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
         EventType::Other(kind) => Event::Unknown(UnknownEvent {
             kind,
             value: v,
-            _nonexhaustive: (),
         }),
     })
 }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -13,6 +13,7 @@ use bitflags::bitflags;
 ///
 /// This is only applicable to bot users.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct BotGateway {
     /// Information describing how many gateway sessions you can initiate within
     /// a ratelimit period.
@@ -22,12 +23,11 @@ pub struct BotGateway {
     pub shards: u64,
     /// The gateway to connect to.
     pub url: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Representation of an activity that a [`User`] is performing.
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub struct Activity {
     /// The ID of the application for the activity.
     pub application_id: Option<ApplicationId>,
@@ -59,8 +59,6 @@ pub struct Activity {
     /// [`ActivityType::Streaming`]: enum.ActivityType.html#variant.Streaming
     /// [`kind`]: #structfield.kind
     pub url: Option<String>,
-    #[serde(skip_serializing)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -105,7 +103,6 @@ impl Activity {
             emoji: None,
             timestamps: None,
             url: None,
-            _nonexhaustive: (),
         }
     }
 
@@ -152,7 +149,6 @@ impl Activity {
             emoji: None,
             timestamps: None,
             url: Some(url.to_string()),
-            _nonexhaustive: (),
         }
     }
 
@@ -196,7 +192,6 @@ impl Activity {
             emoji: None,
             timestamps: None,
             url: None,
-            _nonexhaustive: (),
         }
     }
 
@@ -240,7 +235,6 @@ impl Activity {
             emoji: None,
             timestamps: None,
             url: None,
-            _nonexhaustive: (),
         }
     }
 }
@@ -313,13 +307,13 @@ impl<'de> Deserialize<'de> for Activity {
             emoji,
             timestamps,
             url,
-            _nonexhaustive: (),
         })
     }
 }
 
 /// The assets for an activity.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ActivityAssets {
     /// The ID for a large asset of the activity, usually a snowflake.
     pub large_image: Option<String>,
@@ -329,8 +323,6 @@ pub struct ActivityAssets {
     pub small_image: Option<String>,
     /// Text displayed when hovering over the small image of the activity.
     pub small_text: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 bitflags! {
@@ -354,17 +346,17 @@ bitflags! {
 
 /// Information about an activity's party.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ActivityParty {
     /// The ID of the party.
     pub id: Option<String>,
     /// Used to show the party's current and maximum size.
     pub size: Option<[u64; 2]>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Secrets for an activity.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ActivitySecrets {
     /// The secret for joining a party.
     pub join: Option<String>,
@@ -373,8 +365,6 @@ pub struct ActivitySecrets {
     pub match_: Option<String>,
     /// The secret for spectating an activity.
     pub spectate: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Representation of an emoji used in a custom status
@@ -438,11 +428,10 @@ impl Default for ActivityType {
 ///
 /// [`BotGateway`]: struct.BotGateway.html
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Gateway {
     /// The gateway to connect to.
     pub url: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Information detailing the current active status of a [`User`].
@@ -459,6 +448,7 @@ pub struct ClientStatus {
 ///
 /// [`User`]: ../user/struct.User.html
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Presence {
     /// [`User`]'s current activities.
     ///
@@ -475,7 +465,6 @@ pub struct Presence {
     pub user_id: UserId,
     /// The associated user instance.
     pub user: Option<User>,
-    pub(crate) _nonexhaustive: (),
 }
 
 impl<'de> Deserialize<'de> for Presence {
@@ -533,7 +522,6 @@ impl<'de> Deserialize<'de> for Presence {
             status,
             user,
             user_id,
-            _nonexhaustive: (),
         })
     }
 }
@@ -568,6 +556,7 @@ impl Serialize for Presence {
 
 /// An initial set of information given after IDENTIFYing to the gateway.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Ready {
     pub guilds: Vec<GuildStatus>,
     #[serde(default, serialize_with = "serialize_presences", deserialize_with = "deserialize_presences")]
@@ -581,13 +570,12 @@ pub struct Ready {
     pub user: CurrentUser,
     #[serde(rename = "v")]
     pub version: u64,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// Information describing how many gateway sessions you can initiate within a
 /// ratelimit period.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct SessionStartLimit {
     /// The number of sessions that you can still initiate within the current
     /// ratelimit period.
@@ -596,14 +584,11 @@ pub struct SessionStartLimit {
     pub reset_after: u64,
     /// The total number of session starts within the ratelimit period allowed.
     pub total: u64,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 /// Timestamps of when a user started and/or is ending their activity.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ActivityTimestamps {
     pub end: Option<u64>,
     pub start: Option<u64>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -259,14 +259,15 @@ pub struct Change {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct AuditLogs {
     pub entries: HashMap<AuditLogEntryId, AuditLogEntry>,
     pub webhooks: Vec<Webhook>,
     pub users: Vec<User>,
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct AuditLogEntry {
     /// Determines to what entity an [`action`] was used on.
     ///
@@ -291,11 +292,10 @@ pub struct AuditLogEntry {
     pub id: AuditLogEntryId,
     /// Some optional data assosiated with this entry.
     pub options: Option<Options>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Options {
     /// Number of days after which inactive members were kicked.
     #[serde(default, with = "option_u64_handler")]
@@ -318,8 +318,6 @@ pub struct Options {
     /// Name of the role if type is "role"
     #[serde(default)]
     pub role_name: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 mod option_u64_handler {
@@ -475,7 +473,6 @@ impl<'de> Deserialize<'de> for AuditLogs {
                         .collect(),
                     webhooks: webhooks.unwrap(),
                     users: users.unwrap(),
-                    _nonexhaustive: (),
                 })
             }
         }

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -23,6 +23,7 @@ use crate::http::CacheHttp;
 /// or via an integration. Emojis created using the API only work within the
 /// guild it was created in.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Emoji {
     /// Whether the emoji is animated.
     #[serde(default)]
@@ -44,8 +45,6 @@ pub struct Emoji {
     ///
     /// [`Role`]: struct.Role.html
     pub roles: Vec<RoleId>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -2,6 +2,7 @@ use super::*;
 
 /// Various information about integrations.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Integration {
     pub id: IntegrationId,
     pub account: IntegrationAccount,
@@ -14,8 +15,6 @@ pub struct Integration {
     pub synced_at: u64,
     pub syncing: bool,
     pub user: User,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 impl From<Integration> for IntegrationId {
@@ -25,9 +24,8 @@ impl From<Integration> for IntegrationId {
 
 /// Integration account object.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct IntegrationAccount {
     pub id: String,
     pub name: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -24,6 +24,7 @@ use crate::http::{Http, CacheHttp};
 
 /// Information about a member of a guild.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Member {
     /// Indicator of whether the member can hear in voice channels.
     pub deaf: bool,
@@ -41,8 +42,6 @@ pub struct Member {
     pub roles: Vec<RoleId>,
     /// Attached User struct.
     pub user: User,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -490,6 +489,7 @@ impl Display for Member {
 /// [`Guild`]: struct.Guild.html
 /// [`Message`]: ../channel/struct.Message.html
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct PartialMember {
     /// Indicator of whether the member can hear in voice channels.
     pub deaf: bool,
@@ -503,6 +503,4 @@ pub struct PartialMember {
     pub nick: Option<String>,
     /// Vector of Ids of [`Role`]s given to the member.
     pub roles: Vec<RoleId>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -48,6 +48,7 @@ pub struct Ban {
 
 /// Information about a Discord guild, such as channels, emojis, etc.
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub struct Guild {
     /// Id of a voice channel that's considered the AFK channel.
     pub afk_channel_id: Option<ChannelId>,
@@ -170,8 +171,6 @@ pub struct Guild {
     /// The preferred locale of this guild only set if guild has the "DISCOVERABLE"
     /// feature, defaults to en-US.
     pub preferred_locale: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -1946,7 +1945,6 @@ impl<'de> Deserialize<'de> for Guild {
             banner,
             vanity_url_code,
             preferred_locale,
-            _nonexhaustive: (),
         })
     }
 }
@@ -2291,7 +2289,6 @@ mod test {
                 bot: true,
                 discriminator: 1432,
                 name: "test".to_string(),
-                _nonexhaustive: (),
             }
         }
 
@@ -2311,7 +2308,6 @@ mod test {
                 nick: Some("aaaa".to_string()),
                 roles: vec1,
                 user: u,
-                _nonexhaustive: (),
             }
         }
 
@@ -2366,7 +2362,6 @@ mod test {
                 banner: None,
                 vanity_url_code: Some("bruhmoment".to_string()),
                 preferred_locale: "en-US".to_string(),
-                _nonexhaustive: (),
             }
         }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -22,6 +22,7 @@ use crate::collector::{
 ///
 /// [`Guild`]: struct.Guild.html
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub struct PartialGuild {
     pub id: GuildId,
     pub afk_channel_id: Option<ChannelId>,
@@ -51,8 +52,6 @@ pub struct PartialGuild {
     pub premium_subscription_count: u64,
     pub banner: Option<String>,
     pub vanity_url_code: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -753,7 +752,6 @@ impl<'de> Deserialize<'de> for PartialGuild {
             premium_subscription_count,
             banner,
             vanity_url_code,
-            _nonexhaustive: (),
         })
     }
 }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -26,6 +26,7 @@ use async_trait::async_trait;
 /// can have channel-specific permission overrides in addition to guild-level
 /// permissions.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Role {
     /// The Id of the role. Can be used to calculate the role's creation date.
     pub id: RoleId,
@@ -70,8 +71,6 @@ pub struct Role {
     ///
     /// The `@everyone` role is usually either `-1` or `0`.
     pub position: i64,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -23,6 +23,7 @@ use crate::http::{Http, CacheHttp};
 ///
 /// Information can not be accessed for guilds the current user is banned from.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Invite {
     /// The approximate number of [`Member`]s in the related [`Guild`].
     ///
@@ -59,8 +60,6 @@ pub struct Invite {
     ///
     /// [`User`]: ../user/struct.User.html
     pub inviter: Option<InviteUser>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -196,13 +195,12 @@ impl Invite {
 
 /// A minimal amount of information about the inviter (person who created the invite).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct InviteUser {
     pub id: UserId,
     #[serde(rename = "username")] pub name: String,
     #[serde(deserialize_with = "deserialize_u16")] pub discriminator: u16,
     pub avatar: Option<String>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// InviteUser implements a Deref to UserId so it gains the convenience methods
@@ -218,17 +216,17 @@ impl Deref for InviteUser {
 }
 
 /// A minimal amount of information about the channel an invite points to.
+#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InviteChannel {
     pub id: ChannelId,
     pub name: String,
     #[serde(rename = "type")] pub kind: ChannelType,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// A minimal amount of information about the guild an invite points to.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct InviteGuild {
     pub id: GuildId,
     pub icon: Option<String>,
@@ -236,8 +234,6 @@ pub struct InviteGuild {
     pub splash_hash: Option<String>,
     pub text_channel_count: Option<u64>,
     pub voice_channel_count: Option<u64>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -293,6 +289,7 @@ impl InviteGuild {
 /// [`Invite`]: struct.Invite.html
 /// [Manage Guild]: ../permissions/struct.Permissions.html#associatedconstant.MANAGE_GUILD
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct RichInvite {
     /// A representation of the minimal amount of information needed about the
     /// channel being invited to.
@@ -326,8 +323,6 @@ pub struct RichInvite {
     pub temporary: bool,
     /// The amount of times that an invite has been used.
     pub uses: u64,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -213,16 +213,16 @@ impl FromStr for EmojiIdentifier {
 ///
 /// This is pulled from the Discord status page.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct AffectedComponent {
     pub name: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// An incident retrieved from the Discord status page.
 ///
 /// This is not necessarily a representation of an ongoing incident.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Incident {
     pub created_at: String,
     pub id: String,
@@ -235,8 +235,6 @@ pub struct Incident {
     pub short_link: String,
     pub status: String,
     pub updated_at: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// An update to an incident from the Discord status page.
@@ -244,6 +242,7 @@ pub struct Incident {
 /// This will typically state what new information has been discovered about an
 /// incident.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct IncidentUpdate {
     pub affected_components: Vec<AffectedComponent>,
     pub body: String,
@@ -253,8 +252,6 @@ pub struct IncidentUpdate {
     pub incident_id: String,
     pub status: IncidentStatus,
     pub updated_at: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// The type of status update during a service incident.
@@ -272,14 +269,13 @@ pub enum IncidentStatus {
 /// A Discord status maintenance message. This can be either for active
 /// maintenances or for scheduled maintenances.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Maintenance {
     pub description: String,
     pub id: String,
     pub name: String,
     pub start: String,
     pub stop: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(test)]
@@ -317,7 +313,6 @@ mod test {
                 user_limit: None,
                 nsfw: false,
                 slow_mode_rate: Some(0),
-                _nonexhaustive: (),
             });
             let emoji = Emoji {
                 animated: false,
@@ -326,7 +321,6 @@ mod test {
                 managed: true,
                 require_colons: true,
                 roles: vec![],
-                _nonexhaustive: (),
             };
             let role = Role {
                 id: RoleId(2),
@@ -338,7 +332,6 @@ mod test {
                 name: "fake role".to_string(),
                 permissions: Permissions::empty(),
                 position: 1,
-                _nonexhaustive: (),
             };
             let user = User {
                 id: UserId(6),
@@ -346,7 +339,6 @@ mod test {
                 bot: false,
                 discriminator: 4132,
                 name: "fake".to_string(),
-                _nonexhaustive: (),
             };
             let member = Member {
                 deaf: false,
@@ -356,7 +348,6 @@ mod test {
                 nick: None,
                 roles: vec![],
                 user: user.clone(),
-                _nonexhaustive: (),
             };
 
             assert_eq!(ChannelId(1).mention(), "<#1>");

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -31,6 +31,7 @@ use crate::http::{Http, CacheHttp};
 
 /// Information about the current user.
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct CurrentUser {
     pub id: UserId,
     pub avatar: Option<String>,
@@ -40,8 +41,6 @@ pub struct CurrentUser {
     pub mfa_enabled: bool,
     #[serde(rename = "username")] pub name: String,
     pub verified: Option<bool>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 #[cfg(feature = "model")]
@@ -379,6 +378,7 @@ impl Default for OnlineStatus {
 
 /// Information about a user.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct User {
     /// The unique Id of the user. Can be used to calculate the account's
     /// creation date.
@@ -398,8 +398,6 @@ pub struct User {
     /// change if the username+discriminator pair becomes non-unique.
     #[serde(rename = "username")]
     pub name: String,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 impl Default for User {
@@ -416,7 +414,6 @@ impl Default for User {
             bot: true,
             discriminator: 1432,
             name: "test".to_string(),
-            _nonexhaustive: (),
         }
     }
 }
@@ -833,7 +830,6 @@ impl From<CurrentUser> for User {
             discriminator: user.discriminator,
             id: user.id,
             name: user.name,
-            _nonexhaustive: (),
         }
     }
 }
@@ -846,7 +842,6 @@ impl<'a> From<&'a CurrentUser> for User {
             discriminator: user.discriminator,
             id: user.id,
             name: user.name.clone(),
-            _nonexhaustive: (),
         }
     }
 }

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -11,6 +11,7 @@ use std::fmt;
 
 /// Information about an available voice region.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct VoiceRegion {
     /// Whether it is a custom voice region, which is used for events.
     pub custom: bool,
@@ -28,12 +29,11 @@ pub struct VoiceRegion {
     pub sample_port: u64,
     /// Indicator of whether the voice region is only for VIP guilds.
     pub vip: bool,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 /// A user's state within a voice channel.
 #[derive(Clone, Serialize)]
+#[non_exhaustive]
 pub struct VoiceState {
     pub channel_id: Option<ChannelId>,
     pub deaf: bool,
@@ -48,8 +48,6 @@ pub struct VoiceState {
     pub suppress: bool,
     pub token: Option<String>,
     pub user_id: UserId,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 
@@ -95,6 +93,7 @@ impl<'de> Deserialize<'de> for VoiceState {
         }
 
         #[derive(Deserialize)]
+        #[non_exhaustive]
         struct PartialMember {
             deaf: bool,
             joined_at: Option<DateTime<Utc>>,
@@ -102,8 +101,6 @@ impl<'de> Deserialize<'de> for VoiceState {
             nick: Option<String>,
             roles: Vec<RoleId>,
             user: User,
-            #[serde(skip)]
-            _nonexhaustive: (),
         }
 
         struct VoiceStateVisitor;
@@ -174,7 +171,6 @@ impl<'de> Deserialize<'de> for VoiceState {
                                     nick: partial_member.nick,
                                     roles: partial_member.roles,
                                     user: partial_member.user,
-                                    _nonexhaustive: ()
                                 });
                             }
                         }
@@ -262,7 +258,6 @@ impl<'de> Deserialize<'de> for VoiceState {
                     suppress,
                     token,
                     user_id,
-                    _nonexhaustive: ()
                 })
             }
         }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -28,6 +28,7 @@ use crate::http::Http;
 /// channels. They do not necessarily require a bot user or authentication to
 /// use.
 #[derive(Clone, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Webhook {
     /// The unique Id.
     ///
@@ -55,8 +56,6 @@ pub struct Webhook {
     ///
     /// **Note**: This is not received when getting a webhook by its token.
     pub user: Option<User>,
-    #[serde(skip)]
-    pub(crate) _nonexhaustive: (),
 }
 
 impl fmt::Debug for Webhook {

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -250,7 +250,6 @@ fn dummy_message() -> Message {
             bot: false,
             discriminator: 0x0000,
             name: String::new(),
-            _nonexhaustive: (),
         },
         channel_id: ChannelId::default(),
         content: String::new(),
@@ -274,6 +273,5 @@ fn dummy_message() -> Message {
         message_reference: None,
         flags: None,
         referenced_message: None,
-        _nonexhaustive: (),
     }
 }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1327,7 +1327,6 @@ mod test {
                 managed: false,
                 require_colons: true,
                 roles: vec![],
-                _nonexhaustive: (),
             })
             .build();
         let content_mentions = MessageBuilder::new()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -839,7 +839,6 @@ mod test {
             bot: false,
             discriminator: 0000,
             name: "Crab".to_string(),
-            _nonexhaustive: (),
         };
 
         let mut guild = Guild {
@@ -876,7 +875,6 @@ mod test {
             banner: None,
             vanity_url_code: Some("bruhmoment1".to_string()),
             preferred_locale: "en-US".to_string(),
-            _nonexhaustive: (),
         };
 
         let member = Member {
@@ -887,7 +885,6 @@ mod test {
             nick: Some("Ferris".to_string()),
             roles: Vec::new(),
             user: user.clone(),
-            _nonexhaustive: (),
         };
 
         let role = Role {
@@ -900,7 +897,6 @@ mod test {
             name: "ferris-club-member".to_string(),
             permissions: Permissions::all(),
             position: 0,
-            _nonexhaustive: (),
         };
 
         let channel = GuildChannel {
@@ -918,7 +914,6 @@ mod test {
             user_limit: None,
             nsfw: false,
             slow_mode_rate: Some(0),
-            _nonexhaustive: (),
         };
 
         let cache = Arc::new(Cache::default());


### PR DESCRIPTION
This Pull Request removes any and all remaining traces of the `_nonexhaustive()` struct field in favor of the relatively new `#[non_exhaustive]` attribute that was introduced with Rust 1.40. There was a previous Pull Request prior to this, #959, that made an attempt to replace the field, however that Pull Request did not cover all of the aforementioned places where the field was present whereas this one does. I ran all of the tests afterwards as well to ensure that they pass, and they do, despite some tests being ignored. I'm guessing that that is normal behavior, however.