### PR TITLE
Support command create, update and delete events

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -765,7 +765,7 @@ async fn handle_event(
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
-                event_handler.integration_create(context, event.integration, event.guild_id).await;
+                event_handler.integration_create(context, event.integration).await;
             });
         },
         #[cfg(feature = "unstable_discord_api")]
@@ -773,7 +773,7 @@ async fn handle_event(
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
-                event_handler.integration_update(context, event.integration, event.guild_id).await;
+                event_handler.integration_update(context, event.integration).await;
             });
         },
         #[cfg(feature = "unstable_discord_api")]

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -786,5 +786,29 @@ async fn handle_event(
                     .await;
             });
         },
+        #[cfg(feature = "unstable_discord_api")]
+        DispatchEvent::Model(Event::ApplicationCommandCreate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.application_command_create(context, event.application_command).await;
+            });
+        },
+        #[cfg(feature = "unstable_discord_api")]
+        DispatchEvent::Model(Event::ApplicationCommandUpdate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.application_command_update(context, event.application_command).await;
+            });
+        },
+        #[cfg(feature = "unstable_discord_api")]
+        DispatchEvent::Model(Event::ApplicationCommandDelete(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            tokio::spawn(async move {
+                event_handler.application_command_delete(context, event.application_command).await;
+            });
+        },
     }
 }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -431,14 +431,14 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when a guild integration is created.
     ///
-    /// Provides the created integration and the id of the guild this integration belongs to.
+    /// Provides the created integration.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn integration_create(&self, _ctx: Context, _integration: Integration) {}
 
     /// Dispatched when a guild integration is updated.
     ///
-    /// Provides the updated integration and the id of the guild this integration belongs to.
+    /// Provides the updated integration.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn integration_update(&self, _ctx: Context, _integration: Integration) {}
@@ -459,7 +459,7 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when an application command is created.
     ///
-    /// Provides the application command.
+    /// Provides the created application command.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn application_command_create(
@@ -471,7 +471,7 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when an application command is updated.
     ///
-    /// Provides the application command.
+    /// Provides the updated application command.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn application_command_update(
@@ -483,7 +483,7 @@ pub trait EventHandler: Send + Sync {
 
     /// Dispatched when an application command is deleted.
     ///
-    /// Provides the application command.
+    /// Provides the deleted application command.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn application_command_delete(

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -434,26 +434,14 @@ pub trait EventHandler: Send + Sync {
     /// Provides the created integration and the id of the guild this integration belongs to.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    async fn integration_create(
-        &self,
-        _ctx: Context,
-        _integration: Integration,
-        _guild_id: GuildId,
-    ) {
-    }
+    async fn integration_create(&self, _ctx: Context, _integration: Integration) {}
 
     /// Dispatched when a guild integration is updated.
     ///
     /// Provides the updated integration and the id of the guild this integration belongs to.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    async fn integration_update(
-        &self,
-        _ctx: Context,
-        _integration: Integration,
-        _guild_id: GuildId,
-    ) {
-    }
+    async fn integration_update(&self, _ctx: Context, _integration: Integration) {}
 
     /// Dispatched when a guild integration is deleted.
     ///

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -468,6 +468,42 @@ pub trait EventHandler: Send + Sync {
         _application_id: Option<ApplicationId>,
     ) {
     }
