### PR TITLE
Allow spanning description content across many lines like Markdown

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -126,18 +126,8 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
                 options.examples.push(propagate_err!(attributes::parse(values)));
             },
             "description" => {
-                let mut arg: String = propagate_err!(attributes::parse(values));
-                if arg.starts_with(' ') {
-                    arg.remove(0);
-                }
-
-                if let Some(desc) = &mut options.description.0 {
-                    use std::fmt::Write;
-
-                    let _ = write!(desc, "\n{}", arg);
-                } else {
-                    options.description = AsOption(Some(arg));
-                }
+                let line: String = propagate_err!(attributes::parse(values));
+                util::append_line(&mut options.description, line);
             },
             _ => {
                 match_options!(name, values, options, span => [
@@ -628,18 +618,8 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
                 options.prefixes = vec![propagate_err!(attributes::parse(values))];
             },
             "description" => {
-                let mut arg: String = propagate_err!(attributes::parse(values));
-                if arg.starts_with(' ') {
-                    arg.remove(0);
-                }
-
-                if let Some(desc) = &mut options.description.0 {
-                    use std::fmt::Write;
-
-                    let _ = write!(desc, "\n{}", arg.trim_matches(' '));
-                } else {
-                    options.description = AsOption(Some(arg));
-                }
+                let line: String = propagate_err!(attributes::parse(values));
+                util::append_line(&mut options.description, line);
             },
             "summary" => {
                 let arg: String = propagate_err!(attributes::parse(values));

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -263,3 +263,21 @@ pub fn rename_attributes(attributes: &mut Vec<Attribute>, name: &str, target: &s
         }
     }
 }
+
+pub fn append_line(desc: &mut AsOption<String>, mut line: String) {
+    if line.starts_with(' ') {
+        line.remove(0);
+    }
+
+    match &mut desc.0 {
+        Some(desc) => {
+            if line.trim().is_empty() {
+                desc.push('\n');
+            } else {
+                desc.push(' ');
+                desc.push_str(&line);
+            }
+        },
+        None => *desc = AsOption(Some(line)),
+    }
+}


### PR DESCRIPTION
## Description

This adds support for splitting content of command and group descriptions across multiple lines for readability like in the Markdown format. To be specific, when several `#[description]` attributes are provided to the `#[command]` and `#[group]` macros, their content is stitched together to a single string according to the following new rules:

- If the content of a `#[description]` consists of just whitespace or is empty, a plain newline (`'\n'`) is appended to the string.
- If the content isn't just whitespace nor empty, a space (`' '`) and the content are appended to the string.

## Type of Change

This enhances the usage of `command_attr`'s macros, a part of the framework.

## How Has This Been Tested?

This has been tested by checking the output of `cargo expand` for the values of descriptions for commands and groups, where it has been confirmed that the stitching works as expected.
