### PR TITLE
Handle nested sub-commands in help

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -360,7 +360,8 @@ async fn check_command_behaviour(
 ) -> HelpBehaviour {
     let behaviour = check_common_behaviour(&ctx, msg, &options, owners, help_options).await;
 
-    if behaviour == HelpBehaviour::Nothing && (!options.owner_privilege || !owners.contains(&msg.author.id))
+    if behaviour == HelpBehaviour::Nothing
+        && (!options.owner_privilege || !owners.contains(&msg.author.id))
     {
         for check in group_checks.iter().chain(options.checks) {
             if !check.check_in_help {

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -382,6 +382,7 @@ async fn check_command_behaviour(
 // This function will recursively go through all commands and
 // their sub-commands, trying to find `name`.
 // Similar commands will be collected into `similar_commands`.
+#[cfg(all(feature = "cache", feature = "http"))]
 fn nested_commands_search<'rec, 'a: 'rec>(
     ctx: &'rec Context,
     msg: &'rec Message,


### PR DESCRIPTION
## Problem
First, a group with a prefix caused sub-commands to fail in help.
Additionally, nesting sub-commands inside sub-commands did not work either.

## Solution
This fix allows sub-commands to be nested multiple levels.
Also, groups holding the command may have any amount of prefixes or aliases.

On a side-note, this pull request changes and adds some documentation to the help system.

Please help testing this by running help on previously failed and working commands to catch regressions.