### PR TITLE
feat: Add support for stage channels

### DIFF
--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -5,11 +5,11 @@ use chrono::{DateTime, Utc};
 use super::create_embed::Timestamp;
 use crate::internal::prelude::*;
 
-/// A builder which edits the properties of a [`Member`], to be used in
-/// conjunction with [`Member::edit`].
+/// A builder which edits a user's voice state, to be used in conjunction with
+/// [`GuildChannel::edit_voice_state`].
 ///
 /// [`Member`]: crate::model::guild::Member
-/// [`Member::edit`]: crate::model::guild::Member::edit
+/// [`GuildChannel::edit_voice_state`]: crate::model::channel::GuildChannel::edit_voice_state
 #[derive(Clone, Debug, Default)]
 pub struct EditVoiceState(pub HashMap<&'static str, Value>);
 

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -43,7 +43,7 @@ impl EditVoiceState {
     }
 
     /// Sets the current bot user's request to speak timestamp. This can be any
-    /// present or future time.
+    /// present or future time. Set this to `None` to clear a request to speak.
     ///
     /// Requires the [Request to Speak] permission.
     ///

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use super::create_embed::Timestamp;
+use crate::internal::prelude::*;
+
+/// A builder which edits the properties of a [`Member`], to be used in
+/// conjunction with [`Member::edit`].
+///
+/// [`Member`]: crate::model::guild::Member
+/// [`Member::edit`]: crate::model::guild::Member::edit
+#[derive(Clone, Debug, Default)]
+pub struct EditVoiceState(pub HashMap<&'static str, Value>);
+
+impl EditVoiceState {
+    /// Whether to suppress the user. Setting this to false will invite a user
+    /// to speak.
+    ///
+    /// Requires the [Mute Members] permission to suppress another user or
+    /// unsuppress the current user.
+    ///
+    /// [Mute Members]: crate::model::permissions::Permissions::MUTE_MEMBERS
+    pub fn suppress(&mut self, deafen: bool) -> &mut Self {
+        self.0.insert("suppress", Value::Bool(deafen));
+        self
+    }
+
+    /// Requests or clears a request to speak. This is equivalent to passing the
+    /// current time to `request_to_speak_timestamp`.
+    ///
+    /// Requires the [Request to Speak] permission.
+    ///
+    /// [Request to Speak]: crate::model::permissions::Permissions::REQUEST_TO_SPEAK
+    pub fn request_to_speak(&mut self, request: bool) -> &mut Self {
+        if request {
+            self.request_to_speak_timestamp(Some(&Utc::now()));
+        } else {
+            self.request_to_speak_timestamp(None::<&DateTime<Utc>>);
+        }
+
+        self
+    }
+
+    /// Sets the current bot user's request to speak timestamp. This can be any
+    /// present or future time.
+    ///
+    /// Requires the [Request to Speak] permission.
+    ///
+    /// [Request to Speak]: crate::model::permissions::Permissions::REQUEST_TO_SPEAK
+    pub fn request_to_speak_timestamp<T: Into<Timestamp>>(
+        &mut self,
+        timestamp: Option<T>,
+    ) -> &mut Self {
+        if let Some(timestamp) = timestamp {
+            self.0.insert("request_to_speak_timestamp", Value::String(timestamp.into().ts));
+        } else {
+            self.0.insert("request_to_speak_timestamp", Value::Null);
+        }
+
+        self
+    }
+}

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -30,6 +30,7 @@ mod edit_member;
 mod edit_message;
 mod edit_profile;
 mod edit_role;
+mod edit_voice_state;
 mod edit_webhook_message;
 mod execute_webhook;
 mod get_messages;
@@ -47,6 +48,7 @@ pub use self::{
     edit_message::EditMessage,
     edit_profile::EditProfile,
     edit_role::EditRole,
+    edit_voice_state::EditVoiceState,
     edit_webhook_message::EditWebhookMessage,
     execute_webhook::ExecuteWebhook,
     get_messages::GetMessages,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1147,7 +1147,7 @@ impl Http {
         serde_json::from_value(value).map_err(From::from)
     }
 
-    /// Changes another user's voice state in a stage channel.
+    /// Changes a user's voice state in a stage channel.
     ///
     /// The Value is a map with values of:
     ///
@@ -1155,6 +1155,9 @@ impl Http {
     ///   (**required**)
     /// - **supress**: Bool which toggles user's suppressed state. Setting this
     ///   to `false` will invite the user to speak.
+    /// - **request_to_speak_timestamp**: Only when changing the current user's
+    ///   voice state, ISO8601 timestamp to set the user's request to speak.
+    ///   This can be any present or future time.
     ///
     /// # Examples
     ///
@@ -1173,38 +1176,26 @@ impl Http {
     ///     "suppress": false,
     /// });
     ///
-    /// http.edit_voice_state(guild_id, user_id, &map).await?;
+    /// // Edit state for another user
+    /// http.edit_voice_state(guild_id, Some(user_id), &map).await?;
+    ///
+    /// // Edit state for current user
+    /// http.edit_voice_state(guild_id, None, &map).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    pub async fn edit_voice_state(&self, guild_id: u64, user_id: u64, map: &Value) -> Result<()> {
+    pub async fn edit_voice_state(
+        &self,
+        guild_id: u64,
+        user_id: Option<u64>,
+        map: &Value,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: Some(map.to_string().as_bytes()),
             headers: None,
             route: RouteInfo::EditVoiceState {
                 guild_id,
                 user_id,
-            },
-        })
-        .await
-    }
-
-    /// Edits the current bot user's voice state.
-    ///
-    /// The Value is a map with values of:
-    ///
-    /// - **channel_id**: ID of the channel the user is currently in
-    ///   (**required**)
-    /// - **supress**: Bool which toggles user's suppressed state. Setting this
-    ///   to `false` will invite the user to speak.
-    /// - **request_to_speak_timestamp**: ISO8601 timestamp to set the user's
-    ///   request to speak. This can be any present or future time.
-    pub async fn edit_voice_state_self(&self, guild_id: u64, map: &Value) -> Result<()> {
-        self.wind(204, Request {
-            body: Some(map.to_string().as_bytes()),
-            headers: None,
-            route: RouteInfo::EditVoiceStateSelf {
-                guild_id,
             },
         })
         .await

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1171,10 +1171,12 @@ impl Http {
     /// #     let http = Http::default();
     /// let guild_id = 187450744427773963;
     /// let user_id = 150443906511667200;
-    /// let map = json!({
+    /// let value = json!({
     ///     "channel_id": "826929611849334784",
     ///     "suppress": false,
     /// });
+    ///
+    /// let map = value.as_object().unwrap();
     ///
     /// // Edit state for another user
     /// http.edit_voice_state(guild_id, Some(user_id), &map).await?;
@@ -1188,10 +1190,12 @@ impl Http {
         &self,
         guild_id: u64,
         user_id: Option<u64>,
-        map: &Value,
+        map: &JsonMap,
     ) -> Result<()> {
+        let body = serde_json::to_vec(map)?;
+
         self.wind(204, Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(&body),
             headers: None,
             route: RouteInfo::EditVoiceState {
                 guild_id,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1147,6 +1147,69 @@ impl Http {
         serde_json::from_value(value).map_err(From::from)
     }
 
+    /// Changes another user's voice state in a stage channel.
+    ///
+    /// The Value is a map with values of:
+    ///
+    /// - **channel_id**: ID of the channel the user is currently in
+    ///   (**required**)
+    /// - **supress**: Bool which toggles user's suppressed state. Setting this
+    ///   to `false` will invite the user to speak.
+    ///
+    /// # Examples
+    ///
+    /// Suppress a user
+    ///
+    /// ```rust,no_run
+    /// use serde_json::json;
+    /// use serenity::http::Http;
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// #     let http = Http::default();
+    /// let guild_id = 187450744427773963;
+    /// let user_id = 150443906511667200;
+    /// let map = json!({
+    ///     "channel_id": "826929611849334784",
+    ///     "suppress": false,
+    /// });
+    ///
+    /// http.edit_voice_state(guild_id, user_id, &map).await?;
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub async fn edit_voice_state(&self, guild_id: u64, user_id: u64, map: &Value) -> Result<()> {
+        self.wind(204, Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::EditVoiceState {
+                guild_id,
+                user_id,
+            },
+        })
+        .await
+    }
+
+    /// Edits the current bot user's voice state.
+    ///
+    /// The Value is a map with values of:
+    ///
+    /// - **channel_id**: ID of the channel the user is currently in
+    ///   (**required**)
+    /// - **supress**: Bool which toggles user's suppressed state. Setting this
+    ///   to `false` will invite the user to speak.
+    /// - **request_to_speak_timestamp**: ISO8601 timestamp to set the user's
+    ///   request to speak. This can be any present or future time.
+    pub async fn edit_voice_state_self(&self, guild_id: u64, map: &Value) -> Result<()> {
+        self.wind(204, Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::EditVoiceStateSelf {
+                guild_id,
+            },
+        })
+        .await
+    }
+
     /// Edits a the webhook with the given data.
     ///
     /// The Value is a map with optional values of:

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1147,7 +1147,7 @@ impl Http {
         serde_json::from_value(value).map_err(From::from)
     }
 
-    /// Changes a user's voice state in a stage channel.
+    /// Changes another user's voice state in a stage channel.
     ///
     /// The Value is a map with values of:
     ///
@@ -1155,9 +1155,6 @@ impl Http {
     ///   (**required**)
     /// - **supress**: Bool which toggles user's suppressed state. Setting this
     ///   to `false` will invite the user to speak.
-    /// - **request_to_speak_timestamp**: Only when changing the current user's
-    ///   voice state, ISO8601 timestamp to set the user's request to speak.
-    ///   This can be any present or future time.
     ///
     /// # Examples
     ///
@@ -1186,12 +1183,7 @@ impl Http {
     /// #     Ok(())
     /// # }
     /// ```
-    pub async fn edit_voice_state(
-        &self,
-        guild_id: u64,
-        user_id: Option<u64>,
-        map: &JsonMap,
-    ) -> Result<()> {
+    pub async fn edit_voice_state(&self, guild_id: u64, user_id: u64, map: &JsonMap) -> Result<()> {
         let body = serde_json::to_vec(map)?;
 
         self.wind(204, Request {
@@ -1200,6 +1192,29 @@ impl Http {
             route: RouteInfo::EditVoiceState {
                 guild_id,
                 user_id,
+            },
+        })
+        .await
+    }
+
+    /// Changes the current user's voice state in a stage channel.
+    ///
+    /// The Value is a map with values of:
+    ///
+    /// - **channel_id**: ID of the channel the user is currently in
+    ///   (**required**)
+    /// - **supress**: Bool which toggles user's suppressed state. Setting this
+    ///   to `false` will invite the user to speak.
+    /// - **request_to_speak_timestamp**: ISO8601 timestamp to set the user's
+    ///   request to speak. This can be any present or future time.
+    pub async fn edit_voice_state_me(&self, guild_id: u64, map: &JsonMap) -> Result<()> {
+        let body = serde_json::to_vec(map)?;
+
+        self.wind(204, Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditVoiceStateMe {
+                guild_id,
             },
         })
         .await

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1156,7 +1156,7 @@ impl Http {
     /// - **supress**: Bool which toggles user's suppressed state. Setting this
     ///   to `false` will invite the user to speak.
     ///
-    /// # Examples
+    /// # Example
     ///
     /// Suppress a user
     ///
@@ -1170,16 +1170,13 @@ impl Http {
     /// let user_id = 150443906511667200;
     /// let value = json!({
     ///     "channel_id": "826929611849334784",
-    ///     "suppress": false,
+    ///     "suppress": true,
     /// });
     ///
     /// let map = value.as_object().unwrap();
     ///
     /// // Edit state for another user
-    /// http.edit_voice_state(guild_id, Some(user_id), &map).await?;
-    ///
-    /// // Edit state for current user
-    /// http.edit_voice_state(guild_id, None, &map).await?;
+    /// http.edit_voice_state(guild_id, user_id, &map).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -1207,6 +1204,31 @@ impl Http {
     ///   to `false` will invite the user to speak.
     /// - **request_to_speak_timestamp**: ISO8601 timestamp to set the user's
     ///   request to speak. This can be any present or future time.
+    ///
+    /// # Example
+    ///
+    /// Unsuppress the current bot user
+    ///
+    /// ```rust,no_run
+    /// use serde_json::json;
+    /// use serenity::http::Http;
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// #     let http = Http::default();
+    /// let guild_id = 187450744427773963;
+    /// let value = json!({
+    ///     "channel_id": "826929611849334784",
+    ///     "suppress": false,
+    ///     "request_to_speak_timestamp": "2021-03-31T18:45:31.297561+00:00"
+    /// });
+    ///
+    /// let map = value.as_object().unwrap();
+    ///
+    /// // Edit state for current user
+    /// http.edit_voice_state_me(guild_id, &map).await?;
+    /// #     Ok(())
+    /// # }
+    /// ```
     pub async fn edit_voice_state_me(&self, guild_id: u64, map: &JsonMap) -> Result<()> {
         let body = serde_json::to_vec(map)?;
 

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -236,6 +236,18 @@ pub enum Route {
     ///
     /// [`GuildId`]: crate::model::id::GuildId
     GuildsIdVanityUrl(u64),
+    /// Route for the `/guilds/:guild_id/voice-states/:user_id` path.
+    ///
+    /// The data is the relevant [`GuildId`].
+    ///
+    /// [`GuildId`]: crate::model::id::GuildId
+    GuildsIdVoiceStates(u64),
+    /// Route for the `/guilds/:guild_id/voice-states/@me` path.
+    ///
+    /// The data is the relevant [`GuildId`].
+    ///
+    /// [`GuildId`]: crate::model::id::GuildId
+    GuildsIdVoiceStatesSelf(u64),
     /// Route for the `/guilds/:guild_id/webhooks` path.
     ///
     /// The data is the relevant [`GuildId`].
@@ -562,6 +574,14 @@ impl Route {
 
     pub fn guild_vanity_url(guild_id: u64) -> String {
         format!(api!("/guilds/{}/vanity-url"), guild_id)
+    }
+
+    pub fn guild_voice_states(guild_id: u64, user_id: u64) -> String {
+        format!(api!("/guilds/{}/voice-states/{}"), guild_id, user_id)
+    }
+
+    pub fn guild_voice_states_self(guild_id: u64) -> String {
+        format!(api!("/guilds/{}/voice-states/@me"), guild_id)
     }
 
     pub fn guild_webhooks(guild_id: u64) -> String {
@@ -953,6 +973,13 @@ pub enum RouteInfo<'a> {
         role_id: u64,
     },
     EditRolePosition {
+        guild_id: u64,
+    },
+    EditVoiceState {
+        guild_id: u64,
+        user_id: u64,
+    },
+    EditVoiceStateSelf {
         guild_id: u64,
     },
     EditWebhook {
@@ -1561,6 +1588,21 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Patch,
                 Route::GuildsIdRolesId(guild_id),
                 Cow::from(Route::guild_roles(guild_id)),
+            ),
+            RouteInfo::EditVoiceState {
+                guild_id,
+                user_id,
+            } => (
+                LightMethod::Patch,
+                Route::GuildsIdVoiceStates(guild_id),
+                Cow::from(Route::guild_voice_states(guild_id, user_id)),
+            ),
+            RouteInfo::EditVoiceStateSelf {
+                guild_id,
+            } => (
+                LightMethod::Patch,
+                Route::GuildsIdVoiceStatesSelf(guild_id),
+                Cow::from(Route::guild_voice_states_self(guild_id)),
             ),
             RouteInfo::EditWebhook {
                 webhook_id,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -242,6 +242,12 @@ pub enum Route {
     ///
     /// [`GuildId`]: crate::model::id::GuildId
     GuildsIdVoiceStates(u64),
+    /// Route for the `/guilds/:guild_id/voice-states/@me` path.
+    ///
+    /// The data is the relevant [`GuildId`].
+    ///
+    /// [`GuildId`]: crate::model::id::GuildId
+    GuildsIdVoiceStatesMe(u64),
     /// Route for the `/guilds/:guild_id/webhooks` path.
     ///
     /// The data is the relevant [`GuildId`].
@@ -570,8 +576,12 @@ impl Route {
         format!(api!("/guilds/{}/vanity-url"), guild_id)
     }
 
-    pub fn guild_voice_states<D: Display>(guild_id: u64, target: D) -> String {
-        format!(api!("/guilds/{}/voice-states/{}"), guild_id, target)
+    pub fn guild_voice_states(guild_id: u64, user_id: u64) -> String {
+        format!(api!("/guilds/{}/voice-states/{}"), guild_id, user_id)
+    }
+
+    pub fn guild_voice_states_me(guild_id: u64) -> String {
+        format!(api!("/guilds/{}/voice-states/@me"), guild_id)
     }
 
     pub fn guild_webhooks(guild_id: u64) -> String {
@@ -967,7 +977,10 @@ pub enum RouteInfo<'a> {
     },
     EditVoiceState {
         guild_id: u64,
-        user_id: Option<u64>,
+        user_id: u64,
+    },
+    EditVoiceStateMe {
+        guild_id: u64,
     },
     EditWebhook {
         webhook_id: u64,
@@ -1579,15 +1592,18 @@ impl<'a> RouteInfo<'a> {
             RouteInfo::EditVoiceState {
                 guild_id,
                 user_id,
-            } => {
-                let route = if let Some(user_id) = user_id {
-                    Cow::from(Route::guild_voice_states(guild_id, user_id))
-                } else {
-                    Cow::from(Route::guild_voice_states(guild_id, "@me"))
-                };
-
-                (LightMethod::Patch, Route::GuildsIdVoiceStates(guild_id), route)
-            },
+            } => (
+                LightMethod::Patch,
+                Route::GuildsIdVoiceStates(guild_id),
+                Cow::from(Route::guild_voice_states(guild_id, user_id)),
+            ),
+            RouteInfo::EditVoiceStateMe {
+                guild_id,
+            } => (
+                LightMethod::Patch,
+                Route::GuildsIdVoiceStatesMe(guild_id),
+                Cow::from(Route::guild_voice_states_me(guild_id)),
+            ),
             RouteInfo::EditWebhook {
                 webhook_id,
             } => (

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1580,19 +1580,13 @@ impl<'a> RouteInfo<'a> {
                 guild_id,
                 user_id,
             } => {
-                if let Some(user_id) = user_id {
-                    (
-                        LightMethod::Patch,
-                        Route::GuildsIdVoiceStates(guild_id),
-                        Cow::from(Route::guild_voice_states(guild_id, user_id)),
-                    )
+                let route = if let Some(user_id) = user_id {
+                    Cow::from(Route::guild_voice_states(guild_id, user_id))
                 } else {
-                    (
-                        LightMethod::Patch,
-                        Route::GuildsIdVoiceStates(guild_id),
-                        Cow::from(Route::guild_voice_states(guild_id, "@me")),
-                    )
-                }
+                    Cow::from(Route::guild_voice_states(guild_id, "@me"))
+                };
+
+                (LightMethod::Patch, Route::GuildsIdVoiceStates(guild_id), route)
             },
             RouteInfo::EditWebhook {
                 webhook_id,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -480,10 +480,7 @@ impl GuildChannel {
     /// use serenity::model::ModelError;
     ///
     /// // assuming the cache has been unlocked
-    /// let channel = cache
-    ///     .guild_channel(channel_id)
-    ///     .await
-    ///     .ok_or(ModelError::ItemMissing)?;
+    /// let channel = cache.guild_channel(channel_id).await.ok_or(ModelError::ItemMissing)?;
     ///
     /// channel.edit_voice_state(&http, user_id, |v| v.suppress(false)).await?;
     /// #   Ok(())
@@ -533,10 +530,7 @@ impl GuildChannel {
     /// use serenity::model::ModelError;
     ///
     /// // assuming the cache has been unlocked
-    /// let channel = cache
-    ///     .guild_channel(channel_id)
-    ///     .await
-    ///     .ok_or(ModelError::ItemMissing)?;
+    /// let channel = cache.guild_channel(channel_id).await.ok_or(ModelError::ItemMissing)?;
     ///
     /// // Send a request to speak
     /// channel.edit_own_voice_state(&http, |v| v.request_to_speak(true)).await?;
@@ -554,11 +548,7 @@ impl GuildChannel {
     ///
     /// [Mute Members]: crate::model::permissions::Permissions::MUTE_MEMBERS
     /// [Request to Speak]: crate::model::permissions::Permissions::REQUEST_TO_SPEAK
-    pub async fn edit_own_voice_state<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<()>
+    pub async fn edit_own_voice_state<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
     where
         F: FnOnce(&mut EditVoiceState) -> &mut EditVoiceState,
     {
@@ -581,8 +571,10 @@ impl GuildChannel {
         let mut voice_state = EditVoiceState::default();
         f(&mut voice_state);
 
+        voice_state.0.insert("channel_id", Value::String(self.id.0.to_string()));
+
         let map = serenity_utils::hashmap_to_json_map(voice_state.0);
-        http.as_ref().edit_voice_state(self.id.0, user_id.map(|id| id.into().0), &map).await
+        http.as_ref().edit_voice_state(self.guild_id.0, user_id.map(|id| id.into().0), &map).await
     }
 
     /// Attempts to find this channel's guild in the Cache.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -82,7 +82,7 @@ pub struct GuildChannel {
     pub position: i64,
     /// The topic of the channel.
     ///
-    /// **Note**: This is only available for text channels.
+    /// **Note**: This is only available for text and stage channels.
     pub topic: Option<String>,
     /// The maximum number of members allowed in the channel.
     ///

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -48,7 +48,7 @@ pub struct GuildChannel {
     pub id: ChannelId,
     /// The bitrate of the channel.
     ///
-    /// **Note**: This is only available for voice channels.
+    /// **Note**: This is only available for voice and stage channels.
     pub bitrate: Option<u64>,
     /// Whether this guild channel belongs in a category.
     #[serde(rename = "parent_id")]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -574,7 +574,12 @@ impl GuildChannel {
         voice_state.0.insert("channel_id", Value::String(self.id.0.to_string()));
 
         let map = serenity_utils::hashmap_to_json_map(voice_state.0);
-        http.as_ref().edit_voice_state(self.guild_id.0, user_id.map(|id| id.into().0), &map).await
+
+        if let Some(id) = user_id {
+            http.as_ref().edit_voice_state(self.guild_id.0, id.into().0, &map).await
+        } else {
+            http.as_ref().edit_voice_state_me(self.guild_id.0, &map).await
+        }
     }
 
     /// Attempts to find this channel's guild in the Cache.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -48,7 +48,7 @@ pub enum Channel {
     ///
     /// [text]: ChannelType::Text
     /// [voice]: ChannelType::Voice
-    /// [Stage]: ChannelType::Stage
+    /// [stage]: ChannelType::Stage
     Guild(GuildChannel),
     /// A private channel to another [`User`]. No other users may access the
     /// channel. For multi-user "private channels", use a group.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -306,7 +306,7 @@ pub enum ChannelType {
     ///
     /// Note: `StoreChannel` is serialized into a [`GuildChannel`]
     Store = 6,
-    /// An indicator that the channel is a `StageChannel`
+    /// An indicator that the channel is a stage [`GuildChannel`].
     Stage = 13,
 }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -44,10 +44,11 @@ use crate::utils::parse_channel;
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Channel {
-    /// A [text] or [voice] channel within a [`Guild`].
+    /// A [text], [voice], or [stage] channel within a [`Guild`].
     ///
     /// [text]: ChannelType::Text
     /// [voice]: ChannelType::Voice
+    /// [Stage]: ChannelType::Stage
     Guild(GuildChannel),
     /// A private channel to another [`User`]. No other users may access the
     /// channel. For multi-user "private channels", use a group.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -242,7 +242,7 @@ impl<'de> Deserialize<'de> for Channel {
         };
 
         match kind {
-            0 | 2 | 5 | 6 => serde_json::from_value::<GuildChannel>(Value::Object(v))
+            0 | 2 | 5 | 6 | 13 => serde_json::from_value::<GuildChannel>(Value::Object(v))
                 .map(Channel::Guild)
                 .map_err(DeError::custom),
             1 => serde_json::from_value::<PrivateChannel>(Value::Object(v))
@@ -306,6 +306,8 @@ pub enum ChannelType {
     ///
     /// Note: `StoreChannel` is serialized into a [`GuildChannel`]
     Store = 6,
+    /// An indicator that the channel is a `StageChannel`
+    Stage = 13,
 }
 
 enum_number!(ChannelType {
@@ -314,7 +316,8 @@ enum_number!(ChannelType {
     Voice,
     Category,
     News,
-    Store
+    Store,
+    Stage,
 });
 
 impl ChannelType {
@@ -327,6 +330,7 @@ impl ChannelType {
             ChannelType::Category => "category",
             ChannelType::News => "news",
             ChannelType::Store => "store",
+            ChannelType::Stage => "stage",
         }
     }
 
@@ -339,6 +343,7 @@ impl ChannelType {
             ChannelType::Category => 4,
             ChannelType::News => 5,
             ChannelType::Store => 6,
+            ChannelType::Stage => 13,
         }
     }
 }

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -315,6 +315,8 @@ __impl_bitflags! {
         ///
         /// [`Integration`]: super::guild::Integration
         MANAGE_EMOJIS = 0b0100_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows for requesting to speak in stage channels.
+        REQUEST_TO_SPEAK = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
     }
 }
 
@@ -342,6 +344,7 @@ generate_get_permission_names! {
     mute_members: "Mute Members",
     priority_speaker: "Priority Speaker",
     read_message_history: "Read Message History",
+    request_to_speak: "Request To Speak",
     read_messages: "Read Messages",
     send_messages: "Send Messages",
     send_tts_messages: "Send TTS Messages",
@@ -584,6 +587,14 @@ impl Permissions {
     /// [Speak]: Self::SPEAK
     pub fn speak(self) -> bool {
         self.contains(Self::SPEAK)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
+    /// [Request To Speak] permission.
+    ///
+    /// [Request To Speak]: Self::REQUEST_TO_SPEAK
+    pub fn request_to_speak(self) -> bool {
+        self.contains(Self::REQUEST_TO_SPEAK)
     }
 
     /// Shorthand for checking that the set of permissions contains the

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -46,6 +46,10 @@ pub struct VoiceState {
     pub suppress: bool,
     pub token: Option<String>,
     pub user_id: UserId,
+    /// When unsuppressed, non-bot users will have this set to the current time.
+    /// Bot users will not. When suppressed, the user will have their
+    /// `request_to_speak_timestamp` removed.
+    pub request_to_speak_timestamp: Option<DateTime<Utc>>,
 }
 
 impl fmt::Debug for VoiceState {
@@ -63,6 +67,7 @@ impl fmt::Debug for VoiceState {
             .field("session_id", &self.session_id)
             .field("suppress", &self.suppress)
             .field("user_id", &self.user_id)
+            .field("request_to_speak_timestamp", &self.request_to_speak_timestamp)
             .finish()
     }
 }
@@ -85,6 +90,7 @@ impl<'de> Deserialize<'de> for VoiceState {
             Suppress,
             Token,
             UserId,
+            RequestToSpeakTimestamp,
         }
 
         #[derive(Deserialize)]
@@ -126,6 +132,7 @@ impl<'de> Deserialize<'de> for VoiceState {
                 let mut suppress = None;
                 let mut token = None;
                 let mut user_id = None;
+                let mut request_to_speak_timestamp = None;
 
                 loop {
                     let key = match map.next_key() {
@@ -232,6 +239,14 @@ impl<'de> Deserialize<'de> for VoiceState {
                             }
                             user_id = Some(map.next_value()?);
                         },
+                        Field::RequestToSpeakTimestamp => {
+                            if request_to_speak_timestamp.is_some() {
+                                return Err(de::Error::duplicate_field(
+                                    "request_to_speak_timestamp",
+                                ));
+                            }
+                            request_to_speak_timestamp = Some(map.next_value()?);
+                        },
                     }
                 }
 
@@ -245,6 +260,8 @@ impl<'de> Deserialize<'de> for VoiceState {
                     session_id.ok_or_else(|| de::Error::missing_field("session_id"))?;
                 let suppress = suppress.ok_or_else(|| de::Error::missing_field("suppress"))?;
                 let user_id = user_id.ok_or_else(|| de::Error::missing_field("user_id"))?;
+                let request_to_speak_timestamp = request_to_speak_timestamp
+                    .ok_or_else(|| de::Error::missing_field("request_to_speak"))?;
 
                 if let (Some(guild_id), Some(member)) = (guild_id, member.as_mut()) {
                     member.guild_id = guild_id;
@@ -264,6 +281,7 @@ impl<'de> Deserialize<'de> for VoiceState {
                     suppress,
                     token,
                     user_id,
+                    request_to_speak_timestamp,
                 })
             }
         }
@@ -282,6 +300,7 @@ impl<'de> Deserialize<'de> for VoiceState {
             "suppress",
             "token",
             "user_id",
+            "request_to_speak_timestamp",
         ];
 
         deserializer.deserialize_struct("VoiceState", FIELDS, VoiceStateVisitor)

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -260,8 +260,7 @@ impl<'de> Deserialize<'de> for VoiceState {
                     session_id.ok_or_else(|| de::Error::missing_field("session_id"))?;
                 let suppress = suppress.ok_or_else(|| de::Error::missing_field("suppress"))?;
                 let user_id = user_id.ok_or_else(|| de::Error::missing_field("user_id"))?;
-                let request_to_speak_timestamp = request_to_speak_timestamp
-                    .ok_or_else(|| de::Error::missing_field("request_to_speak"))?;
+                let request_to_speak_timestamp = request_to_speak_timestamp.unwrap_or(None);
 
                 if let (Some(guild_id), Some(member)) = (guild_id, member.as_mut()) {
                     member.guild_id = guild_id;

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -47,8 +47,8 @@ pub struct VoiceState {
     pub token: Option<String>,
     pub user_id: UserId,
     /// When unsuppressed, non-bot users will have this set to the current time.
-    /// Bot users will not. When suppressed, the user will have their
-    /// `request_to_speak_timestamp` removed.
+    /// Bot users will be set to `None`. When suppressed, the user will have
+    /// their `request_to_speak_timestamp` removed.
     pub request_to_speak_timestamp: Option<DateTime<Utc>>,
 }
 


### PR DESCRIPTION
#### Description

Adds support for [stage channel](https://support.discord.com/hc/en-us/articles/1500005513722#h_01F22AKG1WM0JYC69N1JW22JBZ).  Documentation: https://github.com/discord/discord-api-docs/pull/2751

Adds `GuildChannel::edit_voice_state` method. The API endpoint also requires the guild ID so it isn't impl on `ChannelId`.

#### Tested

The following has been tested

- [x] `ChannelId::to_channel` deserialization
- [x] `request_to_speak_timestamp` field deserialization
- [x] `Http::edit_voice_state` for other user
- [x] `Http::edit_voice_state` for current user while bot is connected with songbird example
- [x] `GuildChannel::edit_voice_state` for other user

Minimal code used to test `GuildChannel::edit_voice_state`

```rust
let chan = ChannelId(826929611849334784).to_channel(&ctx).await.unwrap().guild().unwrap();
dbg!(chan.edit_voice_state(&ctx, 167442959904538624, |v| v.suppress(false)).await);

sleep(Duration::from_secs(10)).await;
dbg!(chan.edit_voice_state(&ctx, 167442959904538624, |v| v.suppress(true)).await);
```

#### Other Changes

~~- missing `rtc_region` and `video_quality_mode` fields added to `GuildChannel` (`video_quality_mode` not applicable to stage channels, shows up due to client bug: https://github.com/discord/discord-api-docs/pull/2754)~~ - merged in a separate pull request (https://github.com/serenity-rs/serenity/pull/1276).

#### Related Issue

#1270