### PR TITLE
Better errors display

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -17,7 +17,7 @@ pub struct DiscordJsonError {
     pub code: isize,
     /// The error message.
     pub message: String,
-    /// The full explaned errors with their path in the request
+    /// The full explained errors with their path in the request
     /// body.
     pub errors: Vec<DiscordJsonSingleError>,
 }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -48,12 +48,6 @@ impl<'de> Deserialize<'de> for DiscordJsonError {
     }
 }
 
-// impl std::fmt::Debug for DiscordJsonError {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         write!(f, "\"{}\"", self.message)
-//     }
-// }
-
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct DiscordJsonSingleError {
     pub code: String,

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -13,8 +13,12 @@ use crate::internal::prelude::{JsonMap, StdResult};
 #[derive(Clone, Serialize, PartialEq, Debug)]
 #[non_exhaustive]
 pub struct DiscordJsonError {
+    /// The error code.
     pub code: isize,
+    /// The error message.
     pub message: String,
+    /// The full explaned errors with their path in the request
+    /// body.
     pub errors: Vec<DiscordJsonSingleError>,
 }
 
@@ -50,9 +54,11 @@ impl<'de> Deserialize<'de> for DiscordJsonError {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct DiscordJsonSingleError {
+    /// The error code.
     pub code: String,
+    /// The error message.
     pub message: String,
-    /// The path to the error in the request itself, dot separated.
+    /// The path to the error in the request body itself, dot separated.
     pub path: String,
 }
 

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -11,12 +11,11 @@ use std::path::{Path, PathBuf};
 use crate::http::utils::deserialize_errors;
 
 #[derive(Clone, Serialize, PartialEq, Debug)]
+#[non_exhaustive]
 pub struct DiscordJsonError {
     pub code: isize,
     pub message: String,
     pub errors: Vec<DiscordJsonSingleError>,
-    #[serde(skip)]
-    non_exhaustive: (),
 }
 
 impl<'de> Deserialize<'de> for DiscordJsonError {
@@ -44,8 +43,7 @@ impl<'de> Deserialize<'de> for DiscordJsonError {
         Ok(Self {
             code,
             message,
-            errors,
-            non_exhaustive: ()
+            errors
         })
     }
 }
@@ -84,8 +82,7 @@ impl ErrorResponse {
             message:
             "[Serenity] Could not decode json when receiving error response from discord!"
                 .to_string(),
-            errors: vec![],
-            non_exhaustive: (),
+            errors: vec![]
         });
 
         ErrorResponse {
@@ -212,7 +209,7 @@ mod test {
         let error = DiscordJsonError {
             code: 43121215,
             message: String::from("This is a Ferris error"),
-            non_exhaustive: (),
+            errors: vec![]
         };
 
         let mut builder = Builder::new();

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -73,20 +73,16 @@ impl ErrorResponse {
     // We need a freestanding from-function since we cannot implement an async
     // From-trait.
     pub async fn from_response(r: Response) -> Self {
-        let status_code = r.status();
-        let url = r.url().clone();
-
-        let json = r.json().await.unwrap_or_else(|_| DiscordJsonError {
-            code: -1,
-            message: "[Serenity] Could not decode json when receiving error response from discord!"
-                .to_string(),
-            errors: vec![]
-        });
-
         ErrorResponse {
-            status_code,
-            url,
-            error: json,
+            status_code: r.status(),
+            url: r.url().clone(),
+            error: r.json().await.unwrap_or_else(|_| DiscordJsonError {
+                code: -1,
+                message:
+                    "[Serenity] Could not decode json when receiving error response from discord!"
+                        .to_string(),
+                errors: vec![],
+            }),
         }
     }
 }
@@ -207,7 +203,7 @@ mod test {
         let error = DiscordJsonError {
             code: 43121215,
             message: String::from("This is a Ferris error"),
-            errors: vec![]
+            errors: vec![],
         };
 
         let mut builder = Builder::new();

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -29,6 +29,7 @@ pub mod ratelimiting;
 pub mod request;
 pub mod routing;
 pub mod typing;
+pub mod utils;
 
 use std::{
     borrow::Cow,

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -8,6 +8,10 @@ pub fn deserialize_errors<'de, D: Deserializer<'de>>(
 ) -> StdResult<Vec<DiscordJsonSingleError>, D::Error> {
     let map: Value = Value::deserialize(deserializer)?;
 
+    if !map.is_object() {
+        return Ok(vec![]);
+    }
+
     let mut errors: Vec<DiscordJsonSingleError> = vec![];
 
     loop_errors(map, &mut errors, &mut Vec::new());

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -1,0 +1,42 @@
+use crate::internal::prelude::{StdResult, JsonMap, Value};
+use crate::http::error::DiscordJsonSingleError;
+use serde::{Deserializer, Deserialize};
+use futures::future::err;
+
+pub fn deserialize_errors<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> StdResult<Vec<DiscordJsonSingleError>, D::Error> {
+    let map: Value = Value::deserialize(deserializer)?;
+
+    let mut errors: Vec<DiscordJsonSingleError> = vec![];
+
+    loop_errors(map, &mut errors, &mut Vec::new());
+    
+    Ok(errors)
+}
+
+
+fn loop_errors(mut value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: &mut Vec<String>) {
+    for (key, looped) in value.as_object().unwrap().iter() {
+        let object = looped.as_object().unwrap();
+        if object.contains_key("_errors") {
+            let found_errors = object.get("_errors").unwrap().as_array().unwrap().to_owned();
+            for error in found_errors {
+                    let real_object = error.as_object().unwrap();
+                    let mut object_path = path.clone();
+
+                    object_path.push(key.to_string());
+
+                    errors.push(DiscordJsonSingleError {
+                        code: real_object.get("code").unwrap().as_str().unwrap().to_owned(),
+                        message: real_object.get("message").unwrap().as_str().unwrap().to_owned(),
+                        path: object_path.join(".")
+                    });
+            }
+            continue;
+        }
+        path.push(key.to_string());
+
+        loop_errors(looped.clone(), errors, path);
+    }
+}

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -4,6 +4,7 @@ use crate::http::error::DiscordJsonSingleError;
 use crate::internal::prelude::*;
 use crate::prelude::*;
 
+#[allow(clippy::missing_errors_doc)]
 pub fn deserialize_errors<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<Vec<DiscordJsonSingleError>, D::Error> {

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -1,7 +1,8 @@
+use serde::de::{Deserialize, Deserializer};
+
 use crate::http::error::DiscordJsonSingleError;
 use crate::internal::prelude::*;
 use crate::prelude::*;
-use serde::de::{Deserializer, Deserialize};
 
 pub fn deserialize_errors<'de, D: Deserializer<'de>>(
     deserializer: D,
@@ -23,7 +24,12 @@ fn loop_errors(value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: &mu
     for (key, looped) in value.as_object().expect("expected object").iter() {
         let object = looped.as_object().expect("expected object");
         if object.contains_key("_errors") {
-            let found_errors = object.get("_errors").expect("expected _errors").as_array().expect("expected array").to_owned();
+            let found_errors = object
+                .get("_errors")
+                .expect("expected _errors")
+                .as_array()
+                .expect("expected array")
+                .to_owned();
             for error in found_errors {
                 let real_object = error.as_object().expect("expected object");
                 let mut object_path = path.clone();
@@ -31,8 +37,18 @@ fn loop_errors(value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: &mu
                 object_path.push(key.to_string());
 
                 errors.push(DiscordJsonSingleError {
-                    code: real_object.get("code").expect("expected code").as_str().expect("expected string").to_owned(),
-                    message: real_object.get("message").expect("expected message").as_str().expect("expected string").to_owned(),
+                    code: real_object
+                        .get("code")
+                        .expect("expected code")
+                        .as_str()
+                        .expect("expected string")
+                        .to_owned(),
+                    message: real_object
+                        .get("message")
+                        .expect("expected message")
+                        .as_str()
+                        .expect("expected string")
+                        .to_owned(),
                     path: object_path.join("."),
                 });
             }

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -1,7 +1,7 @@
-use crate::internal::prelude::{StdResult, JsonMap, Value};
+use serde::{Deserialize, Deserializer};
+
 use crate::http::error::DiscordJsonSingleError;
-use serde::{Deserializer, Deserialize};
-use futures::future::err;
+use crate::internal::prelude::{StdResult, Value};
 
 pub fn deserialize_errors<'de, D: Deserializer<'de>>(
     deserializer: D,
@@ -11,27 +11,26 @@ pub fn deserialize_errors<'de, D: Deserializer<'de>>(
     let mut errors: Vec<DiscordJsonSingleError> = vec![];
 
     loop_errors(map, &mut errors, &mut Vec::new());
-    
+
     Ok(errors)
 }
 
-
-fn loop_errors(mut value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: &mut Vec<String>) {
+fn loop_errors(value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: &mut Vec<String>) {
     for (key, looped) in value.as_object().unwrap().iter() {
         let object = looped.as_object().unwrap();
         if object.contains_key("_errors") {
             let found_errors = object.get("_errors").unwrap().as_array().unwrap().to_owned();
             for error in found_errors {
-                    let real_object = error.as_object().unwrap();
-                    let mut object_path = path.clone();
+                let real_object = error.as_object().unwrap();
+                let mut object_path = path.clone();
 
-                    object_path.push(key.to_string());
+                object_path.push(key.to_string());
 
-                    errors.push(DiscordJsonSingleError {
-                        code: real_object.get("code").unwrap().as_str().unwrap().to_owned(),
-                        message: real_object.get("message").unwrap().as_str().unwrap().to_owned(),
-                        path: object_path.join(".")
-                    });
+                errors.push(DiscordJsonSingleError {
+                    code: real_object.get("code").unwrap().as_str().unwrap().to_owned(),
+                    message: real_object.get("message").unwrap().as_str().unwrap().to_owned(),
+                    path: object_path.join("."),
+                });
             }
             continue;
         }

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -1,7 +1,7 @@
-use serde::{Deserialize, Deserializer};
-
 use crate::http::error::DiscordJsonSingleError;
-use crate::internal::prelude::{StdResult, Value};
+use crate::internal::prelude::*;
+use crate::prelude::*;
+use serde::de::{Deserializer, Deserialize};
 
 pub fn deserialize_errors<'de, D: Deserializer<'de>>(
     deserializer: D,
@@ -20,19 +20,19 @@ pub fn deserialize_errors<'de, D: Deserializer<'de>>(
 }
 
 fn loop_errors(value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: &mut Vec<String>) {
-    for (key, looped) in value.as_object().unwrap().iter() {
-        let object = looped.as_object().unwrap();
+    for (key, looped) in value.as_object().expect("expected object").iter() {
+        let object = looped.as_object().expect("expected object");
         if object.contains_key("_errors") {
-            let found_errors = object.get("_errors").unwrap().as_array().unwrap().to_owned();
+            let found_errors = object.get("_errors").expect("expected _errors").as_array().expect("expected array").to_owned();
             for error in found_errors {
-                let real_object = error.as_object().unwrap();
+                let real_object = error.as_object().expect("expected object");
                 let mut object_path = path.clone();
 
                 object_path.push(key.to_string());
 
                 errors.push(DiscordJsonSingleError {
-                    code: real_object.get("code").unwrap().as_str().unwrap().to_owned(),
-                    message: real_object.get("message").unwrap().as_str().unwrap().to_owned(),
+                    code: real_object.get("code").expect("expected code").as_str().expect("expected string").to_owned(),
+                    message: real_object.get("message").expect("expected message").as_str().expect("expected string").to_owned(),
                     path: object_path.join("."),
                 });
             }

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -32,19 +32,19 @@ fn loop_errors(value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: &mu
                 .expect("expected array")
                 .to_owned();
             for error in found_errors {
-                let real_object = error.as_object().expect("expected object");
+                let error_object = error.as_object().expect("expected object");
                 let mut object_path = path.clone();
 
                 object_path.push(key.to_string());
 
                 errors.push(DiscordJsonSingleError {
-                    code: real_object
+                    code: error_object
                         .get("code")
                         .expect("expected code")
                         .as_str()
                         .expect("expected string")
                         .to_owned(),
-                    message: real_object
+                    message: error_object
                         .get("message")
                         .expect("expected message")
                         .as_str()


### PR DESCRIPTION
This PR improves the error system which was introduced in v8: https://discord.com/developers/docs/reference#error-messages

It gives an additionnal `errors` field which lists each problematic field with an error code, message and a path to this field in the request.

It was tested.