+
+    /// Dispatched when an application command is created.
+    ///
+    /// Provides the application command.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    async fn application_command_create(
+        &self,
+        _ctx: Context,
+        _application_command: ApplicationCommand,
+    ) {
+    }
+
+    /// Dispatched when an application command is updated.
+    ///
+    /// Provides the application command.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    async fn application_command_update(
+        &self,
+        _ctx: Context,
+        _application_command: ApplicationCommand,
+    ) {
+    }
+
+    /// Dispatched when an application command is deleted.
+    ///
+    /// Provides the application command.
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    async fn application_command_delete(
+        &self,
+        _ctx: Context,
+        _application_command: ApplicationCommand,
+    ) {
+    }
 }
 
 /// This core trait for handling raw events

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -2146,8 +2146,6 @@ impl EventType {
     /// the information to recover the original event name for these events, in which
     /// case this method returns [`None`].
     pub fn name(&self) -> Option<&str> {
-        dbg!(self);
-
         match self {
             Self::ChannelCreate => Some(Self::CHANNEL_CREATE),
             Self::ChannelDelete => Some(Self::CHANNEL_DELETE),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1388,7 +1388,6 @@ impl Serialize for InteractionCreateEvent {
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct IntegrationCreateEvent {
-    pub guild_id: GuildId,
     pub integration: Integration,
 }
 
@@ -1396,17 +1395,10 @@ pub struct IntegrationCreateEvent {
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl<'de> Deserialize<'de> for IntegrationCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
-
-        let guild_id = map
-            .remove("guild_id")
-            .ok_or_else(|| DeError::custom("expected guild_id"))
-            .and_then(GuildId::deserialize)
-            .map_err(DeError::custom)?;
+        let integration = Integration::deserialize(deserializer)?;
 
         Ok(Self {
-            guild_id,
-            integration: Integration::deserialize(Value::Object(map)).map_err(DeError::custom)?,
+            integration,
         })
     }
 }
@@ -1416,7 +1408,6 @@ impl<'de> Deserialize<'de> for IntegrationCreateEvent {
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct IntegrationUpdateEvent {
-    pub guild_id: GuildId,
     pub integration: Integration,
 }
 
@@ -1424,17 +1415,10 @@ pub struct IntegrationUpdateEvent {
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl<'de> Deserialize<'de> for IntegrationUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
-
-        let guild_id = map
-            .remove("guild_id")
-            .ok_or_else(|| DeError::custom("expected guild_id"))
-            .and_then(GuildId::deserialize)
-            .map_err(DeError::custom)?;
+        let integration = Integration::deserialize(deserializer)?;
 
         Ok(Self {
-            guild_id,
-            integration: Integration::deserialize(Value::Object(map)).map_err(DeError::custom)?,
+            integration,
         })
     }
 }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1449,6 +1449,66 @@ pub struct IntegrationDeleteEvent {
     pub application_id: Option<ApplicationId>,
 }
 
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
+pub struct ApplicationCommandCreateEvent {
+    pub application_command: ApplicationCommand,
+}
+
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+impl<'de> Deserialize<'de> for ApplicationCommandCreateEvent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        let application_command = ApplicationCommand::deserialize(deserializer)?;
+
+        Ok(Self {
+            application_command,
+        })
+    }
+}
+
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
+pub struct ApplicationCommandUpdateEvent {
+    pub application_command: ApplicationCommand,
+}
+
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+impl<'de> Deserialize<'de> for ApplicationCommandUpdateEvent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        let application_command = ApplicationCommand::deserialize(deserializer)?;
+
+        Ok(Self {
+            application_command,
+        })
+    }
+}
+
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
+pub struct ApplicationCommandDeleteEvent {
+    pub application_command: ApplicationCommand,
+}
+
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+impl<'de> Deserialize<'de> for ApplicationCommandDeleteEvent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        let application_command = ApplicationCommand::deserialize(deserializer)?;
+
+        Ok(Self {
+            application_command,
+        })
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
@@ -1651,6 +1711,18 @@ pub enum Event {
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     IntegrationDelete(IntegrationDeleteEvent),
+    /// An application command was created
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    ApplicationCommandCreate(ApplicationCommandCreateEvent),
+    /// An application command was updated
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    ApplicationCommandUpdate(ApplicationCommandUpdateEvent),
+    /// An application command was deleted
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    ApplicationCommandDelete(ApplicationCommandDeleteEvent),
     /// An event type not covered by the above
     Unknown(UnknownEvent),
 }
@@ -1704,6 +1776,12 @@ impl Event {
             Self::IntegrationUpdate(_) => EventType::IntegrationUpdate,
             #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationDelete(_) => EventType::IntegrationDelete,
+            #[cfg(feature = "unstable_discord_api")]
+            Self::ApplicationCommandCreate(_) => EventType::ApplicationCommandCreate,
+            #[cfg(feature = "unstable_discord_api")]
+            Self::ApplicationCommandUpdate(_) => EventType::ApplicationCommandUpdate,
+            #[cfg(feature = "unstable_discord_api")]
+            Self::ApplicationCommandDelete(_) => EventType::ApplicationCommandDelete,
             Self::Unknown(unknown) => EventType::Other(unknown.kind.clone()),
         }
     }
@@ -1795,6 +1873,18 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
         EventType::IntegrationUpdate => Event::IntegrationUpdate(serde_json::from_value(v)?),
         #[cfg(feature = "unstable_discord_api")]
         EventType::IntegrationDelete => Event::IntegrationDelete(serde_json::from_value(v)?),
