### PR TITLE
Add Cargo-features for `tokio` version `0.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,10 +126,10 @@ package = "http"
 
 [features]
 # Defaults with different backends
-default = ["default_no_backend" "rustls_backend"]
-default_native_tls = ["default_no_backend" "native_tls_backend"]
-default_tokio_0_2 = ["default_no_backend" "rustls_tokio_0_2_backend"]
-default_native_tls_tokio_0_2 = ["default_no_backend" "native_tls_tokio_0_2_backend"]
+default = ["default_no_backend", "rustls_backend"]
+default_native_tls = ["default_no_backend", "native_tls_backend"]
+default_tokio_0_2 = ["default_no_backend", "rustls_tokio_0_2_backend"]
+default_native_tls_tokio_0_2 = ["default_no_backend", "native_tls_tokio_0_2_backend"]
 
 # Serenity requires a backend, this picks all default features without a backend.
 default_no_backend = ["builder", "cache", "client", "framework", "gateway", "model", "http", "standard_framework", "utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,14 @@ features = ["json", "multipart", "stream"]
 optional = true
 version = "0.11"
 
+# Tokio v0.2
+[dependencies.reqwest_compat]
+package = "reqwest"
+default-features = false
+features = ["json", "stream"]
+optional = true
+version = "0.10"
+
 [dependencies.serenity-voice-model]
 path = "./voice-model"
 version = "0.1"
@@ -65,6 +73,14 @@ features = ["tokio-runtime"]
 optional = true
 version = "0.11"
 
+# Tokio v0.2
+[dependencies.async-tungstenite_compat]
+package = "async-tungstenite"
+default-features = false
+features = ["tokio-runtime"]
+optional = true
+version = "0.9"
+
 [dependencies.typemap_rev]
 optional = true
 version = "0.1.3"
@@ -77,10 +93,24 @@ version = "^2.1"
 optional = true
 version = "1.0"
 
+[dependencies.bytes_compat]
+package = "bytes"
+optional = true
+version = "0.5"
+
 [dependencies.tokio]
 version = "1.0"
-default-features = false
+default-features = true
+optional = true
 features = ["fs", "macros", "rt", "sync", "time"]
+
+# Tokio v0.2
+[dependencies.tokio_compat]
+package = "tokio"
+version = "0.2"
+optional = true
+default-features = true
+features = ["fs", "macros", "rt-core", "sync", "time", "stream"]
 
 [dependencies.futures]
 version = "0.3"
@@ -104,16 +134,23 @@ client = ["http", "typemap_rev"]
 extras = []
 framework = ["client", "model", "utils"]
 gateway = ["flate2", "http", "url", "utils"]
-http = ["url", "bytes"]
+http = ["url"]
 absolute_ratelimits = ["http"]
-rustls_backend = ["reqwest/rustls-tls", "async-tungstenite/tokio-rustls"]
-native_tls_backend = ["reqwest/native-tls", "async-tungstenite/tokio-native-tls"]
 model = ["builder", "http"]
 voice-model = ["serenity-voice-model"]
 standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]
 unstable_discord_api = []
 utils = ["base64"]
 voice = ["client", "model"]
+
+# Backends
+rustls_backend = ["reqwest/rustls-tls", "async-tungstenite/tokio-rustls", "tokio", "rustls_backend_marker", "bytes"]
+rustls_tokio_0_2_backend = ["reqwest_compat/rustls-tls", "async-tungstenite_compat/tokio-rustls", "tokio_compat", "bytes_compat", "rustls_backend_marker"]
+rustls_backend_marker = []
+
+native_tls_backend = ["reqwest/native-tls", "async-tungstenite/tokio-native-tls", "tokio", "bytes", "native_tls_backend_marker"]
+native_tls_tokio_0_2_backend = ["reqwest_compat/native-tls", "async-tungstenite_compat/tokio-native-tls", "tokio_compat", "bytes_compat", "native_tls_backend_marker"]
+native_tls_backend_marker = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,8 +125,15 @@ version = "0.2"
 package = "http"
 
 [features]
-default = ["builder", "cache", "client", "framework", "gateway", "model", "http", "standard_framework", "utils", "rustls_backend"]
-default_native_tls = ["builder", "cache", "client", "framework", "gateway", "model", "http", "standard_framework", "utils", "native_tls_backend"]
+# Defaults with different backends
+default = ["default_no_backend" "rustls_backend"]
+default_native_tls = ["default_no_backend" "native_tls_backend"]
+default_tokio_0_2 = ["default_no_backend" "rustls_tokio_0_2_backend"]
+default_native_tls_tokio_0_2 = ["default_no_backend" "native_tls_tokio_0_2_backend"]
+
+# Serenity requires a backend, this picks all default features without a backend.
+default_no_backend = ["builder", "cache", "client", "framework", "gateway", "model", "http", "standard_framework", "utils"]
+
 builder = ["utils"]
 cache = []
 collector = ["gateway", "model"]
@@ -143,13 +150,17 @@ unstable_discord_api = []
 utils = ["base64"]
 voice = ["client", "model"]
 
-# Backends
+# Backends to pick from:
+# - Rustls Backends
 rustls_backend = ["reqwest/rustls-tls", "async-tungstenite/tokio-rustls", "tokio", "rustls_backend_marker", "bytes"]
 rustls_tokio_0_2_backend = ["reqwest_compat/rustls-tls", "async-tungstenite_compat/tokio-rustls", "tokio_compat", "bytes_compat", "rustls_backend_marker"]
+# Marks that a Rustls backend is active
 rustls_backend_marker = []
 
+# - Native TLS Backends
 native_tls_backend = ["reqwest/native-tls", "async-tungstenite/tokio-native-tls", "tokio", "bytes", "native_tls_backend_marker"]
 native_tls_tokio_0_2_backend = ["reqwest_compat/native-tls", "async-tungstenite_compat/tokio-native-tls", "tokio_compat", "bytes_compat", "native_tls_backend_marker"]
+# Marks that a Native TLS backend is active
 native_tls_backend_marker = []
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ optional = true
 version = "0.5"
 
 [dependencies.tokio]
-version = "1.0"
+version = "1"
 default-features = true
 optional = true
 features = ["fs", "macros", "rt", "sync", "time"]

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ There are these alternative default features, they require to set `default-featu
 - **default_native_tls_tokio_0_2**: Uses `native_tls_backend` with `tokio` version `0.2`.
 - **default_no_backend**: Excludes the default backend, pick your own backend instead.
 
