### PR TITLE
Fix GuildEmbed removal to avoid breaking change

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2177,6 +2177,19 @@ impl Http {
         .await
     }
 
+    /// Gets a guild embed information.
+    #[deprecated(note = "get_guild_embed was renamed to get_guild_widget")]
+    pub async fn get_guild_embed(&self, guild_id: u64) -> Result<GuildEmbed> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildEmbed {
+                guild_id,
+            },
+        })
+        .await
+    }
+
     /// Gets a guild widget information.
     pub async fn get_guild_widget(&self, guild_id: u64) -> Result<GuildWidget> {
         self.fire(Request {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2183,7 +2183,7 @@ impl Http {
         self.fire(Request {
             body: None,
             headers: None,
-            route: RouteInfo::GetGuildEmbed {
+            route: RouteInfo::GetGuildWidget {
                 guild_id,
             },
         })

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -145,12 +145,6 @@ pub enum Route {
     ///
     /// [`GuildId`]: crate::model::id::GuildId
     GuildsIdChannels(u64),
-    /// Route for the `/guilds/:guild_id/embed` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdEmbed(u64),
     /// Route for the `/guilds/:guild_id/widget` path.
     ///
     /// The data is the relevant [`GuildId`].
@@ -542,10 +536,6 @@ impl Route {
 
     pub fn guild_channels(guild_id: u64) -> String {
         format!(api!("/guilds/{}/channels"), guild_id)
-    }
-
-    pub fn guild_embed(guild_id: u64) -> String {
-        format!(api!("/guilds/{}/embed"), guild_id)
     }
 
     pub fn guild_widget(guild_id: u64) -> String {
@@ -1186,9 +1176,6 @@ pub enum RouteInfo<'a> {
         application_id: u64,
         guild_id: u64,
         command_id: u64,
-    },
-    GetGuildEmbed {
-        guild_id: u64,
     },
     GetGuildWidget {
         guild_id: u64,
@@ -1992,13 +1979,6 @@ impl<'a> RouteInfo<'a> {
                     guild_id,
                     command_id,
                 )),
-            ),
-            RouteInfo::GetGuildEmbed {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdEmbed(guild_id),
-                Cow::from(Route::guild_embed(guild_id)),
             ),
             RouteInfo::GetGuildWidget {
                 guild_id,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -145,6 +145,12 @@ pub enum Route {
     ///
     /// [`GuildId`]: crate::model::id::GuildId
     GuildsIdChannels(u64),
+    /// Route for the `/guilds/:guild_id/embed` path.
+    ///
+    /// The data is the relevant [`GuildId`].
+    ///
+    /// [`GuildId`]: crate::model::id::GuildId
+    GuildsIdEmbed(u64),
     /// Route for the `/guilds/:guild_id/widget` path.
     ///
     /// The data is the relevant [`GuildId`].
@@ -536,6 +542,10 @@ impl Route {
 
     pub fn guild_channels(guild_id: u64) -> String {
         format!(api!("/guilds/{}/channels"), guild_id)
+    }
+
+    pub fn guild_embed(guild_id: u64) -> String {
+        format!(api!("/guilds/{}/embed"), guild_id)
     }
 
     pub fn guild_widget(guild_id: u64) -> String {
@@ -1176,6 +1186,9 @@ pub enum RouteInfo<'a> {
         application_id: u64,
         guild_id: u64,
         command_id: u64,
+    },
+    GetGuildEmbed {
+        guild_id: u64,
     },
     GetGuildWidget {
         guild_id: u64,
@@ -1979,6 +1992,13 @@ impl<'a> RouteInfo<'a> {
                     guild_id,
                     command_id,
                 )),
+            ),
+            RouteInfo::GetGuildEmbed {
+                guild_id,
+            } => (
+                LightMethod::Get,
+                Route::GuildsIdEmbed(guild_id),
+                Cow::from(Route::guild_embed(guild_id)),
             ),
             RouteInfo::GetGuildWidget {
                 guild_id,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2711,6 +2711,17 @@ pub enum GuildWelcomeScreenEmoji {
     Unicode(String),
 }
 
+/// A [`Guild`] embed.
+#[deprecated(note = "GuildEmbed was renamed to GuildWidget")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct GuildEmbed {
+    /// Whether the embed is enabled.
+    pub enabled: bool,
+    /// The widget channel id.
+    pub channel_id: Option<ChannelId>,
+}
+
 /// A [`Guild`] widget.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]


### PR DESCRIPTION
This PR fixes a breaking change which was introduced in #1306 with the removal of `GuildEmbed` in favor of `GuildWidget` by adding it but with a deprecation warning. Note that the route was removed in API v8.