### PR TITLE
event.rs: reverted removal of type for Embeds in MessageUpdateEvent

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -920,7 +920,7 @@ pub struct MessageUpdateEvent {
     pub mentions: Option<Vec<User>>,
     pub mention_roles: Option<Vec<RoleId>>,
     pub attachments: Option<Vec<Attachment>>,
-    pub embeds: Option<Vec<Value>>,
+    pub embeds: Option<Vec<Embed>>,
 }
 
 #[cfg(feature = "cache")]


### PR DESCRIPTION
Fixes #1206 

related discord conversation:
https://discord.com/channels/381880193251409931/381912587505500160/804695379626295327

Signed-off-by: Vladimir Serov <me@cab404.ru>