### PR TITLE
Update Example 6

### DIFF
--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -40,7 +40,7 @@ use commands::{
     owner::*,
 };
 
-struct ShardManagerContainer;
+pub struct ShardManagerContainer;
 
 impl TypeMapKey for ShardManagerContainer {
     type Value = Arc<Mutex<ShardManager>>;


### PR DESCRIPTION
Example 6 uses the `ShardManagerContainer` in different files, despite not being public. This PR fixes that