### PR TITLE
Default to the `Unknown` variant for new model types

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -116,26 +116,6 @@ enum_number!(OpCode {
     HeartbeatAck,
 });
 
-impl OpCode {
-    pub fn num(self) -> u64 {
-        match self {
-            OpCode::Event => 0,
-            OpCode::Heartbeat => 1,
-            OpCode::Identify => 2,
-            OpCode::StatusUpdate => 3,
-            OpCode::VoiceStateUpdate => 4,
-            OpCode::VoiceServerPing => 5,
-            OpCode::Resume => 6,
-            OpCode::Reconnect => 7,
-            OpCode::GetGuildMembers => 8,
-            OpCode::InvalidSession => 9,
-            OpCode::Hello => 10,
-            OpCode::HeartbeatAck => 11,
-            OpCode::Unknown => !0,
-        }
-    }
-}
-
 pub mod close_codes {
     /// Unknown error; try reconnecting?
     ///

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -97,6 +97,8 @@ pub enum OpCode {
     Hello = 10,
     /// Sent immediately following a client heartbeat that was received.
     HeartbeatAck = 11,
+    /// Unknown opcode.
+    Unknown = !0,
 }
 
 enum_number!(OpCode {
@@ -129,6 +131,7 @@ impl OpCode {
             OpCode::InvalidSession => 9,
             OpCode::Hello => 10,
             OpCode::HeartbeatAck => 11,
+            OpCode::Unknown => !0,
         }
     }
 }

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -74,9 +74,11 @@ macro_rules! enum_number {
                         // number to an enum, so use a big `match`.
                         match value {
                             $( v if v == $name::$variant as u64 => Ok($name::$variant), )*
-                            _ => Err(E::custom(
-                                format!("unknown {} value: {}",
-                                stringify!($name), value))),
+                            _ => {
+                                tracing::warn!("Unknown {} value: {}", stringify!($name), value);
+
+                                Ok($name::Unknown)
+                            }
                         }
                     }
                 }

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -51,31 +51,31 @@ macro_rules! enum_number {
             }
         }
 
-        impl ::serde::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
-                where S: ::serde::Serializer
+        impl serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where S: serde::Serializer
             {
                 // Serialize the enum as a u64.
                 serializer.serialize_u64(*self as u64)
             }
         }
 
