### PR TITLE
Check if Private Channel Before Returning `NotAuthor`

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -261,7 +261,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.author.id != cache.current_user().await.id {
+                if self.author.id != cache.current_user_id().await {
                     return Err(Error::Model(ModelError::InvalidUser));
                 }
             }
@@ -701,7 +701,7 @@ impl Message {
                 )
                 .await?;
 
-                if !(self.author.id == cache.current_user_id().await) {
+                if self.author.id != cache.current_user_id().await {
                     return Err(Error::Model(ModelError::NotAuthor));
                 }
             }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -701,7 +701,7 @@ impl Message {
                 )
                 .await?;
 
-                if !(self.author.id == cache.current_user().await.id) {
+                if !(self.author.id == cache.current_user_id().await) {
                     return Err(Error::Model(ModelError::NotAuthor));
                 }
             }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -140,14 +140,18 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let permissions = Permissions::MANAGE_MESSAGES;
-                let is_author = self.author.id == cache.current_user().await.id;
-
-                utils::user_has_perms_cache(cache, self.channel_id, self.guild_id, permissions)
-                    .await?;
-
-                if !is_author {
-                    return Err(Error::Model(ModelError::NotAuthor));
+                if self.author.id != cache.current_user().await.id {
+                    if self.is_private() {
+                        return Err(Error::Model(ModelError::NotAuthor));
+                    } else {
+                        utils::user_has_perms_cache(
+                            cache,
+                            self.channel_id,
+                            self.guild_id,
+                            Permissions::MANAGE_MESSAGES,
+                        )
+                        .await?;
+                    }
                 }
             }
         }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -140,7 +140,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.author.id != cache.current_user().await.id {
+                if self.author.id != cache.current_user_id().await {
                     if self.is_private() {
                         return Err(Error::Model(ModelError::NotAuthor));
                     } else {

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -146,6 +146,7 @@ pub enum Error {
     /// Indicates that the webhook name is over the 100 characters limit.
     NameTooLong,
     /// Indicates that the bot is not author of the message.
+    /// This error is returnend in private/direct channels.
     NotAuthor,
 }
 

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -146,7 +146,7 @@ pub enum Error {
     /// Indicates that the webhook name is over the 100 characters limit.
     NameTooLong,
     /// Indicates that the bot is not author of the message.
-    /// This error is returnend in private/direct channels.
+    /// This error is returned in private/direct channels.
     NotAuthor,
 }
 


### PR DESCRIPTION
# Description
This pull request corrects behaviour for `Message::delete` and `Message::suppress_embeds` to consider whether the message has been sent in a direct or guild channel.
In direct channels, it will return the `NotAuthor`-error if the bot is not the error of the message.
In guild channels, it will check whether the bot has the needed permissions (`MANAGE_MESSAGE`).

# Type of Change
This pull request *fixes* the behaviour of two methods residing in the *model* module.

# How Has This Been Tested?
The code has been tested by two users.

Please help me testing this pull request! 


