### PR TITLE
Properly fix tracing version to force a version over or equal to .23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1"
 async-trait = "0.1"
 
 [dependencies.tracing]
-version = "0.1.23"
+version = "^0.1.23"
 features = ["log"]
 
 [dependencies.command_attr]

--- a/examples/e06_sample_bot_structure/Cargo.toml
+++ b/examples/e06_sample_bot_structure/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 dotenv = "0.15"
-tracing = "0.1.23"
+tracing = "^0.1.23"
 tracing-subscriber = "0.2"
 
 [dependencies.tokio]

--- a/examples/e07_env_logging/Cargo.toml
+++ b/examples/e07_env_logging/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-tracing = "0.1.23"
+tracing = "^0.1.23"
 tracing-subscriber = "0.2"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 


### PR DESCRIPTION
Just added ^ to the versions so a version over or equal to the supported is guaranteed to be used.

	modified:   Cargo.toml
	modified:   examples/e06_sample_bot_structure/Cargo.toml
	modified:   examples/e07_env_logging/Cargo.toml