### PR TITLE
Slash command support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         env:
           RUSTDOCFLAGS: -D broken_intra_doc_links
         run: |
-          cargo doc --no-deps --features collector,voice,unstable
+          cargo doc --no-deps --features collector,voice,unstable_discord_api
           cargo doc --no-deps -p command_attr
 
   examples:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ model = ["builder", "http"]
 voice-model = ["serenity-voice-model"]
 standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]
 unstable = []
+unstable_discord_api = []
 utils = ["base64"]
 voice = ["client", "model"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,6 @@ native_tls_backend = ["reqwest/native-tls", "async-tungstenite/tokio-native-tls"
 model = ["builder", "http"]
 voice-model = ["serenity-voice-model"]
 standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]
-unstable = []
 unstable_discord_api = []
 utils = ["base64"]
 voice = ["client", "model"]

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -732,6 +732,8 @@ async fn handle_event(
                 event_handler.webhook_update(context, event.guild_id, event.channel_id).await;
             });
         },
+        #[cfg(feature = "unstable_discord_api")]
+        #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
         DispatchEvent::Model(Event::InteractionCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -733,7 +733,6 @@ async fn handle_event(
             });
         },
         #[cfg(feature = "unstable_discord_api")]
-        #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
         DispatchEvent::Model(Event::InteractionCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -732,5 +732,12 @@ async fn handle_event(
                 event_handler.webhook_update(context, event.guild_id, event.channel_id).await;
             });
         },
+        DispatchEvent::Model(Event::InteractionCreate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.interaction_create(context, event.interaction).await;
+            });
+        },
     }
 }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -339,6 +339,11 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Provides the guild's id and the channel's id the webhook belongs in.
     async fn webhook_update(&self, _ctx: Context, _guild_id: GuildId, _belongs_to_channel_id: ChannelId) {}
+
+    /// Dispatched when an user used a slash command.
+    ///
+    /// Provides the created Interaction
+    async fn interaction_create(&self, _ctx: Context, _interaction: Interaction) {}
 }
 
 /// This core trait for handling raw events

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -343,6 +343,8 @@ pub trait EventHandler: Send + Sync {
     /// Dispatched when a user used a slash command.
     ///
     /// Provides the created interaction.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     async fn interaction_create(&self, _ctx: Context, _interaction: Interaction) {}
 }
 

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -340,9 +340,9 @@ pub trait EventHandler: Send + Sync {
     /// Provides the guild's id and the channel's id the webhook belongs in.
     async fn webhook_update(&self, _ctx: Context, _guild_id: GuildId, _belongs_to_channel_id: ChannelId) {}
 
-    /// Dispatched when an user used a slash command.
+    /// Dispatched when a user used a slash command.
     ///
-    /// Provides the created Interaction
+    /// Provides the created interaction.
     async fn interaction_create(&self, _ctx: Context, _interaction: Interaction) {}
 }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -165,11 +165,13 @@ impl Http {
         }).await
     }
 
-    /// Create a followup message for an Interaction.
+    /// Create a follow-up message for an Interaction.
     ///
     /// Functions the same as [`execute_webhook`]
     ///
     /// [`execute_webhook`]: Self::execute_webhook
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn create_followup_message(
         &self,
         application_id: u64,
@@ -209,6 +211,8 @@ impl Http {
     /// will overwrite the old command.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn create_global_application_command(
         &self,
         application_id: u64,
@@ -271,6 +275,8 @@ impl Http {
     /// Refer to Discord's [docs] for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn create_guild_application_command(
         &self,
         application_id: u64,
@@ -305,6 +311,8 @@ impl Http {
     /// Refer to Discord's [docs] for the object it takes.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#interaction-interaction-response
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn create_interaction_response(
         &self,
         interaction_id: u64,
@@ -451,7 +459,9 @@ impl Http {
         }).await
     }
 
-    /// Deletes a followup message for an interaction.
+    /// Deletes a follow-up message for an interaction.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn delete_followup_message(
         &self,
         application_id: u64,
@@ -470,6 +480,8 @@ impl Http {
     }
 
     /// Deletes a global command.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn delete_global_application_command(
         &self,
         application_id: u64,
@@ -495,6 +507,8 @@ impl Http {
     }
 
     /// Deletes a guild command.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn delete_guild_application_command(
         &self,
         application_id: u64,
@@ -594,6 +608,8 @@ impl Http {
     }
 
     /// Deletes the initial interaction response.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn delete_original_interaction_response(
         &self,
         application_id: u64,
@@ -738,6 +754,8 @@ impl Http {
     /// Refer to Discord's [docs] for Edit Webhook Message for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn edit_followup_message(
         &self,
         application_id: u64,
@@ -763,6 +781,8 @@ impl Http {
     /// Refer to Discord's [docs] for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn edit_global_application_command(
         &self,
         application_id: u64,
@@ -797,6 +817,8 @@ impl Http {
     /// Refer to Discord's [docs] for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn edit_guild_application_command(
         &self,
         application_id: u64,
@@ -890,6 +912,8 @@ impl Http {
     /// Refer to Discord's [docs] for Edit Webhook Message for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn edit_original_interaction_response(
         &self,
         application_id: u64,
@@ -1368,6 +1392,8 @@ impl Http {
     }
 
     /// Fetches all of the global commands for your application.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn get_global_application_commands(
         &self,
         application_id: u64,
@@ -1389,6 +1415,8 @@ impl Http {
     }
 
     /// Fetches all of the guild commands for your application for a specific guild.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub async fn get_guild_application_commands(
         &self,
         application_id: u64,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -167,7 +167,9 @@ impl Http {
 
     /// Create a followup message for an Interaction.
     ///
-    /// Functions the same as [`self::execute_webhook`]
+    /// Functions the same as [`execute_webhook`]
+    ///
+    /// [`execute_webhook`]: Self::execute_webhook
     pub async fn create_followup_message(
         &self,
         application_id: u64,
@@ -733,7 +735,9 @@ impl Http {
 
     /// Edits a followup message for an Interaction.
     ///
-    /// Functions the same as [`self::edit_webhook_message`]
+    /// Refer to Discord's [docs] for Edit Webhook Message for field information.
+    ///
+    /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
     pub async fn edit_followup_message(
         &self,
         application_id: u64,
@@ -883,7 +887,9 @@ impl Http {
 
     /// Edits the initial Interaction response.
     ///
-    /// Functions the same as [`self::edit_webhook_message`]
+    /// Refer to Discord's [docs] for Edit Webhook Message for field information.
+    ///
+    /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
     pub async fn edit_original_interaction_response(
         &self,
         application_id: u64,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -451,7 +451,7 @@ impl Http {
         }).await
     }
 
-    /// Deletes a followup message for an Interaction.
+    /// Deletes a followup message for an interaction.
     pub async fn delete_followup_message(
         &self,
         application_id: u64,
@@ -593,7 +593,7 @@ impl Http {
         }).await
     }
 
-    /// Deletes the initial Interaction response.
+    /// Deletes the initial interaction response.
     pub async fn delete_original_interaction_response(
         &self,
         application_id: u64,
@@ -733,7 +733,7 @@ impl Http {
         }).await
     }
 
-    /// Edits a followup message for an Interaction.
+    /// Edits a follow-up message for an interaction.
     ///
     /// Refer to Discord's [docs] for Edit Webhook Message for field information.
     ///
@@ -885,7 +885,7 @@ impl Http {
         }).await
     }
 
-    /// Edits the initial Interaction response.
+    /// Edits the initial interaction response.
     ///
     /// Refer to Discord's [docs] for Edit Webhook Message for field information.
     ///

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -165,6 +165,60 @@ impl Http {
         }).await
     }
 
+    /// Create a followup message for an Interaction.
+    ///
+    /// Functions the same as [`self::execute_webhook`]
+    pub async fn create_followup_message(
+        &self,
+        application_id: u64,
+        interaction_token: &str,
+        wait: bool,
+        map: &JsonMap
+    ) -> Result<Option<Message>> {
+        let body = serde_json::to_vec(map)?;
+
+        let mut headers = Headers::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
+    
+        let response = self.request(Request {
+            body: Some(&body),
+            headers: Some(headers),
+            route: RouteInfo::CreateFollowupMessage { application_id, interaction_token, wait },
+        }).await?;
+
+        if response.status() == StatusCode::NO_CONTENT {
+            return Ok(None);
+        }
+
+        response
+            .json::<Message>()
+            .await
+            .map(Some)
+            .map_err(From::from)
+    }
+
+    /// Creates a new global command.
+    ///
+    /// New global commands will be available in all guilds after 1 hour.
+    ///
+    /// Refer to Discord's [docs] for field information.
+    ///
+    /// **note:** Creating a command with the same name as an existing command for your application
+    /// will overwrite the old command.
+    ///
+    /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
+    pub async fn create_global_application_command(
+        &self,
+        application_id: u64,
+        map: &Value,
+    ) -> Result<ApplicationCommand> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::CreateGlobalApplicationCommand { application_id }
+        }).await
+    }
+
     /// Creates a guild with the data provided.
     ///
     /// Only a [`PartialGuild`] will be immediately returned, and a full [`Guild`]
@@ -208,6 +262,26 @@ impl Http {
         }).await
     }
 
