### PR TITLE
Fix unreachable code warning for framework macros

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -227,8 +227,9 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
             use ::serenity::futures::future::FutureExt;
 
             async move {
-                let output: #ret = { #(#body)* };
-                output
+                let _output: #ret = { #(#body)* };
+                #[allow(unreachable_code)]
+                _output
             }.boxed()
         }
     })
@@ -522,8 +523,9 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
             use ::serenity::futures::future::FutureExt;
 
             async move {
-                let output: #ret = { #(#body)* };
-                output
+                let _output: #ret = { #(#body)* };
+                #[allow(unreachable_code)]
+                _output
             }.boxed()
         }
     })
@@ -801,8 +803,9 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
             use ::serenity::futures::future::FutureExt;
 
             async move {
-                let output: #ret = { #(#body)* };
-                output
+                let _output: #ret = { #(#body)* };
+                #[allow(unreachable_code)]
+                _output
             }.boxed()
         }
     })
@@ -939,8 +942,9 @@ pub fn hook(_attr: TokenStream, input: TokenStream) -> TokenStream {
                     use ::serenity::futures::future::FutureExt;
 
                     async move {
-                        let output: #ret = { #(#body)* };
-                        output
+                        let _output: #ret = { #(#body)* };
+                        #[allow(unreachable_code)]
+                        _output
                     }.boxed()
                 }
             })


### PR DESCRIPTION
## Description

This silences the `unreachable_code` lint that is triggered when a `return` statement appears at the end of an `async` function for the framework.

## Type of Change

This reduces clutter in the terminal output from `cargo check` and other compilation commands, improving the user experience.

## How Has This Been Tested?

This has been tested by verifying that warnings no longer get triggered, which they don't.