### PR TITLE
Rename `#[doc]` attributes to `#[description]` for groups

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -628,7 +628,10 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
                 options.prefixes = vec![propagate_err!(attributes::parse(values))];
             },
             "description" => {
-                let arg: String = propagate_err!(attributes::parse(values));
+                let mut arg: String = propagate_err!(attributes::parse(values));
+                if arg.starts_with(' ') {
+                    arg.remove(0);
+                }
 
                 if let Some(desc) = &mut options.description.0 {
                     use std::fmt::Write;

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -581,6 +581,8 @@ impl Parse for GroupStruct {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let mut attributes = input.call(Attribute::parse_outer)?;
 
+        util::rename_attributes(&mut attributes, "doc", "description");
+
         let cooked = remove_cooked(&mut attributes);
 
         let visibility = input.parse()?;


### PR DESCRIPTION
## Description

This copies the rename action for the `#[doc]` attribute from commands to groups, allowing a user to describe a group with documentation comments.

## Type of Change

This changes code in the `command_attr` crate, a part of the framework. This enhances the experience for `#[group]`s by granting an alternative to `#[description]`. It also fixes an error that developed when `#[doc]` was removed from the list of cooked attributes, which resulted in compilation failures as the `#[group]` does not acknowledge the `#[doc]` attribute.

## How Has This Been Tested?

This has been tested by running `cargo check` to see if `#[group]`s with documentation comments compiled, and with `cargo expand` to ascertain that the documentation comment was correctly converted into a description. Both commands were a success.