### PR TITLE
Allow editing and deleting messages from webhooks

### DIFF
--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+
+use super::CreateAllowedMentions;
+use crate::internal::prelude::*;
+use crate::utils;
+
+/// A builder to specify the fields to edit in an existing [`Webhook`]'s message.
+///
+/// [`Webhook`]: crate::model::webhook::Webhook
+#[derive(Clone, Debug, Default)]
+pub struct EditWebhookMessage(pub HashMap<&'static str, Value>);
+
+impl EditWebhookMessage {
+    /// Set the content of the message.
+    ///
+    /// **Note**: Message contents must be under 2000 unicode code points.
+    #[inline]
+    pub fn content<D: ToString>(&mut self, content: D) -> &mut Self {
+        self.0.insert("content", Value::String(content.to_string()));
+        self
+    }
+
+    /// Set the embeds associated with the message.
+    ///
+    /// This should be used in combination with [`Embed::fake`], creating one
+    /// or more fake embeds to send to the API.
+    ///
+    /// # Examples
+    ///
+    /// Refer to [struct-level documentation of `ExecuteWebhook`] for an example
+    /// on how to use embeds.
+    ///
+    /// [`Embed::fake`]: crate::model::channel::Embed::fake
+    /// [struct-level documentation of `ExecuteWebhook`]: crate::builder::ExecuteWebhook#examples
+    #[inline]
+    pub fn embeds(&mut self, embeds: Vec<Value>) -> &mut Self {
+        self.0.insert("embeds", Value::Array(embeds));
+        self
+    }
+
+    /// Set the allowed mentions for the message.
+    pub fn allowed_mentions<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateAllowedMentions) -> &mut CreateAllowedMentions,
+    {
+        let mut allowed_mentions = CreateAllowedMentions::default();
+        f(&mut allowed_mentions);
+        let map = utils::hashmap_to_json_map(allowed_mentions.0);
+        let allowed_mentions = Value::Object(map);
+
+        self.0.insert("allowed_mentions", allowed_mentions);
+        self
+    }
+}

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -30,6 +30,7 @@ mod edit_member;
 mod edit_message;
 mod edit_profile;
 mod edit_role;
+mod edit_webhook_message;
 mod execute_webhook;
 mod get_messages;
 
@@ -46,6 +47,7 @@ pub use self::{
     edit_message::EditMessage,
     edit_profile::EditProfile,
     edit_role::EditRole,
+    edit_webhook_message::EditWebhookMessage,
     execute_webhook::ExecuteWebhook,
     get_messages::GetMessages,
 };

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1410,6 +1410,47 @@ impl Http {
         response.json::<Message>().await.map(Some).map_err(From::from)
     }
 
+    /// Edits a webhook's message by Id.
+    pub async fn edit_webhook_message(
+        &self,
+        webhook_id: u64,
+        token: &str,
+        message_id: u64,
+        map: &JsonMap,
+    ) -> Result<Message> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditWebhookMessage {
+                token,
+                webhook_id,
+                message_id,
+            },
+        })
+        .await
+    }
+
+    /// Deletes a webhook's messsage by Id.
+    pub async fn delete_webhook_message(
+        &self,
+        webhook_id: u64,
+        token: &str,
+        message_id: u64,
+    ) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::DeleteWebhookMessage {
+                token,
+                webhook_id,
+                message_id,
+            },
+        })
+        .await
+    }
+
     /// Gets the active maintenances from Discord's Status API.
     ///
     /// Does not require authentication.

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -655,6 +655,13 @@ impl Route {
         format!(api!("/webhooks/{}/{}?wait={}"), webhook_id, token, wait)
     }
 
+    pub fn webhook_message<D>(webhook_id: u64, token: D, message_id: u64) -> String
+    where
+        D: Display,
+    {
+        format!(api!("/webhooks/{}/{}/messages/{}"), webhook_id, token, message_id)
+    }
+
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn webhook_original_interaction_response<D: Display>(
@@ -876,6 +883,11 @@ pub enum RouteInfo<'a> {
         token: &'a str,
         webhook_id: u64,
     },
+    DeleteWebhookMessage {
+        token: &'a str,
+        webhook_id: u64,
+        message_id: u64,
+    },
     EditChannel {
         channel_id: u64,
     },
@@ -943,6 +955,11 @@ pub enum RouteInfo<'a> {
     EditWebhookWithToken {
         token: &'a str,
         webhook_id: u64,
+    },
+    EditWebhookMessage {
+        token: &'a str,
+        webhook_id: u64,
+        message_id: u64,
     },
     ExecuteWebhook {
         token: &'a str,
@@ -1412,6 +1429,16 @@ impl<'a> RouteInfo<'a> {
                 Route::WebhooksId(webhook_id),
                 Cow::from(Route::webhook_with_token(webhook_id, token)),
             ),
+            RouteInfo::DeleteWebhookMessage {
+                token,
+                webhook_id,
+                message_id,
+            } => (
+                LightMethod::Delete,
+                // FIXME: This should probably be another route.
+                Route::WebhooksId(webhook_id),
+                Cow::from(Route::webhook_message(webhook_id, token, message_id)),
+            ),
             RouteInfo::EditChannel {
                 channel_id,
             } => (
@@ -1544,6 +1571,16 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Patch,
                 Route::WebhooksId(webhook_id),
                 Cow::from(Route::webhook_with_token(webhook_id, token)),
+            ),
+            RouteInfo::EditWebhookMessage {
+                token,
+                webhook_id,
+                message_id,
+            } => (
+                LightMethod::Patch,
+                // FIXME: This should probably be another route.
+                Route::WebhooksId(webhook_id),
+                Cow::from(Route::webhook_message(webhook_id, token, message_id)),
             ),
             RouteInfo::ExecuteWebhook {
                 token,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -258,6 +258,12 @@ pub enum Route {
     VoiceRegions,
     /// Route for the `/webhooks/:webhook_id` path.
     WebhooksId(u64),
+    /// Route for the `/webhooks/:webhook_id/:token/messages/:message_id` path.
+    ///
+    /// The data is the relevant [`WebhookId`].
+    ///
+    /// [`WebhookId`]: crate::model::id::WebhookId
+    WebhooksIdMessagesId(u64),
     /// Route for the `/webhooks/:application_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
@@ -1435,8 +1441,7 @@ impl<'a> RouteInfo<'a> {
                 message_id,
             } => (
                 LightMethod::Delete,
-                // FIXME: This should probably be another route.
-                Route::WebhooksId(webhook_id),
+                Route::WebhooksIdMessagesId(webhook_id),
                 Cow::from(Route::webhook_message(webhook_id, token, message_id)),
             ),
             RouteInfo::EditChannel {
@@ -1578,8 +1583,7 @@ impl<'a> RouteInfo<'a> {
                 message_id,
             } => (
                 LightMethod::Patch,
-                // FIXME: This should probably be another route.
-                Route::WebhooksId(webhook_id),
+                Route::WebhooksIdMessagesId(webhook_id),
                 Cow::from(Route::webhook_message(webhook_id, token, message_id)),
             ),
             RouteInfo::ExecuteWebhook {


### PR DESCRIPTION
## Description

This adds support for editing and deleting messages originating from webhooks. Current `Message::{edit, delete}` methods cannot be used as the endpoints for webhook messages are different, with slightly different data that can be submitted when editing a message.

## Type of Change

This is an enhancement to the HTTP and model interfaces by covering more surface area of the Discord API.

## How Has This Been Tested?

This has been tested by sending a webhook message, editing, and then deleting it. All operations have been successful.
