### PR TITLE
Fix faulty (de)serialisation of `UserPublicFlags`

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -6,6 +6,7 @@ use std::fmt::Write;
 
 use bitflags::__impl_bitflags;
 use futures::future::{BoxFuture, FutureExt};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "model")]
 use serde_json::json;
 
@@ -453,7 +454,7 @@ pub struct User {
 }
 
 /// User's public flags
-#[derive(Clone, Copy, Deserialize, Serialize)]
+#[derive(Clone, Copy)]
 pub struct UserPublicFlags {
     pub bits: u32,
 }
@@ -486,6 +487,24 @@ __impl_bitflags! {
         VERIFIED_BOT = 0b00000000_00000001_00000000_00000000;
         /// User's flag as early verified bot developer
         EARLY_VERIFIED_BOT_DEVELOPER = 0b00000000_00000010_00000000_00000000;
+    }
+}
+
+impl<'de> Deserialize<'de> for UserPublicFlags {
+    fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(UserPublicFlags::from_bits_truncate(deserializer.deserialize_u32(U32Visitor)?))
+    }
+}
+
+impl Serialize for UserPublicFlags {
+    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u32(self.bits())
     }
 }
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -348,4 +348,4 @@ macro_rules! num_visitors {
     }
 }
 
-num_visitors!(U16Visitor: u16, U64Visitor: u64);
+num_visitors!(U16Visitor: u16, U32Visitor: u32, U64Visitor: u64);


### PR DESCRIPTION
## Description

This fixes serialisation and deserialisation for `UserPublicFlags` as a consequence of wrong `Serialize` and `Deserialize` implementations introduced in #1234.

## Type of Change

This is a fix for the `UserPublicFlags` bitflags-like struct, a part of the `model` module.

## How Has This Been Tested?

This has not been tested yet, but according to `Serialize` and `Deserialize` implementations of other bitflags-like structures it should hypothetically work. 
