### PR TITLE
Remove useless `mut` modifiers in builder code

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -89,7 +89,7 @@ impl CreateInteractionResponseData {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
-        let mut embeds = self.0.entry("embeds").or_insert_with(|| Value::Array(vec![]));
+        let embeds = self.0.entry("embeds").or_insert_with(|| Value::Array(vec![]));
 
         if let Some(embeds) = embeds.as_array_mut() {
             embeds.push(embed);

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -39,7 +39,7 @@ impl EditInteractionResponse {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
-        let mut embeds = self.0.entry("embeds").or_insert_with(|| Value::Array(vec![]));
+        let embeds = self.0.entry("embeds").or_insert_with(|| Value::Array(vec![]));
 
         if let Some(embeds) = embeds.as_array_mut() {
             embeds.push(embed);


### PR DESCRIPTION
## Description

This resolves a warning for let bindings in interaction builder code that had a useless `mut`.

## Type of Change

This is a fix to resolve a warning in the builder code for interactions.

## How Has This Been Tested?

This has been tested by verifying compilation is still successful, which it is.