-If you are unsure which to pick, just go with the normal default features (by not setting `default-features = false`).
+If you are unsure which to pick, use the default features by not setting `default-features = false`.
 
 The following is a full list of features:
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ TLS implementation.
 - **native_tls_backend**: Uses SChannel on Windows, Secure Transport on macOS,
 and OpenSSL on other platforms.
 
-In case you need the old `tokio` version `0.2`, pick one of these backends instead:
+If you need to use `tokio` version `0.2` use the backends below:
 
 - **rustls_tokio_0_2_backend**: Combines **rustls_backend** with `tokio` version `0.2`.
 - **native_tls_tokio_0_2_backend**: Combines **native_tls_backend** with `tokio` version `0.2`.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ version = "0.10"
 The default features are: `builder`, `cache`, `client`, `framework`, `gateway`,
 `http`, `model`, `standard_framework`, `utils`, and `rustls_backend`.
 
+There are these alternative default features, they require to set `default-features = false`:
+
+- **default_tokio_0_2**: Uses the default backend with `tokio` version `0.2`.
+- **default_native_tls**: Uses `native_tls_backend` instead of the default `rustls_backend`.
+- **default_native_tls_tokio_0_2**: Uses `native_tls_backend` with `tokio` version `0.2`.
+- **default_no_backend**: Excludes the default backend, pick your own backend instead.
+
+If you are unsure which to pick, just go with the normal default features (by not setting `default-features = false`).
+
 The following is a full list of features:
 
 - **builder**: The builders used in conjunction with models' methods.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ TLS implementation.
 - **native_tls_backend**: Uses SChannel on Windows, Secure Transport on macOS,
 and OpenSSL on other platforms.
 
