### PR TITLE
API v9 and threads

### DIFF
--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use crate::internal::prelude::*;
+
+#[derive(Debug, Clone, Default)]
+pub struct CreateThread(pub HashMap<&'static str, Value>);
+
+impl CreateThread {
+    /// The name of the thread.
+    ///
+    /// **Note**: Must be between 2 and 100 characters long.
+    pub fn name<D: ToString>(&mut self, name: D) -> &mut Self {
+        self.0.insert("name", Value::String(name.to_string()));
+
+        self
+    }
+
+    /// Duration in minutes to automatically archive the thread after recent activity.
+    ///
+    /// **Note**: Can only be set to 60, 1440, 4320, 10080 currently.
+    pub fn auto_archive_duration(&mut self, duration: u16) -> &mut Self {
+        self.0.insert("bitrate", Value::Number(Number::from(duration)));
+
+        self
+    }
+}

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -19,7 +19,7 @@ impl CreateThread {
     ///
     /// **Note**: Can only be set to 60, 1440, 4320, 10080 currently.
     pub fn auto_archive_duration(&mut self, duration: u16) -> &mut Self {
-        self.0.insert("bitrate", Value::Number(Number::from(duration)));
+        self.0.insert("auto_archive_duration", Value::Number(Number::from(duration)));
 
         self
     }

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::internal::prelude::*;
+use crate::model::channel::ChannelType;
 
 #[derive(Debug, Clone, Default)]
 pub struct CreateThread(pub HashMap<&'static str, Value>);
@@ -20,6 +21,20 @@ impl CreateThread {
     /// **Note**: Can only be set to 60, 1440, 4320, 10080 currently.
     pub fn auto_archive_duration(&mut self, duration: u16) -> &mut Self {
         self.0.insert("auto_archive_duration", Value::Number(Number::from(duration)));
+
+        self
+    }
+
+    /// The thread type, which can be [`ChannelType::PublicThread`] or [`ChannelType::PrivateThread`].
+    ///
+    /// **Note**: It defaults to [`ChannelType::PrivateThread`] in order to match the behavior when thread documentation was first published.
+    /// This is a bit of a weird default though, and thus is highly likely to change in the future,
+    /// so it is recommended to always explicitly setting it to avoid any breaking change.
+    ///
+    /// [`ChannelType::PublicThread`]: crate::model::channel::ChannelType::PublicThread
+    /// [`ChannelType::PrivateThread`]: crate::model::channel::ChannelType::PrivateThread
+    pub fn kind(&mut self, kind: ChannelType) -> &mut Self {
+        self.0.insert("type", Value::Number(Number::from(kind as u8)));
 
         self
     }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -28,6 +28,7 @@ mod create_interaction_response_followup;
 mod create_invite;
 mod create_message;
 mod create_stage_instance;
+mod create_thread;
 mod edit_channel;
 mod edit_guild;
 mod edit_guild_welcome_screen;
@@ -53,6 +54,7 @@ pub use self::{
     create_invite::CreateInvite,
     create_message::CreateMessage,
     create_stage_instance::CreateStageInstance,
+    create_thread::CreateThread,
     edit_channel::EditChannel,
     edit_guild::EditGuild,
     edit_guild_welcome_screen::EditGuildWelcomeScreen,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1074,6 +1074,9 @@ mod test {
             slow_mode_rate: Some(0),
             rtc_region: None,
             video_quality_mode: None,
+            message_count: None,
+            member_count: None,
+            member: None
         };
 
         // Add a channel delete event to the cache, the cached messages for that

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1143,6 +1143,7 @@ mod test {
                     widget_enabled: Some(false),
                     widget_channel_id: None,
                     stage_instances: vec![],
+                    threads: vec![],
                 },
             }
         };

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1076,7 +1076,7 @@ mod test {
             video_quality_mode: None,
             message_count: None,
             member_count: None,
-            member: None
+            member: None,
         };
 
         // Add a channel delete event to the cache, the cached messages for that

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1078,7 +1078,7 @@ mod test {
             member_count: None,
             thread_metadata: None,
             member: None,
-            default_auto_archive_duration: None
+            default_auto_archive_duration: None,
         };
 
         // Add a channel delete event to the cache, the cached messages for that

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1076,7 +1076,9 @@ mod test {
             video_quality_mode: None,
             message_count: None,
             member_count: None,
+            thread_metadata: None,
             member: None,
+            default_auto_archive_duration: None
         };
 
         // Add a channel delete event to the cache, the cached messages for that

--- a/src/client/bridge/gateway/intents.rs
+++ b/src/client/bridge/gateway/intents.rs
@@ -138,7 +138,6 @@ __impl_bitflags! {
         GUILD_MESSAGE_TYPING = 1 << 11;
         /// Enable following gateway events:
         ///
-        /// - CHANNEL_CREATE
         /// - MESSAGE_CREATE
         /// - MESSAGE_UPDATE
         /// - MESSAGE_DELETE

--- a/src/client/bridge/gateway/intents.rs
+++ b/src/client/bridge/gateway/intents.rs
@@ -54,12 +54,22 @@ __impl_bitflags! {
         /// - CHANNEL_UPDATE
         /// - CHANNEL_DELETE
         /// - CHANNEL_PINS_UPDATE
+        /// - THREAD_CREATE
+        /// - THREAD_UPDATE
+        /// - THREAD_DELETE
+        /// - THREAD_LIST_SYNC
+        /// - THREAD_MEMBER_UPDATE
+        /// - THREAD_MEMBERS_UPDATE
+        /// - STAGE_INSTANCE_CREATE
+        /// - STAGE_INSTANCE_UPDATE
+        /// - STAGE_INSTANCE_DELETE
         GUILDS = 1;
         /// Enables following gateway events:
         ///
         /// - GUILD_MEMBER_ADD
         /// - GUILD_MEMBER_UPDATE
         /// - GUILD_MEMBER_REMOVE
+        /// - THREAD_MEMBERS_UPDATE
         ///
         /// **Info**:
         /// This intent is *privileged*.
@@ -80,6 +90,9 @@ __impl_bitflags! {
         /// Enables following gateway event:
         ///
         /// - GUILD_INTEGRATIONS_UPDATE
+        /// - INTEGRATION_CREATE
+        /// - INTEGRATION_UPDATE
+        /// - INTEGRATION_DELETE
         GUILD_INTEGRATIONS = 1 << 4;
         /// Enables following gateway event:
         ///
@@ -110,6 +123,7 @@ __impl_bitflags! {
         /// - MESSAGE_CREATE
         /// - MESSAGE_UPDATE
         /// - MESSAGE_DELETE
+        /// - MESSAGE_DELETE_BULK
         GUILD_MESSAGES = 1 << 9;
         /// Enables following gateway events:
         ///

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -852,5 +852,26 @@ async fn handle_event(
                 event_handler.thread_delete(context, event.thread).await;
             });
         },
+        DispatchEvent::Model(Event::ThreadListSync(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.thread_list_sync(context, event).await;
+            });
+        },
+        DispatchEvent::Model(Event::ThreadMemberUpdate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.thread_member_update(context, event.member).await;
+            });
+        },
+        DispatchEvent::Model(Event::ThreadMembersUpdate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.thread_members_update(context, event).await;
+            });
+        },
     }
 }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -831,5 +831,26 @@ async fn handle_event(
                 event_handler.stage_instance_delete(context, event.stage_instance).await;
             });
         },
