### PR TITLE
Enable log feature in tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,13 @@ include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 
 [dependencies]
 bitflags = "1"
-tracing = "0.1"
 tracing-futures = "0.2"
 serde_json = "1"
 async-trait = "0.1"
+
+[dependencies.tracing]
+version = "0.1"
+features = ["log"]
 
 [dependencies.command_attr]
 path = "./command_attr"


### PR DESCRIPTION
This allows tracing to emit `log::Record`s. That way, users of `serenity` won't be forced into using `tracing`, and instead can pick their own logging implementation (e.g. `slog`, `env_logger`, `fern`, etc.)