### PR TITLE
Member: use permissions object instead of string

### DIFF
--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -13,6 +13,8 @@ use crate::cache::Cache;
 use crate::http::{CacheHttp, Http};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
+#[cfg(feature = "unstable_discord_api")]
+use crate::model::permissions::Permissions;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::utils;
@@ -51,7 +53,7 @@ pub struct Member {
     /// [`Interaction`]: crate::model::interactions::Interaction
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub permissions: Option<String>,
+    pub permissions: Option<Permissions>,
 }
 
 #[cfg(feature = "model")]
@@ -562,5 +564,5 @@ pub struct PartialMember {
     /// [`Interaction`]: crate::model::interactions::Interaction
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub permissions: Option<String>,
+    pub permissions: Option<Permissions>,
 }

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -10,6 +10,8 @@ use super::{
     id::{ChannelId, GuildId, RoleId, UserId},
     user::User,
 };
+#[cfg(feature = "unstable_discord_api")]
+use crate::model::permissions::Permissions;
 
 /// Information about an available voice region.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -106,7 +108,7 @@ impl<'de> Deserialize<'de> for VoiceState {
             pending: bool,
             premium_since: Option<DateTime<Utc>>,
             #[cfg(feature = "unstable_discord_api")]
-            permissions: Option<String>,
+            permissions: Option<Permissions>,
         }
 
         struct VoiceStateVisitor;


### PR DESCRIPTION
This PR improves the `Member` and `PartialMember` `permissions` field by making it a `Permissions` object instead of a string.

This has been tested.