### PR TITLE
Make `RichInvite::inviter` optional and replace `InviteUser` with `User`

### DIFF
--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -1,7 +1,5 @@
 //! Models for server and channel invites.
 
-use std::ops::Deref;
-
 use chrono::{DateTime, Utc};
 
 use super::prelude::*;
@@ -45,7 +43,7 @@ pub struct Invite {
     ///
     /// This can be `None` for invites created by Discord such as invite-widgets
     /// or vanity invite links.
-    pub inviter: Option<InviteUser>,
+    pub inviter: Option<User>,
 }
 
 #[cfg(feature = "model")]
@@ -176,28 +174,6 @@ impl Invite {
     /// ```
     pub fn url(&self) -> String {
         format!("https://discord.gg/{}", self.code)
-    }
-}
-
-/// A minimal amount of information about the inviter (person who created the invite).
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
-pub struct InviteUser {
-    pub id: UserId,
-    #[serde(rename = "username")]
-    pub name: String,
-    #[serde(deserialize_with = "deserialize_u16")]
-    pub discriminator: u16,
-    pub avatar: Option<String>,
-}
-
-/// InviteUser implements a Deref to UserId so it gains the convenience methods
-/// for converting it into a [`User`] instance.
-impl Deref for InviteUser {
-    type Target = UserId;
-
-    fn deref(&self) -> &Self::Target {
-        &self.id
     }
 }
 

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -286,7 +286,7 @@ pub struct RichInvite {
     /// [`Guild`] being invited to.
     pub guild: Option<InviteGuild>,
     /// The user that created the invite.
-    pub inviter: User,
+    pub inviter: Option<User>,
     /// The maximum age of the invite in seconds, from when it was created.
     pub max_age: u64,
     /// The maximum number of times that an invite may be used before it expires.


### PR DESCRIPTION
This fixes the `RichInvite` model to properly conform to the layout of an [invite object]. While most of the time, the `inviter` field will be present, in some cases, it may not. On the occasions it is missing, it can cause failure for deserialisation of invites (such as those returned from [`Http::get_guild_invites`]).

This also removes `InviteUser`, replacing it with `User`. The only difference between them is that `InviteUser` lacks the `bot` field, but even then, the `User` model defaults to `false` if the field is missing, thus this should be safe.

Consequently, this makes the invite models more consistent with one another. However, these are breaking changes, so this must land on the `next` branch.


[invite object]: https://discord.com/developers/docs/resources/invite#invite-object-invite-structure
[`Http::get_guild_invites`]: https://serenity-rs.github.io/serenity/current/serenity/http/client/struct.Http.html#method.get_guild_invites