### PR TITLE
Make Join Public

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -156,7 +156,7 @@ pub struct Suggestions(pub Vec<SuggestedCommandName>);
 impl Suggestions {
     /// Immutably borrow inner `Vec`.
     #[inline]
-    fn as_vec(&self) -> &Vec<SuggestedCommandName> {
+    pub fn as_vec(&self) -> &Vec<SuggestedCommandName> {
         &self.0
     }
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -161,7 +161,7 @@ impl Suggestions {
     }
 
     /// Concats names of suggestions with a given `separator`.
-    fn join(&self, separator: &str) -> String {
+    pub fn join(&self, separator: &str) -> String {
         let mut iter = self.as_vec().iter();
 
         let first_iter_element = match iter.next() {


### PR DESCRIPTION
When created a public help command using 

https://docs.rs/serenity/0.10.4/serenity/framework/standard/help_commands/enum.CustomisedHelpData.html

The join func is needed, however it is private and cannot be used.

This makes this fn public