### PR TITLE
Support member field on message reaction add event

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -616,6 +616,7 @@ impl Message {
             message_id: self.id,
             user_id,
             guild_id: self.guild_id,
+            member: self.member.clone(),
         })
     }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -17,7 +17,7 @@ use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// An emoji reaction to a message.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct Reaction {
     /// The [`Channel`] of the associated [`Message`].
@@ -32,6 +32,79 @@ pub struct Reaction {
     pub user_id: Option<UserId>,
     /// The optional Id of the [`Guild`] where the reaction was sent.
     pub guild_id: Option<GuildId>,
+    /// The optional object of the member which added the reaction..
+    pub member: Option<PartialMember>,
+}
+
+impl<'de> Deserialize<'de> for Reaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        let mut map = JsonMap::deserialize(deserializer)?;
+
+        let channel_id = map
+            .remove("channel_id")
+            .ok_or_else(|| DeError::custom("expected channel_id"))
+            .and_then(ChannelId::deserialize)
+            .map_err(DeError::custom)?;
+
+        let message_id = map
+            .remove("message_id")
+            .ok_or_else(|| DeError::custom("expected message_id"))
+            .and_then(MessageId::deserialize)
+            .map_err(DeError::custom)?;
+
+        let emoji = map
+            .remove("emoji")
+            .ok_or_else(|| DeError::custom("expected emoji"))
+            .and_then(ReactionType::deserialize)
+            .map_err(DeError::custom)?;
+
+        let user_id = match map.contains_key("user_id") {
+            true => Some(
+                map.remove("user_id")
+                    .ok_or_else(|| DeError::custom("expected user_id"))
+                    .and_then(UserId::deserialize)
+                    .map_err(DeError::custom)?,
+            ),
+            false => None,
+        };
+
+        let guild_id = match map.contains_key("guild_id") {
+            true => Some(
+                map.remove("guild_id")
+                    .ok_or_else(|| DeError::custom("expected guild_id"))
+                    .and_then(GuildId::deserialize)
+                    .map_err(DeError::custom)?,
+            ),
+            false => None,
+        };
+
+        if let Some(id) = guild_id {
+            if let Some(member) = map.get_mut("member") {
+                if let Some(object) = member.as_object_mut() {
+                    object.insert("guild_id".to_owned(), Value::String(id.to_string()));
+                }
+            }
+        }
+
+        let member = match map.contains_key("member") {
+            true => Some(
+                map.remove("member")
+                    .ok_or_else(|| DeError::custom("expected member"))
+                    .and_then(PartialMember::deserialize)
+                    .map_err(DeError::custom)?,
+            ),
+            false => None,
+        };
+
+        Ok(Self {
+            channel_id,
+            emoji,
+            message_id,
+            user_id,
+            guild_id,
+            member,
+        })
+    }
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -32,7 +32,7 @@ pub struct Reaction {
     pub user_id: Option<UserId>,
     /// The optional Id of the [`Guild`] where the reaction was sent.
     pub guild_id: Option<GuildId>,
-    /// The optional object of the member which added the reaction..
+    /// The optional object of the member which added the reaction.
     pub member: Option<PartialMember>,
 }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -551,4 +551,16 @@ pub struct PartialMember {
     pub pending: bool,
     /// Timestamp representing the date since the member is boosting the guild.
     pub premium_since: Option<DateTime<Utc>>,
+    /// The unique Id of the guild that the member is a part of.
+    pub guild_id: Option<GuildId>,
+    /// Attached User struct.
+    pub user: Option<User>,
+    /// The total permissions of the member in a channel, including overrides.
+    ///
+    /// This is only [`Some`] when returned in an [`Interaction`] object.
+    ///
+    /// [`Interaction`]: crate::model::interactions::Interaction
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    pub permissions: Option<String>,
 }


### PR DESCRIPTION
This PR adds support to the `member` field in the message reaction add event. It also updates PartialMember to include some new  optional fields.

This has been tested.

Closes #922.