### PR TITLE
Change Message.author_nick() documentation

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -723,9 +723,7 @@ impl Message {
 
     /// Tries to return author's nickname in the current channel's guild.
     ///
-    /// **Note**:
-    /// If message was sent in a private channel, then the function will return
-    /// `None`.
+    /// Refer to [`User::nick_in()`] inside and `None` outside of a guild.
     #[inline]
     pub async fn author_nick(&self, cache_http: impl CacheHttp) -> Option<String> {
         self.author.nick_in(cache_http, self.guild_id?).await


### PR DESCRIPTION
This changes the documentation of `Message::author_nick()` to refer to the underlying functionality. The underlying functionality also can return `None` for the user not having one set.