+    /// Creates a new guild command.
+    ///
+    /// New guild commands will be available in the guild immediately.
+    ///
+    /// Refer to Discord's [docs] for field information.
+    ///
+    /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
+    pub async fn create_guild_application_command(
+        &self,
+        application_id: u64,
+        guild_id: u64,
+        map: &Value,
+    ) -> Result<ApplicationCommand> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::CreateGuildApplicationCommand { application_id, guild_id },
+        }).await
+    }
+
     /// Creates an [`Integration`] for a [`Guild`].
     ///
     /// Refer to Discord's [docs] for field information.
@@ -221,6 +295,24 @@ impl Http {
             body: Some(map.to_string().as_bytes()),
             headers: None,
             route: RouteInfo::CreateGuildIntegration { guild_id, integration_id },
+        }).await
+    }
+
+    /// Creates a response to an [`Interaction`] from the gateway.
+    ///
+    /// Refer to Discord's [docs] for the object it takes.
+    ///
+    /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#interaction-interaction-response
+    pub async fn create_interaction_response(
+        &self,
+        interaction_id: u64,
+        interaction_token: &str,
+        map: &Value
+    ) -> Result<()> {
+        self.wind(204, Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::CreateInteractionResponse { interaction_id, interaction_token },
         }).await
     }
 
@@ -357,12 +449,64 @@ impl Http {
         }).await
     }
 
+    /// Deletes a followup message for an Interaction.
+    pub async fn delete_followup_message(
+        &self,
+        application_id: u64,
+        interaction_token: &str,
+        message_id: u64,
+    ) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteFollowupMessage {
+                application_id,
+                interaction_token,
+                message_id
+            },
+        }).await
+    }
+
+    /// Deletes a global command.
+    pub async fn delete_global_application_command(
+        &self,
+        application_id: u64,
+        command_id: u64,
+    ) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteGlobalApplicationCommand {
+                application_id,
+                command_id,
+            },
+        }).await
+    }
+
     /// Deletes a guild, only if connected account owns it.
     pub async fn delete_guild(&self, guild_id: u64) -> Result<PartialGuild> {
         self.fire(Request {
             body: None,
             headers: None,
             route: RouteInfo::DeleteGuild { guild_id },
+        }).await
+    }
+
+    /// Deletes a guild command.
+    pub async fn delete_guild_application_command(
+        &self,
+        application_id: u64,
+        guild_id: u64,
+        command_id: u64,
+    ) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteGuildApplicationCommand {
+                application_id,
+                guild_id,
+                command_id,
+            },
         }).await
     }
 
@@ -443,6 +587,22 @@ impl Http {
                 reaction: &reaction_type.as_data(),
                 channel_id,
                 message_id,
+            },
+        }).await
+    }
+
+    /// Deletes the initial Interaction response.
+    pub async fn delete_original_interaction_response(
+        &self,
+        application_id: u64,
+        interaction_token: &str,
+    ) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteOriginalInteractionResponse {
+                application_id,
+                interaction_token,
             },
         }).await
     }
@@ -571,6 +731,50 @@ impl Http {
         }).await
     }
 
+    /// Edits a followup message for an Interaction.
+    ///
+    /// Functions the same as [`self::edit_webhook_message`]
+    pub async fn edit_followup_message(
+        &self,
+        application_id: u64,
+        interaction_token: &str,
+        message_id: u64,
+        map: &Value,
+    ) -> Result<Message> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::EditFollowupMessage {
+                application_id,
+                interaction_token,
+                message_id,
+            },
+        }).await
+    }
+
+    /// Edits a global command.
+    ///
+    /// Updates will be available in all guilds after 1 hour.
+    ///
+    /// Refer to Discord's [docs] for field information.
+    ///
+    /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
+    pub async fn edit_global_application_command(
+        &self,
+        application_id: u64,
+        command_id: u64,
+        map: &Value,
+    ) -> Result<ApplicationCommand> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::EditGlobalApplicationCommand {
+                application_id,
+                command_id,
+            },
+        }).await
+    }
+
     /// Changes guild information.
     pub async fn edit_guild(&self, guild_id: u64, map: &JsonMap) -> Result<PartialGuild> {
         let body = serde_json::to_vec(map)?;
@@ -579,6 +783,31 @@ impl Http {
             body: Some(&body),
             headers: None,
             route: RouteInfo::EditGuild { guild_id },
+        }).await
+    }
+
+    /// Edits a guild command.
+    ///
+    /// Updates for guild commands will be available immediately.
+    ///
+    /// Refer to Discord's [docs] for field information.
+    ///
+    /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
+    pub async fn edit_guild_application_command(
+        &self,
+        application_id: u64,
+        guild_id: u64,
+        command_id: u64,
+        map: &Value,
+    ) -> Result<ApplicationCommand> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::EditGuildApplicationCommand {
+                application_id,
+                guild_id,
+                command_id,
+            },
         }).await
     }
 
