### PR TITLE
Log unhandled errors when handling gateway events

### DIFF
--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -561,7 +561,13 @@ impl Shard {
 
                 Ok(Some(ShardAction::Reconnect(self.reconnection_type())))
             },
-            _ => Ok(None),
+            Err(ref why) => {
+                warn!("[Shard {:?}] Unhandled error: {:?}",
+                    self.shard_info,
+                    why);
+
+                Ok(None)
+            },
         }
     }
 


### PR DESCRIPTION
Was debugging something that was actually an error that wasn't being logged to the console. Replaced the catch all it's okay don't you don't have to worry about a thing, it's going to be `Ok(None)` handler.