### PR TITLE
add ChannelFollowAdd to MessageType enum.

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -953,6 +953,8 @@ pub enum MessageType {
     NitroTier2 = 10,
     /// An indicator that the guild has reached nitro tier 3
     NitroTier3 = 11,
+    /// An indicator that the channel is now following an announcement channel
+    ChannelFollowAdd = 12,
     /// A message reply.
     InlineReply = 19,
     /// A slash command
@@ -993,6 +995,7 @@ impl MessageType {
             NitroTier1 => 9,
             NitroTier2 => 10,
             NitroTier3 => 11,
+            ChannelFollowAdd => 12,
             InlineReply => 19,
             ApplicationCommand => 20,
         }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -955,6 +955,10 @@ pub enum MessageType {
     NitroTier3 = 11,
     /// An indicator that the channel is now following an announcement channel
     ChannelFollowAdd = 12,
+    /// An indicator that the guild is disqualified for Discovery Feature
+    GuildDiscoveryDisqualified = 14,
+    /// An indicator that the guild is requalified for Discovery Feature
+    GuildDiscoveryRequalified = 15,
     /// A message reply.
     InlineReply = 19,
     /// A slash command
@@ -996,6 +1000,8 @@ impl MessageType {
             NitroTier2 => 10,
             NitroTier3 => 11,
             ChannelFollowAdd => 12,
+            GuildDiscoveryDisqualified => 14,
+            GuildDiscoveryRequalified => 15,
             InlineReply => 19,
             ApplicationCommand => 20,
         }


### PR DESCRIPTION
Hi, 
We're seing lot of warning in console due to the unknown messagetype.
I've added the ChannelFollowAdd to MessageType.
Ref: [Discord Doc - Message Types](https://discord.com/developers/docs/resources/channel#message-object-message-types)
PS: could be good to add GUILD_DISCOVERY_DISQUALIFIED and GUILD_DISCOVERY_REQUALIFIED too.