### PR TITLE
Build docs with rust stable instead of rust nightly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         id: tc
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           override: true
 


### PR DESCRIPTION
Currently, docs are built with rust nightly instead of rust stable. This PR makes the github pages docs built on stable, to avoid issues.

It does not contain any change to the library itself.