### PR TITLE
feat(model): Add `rtc_region` and `video_quality_mode` guildchannel fields

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1081,6 +1081,8 @@ mod test {
             user_limit: None,
             nsfw: false,
             slow_mode_rate: Some(0),
+            rtc_region: None,
+            video_quality_mode: None,
         };
 
         // Add a channel delete event to the cache, the cached messages for that

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -104,7 +104,8 @@ pub struct GuildChannel {
     pub slow_mode_rate: Option<u64>,
     /// The region override.
     ///
-    /// **Note**: This is only available for voice and stage channels.
+    /// **Note**: This is only available for voice and stage channels. `None`
+    /// for voice and stage channels means automatic region selection.
     pub rtc_region: Option<String>,
     /// The video quality mode for a voice channel.
     pub video_quality_mode: Option<VideoQualityMode>,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -102,6 +102,12 @@ pub struct GuildChannel {
     /// channels.
     #[serde(default, rename = "rate_limit_per_user")]
     pub slow_mode_rate: Option<u64>,
+    /// The region override.
+    ///
+    /// **Note**: This is only available for voice and stage channels.
+    pub rtc_region: Option<String>,
+    /// The video quality mode for a voice channel.
+    pub video_quality_mode: Option<VideoQualityMode>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -413,6 +413,22 @@ pub enum PermissionOverwriteType {
     Role(RoleId),
 }
 
+/// The video quality mode for a voice channel.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum VideoQualityMode {
+    /// An indicator that the video quality is chosen by Discord for optimal
+    /// performance.
+    Auto = 1,
+    /// An indicator that the video quality is 720p.
+    Full = 2,
+}
+
+enum_number!(VideoQualityMode {
+    Auto,
+    Full,
+});
+
 #[cfg(test)]
 mod test {
     #[cfg(all(feature = "model", feature = "utils"))]
@@ -435,6 +451,8 @@ mod test {
                 user_limit: None,
                 nsfw: false,
                 slow_mode_rate: Some(0),
+                rtc_region: None,
+                video_quality_mode: None,
             }
         }
 

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -401,6 +401,8 @@ mod test {
                 user_limit: None,
                 nsfw: false,
                 slow_mode_rate: Some(0),
+                rtc_region: None,
+                video_quality_mode: None,
             });
             let emoji = Emoji {
                 animated: false,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -900,6 +900,8 @@ mod test {
             user_limit: None,
             nsfw: false,
             slow_mode_rate: Some(0),
+            rtc_region: None,
+            video_quality_mode: None,
         };
 
         let cache = Arc::new(Cache::default());


### PR DESCRIPTION
#### Description

Adds new fields `rtc_region` and `video_quality_mode` to `GuildChannel`.

Documentation:

- rtc_region: https://github.com/discord/discord-api-docs/pull/2692
- video_quality_mode: https://github.com/discord/discord-api-docs/pull/2754

#### Tested

`cargo test --all-features` passes.  

Basic test using `ChannelId(channel_id)to_channel(&ctx).await` shows deserialization works with a `rtc_region` override set and `video_quality_mode` set to 720p in channel settings:

