### PR TITLE
Silence warnings related to the deprecation of `(Partial)Guild::region`

### DIFF
--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -2,7 +2,6 @@ use serde::de::{Deserialize, Deserializer};
 
 use crate::http::error::DiscordJsonSingleError;
 use crate::internal::prelude::*;
-use crate::prelude::*;
 
 #[allow(clippy::missing_errors_doc)]
 pub fn deserialize_errors<'de, D: Deserializer<'de>>(

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -798,7 +798,13 @@ impl CacheUpdate for GuildUpdateEvent {
             guild.icon.clone_from(&self.guild.icon);
             guild.name.clone_from(&self.guild.name);
             guild.owner_id.clone_from(&self.guild.owner_id);
-            guild.region.clone_from(&self.guild.region);
+
+            #[allow(deprecated)]
+            {
+
+                guild.region.clone_from(&self.guild.region);
+            }
+
             guild.roles.clone_from(&self.guild.roles);
             guild.verification_level = self.guild.verification_level;
         }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -801,7 +801,6 @@ impl CacheUpdate for GuildUpdateEvent {
 
             #[allow(deprecated)]
             {
-
                 guild.region.clone_from(&self.guild.region);
             }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -924,7 +924,12 @@ impl Guild {
                 self.mfa_level = guild.mfa_level;
                 self.name = guild.name;
                 self.owner_id = guild.owner_id;
-                self.region = guild.region;
+
+                #[allow(deprecated)]
+                {
+                    self.region = guild.region;
+                }
+
                 self.roles = guild.roles;
                 self.splash = guild.splash;
                 self.verification_level = guild.verification_level;
@@ -2501,6 +2506,7 @@ impl<'de> Deserialize<'de> for Guild {
             .and_then(SystemChannelFlags::deserialize)
             .map_err(DeError::custom)?;
 
+        #[allow(deprecated)]
         Ok(Self {
             afk_channel_id,
             application_id,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -577,7 +577,12 @@ impl PartialGuild {
                 self.mfa_level = guild.mfa_level;
                 self.name = guild.name;
                 self.owner_id = guild.owner_id;
-                self.region = guild.region;
+
+                #[allow(deprecated)]
+                {
+                    self.region = guild.region;
+                }
+
                 self.roles = guild.roles;
                 self.splash = guild.splash;
                 self.verification_level = guild.verification_level;
@@ -1321,6 +1326,7 @@ impl<'de> Deserialize<'de> for PartialGuild {
             false => None,
         };
 
+        #[allow(deprecated)]
         Ok(Self {
             application_id,
             afk_channel_id,


### PR DESCRIPTION
## Description

This silences the `deprecated` lint that is triggered for the deprecated `region` field of `PartialGuild` and `Guild`. This is only temporary; once we prepare for a new major release, the `region` field should be removed. Also, an unused import is removed.

## Type of Change

This reduces clutter in the terminal output from `cargo check` and other compilation commands, improving the user experience.

## How Has This Been Tested?

This has been tested by verifying that warnings no longer get triggered, which they don't.