### PR TITLE
Bump to 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 This project mostly adheres to [Semantic Versioning][semver].
 
+## [0.9.3] - 2020-12-18
+
+Thanks to the following for their contributions:
+
+- [@acdenisSK]
+- [@Lakelezz]
+- [@SadiinsoSnowfall]
+
+### Added
+
+- [command_attr/framework] Support custom colours in the help command attributes ([@acdenisSK]) [c:1cc66b3]
+
+### Fixed
+
+- [framework] Fix invocation by defaulting ticket limit to 1. ([@Lakelezz]) [c:1047eac]
+- [framework] Fix handling sub-commands in the help-system. Adds an example command with sub-command to the command framework example as well. ([@Lakelezz]) [c:fac94f2]
+- [framework] Fix not setting `set_time` by default. ([@Lakelezz]) [c:5399d44]
+- [framework] Check for discrepancies in prefixless groups ([@acdenisSK]) [c:75feff2]
+- [command_attr/framework] Remove only one leading space in command descriptions ([@acdenisSK]) [c:8f5a2e9]
+- [model] Reverse the message buffer before returning messages from it ([@acdenisSK]) [c:1dba16a]
+- [model] Fix incorrect documentation for the `MessageTooLong` error ([@SadiinsoSnowfall]) [c:8b42790]
+
 ## [0.9.2] - 2020-11-28
 
 Thanks to the following for their contributions:
@@ -3803,6 +3825,9 @@ rest::get_guilds(GuildPagination::After(GuildId(777)), 50);
 
 Initial commit.
 
+<!-- COMPARISONS -->
+
+[0.9.3]: https://github.com/serenity-rs/serenity/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/serenity-rs/serenity/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/serenity-rs/serenity/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/serenity-rs/serenity/compare/v0.9.0-rc.4...v0.9.0
@@ -3873,6 +3898,7 @@ Initial commit.
 [issue:56]: https://github.com/serenity-rs/serenity/issues/56
 [rust-websocket:issue:137]: https://github.com/cyderize/rust-websocket/issues/137
 
+<!-- AUTHORS -->
 
 [@7596ff]: https://github.com/7596ff
 [@Alch-Emi]: https://github.com/Alch-Emi
@@ -4004,6 +4030,17 @@ Initial commit.
 [@zack37]: https://github.com/zack37
 [@zeyla]: https://github.com/zeyla
 
+
+<!-- COMMITS -->
+
+[c:1cc66b3]: https://github.com/serenity/serenity/commit/1cc66b3d4ba70f75823cb59c5db4e4b0ef162ac7
+[c:1047eac]: https://github.com/serenity/serenity/commit/1047eac908eb28c69691292db8e35e089985a09e
+[c:fac94f2]: https://github.com/serenity/serenity/commit/fac94f2559abe1cfdafe0ca998e011ba08a1e84c
+[c:5399d44]: https://github.com/serenity/serenity/commit/5399d443f4e9962b5a40fd9635eb6e3441600769
+[c:75feff2]: https://github.com/serenity/serenity/commit/75feff2869fcb4a59b19a40794182e497925d37f
+[c:8f5a2e9]: https://github.com/serenity/serenity/commit/8f5a2e9e6073ba85519f531e8f2c6324bc07ca3b
+[c:1dba16a]: https://github.com/serenity/serenity/commit/1dba16a7281a6c367e636f71abd89772ab6d74ab
+[c:8b42790]: https://github.com/serenity/serenity/commit/8b42790306e9165acd3e092c71a3d280353185a4
 
 [c:bc78991]: https://github.com/serenity-rs/serenity/commit/bc78991f7cdbdeaeba308785a42953423f5e89aa
 [c:85e5722]: https://github.com/serenity-rs/serenity/commit/85e5722c997d5cc024cb3f687a8fda3a368db2cd

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 name = "serenity"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/serenity.git"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2018"
 include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 

--- a/command_attr/Cargo.toml
+++ b/command_attr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "command_attr"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["acdenisSK <acdenissk69@gmail.com>"]
 edition = "2018"
 description = "Procedural macros for command creation for the Serenity library."


### PR DESCRIPTION
This prepares for the release of `0.9.3` by updating the `CHANGELOG.md` file and updating the version in relevant places.

This is a small-ish release to publish a few fixes, and support for custom colours in the embed help command.

- Buckets configured with only a `delay` will now go into effect on the first invocation of a command.
- Limits for buckets are no longer `2n` after the creation of a ratelimit and buckets will go effect at the proper `n` limit. 
- Subcommands are now handled in the help system.
- Descrepancies (guild/dm only, required permissions, roles, etc.) are now checked for prefixless groups.
- Custom colours in the `#RRGGBB` hexadecimal format are now supported in the embed help command. 
- Indentation in command descriptions is now preserved, removing only one space before each `///` or `#[description = "..."]` line.
- The internal buffer used by `MessagesIter` is now reversed in order to work as advertised.
- The wording regarding the maximum amount of "characters" permitted in a message has been amended.

Also, *markers* have been added to the changelog to make it simpler for addition of new releases by tracking the position of information (authors, commits, comparisons) buried deep within the changelog.

The full, unsullied changelog for the release that will be put on Github's releases is:

---
Thanks to the following for their contributions:

- [@acdenisSK]
- [@Lakelezz]
- [@SadiinsoSnowfall]

### Added

- [command_attr/framework] Support custom colours in the help command attributes ([@acdenisSK]) [c:1cc66b3]

### Fixed

- [framework] Fix invocation by defaulting ticket limit to 1. ([@Lakelezz]) [c:1047eac]
- [framework] Fix handling sub-commands in the help-system. Adds an example command with sub-command to the command framework example as well. ([@Lakelezz]) [c:fac94f2]
- [framework] Fix not setting `set_time` by default. ([@Lakelezz]) [c:5399d44]
- [framework] Check for discrepancies in prefixless groups ([@acdenisSK]) [c:75feff2]
- [command_attr/framework] Remove only one leading space in command descriptions ([@acdenisSK]) [c:8f5a2e9]
- [model] Reverse the message buffer before returning messages from it ([@acdenisSK]) [c:1dba16a]
- [model] Fix incorrect documentation for the `MessageTooLong` error ([@SadiinsoSnowfall]) [c:8b42790]

[@acdenisSK]: https://github.com/acdenisSK
[@Lakelezz]: https://github.com/Lakelezz
[@SadiinsoSnowfall]: https://github.com/SadiinsoSnowfall

[c:1cc66b3]: https://github.com/serenity/serenity/commit/1cc66b3d4ba70f75823cb59c5db4e4b0ef162ac7
[c:1047eac]: https://github.com/serenity/serenity/commit/1047eac908eb28c69691292db8e35e089985a09e
[c:fac94f2]: https://github.com/serenity/serenity/commit/fac94f2559abe1cfdafe0ca998e011ba08a1e84c
[c:5399d44]: https://github.com/serenity/serenity/commit/5399d443f4e9962b5a40fd9635eb6e3441600769
[c:75feff2]: https://github.com/serenity/serenity/commit/75feff2869fcb4a59b19a40794182e497925d37f
[c:8f5a2e9]: https://github.com/serenity/serenity/commit/8f5a2e9e6073ba85519f531e8f2c6324bc07ca3b
[c:1dba16a]: https://github.com/serenity/serenity/commit/1dba16a7281a6c367e636f71abd89772ab6d74ab
[c:8b42790]: https://github.com/serenity/serenity/commit/8b42790306e9165acd3e092c71a3d280353185a4


