### PR TITLE
fix(model): Use guild splash hash for splash_url() instead of icon hash

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2005,7 +2005,7 @@ impl From<u64> for GuildContainer {
 impl InviteGuild {
     /// Returns the formatted URL of the guild's splash image, if one exists.
     pub fn splash_url(&self) -> Option<String> {
-        self.splash_hash
+        self.splash
             .as_ref()
             .map(|splash| format!(cdn!("/splashes/{}/{}.webp?size=4096"), self.id, splash))
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1558,9 +1558,9 @@ impl Guild {
 
     /// Returns the formatted URL of the guild's splash image, if one exists.
     pub fn splash_url(&self) -> Option<String> {
-        self.icon
+        self.splash
             .as_ref()
-            .map(|icon| format!(cdn!("/splashes/{}/{}.webp"), self.id, icon))
+            .map(|splash| format!(cdn!("/splashes/{}/{}.webp?size=4096"), self.id, splash))
     }
 
     /// Starts an integration sync for the given integration Id.
@@ -2005,9 +2005,9 @@ impl From<u64> for GuildContainer {
 impl InviteGuild {
     /// Returns the formatted URL of the guild's splash image, if one exists.
     pub fn splash_url(&self) -> Option<String> {
-        self.icon
+        self.splash_hash
             .as_ref()
-            .map(|icon| format!(cdn!("/splashes/{}/{}.webp"), self.id, icon))
+            .map(|splash| format!(cdn!("/splashes/{}/{}.webp?size=4096"), self.id, splash))
     }
 }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -494,9 +494,9 @@ impl PartialGuild {
     /// Returns the formatted URL of the guild's splash image, if one exists.
     #[inline]
     pub fn splash_url(&self) -> Option<String> {
-        self.icon
+        self.splash
             .as_ref()
-            .map(|icon| format!(cdn!("/splashes/{}/{}.webp"), self.id, icon))
+            .map(|splash| format!(cdn!("/splashes/{}/{}.webp?size=4096"), self.id, splash))
     }
 
     /// Starts an integration sync for the given integration Id.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -213,7 +213,7 @@ pub struct InviteGuild {
     pub id: GuildId,
     pub icon: Option<String>,
     pub name: String,
-    pub splash_hash: Option<String>,
+    pub splash: Option<String>,
     pub text_channel_count: Option<u64>,
     pub voice_channel_count: Option<u64>,
 }


### PR DESCRIPTION
Currently it incorrectly uses the icon hash instead of the splash hash to create the splash_url.

### Other Changes

Renames `InviteGuild::splash_hash` field to `InviteGuild::splash` to correctly match the API response.

