### PR TITLE
Fix a case of iterator invalidation when moving `#[doc]` attributes

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -297,9 +297,15 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     // Additionally, place the documentation attributes to the `cooked` list
     // to prevent the macro from rejecting them as invalid attributes.
-    for i in 0..fun.attributes.len() {
-        if fun.attributes[i].path.is_ident("doc") {
-            fun.cooked.push(fun.attributes.remove(i));
+    {
+        let mut i = 0;
+        while i < fun.attributes.len() {
+            if fun.attributes[i].path.is_ident("doc") {
+                fun.cooked.push(fun.attributes.remove(i));
+                continue;
+            }
+
+            i += 1;
         }
     }
 


### PR DESCRIPTION
## Description

This fixes index-based iterator invalidation when `#[doc]` attributes are being moved to the `cooked` list to prevent the `#[help]` macro from rejecting them. Without this, a panic would occur.

## Type of Change

This fixes code for the `#[help]` macro, a part of `command_attr`.

## How Has This Been Tested?

This has been tested by using more than one documentation comment (i.e., two or more), which now compiles successfully.