### PR TITLE
Fix deserialization of `Interaction`s

### DIFF
--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -3,11 +3,14 @@
 use super::prelude::*;
 use crate::internal::prelude::*;
 
+use serde::de::{Deserialize, Deserializer, Error as DeError};
+use serde_json::{Value, Number};
+
 /// Information about an interaction.
 ///
 /// An interaction is sent when a user invokes a slash command and is the same
 /// for slash commands and other future interaction types.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct Interaction {
     pub id: InteractionId,
@@ -21,14 +24,88 @@ pub struct Interaction {
     pub version: u8,
 }
 
+impl<'de> Deserialize<'de> for Interaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        let mut map = JsonMap::deserialize(deserializer)?;
+
+        let id = map.get("guild_id")
+            .and_then(|x| x.as_str())
+            .and_then(|x| x.parse::<u64>().ok());
+
+        if let Some(guild_id) = id {
+            if let Some(member) = map.get_mut("member").and_then(|x| x.as_object_mut()) {
+                member
+                    .insert("guild_id".to_string(), Value::Number(Number::from(guild_id)));
+            }
+        }
+
+        let id = map.remove("id")
+            .ok_or_else(|| DeError::custom("expected id"))
+            .and_then(InteractionId::deserialize)
+            .map_err(DeError::custom)?;
+
+        let kind = map.remove("type")
+            .ok_or_else(|| DeError::custom("expected type"))
+            .and_then(InteractionType::deserialize)
+            .map_err(DeError::custom)?;
+
+        let data = match map.remove("data") {
+            Some(v) => serde_json::from_value::<Option<ApplicationCommandInteractionData>>(v)
+                .map_err(DeError::custom)?,
+            None => None,
+        };
+
+        let guild_id = map.remove("guild_id")
+            .ok_or_else(|| DeError::custom("expected guild_id"))
+            .and_then(GuildId::deserialize)
+            .map_err(DeError::custom)?;
+
+        let channel_id = map.remove("channel_id")
+            .ok_or_else(|| DeError::custom("expected channel_id"))
+            .and_then(ChannelId::deserialize)
+            .map_err(DeError::custom)?;
+
+        let member = map.remove("member")
+            .ok_or_else(|| DeError::custom("expected member"))
+            .and_then(Member::deserialize)
+            .map_err(DeError::custom)?;
+
+        let token = map.remove("token")
+            .ok_or_else(|| DeError::custom("expected token"))
+            .and_then(String::deserialize)
+            .map_err(DeError::custom)?;
+
+        let version = map.remove("version")
+            .ok_or_else(|| DeError::custom("expected version"))
+            .and_then(u8::deserialize)
+            .map_err(DeError::custom)?;
+
+        Ok(Self {
+            id,
+            kind,
+            data,
+            guild_id,
+            channel_id,
+            member,
+            token,
+            version,
+        })
+    }
+}
+
 /// The type of an Interaction
-#[derive(Copy, Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum InteractionType {
     Ping = 1,
     ApplicationCommand = 2,
 }
+
+enum_number!(InteractionType {
+    Ping,
+    ApplicationCommand,
+});
 
 /// The command data payload.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -125,7 +125,7 @@ pub struct ApplicationCommandInteractionData {
 #[non_exhaustive]
 pub struct ApplicationCommandInteractionDataOption {
     pub name: String,
-    pub value: Option<ApplicationCommandOptionType>,
+    pub value: Option<Value>,
     #[serde(default)]
     pub options: Vec<ApplicationCommandInteractionDataOption>,
 }
@@ -161,7 +161,7 @@ pub struct ApplicationCommandOption {
 }
 
 /// The type of an application command option.
-#[derive(Copy, Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum ApplicationCommandOptionType {
@@ -174,6 +174,17 @@ pub enum ApplicationCommandOptionType {
     Channel = 7,
     Role = 8,
 }
+
+enum_number!(ApplicationCommandOptionType {
+    SubCommand,
+    SubCommandGroup,
+    String,
+    Integer,
+    Boolean,
+    User,
+    Channel,
+    Role,
+});
 
 /// The only valid values a user can pick in a command option.
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This fixes deserialization of interactions by:
- Injecting the `guild_id` field into the `member` field in the `Interaction` structure
- Implementing `Serialize` and `Deserialize` for `InteractionType` using `enum_number!`
- Implementing `Serialize` and `Deserialize` for `ApplicationCommandOptionType` using `enum_number!`
- Changing `Option<ApplicationCommandOptionType>` to `Option<Value>`

Closes #1160.