### PR TITLE
rephrase documentation for accuracy

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -249,8 +249,9 @@ async fn main() {
     // provides the context of the command, the message that was received,
     // and the full name of the command that will be called.
     //
-    // You can not use this to determine whether a command should be
-    // executed. Instead, the `#[check]` macro gives you this functionality.
+    // Avoid using this to determine whether a specific command should be
+    // executed. Instead, prefer using the `#[check]` macro which
+    // gives you this functionality.
     //
     // **Note**: Async closures are unstable, you may use them in your
     // application if you are fine using nightly Rust.


### PR DESCRIPTION
https://serenity-rs.github.io/serenity/current/serenity/framework/standard/struct.StandardFramework.html#examples-4:
> Using before to **prevent** command usage

but in the code sample where usage of `.before` is demonstrated:
https://github.com/serenity-rs/serenity/blob/feda47ca0b4b61061d8c02623c0fcdafe1e17c8b/examples/e05_command_framework/src/main.rs#L252
> You can not use this to determine whether a command should be executed