+        #[cfg(feature = "unstable_discord_api")]
+        EventType::ApplicationCommandCreate => {
+            Event::ApplicationCommandCreate(serde_json::from_value(v)?)
+        },
+        #[cfg(feature = "unstable_discord_api")]
+        EventType::ApplicationCommandUpdate => {
+            Event::ApplicationCommandUpdate(serde_json::from_value(v)?)
+        },
+        #[cfg(feature = "unstable_discord_api")]
+        EventType::ApplicationCommandDelete => {
+            Event::ApplicationCommandDelete(serde_json::from_value(v)?)
+        },
         EventType::Other(kind) => Event::Unknown(UnknownEvent {
             kind,
             value: v,
@@ -1981,6 +2071,21 @@ pub enum EventType {
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     IntegrationDelete,
+    /// Indicator that an application command was created.
+    /// This maps to [`ApplicationCommandCreateEvent`].
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    ApplicationCommandCreate,
+    /// Indicator that an application command was updated.
+    /// This maps to [`ApplicationCommandUpdateEvent`].
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    ApplicationCommandUpdate,
+    /// Indicator that an application command was deleted.
+    /// This maps to [`ApplicationCommandDeleteEvent`].
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    ApplicationCommandDelete,
     /// An unknown event was received over the gateway.
     ///
     /// This should be logged so that support for it can be added in the
@@ -2043,11 +2148,22 @@ impl EventType {
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     const INTEGRATION_DELETE: &'static str = "INTEGRATION_DELETE";
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    const APPLICATION_COMMAND_CREATE: &'static str = "APPLICATION_COMMAND_CREATE";
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    const APPLICATION_COMMAND_UPDATE: &'static str = "APPLICATION_COMMAND_UPDATE";
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    const APPLICATION_COMMAND_DELETE: &'static str = "APPLICATION_COMMAND_DELETE";
 
     /// Return the event name of this event. Some events are synthetic, and we lack
     /// the information to recover the original event name for these events, in which
     /// case this method returns [`None`].
     pub fn name(&self) -> Option<&str> {
+        dbg!(self);
+
         match self {
             Self::ChannelCreate => Some(Self::CHANNEL_CREATE),
             Self::ChannelDelete => Some(Self::CHANNEL_DELETE),
@@ -2093,6 +2209,12 @@ impl EventType {
             Self::IntegrationUpdate => Some(Self::INTEGRATION_UPDATE),
             #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationDelete => Some(Self::INTEGRATION_DELETE),
+            #[cfg(feature = "unstable_discord_api")]
+            Self::ApplicationCommandCreate => Some(Self::APPLICATION_COMMAND_CREATE),
+            #[cfg(feature = "unstable_discord_api")]
+            Self::ApplicationCommandUpdate => Some(Self::APPLICATION_COMMAND_UPDATE),
+            #[cfg(feature = "unstable_discord_api")]
+            Self::ApplicationCommandDelete => Some(Self::APPLICATION_COMMAND_DELETE),
             // GuildUnavailable is a synthetic event type, corresponding to either
             // `GUILD_CREATE` or `GUILD_DELETE`, but we don't have enough information
             // to recover the name here, so we return `None` instead.
@@ -2165,6 +2287,12 @@ impl<'de> Deserialize<'de> for EventType {
                     EventType::INTEGRATION_UPDATE => EventType::IntegrationUpdate,
                     #[cfg(feature = "unstable_discord_api")]
                     EventType::INTEGRATION_DELETE => EventType::IntegrationDelete,
+                    #[cfg(feature = "unstable_discord_api")]
+                    EventType::APPLICATION_COMMAND_CREATE => EventType::ApplicationCommandCreate,
+                    #[cfg(feature = "unstable_discord_api")]
+                    EventType::APPLICATION_COMMAND_UPDATE => EventType::ApplicationCommandUpdate,
+                    #[cfg(feature = "unstable_discord_api")]
+                    EventType::APPLICATION_COMMAND_DELETE => EventType::ApplicationCommandDelete,
                     other => EventType::Other(other.to_owned()),
                 })
             }

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -5,6 +5,7 @@ use super::*;
 #[non_exhaustive]
 pub struct Integration {
     pub id: IntegrationId,
+    pub guild_id: GuildId,
     pub account: IntegrationAccount,
     pub enabled: bool,
     #[serde(rename = "expire_behaviour")]

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -420,6 +420,10 @@ pub struct ApplicationCommand {
     pub id: CommandId,
     /// The parent application Id.
     pub application_id: ApplicationId,
+    /// The command guild Id, if there is one.
+    ///
+    /// **Note**: It is only present if it is received through the gateway.
+    pub guild_id: Option<GuildId>,
     /// The command name.
     pub name: String,
     /// The command description.

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -420,9 +420,9 @@ pub struct ApplicationCommand {
     pub id: CommandId,
     /// The parent application Id.
     pub application_id: ApplicationId,
-    /// The command guild Id, if there is one.
+    /// The command guild Id, if it is a guild command.
     ///
-    /// **Note**: It is only present if it is received through the gateway.
+    /// **Note**: It may only be present if it is received through the gateway.
     pub guild_id: Option<GuildId>,
     /// The command name.
     pub name: String,


### PR DESCRIPTION
This PR adds support to application command create, update and delete events, see discord/discord-api-docs#2367

It also updates integration create, update and delete events for consistency by adding the `guild_id` field to the integration object instead of in another parameter.

This has been tested