### PR TITLE
Consider group restrictions when displaying command availability

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -579,9 +579,11 @@ fn nested_group_command_search<'rec, 'a: 'rec>(
                     });
                 }
 
-                let available_text = if options.only_in == OnlyIn::Dm {
+                let is_only = |only| group.options.only_in == only || options.only_in == only;
+
+                let available_text = if is_only(OnlyIn::Dm) {
                     &help_options.dm_only_text
-                } else if options.only_in == OnlyIn::Guild {
+                } else if is_only(OnlyIn::Guild) {
                     &help_options.guild_only_text
                 } else {
                     &help_options.dm_and_guild_text


### PR DESCRIPTION
## Description

This expands the conditions for deciding what the help command should show when a command can only be used in DMs, guilds, or both to account for the restriction of the command's group as well.

Fixes #1311.  

## Type of Change

This is a fix for the help command code, which is part of the framework.

## How Has This Been Tested?

This has been tested by configuring a group with a `only_in` restriction to guilds, and a command with a restriction to DMs. The availability text that is shown is for guilds, which is expected as groups have higher precedence than commands.