### PR TITLE
Remove only one leading space in command descriptions

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -125,12 +125,15 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
                     .push(propagate_err!(attributes::parse(values)));
             }
             "description" => {
-                let arg: String = propagate_err!(attributes::parse(values));
+                let mut arg: String = propagate_err!(attributes::parse(values));
+                if arg.starts_with(' ') {
+                    arg.remove(0);
+                }
 
                 if let Some(desc) = &mut options.description.0 {
                     use std::fmt::Write;
 
-                    let _ = write!(desc, "\n{}", arg.trim_matches(' '));
+                    let _ = write!(desc, "\n{}", arg);
                 } else {
                     options.description = AsOption(Some(arg));
                 }


### PR DESCRIPTION
This changes the `#[description = "..."]` attribute's parsing to remove just one leading space if present, not all whitespace. This is useful for a description that has indentations. For example:

```
/// first line is normal
///   second line is indented
/// third line is normal
```