### PR TITLE
Support getting interaction response, editing/deleting followup and flags

### DIFF
--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use super::{CreateAllowedMentions, CreateEmbed};
+use crate::model::interactions::InteractionApplicationCommandCallbackDataFlags;
 use crate::{http::AttachmentType, utils};
 
 #[derive(Clone, Debug, Default)]
@@ -113,6 +114,12 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         let allowed_mentions = Value::Object(map);
 
         self.0.insert("allowed_mentions", allowed_mentions);
+        self
+    }
+
+    /// Sets the flags for the response.
+    pub fn flags(&mut self, flags: InteractionApplicationCommandCallbackDataFlags) -> &mut Self {
+        self.0.insert("flags", Value::Number(serde_json::Number::from(flags.bits())));
         self
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1382,7 +1382,7 @@ impl Http {
                 interaction_token,
             },
         })
-            .await
+        .await
     }
 
     /// Edits the initial interaction response.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1364,10 +1364,6 @@ impl Http {
     }
 
     /// Gets the initial interaction response.
-    ///
-    /// Refer to Discord's [docs] for Edit Webhook Message for field information.
-    ///
-    /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_original_interaction_response(

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -396,31 +396,17 @@ impl Http {
     pub async fn create_followup_message(
         &self,
         interaction_token: &str,
-        wait: bool,
-        map: &JsonMap,
-    ) -> Result<Option<Message>> {
-        let body = serde_json::to_vec(map)?;
-
-        let mut headers = Headers::new();
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
-
-        let response = self
-            .request(Request {
-                body: Some(&body),
-                headers: Some(headers),
-                route: RouteInfo::CreateFollowupMessage {
-                    application_id: self.application_id,
-                    interaction_token,
-                    wait,
-                },
-            })
-            .await?;
-
-        if response.status() == StatusCode::NO_CONTENT {
-            return Ok(None);
-        }
-
-        response.json::<Message>().await.map(Some).map_err(From::from)
+        map: &Value,
+    ) -> Result<Message> {
+        self.fire(Request {
+            body: Some(map.to_string().as_bytes()),
+            headers: None,
+            route: RouteInfo::CreateFollowupMessage {
+                application_id: self.application_id,
+                interaction_token,
+            },
+        })
+        .await
     }
 
     /// Creates a new global command.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -395,7 +395,6 @@ impl Http {
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_followup_message(
         &self,
-        application_id: u64,
         interaction_token: &str,
         wait: bool,
         map: &JsonMap,
@@ -410,7 +409,7 @@ impl Http {
                 body: Some(&body),
                 headers: Some(headers),
                 route: RouteInfo::CreateFollowupMessage {
-                    application_id,
+                    application_id: self.application_id,
                     interaction_token,
                     wait,
                 },
@@ -773,7 +772,6 @@ impl Http {
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_followup_message(
         &self,
-        application_id: u64,
         interaction_token: &str,
         message_id: u64,
     ) -> Result<()> {
@@ -781,7 +779,7 @@ impl Http {
             body: None,
             headers: None,
             route: RouteInfo::DeleteFollowupMessage {
-                application_id,
+                application_id: self.application_id,
                 interaction_token,
                 message_id,
             },
@@ -941,14 +939,13 @@ impl Http {
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_original_interaction_response(
         &self,
-        application_id: u64,
         interaction_token: &str,
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             headers: None,
             route: RouteInfo::DeleteOriginalInteractionResponse {
-                application_id,
+                application_id: self.application_id,
                 interaction_token,
             },
         })
@@ -1108,7 +1105,6 @@ impl Http {
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_followup_message(
         &self,
-        application_id: u64,
         interaction_token: &str,
         message_id: u64,
         map: &Value,
@@ -1117,7 +1113,7 @@ impl Http {
             body: Some(map.to_string().as_bytes()),
             headers: None,
             route: RouteInfo::EditFollowupMessage {
-                application_id,
+                application_id: self.application_id,
                 interaction_token,
                 message_id,
             },
@@ -1367,6 +1363,28 @@ impl Http {
         .await
     }
 
+    /// Gets the initial interaction response.
+    ///
+    /// Refer to Discord's [docs] for Edit Webhook Message for field information.
+    ///
+    /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    pub async fn get_original_interaction_response(
+        &self,
+        interaction_token: &str,
+    ) -> Result<Message> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetOriginalInteractionResponse {
+                application_id: self.application_id,
+                interaction_token,
+            },
+        })
+            .await
+    }
+
     /// Edits the initial interaction response.
     ///
     /// Refer to Discord's [docs] for Edit Webhook Message for field information.
@@ -1376,7 +1394,6 @@ impl Http {
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_original_interaction_response(
         &self,
-        application_id: u64,
         interaction_token: &str,
         map: &Value,
     ) -> Result<Message> {
@@ -1384,7 +1401,7 @@ impl Http {
             body: Some(map.to_string().as_bytes()),
             headers: None,
             route: RouteInfo::EditOriginalInteractionResponse {
-                application_id,
+                application_id: self.application_id,
                 interaction_token,
             },
         })

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -759,12 +759,8 @@ impl Route {
 
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub fn webhook_followup_messages<D: Display>(
-        application_id: u64,
-        token: D,
-        wait: bool,
-    ) -> String {
-        format!(api!("/webhooks/{}/{}?wait={}"), application_id, token, wait)
+    pub fn webhook_followup_messages<D: Display>(application_id: u64, token: D) -> String {
+        format!(api!("/webhooks/{}/{}"), application_id, token)
     }
 
     #[cfg(feature = "unstable_discord_api")]
@@ -852,7 +848,6 @@ pub enum RouteInfo<'a> {
     CreateFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
-        wait: bool,
     },
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
@@ -1357,15 +1352,10 @@ impl<'a> RouteInfo<'a> {
             RouteInfo::CreateFollowupMessage {
                 application_id,
                 interaction_token,
-                wait,
             } => (
                 LightMethod::Post,
                 Route::WebhooksId(application_id),
-                Cow::from(Route::webhook_followup_messages(
-                    application_id,
-                    interaction_token,
-                    wait,
-                )),
+                Cow::from(Route::webhook_followup_messages(application_id, interaction_token)),
             ),
             #[cfg(feature = "unstable_discord_api")]
             RouteInfo::CreateGlobalApplicationCommand {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1063,6 +1063,12 @@ pub enum RouteInfo<'a> {
     },
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    GetOriginalInteractionResponse {
+        application_id: u64,
+        interaction_token: &'a str,
+    },
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     EditOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
@@ -1748,6 +1754,18 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Patch,
                 Route::GuildsIdMembersMeNick(guild_id),
                 Cow::from(Route::guild_nickname(guild_id)),
+            ),
+            #[cfg(feature = "unstable_discord_api")]
+            RouteInfo::GetOriginalInteractionResponse {
+                application_id,
+                interaction_token,
+            } => (
+                LightMethod::Get,
+                Route::WebhooksApplicationId(application_id),
+                Cow::from(Route::webhook_original_interaction_response(
+                    application_id,
+                    interaction_token,
+                )),
             ),
             #[cfg(feature = "unstable_discord_api")]
             RouteInfo::EditOriginalInteractionResponse {

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -738,7 +738,6 @@ pub struct MessageInteraction {
 }
 
 impl Interaction {
-
     /// Gets the interaction response.
     ///
     /// # Errors
@@ -816,9 +815,7 @@ impl Interaction {
         Message::check_content_length(&map)?;
         Message::check_embed_length(&map)?;
 
-        http.as_ref()
-            .edit_original_interaction_response(&self.token, &Value::Object(map))
-            .await
+        http.as_ref().edit_original_interaction_response(&self.token, &Value::Object(map)).await
     }
 
     /// Deletes the initial interaction response.
@@ -827,10 +824,7 @@ impl Interaction {
     ///
     /// May return [`Error::Http`] if the API returns an error.
     /// Such as if the response was already deleted.
-    pub async fn delete_original_interaction_response(
-        &self,
-        http: impl AsRef<Http>,
-    ) -> Result<()> {
+    pub async fn delete_original_interaction_response(&self, http: impl AsRef<Http>) -> Result<()> {
         http.as_ref().delete_original_interaction_response(&self.token).await
     }
 

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -738,6 +738,18 @@ pub struct MessageInteraction {
 }
 
 impl Interaction {
+
+    /// Gets the interaction response.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if there is no interaction response.
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    pub async fn get_interaction_response(&self, http: impl AsRef<Http>) -> Result<Message> {
+        http.as_ref().get_original_interaction_response(&self.token).await
+    }
+
     /// Creates a response to the interaction received.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
@@ -791,7 +803,6 @@ impl Interaction {
     pub async fn edit_original_interaction_response<F>(
         &self,
         http: impl AsRef<Http>,
-        application_id: u64,
         f: F,
     ) -> Result<Message>
     where
@@ -806,7 +817,7 @@ impl Interaction {
         Message::check_embed_length(&map)?;
 
         http.as_ref()
-            .edit_original_interaction_response(application_id, &self.token, &Value::Object(map))
+            .edit_original_interaction_response(&self.token, &Value::Object(map))
             .await
     }
 
@@ -819,9 +830,8 @@ impl Interaction {
     pub async fn delete_original_interaction_response(
         &self,
         http: impl AsRef<Http>,
-        application_id: u64,
     ) -> Result<()> {
-        http.as_ref().delete_original_interaction_response(application_id, &self.token).await
+        http.as_ref().delete_original_interaction_response(&self.token).await
     }
 
     /// Creates a followup response to the response sent.
@@ -840,7 +850,6 @@ impl Interaction {
     pub async fn create_followup_message<'a, F>(
         &self,
         http: impl AsRef<Http>,
-        application_id: u64,
         wait: bool,
         f: F,
     ) -> Result<Option<Message>>
@@ -857,7 +866,7 @@ impl Interaction {
         Message::check_content_length(&map)?;
         Message::check_embed_length(&map)?;
 
-        http.as_ref().create_followup_message(application_id, &self.token, wait, &map).await
+        http.as_ref().create_followup_message(&self.token, wait, &map).await
     }
 }
 

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -844,9 +844,8 @@ impl Interaction {
     pub async fn create_followup_message<'a, F>(
         &self,
         http: impl AsRef<Http>,
-        wait: bool,
         f: F,
-    ) -> Result<Option<Message>>
+    ) -> Result<Message>
     where
         for<'b> F: FnOnce(
             &'b mut CreateInteractionResponseFollowup<'a>,
@@ -860,7 +859,58 @@ impl Interaction {
         Message::check_content_length(&map)?;
         Message::check_embed_length(&map)?;
 
-        http.as_ref().create_followup_message(&self.token, wait, &map).await
+        http.as_ref().create_followup_message(&self.token, &Value::Object(map)).await
+    }
+
+    /// Edits a followup response to the response sent.
+    ///
+    /// **Note**: Message contents must be under 2000 unicode code points.
+    ///
+    /// # Errors
+    ///
+    /// Will return [`Error::Model`] if the content is too long.
+    /// May also return [`Error::Http`] if the API returns an error,
+    /// or a [`Error::Json`] if there is an error in deserializing the response.
+    ///
+    /// [`Error::Model`]: crate::error::Error::Model
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
+    pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
+        &self,
+        http: impl AsRef<Http>,
+        message_id: M,
+        f: F,
+    ) -> Result<Message>
+    where
+        for<'b> F: FnOnce(
+            &'b mut CreateInteractionResponseFollowup<'a>,
+        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
+    {
+        let mut interaction_response = CreateInteractionResponseFollowup::default();
+        f(&mut interaction_response);
+
+        let map = utils::hashmap_to_json_map(interaction_response.0);
+
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
+
+        http.as_ref()
+            .edit_followup_message(&self.token, message_id.into().into(), &Value::Object(map))
+            .await
+    }
+
+    /// Deletes a followup message.
+    ///
+    /// # Errors
+    ///
+    /// May return [`Error::Http`] if the API returns an error.
+    /// Such as if the response was already deleted.
+    pub async fn delete_followup_message<M: Into<MessageId>>(
+        &self,
+        http: impl AsRef<Http>,
+        message_id: M,
+    ) -> Result<()> {
+        http.as_ref().delete_followup_message(&self.token, message_id.into().into()).await
     }
 }
 


### PR DESCRIPTION
This PR adds support to getting an original interaction response, editing and deleting a followup message. It updates the `Interaction` methods to use the client `application_id` instead of having to add it to each request, which was not made for these in #1283 and add `flags` to interaction response builder.

This PR also removes the `wait` parameter as it will always be true, and makes the returned message always present.

This has been tested