### PR TITLE
Use vectors for passing permissions in the builders' documentation

### DIFF
--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -106,11 +106,11 @@ impl CreateChannel {
     /// use serenity::model::permissions::Permissions;
     ///
     /// // Assuming a guild has already been bound.
-    /// let permissions = Some(PermissionOverwrite {
+    /// let permissions = vec![PermissionOverwrite {
     ///     allow: Permissions::READ_MESSAGES,
     ///     deny: Permissions::SEND_TTS_MESSAGES,
     ///     kind: PermissionOverwriteType::Member(UserId(1234)),
-    /// });
+    /// }];
     ///
     /// guild.create_channel(http, |c| {
     ///     c.name("my_new_cool_channel")

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -139,11 +139,11 @@ impl EditChannel {
     /// use serenity::model::permissions::Permissions;
     ///
     /// // Assuming a channel has already been bound.
-    /// let permissions = Some(PermissionOverwrite {
+    /// let permissions = vec![PermissionOverwrite {
     ///     allow: Permissions::READ_MESSAGES,
     ///     deny: Permissions::SEND_TTS_MESSAGES,
     ///     kind: PermissionOverwriteType::Member(UserId(1234)),
-    /// });
+    /// }];
     ///
     /// channel.edit(http, |c| {
     ///     c.name("my_edited_cool_channel")


### PR DESCRIPTION
This changes the use of `Some` to `vec!` for examples in `CreateChannel::permissions` and `EditChannel::permissions` to initialise the `PermissionOverwrite`. A user who was new to Rust got confused by the examples, thinking they had to wrap permission overwrites in an `Option` when they wanted to pass multiple overwrites. The `Option` was used because it implements `Iterator`, which is what the `permissions` method wants. Thus, to avoid said confusion, the option has been replaced in lieu of a vector.