### PR TITLE
feat: Add Discord API proxy support

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2331,10 +2331,14 @@ impl Http {
         T: Into<AttachmentType<'a>>,
     {
         let uri = api!("/channels/{}/messages", channel_id);
-        let url = match Url::parse(&uri) {
+        let mut url = match Url::parse(&uri) {
             Ok(url) => url,
             Err(_) => return Err(Error::Url(uri)),
         };
+
+        if let Some(proxy) = &self.proxy {
+            url.set_host(Some(proxy)).map_err(|e| Error::Http(Box::new(e.into())))?;
+        }
 
         let mut multipart = reqwest::multipart::Form::new();
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -98,7 +98,8 @@ impl<'a> HttpBuilder<'a> {
         self
     }
 
-    /// Sets the [`reqwest::Client`]
+    /// Sets the [`reqwest::Client`]. If one isn't provided, a default one will
+    /// be used.
     pub fn client(mut self, client: Arc<Client>) -> Self {
         self.client = Some(client);
 
@@ -113,14 +114,14 @@ impl<'a> HttpBuilder<'a> {
         self
     }
 
-    /// Sets whether or not the ratelimiter is disabled. By default, it is
-    /// enabled. In most cases, this should be used in conjunction with
-    /// [`Self::proxy`].
+    /// Sets whether or not the ratelimiter is disabled. By default if this this
+    /// not used, it is enabled. In most cases, this should be used in
+    /// conjunction with [`Self::proxy`].
     ///
     /// **Note**: You should **not** disable the ratelimiter unless you have
     /// another form of rate limiting. Disabling the ratelimiter has the main
-    /// purpose of delegating ratelimiting to an API proxy instead of the
-    /// current process.
+    /// purpose of delegating rate limiting to an API proxy via [`Self::proxy`]
+    /// instead of the current process.
     pub fn ratelimiter_disabled(mut self, ratelimiter_disabled: bool) -> Self {
         self.ratelimiter_disabled = Some(ratelimiter_disabled);
 
@@ -128,17 +129,18 @@ impl<'a> HttpBuilder<'a> {
     }
 
     /// Sets the proxy that Discord HTTP API requests will be passed to. This is
-    /// mainly intended for something like [`twilight-http-proxy`] where multiple
-    /// processes can make API requests while sharing a single ratelimiter.
-    /// 
+    /// mainly intended for something like [`twilight-http-proxy`] where
+    /// multiple processes can make API requests while sharing a single
+    /// ratelimiter.
+    ///
     /// The proxy should be in the form of the protocol and hostname, e.g.
     /// `http://127.0.0.1:3000` or `http://myproxy.example`
     ///
-    /// This will act like a transparent proxy, simply sending HTTP API requests
-    /// to the proxy instead of Discord API to allow the proxy to intercept and
-    /// rate limit requests. This is different than a native proxy's behavior
-    /// where it will tunnel requests using TLS via [`HTTP CONNECT`] method
-    /// (e.g. using [`reqwest::Proxy`]).
+    /// This will simply send HTTP API requests to the proxy instead of Discord
+    /// API to allow the proxy to intercept, rate limit, and forward requests.
+    /// This is different than a native proxy's behavior where it will tunnel
+    /// requests that use TLS via [`HTTP CONNECT`] method (e.g. using
+    /// [`reqwest::Proxy`]).
     /// 
     /// [`twilight-http-proxy`]: https://github.com/twilight-rs/http-proxy
     /// [`HTTP CONNECT`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,7 +1,15 @@
 #![allow(clippy::missing_errors_doc)]
-use std::{collections::BTreeMap, fmt, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context as FutContext, Poll},
+};
 
 use bytes::buf::Buf;
+use futures::future::BoxFuture;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::{
     header::{HeaderMap as Headers, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT},
@@ -9,8 +17,8 @@ use reqwest::{
     Url,
 };
 use reqwest::{multipart::Part, Client, ClientBuilder, Response as ReqwestResponse};
-use serde::de::DeserializeOwned;
 use serde_json::json;
+use serde::de::DeserializeOwned;
 use tokio::{fs::File, io::AsyncReadExt};
 use tracing::{debug, instrument, trace};
 
@@ -28,6 +36,156 @@ use crate::http::routing::Route;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
+/// A builder implementing [`Future`] building a [`Http`] client to perform
+/// requests to Discord's HTTP API. If you do not need to use a proxy or do not
+/// need to disable the rate limiter, you can use [`Http::new`] or
+/// [`Http::new_with_token`] instead.
+///
+/// ## Example
+///
+/// Create an instance of [`Http`] with a proxy and rate limiter disabled
+///
+/// ```rust
+/// # use serenity::http::HttpBuilder;
+/// # async fn run() {
+/// let http = HttpBuilder::new("token")
+///     .proxy("http://127.0.0.1:3000")
+///     .ratelimiter_disabled(true)
+///     .await
+///     .expect("Error creating Http");
+/// # }
+/// ```
+pub struct HttpBuilder<'a> {
+    client: Option<Arc<Client>>,
+    ratelimiter: Option<Ratelimiter>,
+    ratelimiter_disabled: Option<bool>,
+    token: Option<String>,
+    proxy: Option<String>,
+    fut: Option<BoxFuture<'a, Result<Http>>>,
+}
+
+impl<'a> HttpBuilder<'a> {
+    fn _new() -> Self {
+        Self {
+            client: None,
+            ratelimiter: None,
+            ratelimiter_disabled: Some(false),
+            token: None,
+            proxy: None,
+            fut: None,
+        }
+    }
+
+    /// Construct a new builder to call methods on for the Http construction.
+    /// The `token` will automatically be prefixed "Bot " if not already.
+    pub fn new(token: impl AsRef<str>) -> Self {
+        Self::_new().token(token)
+    }
+
+    /// Sets a token for the bot. If the token is not prefixed "Bot ", this
+    /// method will automatically do so.
+    pub fn token(mut self, token: impl AsRef<str>) -> Self {
+        let token = token.as_ref().trim();
+
+        let token = if token.starts_with("Bot ") {
+            token.to_string()
+        } else {
+            format!("Bot {}", token)
+        };
+
+        self.token = Some(token);
+
+        self
+    }
+
+    /// Sets the [`reqwest::Client`]
+    pub fn client(mut self, client: Arc<Client>) -> Self {
+        self.client = Some(client);
+
+        self
+    }
+
+    /// Sets the ratelimiter to be used. If one isn't provided, a default one
+    /// will be used.
+    pub fn ratelimiter(mut self, ratelimiter: Ratelimiter) -> Self {
+        self.ratelimiter = Some(ratelimiter);
+
+        self
+    }
+
+    /// Sets whether or not the ratelimiter is disabled. By default, it is
+    /// enabled. In most cases, this should be used in conjunction with
+    /// [`Self::proxy`].
+    ///
+    /// **Note**: You should **not** disable the ratelimiter unless you have
+    /// another form of rate limiting. Disabling the ratelimiter has the main
+    /// purpose of delegating ratelimiting to an API proxy instead of the
+    /// current process.
+    pub fn ratelimiter_disabled(mut self, ratelimiter_disabled: bool) -> Self {
+        self.ratelimiter_disabled = Some(ratelimiter_disabled);
+
+        self
+    }
+
+    /// Sets the proxy that Discord HTTP API requests will be passed to. This is
+    /// mainly intended for something like [`twilight-http-proxy`] where multiple
+    /// processes can make API requests while sharing a single ratelimiter.
+    /// 
+    /// The proxy should be in the form of the protocol and hostname, e.g.
+    /// `http://127.0.0.1:3000` or `http://myproxy.example`
+    ///
+    /// This will act like a transparent proxy, simply sending HTTP API requests
+    /// to the proxy instead of Discord API to allow the proxy to intercept and
+    /// rate limit requests. This is different than a native proxy's behavior
+    /// where it will tunnel requests using TLS via [`HTTP CONNECT`] method
+    /// (e.g. using [`reqwest::Proxy`]).
+    /// 
+    /// [`twilight-http-proxy`]: https://github.com/twilight-rs/http-proxy
+    /// [`HTTP CONNECT`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
+    pub fn proxy(mut self, proxy: impl Into<String>) -> Self {
+        self.proxy = Some(proxy.into());
+
+        self
+    }
+}
+
+impl<'a> Future for HttpBuilder<'a> {
+    type Output = Result<Http>;
+
+    #[allow(clippy::unwrap_used)]
+    #[instrument(skip(self))]
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let token = self.token.take().unwrap();
+
+            let client = self.client.take().unwrap_or_else(|| {
+                let builder = configure_client_backend(Client::builder());
+                Arc::new(builder.build().expect("Cannot build reqwest::Client"))
+            });
+
+            let ratelimiter = self.ratelimiter.take().unwrap_or_else(|| {
+                let client = Arc::clone(&client);
+                Ratelimiter::new(client, token.to_string())
+            });
+
+            let ratelimiter_disabled = self.ratelimiter_disabled.take().unwrap();
+            let proxy = self.proxy.take();
+
+            self.fut = Some(Box::pin(async move {
+                Ok(Http {
+                    client,
+                    ratelimiter,
+                    ratelimiter_disabled,
+                    proxy,
+                    token,
+                })
+            }))
+        }
+
+        self.fut.as_mut().unwrap().as_mut().poll(ctx)
+    }
+}
+
 /// **Note**: For all member functions that return a `Result`, the
 /// Error kind will be either [`Error::Http`] or [`Error::Json`].
 ///
@@ -36,6 +194,8 @@ use crate::model::prelude::*;
 pub struct Http {
     pub(crate) client: Arc<Client>,
     pub ratelimiter: Ratelimiter,
+    pub ratelimiter_disabled: bool,
+    pub proxy: Option<String>,
     pub token: String,
 }
 
@@ -44,6 +204,8 @@ impl fmt::Debug for Http {
         f.debug_struct("Http")
             .field("client", &self.client)
             .field("ratelimiter", &self.ratelimiter)
+            .field("ratelimiter_disabled", &self.ratelimiter_disabled)
+            .field("proxy", &self.proxy)
             .finish()
     }
 }
@@ -55,6 +217,8 @@ impl Http {
         Http {
             client,
             ratelimiter: Ratelimiter::new(client2, token.to_string()),
+            ratelimiter_disabled: false,
+            proxy: None,
             token: token.to_string(),
         }
     }
@@ -2488,8 +2652,15 @@ impl Http {
     /// [`fire`]: Self::fire
     #[instrument]
     pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
-        let ratelimiting_req = RatelimitedRequest::from(req);
-        let response = self.ratelimiter.perform(ratelimiting_req).await?;
+        let response = if self.ratelimiter_disabled {
+            let request = req
+                .build(&self.client, &self.token, self.proxy.as_deref())?
+                .build()?;
+            self.client.execute(request).await?
+        } else {
+            let ratelimiting_req = RatelimitedRequest::from(req);
+            self.ratelimiter.perform(ratelimiting_req).await?
+        };
 
         if response.status().is_success() {
             Ok(response)
@@ -2542,7 +2713,36 @@ impl Default for Http {
         Self {
             client,
             ratelimiter: Ratelimiter::new(client2, ""),
+            ratelimiter_disabled: false,
+            proxy: None,
             token: "".to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HttpBuilder;
+
+    #[tokio::test]
+    async fn test_http_builder_defaults() {
+        let http = HttpBuilder::new("is this dubu?")
+            .await
+            .expect("Create Http");
+
+        assert!(!http.ratelimiter_disabled);
+        assert!(http.proxy.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_http_builder_with_proxy() {
+        let http = HttpBuilder::new("no it is token")
+            .ratelimiter_disabled(true)
+            .proxy("http://127.0.0.1:3000")
+            .await
+            .expect("Create Http");
+
+        assert!(http.ratelimiter_disabled);
+        assert_eq!(http.proxy.as_deref(), Some("http://127.0.0.1:3000"));
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -78,7 +78,7 @@ impl<'a> HttpBuilder<'a> {
         }
     }
 
-    /// Construct a new builder to call methods on for the Http construction.
+    /// Construct a new builder to call methods on for the HTTP construction.
     /// The `token` will automatically be prefixed "Bot " if not already.
     pub fn new(token: impl AsRef<str>) -> Self {
         Self::_new().token(token)

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -17,8 +17,8 @@ use reqwest::{
     Url,
 };
 use reqwest::{multipart::Part, Client, ClientBuilder, Response as ReqwestResponse};
-use serde_json::json;
 use serde::de::DeserializeOwned;
+use serde_json::json;
 use tokio::{fs::File, io::AsyncReadExt};
 use tracing::{debug, instrument, trace};
 
@@ -87,11 +87,8 @@ impl<'a> HttpBuilder<'a> {
     pub fn token(mut self, token: impl AsRef<str>) -> Self {
         let token = token.as_ref().trim();
 
-        let token = if token.starts_with("Bot ") {
-            token.to_string()
-        } else {
-            format!("Bot {}", token)
-        };
+        let token =
+            if token.starts_with("Bot ") { token.to_string() } else { format!("Bot {}", token) };
 
         self.token = Some(token);
 
@@ -141,7 +138,7 @@ impl<'a> HttpBuilder<'a> {
     /// This is different than a native proxy's behavior where it will tunnel
     /// requests that use TLS via [`HTTP CONNECT`] method (e.g. using
     /// [`reqwest::Proxy`]).
-    /// 
+    ///
     /// [`twilight-http-proxy`]: https://github.com/twilight-rs/http-proxy
     /// [`HTTP CONNECT`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
     pub fn proxy(mut self, proxy: impl Into<String>) -> Self {
@@ -2655,9 +2652,7 @@ impl Http {
     #[instrument]
     pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
         let response = if self.ratelimiter_disabled {
-            let request = req
-                .build(&self.client, &self.token, self.proxy.as_deref())?
-                .build()?;
+            let request = req.build(&self.client, &self.token, self.proxy.as_deref())?.build()?;
             self.client.execute(request).await?
         } else {
             let ratelimiting_req = RatelimitedRequest::from(req);
@@ -2728,9 +2723,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_http_builder_defaults() {
-        let http = HttpBuilder::new("is this dubu?")
-            .await
-            .expect("Create Http");
+        let http = HttpBuilder::new("is this dubu?").await.expect("Create Http");
 
         assert!(!http.ratelimiter_disabled);
         assert!(http.proxy.is_none());

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -62,6 +62,10 @@ pub enum Error {
     InvalidHeader(InvalidHeaderValue),
     /// Reqwest's Error contain information on why sending a request failed.
     Request(ReqwestError),
+    /// When using a proxy with an invalid scheme.
+    InvalidScheme,
+    /// When using a proxy with an invalid port.
+    InvalidPort,
 }
 
 impl Error {
@@ -128,6 +132,8 @@ impl Display for Error {
             Error::Url(_) => f.write_str("Provided URL is incorrect."),
             Error::InvalidHeader(_) => f.write_str("Provided value is an invalid header value."),
             Error::Request(_) => f.write_str("Error while sending HTTP request."),
+            Error::InvalidScheme => f.write_str("Invalid Url scheme."),
+            Error::InvalidPort => f.write_str("Invalid port."),
         }
     }
 }

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -188,7 +188,7 @@ impl Ratelimiter {
 
             bucket.lock().await.pre_hook(&route).await;
 
-            let request = req.build(&self.client, &self.token)?.build()?;
+            let request = req.build(&self.client, &self.token, None)?.build()?;
             let response = self.client.execute(request).await?;
 
             // Check if the request got ratelimited by checking for status 429,

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -155,6 +155,7 @@ impl Ratelimiter {
     /// # Errors
     ///
     /// Only error kind that may be returned is [`Error::Http`].
+    ///
     /// [`Error::Http`]: crate::error::Error::Http
     pub async fn perform(&self, req: RatelimitedRequest<'_>) -> Result<Response> {
         let RatelimitedRequest {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -10,6 +10,7 @@ use reqwest::{
     Url,
 };
 use reqwest::{Client, RequestBuilder as ReqwestRequestBuilder};
+use std::borrow::Cow;
 use tracing::instrument;
 
 use super::{routing::RouteInfo, HttpError};
@@ -80,6 +81,7 @@ impl<'a> Request<'a> {
         &'a self,
         client: &Client,
         token: &str,
+        proxy: Option<&str>
     ) -> Result<ReqwestRequestBuilder, HttpError> {
         let Request {
             body,
@@ -87,7 +89,11 @@ impl<'a> Request<'a> {
             route: ref route_info,
         } = *self;
 
-        let (method, _, path) = route_info.deconstruct();
+        let (method, _, mut path) = route_info.deconstruct();
+
+        if let Some(proxy) = proxy {
+            path = Cow::Owned(path.to_mut().replace("https://discord.com", proxy));
+        }
 
         let mut builder = client.request(method.reqwest_method(), Url::parse(&path)?);
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use reqwest::{
     header::{
         HeaderMap as Headers,
@@ -10,7 +12,6 @@ use reqwest::{
     Url,
 };
 use reqwest::{Client, RequestBuilder as ReqwestRequestBuilder};
-use std::borrow::Cow;
 use tracing::instrument;
 
 use super::{routing::RouteInfo, HttpError};
@@ -81,7 +82,7 @@ impl<'a> Request<'a> {
         &'a self,
         client: &Client,
         token: &str,
-        proxy: Option<&str>
+        proxy: Option<&str>,
     ) -> Result<ReqwestRequestBuilder, HttpError> {
         let Request {
             body,

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -82,7 +82,7 @@ impl<'a> Request<'a> {
         &'a self,
         client: &Client,
         token: &str,
-        proxy: Option<&str>,
+        proxy: Option<&Url>,
     ) -> Result<ReqwestRequestBuilder, HttpError> {
         let Request {
             body,
@@ -93,7 +93,7 @@ impl<'a> Request<'a> {
         let (method, _, mut path) = route_info.deconstruct();
 
         if let Some(proxy) = proxy {
-            path = Cow::Owned(path.to_mut().replace("https://discord.com", proxy));
+            path = Cow::Owned(path.to_mut().replace("https://discord.com/", proxy.as_str()));
         }
 
         let mut builder = client.request(method.reqwest_method(), Url::parse(&path)?);


### PR DESCRIPTION
### Description

Adds a new `HttpBuilder` to allow configuration of the http client to disable the proxy and/or add an API proxy.  This should be a non-breaking change as it preserves the existing `Http::new` and `Http::new_with_token` fns.

### Tested

Added basic http builder unit tests for default and proxy/disabled ratelimiter.  Also tested with twilight-http-proxy and API requests correctly get sent to the proxy instead of Discord API directly.