### PR TITLE
Add a way for joining lines in `#[doc]` comments using `\$`

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -82,7 +82,7 @@ macro_rules! match_options {
 /// `#[description]` option. When more than one application of the option is performed,
 /// the text is delimited by newlines. This mimics the behaviour of regular doc-comments,
 /// which are sugar for the `#[doc = "..."]` attribute. If you wish to join lines together,
-/// end the previous lines with `\$`.
+/// however, you have to end the previous lines with `\$`.
 ///
 /// # Notes
 /// The name of the command is parsed from the applied function,
@@ -591,7 +591,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// `#[description]` option. When more than one application of the option is performed,
 /// the text is delimited by newlines. This mimics the behaviour of regular doc-comments,
 /// which are sugar for the `#[doc = "..."]` attribute. If you wish to join lines together,
-/// end the previous lines with `\$`.
+/// however, you have to end the previous lines with `\$`.
 ///
 /// Similarly to [`command`], this macro generates static instances of the group
 /// and its options. The identifiers of these instances are based off the name of the struct to differentiate

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -81,7 +81,8 @@ macro_rules! match_options {
 /// Documentation comments (`///`) applied onto the function are interpreted as sugar for the
 /// `#[description]` option. When more than one application of the option is performed,
 /// the text is delimited by newlines. This mimics the behaviour of regular doc-comments,
-/// which are sugar for the `#[doc = "..."]` attribute.
+/// which are sugar for the `#[doc = "..."]` attribute. If you wish to join lines together,
+/// end the previous lines with `\$`.
 ///
 /// # Notes
 /// The name of the command is parsed from the applied function,
@@ -585,6 +586,12 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// | `#[default_command(cmd)]`                            | A command to execute if none of the group's prefixes are given.                    | `cmd` is an identifier referencing a function marked by the `#[command]` macro                                                                                                       |
 /// | `#[description(desc)]` </br> `#[description = desc]` | The group's description or summary.                                                | `desc` is a string describing the group.                                                                                                                                             |
 /// | `#[summary(desc)]` </br> `#[summary = desc]`         | A summary group description displayed when shown multiple groups.                  | `desc` is a string summaryly describing the group.                                                                                                                                   |
+///
+/// Documentation comments (`///`) applied onto the struct are interpreted as sugar for the
+/// `#[description]` option. When more than one application of the option is performed,
+/// the text is delimited by newlines. This mimics the behaviour of regular doc-comments,
+/// which are sugar for the `#[doc = "..."]` attribute. If you wish to join lines together,
+/// end the previous lines with `\$`.
 ///
 /// Similarly to [`command`], this macro generates static instances of the group
 /// and its options. The identifiers of these instances are based off the name of the struct to differentiate

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -269,15 +269,16 @@ pub fn append_line(desc: &mut AsOption<String>, mut line: String) {
         line.remove(0);
     }
 
-    match &mut desc.0 {
-        Some(desc) => {
-            if line.trim().is_empty() {
-                desc.push('\n');
-            } else {
-                desc.push(' ');
-                desc.push_str(&line);
-            }
+    let desc = desc.0.get_or_insert_with(String::default);
+
+    match line.rfind("\\$") {
+        Some(i) => {
+            desc.push_str(line[..i].trim_end());
+            desc.push(' ');
         },
-        None => *desc = AsOption(Some(line)),
+        None => {
+            desc.push_str(&line);
+            desc.push('\n');
+        },
     }
 }


### PR DESCRIPTION
## Description

This adds a way for joining lines in the documentation comments of the `#[command]` and `#[group]` macros, while simultaneously reverting the Markdown-like behaviour of joining lines introduced in https://github.com/serenity-rs/serenity/pull/1254. With these changes, the macros try to retain all newlines, unless the user explicitly opts-out by ending a line with `\$`, in which case the line will end with a space.

For example:
```
This is a paragraph.


This is a second paragraph.

This is\$
a third\$
paragraph.
```
Would result in:
```
This is a paragraph.


This is a second paragraph.

This is a third paragraph.
```
In the output for descriptions of commands and groups. 

The reason for these changes is due to unintentional breakage caused by https://github.com/serenity-rs/serenity/pull/1254 for inputs such as:
```
/// Executes the provided code
/// - There's a 10 second timeout.
///
/// usage:
/// eval \`\`\`py
/// for i in range(0, 10):
///     print("Hello, world!")
/// \`\`\`
```
That would result in:
![](https://5124.16-b.it/ss/02:55:25_29-03-2021.png)

When it really should be:
![](https://5124.16-b.it/ss/03:04:43_29-03-2021.png)

## Type of Change

This fixes and improves code for the `#[command]` and `#[group]` macros, parts of `command_attr`.

## How Has This Been Tested?

To test the reversal, this has been tested with the above input and verifying that it looks as expected in the output when printing it with the help command. To test the new way of using a backslash and a dollar sign, this has been tested with the above paragraph example. Both tests have been successful.