### PR TITLE
Update `README.md` Discord Guild Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ If you use the `native_tls_backend` and you are not developing on macOS or Windo
 [docs-badge]: https://img.shields.io/badge/docs-online-5023dd.svg?style=flat-square
 [examples]: https://github.com/serenity-rs/serenity/tree/current/examples
 [gateway docs]: https://docs.rs/serenity/*/serenity/gateway/index.html
-[guild]: https://discord.gg/9X7vCus
+[guild]: https://discord.gg/serenity-rs
 [guild-badge]: https://img.shields.io/discord/381880193251409931.svg?style=flat-square&colorB=7289DA
 [project:lavalink-rs]: https://gitlab.com/nitsuga5124/lavalink-rs/
 [project:songbird]: https://github.com/serenity-rs/songbird


### PR DESCRIPTION
## Description

The integrity of the guild badge needs to be preserved by updating its link target to our vanity URL.
There is one disadvantage, the moment we change the vanity URL, it will break. This trade-off has not been considered, I simply like the vanity URL.

## Type of Change

This is a very important change that may not be questioned!!

## How Has This Been Tested?

I clicked on the badge and it launched Discord for me, sadly I cannot join the Discord guild, as I have already. Please test if you can, it's an integral part to fully fathom the potential side-effect of this essential change. Here are some words nobody will read. The history of badges dates back into the very first years of dinosaurs, where dinos wore badges to associate with their tribe and clan. They added more and more badges based on their accomplishments.