### PR TITLE
docs: Clarify framework configuration dynamic_prefix docs

### DIFF
--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -283,19 +283,26 @@ impl Configuration {
         self
     }
 
-    /// Sets the prefix to respond to dynamically based on conditions.
+    /// Sets the prefix to respond to dynamically, in addition to the one
+    /// configured with [`prefix`] or [`prefixes`].
     ///
-    /// Return `None` to not have a special prefix for the dispatch, and to
-    /// instead use the inherited prefix.
+    /// Return `None` to not have a special prefix for the dispatch and to
+    /// instead use the configured prefix from [`prefix`] or [`prefixes`].
     ///
     /// This method can be called many times to add more dynamic prefix hooks.
     ///
     /// **Note**: Defaults to no dynamic prefix check.
     ///
+    /// **Note**: If using dynamic_prefix *without* [`prefix`] or [`prefixes`],
+    /// there will still be the default framework prefix of `"~"`. You can disable
+    /// the default prefix by setting the prefix to an empty string `""` with
+    /// [`prefix`].
+    ///
     /// # Examples
     ///
     /// If the Id of the channel is divisible by 5, return a prefix of `"!"`,
-    /// otherwise return a prefix of `"~"`.
+    /// otherwise return a prefix of `"*"`. The default framework prefix `"~"`
+    /// will always be valid in addition to the one returned by dynamic_prefix.
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
@@ -306,10 +313,33 @@ impl Configuration {
     ///         Some(if msg.channel_id.0 % 5 == 0 {
     ///             "!"
     ///         } else {
-    ///             "~"
+    ///             "*"
     ///         }.to_string())
     ///     })));
     /// ```
+    ///
+    /// This will only use the prefix `"!"` or `"*"` depending on channel ID.
+    ///
+    /// ```rust,no_run
+    /// # use serenity::prelude::*;
+    /// use serenity::framework::StandardFramework;
+    ///
+    /// let framework = StandardFramework::new()
+    ///     .configure(|c| c
+    ///        .dynamic_prefix(|_, msg| Box::pin(async move {
+    ///             Some(if msg.channel_id.0 % 5 == 0 {
+    ///                 "!"
+    ///             } else {
+    ///                 "*"
+    ///             }.to_string())
+    ///         }))
+    ///         // This disables the default prefix "~"
+    ///         .prefix("") 
+    ///     );
+    /// ```
+    ///
+    ///  [`prefix`]: Self::prefix
+    ///  [`prefixes`]: Self::prefixes
     #[inline]
     pub fn dynamic_prefix(&mut self, dynamic_prefix: DynamicPrefixHook) -> &mut Self {
         self.dynamic_prefixes.push(dynamic_prefix);

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -284,10 +284,13 @@ impl Configuration {
     }
 
     /// Sets the prefix to respond to dynamically, in addition to the one
-    /// configured with [`prefix`] or [`prefixes`].
+    /// configured with [`prefix`] or [`prefixes`]. This is useful if you want
+    /// to have user configurable per-guild or per-user prefixes, such as by
+    /// fetching a guild's prefix from a database accessible via
+    /// [`Context::data`].
     ///
-    /// Return `None` to not have a special prefix for the dispatch and to
-    /// instead use the configured prefix from [`prefix`] or [`prefixes`].
+    /// Return `None` to not have a special prefix for the dispatch and to only
+    /// use the configured prefix from [`prefix`] or [`prefixes`].
     ///
     /// This method can be called many times to add more dynamic prefix hooks.
     ///
@@ -300,9 +303,9 @@ impl Configuration {
     ///
     /// # Examples
     ///
-    /// If the Id of the channel is divisible by 5, return a prefix of `"!"`,
-    /// otherwise return a prefix of `"*"`. The default framework prefix `"~"`
-    /// will always be valid in addition to the one returned by dynamic_prefix.
+    /// If the Id of the channel is divisible by 5, use the prefix `"!"`,
+    /// otherwise use `"*"`. The default framework prefix `"~"` will always be
+    /// valid in addition to the one returned by dynamic_prefix.
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
@@ -318,7 +321,8 @@ impl Configuration {
     ///     })));
     /// ```
     ///
-    /// This will only use the prefix `"!"` or `"*"` depending on channel ID.
+    /// This will only use the prefix `"!"` or `"*"` depending on channel ID,
+    /// with the default prefix `"~"` disabled.
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
@@ -338,6 +342,7 @@ impl Configuration {
     ///     );
     /// ```
     ///
+    ///  [`Context::data`]: crate::client::Context::data
     ///  [`prefix`]: Self::prefix
     ///  [`prefixes`]: Self::prefixes
     #[inline]
@@ -438,6 +443,9 @@ impl Configuration {
     ///
     /// **Note**: Passing empty string `""` will set no prefix.
     ///
+    /// **Note**: This prefix will always be usable, even if there is a
+    /// [`dynamic_prefix`] configured.
+    ///
     /// # Examples
     ///
     /// Assign a basic prefix:
@@ -448,6 +456,8 @@ impl Configuration {
     /// let framework = StandardFramework::new().configure(|c| c
     ///     .prefix("!"));
     /// ```
+    ///
+    /// [`dynamic_prefix`]: Self::dynamic_prefix
     pub fn prefix(&mut self, prefix: &str) -> &mut Self {
         self.prefixes = if prefix.is_empty() {
             vec![]
@@ -463,6 +473,9 @@ impl Configuration {
     ///
     /// **Note**: Refer to [`prefix`] for the default value.
     ///
+    /// **Note**: These prefixes will always be usable, even if there is a
+    /// [`dynamic_prefix`] configured.
+    ///
     /// # Examples
     ///
     /// Assign a set of prefixes the bot can respond to:
@@ -475,6 +488,7 @@ impl Configuration {
     /// ```
     ///
     /// [`prefix`]: Self::prefix
+    /// [`dynamic_prefix`]: Self::dynamic_prefix
     #[inline]
     pub fn prefixes<T, It>(&mut self, prefixes: It) -> &mut Self
     where


### PR DESCRIPTION
Clarifies use of `dynamic_prefix` and configured prefix via `prefix()` and `prefixes()`.  Also adds information relating to the default prefix of `~`.

Closes #898