### PR TITLE
Fix rustdoc not parsing docs.rs config attributes.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: -D broken_intra_doc_links
+          RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
           cargo doc --no-deps --features collector,voice
           cargo doc --no-deps -p command_attr

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,4 @@ voice = ["client", "model"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
I completely forgot to add `rustdoc-args` to the `package.metadata.docs.rs` section of `Cargo.toml`, meaning that no docrs config attributes were getting parsed during rustdoc compilation. This tiny PR fixes that.