### PR TITLE
Add clippy lint for denying usage of `unwrap()`

### DIFF
--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -75,10 +75,8 @@ impl CreateAllowedMentions {
     pub fn parse(&mut self, value: ParseValue) -> &mut Self {
         let val = self.0.entry("parse").or_insert_with(|| Value::Array(Vec::new()));
 
-        if let Some(arr) = val.as_array_mut() {
-            arr.push(json![value]);
-        }
-        // Should there be an "else" block that panics?
+        let arr = val.as_array_mut().expect("Must be an array");
+        arr.push(json![value]);
 
         self
     }
@@ -94,10 +92,8 @@ impl CreateAllowedMentions {
     pub fn empty_parse(&mut self) -> &mut Self {
         let val = self.0.entry("parse").or_insert_with(|| Value::Array(Vec::new()));
 
-        if let Some(arr) = val.as_array_mut() {
-            arr.clear();
-        }
-        // Should there be an "else" block that panics?
+        let arr = val.as_array_mut().expect("Must be an array");
+        arr.clear();
 
         self
     }
@@ -119,10 +115,8 @@ impl CreateAllowedMentions {
     pub fn empty_users(&mut self) -> &mut Self {
         let val = self.0.entry("users").or_insert_with(|| Value::Array(Vec::new()));
 
-        if let Some(arr) = val.as_array_mut() {
-            arr.clear();
-        }
-        // Should there be an "else" block that panics?
+        let arr = val.as_array_mut().expect("Must be an array");
+        arr.clear();
 
         self
     }
@@ -144,10 +138,8 @@ impl CreateAllowedMentions {
     pub fn empty_roles(&mut self) -> &mut Self {
         let val = self.0.entry("roles").or_insert_with(|| Value::Array(Vec::new()));
 
-        if let Some(arr) = val.as_array_mut() {
-            arr.clear();
-        }
-        // Should there be an "else" block that panics?
+        let arr = val.as_array_mut().expect("Must be an array");
+        arr.clear();
 
         self
     }

--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -73,9 +73,8 @@ impl CreateAllowedMentions {
     /// [`roles`]: Self::roles
     #[inline]
     pub fn parse(&mut self, value: ParseValue) -> &mut Self {
-        
         let val = self.0.entry("parse").or_insert_with(|| Value::Array(Vec::new()));
-        
+
         if let Some(arr) = val.as_array_mut() {
             arr.push(json![value]);
         }
@@ -93,7 +92,6 @@ impl CreateAllowedMentions {
     /// [`roles`]: Self::roles
     #[inline]
     pub fn empty_parse(&mut self) -> &mut Self {
-
         let val = self.0.entry("parse").or_insert_with(|| Value::Array(Vec::new()));
 
         if let Some(arr) = val.as_array_mut() {
@@ -119,7 +117,6 @@ impl CreateAllowedMentions {
     /// Makes users unable to be mentioned.
     #[inline]
     pub fn empty_users(&mut self) -> &mut Self {
-        
         let val = self.0.entry("users").or_insert_with(|| Value::Array(Vec::new()));
 
         if let Some(arr) = val.as_array_mut() {
@@ -145,7 +142,6 @@ impl CreateAllowedMentions {
     /// Makes roles unable to be mentioned.
     #[inline]
     pub fn empty_roles(&mut self) -> &mut Self {
-
         let val = self.0.entry("roles").or_insert_with(|| Value::Array(Vec::new()));
 
         if let Some(arr) = val.as_array_mut() {

--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -73,11 +73,14 @@ impl CreateAllowedMentions {
     /// [`roles`]: Self::roles
     #[inline]
     pub fn parse(&mut self, value: ParseValue) -> &mut Self {
-        if let Some(val) = self.0.get_mut("parse") {
-            val.as_array_mut().unwrap().push(json![value]);
-        } else {
-            self.0.insert("parse", Value::Array(vec![json!(value)]));
+        
+        let val = self.0.entry("parse").or_insert_with(|| Value::Array(Vec::new()));
+        
+        if let Some(arr) = val.as_array_mut() {
+            arr.push(json![value]);
         }
+        // Should there be an "else" block that panics?
+
         self
     }
 
@@ -90,11 +93,14 @@ impl CreateAllowedMentions {
     /// [`roles`]: Self::roles
     #[inline]
     pub fn empty_parse(&mut self) -> &mut Self {
-        if let Some(val) = self.0.get_mut("parse") {
-            val.as_array_mut().unwrap().clear();
-        } else {
-            self.0.insert("parse", Value::Array(vec![]));
+
+        let val = self.0.entry("parse").or_insert_with(|| Value::Array(Vec::new()));
+
+        if let Some(arr) = val.as_array_mut() {
+            arr.clear();
         }
+        // Should there be an "else" block that panics?
+
         self
     }
 
@@ -113,11 +119,14 @@ impl CreateAllowedMentions {
     /// Makes users unable to be mentioned.
     #[inline]
     pub fn empty_users(&mut self) -> &mut Self {
-        if let Some(val) = self.0.get_mut("users") {
-            val.as_array_mut().unwrap().clear();
-        } else {
-            self.0.insert("users", Value::Array(vec![]));
+        
+        let val = self.0.entry("users").or_insert_with(|| Value::Array(Vec::new()));
+
+        if let Some(arr) = val.as_array_mut() {
+            arr.clear();
         }
+        // Should there be an "else" block that panics?
+
         self
     }
 
@@ -136,11 +145,14 @@ impl CreateAllowedMentions {
     /// Makes roles unable to be mentioned.
     #[inline]
     pub fn empty_roles(&mut self) -> &mut Self {
-        if let Some(val) = self.0.get_mut("roles") {
-            val.as_array_mut().unwrap().clear();
-        } else {
-            self.0.insert("roles", Value::Array(vec![]));
+
+        let val = self.0.entry("roles").or_insert_with(|| Value::Array(Vec::new()));
+
+        if let Some(arr) = val.as_array_mut() {
+            arr.clear();
         }
+        // Should there be an "else" block that panics?
+
         self
     }
 

--- a/src/builder/create_interaction.rs
+++ b/src/builder/create_interaction.rs
@@ -78,7 +78,7 @@ impl CreateInteractionOption {
         let choices = self.0.entry("choices").or_insert_with(|| Value::Array(Vec::new()));
         let choices_arr = choices.as_array_mut().expect("Must be an array");
         choices_arr.push(value);
-        
+
         self
     }
 
@@ -149,12 +149,11 @@ impl CreateInteraction {
     ///
     /// **Note**: Interactions can only have up to 10 options.
     pub fn add_interaction_option(&mut self, option: CreateInteractionOption) -> &mut Self {
-
         let new_option = utils::hashmap_to_json_map(option.0);
         let options = self.0.entry("options").or_insert_with(|| Value::Array(Vec::new()));
         let opt_arr = options.as_array_mut().expect("Must be an array");
         opt_arr.push(Value::Object(new_option));
-        
+
         self
     }
 

--- a/src/builder/create_interaction.rs
+++ b/src/builder/create_interaction.rs
@@ -76,9 +76,9 @@ impl CreateInteractionOption {
 
     fn add_choice(&mut self, value: Value) -> &mut Self {
         let choices = self.0.entry("choices").or_insert_with(|| Value::Array(Vec::new()));
-        if let Some(choices_arr) = choices.as_array_mut() {
-            choices_arr.push(value);
-        };
+        let choices_arr = choices.as_array_mut().expect("Must be an array");
+        choices_arr.push(value);
+        
         self
     }
 
@@ -98,9 +98,9 @@ impl CreateInteractionOption {
     pub fn add_sub_option(&mut self, sub_option: CreateInteractionOption) -> &mut Self {
         let new_option = utils::hashmap_to_json_map(sub_option.0);
         let options = self.0.entry("options").or_insert_with(|| Value::Array(Vec::new()));
-        if let Some(opt_arr) = options.as_array_mut() {
-            opt_arr.push(Value::Object(new_option));
-        };
+        let opt_arr = options.as_array_mut().expect("Must be an array");
+        opt_arr.push(Value::Object(new_option));
+
         self
     }
 }
@@ -149,12 +149,12 @@ impl CreateInteraction {
     ///
     /// **Note**: Interactions can only have up to 10 options.
     pub fn add_interaction_option(&mut self, option: CreateInteractionOption) -> &mut Self {
+
         let new_option = utils::hashmap_to_json_map(option.0);
         let options = self.0.entry("options").or_insert_with(|| Value::Array(Vec::new()));
-        if let Some(opt_arr) = options.as_array_mut() {
-            opt_arr.push(Value::Object(new_option));
-        };
-        // should this be changed to have None be a panic?
+        let opt_arr = options.as_array_mut().expect("Must be an array");
+        opt_arr.push(Value::Object(new_option));
+        
         self
     }
 

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -159,6 +159,7 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Set the reference message this message is a reply to.
+    #[allow(clippy::unwrap_used)] // allowing unwrap here because serializing MessageReference should never error
     pub fn reference_message(&mut self, reference: impl Into<MessageReference>) -> &mut Self {
         self.0.insert("message_reference", serde_json::to_value(reference.into()).unwrap());
         self

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -988,6 +988,7 @@ mod test {
     };
 
     #[tokio::test]
+    #[allow(clippy::unwrap_used)]
     async fn test_cache_messages() {
         let mut settings = Settings::new();
         settings.max_messages(2);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -293,6 +293,7 @@ impl<'a> ClientBuilder<'a> {
 impl<'a> Future for ClientBuilder<'a> {
     type Output = Result<Client>;
 
+    #[allow(clippy::unwrap_used)] // Allowing unwrap because all should be Some() by this point
     #[instrument(skip(self))]
     fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -184,6 +184,7 @@ impl<'a> MessageCollectorBuilder<'a> {
     ///
     /// A message is considered *collected*, if the message
     /// passes all the requirements.
+    #[allow(clippy::unwrap_used)]
     pub fn collect_limit(mut self, limit: u32) -> Self {
         self.filter.as_mut().unwrap().collect_limit = Some(limit);
 
@@ -193,7 +194,7 @@ impl<'a> MessageCollectorBuilder<'a> {
 
 impl<'a> Future for MessageCollectorBuilder<'a> {
     type Output = MessageCollector;
-
+    #[allow(clippy::unwrap_used)]
     fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {
             let shard_messenger = self.shard.take().unwrap();
@@ -234,7 +235,7 @@ impl<'a> CollectReply<'a> {
 
 impl<'a> Future for CollectReply<'a> {
     type Output = Option<Arc<Message>>;
-
+    #[allow(clippy::unwrap_used)]
     fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {
             let shard_messenger = self.shard.take().unwrap();

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -289,7 +289,7 @@ impl<'a> ReactionCollectorBuilder<'a> {
 
 impl<'a> Future for ReactionCollectorBuilder<'a> {
     type Output = ReactionCollector;
-
+    #[allow(clippy::unwrap_used)]
     fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {
             let shard_messenger = self.shard.take().unwrap();
@@ -330,7 +330,7 @@ impl<'a> CollectReaction<'a> {
 
 impl<'a> Future for CollectReaction<'a> {
     type Output = Option<Arc<ReactionAction>>;
-
+    #[allow(clippy::unwrap_used)]
     fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {
             let shard_messenger = self.shard.take().unwrap();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -26,6 +26,7 @@ pub const USER_AGENT: &str = concat!(
 );
 
 /// List of messages Discord shows on member join.
+#[allow(clippy::non_ascii_literal)] // allow for discord join messages
 pub static JOIN_MESSAGES: &[&str] = &[
     "$user just joined the server - glhf!",
     "$user just joined. Everyone, look busy!",

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -845,7 +845,7 @@ pub(crate) async fn has_correct_permissions(
             Ok(perms) => perms,
             Err(e) => {
                 tracing::error!(
-                    "(╯°□°）╯︵ ┻━┻ error getting permissions for user {} in channel {}: {}",
+                    "Error getting permissions for user {} in channel {}: {}",
                     member.user.id,
                     channel.id,
                     e

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -668,6 +668,7 @@ impl Framework for StandardFramework {
                 let groups = self.groups.iter().map(|(g, _)| *g).collect::<Vec<_>>();
 
                 // `parse_command` promises to never return a help invocation if `StandardFramework::help` is `None`.
+                #[allow(clippy::unwrap_used)]
                 let help = self.help.unwrap();
 
                 if let Some(before) = &self.before {
@@ -698,6 +699,7 @@ impl Framework for StandardFramework {
 
                         for delim in command.options.delimiters {
                             if delim.len() == 1 {
+                                #[allow(clippy::unwrap_used)] // Should always be Some() in this case
                                 v.push(Delimiter::Single(delim.chars().next().unwrap()));
                             } else {
                                 // This too.

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -699,7 +699,8 @@ impl Framework for StandardFramework {
 
                         for delim in command.options.delimiters {
                             if delim.len() == 1 {
-                                #[allow(clippy::unwrap_used)] // Should always be Some() in this case
+                                // Should always be Some() in this case
+                                #[allow(clippy::unwrap_used)]
                                 v.push(Delimiter::Single(delim.chars().next().unwrap()));
                             } else {
                                 // This too.

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -276,7 +276,7 @@ async fn check_discrepancy(
                 // Guild not found.
                 None => return Ok(()),
             };
-
+            #[allow(clippy::unwrap_used)] // Allowing unwrap because should always return Some()
             let roles = ctx.cache.guild_field(guild_id, |guild| guild.roles.clone()).await.unwrap();
             let perms = permissions_in(ctx, guild_id, msg.channel_id, &member, &roles).await;
 

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -143,6 +143,7 @@ impl StdError for Error {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use http_crate::response::Builder;
     use reqwest::ResponseBuilderExt;

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -409,7 +409,7 @@ mod tests {
     use crate::{error::Error, http::HttpError};
 
     type Result<T> = StdResult<T, Box<dyn StdError>>;
-    
+
     #[allow(clippy::unwrap_used)]
     fn headers() -> HeaderMap {
         let pairs = &[

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -409,7 +409,8 @@ mod tests {
     use crate::{error::Error, http::HttpError};
 
     type Result<T> = StdResult<T, Box<dyn StdError>>;
-
+    
+    #[allow(clippy::unwrap_used)]
     fn headers() -> HeaderMap {
         let pairs = &[
             (HeaderName::from_static("x-ratelimit-limit"), HeaderValue::from_static("5")),
@@ -435,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::float_cmp)]
+    #[allow(clippy::float_cmp, clippy::unwrap_used)]
     fn test_parse_header_good() -> Result<()> {
         let headers = headers();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rust_2018_idioms)]
 #![deny(broken_intra_doc_links)]
+#![deny(clippy::unwrap_used)]
 #![type_length_limit = "3294819"] // needed so ShardRunner::run compiles with instrument.
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rust_2018_idioms)]
 #![deny(broken_intra_doc_links)]
-#![deny(clippy::unwrap_used)]
+#![deny(clippy::unwrap_used, clippy::non_ascii_literal)]
 #![type_length_limit = "3294819"] // needed so ShardRunner::run compiles with instrument.
 
 #[macro_use]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -228,8 +228,11 @@ impl<'de> Deserialize<'de> for Channel {
             match kind.as_u64() {
                 Some(kind) => kind,
                 None => {
-                    return Err(DeError::invalid_type(Unexpected::Other("non-positive integer"), &"a positive integer"));
-                }
+                    return Err(DeError::invalid_type(
+                        Unexpected::Other("non-positive integer"),
+                        &"a positive integer",
+                    ));
+                },
             }
         };
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -15,7 +15,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use async_trait::async_trait;
-use serde::de::Error as DeError;
+use serde::de::{Error as DeError, Unexpected};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 pub use self::attachment::*;
@@ -225,7 +225,12 @@ impl<'de> Deserialize<'de> for Channel {
         let kind = {
             let kind = v.get("type").ok_or_else(|| DeError::missing_field("type"))?;
 
-            kind.as_u64().unwrap()
+            match kind.as_u64() {
+                Some(kind) => kind,
+                None => {
+                    return Err(DeError::invalid_type(Unexpected::Other("non-positive integer"), &"a positive integer"));
+                }
+            }
         };
 
         match kind {

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -244,6 +244,7 @@ pub enum ReactionType {
 }
 
 impl<'de> Deserialize<'de> for ReactionType {
+    #[allow(clippy::unwrap_used)] // allow unwrap here because name being none is unreachable
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         #[derive(Deserialize)]
         #[serde(field_identifier, rename_all = "snake_case")]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -388,7 +388,7 @@ pub struct GuildIntegrationsUpdateEvent {
     pub guild_id: GuildId,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildMemberAddEvent {
     pub guild_id: GuildId,
@@ -430,23 +430,6 @@ impl<'de> Deserialize<'de> for GuildMemberAddEvent {
             guild_id,
             member: Member::deserialize(Value::Object(map)).map_err(DeError::custom)?,
         })
-    }
-}
-
-impl Serialize for GuildMemberAddEvent {
-    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s: Vec<u8> = Vec::new();
-        let mut ser = serde_json::Serializer::new(&mut s);
-        Member::serialize(&self.member, &mut ser).unwrap(); // TODO find better way to do this
-        let mut map: JsonMap = serde_json::from_str(std::str::from_utf8(&s).unwrap()).unwrap();
-        map.insert(
-            "guild_id".to_string(),
-            serde_json::value::Value::Number(serde_json::Number::from(self.guild_id.0)),
-        );
-        map.serialize(serializer)
     }
 }
 
@@ -1292,7 +1275,7 @@ impl fmt::Debug for VoiceServerUpdateEvent {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct VoiceStateUpdateEvent {
     pub guild_id: Option<GuildId>,
@@ -1339,25 +1322,6 @@ impl<'de> Deserialize<'de> for VoiceStateUpdateEvent {
             guild_id,
             voice_state: VoiceState::deserialize(Value::Object(map)).map_err(DeError::custom)?,
         })
-    }
-}
-
-impl Serialize for VoiceStateUpdateEvent {
-    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s: Vec<u8> = Vec::new();
-        let mut ser = serde_json::Serializer::new(&mut s);
-        VoiceState::serialize(&self.voice_state, &mut ser).unwrap(); // TODO find better way to do this
-        let mut map: JsonMap = serde_json::from_str(std::str::from_utf8(&s).unwrap()).unwrap();
-        if let Some(guild_id) = self.guild_id {
-            map.insert(
-                "guild_id".to_string(),
-                serde_json::value::Value::Number(serde_json::Number::from(guild_id.0)),
-            );
-        }
-        map.serialize(serializer)
     }
 }
 

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -461,11 +461,11 @@ impl<'de> Deserialize<'de> for AuditLogs {
                     }
                 }
 
-                let entries = audit_log_entries.ok_or_else(
-                    || de::Error::missing_field("audit_log_entries")
-                )?.into_iter().map(
-                    |entry| (entry.id, entry)
-                ).collect::<HashMap<AuditLogEntryId, AuditLogEntry>>();
+                let entries = audit_log_entries
+                    .ok_or_else(|| de::Error::missing_field("audit_log_entries"))?
+                    .into_iter()
+                    .map(|entry| (entry.id, entry))
+                    .collect::<HashMap<AuditLogEntryId, AuditLogEntry>>();
 
                 let webhooks = webhooks.ok_or_else(|| de::Error::missing_field("webhooks"))?;
                 let users = users.ok_or_else(|| de::Error::missing_field("users"))?;

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -461,14 +461,19 @@ impl<'de> Deserialize<'de> for AuditLogs {
                     }
                 }
 
+                let entries = audit_log_entries.ok_or_else(
+                    || de::Error::missing_field("audit_log_entries")
+                )?.into_iter().map(
+                    |entry| (entry.id, entry)
+                ).collect::<HashMap<AuditLogEntryId, AuditLogEntry>>();
+
+                let webhooks = webhooks.ok_or_else(|| de::Error::missing_field("webhooks"))?;
+                let users = users.ok_or_else(|| de::Error::missing_field("users"))?;
+
                 Ok(AuditLogs {
-                    entries: audit_log_entries
-                        .unwrap()
-                        .into_iter()
-                        .map(|entry| (entry.id, entry))
-                        .collect(),
-                    webhooks: webhooks.unwrap(),
-                    users: users.unwrap(),
+                    entries,
+                    webhooks,
+                    users,
                 })
             }
         }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1348,7 +1348,7 @@ impl Guild {
         let everyone = match self.roles.get(&RoleId(self.id.0)) {
             Some(everyone) => everyone,
             None => {
-                error!("(╯°□°）╯︵ ┻━┻ @everyone role ({}) missing in '{}'", self.id, self.name,);
+                error!("@everyone role ({}) missing in '{}'", self.id, self.name,);
 
                 return Ok(Permissions::empty());
             },
@@ -1367,7 +1367,7 @@ impl Guild {
                 permissions |= role.permissions;
             } else {
                 warn!(
-                    "(╯°□°）╯︵ ┻━┻ {} on {} has non-existent role {:?}",
+                    "{} on {} has non-existent role {:?}",
                     member.user.id, self.id, role,
                 );
             }
@@ -1418,7 +1418,7 @@ impl Guild {
         let everyone = match roles.get(&RoleId(guild_id.0)) {
             Some(everyone) => everyone,
             None => {
-                error!("(╯°□°）╯︵ ┻━┻ @everyone role missing in {}", guild_id,);
+                error!("@everyone role missing in {}", guild_id,);
                 return Err(Error::Model(ModelError::RoleNotFound));
             },
         };
@@ -1431,7 +1431,7 @@ impl Guild {
                 permissions |= role.permissions;
             } else {
                 error!(
-                    "(╯°□°）╯︵ ┻━┻ {} on {} has non-existent role {:?}",
+                    "{} on {} has non-existent role {:?}",
                     member.user.id, guild_id, role
                 );
                 return Err(Error::Model(ModelError::RoleNotFound));

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1366,10 +1366,7 @@ impl Guild {
 
                 permissions |= role.permissions;
             } else {
-                warn!(
-                    "{} on {} has non-existent role {:?}",
-                    member.user.id, self.id, role,
-                );
+                warn!("{} on {} has non-existent role {:?}", member.user.id, self.id, role,);
             }
         }
 
@@ -1430,10 +1427,7 @@ impl Guild {
             if let Some(role) = roles.get(&role) {
                 permissions |= role.permissions;
             } else {
-                error!(
-                    "{} on {} has non-existent role {:?}",
-                    member.user.id, guild_id, role
-                );
+                error!("{} on {} has non-existent role {:?}", member.user.id, guild_id, role);
                 return Err(Error::Model(ModelError::RoleNotFound));
             }
         }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2435,6 +2435,7 @@ mod test {
         }
 
         #[tokio::test]
+        #[allow(clippy::unwrap_used)]
         async fn member_named_username() {
             let guild = gen();
             let lhs = guild.member_named("test#1432").unwrap().display_name();
@@ -2443,6 +2444,7 @@ mod test {
         }
 
         #[tokio::test]
+        #[allow(clippy::unwrap_used)]
         async fn member_named_nickname() {
             let guild = gen();
             let lhs = guild.member_named("aaaa").unwrap().display_name();

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -344,8 +344,8 @@ impl Interaction {
 
         let map = utils::hashmap_to_json_map(interaction_response.0);
 
-        Message::check_content_length(&map).unwrap();
-        Message::check_embed_length(&map).unwrap();
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
 
         http.as_ref().create_interaction_response(self.id.0, &self.token, &Value::Object(map)).await
     }
@@ -373,8 +373,8 @@ impl Interaction {
 
         let map = utils::hashmap_to_json_map(interaction_response.0);
 
-        Message::check_content_length(&map).unwrap();
-        Message::check_embed_length(&map).unwrap();
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
 
         http.as_ref()
             .edit_original_interaction_response(application_id, &self.token, &Value::Object(map))
@@ -410,8 +410,8 @@ impl Interaction {
 
         let map = utils::hashmap_to_json_map(interaction_response.0);
 
-        Message::check_content_length(&map).unwrap();
-        Message::check_embed_length(&map).unwrap();
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
 
         http.as_ref().create_followup_message(application_id, &self.token, wait, &map).await
     }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -449,6 +449,7 @@ mod test {
         }
 
         #[test]
+        #[allow(clippy::unwrap_used)]
         fn parse_mentions() {
             assert_eq!("<@1234>".parse::<UserId>().unwrap(), UserId(1234));
             assert_eq!("<@&1234>".parse::<RoleId>().unwrap(), RoleId(1234));

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -958,6 +958,7 @@ fn tag(name: &str, discriminator: u16) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     #[cfg(feature = "model")]
     mod model {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -789,7 +789,6 @@ mod test {
         assert_eq!(parsed, ["a", "b c", "d", "e f", "g"]);
     }
 
-
     #[cfg(feature = "cache")]
     #[allow(clippy::non_ascii_literal)]
     #[tokio::test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -789,7 +789,9 @@ mod test {
         assert_eq!(parsed, ["a", "b c", "d", "e f", "g"]);
     }
 
+
     #[cfg(feature = "cache")]
+    #[allow(clippy::non_ascii_literal)]
     #[tokio::test]
     async fn test_content_safe() {
         use std::{collections::HashMap, sync::Arc};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -743,6 +743,7 @@ pub async fn content_safe(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
     #[cfg(feature = "cache")]


### PR DESCRIPTION
This PR removes most usages of `unwrap()` and adds `#![deny(clippy::unwrap_used)]` to `lib.rs`, as mentioned in #1198.

Added `#[allow(clippy::unwrap_used)]` to functions where it should always be `Some` or `Ok` and it'd be a breaking change to instead return an Error/None.