### PR TITLE
Improve permission checking

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -822,7 +822,27 @@ pub(crate) async fn has_correct_permissions(
     if options.required_permissions().is_empty() {
         true
     } else if let Some(guild) = message.guild(&cache).await {
-        let perms = guild.user_permissions_in(message.channel_id, message.author.id);
+        let channel = match guild.channels.get(&message.channel_id) {
+            Some(channel) => channel,
+            None => return false,
+        };
+        let member = match guild.members.get(&message.author.id) {
+            Some(member) => member,
+            None => return false,
+        };
+
+        let perms = match guild.user_permissions_in(channel, member) {
+            Ok(perms) => perms,
+            Err(e) => {
+                tracing::error!(
+                    "(╯°□°）╯︵ ┻━┻ error getting permissions for user {} in channel {}: {}",
+                    member.user.id,
+                    channel.id,
+                    e
+                );
+                return false;
+            }
+        };
 
         perms.contains(*options.required_permissions())
     } else {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -554,7 +554,8 @@ impl GuildChannel {
     #[inline]
     pub async fn permissions_for_user(&self, cache: impl AsRef<Cache>, user_id: impl Into<UserId>) -> Result<Permissions> {
         let guild = self.guild(&cache).await.ok_or(Error::Model(ModelError::GuildNotFound))?;
-        Ok(guild.user_permissions_in(self.id, user_id))
+        let member = guild.members.get(&user_id.into()).ok_or(Error::Model(ModelError::MemberNotFound))?;
+        guild.user_permissions_in(self, member)
     }
 
     /// Calculates the permissions of a role.
@@ -573,7 +574,8 @@ impl GuildChannel {
     #[inline]
     pub async fn permissions_for_role(&self, cache: impl AsRef<Cache>, role_id: impl Into<RoleId>) -> Result<Permissions> {
         let guild = self.guild(&cache).await.ok_or(Error::Model(ModelError::GuildNotFound))?;
-        guild.role_permissions_in(self.id, role_id).ok_or(Error::Model(ModelError::GuildNotFound))
+        let role = guild.roles.get(&role_id.into()).ok_or(Error::Model(ModelError::RoleNotFound))?;
+        guild.role_permissions_in(self, role)
     }
 
     /// Pins a [`Message`] to the channel.

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -89,6 +89,20 @@ pub enum Error {
     /// [`RoleId`]: super::id::RoleId
     /// [`Cache`]: crate::cache::Cache
     RoleNotFound,
+    /// An indication that a [member][`Member`] could not be found by
+    /// [Id][`UserId`] in the [`Cache`].
+    ///
+    /// [`Member`]: super::guild::Member
+    /// [`UserId`]: super::id::UserId
+    /// [`Cache`]: crate::cache::Cache
+    MemberNotFound,
+    /// An indication that a [channel][`Channel`] could not be found by
+    /// [Id][`ChannelId`] in the [`Cache`].
+    ///
+    /// [`Channel`]: super::channel::Channel
+    /// [`ChannelId`]: super::id::ChannelId
+    /// [`Cache`]: crate::cache::Cache
+    ChannelNotFound,
     /// Indicates that there are hierarchy problems restricting an action.
     ///
     /// For example, when banning a user, if the other user has a role with an
@@ -112,6 +126,10 @@ pub enum Error {
     ///
     /// [`Cache`]: crate::cache::Cache
     ItemMissing,
+    /// Indicates that a member, role or channel from the wrong [`Guild`] was provided.
+    ///
+    /// [`Guild`]: super::guild::Guild
+    WrongGuild,
     /// Indicates that a [`Message`]s content was too long and will not
     /// successfully send, as the length is over 2000 codepoints.
     ///
@@ -140,11 +158,16 @@ impl Display for Error {
             Error::EmbedTooLarge(_) => f.write_str("Embed too large."),
             Error::GuildNotFound => f.write_str("Guild not found in the cache."),
             Error::RoleNotFound => f.write_str("Role not found in the cache."),
+            Error::MemberNotFound => f.write_str("Member not found in the cache."),
+            Error::ChannelNotFound => f.write_str("Channel not found in the cache."),
             Error::Hierarchy => f.write_str("Role hierarchy prevents this action."),
             Error::InvalidChannelType => f.write_str("The channel cannot perform the action."),
             Error::InvalidPermissions(_) => f.write_str("Invalid permissions."),
             Error::InvalidUser => f.write_str("The current user cannot perform the action."),
             Error::ItemMissing => f.write_str("The required item is missing from the cache."),
+            Error::WrongGuild => {
+                f.write_str("Provided member or channel is from the wrong guild.")
+            }
             Error::MessageTooLong(_) => f.write_str("Message too large."),
             Error::MessagingBot => f.write_str("Attempted to message another bot user."),
             Error::NameTooShort => f.write_str("Name is under the character limit."),

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -146,8 +146,10 @@ impl Member {
     pub async fn default_channel(&self, cache: impl AsRef<Cache>) -> Option<GuildChannel> {
         let guild = self.guild_id.to_guild_cached(cache).await?;
 
-        for (cid, channel) in &guild.channels {
-            if guild.user_permissions_in(*cid, self.user.id).read_messages() {
+        let member = guild.members.get(&self.user.id)?;
+
+        for channel in guild.channels.values() {
+            if guild.user_permissions_in(channel, member).ok()?.read_messages() {
                 return Some(channel.clone());
             }
         }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -182,8 +182,9 @@ impl Guild {
     /// (This returns the first channel that can be read by the user, if there isn't one,
     /// returns `None`)
     pub async fn default_channel(&self, uid: UserId) -> Option<&GuildChannel> {
-        for (cid, channel) in &self.channels {
-            if self.user_permissions_in(*cid, uid).read_messages() {
+        let member = self.members.get(&uid)?;
+        for channel in self.channels.values() {
+            if self.user_permissions_in(channel, member).ok()?.read_messages() {
                 return Some(channel);
             }
         }
@@ -197,9 +198,9 @@ impl Guild {
     /// Note however that this is very costy if used in a server with lots of channels,
     /// members, or both.
     pub async fn default_channel_guaranteed(&self) -> Option<&GuildChannel> {
-        for (cid, channel) in &self.channels {
-            for memid in self.members.keys() {
-                if self.user_permissions_in(*cid, *memid).read_messages() {
+        for channel in self.channels.values() {
+            for member in self.members.values() {
+                if self.user_permissions_in(channel, member).ok()?.read_messages() {
                     return Some(channel);
                 }
             }
@@ -1291,20 +1292,13 @@ impl Guild {
         self.id.move_member(&http, user_id, channel_id).await
     }
 
-    /// Calculate a [`User`]'s permissions in a given channel in the guild.
-    #[inline]
-    pub fn user_permissions_in(&self, channel_id: impl Into<ChannelId>, user_id: impl Into<UserId>) -> Permissions {
-        self._user_permissions_in(channel_id.into(), user_id.into())
-    }
+    /// Calculate a [`Member`]'s permissions in a given channel in the guild.
+    pub fn user_permissions_in(&self, channel: &GuildChannel, member: &Member) -> Result<Permissions> {
 
-    fn _user_permissions_in(
-        &self,
-        channel_id: ChannelId,
-        user_id: UserId,
-    ) -> Permissions {
+
         // The owner has all permissions in all cases.
-        if user_id == self.owner_id {
-            return Permissions::all();
+        if member.user.id == self.owner_id {
+            return Ok(self.remove_unnecessary_voice_permissions(channel, Permissions::all()));
         }
 
         // Start by retrieving the @everyone role's permissions.
@@ -1316,163 +1310,107 @@ impl Guild {
                     self.id,
                     self.name
                 );
-
-                return Permissions::empty();
+                return Err(Error::Model(ModelError::RoleNotFound));
             },
         };
 
         // Create a base set of permissions, starting with `@everyone`s.
         let mut permissions = everyone.permissions;
 
-        let member = self.members.get(&user_id);
-
-        if let Some(member) = &member {
-            for &role in &member.roles {
-                if let Some(role) = self.roles.get(&role) {
-                    permissions |= role.permissions;
-                } else {
-                    warn!(
-                        "(╯°□°）╯︵ ┻━┻ {} on {} has non-existent role {:?}",
-                        member.user.id,
-                        self.id,
-                        role
-                    );
-                }
+        for &role in &member.roles {
+            if let Some(role) = self.roles.get(&role) {
+                permissions |= role.permissions;
+            } else {
+                error!(
+                    "(╯°□°）╯︵ ┻━┻ {} on {} has non-existent role {:?}",
+                    member.user.id,
+                    self.id,
+                    role
+                );
+                return Err(Error::Model(ModelError::RoleNotFound));
             }
         }
 
         // Administrators have all permissions in any channel.
         if permissions.contains(Permissions::ADMINISTRATOR) {
-            return Permissions::all();
+            return Ok(self.remove_unnecessary_voice_permissions(channel, Permissions::all()));
         }
 
-        if let Some(channel) = self.channels.get(&channel_id) {
-            // If this is a text channel, then throw out voice permissions.
-            if channel.kind == ChannelType::Text {
-                permissions &= !(Permissions::CONNECT
-                    | Permissions::SPEAK
-                    | Permissions::MUTE_MEMBERS
-                    | Permissions::DEAFEN_MEMBERS
-                    | Permissions::MOVE_MEMBERS
-                    | Permissions::USE_VAD
-                    | Permissions::STREAM);
-            }
+        // Apply the permission overwrites for the channel for each of the
+        // overwrites that - first - applies to the member's roles, and then
+        // the member itself.
+        //
+        // First apply the denied permission overwrites for each, then apply
+        // the allowed.
 
-            // Apply the permission overwrites for the channel for each of the
-            // overwrites that - first - applies to the member's roles, and then
-            // the member itself.
-            //
-            // First apply the denied permission overwrites for each, then apply
-            // the allowed.
+        let mut data = Vec::with_capacity(member.roles.len());
 
-            if let Some(member) = member {
-                let mut data = Vec::with_capacity(member.roles.len());
-
-                // Roles
-                for overwrite in &channel.permission_overwrites {
-                    if let PermissionOverwriteType::Role(role) = overwrite.kind {
-                        if role.0 != self.id.0 && !member.roles.contains(&role) {
-                            continue;
-                        }
-
-                        if let Some(role) = self.roles.get(&role) {
-                            data.push((role.position, overwrite.deny, overwrite.allow));
-                        }
-                    }
-                }
-
-                data.sort_by(|a, b| a.0.cmp(&b.0));
-
-                for overwrite in data {
-                    permissions = (permissions & !overwrite.1) | overwrite.2;
-                }
-            } else {
-                // Apply @everyone overwrites even if member's role list is unavailable
-                let everyone_overwrite = channel
-                    .permission_overwrites
-                    .iter()
-                    .find(|overwrite| match &overwrite.kind {
-                        PermissionOverwriteType::Role(role) => {
-                            role.0 == self.id.0
-                        }
-                        _ => false
-                    });
-
-                if let Some(overwrite) = everyone_overwrite {
-                    permissions = (permissions & !overwrite.deny) | overwrite.allow;
-                }
-            }
-
-            // Member
-            for overwrite in &channel.permission_overwrites {
-                if PermissionOverwriteType::Member(user_id) != overwrite.kind {
+        // Roles
+        for overwrite in &channel.permission_overwrites {
+            if let PermissionOverwriteType::Role(role) = overwrite.kind {
+                if role.0 != self.id.0 && !member.roles.contains(&role) {
                     continue;
                 }
 
-                permissions = (permissions & !overwrite.deny) | overwrite.allow;
+                if let Some(role) = self.roles.get(&role) {
+                    data.push((role.position, overwrite.deny, overwrite.allow));
+                }
             }
-        } else {
-            warn!(
-                "(╯°□°）╯︵ ┻━┻ Guild {} does not contain channel {}",
-                self.id,
-                channel_id
-            );
+        }
+
+        data.sort_by(|a, b| a.0.cmp(&b.0));
+
+        for overwrite in data {
+            permissions = (permissions & !overwrite.1) | overwrite.2;
+        }
+
+        // Member
+        for overwrite in &channel.permission_overwrites {
+            if PermissionOverwriteType::Member(member.user.id) != overwrite.kind {
+                continue;
+            }
+
+            permissions = (permissions & !overwrite.deny) | overwrite.allow;
         }
 
         // The default channel is always readable.
-        if channel_id.0 == self.id.0 {
+        if channel.id.0 == self.id.0 {
             permissions |= Permissions::READ_MESSAGES;
         }
 
         self.remove_unusable_permissions(&mut permissions);
 
-        permissions
+        Ok(permissions)
     }
 
     /// Calculate a [`Role`]'s permissions in a given channel in the guild.
     /// Returns `None` if given `role_id` cannot be found.
     #[inline]
-    pub fn role_permissions_in(&self, channel_id: impl Into<ChannelId>, role_id: impl Into<RoleId>) -> Option<Permissions> {
-        self._role_permissions_in(channel_id.into(), role_id.into())
-    }
-
-    fn _role_permissions_in(
-        &self,
-        channel_id: ChannelId,
-        role_id: RoleId,
-    ) -> Option<Permissions> {
-        let mut permissions = match self.roles.get(&role_id) {
-            Some(role) => role.permissions,
-            None => return None,
-        };
-
-        if permissions.contains(Permissions::ADMINISTRATOR) {
-            return Some(Permissions::all());
+    pub fn role_permissions_in(&self, channel: &GuildChannel, role: &Role) -> Result<Permissions> {
+        // Fail if the role or channel is not from this guild.
+        if role.guild_id != self.id || channel.guild_id != self.id {
+            return Err(Error::Model(ModelError::WrongGuild));
         }
 
-        if let Some(channel) = self.channels.get(&channel_id) {
-            for overwrite in &channel.permission_overwrites {
-                if let PermissionOverwriteType::Role(permissions_role_id) = overwrite.kind {
-                    if permissions_role_id == role_id {
-                        permissions = (permissions & !overwrite.deny) | overwrite.allow;
+        let mut permissions = role.permissions;
 
-                        break;
-                    }
+        if permissions.contains(Permissions::ADMINISTRATOR) {
+            return Ok(self.remove_unnecessary_voice_permissions(channel, Permissions::all()));
+        }
+
+        for overwrite in &channel.permission_overwrites {
+            if let PermissionOverwriteType::Role(permissions_role_id) = overwrite.kind {
+                if permissions_role_id == role.id {
+                    permissions = (permissions & !overwrite.deny) | overwrite.allow;
+
+                    break;
                 }
             }
-        } else {
-            warn!(
-                "(╯°□°）╯︵ ┻━┻ Guild {} does not contain channel {}",
-                self.id,
-                channel_id
-            );
-
-            return None;
         }
 
         self.remove_unusable_permissions(&mut permissions);
 
-        Some(permissions)
+        Ok(permissions)
     }
 
     /// Retrieves the count of the number of [`Member`]s that would be pruned
@@ -1524,6 +1462,21 @@ impl Guild {
                 | Permissions::CHANGE_NICKNAME
                 | Permissions::MANAGE_NICKNAMES);
         }
+    }
+
+    pub(crate) fn remove_unnecessary_voice_permissions(&self, channel: &GuildChannel, mut permissions: Permissions) -> Permissions {
+        // If this is a text channel, then throw out voice permissions.
+        if channel.kind == ChannelType::Text {
+            permissions &= !(Permissions::CONNECT
+                | Permissions::SPEAK
+                | Permissions::MUTE_MEMBERS
+                | Permissions::DEAFEN_MEMBERS
+                | Permissions::MOVE_MEMBERS
+                | Permissions::USE_VAD
+                | Permissions::STREAM);
+        }
+
+        permissions
     }
 
     /// Re-orders the channels of the guild.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -420,6 +420,24 @@ impl PartialGuild {
         self.id.move_member(&http, user_id, channel_id).await
     }
 
+    /// Calculate a [`Member`]'s permissions in a given channel in the guild.
+    #[inline]
+    pub fn user_permissions_in(&self, channel: &GuildChannel, member: &Member) -> Result<Permissions> {
+        Guild::_user_permissions_in(
+            channel,
+            member,
+            &self.roles,
+            self.owner_id,
+            self.id
+        )
+    }
+
+    /// Calculate a [`Role`]'s permissions in a given channel in the guild.
+    #[inline]
+    pub fn role_permissions_in(&self, channel: &GuildChannel, role: &Role) -> Result<Permissions> {
+        Guild::_role_permissions_in(channel, role, self.id)
+    }
+
     /// Gets the number of [`Member`]s that would be pruned with the given
     /// number of days.
     ///


### PR DESCRIPTION
These are currently the minimum changes I think would workably solve the problems with permissions in #1134. However, I think another breaking change *could* make the API nicer to use. If `GuildChannel::user_permissions_in` used `CacheHttp` instead of `AsRef<Cache>` it could fetch any uncached users. I'm guessing `Context` is being used most of the time and it implements both so I don't think this would be a roadblock for migrating for many and it would make that method correct more often.

Closes #1134.