### PR TITLE
Bump to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project mostly adheres to [Semantic Versioning][semver].
 
+## [0.10.1] - 2021-01-07
+
+Thanks to the following for their contributions:
+
+- [@nickelc]
+
+### Fixed
+
+- [misc] Bump the required version of the `command_attr` crate ([@nickelc]) [c:ab8c82b]
+
 ## [0.10.0] - 2021-01-06
 
 Thanks to the following for their contributions:
@@ -3957,6 +3967,7 @@ Initial commit.
 
 <!-- COMPARISONS -->
 
+[0.10.1]: https://github.com/serenity-rs/serenity/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/serenity-rs/serenity/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/serenity-rs/serenity/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/serenity-rs/serenity/compare/v0.9.2...v0.9.3
@@ -4176,6 +4187,8 @@ Initial commit.
 
 
 <!-- COMMITS -->
+
+[c:ab8c82b]: https://github.com/serenity-rs/serenity/commit/ab8c82bddc2854f17e04efd10ccfd5357a5b415f
 
 [c:2624170]: https://github.com/serenity-rs/serenity/commit/2624170835961e57fe00f027763166d74613b8da
 [c:7647e1e]: https://github.com/serenity-rs/serenity/commit/7647e1e7bb4754a5880246312fb807daede31b23

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 name = "serenity"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/serenity.git"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2018"
 include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 


### PR DESCRIPTION
This prepares for the release of `0.10.1` by updating the `CHANGELOG.md` file and updating the version in relevant places.

This is a hotfix release to fix a versioning issue with `command_attr`, as `0.3.2` is not compatible with `0.10.0`.

The full, unsullied changelog for the release that will be put on Github's releases is:

---
Thanks to the following for their contributions:

- [@nickelc]

### Fixed

- [misc] Bump the required version of the `command_attr` crate ([@nickelc]) [c:ab8c82b]

[@nickelc]: https://github.com/nickelc

[c:ab8c82b]: https://github.com/serenity-rs/serenity/commit/ab8c82bddc2854f17e04efd10ccfd5357a5b415f