### PR TITLE
Alter `Activity` constructor methods to use `ToString`

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -99,7 +99,10 @@ impl Activity {
     ///     Ok(())
     /// }
     /// ```
-    pub fn playing(name: &str) -> Activity {
+    pub fn playing<N>(name: N) -> Activity
+    where
+        N: ToString,
+    {
         Activity {
             application_id: None,
             assets: None,
@@ -149,7 +152,11 @@ impl Activity {
     ///     Ok(())
     /// }
     /// ```
-    pub fn streaming(name: &str, url: &str) -> Activity {
+    pub fn streaming<N, U>(name: N, url: U) -> Activity
+    where
+        N: ToString,
+        U: ToString,
+    {
         Activity {
             application_id: None,
             assets: None,
@@ -196,7 +203,10 @@ impl Activity {
     ///     Ok(())
     /// }
     /// ```
-    pub fn listening(name: &str) -> Activity {
+    pub fn listening<N>(name: N) -> Activity
+    where
+        N: ToString,
+    {
         Activity {
             application_id: None,
             assets: None,
@@ -243,7 +253,10 @@ impl Activity {
     ///     Ok(())
     /// }
     /// ```
-    pub fn competing(name: &str) -> Activity {
+    pub fn competing<N>(name: N) -> Activity
+    where
+        N: ToString,
+    {
         Activity {
             application_id: None,
             assets: None,


### PR DESCRIPTION
## Description

This changes `Activity::{playing, streaming, listening, competing}` to accept their string arguments using `ToString` in order to be consistent with the rest of the library.

## Type of Change

This is an improvement to the `Activity` struct, a part of the `model` module.

## How Has This Been Tested?

This has been tested by verifying that compilation of the new versions of these methods still succeeds, which it does.
