### PR TITLE
Check for discrepancies in prefixless groups

### DIFF
--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -511,12 +511,14 @@ pub async fn command(
                 let res = handle_group(stream, ctx, msg, config, subgroups).await;
 
                 if !is_unrecognised(&res) {
+                    check_discrepancy(ctx, msg, config, &group.options).await?;
                     return res;
                 }
 
                 let res = handle_command(stream, ctx, msg, config, commands, group).await;
 
                 if !is_unrecognised(&res) {
+                    check_discrepancy(ctx, msg, config, &group.options).await?;
                     return res;
                 }
 


### PR DESCRIPTION
If a subgroup or command belonging to a prefixless group is found, check for discrepancies in the group before returning.
Fixes #973

This is applied in 0.9. The commit will be cherry-picked onto `current` and `next` when it is merged.