### PR TITLE
Add Max Delay Limits, Delay Hook, and RateLimitInfo

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -29,7 +29,6 @@ use crate::model::{
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::sync::Mutex;
 use futures::future::BoxFuture;


### PR DESCRIPTION
This commit limits the maximum amount of rate limit delayed invocations.
By setting this limit to 0, all invocations will error instantly. Otherwise, they will only error once the limit is hit.
Maximum delay limits prevent a command user to spam the bot with delayed tasks, by default we allow 1 delay task.

Once a delay will be suggested, the bucket will hook an optional function.
This function may inform the user about the delay as delays are not forwarded to dispatch errors.

Errors will now contain a rate limit error, providing a comprehensive note about the rate limit.
They allow to avoid spamming "Try again in X seconds"-messages by checking `is_first_try`.
Additionally the info contains the duration, the active delays, maximum delays, and the action taken by the invocation handler.

Example 5 has been adjusted accordingly. The text is now clearer about what builder method affects the bucket in what way.

Please help testing this! :)