### PR TITLE
Signify code that needs the `collector` feature in the documentation

### DIFF
--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -250,6 +250,7 @@ impl ShardMessenger {
     /// Sets a new filter for a message collector.
     #[inline]
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn set_message_filter(&self, collector: MessageFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetMessageFilter(collector));
@@ -257,6 +258,7 @@ impl ShardMessenger {
 
     /// Sets a new filter for a message collector.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn set_reaction_filter(&self, collector: ReactionFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetReactionFilter(collector));

--- a/src/client/bridge/gateway/shard_runner_message.rs
+++ b/src/client/bridge/gateway/shard_runner_message.rs
@@ -61,8 +61,10 @@ pub enum ShardRunnerMessage {
     SetStatus(OnlineStatus),
     /// Sends a new filter for messages to the shard.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     SetMessageFilter(MessageFilter),
     /// Sends a new filter for reactions to the shard.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     SetReactionFilter(ReactionFilter),
 }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -389,6 +389,7 @@ impl Context {
     /// sent back to `filter`'s paired receiver.
     #[inline]
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub async fn set_message_filter(&self, filter: MessageFilter) {
         self.shard.set_message_filter(filter);
     }
@@ -397,6 +398,7 @@ impl Context {
     /// sent back to `filter`'s paired receiver.
     #[inline]
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub async fn set_reaction_filter(&self, filter: ReactionFilter) {
         self.shard.set_reaction_filter(filter);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub mod cache;
 #[cfg(feature = "client")]
 pub mod client;
 #[cfg(feature = "collector")]
+#[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
 pub mod collector;
 #[cfg(feature = "framework")]
 pub mod framework;

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -840,6 +840,7 @@ impl ChannelId {
 
     /// Returns a future that will await one message sent in this channel.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -849,6 +850,7 @@ impl ChannelId {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this channel.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -858,6 +860,7 @@ impl ChannelId {
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -867,6 +870,7 @@ impl ChannelId {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this channel.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -941,6 +941,7 @@ impl GuildChannel {
 
     /// Returns a future that will await one message by this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -950,6 +951,7 @@ impl GuildChannel {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -959,6 +961,7 @@ impl GuildChannel {
 
     /// Await a single reaction by this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -968,6 +971,7 @@ impl GuildChannel {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -812,6 +812,7 @@ impl Message {
 
     /// Await a single reaction on this message.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -821,6 +822,7 @@ impl Message {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions on this message.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1032,6 +1032,7 @@ impl GuildId {
 
     /// Returns a future that will await one message sent in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1041,6 +1042,7 @@ impl GuildId {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1050,6 +1052,7 @@ impl GuildId {
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1059,6 +1062,7 @@ impl GuildId {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -815,6 +815,7 @@ impl PartialGuild {
 
     /// Returns a future that will await one message sent in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -824,6 +825,7 @@ impl PartialGuild {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -833,6 +835,7 @@ impl PartialGuild {
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -842,6 +845,7 @@ impl PartialGuild {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -869,6 +869,7 @@ impl User {
 
     /// Returns a future that will await one message by this user.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -878,6 +879,7 @@ impl User {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this user.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -887,6 +889,7 @@ impl User {
 
     /// Await a single reaction by this user.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -896,6 +899,7 @@ impl User {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this user.
     #[cfg(feature = "collector")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,


### PR DESCRIPTION
## Description

This adds `#[doc(cfg(feature = "collector"))]` for all structures and functions that need the `collector` feature to be enabled in order to be used. This is done similarly like the `unstable_discord_api` feature, as just like the `collector` feature, it's disabled by default and it's not apparent to the user in the documentation that certain code requires a feature.

## Type of Change

This improves the reading experience of the documentation for users.

## How Has This Been Tested?

This has been tested by building the documentation with the `collector` feature, and the `docsrs` feature, which is passed to rustdoc via the `RUSTDOCFLAGS` environment variable. After building the documentation, the disclaimer detailing the `collector` feature requirement is successfully shown for `#[cfg(feature = "collector")]` code:

![image](https://user-images.githubusercontent.com/16745149/113003418-02d96400-9173-11eb-8858-ce65f3b34d7f.png)