### PR TITLE
Preserve documentation comments for the help command

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -305,6 +305,14 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     // parsing the function input with `CommandFun`.
     util::rename_attributes(&mut fun.attributes, "description", "doc");
 
+    // Additionally, place the documentation attributes to the `cooked` list
+    // to prevent the macro from rejecting them as invalid attributes.
+    for i in 0..fun.attributes.len() {
+        if fun.attributes[i].path.is_ident("doc") {
+            fun.cooked.push(fun.attributes.remove(i));
+        }
+    }
+
     let mut options = HelpOptions::default();
 
     for attribute in &fun.attributes {

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -301,6 +301,10 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
         vec!["help".to_string()]
     };
 
+    // Revert the change for the names of documentation attributes done when
+    // parsing the function input with `CommandFun`.
+    util::rename_attributes(&mut fun.attributes, "description", "doc");
+
     let mut options = HelpOptions::default();
 
     for attribute in &fun.attributes {

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -15,8 +15,6 @@ use syn::{
     FnArg,
     Ident,
     Pat,
-    Path,
-    PathSegment,
     ReturnType,
     Stmt,
     Token,

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -25,7 +25,7 @@ use syn::{
 };
 
 use crate::consts::CHECK;
-use crate::util::{Argument, AsOption, IdentExt2, Parenthesised};
+use crate::util::{self, Argument, AsOption, IdentExt2, Parenthesised};
 
 #[derive(Debug, PartialEq)]
 pub enum OnlyIn {
@@ -103,7 +103,7 @@ fn parse_argument(arg: FnArg) -> Result<Argument> {
 /// Test if the attribute is cooked.
 fn is_cooked(attr: &Attribute) -> bool {
     const COOKED_ATTRIBUTE_NAMES: &[&str] =
-        &["cfg", "cfg_attr", "doc", "derive", "inline", "allow", "warn", "deny", "forbid"];
+        &["cfg", "cfg_attr", "derive", "inline", "allow", "warn", "deny", "forbid"];
 
     COOKED_ATTRIBUTE_NAMES.iter().any(|n| attr.path.is_ident(n))
 }
@@ -148,14 +148,8 @@ impl Parse for CommandFun {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let mut attributes = input.call(Attribute::parse_outer)?;
 
-        // `#[doc = "..."]` is a cooked attribute but it is special-cased for commands.
-        for attr in &mut attributes {
-            // Rename documentation comment attributes (`#[doc = "..."]`) to `#[description = "..."]`.
-            if attr.path.is_ident("doc") {
-                attr.path =
-                    Path::from(PathSegment::from(Ident::new("description", Span::call_site())));
-            }
-        }
+        // Rename documentation comment attributes (`#[doc = "..."]`) to `#[description = "..."]`.
+        util::rename_attributes(&mut attributes, "doc", "description");
 
         let cooked = remove_cooked(&mut attributes);
 

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -11,9 +11,12 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     token::{Comma, Mut},
+    Attribute,
     Ident,
     Lifetime,
     Lit,
+    Path,
+    PathSegment,
     Type,
 };
 
@@ -248,6 +251,15 @@ pub fn populate_fut_lifetimes_on_refs(args: &mut Vec<Argument>) {
     for arg in args {
         if let Type::Reference(reference) = &mut arg.kind {
             reference.lifetime = Some(Lifetime::new("'fut", Span::call_site()));
+        }
+    }
+}
+
+/// Renames all attributes that have a specific `name` to the `target`.
+pub fn rename_attributes(attributes: &mut Vec<Attribute>, name: &str, target: &str) {
+    for attr in attributes {
+        if attr.path.is_ident(name) {
+            attr.path = Path::from(PathSegment::from(Ident::new(target, Span::call_site())));
         }
     }
 }


### PR DESCRIPTION
## Description

This fixes a compilation error if a user provides documentation comments to the `#[help]` macro:
```
invalid attribute: "description"
```

The help macro uses similar code to parse the function it is applied on, which converts `#[doc = "..."]` attributes (desugared form of `///` comments) to `#[description = "..."]`. This pull request reverses that action to allow usage of `///` comments on help functions.

## Type of Change

This is a fix for the `command_attr` crate, a part of the framework. The pull request has been marked with the appropriate labels as such.

## How Has This Been Tested?

It's been tested with the command framework example (`e05_command_framework`) and my personal bot with a simple documentation comment, which compiled successfully and generating documentation showed that the help command function had the comment.