### PR TITLE
Ignore Missing Cache Items on Permission Checks

### DIFF
--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -170,5 +170,5 @@ pub enum MembershipState {
 
 enum_number!(MembershipState {
     Invited,
-    Accepted,
+    Accepted
 });

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -152,11 +152,13 @@ impl GuildChannel {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::CREATE_INVITE;
-
-                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                utils::user_has_perms_cache(
+                    cache,
+                    self.id,
+                    Some(self.guild_id),
+                    Permissions::CREATE_INVITE,
+                )
+                .await?;
             }
         }
 
@@ -286,11 +288,13 @@ impl GuildChannel {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_CHANNELS;
-
-                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                utils::user_has_perms_cache(
+                    cache,
+                    self.id,
+                    Some(self.guild_id),
+                    Permissions::MANAGE_CHANNELS,
+                )
+                .await?;
             }
         }
 
@@ -390,11 +394,13 @@ impl GuildChannel {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_CHANNELS;
-
-                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                utils::user_has_perms_cache(
+                    cache,
+                    self.id,
+                    Some(self.guild_id),
+                    Permissions::MANAGE_CHANNELS,
+                )
+                .await?;
             }
         }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -140,13 +140,14 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_MESSAGES;
+                let permissions = Permissions::MANAGE_MESSAGES;
                 let is_author = self.author.id == cache.current_user().await.id;
-                let has_perms =
-                    utils::user_has_perms(&cache, self.channel_id, self.guild_id, req).await?;
 
-                if !is_author && !has_perms {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                utils::user_has_perms_cache(cache, self.channel_id, self.guild_id, permissions)
+                    .await?;
+
+                if !is_author {
+                    return Err(Error::Model(ModelError::NotAuthor));
                 }
             }
         }
@@ -169,11 +170,13 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_MESSAGES;
-
-                if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                utils::user_has_perms_cache(
+                    cache,
+                    self.channel_id,
+                    self.guild_id,
+                    Permissions::MANAGE_MESSAGES,
+                )
+                .await?;
             }
         }
 
@@ -199,11 +202,13 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_MESSAGES;
-
-                if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                utils::user_has_perms_cache(
+                    cache,
+                    self.channel_id,
+                    self.guild_id,
+                    Permissions::MANAGE_MESSAGES,
+                )
+                .await?;
             }
         }
 
