### PR TITLE
Stricter validate_token checks

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -955,8 +955,6 @@ pub fn validate_token(token: impl AsRef<str>) -> Result<()> {
     let (user_id, generation_time) =
         parse_token(token.as_ref()).ok_or(Error::Client(ClientError::InvalidToken))?;
 
-    dbg!(user_id, generation_time);
-
     // Check if timestamps are in a sensible range
     if user_id.created_at().year() >= 2100 || generation_time.year() >= 2100 {
         return Err(Error::Client(ClientError::InvalidToken));

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -952,14 +952,11 @@ impl Client {
 /// Returns a [`ClientError::InvalidToken`] when one of the above checks fail.
 /// The type of failure is not specified.
 pub fn validate_token(token: impl AsRef<str>) -> Result<()> {
-    let token = parse_token(token.as_ref()).ok_or(Error::Client(ClientError::InvalidToken))?;
-
-    // Check if timestamps are in a sensible range
-    if token.bot_user_id.created_at().year() >= 2100 || token.creation_time.year() >= 2100 {
-        return Err(Error::Client(ClientError::InvalidToken));
+    if parse_token(token.as_ref()).is_some() {
+        Ok(())
+    } else {
+        Err(Error::Client(ClientError::InvalidToken))
     }
-
-    Ok(())
 }
 
 /// Part of the data contained within a Discord bot token. Returned by [`parse_token`].


### PR DESCRIPTION
Implements #1032. In essence, `serenity::client::validate_token` has been changed to fully parse the token's components and check if they are meaningful, to catch more errors.

Tested on one of my bot tokens; the extracted user ID and token creation timestamp are correct.

Question: should the function that extracts the bot user ID and token creation timestamp out of the token be made public?