### PR TITLE
Silence `dead_code` lint for `ClientBuilder::token`

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -73,6 +73,9 @@ pub use crate::CacheAndHttp;
 /// A builder implementing [`Future`] building a [`Client`] to interact with Discord.
 #[cfg(feature = "gateway")]
 pub struct ClientBuilder<'a> {
+    // FIXME: Remove this allow attribute once `application_id` is no longer feature-gated
+    // under `unstable_discord_api`.
+    #[allow(dead_code)]
     token: Option<String>,
     data: Option<TypeMap>,
     http: Option<Http>,


### PR DESCRIPTION
## Description

This gets rid of a warning emitted by the `dead_code` lint for the `ClientBuilder::token` field. The warning is emitted in situations where the `unstable_discord_api` feature is disabled, as `ClientBuilder::application_id` is the only place where the field is used at the moment, and is behind the `unstable_discord_api` feature.

## Type of Change

This reduces noise when compiling Serenity, thus enhancing the user experience.

## How Has This Been Tested?

This has been tested by compiling without the `unstable_discord_api` feature. The warning has disappeared successfully.