### PR TITLE
Fix warnings for the `deprecated` lint and clippy's lints

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1088,6 +1088,7 @@ mod test {
             let mut channels = HashMap::new();
             channels.insert(ChannelId(2), guild_channel.clone());
 
+            #[allow(deprecated)]
             GuildCreateEvent {
                 guild: Guild {
                     id: GuildId(1),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1003,22 +1003,20 @@ impl CacheUpdate for PresenceUpdateEvent {
 
                 // Create a partial member instance out of the presence update
                 // data.
-                if !guild.members.contains_key(&self.presence.user_id) {
-                    if let Some(user) = self.presence.user.as_ref() {
-                        guild.members.insert(self.presence.user_id, Member {
-                            deaf: false,
-                            guild_id,
-                            joined_at: None,
-                            mute: false,
-                            nick: None,
-                            user: user.clone(),
-                            roles: vec![],
-                            pending: false,
-                            premium_since: None,
-                            #[cfg(feature = "unstable_discord_api")]
-                            permissions: None,
-                        });
-                    }
+                if let Some(user) = self.presence.user.as_ref() {
+                    guild.members.entry(self.presence.user_id).or_insert(Member {
+                        deaf: false,
+                        guild_id,
+                        joined_at: None,
+                        mute: false,
+                        nick: None,
+                        user: user.clone(),
+                        roles: vec![],
+                        pending: false,
+                        premium_since: None,
+                        #[cfg(feature = "unstable_discord_api")]
+                        permissions: None,
+                    });
                 }
             }
         } else if self.presence.status == OnlineStatus::Offline {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1004,7 +1004,7 @@ impl CacheUpdate for PresenceUpdateEvent {
                 // Create a partial member instance out of the presence update
                 // data.
                 if let Some(user) = self.presence.user.as_ref() {
-                    guild.members.entry(self.presence.user_id).or_insert(Member {
+                    guild.members.entry(self.presence.user_id).or_insert_with(|| Member {
                         deaf: false,
                         guild_id,
                         joined_at: None,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1507,10 +1507,9 @@ impl Guild {
 
         if sorted {
             members.sort_by(|a, b| closest_to_origin(prefix, &a.1[..], &b.1[..]));
-            members
-        } else {
-            members
         }
+
+        members
     }
 
     /// Retrieves all [`Member`] containing a given [`String`] as
@@ -1576,10 +1575,9 @@ impl Guild {
 
         if sorted {
             members.sort_by(|a, b| closest_to_origin(substring, &a.1[..], &b.1[..]));
-            members
-        } else {
-            members
         }
+
+        members
     }
 
     /// Retrieves a tuple of [`Member`]s containing a given [`String`] in
@@ -1613,22 +1611,18 @@ impl Guild {
     ) -> Vec<(&Member, String)> {
         let mut members = futures::stream::iter(self.members.values())
             .filter_map(|member| async move {
-                if case_sensitive {
-                    let name = &member.user.name;
+                let name = &member.user.name;
 
+                if case_sensitive {
                     if name.contains(substring) {
                         Some((member, name.to_string()))
                     } else {
                         None
                     }
+                } else if contains_case_insensitive(name, substring) {
+                    Some((member, name.to_string()))
                 } else {
-                    let name = &member.user.name;
-
-                    if contains_case_insensitive(name, substring) {
-                        Some((member, name.to_string()))
-                    } else {
-                        None
-                    }
+                    None
                 }
             })
             .collect::<Vec<(&Member, String)>>()
@@ -1636,10 +1630,9 @@ impl Guild {
 
         if sorted {
             members.sort_by(|a, b| closest_to_origin(substring, &a.1[..], &b.1[..]));
-            members
-        } else {
-            members
         }
+
+        members
     }
 
     /// Retrieves all [`Member`] containing a given [`String`] in
@@ -1694,10 +1687,9 @@ impl Guild {
 
         if sorted {
             members.sort_by(|a, b| closest_to_origin(substring, &a.1[..], &b.1[..]));
-            members
-        } else {
-            members
         }
+
+        members
     }
 
     /// Calculate a [`Member`]'s permissions in the guild.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -821,6 +821,7 @@ mod test {
             public_flags: None,
         };
 
+        #[allow(deprecated)]
         let mut guild = Guild {
             afk_channel_id: None,
             afk_timeout: 0,

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -72,7 +72,7 @@ impl Parse for Member {
 
         let lookup_by_mention = || {
             guild.members.get(&UserId(
-                s.strip_prefix("<@")?.trim_start_matches('!').strip_suffix(">")?.parse().ok()?,
+                s.strip_prefix("<@")?.trim_start_matches('!').strip_suffix('>')?.parse().ok()?,
             ))
         };
 


### PR DESCRIPTION
## Description

This silences the `deprecated` lint and fixes some of clippy's lints. 

## Type of Change

This improves the quality of the codebase.

## How Has This Been Tested?

This has been tested by verifying that warnings no longer get triggered, which they don't.