### PR TITLE
Apply changes to interaction response types and add a new interaction type

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -41,7 +41,7 @@ impl CreateInteractionResponse {
 impl<'a> Default for CreateInteractionResponse {
     fn default() -> CreateInteractionResponse {
         let mut map = HashMap::new();
-        map.insert("type", Value::Number(serde_json::Number::from(2)));
+        map.insert("type", Value::Number(serde_json::Number::from(4)));
 
         CreateInteractionResponse(map)
     }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -89,7 +89,12 @@ impl CreateInteractionResponseData {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
-        self.0.insert("embed", embed);
+        let mut embeds = self.0.entry("embeds").or_insert_with(|| Value::Array(vec![]));
+
+        if let Some(embeds) = embeds.as_array_mut() {
+            embeds.push(embed);
+        }
+
         self
     }
 

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -39,7 +39,12 @@ impl EditInteractionResponse {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
-        self.0.insert("embed", embed);
+        let mut embeds = self.0.entry("embeds").or_insert_with(|| Value::Array(vec![]));
+
+        if let Some(embeds) = embeds.as_array_mut() {
+            embeds.push(embed);
+        }
+
         self
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1033,6 +1033,8 @@ mod test {
                 flags: None,
                 stickers: vec![],
                 referenced_message: None,
+                #[cfg(feature = "unstable_discord_api")]
+                interaction: None,
             },
         };
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -26,6 +26,8 @@ use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::{CollectReaction, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
+#[cfg(feature = "unstable_discord_api")]
+use crate::model::interactions::MessageInteraction;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::U64Visitor;
@@ -104,6 +106,12 @@ pub struct Message {
     pub stickers: Vec<Sticker>,
     /// The message that was replied to using this message.
     pub referenced_message: Option<Box<Message>>, // Boxed to avoid recusion
+    /// Sent if the message is a response to an [`Interaction`].
+    ///
+    /// [`Interaction`]: crate::model::interactions::Interaction
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    pub interaction: Option<MessageInteraction>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -212,10 +212,8 @@ pub struct ApplicationCommandOptionChoice {
 #[repr(u8)]
 pub enum InteractionResponseType {
     Pong = 1,
-    Acknowledge = 2,
-    ChannelMessage = 3,
     ChannelMessageWithSource = 4,
-    AcknowledgeWithSource = 5,
+    DeferredChannelMessageWithSource = 5,
 }
 
 #[derive(Clone, Serialize)]
@@ -229,6 +227,18 @@ __impl_bitflags! {
         /// Interaction message will only be visible to sender
         EPHEMERAL = 0b0000_0000_0000_0000_0000_0000_0100_0000;
     }
+}
+
+/// Sent when a [`Message`] is a response to an [`Interaction`].
+///
+/// [`Message`]: crate::model::channel::Message
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MessageInteraction {
+    pub id: InteractionId,
+    #[serde(rename = "type")]
+    pub kind: InteractionType,
+    pub name: String,
+    pub user: User,
 }
 
 impl Interaction {

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -270,5 +270,7 @@ fn dummy_message() -> Message {
         flags: None,
         stickers: Vec::new(),
         referenced_message: None,
+        #[cfg(feature = "unstable_discord_api")]
+        interaction: None,
     }
 }


### PR DESCRIPTION
## Description

This updates the interaction types to reflect the changes as laid in the slash commands UI changes pull request for Discord's API documentation: https://github.com/discord/discord-api-docs/pull/2615. 

This removes the `Acknowledge` and `ChannelMessage` interaction response types, as they have been deprecated and scheduled for removal on the 9th of April, and renames `AcknowledgeWithSource` to `DeferredChannelMessageWithSource` to suit a better purpose. 

Furthermore, a new `MessageInteraction` type and its corresponding `interaction` field in `Message` is added.

Additionally, a fix is incorporated to the interaction responses builders to use the correct field name for embeds (`embed` -> `embeds`).

## Type of Change

This is a breaking change that enhances the API to be up-to-date with Discord's API. However, as slash commands are locked behind a feature flag that states that they're an unstable feature, the breaking change can be excused and put on the `current` branch.

## How Has This Been Tested?

This hasn't been tested yet, but according to the new documentation, it should work as intended.