### PR TITLE
Add Partial Application object to the Ready Event.

### DIFF
--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -108,6 +108,15 @@ impl fmt::Debug for BotApplication {
     }
 }
 
+/// Partial information about the given application.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PartialCurrentApplicationInfo {
+    /// The unique Id of the user.
+    pub id: UserId,
+    /// The flags associated with the application.
+    pub flags: u64,
+}
+
 /// Information about the current application and its owner.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -114,6 +114,9 @@ pub struct PartialCurrentApplicationInfo {
     /// The unique Id of the user.
     pub id: UserId,
     /// The flags associated with the application.
+    ///
+    /// These flags are unknown and are not yet documented in the Discord API
+    /// documentation.
     pub flags: u64,
 }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -605,6 +605,7 @@ impl Serialize for Presence {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Ready {
+    pub application: PartialCurrentApplicationInfo,
     pub guilds: Vec<GuildStatus>,
     #[serde(default, serialize_with = "serialize_presences", deserialize_with = "deserialize_presences")]
     pub presences: HashMap<UserId, Presence>,


### PR DESCRIPTION
Minor PR that adds support for the partial application object that was added to the Ready event in API v8.