+In case you need the old `tokio` version `0.2`, pick one of these backends instead:
+
+- **rustls_tokio_0_2_backend**: Combines **rustls_backend** with `tokio` version `0.2`.
+- **native_tls_tokio_0_2_backend**: Combines **native_tls_backend** with `tokio` version `0.2`.
 
 If you want all of the default features except for `cache` for example, you can
 list all but that:

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 #[cfg(all(any(feature = "http", feature = "gateway"),
-    not(any(feature = "rustls_backend", feature = "native_tls_backend"))))]
+    not(any(feature = "rustls_backend_marker", feature = "native_tls_backend_marker"))))]
 compile_error!("You have the `http` or `gateway` feature enabled, \
     either the `rustls_backend` or `native_tls_backend` feature must be
     selected to let Serenity use `http` or `gateway`.\n\

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -10,9 +10,10 @@ use futures::{
     StreamExt,
     channel::mpsc::{UnboundedSender as Sender, UnboundedReceiver as Receiver},
 };
-#[cfg(feature = "tokio_compat")]
+#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
 use tokio::time::delay_for as sleep;
-#[cfg(not(feature = "tokio_compat"))]
+
+#[cfg(feature = "tokio")]
 use tokio::time::sleep;
 
 use tokio::time::{timeout, Duration, Instant};

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -10,7 +10,12 @@ use futures::{
     StreamExt,
     channel::mpsc::{UnboundedSender as Sender, UnboundedReceiver as Receiver},
 };
-use tokio::time::{sleep, timeout, Duration, Instant};
+#[cfg(feature = "tokio_compat")]
+use tokio::time::delay_for as sleep;
+#[cfg(not(feature = "tokio_compat"))]
+use tokio::time::sleep;
+
+use tokio::time::{timeout, Duration, Instant};
 use crate::client::{EventHandler, RawEventHandler};
 use super::{
     GatewayIntents,

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -12,8 +12,13 @@ use tokio::{
         UnboundedReceiver as Receiver,
         UnboundedSender as Sender,
     },
-    time::{Sleep, sleep},
 };
+#[cfg(feature = "tokio_compat")]
+use tokio::time::{Delay as Sleep, delay_for as sleep};
+
+#[cfg(not(feature = "tokio_compat"))]
+use tokio::time::{Sleep, sleep};
+
 use futures::{
     future::BoxFuture,
     stream::{Stream, StreamExt},

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -13,10 +13,10 @@ use tokio::{
         UnboundedSender as Sender,
     },
 };
-#[cfg(feature = "tokio_compat")]
+#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
 use tokio::time::{Delay as Sleep, delay_for as sleep};
 
-#[cfg(not(feature = "tokio_compat"))]
+#[cfg(feature = "tokio")]
 use tokio::time::{Sleep, sleep};
 
 use futures::{

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -22,10 +22,10 @@ use crate::{
     model::channel::Reaction,
     model::id::UserId,
 };
-#[cfg(feature = "tokio_compat")]
+#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
 use tokio::time::{Delay as Sleep, delay_for as sleep};
 
-#[cfg(not(feature = "tokio_compat"))]
+#[cfg(feature = "tokio")]
 use tokio::time::{Sleep, sleep};
 
 macro_rules! impl_reaction_collector {

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -12,7 +12,6 @@ use tokio::{
         UnboundedReceiver as Receiver,
         UnboundedSender as Sender,
     },
-    time::{Sleep, sleep},
 };
 use futures::{
     future::BoxFuture,
@@ -23,6 +22,11 @@ use crate::{
     model::channel::Reaction,
     model::id::UserId,
 };
+#[cfg(feature = "tokio_compat")]
+use tokio::time::{Delay as Sleep, delay_for as sleep};
+
+#[cfg(not(feature = "tokio_compat"))]
+use tokio::time::{Sleep, sleep};
 
 macro_rules! impl_reaction_collector {
     ($($name:ident;)*) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ use crate::client::ClientError;
 use crate::gateway::GatewayError;
 #[cfg(feature = "http")]
 use crate::http::HttpError;
-#[cfg(all(feature = "gateway", feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "gateway", feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 use crate::internal::ws_impl::RustlsError;
 
 /// The common result type between most library functions.
@@ -91,7 +91,7 @@ pub enum Error {
     #[cfg(feature = "http")]
     Http(Box<HttpError>),
     /// An error occuring in rustls
-    #[cfg(all(feature = "gateway", feature = "rustls_backend", not(feature = "native_tls_backend")))]
+    #[cfg(all(feature = "gateway", feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
     Rustls(RustlsError),
     /// An error from the `tungstenite` crate.
     #[cfg(feature = "gateway")]
@@ -123,7 +123,7 @@ impl From<ModelError> for Error {
     fn from(e: ModelError) -> Error { Error::Model(e) }
 }
 
-#[cfg(all(feature = "gateway", feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "gateway", feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 impl From<RustlsError> for Error {
     fn from(e: RustlsError) -> Error { Error::Rustls(e) }
 }
@@ -166,7 +166,7 @@ impl Display for Error {
             Error::Gateway(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "http")]
             Error::Http(inner) => fmt::Display::fmt(&inner, f),
-            #[cfg(all(feature = "gateway", not(feature = "native_tls_backend")))]
+            #[cfg(all(feature = "gateway", not(feature = "native_tls_backend_marker")))]
             Error::Rustls(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "gateway")]
             Error::Tungstenite(inner) => fmt::Display::fmt(&inner, f),
@@ -189,7 +189,7 @@ impl StdError for Error {
             Error::Gateway(inner) => Some(inner),
             #[cfg(feature = "http")]
             Error::Http(inner) => Some(inner),
-            #[cfg(all(feature = "gateway", feature = "rustls_backend", not(feature = "native_tls_backend")))]
+            #[cfg(all(feature = "gateway", feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
             Error::Rustls(inner) => Some(inner),
             #[cfg(feature = "gateway")]
             Error::Tungstenite(inner) => Some(inner),

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -45,6 +45,11 @@ use crate::model::guild::Member;
 #[cfg(all(feature = "cache", feature = "http", feature = "model"))]
 use crate::model::{guild::Role, id::RoleId};
 
+#[cfg(feature = "tokio_compat")]
+use tokio::time::delay_for as sleep;
+#[cfg(not(feature = "tokio_compat"))]
+use tokio::time::sleep;
+
 /// An enum representing all possible fail conditions under which a command won't
 /// be executed.
 #[derive(Debug)]
@@ -297,7 +302,7 @@ impl StandardFramework {
             }
 
             match duration {
-                Some(duration) => tokio::time::sleep(duration).await,
+                Some(duration) => sleep(duration).await,
                 None => break,
             }
         }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -45,9 +45,10 @@ use crate::model::guild::Member;
 #[cfg(all(feature = "cache", feature = "http", feature = "model"))]
 use crate::model::{guild::Role, id::RoleId};
 
-#[cfg(feature = "tokio_compat")]
+#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
 use tokio::time::delay_for as sleep;
-#[cfg(not(feature = "tokio_compat"))]
+
+#[cfg(feature = "tokio")]
 use tokio::time::sleep;
 
 /// An enum representing all possible fail conditions under which a command won't

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -28,10 +28,10 @@ use async_tungstenite::tungstenite::{
 use url::Url;
 use tracing::{error, debug, info, trace, warn, instrument};
 
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 use crate::internal::ws_impl::create_rustls_client;
 
-#[cfg(feature = "native_tls_backend")]
+#[cfg(feature = "native_tls_backend_marker")]
 use crate::internal::ws_impl::create_native_tls_client;
 
 /// A Shard is a higher-level handler for a websocket connection to Discord's
@@ -838,14 +838,14 @@ impl Shard {
     }
 }
 
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 async fn connect(base_url: &str) -> Result<WsStream> {
     let url = build_gateway_url(base_url)?;
 
     Ok(create_rustls_client(url).await?)
 }
 
-#[cfg(feature = "native_tls_backend")]
+#[cfg(feature = "native_tls_backend_marker")]
 async fn connect(base_url: &str) -> Result<WsStream> {
     let url = build_gateway_url(base_url)?;
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -34,6 +34,7 @@ use tokio::{
     io::AsyncReadExt,
     fs::File,
 };
+
 use crate::http::routing::Route;
 use percent_encoding::{
     utf8_percent_encode,
@@ -183,7 +184,7 @@ impl Http {
 
         let mut headers = Headers::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
-    
+
         let response = self.request(Request {
             body: Some(&body),
             headers: Some(headers),
@@ -2179,12 +2180,12 @@ impl Http {
     }
 }
 
-#[cfg(not(feature = "native_tls_backend"))]
+#[cfg(not(feature = "native_tls_backend_marker"))]
 fn configure_client_backend(builder: ClientBuilder) -> ClientBuilder {
     builder.use_rustls_tls()
 }
 
-#[cfg(feature = "native_tls_backend")]
+#[cfg(feature = "native_tls_backend_marker")]
 fn configure_client_backend(builder: ClientBuilder) -> ClientBuilder {
     builder.use_native_tls()
 }

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -57,7 +57,12 @@ use std::{
     i64,
     f64,
 };
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration};
+#[cfg(feature = "tokio_compat")]
+use tokio::time::delay_for as sleep;
+#[cfg(not(feature = "tokio_compat"))]
+use tokio::time::sleep;
+
 use super::{HttpError, Request};
 use tracing::{debug, instrument};
 

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -58,9 +58,11 @@ use std::{
     f64,
 };
 use tokio::time::{Duration};
-#[cfg(feature = "tokio_compat")]
+
+#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
 use tokio::time::delay_for as sleep;
-#[cfg(not(feature = "tokio_compat"))]
+
+#[cfg(feature = "tokio")]
 use tokio::time::sleep;
 
 use super::{HttpError, Request};

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -1,6 +1,10 @@
 use crate::{error::Result, http::Http};
 use std::sync::Arc;
-use tokio::{sync::oneshot::{self, Sender, error::TryRecvError}, time::{sleep, Duration}};
+use tokio::{sync::oneshot::{self, Sender, error::TryRecvError}, time::Duration};
+#[cfg(feature = "tokio_compat")]
+use tokio::time::delay_for as sleep;
+#[cfg(not(feature = "tokio_compat"))]
+use tokio::time::sleep;
 
 /// A struct to start typing in a [`Channel`] for an indefinite period of time.
 ///

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -1,9 +1,11 @@
 use crate::{error::Result, http::Http};
 use std::sync::Arc;
 use tokio::{sync::oneshot::{self, Sender, error::TryRecvError}, time::Duration};
-#[cfg(feature = "tokio_compat")]
+
+#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
 use tokio::time::delay_for as sleep;
-#[cfg(not(feature = "tokio_compat"))]
+
+#[cfg(feature = "tokio")]
 use tokio::time::sleep;
 
 /// A struct to start typing in a [`Channel`] for an indefinite period of time.

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -7,7 +7,7 @@ use tracing::{warn, instrument};
 use futures::{SinkExt, StreamExt, TryStreamExt};
 use tokio::time::timeout;
 
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 use std::{
     error::Error as StdError,
     fmt::{
@@ -106,7 +106,7 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Valu
 /// An error that occured while connecting over rustls
 #[derive(Debug)]
 #[non_exhaustive]
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 pub enum RustlsError {
     /// WebPKI X.509 Certificate Validation Error.
     WebPKI,
@@ -116,14 +116,14 @@ pub enum RustlsError {
     Io(IoError),
 }
 
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 impl From<IoError> for RustlsError {
     fn from(e: IoError) -> Self {
         RustlsError::Io(e)
     }
 }
 
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 impl Display for RustlsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
@@ -134,7 +134,7 @@ impl Display for RustlsError {
     }
 }
 
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 impl StdError for RustlsError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
@@ -144,7 +144,7 @@ impl StdError for RustlsError {
     }
 }
 
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
+#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 #[instrument]
 pub(crate) async fn create_rustls_client(url: Url) -> Result<WsStream> {
     let (stream, _) = async_tungstenite::tokio::connect_async_with_config::<Url>(
@@ -160,7 +160,7 @@ pub(crate) async fn create_rustls_client(url: Url) -> Result<WsStream> {
     Ok(stream)
 }
 
-#[cfg(feature = "native_tls_backend")]
+#[cfg(feature = "native_tls_backend_marker")]
 #[instrument]
 pub(crate) async fn create_native_tls_client(url: Url) -> Result<WsStream> {
     let (stream, _) = async_tungstenite::tokio::connect_async_with_config::<Url>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ extern crate tokio_compat as tokio;
 #[cfg(all(feature = "reqwest_compat", not(feature = "reqwest")))]
 extern crate reqwest_compat as reqwest;
 
-#[cfg(all(feature = "async_tungstenite_compat", not(feature = "async_tungstenite")))]
+#[cfg(all(feature = "async_tungstenite_compat", not(feature = "async-tungstenite")))]
 extern crate async_tungstenite_compat as async_tungstenite;
 
 #[cfg(all(feature = "bytes_compat", not(feature = "bytes")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ extern crate tokio_compat as tokio;
 #[cfg(all(feature = "reqwest_compat", not(feature = "reqwest")))]
 extern crate reqwest_compat as reqwest;
 
-#[cfg(all(feature = "async_tungstenite_compat", not(feature = "async-tungstenite")))]
+#[cfg(all(feature = "async-tungstenite_compat", not(feature = "async-tungstenite")))]
 extern crate async_tungstenite_compat as async_tungstenite;
 
 #[cfg(all(feature = "bytes_compat", not(feature = "bytes")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,16 +59,16 @@
 #[macro_use]
 extern crate serde;
 
-#[cfg(feature = "tokio_compat")]
+#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
 extern crate tokio_compat as tokio;
 
-#[cfg(feature = "reqwest_compat")]
+#[cfg(all(feature = "reqwest_compat", not(feature = "reqwest")))]
 extern crate reqwest_compat as reqwest;
 
-#[cfg(feature = "async_tungstenite_compat")]
+#[cfg(all(feature = "async_tungstenite_compat", not(feature = "async_tungstenite")))]
 extern crate async_tungstenite_compat as async_tungstenite;
 
-#[cfg(feature = "bytes_compat")]
+#[cfg(all(feature = "bytes_compat", not(feature = "bytes")))]
 extern crate bytes_compat as bytes;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,18 @@
 #[macro_use]
 extern crate serde;
 
+#[cfg(feature = "tokio_compat")]
+extern crate tokio_compat as tokio;
+
+#[cfg(feature = "reqwest_compat")]
+extern crate reqwest_compat as reqwest;
+
+#[cfg(feature = "async_tungstenite_compat")]
+extern crate async_tungstenite_compat as async_tungstenite;
+
+#[cfg(feature = "bytes_compat")]
+extern crate bytes_compat as bytes;
+
 #[macro_use]
 mod internal;
 


### PR DESCRIPTION
This allows to use `rustls` and `native_tls` together with the old `tokio`.

**Motivation**:
The Rust ecosystem is still catching up, many crates still rely on `tokio` version `0.2`.
This feature offers support to stay up-to-date with Serenity while waiting for crates to upgrade.
There is no guarantee for how long and whether this feature will stay around.

**Implementation**:
It introduces two new features: `rustls_tokio_0_2_backend` and `native_tls_tokio_0_2_backend`, allowing to use `tokio` version `0.2`.
This is a stable change, breaking compilation in Serenity `0.10` or side-effects, e.g. pulling in more dependencies than before, are unintended.
Marker-features were added to both backends to simplify checking if either the `tokio` version `1` or version `0.2` variant is active.

It's up to debate whether these features should get their own CI build.

Please test this pull request to catch regressions and potential broken feature-sets.