### PR TITLE
Add sync_id and session_id fields to Activity.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,45 +95,15 @@ version = "0.2"
 package = "http"
 
 [features]
-default = [
-    "builder",
-    "cache",
-    "client",
-    "framework",
-    "gateway",
-    "model",
-    "http",
-    "standard_framework",
-    "utils",
-    "rustls_backend",
-]
-default_native_tls = [
-    "builder",
-    "cache",
-    "client",
-    "framework",
-    "gateway",
-    "model",
-    "http",
-    "standard_framework",
-    "utils",
-    "native_tls_backend",
-]
+default = ["builder", "cache", "client", "framework", "gateway", "model", "http", "standard_framework", "utils", "rustls_backend"]
+default_native_tls = ["builder", "cache", "client", "framework", "gateway", "model", "http", "standard_framework", "utils", "native_tls_backend"]
 builder = ["utils"]
 cache = []
 collector = ["gateway", "model", "tokio/stream"]
-client = [
-    "http",
-    "typemap_rev"
-]
+client = ["http", "typemap_rev"]
 extras = []
 framework = ["client", "model", "utils"]
-gateway = [
-    "flate2",
-    "http",
-    "url",
-    "utils",
-]
+gateway = ["flate2", "http", "url", "utils"]
 http = ["url", "bytes"]
 absolute_ratelimits = ["http"]
 rustls_backend = ["reqwest/rustls-tls", "async-tungstenite/tokio-rustls"]
@@ -141,6 +111,7 @@ native_tls_backend = ["reqwest/native-tls", "async-tungstenite/tokio-native-tls"
 model = ["builder", "http"]
 voice-model = ["serenity-voice-model"]
 standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]
+unstable = []
 utils = ["base64"]
 voice = ["client", "model"]
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -54,6 +54,15 @@ pub struct Activity {
     pub emoji: Option<ActivityEmoji>,
     /// Unix timestamps for the start and/or end times of the activity.
     pub timestamps: Option<ActivityTimestamps>,
+    /// The sync ID of the activity. Mainly used by the Spotify activity
+    /// type which uses this parameter to store the track ID.
+    #[cfg(feature = "unstable")]
+    pub sync_id: Option<String>,
+    /// The session ID of the activity. Reserved for specific activity
+    /// types, such as the Activity that is transmitted when a user is
+    /// listening to Spotify.
+    #[cfg(feature = "unstable")]
+    pub session_id: Option<String>,
     /// The Stream URL if [`kind`] is [`ActivityType::Streaming`].
     ///
     /// [`kind`]: Self::kind
@@ -101,6 +110,10 @@ impl Activity {
             state: None,
             emoji: None,
             timestamps: None,
+            #[cfg(feature = "unstable")]
+            sync_id: None,
+            #[cfg(feature = "unstable")]
+            session_id: None,
             url: None,
         }
     }
@@ -147,6 +160,10 @@ impl Activity {
             state: None,
             emoji: None,
             timestamps: None,
+            #[cfg(feature = "unstable")]
+            sync_id: None,
+            #[cfg(feature = "unstable")]
+            session_id: None,
             url: Some(url.to_string()),
         }
     }
@@ -190,6 +207,10 @@ impl Activity {
             state: None,
             emoji: None,
             timestamps: None,
+            #[cfg(feature = "unstable")]
+            sync_id: None,
+            #[cfg(feature = "unstable")]
+            session_id: None,
             url: None,
         }
     }
@@ -233,6 +254,10 @@ impl Activity {
             state: None,
             emoji: None,
             timestamps: None,
+            #[cfg(feature = "unstable")]
+            sync_id: None,
+            #[cfg(feature = "unstable")]
+            session_id: None,
             url: None,
         }
     }
@@ -241,54 +266,79 @@ impl Activity {
 impl<'de> Deserialize<'de> for Activity {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
+
         let application_id = match map.remove("application_id") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
         let assets = match map.remove("assets") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
         let details = match map.remove("details") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
         let flags = match map.remove("flags") {
             Some(v) => serde_json::from_value::<Option<u64>>(v)
                 .map_err(DeError::custom)?
                 .map(ActivityFlags::from_bits_truncate),
             None => None,
         };
+
         let instance = match map.remove("instance") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
         let kind = map.remove("type")
             .and_then(|v| ActivityType::deserialize(v).ok())
             .unwrap_or(ActivityType::Playing);
+
         let name = map.remove("name")
             .and_then(|v| String::deserialize(v).ok())
             .unwrap_or_else(String::new);
+
         let party = match map.remove("party") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
         let secrets = match map.remove("secrets") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
         let state = match map.remove("state") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
         let emoji = match map.remove("emoji") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
         let timestamps = match map.remove("timestamps") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
+
+        #[cfg(feature = "unstable")]
+        let sync_id = match map.remove("sync_id") {
+            Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
+            None => None,
+        };
+
+        #[cfg(feature = "unstable")]
+        let session_id = match map.remove("session_id") {
+            Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
+            None => None,
+        };
+
         let url = map.remove("url")
             .and_then(|v| serde_json::from_value::<String>(v).ok());
 
@@ -305,6 +355,10 @@ impl<'de> Deserialize<'de> for Activity {
             state,
             emoji,
             timestamps,
+            #[cfg(feature = "unstable")]
+            sync_id,
+            #[cfg(feature = "unstable")]
+            session_id,
             url,
         })
     }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -57,11 +57,13 @@ pub struct Activity {
     /// The sync ID of the activity. Mainly used by the Spotify activity
     /// type which uses this parameter to store the track ID.
     #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     pub sync_id: Option<String>,
     /// The session ID of the activity. Reserved for specific activity
     /// types, such as the Activity that is transmitted when a user is
     /// listening to Spotify.
     #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     pub session_id: Option<String>,
     /// The Stream URL if [`kind`] is [`ActivityType::Streaming`].
     ///


### PR DESCRIPTION
Relatively minor Pull Request that adds the `sync_id` and `session_id` fields to the Activity struct, and I have also improved the formatting of the file a bit with regards to the Deserialize implementation. However, these fields are not accessible via the default set of features, as these are undocumented fields not shown in Discord's API documentation, meaning that they can change and/or be removed at any given time; as such they have been locked behind a new "unstable" feature flag. 

As a side effect, it is my belief that these fields should be made exempt from the stability / breaking change guarantee. Any developers who depend on / require stability should avoid these fields, but if anybody wants to use them, they will be available by enabling said feature.

Also, while adding the unstable flag, I cleaned up the `cargo.toml` file a little bit. The way the file was formatted and laid out with regards to the `features` section was *very* inconsistent. 
