### PR TITLE
Initial Parse trait PR

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,13 +4,16 @@
 mod colour;
 mod custom_message;
 mod message_builder;
+#[cfg(feature = "client")]
 mod parse;
+
+#[cfg(feature = "client")]
+pub use parse::*;
 
 pub use self::{
     colour::Colour,
     custom_message::CustomMessage,
     message_builder::{Content, ContentModifier, EmbedMessageBuilding, MessageBuilder},
-    parse::*, // export all public items
 };
 pub type Color = Colour;
 
@@ -306,7 +309,11 @@ pub fn parse_emoji(mention: impl AsRef<str>) -> Option<EmojiIdentifier> {
         }
 
         match id.parse::<u64>() {
-            Ok(x) => Some(EmojiIdentifier { animated, name, id: EmojiId(x) }),
+            Ok(x) => Some(EmojiIdentifier {
+                animated,
+                name,
+                id: EmojiId(x),
+            }),
             _ => None,
         }
     } else {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,11 +4,13 @@
 mod colour;
 mod custom_message;
 mod message_builder;
+mod parse;
 
 pub use self::{
     colour::Colour,
     custom_message::CustomMessage,
     message_builder::{Content, ContentModifier, EmbedMessageBuilding, MessageBuilder},
+    parse::*, // export all public items
 };
 pub type Color = Colour;
 
@@ -304,11 +306,7 @@ pub fn parse_emoji(mention: impl AsRef<str>) -> Option<EmojiIdentifier> {
         }
 
         match id.parse::<u64>() {
-            Ok(x) => Some(EmojiIdentifier {
-                animated,
-                name,
-                id: EmojiId(x),
-            }),
+            Ok(x) => Some(EmojiIdentifier { animated, name, id: EmojiId(x) }),
             _ => None,
         }
     } else {

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -30,7 +30,10 @@ impl<T: std::str::FromStr> Parse for T {
 /// Error that can be returned from [`Member::parse`].
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum MemberParseError {
+    /// The guild in which the parser was invoked is not in cache.
     GuildNotInCache,
+    /// The provided member string failed to parse, or the parsed result cannot be found in the
+    /// guild cache data.
     NotFoundOrMalformed,
 }
 
@@ -104,7 +107,9 @@ impl Parse for Member {
 /// Error that can be returned from [`Message::parse`].
 #[derive(Debug)]
 pub enum MessageParseError {
+    /// When the provided string does not adhere to any known guild message format
     Malformed,
+    /// When message data retrieval via HTTP failed
     Http(SerenityError),
     /// When the `gateway` feature is disabled and the required information was not in cache.
     HttpNotAvailable,

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -177,7 +177,7 @@ impl Parse for Message {
             return Ok(msg);
         }
 
-        if cfg!(feature = "gateway") {
+        if cfg!(feature = "http") {
             ctx.http.get_message(channel_id.0, message_id.0).await.map_err(MessageParseError::Http)
         } else {
             Err(MessageParseError::HttpNotAvailable)

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -29,6 +29,7 @@ impl<T: std::str::FromStr> Parse for T {
 }
 
 /// Error that can be returned from [`Member::parse`].
+#[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum MemberParseError {
     /// The guild in which the parser was invoked is not in cache.
@@ -104,6 +105,7 @@ impl Parse for Member {
 }
 
 /// Error that can be returned from [`Message::parse`].
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum MessageParseError {
     /// When the provided string does not adhere to any known guild message format

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -1,14 +1,10 @@
 use crate::{model::prelude::*, prelude::*};
 
-// Questions:
-// - Should the error enums be #[non_exhaustive]?
-// - Should the MessageParseError implement source()? It may be too much boilerplate (maybe add thiserror dependency?)
-
 /// Parse a value from a string in context of a received message.
 ///
 /// This trait is a superset of [`std::str::FromStr`] (the trait used in [`str::parse`]). The
-/// difference is that this trait supports serenity-specific Discord types like [`Member`],
-/// [`Role`] (soon), or [`Emoji`] (soon).
+/// difference is that this trait aims to support serenity-specific Discord types like [`Member`]
+/// or [`Message`].
 ///
 /// Trait implementations may do network requests as part of their parsing procedure.
 ///
@@ -64,7 +60,8 @@ impl std::fmt::Display for MemberParseError {
 impl Parse for Member {
     type Err = MemberParseError;
 
-    #[doc = ""] // to get impl documentation to show
+    // to get impl documentation to show
+    #[doc = ""]
     async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
         let guild = msg.guild(&ctx.cache).await.ok_or(MemberParseError::GuildNotInCache)?;
 
@@ -109,7 +106,7 @@ impl Parse for Member {
 pub enum MessageParseError {
     Malformed,
     Http(SerenityError),
-    /// When the `gateway` feature is disabled and the required information was not in cache
+    /// When the `gateway` feature is disabled and the required information was not in cache.
     HttpNotAvailable,
 }
 
@@ -148,7 +145,8 @@ impl std::fmt::Display for MessageParseError {
 impl Parse for Message {
     type Err = MessageParseError;
 
-    #[doc = ""] // to get impl documentation to show
+    // to get impl documentation to show
+    #[doc = ""]
     async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
         let extract_from_id_pair = || {
             let mut parts = s.splitn(2, '-');

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -39,8 +39,8 @@ impl std::error::Error for MemberParseError {}
 impl std::fmt::Display for MemberParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-			Self::GuildNotInCache => write!(f, "guild is not in cache"),
-			Self::NotFoundOrMalformed => write!(f, "provided member was not found or provided string did not adhere to any known guild member format"),
+			Self::GuildNotInCache => write!(f, "Guild is not in cache"),
+			Self::NotFoundOrMalformed => write!(f, "Provided member was not found or provided string did not adhere to any known guild member format"),
 		}
     }
 }
@@ -60,7 +60,7 @@ impl std::fmt::Display for MemberParseError {
 impl Parse for Member {
     type Err = MemberParseError;
 
-    // to get impl documentation to show
+    // To get impl documentation to show.
     #[doc = ""]
     async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
         let guild = msg.guild(&ctx.cache).await.ok_or(MemberParseError::GuildNotInCache)?;
@@ -124,12 +124,12 @@ impl std::fmt::Display for MessageParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Malformed => {
-                write!(f, "provided string did not adhere to any known guild message format")
+                write!(f, "Provided string did not adhere to any known guild message format")
             },
-            Self::Http(e) => write!(f, "failed to request message data via HTTP: {}", e),
+            Self::Http(e) => write!(f, "Failed to request message data via HTTP: {}", e),
             Self::HttpNotAvailable => write!(
                 f,
-                "gateway feature is disabled and the required information was not in cache"
+                "Gateway feature is disabled and the required information was not in cache"
             ),
         }
     }
@@ -145,7 +145,7 @@ impl std::fmt::Display for MessageParseError {
 impl Parse for Message {
     type Err = MessageParseError;
 
-    // to get impl documentation to show
+    // To get impl documentation to show.
     #[doc = ""]
     async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
         let extract_from_id_pair = || {

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -1,14 +1,15 @@
-use crate::{model::prelude::*, prelude::*};
+use crate::model::prelude::*;
+use crate::prelude::*;
 
 /// Parse a value from a string in context of a received message.
 ///
-/// This trait is a superset of [`std::str::FromStr`] (the trait used in [`str::parse`]). The
+/// This trait is a superset of [`std::str::FromStr`]. The
 /// difference is that this trait aims to support serenity-specific Discord types like [`Member`]
 /// or [`Message`].
 ///
 /// Trait implementations may do network requests as part of their parsing procedure.
 ///
-/// Useful for implementing command argument parsing frameworks.
+/// Useful for implementing argument parsing in command frameworks.
 #[async_trait::async_trait]
 pub trait Parse: Sized {
     /// The associated error which can be returned from parsing.
@@ -60,8 +61,6 @@ impl std::fmt::Display for MemberParseError {
 impl Parse for Member {
     type Err = MemberParseError;
 
-    // To get impl documentation to show.
-    #[doc = ""]
     async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
         let guild = msg.guild(&ctx.cache).await.ok_or(MemberParseError::GuildNotInCache)?;
 
@@ -145,8 +144,6 @@ impl std::fmt::Display for MessageParseError {
 impl Parse for Message {
     type Err = MessageParseError;
 
-    // To get impl documentation to show.
-    #[doc = ""]
     async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
         let extract_from_id_pair = || {
             let mut parts = s.splitn(2, '-');


### PR DESCRIPTION
This PR adds a new `serenity::utils::Parse` trait, mainly for https://github.com/serenity-rs/framework/issues/24.

As described in the docstring below, the `Parse` trait works like `std::str::FromStr`, but it also supports Discord model types like `Member` or `Message`.
```rust
/// Parse a value from a string in context of a received message.
///
/// This trait is a superset of [`std::str::FromStr`] (the trait used in `str::parse`). The
/// difference is that this trait supports serenity-specific Discord types like [`Member`], [`Role`],
/// or [`Emoji`].
///
/// Trait implementations may do network requests as part of their parsing procedure.
///
/// Useful for implementing command argument parsing frameworks.
#[async_trait::async_trait]
pub trait Parse: Sized {
    /// The associated error which can be returned from parsing.
    type Err;

    /// Parses a string `s` as a command parameter of this type.
    async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err>;
}
```

In this PR, support for `Member` and `Message` is implemented.

In a later PR, I hope to add support for more types:
- `User`/`UserId`
- `Channel`/`ChannelId`
- `GuildId`
- `ChannelCategory`
- `Role`/`RoleId`
- `Invite`
- `Emoji`/`EmojiId`/`EmojiIdentifier`
- `Colour`
- did I miss one?