### PR TITLE
Add Watching activity type under unstable feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![ci-badge][]][ci] [![docs-badge][]][docs] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.48.0+ badge]][rust 1.48.0+ link]
-
 # serenity
 
 ![serenity logo][logo]
+
+[![ci-badge][]][ci] [![docs-badge][]][docs] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.48.0+ badge]][rust 1.48.0+ link]
 
 Serenity is a Rust library for the Discord API.
 
@@ -34,7 +34,7 @@ accurate as possible - Discord hosts [official documentation][discord docs]. If
 you need to be sure that some information piece is accurate, refer to their
 docs.
 
-# Example Bot
+## Example Bot
 
 A basic ping-pong bot looks like:
 
@@ -95,7 +95,7 @@ async fn ping(ctx: &Context, msg: &Message) -> CommandResult {
 Full examples, detailing and explaining usage of the basic functionality of the
 library, can be found in the [`examples`] directory.
 
-# Installation
+## Installation
 
 Add the following to your `Cargo.toml` file:
 
@@ -106,7 +106,7 @@ serenity = "0.9"
 
 Serenity supports a minimum of Rust 1.48.
 
-# Features
+## Features
 
 Features can be enabled or disabled by configuring the library through
 Cargo.toml:
@@ -139,6 +139,7 @@ enough level that optional parameters can be provided at will via a JsonMap.
 - **model**: Method implementations for models, acting as helper methods over
 the HTTP functions.
 - **standard_framework**: A standard, default implementation of the Framework
+- **unstable**: Library & API features that are unstable for use.
 - **utils**: Utility functions for common use cases by users.
 - **voice**: Enables registering a voice plugin to the client, which will handle actual voice connections from Discord.
 [lavalink-rs][project:lavalink-rs] or [Songbird][project:songbird] are recommended voice plugins.
@@ -156,7 +157,6 @@ one if you do not use the default features:
 TLS implementation.
 - **native_tls_backend**: Uses SChannel on Windows, Secure Transport on macOS,
 and OpenSSL on other platforms.
-
 
 If you want all of the default features except for `cache` for example, you can
 list all but that:
@@ -178,13 +178,13 @@ features = [
 version = "0.9"
 ```
 
-# Dependencies
+## Dependencies
 
 If you use the `native_tls_backend` and you are not developing on macOS or Windows, you will need:
 
 - openssl
 
-# Projects extending Serenity
+## Projects extending Serenity
 
 - [lavalink-rs][project:lavalink-rs]: An interface to [Lavalink][repo:lavalink], an audio sending node based on [Lavaplayer][repo:lavaplayer]
 - [Songbird][project:songbird]: An async Rust library for the Discord voice API.

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -73,7 +73,7 @@ pub struct Activity {
 
 #[cfg(feature = "model")]
 impl Activity {
-    /// Creates a `Activity` struct that appears as a `Playing <name>` status.
+    /// Creates an `Activity` struct that appears as a `Playing <name>` status.
     ///
     /// **Note**: Maximum `name` length is 128.
     ///
@@ -170,7 +170,7 @@ impl Activity {
         }
     }
 
-    /// Creates a `Activity` struct that appears as a `Listening to <name>` status.
+    /// Creates an `Activity` struct that appears as a `Listening to <name>` status.
     ///
     /// **Note**: Maximum `name` length is 128.
     ///
@@ -217,7 +217,56 @@ impl Activity {
         }
     }
 
-    /// Creates a `Activity` struct that appears as a `Competing in <name>` status.
+    /// Creates an `Activity` struct that appears as a `Watching <name>` status.
+    ///
+    /// **Note**: Maximum `name` length is 128.
+    ///
+    /// # Examples
+    ///
+    /// Create a command that sets the current cometing status:
+    ///
+    /// ```rust,no_run
+    /// use serenity::model::gateway::Activity;
+    /// use serenity::model::channel::Message;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
+    /// # #[cfg(feature = "client")]
+    /// use serenity::client::Context;
+    ///
+    /// # #[cfg(feature = "framework")]
+    /// #[command]
+    /// async fn watch(ctx: &Context, _msg: &Message, args: Args) -> CommandResult {
+    ///     let name = args.message();
+    ///     ctx.set_activity(Activity::watching(&name)).await;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    pub fn watching(name: &str) -> Activity {
+        Activity {
+            application_id: None,
+            assets: None,
+            details: None,
+            flags: None,
+            instance: None,
+            kind: ActivityType::Watching,
+            name: name.to_string(),
+            party: None,
+            secrets: None,
+            state: None,
+            emoji: None,
+            timestamps: None,
+            #[cfg(feature = "unstable")]
+            sync_id: None,
+            #[cfg(feature = "unstable")]
+            session_id: None,
+            url: None,
+        }
+    }
+
+    /// Creates an `Activity` struct that appears as a `Competing in <name>` status.
     ///
     /// **Note**: Maximum `name` length is 128.
     ///
@@ -443,7 +492,11 @@ pub enum ActivityType {
     Streaming = 1,
     /// An indicator that the user is listening to something.
     Listening = 2,
-    /// An indicator that the user uses custum statuses
+    /// An indicator that the user is watching something.
+    #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    Watching = 3,
+    /// An indicator that the user has a custom status set.
     Custom = 4,
     /// An indicator that the user is competing somewhere.
     Competing = 5,
@@ -454,6 +507,7 @@ enum_number!(
         Playing,
         Streaming,
         Listening,
+        Watching,
         Custom,
         Competing,
     }
@@ -467,6 +521,9 @@ impl ActivityType {
             Playing => 0,
             Streaming => 1,
             Listening => 2,
+            #[cfg(feature = "unstable")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+            Watching => 3,
             Custom => 4,
             Competing => 5,
         }


### PR DESCRIPTION
I previously submitted a PR of this nature back in February 2020, which was rejected. However, this PR adds the Watching activity type under the `unstable` feature flag, meaning that this is exempt from any stability guarantee, similar to the `sync_id` and `session_id` fields that were added to `Activity` yesterday. With this addition, the Activity structure is now 100% complete. Grammar for the other activity types' documentation was also fixed, and the `unstable` feature flag has been added to the Features section of the README, and it has been cleaned up a small bit as well.