### PR TITLE
Fix the type of `token` and add field `kind` to `Webhook`

### DIFF
--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -148,6 +148,8 @@ pub enum Error {
     /// Indicates that the bot is not author of the message.
     /// This error is returned in private/direct channels.
     NotAuthor,
+    /// Indicates that the webhook token is missing.
+    NoTokenSet,
 }
 
 impl Error {
@@ -186,6 +188,7 @@ impl Display for Error {
             Error::NameTooShort => f.write_str("Name is under the character limit."),
             Error::NameTooLong => f.write_str("Name is over the character limit."),
             Error::NotAuthor => f.write_str("The bot is not author of this message."),
+            Error::NoTokenSet => f.write_str("Token is not set."),
         }
     }
 }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -17,9 +17,46 @@ use crate::http::Http;
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
+use crate::model::prelude::*;
+#[cfg(feature = "model")]
 use crate::model::ModelError;
 #[cfg(feature = "model")]
 use crate::utils;
+
+/// A representation of a type of webhook.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum WebhookType {
+    /// An indicator that the webhook can post messages to channels with
+    /// a token.
+    Incoming = 1,
+    /// An indicator that the webhook is managed by Discord for posting new
+    /// messages to channels without a token.
+    ChannelFollower = 2,
+}
+
+enum_number!(WebhookType {
+    Incoming,
+    ChannelFollower
+});
+
+impl WebhookType {
+    #[inline]
+    pub fn name(&self) -> &str {
+        match self {
+            WebhookType::Incoming => "incoming",
+            WebhookType::ChannelFollower => "channel follower",
+        }
+    }
+
+    #[inline]
+    pub fn num(self) -> u64 {
+        match self {
+            WebhookType::Incoming => 1,
+            WebhookType::ChannelFollower => 2,
+        }
+    }
+}
 
 /// A representation of a webhook, which is a low-effort way to post messages to
 /// channels. They do not necessarily require a bot user or authentication to
@@ -31,6 +68,9 @@ pub struct Webhook {
     ///
     /// Can be used to calculate the creation date of the webhook.
     pub id: WebhookId,
+    /// The type of the webhook.
+    #[serde(rename = "type")]
+    pub kind: WebhookType,
     /// The default avatar.
     ///
     /// This can be modified via [`ExecuteWebhook::avatar_url`].
@@ -55,6 +95,7 @@ impl fmt::Debug for Webhook {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Webhook")
             .field("id", &self.id)
+            .field("kind", &self.kind)
             .field("avatar", &self.avatar)
             .field("channel_id", &self.channel_id)
             .field("guild_id", &self.guild_id)

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -182,9 +182,9 @@ impl Webhook {
     ///
     /// Returns an [`Error::Model`] if the [`token`] is `None`.
     ///
-    /// May also return an [`Error::Http`] if the content is illformed, or if the token is invalid.
+    /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
     ///
-    /// Or may return an [`Error::Json`] if there is an error in deserializing Discord's response.
+    /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
     ///
     /// [`Error::Model`]: crate::error::Error::Model
     /// [`token`]: Self::token
@@ -287,9 +287,9 @@ impl Webhook {
     ///
     /// Returns an [`Error::Model`] if the [`token`] is `None`.
     ///
-    /// May also return an [`Error::Http`] if the content is illformed, or if the webhook's token is invalid.
+    /// May also return an [`Error::Http`] if the content is malformed, or if the webhook's token is invalid.
     ///
-    /// Or may return an [`Error::Json`] if there is an error deserializing Discord's response.
+    /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     ///
     /// [`Error::Model`]: crate::error::Error::Model
     /// [`token`]: Self::token
@@ -333,7 +333,7 @@ impl Webhook {
     /// May also return an [`Error::Http`] if the http client errors or if Discord returns an error.
     /// Such as if the `Webhook` was deleted.
     ///
-    /// Or may return an [`Error::Json`] if there is an error deserializing Discord's response.
+    /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     ///
     /// [`Error::Model`]: crate::error::Error::Model
     /// [`token`]: Self::token
@@ -381,7 +381,7 @@ impl WebhookId {
     /// Returns an [`Error::Http`] if the http client errors or if Discord returns an error.
     /// Such as if the `WebhookId` does not exist.
     ///
-    /// May also return an [`Error::Json`] if there is an error in deserializing the response.
+    /// May also return an [`Error::Json`] if there is an error in deserialising the response.
     ///
     /// [Manage Webhooks]: super::permissions::Permissions::MANAGE_WEBHOOKS
     /// [`Error::Http`]: crate::error::Error::Http


### PR DESCRIPTION
## Description

This changes the type for `Webhook::token` to `Option<String>` and adds a new field to the struct called `kind` with the type `WebhookType`. This updates the structure to [conform to Discord's schema](https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-structure) and to resolve https://github.com/serenity-rs/serenity/issues/1246.

## Type of Change

This is a multiclass change in the `model` module. It improves the correspondence with Discord's API for webhooks, and fixes an issue with the `token` definition, but has to break the library's APi to fix it. This targets `current` despite the breaking change, as otherwise webhooks are broken.


## How Has This Been Tested?

This has been tested by calling `Guild::webhooks` in a guild that had both an incoming webhook and a channel follower webhook. The result was a success, returning a list with the webhooks without errors.
