### PR TITLE
Skip the `Available`-Segment in Help if Empty

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1197,7 +1197,9 @@ async fn send_single_command_embed(
                     );
                 }
 
-                embed.field(&help_options.available_text, &command.availability, true);
+                if !help_options.available_text.is_empty() && !command.availability.is_empty() {
+                    embed.field(&help_options.available_text, &command.availability, true);
+                }
 
                 if !command.checks.is_empty() {
                     embed.field(
@@ -1449,7 +1451,9 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
 
     let _ = writeln!(result, "**{}**: {}", help_options.grouped_label, command.group_name);
 
-    let _ = writeln!(result, "**{}**: {}", help_options.available_text, command.availability);
+    if !help_options.available_text.is_empty() && !command.availability.is_empty() {
+        let _ = writeln!(result, "**{}**: {}", help_options.available_text, command.availability);
+    }
 
     if !command.sub_commands.is_empty() {
         let _ = writeln!(


### PR DESCRIPTION
# Description
Checks if the `available_in`-label or the value is empty and if it is, skips the `Available`-segment in the final help output for the plain and embed variant. This has not been done before for no particular reason.

# Type of Change
This pull request aligns the behaviour of `available_in` with the other other non-essential help-segments, *enhancing* the help-system. The behaviour change is okay, as leaving the related items empty would cause the embed-help to fail sending, *fixing* the behaviour.

# How Has This Been Tested?
The help-command has been run and it skipped the field when the label was set to `""` via `#[available_text("")]`.