+        DispatchEvent::Model(Event::ThreadCreate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.thread_create(context, event.thread).await;
+            });
+        },
+        DispatchEvent::Model(Event::ThreadUpdate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.thread_update(context, event.thread).await;
+            });
+        },
+        DispatchEvent::Model(Event::ThreadDelete(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.thread_delete(context, event.thread).await;
+            });
+        },
     }
 }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -524,6 +524,31 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Provides the partial deleted thread.
     async fn thread_delete(&self, _ctx: Context, _thread: PartialGuildChannel) {}
+
+    /// Dispatched when the current user gains access to a channel
+    ///
+    /// Provides the threads the current user can access, the thread members,
+    /// the guild Id, and the channel Ids of the parent channels being synced.
+    async fn thread_list_sync(&self, _ctx: Context, _thread_list_sync: ThreadListSyncEvent) {}
+
+    /// Dispatched when the [`ThreadMember`] for the current user is updated.
+    ///
+    /// Provides the updated thread member.
+    async fn thread_member_update(&self, _ctx: Context, _thread_member: ThreadMember) {}
+
+    /// Dispatched when anyone is added to or removed from a thread. If the current user does not have the [`GatewayIntents::GUILDS`],
+    /// then this event will only be sent if the current user was added to or removed from the thread.
+    ///
+    /// Provides the added/removed members, the approximate member count of members in the thread,
+    /// the thread Id and its guild Id.
+    ///
+    /// [`GatewayIntents::GUILDS`]: crate::client::bridge::gateway::GatewayIntents::GUILDS
+    async fn thread_members_update(
+        &self,
+        _ctx: Context,
+        _thread_members_update: ThreadMembersUpdateEvent,
+    ) {
+    }
 }
 
 /// This core trait for handling raw events

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -501,13 +501,29 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when a stage instance is updated.
     ///
-    /// Provides the created stage instance.
+    /// Provides the updated stage instance.
     async fn stage_instance_update(&self, _ctx: Context, _stage_instance: StageInstance) {}
 
     /// Dispatched when a stage instance is deleted.
     ///
-    /// Provides the created stage instance.
+    /// Provides the deleted stage instance.
     async fn stage_instance_delete(&self, _ctx: Context, _stage_instance: StageInstance) {}
