### PR TITLE
Do not invoke the help command in DMs if `allow_dm` is false

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -662,6 +662,10 @@ impl Framework for StandardFramework {
 
         match invoke {
             Invoke::Help(name) => {
+                if !self.config.allow_dm && msg.is_private() {
+                    return;
+                }
+
                 let args = Args::new(stream.rest(), &self.config.delimiters);
 
                 let owners = self.config.owners.clone();


### PR DESCRIPTION
## Description

This fixes a bug whereby the help command could be invoked regardless of the value of the `allow_dm` option.

## Type of Change

This is a fix for the framework.

## How Has This Been Tested?

This has been tested by invoking a normal command and the help command when `allow_dm` is false. Both didn't run in a DM as expected.
