### PR TITLE
Add CI jobs for tokio 0.2 and the `unstable_discord_api` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           - Windows
           - no cache
           - no gateway
+          - unstable Discord API features
+          - tokio 0.2
 
         include:
           - name: beta
@@ -35,6 +37,10 @@ jobs:
             features: builder client framework gateway model http standard_framework utils rustls_backend
           - name: no gateway
             features: model http rustls_backend
+          - name: unstable Discord API features
+            features: default unstable_discord_api
+          - name: tokio 0.2
+            features: rustls_tokio_0_2_backend
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
           - no cache
           - no gateway
           - unstable Discord API features
-          - tokio 0.2
+          - tokio 0.2 (rustls)
+          - tokio 0.2 (native-ls)
 
         include:
           - name: beta
@@ -39,8 +40,10 @@ jobs:
             features: model http rustls_backend
           - name: unstable Discord API features
             features: default unstable_discord_api
-          - name: tokio 0.2
+          - name: tokio 0.2 (rustls)
             features: default_tokio_0_2
+          - name: tokio 0.2 (native-tls)
+            features: default_native_tls_tokio_0_2
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           - name: unstable Discord API features
             features: default unstable_discord_api
           - name: tokio 0.2
-            features: rustls_tokio_0_2_backend
+            features: default_tokio_0_2
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: cargo build --no-default-features --features "${{ matrix.features }}"
 
       - name: Test some features
-        if: !matrix.dont-test && matrix.features
+        if: ${{ !matrix.dont-test && matrix.features }}
         run: cargo test --no-default-features --features "${{ matrix.features }}"
 
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           - no cache
           - no gateway
           - unstable Discord API features
-          - tokio 0.2 (rustls)
-          - tokio 0.2 (native-ls)
+          - rustls tokio 0.2
+          - native-tls tokio 0.2
 
         include:
           - name: beta
@@ -40,9 +40,9 @@ jobs:
             features: model http rustls_backend
           - name: unstable Discord API features
             features: default unstable_discord_api
-          - name: tokio 0.2 (rustls)
+          - name: rustls tokio 0.2
             features: default_tokio_0_2
-          - name: tokio 0.2 (native-tls)
+          - name: native-tls tokio 0.2
             features: default_native_tls_tokio_0_2
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,13 @@ jobs:
             features: model http rustls_backend
           - name: unstable Discord API features
             features: default unstable_discord_api
+            dont-test: true
           - name: rustls tokio 0.2
             features: default_tokio_0_2
+            dont-test: true
           - name: native-tls tokio 0.2
             features: default_native_tls_tokio_0_2
+            dont-test: true
 
     steps:
       - name: Checkout sources
@@ -86,7 +89,7 @@ jobs:
         run: cargo build --no-default-features --features "${{ matrix.features }}"
 
       - name: Test some features
-        if: matrix.features
+        if: !matrix.dont-test && matrix.features
         run: cargo test --no-default-features --features "${{ matrix.features }}"
 
   clippy:


### PR DESCRIPTION
Fixes https://github.com/serenity-rs/serenity/issues/1193

This adds 3 new jobs to the CI pipeline:
- unstable Discord API features
- rustls tokio 0.2
- native-tls tokio 0.2

The jobs are only introduced to ascertain compilation success, tests are not compiled nor run for these jobs.