### PR TITLE
Fix webhook creation on news channel

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -3,15 +3,15 @@ use std::fmt::Write as FmtWrite;
 #[cfg(feature = "model")]
 use std::sync::Arc;
 
+#[cfg(feature = "model")]
+use bytes::buf::Buf;
 use futures::stream::Stream;
+#[cfg(feature = "model")]
+use reqwest::Url;
 #[cfg(feature = "model")]
 use serde_json::json;
 #[cfg(feature = "model")]
 use tokio::{fs::File, io::AsyncReadExt};
-#[cfg(feature = "model")]
-use reqwest::Url;
-#[cfg(feature = "model")]
-use bytes::buf::Buf;
 
 #[cfg(feature = "model")]
 use crate::builder::{CreateInvite, CreateMessage, EditChannel, EditMessage, GetMessages};

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -6,6 +6,12 @@ use std::sync::Arc;
 use futures::stream::Stream;
 #[cfg(feature = "model")]
 use serde_json::json;
+#[cfg(feature = "model")]
+use tokio::{fs::File, io::AsyncReadExt};
+#[cfg(feature = "model")]
+use reqwest::Url;
+#[cfg(feature = "model")]
+use bytes::buf::Buf;
 
 #[cfg(feature = "model")]
 use crate::builder::{CreateInvite, CreateMessage, EditChannel, EditMessage, GetMessages};
@@ -851,6 +857,78 @@ impl ChannelId {
     #[inline]
     pub async fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
         http.as_ref().get_channel_webhooks(self.0).await
+    }
+
+    /// Creates a webhook with only a name.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Error::Http`] if the current user lacks permission.
+    pub async fn create_webhook(
+        &self,
+        http: impl AsRef<Http>,
+        name: impl std::fmt::Display,
+    ) -> Result<Webhook> {
+        let map = serde_json::json!({
+            "name": name.to_string(),
+        });
+
+        http.as_ref().create_webhook(self.0, &map).await
+    }
+
+    /// Creates a webhook with a name and an avatar.
+    ///
+    /// # Errors
+    ///
+    /// In addition to the reasons [`Self::create_webhook`] may return an [`Error::Http`],
+    /// if the image is too large.
+    pub async fn create_webhook_with_avatar<'a>(
+        &self,
+        http: impl AsRef<Http>,
+        name: impl std::fmt::Display,
+        avatar: impl Into<AttachmentType<'a>>,
+    ) -> Result<Webhook> {
+        let name = name.to_string();
+        let avatar = avatar.into();
+
+        let avatar = match avatar {
+            AttachmentType::Bytes {
+                data,
+                filename: _,
+            } => "data:image/png;base64,".to_string() + &base64::encode(&data.into_owned()),
+            AttachmentType::File {
+                file,
+                filename: _,
+            } => {
+                let mut buf = Vec::new();
+                file.try_clone().await?.read_to_end(&mut buf).await?;
+
+                "data:image/png;base64,".to_string() + &base64::encode(&buf)
+            },
+            AttachmentType::Path(path) => {
+                let mut file = File::open(path).await?;
+                let mut buf = vec![];
+                file.read_to_end(&mut buf).await?;
+
+                "data:image/png;base64,".to_string() + &base64::encode(&buf)
+            },
+            AttachmentType::Image(url) => {
+                let url = Url::parse(url).map_err(|_| Error::Url(url.to_string()))?;
+                let response = http.as_ref().client.get(url).send().await?;
+                let mut bytes = response.bytes().await?;
+                let mut picture: Vec<u8> = vec![0; bytes.len()];
+                bytes.copy_to_slice(&mut picture[..]);
+
+                "data:image/png;base64,".to_string() + &base64::encode(&picture)
+            },
+        };
+
+        let map = serde_json::json!({
+            "name": name,
+            "avatar": avatar
+        });
+
+        http.as_ref().create_webhook(self.0, &map).await
     }
 
     /// Returns a future that will await one message sent in this channel.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -111,10 +111,7 @@ impl GuildChannel {
     /// Whether or not this channel is text-based, meaning that
     /// it is possible to send messages.
     pub fn is_text_based(&self) -> bool {
-        match self.kind {
-            ChannelType::Text | ChannelType::News => true,
-            _ => false,
-        }
+        matches!(self.kind, ChannelType::Text | ChannelType::News)
     }
 
     /// Broadcasts to the channel that the current user is typing.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -3,12 +3,9 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[cfg(feature = "model")]
 use std::sync::Arc;
 
