### PR TITLE
Fix clippy warning

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1039,7 +1039,7 @@ fn flatten_group_to_string(
     };
 
     if summary_or_prefixes {
-        let _ = write!(group_text, "\n");
+        let _ = writeln!(group_text,);
     }
 
     let mut joined_commands = group

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1039,7 +1039,7 @@ fn flatten_group_to_string(
     };
 
     if summary_or_prefixes {
-        let _ = writeln!(group_text,);
+        let _ = writeln!(group_text);
     }
 
     let mut joined_commands = group


### PR DESCRIPTION
clippy::write_with_newline
```
help: use `writeln!()` instead
     |
1042 |         let _ = writeln!(group_text, );
     |                 ^^^^^^^             --
```