### PR TITLE
Escape hashes in HTTP reaction methods

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -429,7 +429,8 @@ impl Http {
             body: None,
             headers: None,
             route: RouteInfo::CreateReaction {
-                reaction: &reaction_type.as_data(),
+                // Escape emojis like '#️⃣' that contain a hash
+                reaction: &reaction_type.as_data().replace('#', "%23"),
                 channel_id,
                 message_id,
             },
@@ -746,7 +747,8 @@ impl Http {
             body: None,
             headers: None,
             route: RouteInfo::DeleteReaction {
-                reaction: &reaction_type.as_data(),
+                // Escape emojis like '#️⃣' that contain a hash
+                reaction: &reaction_type.as_data().replace('#', "%23"),
                 user: &user,
                 channel_id,
                 message_id,


### PR DESCRIPTION
## Description

This alters `Http::create_reaction` and `Http::delete_reaction` to percent-encode hashes in the given `ReactionType` to allow reacting with certain emojis, such as #️⃣, which is composed of the '#' (hash) character and other Unicode characters to create an emoji.  

## Type of Change

This is a fix to the HTTP interface for reactions, the interface being a part of the `http` module.

## How Has This Been Tested?

This has been tested by reacting with the #️⃣ emoji to attest that it now works, which it does. Normal (Unicode) and custom emojis have also been tested to confirm that this change does not break reactions, which it doesn't