+
+    /// Dispatched when a thread is created or the current user is added
+    /// to a private thread.
+    ///
+    /// Provides the thread.
+    async fn thread_create(&self, _ctx: Context, _thread: GuildChannel) {}
+
+    /// Dispatched when a thread is updated.
+    ///
+    /// Provides the updated thread.
+    async fn thread_update(&self, _ctx: Context, _thread: GuildChannel) {}
+
+    /// Dispatched when a thread is deleted.
+    ///
+    /// Provides the partial deleted thread.
+    async fn thread_delete(&self, _ctx: Context, _thread: PartialGuildChannel) {}
 }
 
 /// This core trait for handling raw events

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,7 +8,7 @@ pub const EMBED_MAX_COUNT: usize = 10;
 
 /// The gateway version used by the library. The gateway URI is retrieved via
 /// the REST API.
-pub const GATEWAY_VERSION: u8 = 8;
+pub const GATEWAY_VERSION: u8 = 9;
 
 /// The large threshold to send on identify.
 pub const LARGE_THRESHOLD: u8 = 250;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -370,7 +370,6 @@ impl Http {
         .await
     }
 
-
     /// Creates a stage instance.
     pub async fn create_stage_instance(&self, map: &Value) -> Result<StageInstance> {
         self.fire(Request {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2129,12 +2129,12 @@ impl Http {
         .await
     }
 
-    /// Adds a user to a thread channel.
-    pub async fn add_thread_channel_user(&self, channel_id: u64, user_id: u64) -> Result<()> {
+    /// Adds a member to a thread channel.
+    pub async fn add_thread_channel_member(&self, channel_id: u64, user_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
             headers: None,
-            route: RouteInfo::AddThreadUser {
+            route: RouteInfo::AddThreadMember {
                 channel_id,
                 user_id,
             },
@@ -2142,12 +2142,12 @@ impl Http {
         .await
     }
 
-    /// Removes a user to a thread channel.
-    pub async fn remove_thread_channel_user(&self, channel_id: u64, user_id: u64) -> Result<()> {
+    /// Removes a member from a thread channel.
+    pub async fn remove_thread_channel_member(&self, channel_id: u64, user_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
             headers: None,
-            route: RouteInfo::RemoveThreadUser {
+            route: RouteInfo::RemoveThreadMember {
                 channel_id,
                 user_id,
             },

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1984,6 +1984,137 @@ impl Http {
         .await
     }
 
+    /// Gets all thread members for a thread.
+    pub async fn get_channel_thread_members(&self, channel_id: u64) -> Result<Vec<ThreadMember>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannelThreadMembers {
+                channel_id,
+            },
+        })
+        .await
+    }
+
+    /// Gets all active threads from a channel.
+    pub async fn get_channel_active_threads(&self, channel_id: u64) -> Result<ThreadsData> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannelActiveThreads {
+                channel_id,
+            },
+        })
+        .await
+    }
+
+    /// Gets all archived public threads from a channel.
+    pub async fn get_channel_archived_public_threads(
+        &self,
+        channel_id: u64,
+        before: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<ThreadsData> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannelArchivedPublicThreads {
+                channel_id,
+                before,
+                limit,
+            },
+        })
+        .await
+    }
+
+    /// Gets all archived private threads from a channel.
+    pub async fn get_channel_archived_private_threads(
+        &self,
+        channel_id: u64,
+        before: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<ThreadsData> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannelArchivedPrivateThreads {
+                channel_id,
+                before,
+                limit,
+            },
+        })
+        .await
+    }
+
+    /// Gets all archived private threads joined from a channel.
+    pub async fn get_channel_joined_archived_private_threads(
+        &self,
+        channel_id: u64,
+        before: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<ThreadsData> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetChannelJoinedPrivateArchivedThreads {
+                channel_id,
+                before,
+                limit,
+            },
+        })
+        .await
+    }
+
+    /// Joins a thread channel.
+    pub async fn join_thread_channel(&self, channel_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::JoinThread {
+                channel_id,
+            },
+        })
+        .await
+    }
+
+    /// Leaves a thread channel.
+    pub async fn leave_thread_channel(&self, channel_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::LeaveThread {
+                channel_id,
+            },
+        })
+        .await
+    }
+
+    /// Adds a user to a thread channel.
+    pub async fn add_thread_channel_user(&self, channel_id: u64, user_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::AddThreadUser {
+                channel_id,
+                user_id,
+            },
+        })
+        .await
+    }
+
+    /// Removes a user to a thread channel.
+    pub async fn remove_thread_channel_user(&self, channel_id: u64, user_id: u64) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::RemoveThreadUser {
+                channel_id,
+                user_id,
+            },
+        })
+        .await
+    }
+
     /// Retrieves the webhooks for the given [channel][`GuildChannel`]'s Id.
     ///
     /// This method requires authentication.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -370,12 +370,52 @@ impl Http {
         .await
     }
 
