### PR TITLE
Ignore the `msg` parameter when creating a tracing span

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -602,7 +602,7 @@ impl StandardFramework {
 
 #[async_trait]
 impl Framework for StandardFramework {
-    #[instrument(skip(self, ctx))]
+    #[instrument(skip(self, ctx, msg))]
     async fn dispatch(&self, mut ctx: Context, msg: Message) {
         if self.should_ignore(&msg) {
             return;


### PR DESCRIPTION
This ignores the `msg` parameter in `StandardFramework::dispatch` when creating tracing spans. Messages can contain a lot of data, and this can oftentimes obscure and clutter a log. For example:
```
Jan 14 17:53:18.295  INFO dispatch{msg=Message { id: MessageId(799320248125751327), attachments: [], author: User { id: UserId(110372470472613888), avatar: Some("1563d975e58947078ebc0a92b97ef316"), bot: false, discriminator: 5503, name: "acdenisSK" }, channel_id: ChannelId(178231442310955008), content: "???ping", edited_timestamp: None, embeds: [], guild_id: Some(GuildId(137234234728251392)), kind: Regular, member: Some(PartialMember { deaf: false, joined_at: Some(2016-01-14T16:39:51.250Z), mute: false, nick: None, roles: [RoleId(751804608829063208), RoleId(775727562764582932), RoleId(775727589859131402)] }), mention_everyone: false, mention_roles: [], mention_channels: [], mentions: [], nonce: String("799320244903477248"), pinned: false, reactions: [], timestamp: 2021-01-14T16:53:17.805Z, tts: false, webhook_id: None, activity: None, application: None, message_reference: None, flags: Some((empty)), stickers: [], referenced_message: None }}: kitty_rs: Command `ping` was used by acdenisSK
```