@@ -649,6 +878,25 @@ impl Http {
             body: Some(&body),
             headers: None,
             route: RouteInfo::EditNickname { guild_id },
+        }).await
+    }
+
+    /// Edits the initial Interaction response.
+    ///
+    /// Functions the same as [`self::edit_webhook_message`]
+    pub async fn edit_original_interaction_response(
+        &self,
+        application_id: u64,
+        interaction_token: &str,
+        map: &Value,
+    ) -> Result<Message> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::EditOriginalInteractionResponse {
+                application_id,
+                interaction_token,
+            },
         }).await
     }
 
@@ -1113,12 +1361,37 @@ impl Http {
         }).await
     }
 
+    /// Fetches all of the global commands for your application.
+    pub async fn get_global_application_commands(
+        &self,
+        application_id: u64,
+    ) -> Result<Vec<ApplicationCommand>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGlobalApplicationCommands { application_id },
+        }).await
+    }
+
     /// Gets guild information.
     pub async fn get_guild(&self, guild_id: u64) -> Result<PartialGuild> {
         self.fire(Request {
             body: None,
             headers: None,
             route: RouteInfo::GetGuild { guild_id },
+        }).await
+    }
+
+    /// Fetches all of the guild commands for your application for a specific guild.
+    pub async fn get_guild_application_commands(
+        &self,
+        application_id: u64,
+        guild_id: u64,
+    ) -> Result<Vec<ApplicationCommand>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildApplicationCommands { application_id, guild_id },
         }).await
     }
 

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -918,6 +918,8 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         emoji_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     EditFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -785,7 +785,7 @@ pub enum RouteInfo<'a> {
     CreateFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
