### PR TITLE
Add new fields for the `Member` model

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -515,6 +515,9 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     nick: self.nick.clone(),
                     roles: self.roles.clone(),
                     user: self.user.clone(),
+                    pending: false,
+                    #[cfg(feature = "unstable_discord_api")]
+                    permissions: None,
                 });
             }
 
@@ -1012,6 +1015,9 @@ impl CacheUpdate for PresenceUpdateEvent {
                             nick: None,
                             user: user.clone(),
                             roles: vec![],
+                            pending: false,
+                            #[cfg(feature = "unstable_discord_api")]
+                            permissions: None,
                         });
                     }
                 }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -39,6 +39,17 @@ pub struct Member {
     pub roles: Vec<RoleId>,
     /// Attached User struct.
     pub user: User,
+    /// Indicator that the member hasn't accepted the rules of the guild yet.
+    #[serde(default)]
+    pub pending: bool,
+    /// The total permissions of the member in a channel, including overrides.
+    ///
+    /// This is only `Some` when returned in an [`Interaction`] object.
+    ///
+    /// [`Interaction`]: crate::model::interactions::Interaction
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    pub permissions: Option<String>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2376,6 +2376,9 @@ mod test {
                 nick: Some("aaaa".to_string()),
                 roles: vec1,
                 user: u,
+                pending: false,
+                #[cfg(feature = "unstable_discord_api")]
+                permissions: None,
             }
         }
 

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -436,6 +436,9 @@ mod test {
                 nick: None,
                 roles: vec![],
                 user: user.clone(),
+                pending: false,
+                #[cfg(feature = "unstable_discord_api")]
+                permissions: None,
             };
 
             assert_eq!(ChannelId(1).mention().to_string(), "<#1>");

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -96,6 +96,10 @@ impl<'de> Deserialize<'de> for VoiceState {
             nick: Option<String>,
             roles: Vec<RoleId>,
             user: User,
+            #[serde(default)]
+            pending: bool,
+            #[cfg(feature = "unstable_discord_api")]
+            permissions: Option<String>,
         }
 
         struct VoiceStateVisitor;
@@ -166,6 +170,9 @@ impl<'de> Deserialize<'de> for VoiceState {
                                     nick: partial_member.nick,
                                     roles: partial_member.roles,
                                     user: partial_member.user,
+                                    pending: partial_member.pending,
+                                    #[cfg(feature = "unstable_discord_api")]
+                                    permissions: partial_member.permissions,
                                 });
                             }
                         },

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -851,6 +851,9 @@ mod test {
             nick: Some("Ferris".to_string()),
             roles: Vec::new(),
             user: user.clone(),
+            pending: false,
+            #[cfg(feature = "unstable_discord_api")]
+            permissions: None,
         };
 
         let role = Role {


### PR DESCRIPTION
This adds two new fields:
- `pending` -- boolean flag indicating that the member hasn't yet accepted the rules of the guild, which has membership screening enabled.
- `permissions` -- total permissions of the member in a channel, including overrides. This is only present in interaction objects, as such it's restricted to the `unstable_discord_api` feature.  