### PR TITLE
Avoid cloning messages if the framework feature is disabled

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -200,10 +200,16 @@ pub(crate) fn dispatch<'rec>(
                         &cache_and_http.cache,
                     );
 
-                    dispatch_message(context.clone(), event.message.clone(), h).await;
+                    #[cfg(not(feature = "framework"))]
+                    {
+                        // Avoid cloning if there will be no framework dispatch.
+                        dispatch_message(context, event.message, h).await;
+                    }
 
                     #[cfg(feature = "framework")]
                     {
+                        dispatch_message(context.clone(), event.message.clone(), h).await;
+
                         let framework = Arc::clone(&framework);
 
                         tokio::spawn(async move {
@@ -233,8 +239,10 @@ pub(crate) fn dispatch<'rec>(
                     );
 
                     #[cfg(not(feature = "framework"))]
-                    // No clone needed, as there will be no framework disaptch.
-                    event_handler.raw_event(context, event).await;
+                    {
+                        // No clone needed, as there will be no framework dispatch.
+                        event_handler.raw_event(context, event).await;
+                    }
 
                     #[cfg(feature = "framework")]
                     {
@@ -249,7 +257,7 @@ pub(crate) fn dispatch<'rec>(
                                 framework.dispatch(context, message).await;
                             });
                         } else {
-                            // Avoid cloning, if there is no framework-dispatch.
+                            // Avoid cloning if there will be no framework dispatch.
                             event_handler.raw_event(context, event).await;
                         }
                     }
@@ -270,10 +278,16 @@ pub(crate) fn dispatch<'rec>(
 
                 match event {
                     DispatchEvent::Model(Event::MessageCreate(event)) => {
-                        dispatch_message(context.clone(), event.message.clone(), handler).await;
+                        #[cfg(not(feature = "framework"))]
+                        {
+                            // Avoid cloning if there will be no framework dispatch.
+                            dispatch_message(context, event.message, handler).await;
+                        }
 
                         #[cfg(feature = "framework")]
                         {
+                            dispatch_message(context.clone(), event.message.clone(), handler).await;
+
                             let framework = Arc::clone(&framework);
                             let message = event.message;
                             tokio::spawn(async move {


### PR DESCRIPTION
## Description

This reduces the number of cloning of messages if the `framework` feature is disabled. Currently, every message is cloned regardless of the `framework` feature, which is needless overhead if there is no framework.

## Type of Change

This enhances (should) the runtime performance of dispatch for the message create event if the `framework` feature is disabled. The change is applied to code that's part of the client.

## How Has This Been Tested?

This has been tested by compiling with and without the `framework` to ensure code compiles correctly. Runtime performance has not been benchmarked, but hypothetically it should have improved.