-        wait: bool
+        wait: bool,
     },
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
@@ -1188,11 +1188,10 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild_emojis(guild_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::CreateFollowupMessage {
                 application_id,
                 interaction_token,
-                wait
+                wait,
             } => (
                 LightMethod::Post,
                 Route::WebhooksId(application_id),
@@ -1201,7 +1200,6 @@ impl<'a> RouteInfo<'a> {
                 )),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::CreateGlobalApplicationCommand { application_id } => (
                 LightMethod::Post,
                 Route::ApplicationsIdCommands(application_id),
@@ -1213,7 +1211,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guilds()),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::CreateGuildApplicationCommand { application_id, guild_id } => (
                 LightMethod::Post,
                 Route::ApplicationsIdGuildsIdCommands(application_id),
@@ -1225,7 +1222,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild_integration(guild_id, integration_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::CreateInteractionResponse { interaction_id, interaction_token } => (
                 LightMethod::Post,
                 Route::InteractionsId(interaction_id),
@@ -1282,7 +1278,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::DeleteFollowupMessage {
                 application_id,
                 interaction_token,
@@ -1297,7 +1292,6 @@ impl<'a> RouteInfo<'a> {
                 )),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::DeleteGlobalApplicationCommand {
                 application_id,
                 command_id
@@ -1312,11 +1306,10 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild(guild_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::DeleteGuildApplicationCommand {
                 application_id,
                 guild_id,
-                command_id
+                command_id,
             } => (
                 LightMethod::Delete,
                 Route::ApplicationsIdGuildsIdCommandsId(application_id),
@@ -1360,7 +1353,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::channel_messages_bulk_delete(channel_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::DeleteOriginalInteractionResponse {
                 application_id,
                 interaction_token,
@@ -1418,7 +1410,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::EditFollowupMessage {
                 application_id,
                 interaction_token,
@@ -1433,7 +1424,6 @@ impl<'a> RouteInfo<'a> {
                 ),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::EditGlobalApplicationCommand {
                 application_id,
                 command_id,
@@ -1448,7 +1438,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild(guild_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::EditGuildApplicationCommand {
                 application_id,
                 guild_id,
@@ -1488,7 +1477,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild_nickname(guild_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::EditOriginalInteractionResponse {
                 application_id,
                 interaction_token,
@@ -1612,7 +1600,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::gateway()),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::GetGlobalApplicationCommands { application_id } => (
                 LightMethod::Get,
                 Route::ApplicationsIdCommands(application_id),
@@ -1624,7 +1611,6 @@ impl<'a> RouteInfo<'a> {
                 Cow::from(Route::guild(guild_id)),
             ),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::GetGuildApplicationCommands {
                 application_id,
                 guild_id,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -263,36 +263,48 @@ pub enum Route {
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     WebhooksApplicationId(u64),
     /// Route for the `/interactions/:interaction_id` path.
     ///
     /// The data is the relevant [`InteractionId`].
     ///
     /// [`InteractionId`]: crate::model::id::InteractionId
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     InteractionsId(u64),
     /// Route for the `/applications/:application_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     ApplicationsIdCommands(u64),
     /// Route for the `/applications/:application_id/commands/:command_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     ApplicationsIdCommandsId(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     ApplicationsIdGuildsIdCommands(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     ApplicationsIdGuildsIdCommandsId(u64),
     /// Route where no ratelimit headers are in place (i.e. user account-only
     /// routes).
@@ -675,6 +687,8 @@ impl Route {
         format!(api!("/webhooks/{}/{}?wait={}"), webhook_id, token, wait)
     }
 
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub fn webhook_original_interaction_response<D: Display>(
         application_id: u64,
         token: D
@@ -682,6 +696,8 @@ impl Route {
         format!(api!("/webhooks/{}/{}/messages/@original"), application_id, token)
     }
 
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub fn webhook_followup_message<D: Display>(
         application_id: u64,
         token: D,
@@ -690,6 +706,8 @@ impl Route {
         format!(api!("/webhooks/{}/{}/messages/{}"), application_id, token, message_id)
     }
 
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub fn webhook_followup_messages<D: Display>(
         application_id: u64,
         token: D,
@@ -697,7 +715,9 @@ impl Route {
     ) -> String {
         format!(api!("/webhooks/{}/{}?wait={}"), application_id, token, wait)
     }
-    
+
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub fn interaction_response<D: Display>(
         application_id: u64,
         token: D,
@@ -705,14 +725,20 @@ impl Route {
         format!(api!("/webhooks/{}/{}/callback"), application_id, token)
     }
 
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub fn application_command(application_id: u64, command_id: u64) -> String {
         format!(api!("applications/{}/commands/{}"), application_id, command_id)
     }
 
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub fn application_commands(application_id: u64) -> String {
         format!(api!("applications/{}/commands"), application_id)
     }
 
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub fn application_guild_command(
         application_id: u64,
         guild_id: u64,
@@ -721,6 +747,8 @@ impl Route {
         format!(api!("applications/{}/guilds/{}/commands/{}"), application_id, guild_id, command_id)
     }
 
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     pub fn application_guild_commands(
         application_id: u64,
         guild_id: u64,
@@ -752,15 +780,21 @@ pub enum RouteInfo<'a> {
     CreateEmoji {
         guild_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     CreateFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
         wait: bool
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     CreateGlobalApplicationCommand {
         application_id: u64,
     },
     CreateGuild,
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     CreateGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
@@ -769,6 +803,8 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         integration_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     CreateInteractionResponse {
         interaction_id: u64,
         interaction_token: &'a str,
@@ -802,11 +838,15 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         emoji_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     DeleteFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
         message_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     DeleteGlobalApplicationCommand {
         application_id: u64,
         command_id: u64,
@@ -814,6 +854,8 @@ pub enum RouteInfo<'a> {
     DeleteGuild {
         guild_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     DeleteGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
@@ -842,6 +884,8 @@ pub enum RouteInfo<'a> {
         message_id: u64,
         reaction: &'a str,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     DeleteOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
@@ -879,6 +923,8 @@ pub enum RouteInfo<'a> {
         interaction_token: &'a str,
         message_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     EditGlobalApplicationCommand {
         application_id: u64,
         command_id: u64,
@@ -886,6 +932,8 @@ pub enum RouteInfo<'a> {
     EditGuild {
         guild_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     EditGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
@@ -908,6 +956,8 @@ pub enum RouteInfo<'a> {
     EditNickname {
         guild_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     EditOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
@@ -966,12 +1016,16 @@ pub enum RouteInfo<'a> {
         emoji_id: u64,
     },
     GetGateway,
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     GetGlobalApplicationCommands {
         application_id: u64,
     },
     GetGuild {
         guild_id: u64,
     },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     GetGuildApplicationCommands {
         application_id: u64,
         guild_id: u64,
@@ -1131,6 +1185,8 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojis(guild_id),
                 Cow::from(Route::guild_emojis(guild_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::CreateFollowupMessage {
                 application_id,
                 interaction_token,
@@ -1142,6 +1198,8 @@ impl<'a> RouteInfo<'a> {
                     application_id, interaction_token, wait
                 )),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::CreateGlobalApplicationCommand { application_id } => (
                 LightMethod::Post,
                 Route::ApplicationsIdCommands(application_id),
@@ -1152,6 +1210,8 @@ impl<'a> RouteInfo<'a> {
                 Route::Guilds,
                 Cow::from(Route::guilds()),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::CreateGuildApplicationCommand { application_id, guild_id } => (
                 LightMethod::Post,
                 Route::ApplicationsIdGuildsIdCommands(application_id),
@@ -1162,6 +1222,8 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdIntegrationsId(guild_id),
                 Cow::from(Route::guild_integration(guild_id, integration_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::CreateInteractionResponse { interaction_id, interaction_token } => (
                 LightMethod::Post,
                 Route::InteractionsId(interaction_id),
@@ -1217,6 +1279,8 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojisId(guild_id),
                 Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::DeleteFollowupMessage {
                 application_id,
                 interaction_token,
@@ -1230,6 +1294,8 @@ impl<'a> RouteInfo<'a> {
                     message_id
                 )),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::DeleteGlobalApplicationCommand {
                 application_id,
                 command_id
@@ -1243,6 +1309,8 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsId(guild_id),
                 Cow::from(Route::guild(guild_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::DeleteGuildApplicationCommand {
                 application_id,
                 guild_id,
@@ -1289,6 +1357,8 @@ impl<'a> RouteInfo<'a> {
                 Route::ChannelsIdMessagesBulkDelete(channel_id),
                 Cow::from(Route::channel_messages_bulk_delete(channel_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::DeleteOriginalInteractionResponse {
                 application_id,
                 interaction_token,
@@ -1345,6 +1415,8 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojisId(guild_id),
                 Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::EditFollowupMessage {
                 application_id,
                 interaction_token,
@@ -1358,6 +1430,8 @@ impl<'a> RouteInfo<'a> {
                     message_id)
                 ),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::EditGlobalApplicationCommand {
                 application_id,
                 command_id,
@@ -1371,6 +1445,8 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsId(guild_id),
                 Cow::from(Route::guild(guild_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::EditGuildApplicationCommand {
                 application_id,
                 guild_id,
@@ -1409,6 +1485,8 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdMembersMeNick(guild_id),
                 Cow::from(Route::guild_nickname(guild_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::EditOriginalInteractionResponse {
                 application_id,
                 interaction_token,
@@ -1531,6 +1609,8 @@ impl<'a> RouteInfo<'a> {
                 Route::Gateway,
                 Cow::from(Route::gateway()),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::GetGlobalApplicationCommands { application_id } => (
                 LightMethod::Get,
                 Route::ApplicationsIdCommands(application_id),
@@ -1541,6 +1621,8 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsId(guild_id),
                 Cow::from(Route::guild(guild_id)),
             ),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             RouteInfo::GetGuildApplicationCommands {
                 application_id,
                 guild_id,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -258,6 +258,42 @@ pub enum Route {
     VoiceRegions,
     /// Route for the `/webhooks/:webhook_id` path.
     WebhooksId(u64),
+    /// Route for the `/webhooks/:application_id` path.
+    ///
+    /// The data is the relevant [`ApplicationId`].
+    ///
+    /// [`ApplicationId`]: crate::model::id::ApplicationId
+    WebhooksApplicationId(u64),
+    /// Route for the `/interactions/:interaction_id` path.
+    ///
+    /// The data is the relevant [`InteractionId`].
+    ///
+    /// [`InteractionId`]: crate::model::id::InteractionId
+    InteractionsId(u64),
+    /// Route for the `/applications/:application_id` path.
+    ///
+    /// The data is the relevant [`ApplicationId`].
+    ///
+    /// [`ApplicationId`]: crate::model::id::ApplicationId
+    ApplicationsIdCommands(u64),
+    /// Route for the `/applications/:application_id/commands/:command_id` path.
+    ///
+    /// The data is the relevant [`ApplicationId`].
+    ///
+    /// [`ApplicationId`]: crate::model::id::ApplicationId
+    ApplicationsIdCommandsId(u64),
+    /// Route for the `/applications/:application_id/guilds/:guild_id` path.
+    ///
+    /// The data is the relevant [`ApplicationId`].
+    ///
+    /// [`ApplicationId`]: crate::model::id::ApplicationId
+    ApplicationsIdGuildsIdCommands(u64),
+    /// Route for the `/applications/:application_id/guilds/:guild_id` path.
+    ///
+    /// The data is the relevant [`ApplicationId`].
+    ///
+    /// [`ApplicationId`]: crate::model::id::ApplicationId
+    ApplicationsIdGuildsIdCommandsId(u64),
     /// Route where no ratelimit headers are in place (i.e. user account-only
     /// routes).
     ///
@@ -638,6 +674,59 @@ impl Route {
         -> String where D: Display {
         format!(api!("/webhooks/{}/{}?wait={}"), webhook_id, token, wait)
     }
+
+    pub fn webhook_original_interaction_response<D: Display>(
+        application_id: u64,
+        token: D
+    ) -> String {
+        format!(api!("/webhooks/{}/{}/messages/@original"), application_id, token)
+    }
+
+    pub fn webhook_followup_message<D: Display>(
+        application_id: u64,
+        token: D,
+        message_id: u64,
+    ) -> String {
+        format!(api!("/webhooks/{}/{}/messages/{}"), application_id, token, message_id)
+    }
+
+    pub fn webhook_followup_messages<D: Display>(
+        application_id: u64,
+        token: D,
+        wait: bool,
+    ) -> String {
+        format!(api!("/webhooks/{}/{}?wait={}"), application_id, token, wait)
+    }
+    
+    pub fn interaction_response<D: Display>(
+        application_id: u64,
+        token: D,
+    ) -> String {
+        format!(api!("/webhooks/{}/{}/callback"), application_id, token)
+    }
+
+    pub fn application_command(application_id: u64, command_id: u64) -> String {
+        format!(api!("applications/{}/commands/{}"), application_id, command_id)
+    }
+
+    pub fn application_commands(application_id: u64) -> String {
+        format!(api!("applications/{}/commands"), application_id)
+    }
+
+    pub fn application_guild_command(
+        application_id: u64,
+        guild_id: u64,
+        command_id: u64
+    ) -> String {
+        format!(api!("applications/{}/guilds/{}/commands/{}"), application_id, guild_id, command_id)
+    }
+
+    pub fn application_guild_commands(
+        application_id: u64,
+        guild_id: u64,
+    ) -> String {
+        format!(api!("applications/{}/guilds/{}/commands"), application_id, guild_id)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -663,10 +752,26 @@ pub enum RouteInfo<'a> {
     CreateEmoji {
         guild_id: u64,
     },
+    CreateFollowupMessage {
+        application_id: u64,
+        interaction_token: &'a str,
+        wait: bool
+    },
+    CreateGlobalApplicationCommand {
+        application_id: u64,
+    },
     CreateGuild,
+    CreateGuildApplicationCommand {
+        application_id: u64,
+        guild_id: u64,
+    },
     CreateGuildIntegration {
         guild_id: u64,
         integration_id: u64,
+    },
+    CreateInteractionResponse {
+        interaction_id: u64,
+        interaction_token: &'a str,
     },
     CreateInvite {
         channel_id: u64,
@@ -697,8 +802,22 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         emoji_id: u64,
     },
+    DeleteFollowupMessage {
+        application_id: u64,
+        interaction_token: &'a str,
+        message_id: u64,
+    },
+    DeleteGlobalApplicationCommand {
+        application_id: u64,
+        command_id: u64,
+    },
     DeleteGuild {
         guild_id: u64,
+    },
+    DeleteGuildApplicationCommand {
+        application_id: u64,
+        guild_id: u64,
+        command_id: u64,
     },
     DeleteGuildIntegration {
         guild_id: u64,
@@ -722,6 +841,10 @@ pub enum RouteInfo<'a> {
         channel_id: u64,
         message_id: u64,
         reaction: &'a str,
+    },
+    DeleteOriginalInteractionResponse {
+        application_id: u64,
+        interaction_token: &'a str,
     },
     DeletePermission {
         channel_id: u64,
@@ -751,8 +874,22 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         emoji_id: u64,
     },
+    EditFollowupMessage {
+        application_id: u64,
+        interaction_token: &'a str,
+        message_id: u64,
+    },
+    EditGlobalApplicationCommand {
+        application_id: u64,
+        command_id: u64,
+    },
     EditGuild {
         guild_id: u64,
+    },
+    EditGuildApplicationCommand {
+        application_id: u64,
+        guild_id: u64,
+        command_id: u64,
     },
     EditGuildChannels {
         guild_id: u64,
@@ -770,6 +907,10 @@ pub enum RouteInfo<'a> {
     },
     EditNickname {
         guild_id: u64,
+    },
+    EditOriginalInteractionResponse {
+        application_id: u64,
+        interaction_token: &'a str,
     },
     EditProfile,
     EditRole {
@@ -825,7 +966,14 @@ pub enum RouteInfo<'a> {
         emoji_id: u64,
     },
     GetGateway,
+    GetGlobalApplicationCommands {
+        application_id: u64,
+    },
     GetGuild {
+        guild_id: u64,
+    },
+    GetGuildApplicationCommands {
+        application_id: u64,
         guild_id: u64,
     },
     GetGuildEmbed {
@@ -983,15 +1131,41 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojis(guild_id),
                 Cow::from(Route::guild_emojis(guild_id)),
             ),
+            RouteInfo::CreateFollowupMessage {
+                application_id,
+                interaction_token,
+                wait
+            } => (
+                LightMethod::Post,
+                Route::WebhooksId(application_id),
+                Cow::from(Route::webhook_followup_messages(
+                    application_id, interaction_token, wait
+                )),
+            ),
+            RouteInfo::CreateGlobalApplicationCommand { application_id } => (
+                LightMethod::Post,
+                Route::ApplicationsIdCommands(application_id),
+                Cow::from(Route::application_commands(application_id))
+            ),
             RouteInfo::CreateGuild => (
                 LightMethod::Post,
                 Route::Guilds,
                 Cow::from(Route::guilds()),
             ),
+            RouteInfo::CreateGuildApplicationCommand { application_id, guild_id } => (
+                LightMethod::Post,
+                Route::ApplicationsIdGuildsIdCommands(application_id),
+                Cow::from(Route::application_guild_commands(application_id, guild_id))
+            ),
             RouteInfo::CreateGuildIntegration { guild_id, integration_id } => (
                 LightMethod::Post,
                 Route::GuildsIdIntegrationsId(guild_id),
                 Cow::from(Route::guild_integration(guild_id, integration_id)),
+            ),
+            RouteInfo::CreateInteractionResponse { interaction_id, interaction_token } => (
+                LightMethod::Post,
+                Route::InteractionsId(interaction_id),
+                Cow::from(Route::interaction_response(interaction_id, interaction_token)),
             ),
             RouteInfo::CreateInvite { channel_id } => (
                 LightMethod::Post,
@@ -1043,10 +1217,40 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojisId(guild_id),
                 Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
+            RouteInfo::DeleteFollowupMessage {
+                application_id,
+                interaction_token,
+                message_id
+            } => (
+                LightMethod::Delete,
+                Route::WebhooksApplicationId(application_id),
+                Cow::from(Route::webhook_followup_message(
+                    application_id,
+                    interaction_token,
+                    message_id
+                )),
+            ),
+            RouteInfo::DeleteGlobalApplicationCommand {
+                application_id,
+                command_id
+            } => (
+                LightMethod::Delete,
+                Route::ApplicationsIdCommandsId(application_id),
+                Cow::from(Route::application_command(application_id, command_id)),
+            ),
             RouteInfo::DeleteGuild { guild_id } => (
                 LightMethod::Delete,
                 Route::GuildsId(guild_id),
                 Cow::from(Route::guild(guild_id)),
+            ),
+            RouteInfo::DeleteGuildApplicationCommand {
+                application_id,
+                guild_id,
+                command_id
+            } => (
+                LightMethod::Delete,
+                Route::ApplicationsIdGuildsIdCommandsId(application_id),
+                Cow::from(Route::application_guild_command(application_id, guild_id, command_id)),
             ),
             RouteInfo::DeleteGuildIntegration { guild_id, integration_id } => (
                 LightMethod::Delete,
@@ -1084,6 +1288,17 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Post,
                 Route::ChannelsIdMessagesBulkDelete(channel_id),
                 Cow::from(Route::channel_messages_bulk_delete(channel_id)),
+            ),
+            RouteInfo::DeleteOriginalInteractionResponse {
+                application_id,
+                interaction_token,
+            } => (
+                LightMethod::Delete,
+                Route::WebhooksApplicationId(application_id),
+                Cow::from(Route::webhook_original_interaction_response(
+                    application_id,
+                    interaction_token,
+                )),
             ),
             RouteInfo::DeletePermission { channel_id, target_id } => (
                 LightMethod::Delete,
@@ -1130,10 +1345,44 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojisId(guild_id),
                 Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
+            RouteInfo::EditFollowupMessage {
+                application_id,
+                interaction_token,
+                message_id,
+            } => (
+                LightMethod::Patch,
+                Route::WebhooksApplicationId(application_id),
+                Cow::from(Route::webhook_followup_message(
+                    application_id,
+                    interaction_token,
+                    message_id)
+                ),
+            ),
+            RouteInfo::EditGlobalApplicationCommand {
+                application_id,
+                command_id,
+            } => (
+                LightMethod::Patch,
+                Route::ApplicationsIdCommandsId(application_id),
+                Cow::from(Route::application_command(application_id, command_id)),
+            ),
             RouteInfo::EditGuild { guild_id } => (
                 LightMethod::Patch,
                 Route::GuildsId(guild_id),
                 Cow::from(Route::guild(guild_id)),
+            ),
+            RouteInfo::EditGuildApplicationCommand {
+                application_id,
+                guild_id,
+                command_id,
+            } => (
+                LightMethod::Patch,
+                Route::ApplicationsIdGuildsIdCommandsId(application_id),
+                Cow::from(Route::application_guild_command(
+                    application_id,
+                    guild_id,
+                    command_id)
+                ),
             ),
             RouteInfo::EditGuildChannels { guild_id } => (
                 LightMethod::Patch,
@@ -1159,6 +1408,17 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Patch,
                 Route::GuildsIdMembersMeNick(guild_id),
                 Cow::from(Route::guild_nickname(guild_id)),
+            ),
+            RouteInfo::EditOriginalInteractionResponse {
+                application_id,
+                interaction_token,
+            } => (
+                LightMethod::Patch,
+                Route::WebhooksApplicationId(application_id),
+                Cow::from(Route::webhook_original_interaction_response(
+                    application_id,
+                    interaction_token
+                )),
             ),
             RouteInfo::EditProfile => (
                 LightMethod::Patch,
@@ -1271,10 +1531,23 @@ impl<'a> RouteInfo<'a> {
                 Route::Gateway,
                 Cow::from(Route::gateway()),
             ),
+            RouteInfo::GetGlobalApplicationCommands { application_id } => (
+                LightMethod::Get,
+                Route::ApplicationsIdCommands(application_id),
+                Cow::from(Route::application_commands(application_id)),
+            ),
             RouteInfo::GetGuild { guild_id } => (
                 LightMethod::Get,
                 Route::GuildsId(guild_id),
                 Cow::from(Route::guild(guild_id)),
+            ),
+            RouteInfo::GetGuildApplicationCommands {
+                application_id,
+                guild_id,
+            } => (
+                LightMethod::Get,
+                Route::ApplicationsIdGuildsIdCommands(application_id),
+                Cow::from(Route::application_guild_commands(application_id, guild_id)),
             ),
             RouteInfo::GetGuildEmbed { guild_id } => (
                 LightMethod::Get,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -886,8 +886,10 @@ pub enum MessageType {
     NitroTier2 = 10,
     /// An indicator that the guild has reached nitro tier 3
     NitroTier3 = 11,
-    // /// An message reply.
+    /// A message reply.
     InlineReply = 19,
+    /// A slash command
+    ApplicationCommand = 20,
 }
 
 enum_number!(
@@ -905,6 +907,7 @@ enum_number!(
         NitroTier2,
         NitroTier3,
         InlineReply,
+        ApplicationCommand,
     }
 );
 
@@ -926,6 +929,7 @@ impl MessageType {
             NitroTier2 => 10,
             NitroTier3 => 11,
             InlineReply => 19,
+            ApplicationCommand => 20,
         }
     }
 }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1577,7 +1577,7 @@ pub enum Event {
     VoiceServerUpdate(VoiceServerUpdateEvent),
     /// A webhook for a [channel][`GuildChannel`] was updated in a [`Guild`].
     WebhookUpdate(WebhookUpdateEvent),
-    /// An user used a slash command.
+    /// A user used a slash command.
     InteractionCreate(InteractionCreateEvent),
     /// An event type not covered by the above
     Unknown(UnknownEvent),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1633,7 +1633,6 @@ impl Event {
             Self::VoiceServerUpdate(_) => EventType::VoiceServerUpdate,
             Self::WebhookUpdate(_) => EventType::WebhookUpdate,
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             Self::InteractionCreate(_) => EventType::InteractionCreate,
             Self::Unknown(unknown) => EventType::Other(unknown.kind.clone()),
         }
@@ -1749,7 +1748,6 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
         },
         EventType::WebhookUpdate => Event::WebhookUpdate(serde_json::from_value(v)?),
         #[cfg(feature = "unstable_discord_api")]
-        #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
         EventType::InteractionCreate => Event::InteractionCreate(serde_json::from_value(v)?),
         EventType::Other(kind) => Event::Unknown(UnknownEvent {
             kind,
@@ -2018,7 +2016,6 @@ impl EventType {
             Self::VoiceStateUpdate => Some(Self::VOICE_STATE_UPDATE),
             Self::WebhookUpdate => Some(Self::WEBHOOKS_UPDATE),
             #[cfg(feature = "unstable_discord_api")]
-            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             Self::InteractionCreate => Some(Self::INTERACTION_CREATE),
             // GuildUnavailable is a synthetic event type, corresponding to either
             // `GUILD_CREATE` or `GUILD_DELETE`, but we don't have enough information
@@ -2082,7 +2079,6 @@ impl<'de> Deserialize<'de> for EventType {
                     EventType::VOICE_STATE_UPDATE => EventType::VoiceStateUpdate,
                     EventType::WEBHOOKS_UPDATE => EventType::WebhookUpdate,
                     #[cfg(feature = "unstable_discord_api")]
-                    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
                     EventType::INTERACTION_CREATE => EventType::InteractionCreate,
                     other => EventType::Other(other.to_owned()),
                 })

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1374,12 +1374,16 @@ pub struct WebhookUpdateEvent {
     pub guild_id: GuildId,
 }
 
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct InteractionCreateEvent {
     pub interaction: Interaction,
 }
 
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
 impl<'de> Deserialize<'de> for InteractionCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
@@ -1388,6 +1392,8 @@ impl<'de> Deserialize<'de> for InteractionCreateEvent {
     }
 }
 
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
 impl Serialize for InteractionCreateEvent {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
         where S: Serializer {
@@ -1578,6 +1584,8 @@ pub enum Event {
     /// A webhook for a [channel][`GuildChannel`] was updated in a [`Guild`].
     WebhookUpdate(WebhookUpdateEvent),
     /// A user used a slash command.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     InteractionCreate(InteractionCreateEvent),
     /// An event type not covered by the above
     Unknown(UnknownEvent),
@@ -1624,6 +1632,8 @@ impl Event {
             Self::VoiceStateUpdate(_) => EventType::VoiceStateUpdate,
             Self::VoiceServerUpdate(_) => EventType::VoiceServerUpdate,
             Self::WebhookUpdate(_) => EventType::WebhookUpdate,
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             Self::InteractionCreate(_) => EventType::InteractionCreate,
             Self::Unknown(unknown) => EventType::Other(unknown.kind.clone()),
         }
@@ -1738,6 +1748,8 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
             Event::VoiceStateUpdate(serde_json::from_value(v)?)
         },
         EventType::WebhookUpdate => Event::WebhookUpdate(serde_json::from_value(v)?),
+        #[cfg(feature = "unstable_discord_api")]
+        #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
         EventType::InteractionCreate => Event::InteractionCreate(serde_json::from_value(v)?),
         EventType::Other(kind) => Event::Unknown(UnknownEvent {
             kind,
@@ -1907,6 +1919,8 @@ pub enum EventType {
     /// Indicator that a slash command was received.
     ///
     /// This maps to [`InteractionCreateEvent`].
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     InteractionCreate,
     /// An unknown event was received over the gateway.
     ///
@@ -1958,6 +1972,8 @@ impl EventType {
     const VOICE_SERVER_UPDATE: &'static str = "VOICE_SERVER_UPDATE";
     const VOICE_STATE_UPDATE: &'static str = "VOICE_STATE_UPDATE";
     const WEBHOOKS_UPDATE: &'static str = "WEBHOOKS_UPDATE";
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
     const INTERACTION_CREATE: &'static str = "INTERACTION_CREATE";
 
     /// Return the event name of this event. Some events are synthetic, and we lack
@@ -2001,6 +2017,8 @@ impl EventType {
             Self::VoiceServerUpdate => Some(Self::VOICE_SERVER_UPDATE),
             Self::VoiceStateUpdate => Some(Self::VOICE_STATE_UPDATE),
             Self::WebhookUpdate => Some(Self::WEBHOOKS_UPDATE),
+            #[cfg(feature = "unstable_discord_api")]
+            #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
             Self::InteractionCreate => Some(Self::INTERACTION_CREATE),
             // GuildUnavailable is a synthetic event type, corresponding to either
             // `GUILD_CREATE` or `GUILD_DELETE`, but we don't have enough information
@@ -2063,6 +2081,8 @@ impl<'de> Deserialize<'de> for EventType {
                     EventType::VOICE_SERVER_UPDATE => EventType::VoiceServerUpdate,
                     EventType::VOICE_STATE_UPDATE => EventType::VoiceStateUpdate,
                     EventType::WEBHOOKS_UPDATE => EventType::WebhookUpdate,
+                    #[cfg(feature = "unstable_discord_api")]
+                    #[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
                     EventType::INTERACTION_CREATE => EventType::InteractionCreate,
                     other => EventType::Other(other.to_owned()),
                 })

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -56,14 +56,14 @@ pub struct Activity {
     pub timestamps: Option<ActivityTimestamps>,
     /// The sync ID of the activity. Mainly used by the Spotify activity
     /// type which uses this parameter to store the track ID.
-    #[cfg(feature = "unstable")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub sync_id: Option<String>,
     /// The session ID of the activity. Reserved for specific activity
     /// types, such as the Activity that is transmitted when a user is
     /// listening to Spotify.
-    #[cfg(feature = "unstable")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub session_id: Option<String>,
     /// The Stream URL if [`kind`] is [`ActivityType::Streaming`].
     ///
@@ -112,9 +112,9 @@ impl Activity {
             state: None,
             emoji: None,
             timestamps: None,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             sync_id: None,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             session_id: None,
             url: None,
         }
@@ -162,9 +162,9 @@ impl Activity {
             state: None,
             emoji: None,
             timestamps: None,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             sync_id: None,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             session_id: None,
             url: Some(url.to_string()),
         }
@@ -209,9 +209,9 @@ impl Activity {
             state: None,
             emoji: None,
             timestamps: None,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             sync_id: None,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             session_id: None,
             url: None,
         }
@@ -256,9 +256,9 @@ impl Activity {
             state: None,
             emoji: None,
             timestamps: None,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             sync_id: None,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             session_id: None,
             url: None,
         }
@@ -329,13 +329,13 @@ impl<'de> Deserialize<'de> for Activity {
             None => None,
         };
 
-        #[cfg(feature = "unstable")]
+        #[cfg(feature = "unstable_discord_api")]
         let sync_id = match map.remove("sync_id") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
         };
 
-        #[cfg(feature = "unstable")]
+        #[cfg(feature = "unstable_discord_api")]
         let session_id = match map.remove("session_id") {
             Some(v) => serde_json::from_value::<Option<_>>(v).map_err(DeError::custom)?,
             None => None,
@@ -357,9 +357,9 @@ impl<'de> Deserialize<'de> for Activity {
             state,
             emoji,
             timestamps,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             sync_id,
-            #[cfg(feature = "unstable")]
+            #[cfg(feature = "unstable_discord_api")]
             session_id,
             url,
         })

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -139,6 +139,14 @@ pub struct StickerId(pub u64);
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct StickerPackId(pub u64);
 
+/// An identifier for an interaction.
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct InteractionId(pub u64);
+
+/// An identifier for a slash command.
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct CommandId(pub u64);
+
 id_u64! {
     AttachmentId;
     ApplicationId;
@@ -153,4 +161,6 @@ id_u64! {
     UserId;
     WebhookId;
     AuditLogEntryId;
+    InteractionId;
+    CommandId;
 }

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -18,7 +18,7 @@ pub struct Interaction {
     pub channel_id: ChannelId,
     pub member: Member,
     pub token: String,
-    pub version: i32
+    pub version: u8,
 }
 
 /// The type of an Interaction

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -12,7 +12,7 @@ use crate::internal::prelude::*;
 pub struct Interaction {
     pub id: InteractionId,
     #[serde(rename = "type")]
-    pub interaction_type: InteractionType,
+    pub kind: InteractionType,
     pub data: Option<ApplicationCommandInteractionData>,
     pub guild_id: GuildId,
     pub channel_id: ChannelId,
@@ -106,4 +106,3 @@ pub struct ApplicationCommandOptionChoice {
     pub name: String,
     pub value: Value
 }
-

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -1,12 +1,12 @@
-//! Interactions information-related models
+//! Interactions information-related models.
 
 use super::prelude::*;
 use crate::internal::prelude::*;
 
-/// Information about an Interaction
+/// Information about an interaction.
 ///
-/// An interaction is the base "thing" that is sent when a user invokes a command, and is the same
-/// for Slash Commands and other future interaction types.
+/// An interaction is sent when a user invokes a slash command and is the same
+/// for slash commands and other future interaction types.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Interaction {
@@ -27,34 +27,33 @@ pub struct Interaction {
 #[repr(u8)]
 pub enum InteractionType {
     Ping = 1,
-    ApplicationCommand = 2
+    ApplicationCommand = 2,
 }
 
-/// The command data payload
+/// The command data payload.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommandInteractionData {
     pub id: CommandId,
     pub name: String,
     #[serde(default)]
-    pub options: Vec<ApplicationCommandInteractionDataOption>
+    pub options: Vec<ApplicationCommandInteractionDataOption>,
 }
 
-/// A set of a param and value from the user.
+/// A set of a parameter and a value from the user.
 ///
-/// All options have names, and an option can either be a parameter and input value--in which case
-/// `value` will be set--or it can denote a subcommand or group--in which case it will contain a
-/// top-level key and another array of `options`.
+/// All options have names and an option can either be a parameter and input `value` or it can denote a sub-command or group, in which case it will contain a
+/// top-level key and another vector of `options`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommandInteractionDataOption {
     pub name: String,
     pub value: Option<ApplicationCommandOptionType>,
     #[serde(default)]
-    pub options: Vec<ApplicationCommandInteractionDataOption>
+    pub options: Vec<ApplicationCommandInteractionDataOption>,
 }
 
-/// The base "command" model that belongs to an application.
+/// The base command model that belongs to an application.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommand {
@@ -63,10 +62,10 @@ pub struct ApplicationCommand {
     pub name: String,
     pub description: String,
     #[serde(default)]
-    pub options: Vec<ApplicationCommandOption>
+    pub options: Vec<ApplicationCommandOption>,
 }
 
-/// The parameters for a command
+/// The parameters for a command.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommandOption {
@@ -81,10 +80,10 @@ pub struct ApplicationCommandOption {
     #[serde(default)]
     pub choices: Vec<ApplicationCommandOptionChoice>,
     #[serde(default)]
-    pub options: Vec<ApplicationCommandOption>
+    pub options: Vec<ApplicationCommandOption>,
 }
 
-/// The type of an application command option
+/// The type of an application command option.
 #[derive(Copy, Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -96,13 +95,13 @@ pub enum ApplicationCommandOptionType {
     Boolean = 5,
     User = 6,
     Channel = 7,
-    Role = 8
+    Role = 8,
 }
 
-/// The only valid values a user can pick in a command option
+/// The only valid values a user can pick in a command option.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommandOptionChoice {
     pub name: String,
-    pub value: Value
+    pub value: Value,
 }

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -1,0 +1,109 @@
+//! Interactions information-related models
+
+use super::prelude::*;
+use crate::internal::prelude::*;
+
+/// Information about an Interaction
+///
+/// An interaction is the base "thing" that is sent when a user invokes a command, and is the same
+/// for Slash Commands and other future interaction types.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Interaction {
+    pub id: InteractionId,
+    #[serde(rename = "type")]
+    pub interaction_type: InteractionType,
+    pub data: Option<ApplicationCommandInteractionData>,
+    pub guild_id: GuildId,
+    pub channel_id: ChannelId,
+    pub member: Member,
+    pub token: String,
+    pub version: i32
+}
+
+/// The type of an Interaction
+#[derive(Copy, Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum InteractionType {
+    Ping = 1,
+    ApplicationCommand = 2
+}
+
+/// The command data payload
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ApplicationCommandInteractionData {
+    pub id: CommandId,
+    pub name: String,
+    #[serde(default)]
+    pub options: Vec<ApplicationCommandInteractionDataOption>
+}
+
+/// A set of a param and value from the user.
+///
+/// All options have names, and an option can either be a parameter and input value--in which case
+/// `value` will be set--or it can denote a subcommand or group--in which case it will contain a
+/// top-level key and another array of `options`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ApplicationCommandInteractionDataOption {
+    pub name: String,
+    pub value: Option<ApplicationCommandOptionType>,
+    #[serde(default)]
+    pub options: Vec<ApplicationCommandInteractionDataOption>
+}
+
+/// The base "command" model that belongs to an application.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ApplicationCommand {
+    pub id: CommandId,
+    pub application_id: ApplicationId,
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub options: Vec<ApplicationCommandOption>
+}
+
+/// The parameters for a command
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ApplicationCommandOption {
+    #[serde(rename = "type")]
+    pub kind: ApplicationCommandOptionType,
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub default: bool,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub choices: Vec<ApplicationCommandOptionChoice>,
+    #[serde(default)]
+    pub options: Vec<ApplicationCommandOption>
+}
+
+/// The type of an application command option
+#[derive(Copy, Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum ApplicationCommandOptionType {
+    SubCommand = 1,
+    SubCommandGroup = 2,
+    String = 3,
+    Integer = 4,
+    Boolean = 5,
+    User = 6,
+    Channel = 7,
+    Role = 8
+}
+
+/// The only valid values a user can pick in a command option
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ApplicationCommandOptionChoice {
+    pub name: String,
+    pub value: Value
+}
+

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -36,6 +36,7 @@ pub mod prelude;
 pub mod user;
 pub mod voice;
 pub mod webhook;
+pub mod interactions;
 
 #[cfg(feature = "voice-model")]
 pub use serenity_voice_model as voice_gateway;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -36,6 +36,8 @@ pub mod prelude;
 pub mod user;
 pub mod voice;
 pub mod webhook;
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
 pub mod interactions;
 
 #[cfg(feature = "voice-model")]

--- a/src/model/prelude.rs
+++ b/src/model/prelude.rs
@@ -22,5 +22,7 @@ pub use super::permissions::*;
 pub use super::user::*;
 pub use super::voice::*;
 pub use super::webhook::*;
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
 pub use super::interactions::*;
 pub use super::*;

--- a/src/model/prelude.rs
+++ b/src/model/prelude.rs
@@ -22,4 +22,5 @@ pub use super::permissions::*;
 pub use super::user::*;
 pub use super::voice::*;
 pub use super::webhook::*;
+pub use super::interactions::*;
 pub use super::*;


### PR DESCRIPTION
This PR adds low-level support for interactions like slash commands. This means support for the new INTERACTION_CREATE gateway event and adds all the new api endpoints related to interactions to the Http struct.

Unless the issue is requested to stay open for further discussion about support further than the low-level support that this adds, this PR closes #1126 

Please let me know if there is anything that should be changed/added 😄 