### PR TITLE
Type check the return type of the body of async functions

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -226,7 +226,10 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
         #visibility fn #name<'fut> (#(#args),*) -> ::serenity::futures::future::BoxFuture<'fut, #ret> {
             use ::serenity::futures::future::FutureExt;
 
-            async move { #(#body)* }.boxed()
+            async move {
+                let output: #ret = { #(#body)* };
+                output
+            }.boxed()
         }
     })
     .into()
@@ -518,7 +521,10 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
         pub fn #nn<'fut>(#(#args),*) -> ::serenity::futures::future::BoxFuture<'fut, #ret> {
             use ::serenity::futures::future::FutureExt;
 
-            async move { #(#body)* }.boxed()
+            async move {
+                let output: #ret = { #(#body)* };
+                output
+            }.boxed()
         }
     })
     .into()
@@ -794,7 +800,10 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
         #visibility fn #n<'fut>(#(#args),*) -> ::serenity::futures::future::BoxFuture<'fut, #ret> {
             use ::serenity::futures::future::FutureExt;
 
-            async move { #(#body)* }.boxed()
+            async move {
+                let output: #ret = { #(#body)* };
+                output
+            }.boxed()
         }
     })
     .into()
@@ -929,7 +938,10 @@ pub fn hook(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 #visibility fn #fun_name<'fut>(#(#args),*) -> ::serenity::futures::future::BoxFuture<'fut, #ret> {
                     use ::serenity::futures::future::FutureExt;
 
-                    async move { #(#body)* }.boxed()
+                    async move {
+                        let output: #ret = { #(#body)* };
+                        output
+                    }.boxed()
                 }
             })
                 .into()


### PR DESCRIPTION
## Description

This nudges the compiler by supplying the expected return type of bodies of `async` functions when `command_attr`'s macros are applied, such as `#[command]` or `#[check]`. This aids the compiler in providing more useful error messages.

## Type of Change

This is an improvement to the macro code in the `command_attr` crate, a part of the framework.

## How Has This Been Tested?

This has been tested by verifying compilation is still successful, which it is. Error messages from the compiler have also improved. They no longer give nonsense advice such as `Box::pin(#[command])`.