@@ -477,11 +482,13 @@ impl Message {
         {
             if let Some(cache) = cache_http.cache() {
                 if self.guild_id.is_some() {
-                    let req = Permissions::MANAGE_MESSAGES;
-
-                    if !utils::user_has_perms(&cache, self.channel_id, self.guild_id, req).await? {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
+                    utils::user_has_perms_cache(
+                        cache,
+                        self.channel_id,
+                        self.guild_id,
+                        Permissions::MANAGE_MESSAGES,
+                    )
+                    .await?;
                 }
             }
         }
@@ -522,11 +529,13 @@ impl Message {
         {
             if let Some(cache) = cache_http.cache() {
                 if self.guild_id.is_some() {
-                    let req = Permissions::ADD_REACTIONS;
-
-                    if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req).await? {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
+                    utils::user_has_perms_cache(
+                        cache,
+                        self.channel_id,
+                        self.guild_id,
+                        Permissions::ADD_REACTIONS,
+                    )
+                    .await?;
                 }
 
                 user_id = Some(cache.current_user().await.id);
@@ -638,13 +647,13 @@ impl Message {
         {
             if let Some(cache) = cache_http.cache() {
                 if self.guild_id.is_some() {
-                    let req = Permissions::SEND_MESSAGES;
-
-                    if !super::utils::user_has_perms(cache, self.channel_id, self.guild_id, req)
-                        .await?
-                    {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
+                    utils::user_has_perms_cache(
+                        cache,
+                        self.channel_id,
+                        self.guild_id,
+                        Permissions::SEND_MESSAGES,
+                    )
+                    .await?;
                 }
             }
         }
@@ -680,14 +689,16 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_MESSAGES;
-                let is_author = self.author.id == cache.current_user().await.id;
-                let has_perms =
-                    super::utils::user_has_perms(&cache, self.channel_id, self.guild_id, req)
-                        .await?;
+                utils::user_has_perms_cache(
+                    cache,
+                    self.channel_id,
+                    self.guild_id,
+                    Permissions::MANAGE_MESSAGES,
+                )
+                .await?;
 
-                if !is_author && !has_perms {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                if !(self.author.id == cache.current_user().await.id) {
+                    return Err(Error::Model(ModelError::NotAuthor));
                 }
             }
         }
@@ -752,13 +763,13 @@ impl Message {
         {
             if let Some(cache) = cache_http.cache() {
                 if self.guild_id.is_some() {
-                    let req = Permissions::MANAGE_MESSAGES;
-
-                    if !super::utils::user_has_perms(cache, self.channel_id, self.guild_id, req)
-                        .await?
-                    {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
+                    utils::user_has_perms_cache(
+                        cache,
+                        self.channel_id,
+                        self.guild_id,
+                        Permissions::MANAGE_MESSAGES,
+                    )
+                    .await?;
                 }
             }
         }
@@ -1002,7 +1013,7 @@ enum_number!(MessageActivityKind {
     JOIN,
     SPECTATE,
     LISTEN,
-    JOIN_REQUEST,
+    JOIN_REQUEST
 });
 
 impl MessageActivityKind {

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -314,7 +314,7 @@ enum_number!(ChannelType {
     Voice,
     Category,
     News,
-    Store,
+    Store
 });
 
 impl ChannelType {

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -84,14 +84,13 @@ impl Reaction {
                 }
 
                 if user_id.is_some() {
-                    let req = Permissions::MANAGE_MESSAGES;
-
-                    if !utils::user_has_perms(cache, self.channel_id, None, req)
-                        .await
-                        .unwrap_or(true)
-                    {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
+                    utils::user_has_perms_cache(
+                        cache,
+                        self.channel_id,
+                        self.guild_id,
+                        Permissions::MANAGE_MESSAGES,
+                    )
+                    .await?;
                 }
             }
         }
@@ -120,11 +119,13 @@ impl Reaction {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_MESSAGES;
-
-                if !utils::user_has_perms(cache, self.channel_id, self.guild_id, req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                utils::user_has_perms_cache(
+                    cache,
+                    self.channel_id,
+                    self.guild_id,
+                    Permissions::MANAGE_MESSAGES,
+                )
+                .await?;
             }
         }
         cache_http
@@ -379,7 +380,9 @@ impl ReactionType {
                 id,
                 ref name,
                 ..
-            } => format!("{}:{}", name.as_ref().map_or("", |s| s.as_str()), id),
+            } => {
+                format!("{}:{}", name.as_ref().map_or("", |s| s.as_str()), id)
+            },
             ReactionType::Unicode(ref unicode) => unicode.clone(),
         }
     }

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -39,7 +39,7 @@ pub enum StickerFormatType {
 enum_number!(StickerFormatType {
     Png,
     Apng,
-    Lottie,
+    Lottie
 });
 
 impl StickerFormatType {

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -145,6 +145,23 @@ pub enum Error {
     NameTooShort,
     /// Indicates that the webhook name is over the 100 characters limit.
     NameTooLong,
+    /// Indicates that the bot is not author of the message.
+    NotAuthor,
+}
+
+impl Error {
+    /// Return `true` if the model error is related to an item missing in the
+    /// cache.
+    pub fn is_cache_err(&self) -> bool {
+        match self {
+            Self::ItemMissing
+            | Self::ChannelNotFound
+            | Self::RoleNotFound
+            | Self::GuildNotFound
+            | Self::MemberNotFound => true,
+            _ => false,
+        }
+    }
 }
 
 impl Display for Error {
@@ -167,6 +184,7 @@ impl Display for Error {
             Error::MessagingBot => f.write_str("Attempted to message another bot user."),
             Error::NameTooShort => f.write_str("Name is under the character limit."),
             Error::NameTooLong => f.write_str("Name is over the character limit."),
+            Error::NotAuthor => f.write_str("The bot is not author of this message."),
         }
     }
 }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -455,7 +455,7 @@ enum_number!(ActivityType {
     Streaming,
     Listening,
     Custom,
-    Competing,
+    Competing
 });
 
 impl ActivityType {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2394,7 +2394,7 @@ pub enum DefaultMessageNotificationLevel {
 
 enum_number!(DefaultMessageNotificationLevel {
     All,
-    Mentions,
+    Mentions
 });
 
 impl DefaultMessageNotificationLevel {
@@ -2421,7 +2421,7 @@ pub enum ExplicitContentFilter {
 enum_number!(ExplicitContentFilter {
     None,
     WithoutRole,
-    All,
+    All
 });
 
 impl ExplicitContentFilter {
@@ -2446,7 +2446,7 @@ pub enum MfaLevel {
 
 enum_number!(MfaLevel {
     None,
-    Elevated,
+    Elevated
 });
 
 impl MfaLevel {
@@ -2547,7 +2547,7 @@ enum_number!(VerificationLevel {
     Low,
     Medium,
     High,
-    Higher,
+    Higher
 });
 
 impl VerificationLevel {

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -13,7 +13,7 @@ enum_number!(PremiumTier {
     Tier0,
     Tier1,
     Tier2,
-    Tier3,
+    Tier3
 });
 
 impl PremiumTier {

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -117,7 +117,7 @@ pub enum InteractionType {
 
 enum_number!(InteractionType {
     Ping,
-    ApplicationCommand,
+    ApplicationCommand
 });
 
 /// The command data payload.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -80,11 +80,13 @@ impl Invite {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::CREATE_INVITE;
-
-                if !model_utils::user_has_perms(cache, channel_id, None, req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                model_utils::user_has_perms_cache(
+                    cache,
+                    channel_id,
+                    None,
+                    Permissions::CREATE_INVITE,
+                )
+                .await?;
             }
         }
 
@@ -112,12 +114,14 @@ impl Invite {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_GUILD;
-
                 let guild_id = self.guild.as_ref().map(|g| g.id);
-                if !model_utils::user_has_perms(cache, self.channel.id, guild_id, req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                model_utils::user_has_perms_cache(
+                    cache,
+                    self.channel.id,
+                    guild_id,
+                    Permissions::MANAGE_GUILD,
+                )
+                .await?;
             }
         }
 
@@ -337,12 +341,15 @@ impl RichInvite {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::MANAGE_GUILD;
-
                 let guild_id = self.guild.as_ref().map(|g| g.id);
-                if !model_utils::user_has_perms(cache, self.channel.id, guild_id, req).await? {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+
+                model_utils::user_has_perms_cache(
+                    cache,
+                    self.channel.id,
+                    guild_id,
+                    Permissions::MANAGE_GUILD,
+                )
+                .await?;
             }
         }
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -218,7 +218,7 @@ pub fn serialize_gen_map<K: Eq + Hash, S: Serializer, V: Serialize>(
 }
 
 /// Tries to find a user's permissions using the cache.
-/// Unline [`user_has_perms`], this function will return `true` even when
+/// Unlike [`user_has_perms`], this function will return `true` even when
 /// the permissions are not in the cache.
 #[cfg(all(feature = "cache", feature = "model"))]
 #[inline]


### PR DESCRIPTION
# Description
When the cache is enabled but the cache is not populated with all the data needed for a permission check, the check failed with an error.
This pull request changes model methods to run the HTTP-request still, as attempting to run the request is cheaper than requesting data for a check.

# Type of Change
This pull request qualifies as a *fix*, relates to code residing in the *utils* and *model*, and closes #1166.
It fixes the behaviour, as the methods were never truly designed to fail, nonetheless, the new gateway intents causes the cache to receive fewer events by default.

# How Has This Been Tested?
Attempted to execute methods that would run a permission check while the gateway intents are disabled.
I would be happy if people can try to run their bots with this pull request, especially if you encountered #1166,
