### PR TITLE
Fix the stated order in `ChannelId::messages_iter`'s documentation

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -410,7 +410,7 @@ impl ChannelId {
     /// A buffer of at most 100 messages is used to reduce the number of calls.
     /// necessary.
     ///
-    /// The stream returns the oldest message first, followed by newer messages.
+    /// The stream returns the newest message first, followed by older messages.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The stream has been changed to return the newest messages first, then older.