### PR TITLE
Update to `tracing` 0.1.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,11 @@ include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 
 [dependencies]
 bitflags = "1"
-tracing-futures = "0.2"
 serde_json = "1"
 async-trait = "0.1"
 
 [dependencies.tracing]
-version = "0.1"
+version = "0.1.23"
 features = ["log"]
 
 [dependencies.command_attr]

--- a/examples/e06_sample_bot_structure/Cargo.toml
+++ b/examples/e06_sample_bot_structure/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2018"
 
 [dependencies]
 dotenv = "0.15"
-tracing = "0.1"
+tracing = "0.1.23"
 tracing-subscriber = "0.2"
-tracing-futures = "0.2" # needed so intrument works with async functions.
 
 [dependencies.tokio]
 version = "1.0"

--- a/examples/e07_env_logging/Cargo.toml
+++ b/examples/e07_env_logging/Cargo.toml
@@ -5,9 +5,8 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-tracing = "0.1"
+tracing = "0.1.23"
 tracing-subscriber = "0.2"
-tracing-futures = "0.2" # needed so intrument works with async functions.
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [dependencies.serenity]


### PR DESCRIPTION
The `tracing-futures` crate is no longer needed with the release of `tracing` v0.1.23

See: [tracing/CHANGELOG.md] & [tracing-attributes/CHANGELOG.md] 

[tracing/CHANGELOG.md]: https://github.com/tokio-rs/tracing/blob/v0.1.x/tracing/CHANGELOG.md#changed
[tracing-attributes/CHANGELOG.md]: https://github.com/tokio-rs/tracing/blob/v0.1.x/tracing-attributes/CHANGELOG.md#changed