### PR TITLE
Fix tracing compilation error in example 7

### DIFF
--- a/examples/e07_env_logging/src/main.rs
+++ b/examples/e07_env_logging/src/main.rs
@@ -24,10 +24,9 @@ impl EventHandler for Handler {
     // For instrument to work, all parameters must implement Debug.
     //
     // Handler doesn't implement Debug here, so we specify to skip that argument.
-    // Context doesn't implement Debug either, but since it's ignored already, it
-    // doesn't need to be skipped.
-    #[instrument(skip(self))]
-    async fn resume(&self, _: Context, resume: ResumedEvent) {
+    // Context doesn't implement Debug either, so it is also skipped.
+    #[instrument(skip(self, _ctx))]
+    async fn resume(&self, _ctx: Context, resume: ResumedEvent) {
         // Log at the DEBUG level.
         //
         // In this example, this will not show up in the logs because DEBUG is


### PR DESCRIPTION
## Description

This fixes a compilation error regarding usage of the `#[instrument]` macro in example 7. The macro mandates all parameters of a function implement `Debug`, which `Context` doesn't and by the discarding it with `_`, it should've been skipped by the macro. However, out of the blue, an error began reporting that `Context` doesn't implement `Debug` and that compilation cannot proceed further. This error didn't happen before, and seems to be regression in one of the tracing crates, but I'm uncertain.

## Type of Change

This fixes a compilation error in example 7.

## How Has This Been Tested?

This has been tested by confirming the example compiles, which it does.