### PR TITLE
Adds a space in a example of CreateEmbed

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -303,7 +303,7 @@ impl CreateEmbed {
     ///     }
     /// }
     ///
-    /// let mut client =Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())


### PR DESCRIPTION
I saw this while browsing the docs, and I can't unsee it now.