### PR TITLE
Write Mentionable as a Display instead of String

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -300,7 +300,7 @@ impl Message {
                 let chosen = constants::JOIN_MESSAGES[sec % constants::JOIN_MESSAGES.len()];
 
                 self.content = if chosen.contains("$user") {
-                    chosen.replace("$user", &self.author.mention())
+                    chosen.replace("$user", &self.author.mention().to_string())
                 } else {
                     chosen.to_string()
                 };
@@ -322,7 +322,7 @@ impl Message {
             at_distinct.push_str(&u.name);
             at_distinct.push('#');
             let _ = write!(at_distinct, "{:04}", u.discriminator);
-            let mut m = u.mention();
+            let mut m = u.mention().to_string();
             // Check whether we're replacing a nickname mention or a normal mention.
             // `UserId::mention` returns a normal mention. If it isn't present in the message, it's a nickname mention.
             if !result.contains(&m) {
@@ -334,7 +334,7 @@ impl Message {
 
         // Then replace all role mentions.
         for id in &self.mention_roles {
-            let mention = id.mention();
+            let mention = id.mention().to_string();
 
             if let Some(role) = id.to_role_cached(&cache).await {
                 result = result.replace(&mention, &format!("@{}", role.name));


### PR DESCRIPTION
This PR lets `.mention()` avoid the intermediate allocation of `String`, as well as provides an API that implements `Copy` for dealing with mentionable strings. This may be breaking for some uses, but the most common may be insertion into format-macros, where this PR should have a painless/unnoticeable transition. Uses that need a `String` can be resolved using `.to_string()` and this is mentioned in the documentation.

Notably, `Emoji` behaves strangely. The name of an emoji is irrelevant when it comes to its use; the id and animation status are what matters. Incidentally, animated emoji are now functional, but that could also be solved as its own issue in the absence of this PR.

Rust does not support deprecating trait implementations. `From<EmojiId> for Mention` would otherwise be deprecated, because it's insufficient information and lacks animation status.

Documentation examples have been added for `Mentionable::mention()` and `Mention`.