### PR TITLE
Fix invalid usage of `#[doc(cfg)]`

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -14,17 +14,17 @@ mod create_interaction;
 
 mod create_allowed_mentions;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod create_interaction_response;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod create_interaction_response_followup;
 mod create_invite;
 mod create_message;
 mod edit_channel;
 mod edit_guild;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(feature = "unstable_discord_api"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod edit_interaction_response;
 mod edit_member;
 mod edit_message;


### PR DESCRIPTION
## Description

This changes `#[doc(feature = "...")]` to the correct `#[doc(cfg(feature = "..."))]` form. Today's nightly (from what I've tested) has started emitting errors for invalid parameters in `#[doc]`, preventing documentation from being built. 

## Type of Change

This fixes usage of `#[doc(cfg)]` in the builder module. 

## How Has This Been Tested?

This has been tested by building documentation. With the changes, it successfully builds and shows the feature required to use slash command builders.