### PR TITLE
Add content_type field to Attachment

### DIFF
--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -26,6 +26,8 @@ pub struct Attachment {
     pub url: String,
     /// If the attachment is an image, then the width of the image is provided.
     pub width: Option<u64>,
+    /// The attachment's [media type](https://en.wikipedia.org/wiki/Media_type)
+    pub content_type: Option<String>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -26,7 +26,9 @@ pub struct Attachment {
     pub url: String,
     /// If the attachment is an image, then the width of the image is provided.
     pub width: Option<u64>,
-    /// The attachment's [media type](https://en.wikipedia.org/wiki/Media_type)
+    /// The attachment's [media type].
+    ///
+    /// [media type]: https://en.wikipedia.org/wiki/Media_type
     pub content_type: Option<String>,
 }
 


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/commit/ab7a51ffea418a354562404da51ee609f8bca539

	modified:   src/model/channel/attachment.rs