### PR TITLE
Bump dependencies to build with minimal versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
         if: ${{ !matrix.dont-test && matrix.features }}
         run: cargo test --no-default-features --features "${{ matrix.features }}"
 
+      - name: Check minimal versions
+        if: matrix.toolchain == 'nightly'
+        run: cargo clean; cargo update -Z minimal-versions; cargo check
+
   clippy:
     name: Run clippy
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 
 [dependencies]
-bitflags = "1"
+bitflags = "1.1"
 serde_json = "1"
-async-trait = "0.1"
+async-trait = "0.1.9"
 
 [dependencies.tracing]
 version = "0.1.23"
@@ -27,7 +27,7 @@ version = "0.3.3"
 optional = true
 
 [dependencies.serde]
-version = "1"
+version = "1.0.103"
 features = ["derive"]
 
 [dependencies.uwl]
@@ -40,11 +40,11 @@ version = "0.13"
 
 [dependencies.chrono]
 features = ["serde"]
-version = "0.4"
+version = "0.4.10"
 
 [dependencies.flate2]
 optional = true
-version = "1"
+version = "1.0.13"
 
 [dependencies.reqwest]
 default-features = false


### PR DESCRIPTION
Some dependencies are too old to be build with minimal versions (`cargo +nightly update -Z minimal-versions`).

The PR bumps dependencies to the minimal required versions and adds a CI step to test it.