### PR TITLE
Fix WebSocketGatewayClientExt::send_chunk_guild to not get disconnected by Discord's gateway

### DIFF
--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -71,7 +71,7 @@ impl WebSocketGatewayClientExt for WsStream {
         });
 
         match filter {
-            ChunkGuildFilter::None => {},
+            ChunkGuildFilter::None => payload["d"]["query"] = json!(""),
             ChunkGuildFilter::Query(query) => payload["d"]["query"] = json!(query),
             ChunkGuildFilter::UserIds(user_ids) => {
                 let ids = user_ids.iter().map(|x| x.0).collect::<Vec<u64>>();

--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -64,7 +64,7 @@ impl WebSocketGatewayClientExt for WsStream {
         let mut payload = json!({
             "op": OpCode::GetGuildMembers.num(),
             "d": {
-                "guild_id": [guild_id.as_ref().0],
+                "guild_id": guild_id.as_ref().0.to_string(),
                 "limit": limit.unwrap_or(0),
                 "nonce": nonce.unwrap_or(""),
             },


### PR DESCRIPTION
Closes #1190.

This pull request makes sure that guild member list requests are sent with the right parameters according to Discord API documentation.

The API surface has not changed.