### PR TITLE
Remove `Box` indirection on `framework`.

### DIFF
--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -346,7 +346,7 @@ pub struct ShardManagerOptions<'a> {
     pub event_handler: &'a Option<Arc<dyn EventHandler>>,
     pub raw_event_handler: &'a Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    pub framework: &'a Arc<Box<dyn Framework + Send + Sync>>,
+    pub framework: &'a Arc<dyn Framework + Send + Sync>,
     pub shard_index: u64,
     pub shard_init: u64,
     pub shard_total: u64,

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -69,7 +69,7 @@ use crate::CacheAndHttp;
 /// let gateway_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 /// let data = Arc::new(RwLock::new(TypeMap::new()));
 /// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
-/// let framework = Arc::new(Box::new(StandardFramework::new()) as Box<dyn Framework + 'static + Send + Sync>);
+/// let framework = Arc::new(StandardFramework::new() as Box<dyn Framework + 'static + Send + Sync>);
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -49,27 +49,29 @@ use crate::CacheAndHttp;
 /// # #[cfg(feature = "framework")]
 /// # async fn run() -> Result<(), Box<dyn Error>> {
 /// #
-/// use tokio::sync::{Mutex, RwLock};
-/// use serenity::client::bridge::gateway::{ShardManager, ShardManagerOptions, GatewayIntents};
-/// use serenity::client::{EventHandler, RawEventHandler};
-/// use serenity::http::Http;
-/// use serenity::CacheAndHttp;
-/// use serenity::prelude::*;
-/// use serenity::framework::{Framework, StandardFramework};
-/// use std::sync::Arc;
 /// use std::env;
+/// use std::sync::Arc;
+///
+/// use serenity::client::bridge::gateway::{GatewayIntents, ShardManager, ShardManagerOptions};
+/// use serenity::client::{EventHandler, RawEventHandler};
+/// use serenity::framework::{Framework, StandardFramework};
+/// use serenity::http::Http;
+/// use serenity::prelude::*;
+/// use serenity::CacheAndHttp;
+/// use tokio::sync::{Mutex, RwLock};
 ///
 /// struct Handler;
 ///
-/// impl EventHandler for Handler { }
-/// impl RawEventHandler for Handler { }
+/// impl EventHandler for Handler {}
+/// impl RawEventHandler for Handler {}
 ///
 /// # let cache_and_http = Arc::new(CacheAndHttp::default());
 /// # let http = &cache_and_http.http;
 /// let gateway_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 /// let data = Arc::new(RwLock::new(TypeMap::new()));
 /// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
-/// let framework = Arc::new(StandardFramework::new()) as Arc<dyn Framework + Send + Sync + 'static>;
+/// let framework =
+///     Arc::new(StandardFramework::new()) as Arc<dyn Framework + Send + Sync + 'static>;
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -38,7 +38,7 @@ use crate::CacheAndHttp;
 /// Initialize a shard manager with a framework responsible for shards 0 through
 /// 2, of 5 total shards:
 ///
-/// ```rust
+/// ```rust,no_run
 /// # use std::error::Error;
 /// #
 /// # #[cfg(feature = "voice")]

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -38,7 +38,7 @@ use crate::CacheAndHttp;
 /// Initialize a shard manager with a framework responsible for shards 0 through
 /// 2, of 5 total shards:
 ///
-/// ```rust,no_run
+/// ```rust
 /// # use std::error::Error;
 /// #
 /// # #[cfg(feature = "voice")]
@@ -69,7 +69,7 @@ use crate::CacheAndHttp;
 /// let gateway_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 /// let data = Arc::new(RwLock::new(TypeMap::new()));
 /// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
-/// let framework = Arc::new(StandardFramework::new() as Box<dyn Framework + 'static + Send + Sync>);
+/// let framework = Arc::new(StandardFramework::new()) as Arc<dyn Framework + Send + Sync + 'static>;
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -63,7 +63,7 @@ pub struct ShardQueuer {
     pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
-    pub framework: Arc<Box<dyn Framework + Send + Sync>>,
+    pub framework: Arc<dyn Framework + Send + Sync>,
     /// The instant that a shard was last started.
     ///
     /// This is used to determine how long to wait between shard IDENTIFYs.

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -34,7 +34,7 @@ pub struct ShardRunner {
     event_handler: Option<Arc<dyn EventHandler>>,
     raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    framework: Arc<Box<dyn Framework + Send + Sync>>,
+    framework: Arc<dyn Framework + Send + Sync>,
     manager_tx: Sender<ShardManagerMessage>,
     // channel to receive messages from the shard manager and dispatches
     runner_rx: Receiver<InterMessage>,
@@ -618,7 +618,7 @@ pub struct ShardRunnerOptions {
     pub event_handler: Option<Arc<dyn EventHandler>>,
     pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    pub framework: Arc<Box<dyn Framework + Send + Sync>>,
+    pub framework: Arc<dyn Framework + Send + Sync>,
     pub manager_tx: Sender<ShardManagerMessage>,
     pub shard: Shard,
     #[cfg(feature = "voice")]

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -150,7 +150,7 @@ impl DispatchEvent {
 pub(crate) fn dispatch<'rec>(
     // #[allow(unused_variables)]
     mut event: DispatchEvent,
-    #[cfg(feature = "framework")] framework: &'rec Arc<Box<dyn Framework + Send + Sync>>,
+    #[cfg(feature = "framework")] framework: &'rec Arc<dyn Framework + Send + Sync>,
     data: &'rec Arc<RwLock<TypeMap>>,
     event_handler: &'rec Option<Arc<dyn EventHandler>>,
     raw_event_handler: &'rec Option<Arc<dyn RawEventHandler>>,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -216,11 +216,11 @@ impl<'a> ClientBuilder<'a> {
     ///
     /// [`framework`]: Self::framework
     #[cfg(feature = "framework")]
-    pub fn framework_arc(
+    pub fn framework_arc<T: Framework + Send + Sync + 'static>(
         mut self,
-        framework: Arc<Box<dyn Framework + Send + Sync + 'static>>,
+        framework: Arc<T>,
     ) -> Self {
-        self.framework = Some(framework);
+        self.framework = Some(framework as Arc<dyn Framework + Send + Sync + 'static>);
 
         self
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -78,7 +78,7 @@ pub struct ClientBuilder<'a> {
     #[cfg(feature = "cache")]
     timeout: Option<Duration>,
     #[cfg(feature = "framework")]
-    framework: Option<Arc<Box<dyn Framework + Send + Sync + 'static>>>,
+    framework: Option<Arc<dyn Framework + Send + Sync + 'static>>,
     #[cfg(feature = "voice")]
     voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
     event_handler: Option<Arc<dyn EventHandler>>,


### PR DESCRIPTION
# Description
This pull request removes the `Box` around the framework, allowing to `as`-cast for the `ClientBuilder::framework_arc`-method.
The `as`-cast is now performed in the method itself, accepting a generic framework instead, easing the use of the API.

# Type of Change
This pull request *breaks the API* in a number of places and relates to code residing in the *framework*-module.
It enhances Serenity by removing an indirection (`Box`), which improves speed and size. Additionally, it takes the burden of casting the framework to a trait object.

# How Has This Been Tested?
The code compiles still.

The removal of the `as`-cast was tested by performing this:

```rust
let framework = Arc::new(StandardFramework::new());
client_builder.framework_arc(Arc::clone(&framework));
```