-        impl<'de> ::serde::Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
-                where D: ::serde::Deserializer<'de>
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where D: serde::Deserializer<'de>
             {
                 struct Visitor;
 
-                impl<'de> ::serde::de::Visitor<'de> for Visitor {
+                impl<'de> serde::de::Visitor<'de> for Visitor {
                     type Value = $name;
 
-                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter<'_>)
-                        -> ::std::fmt::Result {
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>)
+                        -> std::fmt::Result {
                         formatter.write_str("positive integer")
                     }
 
-                    fn visit_u64<E>(self, value: u64) -> ::std::result::Result<$name, E>
-                        where E: ::serde::de::Error
+                    fn visit_u64<E>(self, value: u64) -> std::result::Result<$name, E>
+                        where E: serde::de::Error
                     {
                         // Rust does not come with a simple way of converting a
                         // number to an enum, so use a big `match`.

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -44,6 +44,13 @@ macro_rules! feature_cache {
 
 macro_rules! enum_number {
     ($name:ident { $($variant:ident $(,)? )* }) => {
+        impl $name {
+            #[inline]
+            pub fn num(&self) -> u64 {
+                *self as u64
+            }
+        }
+
         impl ::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
                 where S: ::serde::Serializer

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -166,6 +166,7 @@ pub struct TeamMember {
 pub enum MembershipState {
     Invited = 1,
     Accepted = 2,
+    Unknown = !0,
 }
 
 enum_number!(MembershipState {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1056,34 +1056,6 @@ enum_number!(MessageType {
     ApplicationCommand,
 });
 
-impl MessageType {
-    pub fn num(self) -> u64 {
-        use self::MessageType::*;
-
-        match self {
-            Regular => 0,
-            GroupRecipientAddition => 1,
-            GroupRecipientRemoval => 2,
-            GroupCallCreation => 3,
-            GroupNameUpdate => 4,
-            GroupIconUpdate => 5,
-            PinsAdd => 6,
-            MemberJoin => 7,
-            NitroBoost => 8,
-            NitroTier1 => 9,
-            NitroTier2 => 10,
-            NitroTier3 => 11,
-            ChannelFollowAdd => 12,
-            GuildDiscoveryDisqualified => 14,
-            GuildDiscoveryRequalified => 15,
-            InlineReply => 19,
-            ApplicationCommand => 20,
-            GuildInviteReminder => 22,
-            Unknown => !0,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum MessageActivityKind {
@@ -1101,20 +1073,6 @@ enum_number!(MessageActivityKind {
     LISTEN,
     JOIN_REQUEST
 });
-
-impl MessageActivityKind {
-    pub fn num(self) -> u64 {
-        use self::MessageActivityKind::*;
-
-        match self {
-            JOIN => 1,
-            SPECTATE => 2,
-            LISTEN => 3,
-            JOIN_REQUEST => 5,
-            Unknown => !0,
-        }
-    }
-}
 
 /// Rich Presence application information.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1032,6 +1032,8 @@ pub enum MessageType {
     ApplicationCommand = 20,
     /// Server setup tips.
     GuildInviteReminder = 22,
+    /// An indicator that the message is of unknown type.
+    Unknown = !0,
 }
 
 enum_number!(MessageType {
@@ -1077,6 +1079,7 @@ impl MessageType {
             InlineReply => 19,
             ApplicationCommand => 20,
             GuildInviteReminder => 22,
+            Unknown => !0,
         }
     }
 }
@@ -1089,6 +1092,7 @@ pub enum MessageActivityKind {
     LISTEN = 3,
     #[allow(non_camel_case_types)]
     JOIN_REQUEST = 5,
+    Unknown = !0,
 }
 
 enum_number!(MessageActivityKind {
@@ -1107,6 +1111,7 @@ impl MessageActivityKind {
             SPECTATE => 2,
             LISTEN => 3,
             JOIN_REQUEST => 5,
+            Unknown => !0,
         }
     }
 }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -420,7 +420,7 @@ pub enum VideoQualityMode {
     Auto = 1,
     /// An indicator that the video quality is 720p.
     Full = 2,
-    /// An indicator that video quality of unknown type.
+    /// An indicator that video quality is of unknown type.
     Unknown = !0,
 }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -311,6 +311,8 @@ pub enum ChannelType {
     Store = 6,
     /// An indicator that the channel is a stage [`GuildChannel`].
     Stage = 13,
+    /// An indicator that the channel is of unknown type.
+    Unknown = !0,
 }
 
 enum_number!(ChannelType {
@@ -334,6 +336,7 @@ impl ChannelType {
             ChannelType::News => "news",
             ChannelType::Store => "store",
             ChannelType::Stage => "stage",
+            ChannelType::Unknown => "Unknown",
         }
     }
 
@@ -347,6 +350,7 @@ impl ChannelType {
             ChannelType::News => 5,
             ChannelType::Store => 6,
             ChannelType::Stage => 13,
+            ChannelType::Unknown => !0,
         }
     }
 }
@@ -430,6 +434,8 @@ pub enum VideoQualityMode {
     Auto = 1,
     /// An indicator that the video quality is 720p.
     Full = 2,
+    /// An indicator that video quality of unknown type.
+    Unknown = !0,
 }
 
 enum_number!(VideoQualityMode {

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -336,21 +336,7 @@ impl ChannelType {
             ChannelType::News => "news",
             ChannelType::Store => "store",
             ChannelType::Stage => "stage",
-            ChannelType::Unknown => "Unknown",
-        }
-    }
-
-    #[inline]
-    pub fn num(self) -> u64 {
-        match self {
-            ChannelType::Text => 0,
-            ChannelType::Private => 1,
-            ChannelType::Voice => 2,
-            ChannelType::Category => 4,
-            ChannelType::News => 5,
-            ChannelType::Store => 6,
-            ChannelType::Stage => 13,
-            ChannelType::Unknown => !0,
+            ChannelType::Unknown => "unknown",
         }
     }
 }

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -43,16 +43,3 @@ enum_number!(StickerFormatType {
     Apng,
     Lottie
 });
-
-impl StickerFormatType {
-    pub fn num(self) -> u64 {
-        use self::StickerFormatType::*;
-
-        match self {
-            Png => 1,
-            Apng => 2,
-            Lottie => 3,
-            Unknown => !0,
-        }
-    }
-}

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -34,6 +34,8 @@ pub enum StickerFormatType {
     Apng = 2,
     /// A LOTTIE format animated sticker.
     Lottie = 3,
+    /// Unknown sticker format type.
+    Unknown = !0,
 }
 
 enum_number!(StickerFormatType {
@@ -50,6 +52,7 @@ impl StickerFormatType {
             Png => 1,
             Apng => 2,
             Lottie => 3,
+            Unknown => !0,
         }
     }
 }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -511,7 +511,7 @@ pub enum ActivityType {
     Custom = 4,
     /// An indicator that the user is competing somewhere.
     Competing = 5,
-    /// An indicator that the activity of unknown type.
+    /// An indicator that the activity is of unknown type.
     Unknown = !0,
 }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -524,22 +524,6 @@ enum_number!(ActivityType {
     Competing
 });
 
-impl ActivityType {
-    pub fn num(self) -> u64 {
-        use self::ActivityType::*;
-
-        match self {
-            Playing => 0,
-            Streaming => 1,
-            Listening => 2,
-            Watching => 3,
-            Custom => 4,
-            Competing => 5,
-            Unknown => !0,
-        }
-    }
-}
-
 impl Default for ActivityType {
     fn default() -> Self {
         ActivityType::Playing

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -511,6 +511,8 @@ pub enum ActivityType {
     Custom = 4,
     /// An indicator that the user is competing somewhere.
     Competing = 5,
+    /// An indicator that the activity of unknown type.
+    Unknown = !0,
 }
 
 enum_number!(ActivityType {
@@ -533,6 +535,7 @@ impl ActivityType {
             Watching => 3,
             Custom => 4,
             Competing => 5,
+            Unknown => !0,
         }
     }
 }

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -30,6 +30,7 @@ pub struct Integration {
 pub enum IntegrationExpireBehaviour {
     RemoveRole = 0,
     Kick = 1,
+    Unknown = !0,
 }
 
 enum_number!(IntegrationExpireBehaviour {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2531,16 +2531,6 @@ enum_number!(DefaultMessageNotificationLevel {
     Mentions
 });
 
-impl DefaultMessageNotificationLevel {
-    pub fn num(self) -> u64 {
-        match self {
-            DefaultMessageNotificationLevel::All => 0,
-            DefaultMessageNotificationLevel::Mentions => 1,
-            DefaultMessageNotificationLevel::Unknown => !0,
-        }
-    }
-}
-
 /// Setting used to filter explicit messages from members.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
@@ -2561,17 +2551,6 @@ enum_number!(ExplicitContentFilter {
     All
 });
 
-impl ExplicitContentFilter {
-    pub fn num(self) -> u64 {
-        match self {
-            ExplicitContentFilter::None => 0,
-            ExplicitContentFilter::WithoutRole => 1,
-            ExplicitContentFilter::All => 2,
-            ExplicitContentFilter::Unknown => !0,
-        }
-    }
-}
-
 /// Multi-Factor Authentication level for guild moderators.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
@@ -2588,16 +2567,6 @@ enum_number!(MfaLevel {
     None,
     Elevated
 });
-
-impl MfaLevel {
-    pub fn num(self) -> u64 {
-        match self {
-            MfaLevel::None => 0,
-            MfaLevel::Elevated => 1,
-            MfaLevel::Unknown => !0,
-        }
-    }
-}
 
 /// The name of a region that a voice server can be located in.
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
@@ -2692,19 +2661,6 @@ enum_number!(VerificationLevel {
     High,
     Higher
 });
-
-impl VerificationLevel {
-    pub fn num(self) -> u64 {
-        match self {
-            VerificationLevel::None => 0,
-            VerificationLevel::Low => 1,
-            VerificationLevel::Medium => 2,
-            VerificationLevel::High => 3,
-            VerificationLevel::Higher => 4,
-            VerificationLevel::Unknown => !0,
-        }
-    }
-}
 
 #[cfg(test)]
 mod test {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2522,6 +2522,8 @@ pub enum DefaultMessageNotificationLevel {
     All = 0,
     /// Receive only mentions.
     Mentions = 1,
+    /// Unknown notification level.
+    Unknown = !0,
 }
 
 enum_number!(DefaultMessageNotificationLevel {
@@ -2534,6 +2536,7 @@ impl DefaultMessageNotificationLevel {
         match self {
             DefaultMessageNotificationLevel::All => 0,
             DefaultMessageNotificationLevel::Mentions => 1,
+            DefaultMessageNotificationLevel::Unknown => !0,
         }
     }
 }
@@ -2548,6 +2551,8 @@ pub enum ExplicitContentFilter {
     WithoutRole = 1,
     /// Scan messages sent by all members.
     All = 2,
+    /// Unknown content filter.
+    Unknown = !0,
 }
 
 enum_number!(ExplicitContentFilter {
@@ -2562,6 +2567,7 @@ impl ExplicitContentFilter {
             ExplicitContentFilter::None => 0,
             ExplicitContentFilter::WithoutRole => 1,
             ExplicitContentFilter::All => 2,
+            ExplicitContentFilter::Unknown => !0,
         }
     }
 }
@@ -2574,6 +2580,8 @@ pub enum MfaLevel {
     None = 0,
     /// MFA is enabled.
     Elevated = 1,
+    /// Unknown MFA level.
+    Unknown = !0,
 }
 
 enum_number!(MfaLevel {
@@ -2586,6 +2594,7 @@ impl MfaLevel {
         match self {
             MfaLevel::None => 0,
             MfaLevel::Elevated => 1,
+            MfaLevel::Unknown => !0,
         }
     }
 }
@@ -2672,6 +2681,8 @@ pub enum VerificationLevel {
     High = 3,
     /// Must have a verified phone on the user's Discord account.
     Higher = 4,
+    /// Unknown verification level.
+    Unknown = !0,
 }
 
 enum_number!(VerificationLevel {
@@ -2690,6 +2701,7 @@ impl VerificationLevel {
             VerificationLevel::Medium => 2,
             VerificationLevel::High => 3,
             VerificationLevel::Higher => 4,
+            VerificationLevel::Unknown => !0,
         }
     }
 }

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -7,6 +7,7 @@ pub enum PremiumTier {
     Tier1,
     Tier2,
     Tier3,
+    Unknown = !0,
 }
 
 enum_number!(PremiumTier {
@@ -23,6 +24,7 @@ impl PremiumTier {
             PremiumTier::Tier1 => 1,
             PremiumTier::Tier2 => 2,
             PremiumTier::Tier3 => 3,
+            PremiumTier::Unknown => !0,
         }
     }
 }

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -17,18 +17,6 @@ enum_number!(PremiumTier {
     Tier3
 });
 
-impl PremiumTier {
-    pub fn num(self) -> u64 {
-        match self {
-            PremiumTier::Tier0 => 0,
-            PremiumTier::Tier1 => 1,
-            PremiumTier::Tier2 => 2,
-            PremiumTier::Tier3 => 3,
-            PremiumTier::Unknown => !0,
-        }
-    }
-}
-
 impl Default for PremiumTier {
     fn default() -> Self {
         PremiumTier::Tier0

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -196,6 +196,7 @@ impl<'de> Deserialize<'de> for Interaction {
 pub enum InteractionType {
     Ping = 1,
     ApplicationCommand = 2,
+    Unknown = !0,
 }
 
 enum_number!(InteractionType {
@@ -654,6 +655,7 @@ pub enum ApplicationCommandOptionType {
     User = 6,
     Channel = 7,
     Role = 8,
+    Unknown = !0,
 }
 
 enum_number!(ApplicationCommandOptionType {
@@ -674,6 +676,7 @@ enum_number!(ApplicationCommandOptionType {
 pub enum ApplicationCommandPermissionType {
     Role = 1,
     User = 2,
+    Unknown = !0,
 }
 
 enum_number!(ApplicationCommandPermissionType {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -51,15 +51,6 @@ impl WebhookType {
             WebhookType::Unknown => "unknown",
         }
     }
-
-    #[inline]
-    pub fn num(self) -> u64 {
-        match self {
-            WebhookType::Incoming => 1,
-            WebhookType::ChannelFollower => 2,
-            WebhookType::Unknown => !0,
-        }
-    }
 }
 
 /// A representation of a webhook, which is a low-effort way to post messages to

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -33,6 +33,8 @@ pub enum WebhookType {
     /// An indicator that the webhook is managed by Discord for posting new
     /// messages to channels without a token.
     ChannelFollower = 2,
+    /// An indicator that the webhook is of unknown type.
+    Unknown = !0,
 }
 
 enum_number!(WebhookType {
@@ -46,6 +48,7 @@ impl WebhookType {
         match self {
             WebhookType::Incoming => "incoming",
             WebhookType::ChannelFollower => "channel follower",
+            WebhookType::Unknown => "unknown",
         }
     }
 
@@ -54,6 +57,7 @@ impl WebhookType {
         match self {
             WebhookType::Incoming => 1,
             WebhookType::ChannelFollower => 2,
+            WebhookType::Unknown => !0,
         }
     }
 }


### PR DESCRIPTION
## Description

This adds a new `Unknown` variant to all enumerations whose variants correspond to a specific value, like the type of a channel or message. This change makes deserialisation more robust when Discord introduces new types. Prior to this, the deserialisation code for these enumerations would emit an error, halting deserialisation. Instead, the code will fall back to the `Unknown` variant when it encounters a value it does not recognise. A warning is logged in place of the error. The `Unknown` variant has the value of `!0` to refer to the maximum number an integer type can hold (e.g. for `u8` that would be 255). This is used to avoid collisions with new types. 

## Type of Change

This improves the deserialisation code of a bunch of enumerations in the `model` module to prevent breakage whenever Discord adds new types.

## How Has This Been Tested?

This has been tested by ensuring compilation still works, which it does. As for the runtime behaviour, it hasn't been tested, but hypothetically it should work, and shouldn't constitute as a breaking change.