### PR TITLE
Add new Emoji fields and adjust existing ones

### DIFF
--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -5,16 +5,16 @@ use serde_json::json;
 
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::Cache;
+use crate::http::Http;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::model::id::GuildId;
+use crate::model::id::{EmojiId, RoleId};
+use crate::model::user::User;
+use crate::model::utils::default_true;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::model::ModelError;
-use crate::{
-    http::Http,
-    model::id::{EmojiId, RoleId},
-};
 
 /// Represents a custom guild emoji, which can either be created using the API,
 /// or via an integration. Emojis created using the API only work within the
@@ -25,6 +25,10 @@ pub struct Emoji {
     /// Whether the emoji is animated.
     #[serde(default)]
     pub animated: bool,
+    /// Whether the emoji can be used. This may be false when the guild loses boosts,
+    /// reducing the emoji limit.
+    #[serde(default = "default_true")]
+    pub available: bool,
     /// The Id of the emoji.
     pub id: EmojiId,
     /// The name of the emoji. It must be at least 2 characters long and can
@@ -33,15 +37,20 @@ pub struct Emoji {
     /// Whether the emoji is managed via an [`Integration`] service.
     ///
     /// [`Integration`]: super::Integration
+    #[serde(default)]
     pub managed: bool,
     /// Whether the emoji name needs to be surrounded by colons in order to be
     /// used by the client.
+    #[serde(default)]
     pub require_colons: bool,
     /// A list of [`Role`]s that are allowed to use the emoji. If there are no
     /// roles specified, then usage is unrestricted.
     ///
     /// [`Role`]: super::Role
+    #[serde(default)]
     pub roles: Vec<RoleId>,
+    /// The user who created the emoji.
+    pub user: Option<User>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -404,11 +404,13 @@ mod test {
             });
             let emoji = Emoji {
                 animated: false,
+                available: true,
                 id: EmojiId(5),
                 name: "a".to_string(),
                 managed: true,
                 require_colons: true,
                 roles: vec![],
+                user: None,
             };
             let role = Role {
                 id: RoleId(2),

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -256,7 +256,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, expected);
     /// ```
-    ///
+    /// 
     /// Pushing a codeblock without a language:
     /// ```rust
     /// use serenity::utils::MessageBuilder;

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -256,7 +256,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, expected);
     /// ```
-    /// 
+    ///
     /// Pushing a codeblock without a language:
     /// ```rust
     /// use serenity::utils::MessageBuilder;
@@ -1322,11 +1322,13 @@ mod test {
         let content_emoji = MessageBuilder::new()
             .emoji(&Emoji {
                 animated: false,
+                available: true,
                 id: EmojiId(32),
                 name: "Rohrkatze".to_string(),
                 managed: false,
                 require_colons: true,
                 roles: vec![],
+                user: None,
             })
             .build();
         let content_mentions =


### PR DESCRIPTION
## Description

This adds two new fields to the `Emoji` struct, `available` and `user`, and adjusts `managed`,  `required_colons`, and `roles` to be `false` (in `managed`'s and `required_colons`' case) or empty (in `roles`' case) when the fields are missing, improving conformity with [the schema for `Emoji` objects](https://discord.com/developers/docs/resources/emoji#emoji-object).

## Type of Change

This is an improvement to the `Emoji` struct, a part of the `model` module.

## How Has This Been Tested?

This has been tested by verifying that deserialisation of `Emoji`s doesn't result in an error, which it hasn't. 
