### PR TITLE
add new MessageTypes to serde enum_number macro

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -978,6 +978,9 @@ enum_number!(MessageType {
     NitroTier1,
     NitroTier2,
     NitroTier3,
+    ChannelFollowAdd,
+    GuildDiscoveryDisqualified,
+    GuildDiscoveryRequalified,
     InlineReply,
     ApplicationCommand,
 });

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -953,6 +953,8 @@ pub enum MessageType {
     NitroTier2 = 10,
     /// An indicator that the guild has reached nitro tier 3
     NitroTier3 = 11,
+    /// An indicator that the channel is now following an announcement channel
+    ChannelFollowAdd = 12,
     /// A message reply.
     InlineReply = 19,
     /// A slash command
@@ -993,6 +995,7 @@ impl MessageType {
             NitroTier1 => 9,
             NitroTier2 => 10,
             NitroTier3 => 11,
+            ChannelFollowAdd => 12,
             InlineReply => 19,
             ApplicationCommand => 20,
         }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -955,6 +955,10 @@ pub enum MessageType {
     NitroTier3 = 11,
     /// An indicator that the channel is now following an announcement channel
     ChannelFollowAdd = 12,
+    /// An indicator that the guild is disqualified for Discovery Feature
+    GuildDiscoveryDisqualified = 14,
+    /// An indicator that the guild is requalified for Discovery Feature
+    GuildDiscoveryRequalified = 15,
     /// A message reply.
     InlineReply = 19,
     /// A slash command
@@ -996,6 +1000,8 @@ impl MessageType {
             NitroTier2 => 10,
             NitroTier3 => 11,
             ChannelFollowAdd => 12,
+            GuildDiscoveryDisqualified => 14,
+            GuildDiscoveryRequalified => 15,
             InlineReply => 19,
             ApplicationCommand => 20,
         }


### PR DESCRIPTION
Hi ! 

Since my last pull request ( #1241), the warnings have not disappeared, so I checked the code an I saw that I forgot to add the types to the enum_number macro (for serde json serialization / deserialization), so I added them in this commit.