### PR TITLE
Handle 200 response with member data for modify member on API v8

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -612,7 +612,7 @@ impl Http {
     pub async fn edit_member(&self, guild_id: u64, user_id: u64, map: &JsonMap) -> Result<()> {
         let body = serde_json::to_vec(map)?;
 
-        self.wind(204, Request {
+        self.wind(200, Request {
             body: Some(&body),
             headers: None,
             route: RouteInfo::EditMember { guild_id, user_id },

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -612,11 +612,17 @@ impl Http {
     pub async fn edit_member(&self, guild_id: u64, user_id: u64, map: &JsonMap) -> Result<Member> {
         let body = serde_json::to_vec(map)?;
 
-        self.fire(Request {
+        let mut value = self.request(Request {
             body: Some(&body),
             headers: None,
             route: RouteInfo::EditMember { guild_id, user_id },
-        }).await
+        }).await?.json::<Value>().await?;
+
+        if let Some(map) = value.as_object_mut() {
+            map.insert("guild_id".to_string(), Value::Number(Number::from(guild_id)));
+        }
+
+        serde_json::from_value::<Member>(value).map_err(From::from)
     }
 
     /// Edits a message by Id.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -609,10 +609,10 @@ impl Http {
     }
 
     /// Does specific actions to a member.
-    pub async fn edit_member(&self, guild_id: u64, user_id: u64, map: &JsonMap) -> Result<()> {
+    pub async fn edit_member(&self, guild_id: u64, user_id: u64, map: &JsonMap) -> Result<Member> {
         let body = serde_json::to_vec(map)?;
 
-        self.wind(200, Request {
+        self.fire(Request {
             body: Some(&body),
             headers: None,
             route: RouteInfo::EditMember { guild_id, user_id },

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -317,7 +317,7 @@ impl GuildId {
     /// guild.edit_member(&context, user_id, |m| m.mute(true).roles(&vec![role_id]));
     /// ```
     #[inline]
-    pub async fn edit_member<F>(self, http: impl AsRef<Http>, user_id: impl Into<UserId>, f: F) -> Result<()>
+    pub async fn edit_member<F>(self, http: impl AsRef<Http>, user_id: impl Into<UserId>, f: F) -> Result<Member>
         where F: FnOnce(&mut EditMember) -> &mut EditMember {
         let mut edit_member = EditMember::default();
         f(&mut edit_member);
@@ -527,7 +527,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         user_id: impl Into<UserId>,
         channel_id: impl Into<ChannelId>
-    ) -> Result<()> {
+    ) -> Result<Member> {
         let mut map = Map::new();
         map.insert(
             "channel_id".to_string(),
@@ -550,7 +550,7 @@ impl GuildId {
     ///
     /// [Move Members]: Permissions::MOVE_MEMBERS
     #[inline]
-    pub async fn disconnect_member(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
+    pub async fn disconnect_member(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<Member> {
         let mut map = Map::new();
         map.insert(
             "channel_id".to_string(),

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -622,7 +622,7 @@ impl Guild {
     }
 
     /// Edits the properties of member of the guild, such as muting or
-    /// nicknaming them.
+    /// nicknaming them. Returns the new member.
     ///
     /// Refer to `EditMember`'s documentation for a full list of methods and
     /// permission restrictions.
@@ -635,7 +635,7 @@ impl Guild {
     /// guild.edit_member(user_id, |m| m.mute(true).roles(&vec![role_id]));
     /// ```
     #[inline]
-    pub async fn edit_member<F>(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>, f: F) -> Result<()>
+    pub async fn edit_member<F>(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>, f: F) -> Result<Member>
     where F: FnOnce(&mut EditMember) -> &mut EditMember
     {
         self.id.edit_member(&http, user_id, f).await
@@ -1267,7 +1267,7 @@ impl Guild {
     ///
     /// [Move Members]: Permissions::MOVE_MEMBERS
     #[inline]
-    pub async fn move_member(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>, channel_id: impl Into<ChannelId>) -> Result<()> {
+    pub async fn move_member(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>, channel_id: impl Into<ChannelId>) -> Result<Member> {
         self.id.move_member(&http, user_id, channel_id).await
     }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -286,7 +286,7 @@ impl PartialGuild {
     /// GuildId(7).edit_member(user_id, |m| m.mute(true).roles(&vec![role_id])).await;
     /// ```
     #[inline]
-    pub async fn edit_member<F>(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>, f: F) -> Result<()>
+    pub async fn edit_member<F>(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>, f: F) -> Result<Member>
     where F: FnOnce(&mut EditMember) -> &mut EditMember
     {
         self.id.edit_member(&http, user_id, f).await
@@ -413,7 +413,7 @@ impl PartialGuild {
         http: impl AsRef<Http>,
         user_id: impl Into<UserId>,
         channel_id: impl Into<ChannelId>
-    ) -> Result<()> {
+    ) -> Result<Member> {
         self.id.move_member(&http, user_id, channel_id).await
     }
 


### PR DESCRIPTION
Using `Guild::edit_member` on Discord API v8 currently returns an error even though it successfully modifies a member due to a `200` response with member data instead of the expected `204`.  This appears to be intended behavior but the documentation is not updated yet (https://github.com/discord/discord-api-docs/issues/2273).

New behavior returns a member object:

```bash
$ curl --request PATCH -H "Content-Type: application/json" -H "Authorization: Bot nothingtoseehereuwu" https://discord.com/api/v8/guilds/167058919611xxxxxx/members/150443906511xxxxxx -d '{"roles": [285544195748265984, 193509476538515457]}'
{"user": {"id": "150443906511xxxxxx", "username": "xxxx", "avatar": "afaddec4029eafd36e30fb62efe7bfad", "discriminator": "7080", "public_flags": 131584}, "roles": ["285544195748265984", "193509476538515457"], "nick": "sdfawef", "premium_since": null, "joined_at": "2016-04-05T23:52:30.292000+00:00", "is_pending": false, "pending": false, "mute": false, "deaf": false}
```

#### Changes

`edit_member` returns the new Member data.  `Member::add_roles` and `Member::remove_roles` returns the member's new roles.

For `Guild::move_member`, `disconnect_member` and `disconnect_from_voice`, would it be better to keep it as is (returning `Result<()>`) and discard the new Member object?  It doesn't seem to have any meaningful data related to voice channels.

Can also be added to https://github.com/serenity-rs/serenity/issues/1009