### PR TITLE
fix: Percent encode audit log reasons for ban and kick

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,9 @@ version = "0.3"
 default-features = false
 features = ["std"]
 
+[dependencies.percent-encoding]
+version = "2.1"
+
 [dev-dependencies.http_crate]
 version = "0.2"
 package = "http"

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -35,6 +35,10 @@ use tokio::{
     fs::File,
 };
 use crate::http::routing::Route;
+use percent_encoding::{
+    utf8_percent_encode,
+    NON_ALPHANUMERIC
+};
 
 pub struct Http {
     pub(crate) client: Arc<Client>,
@@ -109,7 +113,7 @@ impl Http {
             headers: None,
             route: RouteInfo::GuildBanUser {
                 delete_message_days: Some(delete_message_days),
-                reason: Some(reason),
+                reason: Some(&utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string()),
                 guild_id,
                 user_id,
             },
@@ -1555,7 +1559,7 @@ impl Http {
             route: RouteInfo::KickMember {
                 guild_id,
                 user_id,
-                reason,
+                reason: &utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string(),
             },
         }).await
     }


### PR DESCRIPTION
### Description

Percent encodes ban and kick reasons.  Currently without percent encoding, certain characters may be missing and the reason can be truncated with a `#` as they are not escaped in the API request.

### Tested

Bans were created with the following reason `"hello=-+ /.,€ƒ#123"` via:

```rust
guild.ban_with_reason(ctx, id, 0, "hello=-+ /.,€ƒ#123").await;
```

**Current behavior:** Characters like `+` are removed, in addition to anything that follows a `#`.

![image](https://user-images.githubusercontent.com/22536567/101584651-06ae6400-3993-11eb-8294-90b1e10b9927.png)

**Changed behavior:** With the reason percent encoded, the reason shows correctly:

![image](https://user-images.githubusercontent.com/22536567/101584716-29d91380-3993-11eb-9128-b2e1e25647bd.png)

### Other Changes

This adds an additional dependency, [percent-encoding](https://crates.io/crates/percent-encoding) which does not depend on other crates.