### PR TITLE
Reconnect in event of failed ShardActions

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -161,6 +161,7 @@ pub enum InterMessage {
     Json(Value),
 }
 
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum ShardAction {
     Heartbeat,
@@ -169,6 +170,7 @@ pub enum ShardAction {
 }
 
 /// The type of reconnection that should be performed.
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum ReconnectType {
     /// Indicator that a new connection should be made by sending an IDENTIFY.


### PR DESCRIPTION
## Description

This removes a `let _ = ...` which was silently causing some resume failures to become permanent, causing the shard to crash the next time it attempted to use its (closed) WS client. This is replaced with code to trigger a further resume and/or reidentification attempt.

In the worst case, this will attempt one further resume before "promoting" the resume into a full reidentify. The `ShardQueuer` is then already responsible for repeated full reidentify attempts from that point on.

## Type of Change

This fixes a (rare) bug in the shard runner triggered when TLS or socket initialisation spuriously fails.

## How Has This Been Tested?

This has been tested by (locally) adding in extra `ShardRunnerMessage` types to test and access the new code paths individually. ~~The underlying bug has not been observed (using the new `warn!`/`debug!` invocations); I haven't seen this bug reoccur in over two weeks, in spite of it being a nightly occurrence around that time (most likely due to my hosting provider)~~.

From the below logs, this has now successfully handled a repeated burst of reconnection failures.
