### PR TITLE
Support `Team::name`

### DIFF
--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -140,6 +140,8 @@ pub struct Team {
     /// The snowflake ID of the team.
     #[serde(deserialize_with = "deserialize_u64")]
     pub id: u64,
+    /// The name of the team.
+    pub name: String,
     /// The members of the team
     pub members: Vec<TeamMember>,
     /// The user id of the team owner.


### PR DESCRIPTION
This PR adds support to `Team::name` field, as per discord/discord-api-docs#2900

This has been tested