+
     /// Creates a stage instance.
     pub async fn create_stage_instance(&self, map: &Value) -> Result<StageInstance> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
             headers: None,
             route: RouteInfo::CreateStageInstance,
+        })
+        .await
+    }
+
+    /// Creates a public thread channel in the [`GuildChannel`] given its Id,
+    /// with a base message Id.
+    pub async fn create_public_thread(
+        &self,
+        channel_id: u64,
+        message_id: u64,
+        map: &JsonMap,
+    ) -> Result<GuildChannel> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::CreatePublicThread {
+                channel_id,
+                message_id,
+            },
+        })
+        .await
+    }
+
+    /// Creates a private thread channel in the [`GuildChannel`] given its Id.
+    pub async fn create_private_thread(
+        &self,
+        channel_id: u64,
+        map: &JsonMap,
+    ) -> Result<GuildChannel> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::CreatePrivateThread {
+                channel_id,
+            },
         })
         .await
     }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1309,11 +1309,11 @@ pub enum RouteInfo<'a> {
     LeaveThread {
         channel_id: u64,
     },
-    AddThreadUser {
+    AddThreadMember {
         channel_id: u64,
         user_id: u64,
     },
-    RemoveThreadUser {
+    RemoveThreadMember {
         channel_id: u64,
         user_id: u64,
     },
@@ -2235,7 +2235,7 @@ impl<'a> RouteInfo<'a> {
                 Route::ChannelsIdThreadMembersMe(channel_id),
                 Cow::from(Route::channel_thread_member_me(channel_id)),
             ),
-            RouteInfo::AddThreadUser {
+            RouteInfo::AddThreadMember {
                 channel_id,
                 user_id,
             } => (
@@ -2243,7 +2243,7 @@ impl<'a> RouteInfo<'a> {
                 Route::ChannelsIdThreadMembersUserId(channel_id),
                 Cow::from(Route::channel_thread_member(channel_id, user_id)),
             ),
-            RouteInfo::RemoveThreadUser {
+            RouteInfo::RemoveThreadMember {
                 channel_id,
                 user_id,
             } => (

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1027,6 +1027,13 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
     },
     CreateStageInstance,
+    CreatePublicThread {
+        channel_id: u64,
+        message_id: u64,
+    },
+    CreatePrivateThread {
+        channel_id: u64,
+    },
     CreateEmoji {
         guild_id: u64,
     },
@@ -1584,6 +1591,21 @@ impl<'a> RouteInfo<'a> {
             RouteInfo::CreateStageInstance => {
                 (LightMethod::Post, Route::StageInstances, Cow::from(Route::stage_instances()))
             },
+            RouteInfo::CreatePublicThread {
+                channel_id,
+                message_id,
+            } => (
+                LightMethod::Post,
+                Route::ChannelsIdMessagesIdThreads(channel_id),
+                Cow::from(Route::channel_public_threads(channel_id, message_id)),
+            ),
+            RouteInfo::CreatePrivateThread {
+                channel_id,
+            } => (
+                LightMethod::Post,
+                Route::ChannelsIdThreads(channel_id),
+                Cow::from(Route::channel_private_threads(channel_id)),
+            ),
             RouteInfo::CreateEmoji {
                 guild_id,
             } => (

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -110,6 +110,60 @@ pub enum Route {
     ///
     /// [`ChannelId`]: crate::model::id::ChannelId
     ChannelsIdWebhooks(u64),
+    /// Route for the `/channels/:channel_id/messages/:message_id/threads` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdMessagesIdThreads(u64),
+    /// Route for the `/channels/:channel_id/threads` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdThreads(u64),
+    /// Route for the `/channels/:channel_id/thread-members/@me` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdThreadMembersMe(u64),
+    /// Route for the `/channels/:channel_id/thread-members/:user_id` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdThreadMembersUserId(u64),
+    /// Route for the `/channels/channel_id/thread-members` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdThreadMembers(u64),
+    /// Route for the `/channels/:channel_id/threads/active` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdActiveThreads(u64),
+    /// Route for the `/channels/:channel_id/threads/archived/public` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdPublicArchivedThreads(u64),
+    /// Route for the `/channels/:channel_id/threads/archived/private` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdPrivateArchivedThreads(u64),
+    /// Route for the `/channels/:channel_id/users/@me/threads/archived/private` path.
+    ///
+    /// The data is the relevant [`ChannelId`].
+    ///
+    /// [`ChannelId`]: crate::model::id::ChannelId
+    ChannelsIdMeJoindedPrivateArchivedThreads(u64),
     /// Route for the `/gateway` path.
     Gateway,
     /// Route for the `/gateway/bot` path.
@@ -489,6 +543,38 @@ impl Route {
 
     pub fn channel_webhooks(channel_id: u64) -> String {
         format!(api!("/channels/{}/webhooks"), channel_id)
+    }
+
+    pub fn channel_public_threads(channel_id: u64, message_id: u64) -> String {
+        format!(api!("/channels/{}/messages/{}/threads"), channel_id, message_id)
+    }
+
+    pub fn channel_private_threads(channel_id: u64) -> String {
+        format!(api!("/channels/{}/threads"), channel_id)
+    }
+
+    pub fn channel_thread_member(channel_id: u64, user_id: u64) -> String {
+        format!(api!("/channels/{}/thread-members/{}"), channel_id, user_id)
+    }
+
+    pub fn channel_thread_members(channel_id: u64) -> String {
+        format!(api!("/channels/{}/thread-members"), channel_id)
+    }
+
+    pub fn channel_active_threads(channel_id: u64) -> String {
+        format!(api!("/channels/{}/threads/active"), channel_id)
+    }
+
+    pub fn channel_public_archived_threads(channel_id: u64) -> String {
+        format!(api!("/channels/{}/threads/archived/public"), channel_id)
+    }
+
+    pub fn channel_private_archived_threads(channel_id: u64) -> String {
+        format!(api!("/channels/{}/threads/archived/private"), channel_id)
+    }
+
+    pub fn channel_private_joined_threads(channel_id: u64) -> String {
+        format!(api!("channels/{}/users/@me/threads/archived/private"), channel_id)
     }
 
     pub fn gateway() -> &'static str {

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -13,7 +13,7 @@ macro_rules! cdn {
 #[cfg(feature = "http")]
 macro_rules! api {
     ($e:expr) => {
-        concat!("https://discord.com/api/v8", $e)
+        concat!("https://discord.com/api/v9", $e)
     };
     ($e:expr, $($rest:tt)*) => {
         format!(api!($e), $($rest)*)

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1034,6 +1034,7 @@ impl ChannelId {
     /// or if there is no stage instance currently.
     pub async fn delete_stage_instance(&self, http: impl AsRef<Http>) -> Result<()> {
         http.as_ref().delete_stage_instance(self.0).await
+    }
 
     /// Gets the thread members, if this channel is a thread.
     ///

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1034,6 +1034,109 @@ impl ChannelId {
     /// or if there is no stage instance currently.
     pub async fn delete_stage_instance(&self, http: impl AsRef<Http>) -> Result<()> {
         http.as_ref().delete_stage_instance(self.0).await
+
+    /// Gets the thread members, if this channel is a thread.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the channel is not a thread channel
+    pub async fn get_thread_members(&self, http: impl AsRef<Http>) -> Result<Vec<ThreadMember>> {
+        http.as_ref().get_channel_thread_members(self.0).await
+    }
+
+    /// Joins the thread, if this channel is a thread.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the channel is not a thread channel
+    pub async fn join_thread(&self, http: impl AsRef<Http>) -> Result<()> {
+        http.as_ref().join_thread_channel(self.0).await
+    }
+
+    /// Leaves the thread, if this channel is a thread.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the channel is not a thread channel
+    pub async fn leave_thread(&self, http: impl AsRef<Http>) -> Result<()> {
+        http.as_ref().leave_thread_channel(self.0).await
+    }
+
+    /// Adds a thread member, if this channel is a thread.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the channel is not a thread channel
+    pub async fn add_thread_member(&self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+        http.as_ref().add_thread_channel_member(self.0, user_id.into()).await
+    }
+
+    /// Removes a thread member, if this channel is a thread.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the channel is not a thread channel
+    pub async fn remove_thread_member(
+        &self,
+        http: impl AsRef<Http>,
+        user_id: UserId,
+    ) -> Result<()> {
+        http.as_ref().remove_thread_channel_member(self.0, user_id.into()).await
+    }
+
+    /// Gets all active threads of a channel.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the bot doesn't have the
+    /// permission to get it.
+    pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
+        http.as_ref().get_channel_active_threads(self.0).await
+    }
+
+    /// Gets private archived threads of a channel.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the bot doesn't have the
+    /// permission to get it.
+    pub async fn get_archived_private_threads(
+        &self,
+        http: impl AsRef<Http>,
+        before: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<ThreadsData> {
+        http.as_ref().get_channel_archived_private_threads(self.0, before, limit).await
+    }
+
+    /// Gets public archived threads of a channel.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the bot doesn't have the
+    /// permission to get it.
+    pub async fn get_archived_public_threads(
+        &self,
+        http: impl AsRef<Http>,
+        before: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<ThreadsData> {
+        http.as_ref().get_channel_archived_public_threads(self.0, before, limit).await
+    }
+
+    /// Gets private archived threads joined by the current user of a channel.
+    ///
+    /// # Errors
+    ///
+    /// It may return an [`Error::Http`] if the bot doesn't have the
+    /// permission to get it.
+    pub async fn get_joined_archived_private_threads(
+        &self,
+        http: impl AsRef<Http>,
+        before: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<ThreadsData> {
+        http.as_ref().get_channel_joined_archived_private_threads(self.0, before, limit).await
     }
 }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1270,3 +1270,18 @@ impl Display for GuildChannel {
         Display::fmt(&self.id.mention(), f)
     }
 }
+
+/// A partial guild channel.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PartialGuildChannel {
+    /// The channel Id.
+    pub id: ChannelId,
+    /// The channel guild Id.
+    pub guild_id: GuildId,
+    /// The channel category Id.
+    #[serde(rename = "parent_id")]
+    pub category_id: ChannelId,
+    /// The channel type.
+    #[serde(rename = "type")]
+    pub kind: ChannelType
+}

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -105,6 +105,17 @@ pub struct GuildChannel {
     pub rtc_region: Option<String>,
     /// The video quality mode for a voice channel.
     pub video_quality_mode: Option<VideoQualityMode>,
+    /// An approximate count of messages in the thread, stops counting at 50.
+    ///
+    /// **Note**: This is only available on thread channels.
+    pub message_count: Option<u8>,
+    /// An approximate count of users in a thread, stops counting at 50.
+    ///
+    /// **Note**: This is only available on thread channels.
+    pub member_count: Option<u8>,
+    /// Thread member object for the current user, if they have joined the thread,
+    /// only included on certain API endpoints.
+    pub member: Option<ThreadMember>
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1283,5 +1283,5 @@ pub struct PartialGuildChannel {
     pub category_id: ChannelId,
     /// The channel type.
     #[serde(rename = "type")]
-    pub kind: ChannelType
+    pub kind: ChannelType,
 }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -72,11 +72,13 @@ pub struct GuildChannel {
     /// The name of the channel.
     pub name: String,
     /// Permission overwrites for [`Member`]s and for [`Role`]s.
+    #[serde(default)]
     pub permission_overwrites: Vec<PermissionOverwrite>,
     /// The position of the channel.
     ///
     /// The default text channel will _almost always_ have a position of `-1` or
     /// `0`.
+    #[serde(default)]
     pub position: i64,
     /// The topic of the channel.
     ///

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -115,7 +115,7 @@ pub struct GuildChannel {
     pub member_count: Option<u8>,
     /// Thread member object for the current user, if they have joined the thread,
     /// only included on certain API endpoints.
-    pub member: Option<ThreadMember>
+    pub member: Option<ThreadMember>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -113,9 +113,18 @@ pub struct GuildChannel {
     ///
     /// **Note**: This is only available on thread channels.
     pub member_count: Option<u8>,
+    /// The thread metadata.
+    ///
+    /// **Note**: This is only available on thread channels.
+    pub thread_metadata: Option<ThreadMetadata>,
     /// Thread member object for the current user, if they have joined the thread,
     /// only included on certain API endpoints.
     pub member: Option<ThreadMember>,
+    /// Default duration for newly created threads, in minutes, to automatically
+    /// archive the thread after recent activity.
+    ///
+    /// **Note**: It can currently only be set to 60, 1440, 4320, 10080.
+    pub default_auto_archive_duration: Option<u64>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1061,10 +1061,18 @@ pub enum MessageType {
     GuildDiscoveryDisqualified = 14,
     /// An indicator that the guild is requalified for Discovery Feature
     GuildDiscoveryRequalified = 15,
+    /// The first warning before guild discovery removal.
+    GuildDiscoveryGracePeriodInitialWarning = 16,
+    /// The last warning before guild discovery removal.
+    GuildDiscoveryGracePeriodFinalWarning = 17,
+    /// Message sent to inform users that a thread was created.
+    ThreadCreated = 18,
     /// A message reply.
     InlineReply = 19,
     /// A slash command.
     ApplicationCommand = 20,
+    /// A thread start message.
+    ThreadStarterMessage = 21,
     /// Server setup tips.
     GuildInviteReminder = 22,
     /// An indicator that the message is of unknown type.
@@ -1087,8 +1095,13 @@ enum_number!(MessageType {
     ChannelFollowAdd,
     GuildDiscoveryDisqualified,
     GuildDiscoveryRequalified,
+    GuildDiscoveryGracePeriodInitialWarning,
+    GuildDiscoveryGracePeriodFinalWarning
+    ThreadCreated,
     InlineReply,
     ApplicationCommand,
+    ThreadStarterMessage,
+    GuildInviteReminder
 });
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -1205,6 +1218,8 @@ __impl_bitflags! {
         SOURCE_MESSAGE_DELETED = 0b0000_0000_0000_0000_0000_0000_0000_1000;
         /// This message came from the urgent message system.
         URGENT = 0b0000_0000_0000_0000_0000_0000_0001_0000;
+        /// This message has an associated thread, with the same id as the message.
+        HAS_THREAD = 0b0000_0000_0000_0000_0000_0000_0010_0000;
         /// This message is only visible to the user who invoked the Interaction.
         EPHEMERAL = 0b0000_0000_0000_0000_0000_0000_0100_0000;
         /// This message is an Interaction Response and the bot is "thinking".

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -501,7 +501,7 @@ mod test {
                 video_quality_mode: None,
                 message_count: None,
                 member_count: None,
-                member: None
+                member: None,
             }
         }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -475,6 +475,18 @@ pub struct StageInstance {
     pub locked: bool,
 }
 
+/// A response to getting several threads channels.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ThreadsData {
+    /// The threads channels.
+    pub threads: Vec<GuildChannel>,
+    /// A thread member for each returned thread the current user has joined.
+    pub members: Vec<ThreadMember>,
+    /// Whether there are potentially additional threads that could be returned on a subsequent call.
+    pub has_more: bool,
+}
+
 #[cfg(test)]
 mod test {
     #[cfg(all(feature = "model", feature = "utils"))]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -462,8 +462,6 @@ pub struct StageInstance {
 #[non_exhaustive]pub struct ThreadMetadata {
     /// Whether the thread is archived.
     pub archived: bool,
-    /// Id of the user that last archived or unarchived the thread.
-    pub archiver_id: Option<UserId>,
     /// Duration in minutes to automatically archive the thread after recent activity.
     ///
     /// **Note**: It can currently only be set to 60, 1440, 4320, 10080.
@@ -513,7 +511,9 @@ mod test {
                 video_quality_mode: None,
                 message_count: None,
                 member_count: None,
+                thread_metadata: None,
                 member: None,
+                default_auto_archive_duration: None,
             }
         }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -459,7 +459,8 @@ pub struct StageInstance {
 
 /// A thread data.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[non_exhaustive]pub struct ThreadMetadata {
+#[non_exhaustive]
+pub struct ThreadMetadata {
     /// Whether the thread is archived.
     pub archived: bool,
     /// Duration in minutes to automatically archive the thread after recent activity.

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1595,7 +1595,7 @@ impl<'de> Deserialize<'de> for ThreadUpdateEvent {
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct ThreadDeleteEvent {
-    pub thread: PartialGuildChannel
+    pub thread: PartialGuildChannel,
 }
 
 impl<'de> Deserialize<'de> for ThreadDeleteEvent {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -620,7 +620,6 @@ pub struct ThreadMemberFlags {
     pub bits: u64,
 }
 
-#[cfg(feature = "model")]
 __impl_bitflags! {
     ThreadMemberFlags: u64 {
         // Not documented.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -6,6 +6,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[cfg(feature = "model")]
 use bitflags::__impl_bitflags;
 use chrono::{DateTime, Utc};
+use serde::{Serialize, Serializer};
 
 #[cfg(feature = "model")]
 use crate::builder::EditMember;
@@ -605,7 +606,7 @@ fn avatar_url(guild_id: GuildId, user_id: UserId, hash: Option<&String>) -> Opti
 #[non_exhaustive]
 pub struct ThreadMember {
     /// The id of the thread.
-    pub id: ChannelId,
+    pub id: Option<ChannelId>,
     /// The id of the user.
     pub user_id: Option<UserId>,
     /// The time the current user last joined the thread.
@@ -615,7 +616,7 @@ pub struct ThreadMember {
 }
 
 /// Describes extra features of the message.
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct ThreadMemberFlags {
     pub bits: u64,
 }
@@ -624,5 +625,23 @@ __impl_bitflags! {
     ThreadMemberFlags: u64 {
         // Not documented.
         NOTIFICATIONS = 0b0000_0000_0000_0000_0000_0000_0000_0001;
+    }
+}
+
+impl<'de> Deserialize<'de> for ThreadMemberFlags {
+    fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(ThreadMemberFlags::from_bits_truncate(deserializer.deserialize_u64(U64Visitor)?))
+    }
+}
+
+impl Serialize for ThreadMemberFlags {
+    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(self.bits())
     }
 }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -3,6 +3,8 @@ use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+#[cfg(feature = "model")]
+use bitflags::__impl_bitflags;
 use chrono::{DateTime, Utc};
 
 #[cfg(feature = "model")]
@@ -597,4 +599,31 @@ fn avatar_url(guild_id: GuildId, user_id: UserId, hash: Option<&String>) -> Opti
 
         cdn!("/guilds/{}/users/{}/avatars/{}.{}?size=1024", guild_id.0, user_id.0, hash, ext)
     })
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ThreadMember {
+    /// The id of the thread.
+    pub id: ChannelId,
+    /// The id of the user.
+    pub user_id: Option<UserId>,
+    /// The time the current user last joined the thread.
+    pub join_timestamp: DateTime<Utc>,
+    /// Any user-thread settings, currently only used for notifications
+    pub flags: ThreadMemberFlags,
+}
+
+/// Describes extra features of the message.
+#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ThreadMemberFlags {
+    pub bits: u64,
+}
+
+#[cfg(feature = "model")]
+__impl_bitflags! {
+    ThreadMemberFlags: u64 {
+        // Not documented.
+        NOTIFICATIONS = 0b0000_0000_0000_0000_0000_0000_0000_0001;
+    }
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -126,6 +126,9 @@ pub struct Guild {
     /// - `VERIFIED`
     /// - `VIP_REGIONS`
     /// - `WELCOME_SCREEN_ENABLED`
+    /// - `THREE_DAY_THREAD_ARCHIVE`
+    /// - `SEVEN_DAY_THREAD_ARCHIVE`
+    /// - `PRIVATE_THREADS`
     ///
     ///
     /// [`discord documentation`]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
@@ -246,6 +249,9 @@ pub struct Guild {
     /// The stage instances in this guild.
     #[serde(default)]
     pub stage_instances: Vec<StageInstance>,
+    /// All active threads in this guild that current user has permission to view.
+    #[serde(default)]
+    pub threads: Vec<GuildChannel>,
 }
 
 #[cfg(feature = "model")]
@@ -2615,6 +2621,11 @@ impl<'de> Deserialize<'de> for Guild {
             None => Vec::new(),
         };
 
+        let threads = match map.remove("threads") {
+            Some(v) => Vec::<GuildChannel>::deserialize(v).map_err(DeError::custom)?,
+            None => Vec::new(),
+        };
+
         #[allow(deprecated)]
         Ok(Self {
             afk_channel_id,
@@ -2662,6 +2673,7 @@ impl<'de> Deserialize<'de> for Guild {
             widget_enabled,
             widget_channel_id,
             stage_instances,
+            threads,
         })
     }
 }
@@ -3220,6 +3232,7 @@ mod test {
                 widget_channel_id: None,
                 public_updates_channel_id: None,
                 stage_instances: vec![],
+                threads: vec![],
             }
         }
 

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -404,6 +404,9 @@ mod test {
                 slow_mode_rate: Some(0),
                 rtc_region: None,
                 video_quality_mode: None,
+                message_count: None,
+                member_count: None,
+                member: None
             });
             let emoji = Emoji {
                 animated: false,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -406,7 +406,7 @@ mod test {
                 video_quality_mode: None,
                 message_count: None,
                 member_count: None,
-                member: None
+                member: None,
             });
             let emoji = Emoji {
                 animated: false,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -406,7 +406,9 @@ mod test {
                 video_quality_mode: None,
                 message_count: None,
                 member_count: None,
+                thread_metadata: None,
                 member: None,
+                default_auto_archive_duration: None
             });
             let emoji = Emoji {
                 animated: false,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -408,7 +408,7 @@ mod test {
                 member_count: None,
                 thread_metadata: None,
                 member: None,
-                default_auto_archive_duration: None
+                default_auto_archive_duration: None,
             });
             let emoji = Emoji {
                 animated: false,

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -319,6 +319,12 @@ __impl_bitflags! {
         REQUEST_TO_SPEAK = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
         /// Allows using slash commands.
         USE_SLASH_COMMANDS = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows for deleting and archiving threads, and viewing all private threads.
+        MANAGE_THREADS = 0b0001_0000_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows for creating and participating in public threads.
+        USE_PUBLIC_THREADS = 0b0010_0000_0000_0000_0000_0000_0000_0000_0000;
+        // Allows for creating and participating in private threads.
+        USE_PRIVATE_THREADS = 0b0100_0000_0000_0000_0000_0000_0000_0000_0000;
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -919,6 +919,9 @@ mod test {
             slow_mode_rate: Some(0),
             rtc_region: None,
             video_quality_mode: None,
+            message_count: None,
+            member_count: None,
+            member: None
         };
 
         let cache = Arc::new(Cache::default());

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -872,6 +872,7 @@ mod test {
             widget_enabled: Some(false),
             widget_channel_id: None,
             stage_instances: vec![],
+            threads: vec![],
         };
 
         let member = Member {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -921,7 +921,7 @@ mod test {
             video_quality_mode: None,
             message_count: None,
             member_count: None,
-            member: None
+            member: None,
         };
 
         let cache = Arc::new(Cache::default());

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -921,7 +921,9 @@ mod test {
             video_quality_mode: None,
             message_count: None,
             member_count: None,
+            thread_metadata: None,
             member: None,
+            default_auto_archive_duration: None
         };
 
         let cache = Arc::new(Cache::default());

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -923,7 +923,7 @@ mod test {
             member_count: None,
             thread_metadata: None,
             member: None,
-            default_auto_archive_duration: None
+            default_auto_archive_duration: None,
         };
 
         let cache = Arc::new(Cache::default());


### PR DESCRIPTION
This PR adds support to guild threads channels, see discord/discord-api-docs#2855. It also bumps the discord API version and gateway to v9.

It has been tested successfuly

Closes #1270