-use bytes::buf::Buf;
 use chrono::{DateTime, Utc};
 #[cfg(feature = "cache")]
 use futures::stream::StreamExt;
-use reqwest::Url;
-use tokio::{fs::File, io::AsyncReadExt};
 
 #[cfg(feature = "model")]
 use crate::builder::EditChannel;
@@ -111,6 +108,15 @@ pub struct GuildChannel {
 
 #[cfg(feature = "model")]
 impl GuildChannel {
+    /// Whether or not this channel is text-based, meaning that
+    /// it is possible to send messages.
+    pub fn is_text_based(&self) -> bool {
+        match self.kind {
+            ChannelType::Text | ChannelType::News => true,
+            _ => false,
+        }
+    }
+
     /// Broadcasts to the channel that the current user is typing.
     ///
     /// For bots, this is a good indicator for long-running commands.
@@ -1114,7 +1120,7 @@ impl GuildChannel {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 
-    /// Sends a message with just the given message content in the channel.
+    /// Creates a webhook with only a name.
     ///
     /// # Errors
     ///
@@ -1134,18 +1140,14 @@ impl GuildChannel {
             return Err(Error::Model(ModelError::NameTooShort));
         } else if name.len() > 100 {
             return Err(Error::Model(ModelError::NameTooLong));
-        } else if self.kind.num() != 0 {
+        } else if !self.is_text_based() {
             return Err(Error::Model(ModelError::InvalidChannelType));
         }
 
-        let map = serde_json::json!({
-            "name": name,
-        });
-
-        http.as_ref().create_webhook(self.id.0, &map).await
+        self.id.create_webhook(&http, name).await
     }
 
-    /// Avatar must be a 128x128 image.
+    /// Creates a webhook with a name and an avatar.
     ///
     /// # Errors
     ///
@@ -1168,44 +1170,7 @@ impl GuildChannel {
             return Err(Error::Model(ModelError::InvalidChannelType));
         }
 
-        let avatar = match avatar {
-            AttachmentType::Bytes {
-                data,
-                filename: _,
-            } => "data:image/png;base64,".to_string() + &base64::encode(&data.into_owned()),
-            AttachmentType::File {
-                file,
-                filename: _,
-            } => {
-                let mut buf = Vec::new();
-                file.try_clone().await?.read_to_end(&mut buf).await?;
-
-                "data:image/png;base64,".to_string() + &base64::encode(&buf)
-            },
-            AttachmentType::Path(path) => {
-                let mut file = File::open(path).await?;
-                let mut buf = vec![];
-                file.read_to_end(&mut buf).await?;
-
-                "data:image/png;base64,".to_string() + &base64::encode(&buf)
-            },
-            AttachmentType::Image(url) => {
-                let url = Url::parse(url).map_err(|_| Error::Url(url.to_string()))?;
-                let response = http.as_ref().client.get(url).send().await?;
-                let mut bytes = response.bytes().await?;
-                let mut picture: Vec<u8> = vec![0; bytes.len()];
-                bytes.copy_to_slice(&mut picture[..]);
-
-                "data:image/png;base64,".to_string() + &base64::encode(&picture)
-            },
-        };
-
-        let map = serde_json::json!({
-            "name": name,
-            "avatar": avatar
-        });
-
-        http.as_ref().create_webhook(self.id.0, &map).await
+        self.id.create_webhook_with_avatar(&http, name, avatar).await
     }
 }
 


### PR DESCRIPTION
This PR fixes the webhook creation on news channel, and also add the methods to `ChannelId`.

This has been tested.

Closes #1328