### PR TITLE
fix(model): use `ApplicationId` instead of `u64` in `MessageApplication`

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -28,6 +28,7 @@ use std::{
 use crate::{
     constants,
     model::id::{
+        ApplicationId,
         MessageId,
         GuildId,
         ChannelId,
@@ -969,7 +970,7 @@ impl MessageActivityKind {
 #[non_exhaustive]
 pub struct MessageApplication {
     /// ID of the application.
-    pub id: u64,
+    pub id: ApplicationId,
     /// ID of the embed's image asset.
     pub cover_image: Option<String>,
     /// Application's description.


### PR DESCRIPTION
Currently messages coming from an application (such as game invites) will fail to deserialise as IDs are transmitted as strings.

Closes #1154