### PR TITLE
Bump the required version of the command_attr crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 
 [dependencies.command_attr]
 path = "./command_attr"
-version = "0.3"
+version = "0.3.3"
 optional = true
 
 [dependencies.serde]


### PR DESCRIPTION
Serenity v0.10 requires command_attr v0.3.3 

```
cargo up -p command_attr --precise 0.3.2
    Updating crates.io index
    Updating command_attr v0.3.3 -> v0.3.2

cargo c
error[E0063]: missing field `summary` in initializer of `GroupOptions`
  --> src/commands.rs:48:1
   |
48 | #[group]
   | ^^^^^^^^ missing `summary`
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```
