### PR TITLE
Bump to 0.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 This project mostly adheres to [Semantic Versioning][semver].
 
+## [0.8.9] - 2020-12-18
+
+Thanks to the following for their contributions:
+
+- [@Lakelezz]
+- [@SadiinsoSnowfall]
+
+### Fixed
+
+- [framework] Fix invocation by defaulting ticket limit to 1. ([@Lakelezz]) [c:eaead53]
+- [framework] Fix handling sub-commands in the help-system. Adds an example command with sub-command to the command framework example as well. ([@Lakelezz]) [c:b96529e]
+- [model] Fix incorrect documentation for the `MessageTooLong` error ([@SadiinsoSnowfall]) [c:bb04fad]
+
 ## [0.8.8] - 2020-11-28
 
 Thanks to the following for their contributions:
@@ -3648,6 +3661,7 @@ Initial commit.
 [@PvdBerg1998]: https://github.com/PvdBerg1998
 [@Roughsketch]: https://github.com/Roughsketch
 [@rsaihe]: https://github.com/rsaihe
+[@SadiinsoSnowfall]: https://github.com/SadiinsoSnowfall
 [@SOF3]: https://github.com/SOF3
 [@Scetch]: https://github.com/Scetch
 [@s0lst1ce]: https://github.com/s0lst1ce
@@ -3672,6 +3686,10 @@ Initial commit.
 [@zack37]: https://github.com/zack37
 [@zeyla]: https://github.com/zeyla
 
+
+[c:eaead53]: https://github.com/serenity/serenity/commit/eaead536db0327fde24c87aebe28470633db4a4c
+[c:b96529e]: https://github.com/serenity/serenity/commit/b96529e92b8d79cb580e15a90506e6637e6809aa
+[c:bb04fad]: https://github.com/serenity/serenity/commit/bb04fad0a8716472a5ba5f7429c18c123f9e650f
 
 [c:72f287c]: https://github.com/serenity-rs/serenity/commit/72f287c5b4ebbd9e9fbaae9afec99187387db0dd
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 name = "serenity"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/serenity.git"
-version = "0.8.8"
+version = "0.8.9"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This prepares for the release of `0.8.9` by updating the `CHANGELOG.md` file and updating the version in relevant places.

This is a small release to publish two fixes in the framework, and a minor documentation fix.

- Buckets configured with only a `delay` will now go into effect on the first invocation of a command.
- Subcommands are now handled in the help system.
- The wording regarding the maximum amount of "characters" permitted in a message has been amended.

The full, unsullied changelog for the release that will be put on Github's releases is:

---
Thanks to the following for their contributions:

- [@Lakelezz]
- [@SadiinsoSnowfall]

### Fixed

- [framework] Fix invocation by defaulting ticket limit to 1. ([@Lakelezz]) [c:eaead53]
- [framework] Fix handling sub-commands in the help-system. Adds an example command with sub-command to the command framework example as well. ([@Lakelezz]) [c:b96529e]
- [model] Fix incorrect documentation for the `MessageTooLong` error ([@SadiinsoSnowfall]) [c:bb04fad]

[@Lakelezz]: https://github.com/Lakelezz
[@SadiinsoSnowfall]: https://github.com/SadiinsoSnowfall

[c:eaead53]: https://github.com/serenity/serenity/commit/eaead536db0327fde24c87aebe28470633db4a4c
[c:b96529e]: https://github.com/serenity/serenity/commit/b96529e92b8d79cb580e15a90506e6637e6809aa
[c:bb04fad]: https://github.com/serenity/serenity/commit/bb04fad0a8716472a5ba5f7429c18c123f9e650f