### PR TITLE
Fix token logging from run:action:resume:send_resume

### DIFF
--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -149,7 +149,7 @@ impl WebSocketGatewayClientExt for WsStream {
         .await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, token))]
     async fn send_resume(
         &mut self,
         shard_info: &[u64; 2],


### PR DESCRIPTION
Simple PR to remove token from being logged on resume.

I've checked whole codebase with `git grep --line -B20 'token' | grep instrument` and this was the only place I found that logged it.

Test result:
```
test result: ok. 253 passed; 0 failed; 35 ignored; 0 measured; 0 filtered out
```