### PR TITLE
Check a sub-command's parent first.

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -485,8 +485,21 @@ async fn _nested_group_command_search<'rec, 'a: 'rec>(
                     // it. This allows the help-system to extract information
                     // from the sub-command.
                     if let Some(ref sub_command) = sub_command_found {
-                        command = sub_command;
-                        Some(sub_command.options.names[0])
+                        // Check parent command's behaviour and permission first
+                        // before we consider the sub-command overwrite it.
+                        if HelpBehaviour::Nothing == check_command_behaviour(
+                            ctx,
+                            msg,
+                            &command.options,
+                            group.options.checks,
+                            &owners,
+                            &help_options,
+                        ).await {
+                            command = sub_command;
+                            Some(sub_command.options.names[0])
+                        } else {
+                            break;
+                        }
                     } else {
                         None
                     }


### PR DESCRIPTION
**Issue**:
When the user of the help-system issues a request for a sub-command, the help-system would ignore the parent's configuration.
Hence the sub-command was executed without the parent's consideration.

**Example**:
A parent command is limited to guild channels only and defines a child.
The child command has no configuration.
The user may not invoke help for the parent command, but for its child.

**Fix**:
The help-system runs a `command_behaviour`-check on the parent first, before picking a matching sub-command.