### PR TITLE
Rework buckets to offer fine-grained control

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -15,6 +15,7 @@ use serenity::{
     framework::standard::{
         Args, CommandOptions, CommandResult, CommandGroup,
         DispatchError, HelpOptions, help_commands, Reason, StandardFramework,
+        buckets::LimitedFor,
         macros::{command, group, help, check, hook},
     },
     http::Http,
@@ -257,8 +258,8 @@ async fn main() {
         .on_dispatch_error(dispatch_error)
     // Can't be used more than once per 5 seconds:
         .bucket("emoji", |b| b.delay(5)).await
-    // Can't be used more than 2 times per 30 seconds, with a 5 second delay:
-        .bucket("complicated", |b| b.delay(5).time_span(30).limit(2)).await
+    // Can't be used more than 2 times per 30 seconds, with a 5 second delay applying per channel.
+        .bucket("complicated", |b| b.delay(5).time_span(30).limit(2).limit_for(LimitedFor::Channel)).await
     // The `#[group]` macro generates `static` instances of the options set for the group.
     // They're made in the pattern: `#name_GROUP` for the group instance and `#name_GROUP_OPTIONS`.
     // #name is turned all uppercase

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -854,6 +854,12 @@ impl Cache {
         self.categories.read().await.len()
     }
 
+   /// Returns the optional category ID of a channel.
+   #[inline]
+   pub async fn channel_category_id(&self, channel_id: ChannelId) -> Option<ChannelId> {
+       self.categories.read().await.get(&channel_id).map(|category| category.id)
+   }
+
     /// This method clones and returns the user used by the bot.
     #[inline]
     pub async fn current_user(&self) -> CurrentUser {

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -1,11 +1,11 @@
 use crate::client::Context;
-use crate::model::id::{ChannelId, GuildId, UserId};
+use crate::model::channel::Message;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 type Check =
-    for<'fut> fn(&'fut Context, Option<GuildId>, ChannelId, UserId) -> BoxFuture<'fut, bool>;
+    for<'fut> fn(&'fut Context, &'fut Message) -> BoxFuture<'fut, bool>;
 
 pub(crate) struct Ratelimit {
     pub delay: Duration,
@@ -13,51 +13,127 @@ pub(crate) struct Ratelimit {
 }
 
 #[derive(Default)]
-pub(crate) struct MemberRatelimit {
+pub(crate) struct UnitRatelimit {
     pub last_time: Option<Instant>,
     pub set_time: Option<Instant>,
     pub tickets: u32,
 }
 
-pub(crate) struct Bucket {
-    pub ratelimit: Ratelimit,
-    pub users: HashMap<u64, MemberRatelimit>,
-    pub check: Option<Check>,
+pub(crate) enum Bucket {
+    /// The bucket will collect tickets for every invocation of a command.
+    Global(TicketCounter),
+    /// The bucket will collect tickets per user.
+    User(TicketCounter),
+    /// The bucket will collect tickets per guild.
+    Guild(TicketCounter),
+    /// The bucket will collect tickets per channel.
+    Channel(TicketCounter),
+    /// The bucket will collect tickets per category.
+    ///
+    /// This requires the cache, as messages do not contain their channel's
+    /// category.
+    #[cfg(feature = "cache")]
+    Category(TicketCounter),
 }
 
 impl Bucket {
-    pub fn take(&mut self, user_id: u64) -> Option<Duration> {
+    #[inline]
+    pub async fn take(&mut self, ctx: &Context, msg: &Message) -> Option<Duration> {
+        match self {
+            Self::Global(counter) => counter.take(ctx, msg, 0).await,
+            Self::User(counter) => counter.take(ctx, msg, msg.author.id.0).await,
+            Self::Guild(counter) => {
+                if let Some(guild_id) = msg.guild_id {
+                    counter.take(ctx, msg, guild_id.0).await
+                } else {
+                    None
+                }
+            }
+            Self::Channel(counter) => counter.take(ctx, msg, msg.channel_id.0).await,
+            // This requires the cache, as messages do not contain their channel's
+            // category.
+            #[cfg(feature = "cache")]
+            Self::Category(counter) =>
+                if let Some(category_id) = msg.category_id(ctx).await {
+                    counter.take(ctx, msg, category_id.0).await
+                } else {
+                    None
+                },
+        }
+    }
+}
+
+pub(crate) struct TicketCounter {
+    pub ratelimit: Ratelimit,
+    pub tickets_for: HashMap<u64, UnitRatelimit>,
+    pub check: Option<Check>,
+}
+
+impl TicketCounter {
+    pub async fn take(&mut self, ctx: &Context, msg: &Message, id: u64) -> Option<Duration> {
+        if let Some(ref check) = self.check {
+
+            if !(check)(ctx, msg).await {
+                return None
+            }
+        }
+
         let now = Instant::now();
         let Self {
-            users, ratelimit, ..
+            tickets_for, ratelimit, ..
         } = self;
-        let user = users.entry(user_id).or_default();
+        let ticket_owner = tickets_for.entry(id).or_default();
 
         if let Some((timespan, limit)) = ratelimit.limit {
-            if (user.tickets + 1) > limit {
-                if let Some(res) = user
+            if (ticket_owner.tickets + 1) > limit {
+                if let Some(res) = ticket_owner
                     .set_time
                     .and_then(|x| (x + timespan).checked_duration_since(now))
                 {
                     return Some(res);
                 } else {
-                    user.tickets = 0;
-                    user.set_time = Some(now);
+                    ticket_owner.tickets = 0;
+                    ticket_owner.set_time = Some(now);
                 }
             }
         }
 
-        if let Some(res) = user
+        if let Some(res) = ticket_owner
             .last_time
             .and_then(|x| (x + ratelimit.delay).checked_duration_since(now))
         {
             return Some(res);
         } else {
-            user.tickets += 1;
-            user.last_time = Some(now);
+            ticket_owner.tickets += 1;
+            ticket_owner.last_time = Some(now);
         }
 
         None
+    }
+}
+
+/// Decides what a bucket will use to collect tickets for.
+pub enum LimitedFor {
+    /// The bucket will collect tickets for every invocation of a command.
+    Global,
+    /// The bucket will collect tickets per user.
+    User,
+    /// The bucket will collect tickets per guild.
+    Guild,
+    /// The bucket will collect tickets per channel.
+    Channel,
+    /// The bucket will collect tickets per category.
+    ///
+    /// This requires the cache, as messages do not contain their channel's
+    /// category.
+    #[cfg(feature = "cache")]
+    Category,
+}
+
+impl Default for LimitedFor {
+    /// We use the previous behaviour of buckets as default.
+    fn default() -> Self {
+        Self::User
     }
 }
 
@@ -67,9 +143,54 @@ pub struct BucketBuilder {
     pub(crate) time_span: Duration,
     pub(crate) limit: u32,
     pub(crate) check: Option<Check>,
+    pub(crate) limited_for: LimitedFor,
 }
 
 impl BucketBuilder {
+    /// A bucket collecting tickets per command invocation.
+    pub fn new_global() -> Self {
+        Self {
+            limited_for: LimitedFor::Global,
+            ..Default::default()
+        }
+    }
+
+    /// A bucket collecting tickets per user.
+    pub fn new_user() -> Self {
+        Self {
+            limited_for: LimitedFor::User,
+            ..Default::default()
+        }
+    }
+
+    /// A bucket collecting tickets per guild.
+    pub fn new_guild() -> Self {
+        Self {
+            limited_for: LimitedFor::Guild,
+            ..Default::default()
+        }
+    }
+
+    /// A bucket collecting tickets per channel.
+    pub fn new_channel() -> Self {
+        Self {
+            limited_for: LimitedFor::Channel,
+            ..Default::default()
+        }
+    }
+
+    /// A bucket collecting tickets per channel category.
+    ///
+    /// This requires the cache, as messages do not contain their channel's
+    /// category.
+    #[cfg(feature = "cache")]
+    pub fn new_category() -> Self {
+        Self {
+            limited_for: LimitedFor::Category,
+            ..Default::default()
+        }
+    }
+
     /// The "break" time between invocations of a command.
     ///
     /// Expressed in seconds.
@@ -109,5 +230,37 @@ impl BucketBuilder {
         self.check = Some(f);
 
         self
+    }
+
+    /// Limit the bucket for a specific type of `target`.
+    #[inline]
+    pub fn limit_for(&mut self, target: LimitedFor) -> &mut Self {
+        self.limited_for = target;
+
+        self
+    }
+
+    /// Constructs the bucket.
+    #[inline]
+    pub(crate) fn construct(self) -> Bucket {
+        let counter = TicketCounter {
+            ratelimit: Ratelimit {
+                delay: self.delay,
+                limit: Some((self.time_span, self.limit)),
+            },
+            tickets_for: HashMap::new(),
+            check: self.check,
+        };
+
+        match self.limited_for {
+            LimitedFor::User => Bucket::User(counter),
+            LimitedFor::Guild => Bucket::Guild(counter),
+            LimitedFor::Channel => Bucket::Channel(counter),
+            // This requires the cache, as messages do not contain their channel's
+            // category.
+            #[cfg(feature = "cache")]
+            LimitedFor::Category => Bucket::Category(counter),
+            LimitedFor::Global => Bucket::Global(counter),
+        }
     }
 }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -750,6 +750,12 @@ impl Message {
         ReactionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 
+    /// Retrieves the message channel's category ID if the channel has such.
+    #[cfg(feature = "cache")]
+    pub async fn category_id(&self, cache: impl AsRef<Cache>) -> Option<ChannelId> {
+        cache.as_ref().channel_category_id(self.channel_id).await
+    }
+
     pub(crate) fn check_content_length(map: &JsonMap) -> Result<()> {
         if let Some(content) = map.get("content") {
             if let Value::String(ref content) = *content {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -750,7 +750,7 @@ impl Message {
         ReactionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 
-    /// Retrieves the message channel's category ID if the channel has such.
+    /// Retrieves the message channel's category ID if the channel has one.
     #[cfg(feature = "cache")]
     pub async fn category_id(&self, cache: impl AsRef<Cache>) -> Option<ChannelId> {
         cache.as_ref().channel_category_id(self.channel_id).await


### PR DESCRIPTION
This pull requests closes #1117. 

Buckets can now apply to channels, users, guilds, categories, or globally.
The check type for buckets has been simplified to `&Message`. The signature no longer provides the optional guild ID, channel ID, and user ID.

This pull requests adds a utility method on `Message` and the `Cache` to retrieve the channel category ID. This addition is being used inside the new bucket code.

Using a bucket applying to categories requires the cache.
Global buckets will count every invocation of a command by every source.

By default, a bucket will work as before, limit per user.

Additionally, example 5 has been updated showcasing the new API addition for buckets.

Please help me testing this! :)
