### PR TITLE
Allow users to reuse `Http` when building the `Client`

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -87,17 +87,7 @@ pub struct ClientBuilder<'a> {
 
 #[cfg(feature = "gateway")]
 impl<'a> ClientBuilder<'a> {
-    /// Construct a new builder to call methods on for the client construction.
-    /// The `token` will automatically be prefixed "Bot " if not already.
-    ///
-    /// **Panic**:
-    /// If you enabled the `framework`-feature (on by default), you must specify
-    /// a framework via the [`framework`] or [`framework_arc`] method,
-    /// otherwise awaiting the builder will cause a panic.
-    ///
-    /// [`framework`]: Self::framework
-    /// [`framework_arc`]: Self::framework_arc
-    pub fn new(token: impl AsRef<str>) -> Self {
+    fn _new() -> Self {
         Self {
             data: Some(TypeMap::new()),
             http: None,
@@ -111,7 +101,38 @@ impl<'a> ClientBuilder<'a> {
             voice_manager: None,
             event_handler: None,
             raw_event_handler: None,
-        }.token(token)
+        }
+    }
+
+    /// Construct a new builder to call methods on for the client construction.
+    /// The `token` will automatically be prefixed "Bot " if not already.
+    ///
+    /// **Panic**:
+    /// If you enabled the `framework`-feature (on by default), you must specify
+    /// a framework via the [`framework`] or [`framework_arc`] method,
+    /// otherwise awaiting the builder will cause a panic.
+    ///
+    /// [`framework`]: Self::framework
+    /// [`framework_arc`]: Self::framework_arc
+    pub fn new(token: impl AsRef<str>) -> Self {
+        Self::_new().token(token)
+    }
+
+    /// Construct a new builder with a [`Http`] instance to calls methods on
+    /// for the client construction.
+    ///
+    /// **Panic**:
+    /// If you enabled the `framework`-feature (on by default), you must specify
+    /// a framework via the [`framework`] or [`framework_arc`] method,
+    /// otherwise awaiting the builder will cause a panic.
+    ///
+    /// [`Http`]: crate::http::Http
+    /// [`framework`]: Self::framework
+    /// [`framework_arc`]: Self::framework_arc
+    pub fn new_with_http(http: Http) -> Self {
+        let mut c = Self::_new();
+        c.http = Some(http);
+        c
     }
 
     /// Sets a token for the bot. If the token is not prefixed "Bot ",

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -108,7 +108,7 @@ impl<'a> ClientBuilder<'a> {
     /// The `token` will automatically be prefixed "Bot " if not already.
     ///
     /// **Panic**:
-    /// If you enabled the `framework`-feature (on by default), you must specify
+    /// If you have enabled the `framework`-feature (on by default), you must specify
     /// a framework via the [`framework`] or [`framework_arc`] method,
     /// otherwise awaiting the builder will cause a panic.
     ///
@@ -122,7 +122,7 @@ impl<'a> ClientBuilder<'a> {
     /// for the client construction.
     ///
     /// **Panic**:
-    /// If you enabled the `framework`-feature (on by default), you must specify
+    /// If you have enabled the `framework`-feature (on by default), you must specify
     /// a framework via the [`framework`] or [`framework_arc`] method,
     /// otherwise awaiting the builder will cause a panic.
     ///


### PR DESCRIPTION
This adds a new construction method to the `ClientBuilder`, `new_with_http`, that will allow users to reuse their instances of the `Http` client. 

This can be useful in the case when a user creates a `Http` instance to retrieve their bot's user id for the [`Configuration::on_mention`][on_mention] method, and then wish to pass that instance to the `ClientBuilder` to bypass unnecessary creation of a second `Http` instance.

[on_mention]: https://serenity-rs.github.io/serenity/current/serenity/framework/standard/struct.Configuration.html#method.on_mention