### PR TITLE
Dispatch error command name

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -176,7 +176,7 @@ async fn delay_action(ctx: &Context, msg: &Message) {
 }
 
 #[hook]
-async fn dispatch_error(ctx: &Context, msg: &Message, error: DispatchError) {
+async fn dispatch_error(ctx: &Context, msg: &Message, error: DispatchError, _command_name: &str) {
     if let DispatchError::Ratelimited(info) = error {
 
         // We notify them only once.
@@ -192,7 +192,7 @@ async fn dispatch_error(ctx: &Context, msg: &Message, error: DispatchError) {
 // You can construct a hook without the use of a macro, too.
 // This requires some boilerplate though and the following additional import.
 use serenity::{futures::future::BoxFuture, FutureExt};
-fn _dispatch_error_no_macro<'fut>(ctx: &'fut mut Context, msg: &'fut Message, error: DispatchError) -> BoxFuture<'fut, ()> {
+fn _dispatch_error_no_macro<'fut>(ctx: &'fut mut Context, msg: &'fut Message, error: DispatchError, _command_name: &str) -> BoxFuture<'fut, ()> {
     async move {
         if let DispatchError::Ratelimited(info) = error {
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -37,7 +37,6 @@ use std::{
     task::{Context as FutContext, Poll},
 };
 
-use chrono::Datelike;
 use futures::future::BoxFuture;
 use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, error, info, instrument};

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -730,8 +730,7 @@ impl Framework for StandardFramework {
                     self.should_fail(&ctx, &msg, &mut args, &command.options, &group.options).await
                 {
                     if let Some(dispatch) = &self.dispatch {
-                        let command_name =
-                            command.options.names.get(0).copied().unwrap_or("<unnamed>");
+                        let command_name = command.options.names[0];
                         dispatch(&mut ctx, &msg, error, command_name).await;
                     }
 

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -516,7 +516,7 @@ pub async fn command(
                         Ok(Invoke::Command {
                             command, ..
                         }) => Some(command.options.names[0]),
-                        Ok(Invoke::Help(name)) => Some(name), // is this correct?
+                        Ok(Invoke::Help(name)) => Some(name), /* unreachable, but fallback just in case */
                         Err(ParseError::UnrecognisedCommand(_)) => None,
                         Err(ParseError::Dispatch {
                             command_name, ..

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -515,7 +515,7 @@ pub async fn command(
                     match res {
                         Ok(Invoke::Command {
                             command, ..
-                        }) => Some(command.options.names.get(0).copied().unwrap_or("<unknown>")),
+                        }) => Some(command.options.names[0]),
                         Ok(Invoke::Help(name)) => Some(name), // is this correct?
                         Err(ParseError::UnrecognisedCommand(_)) => None,
                         Err(ParseError::Dispatch {

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -246,17 +246,17 @@ async fn check_discrepancy(
     msg: &Message,
     config: &Configuration,
     options: &impl CommonOptions,
-) -> Result<(), DispatchErrorKind> {
+) -> Result<(), DispatchError> {
     if options.owners_only() && !config.owners.contains(&msg.author.id) {
-        return Err(DispatchErrorKind::OnlyForOwners);
+        return Err(DispatchError::OnlyForOwners);
     }
 
     if options.only_in() == OnlyIn::Dm && !msg.is_private() {
-        return Err(DispatchErrorKind::OnlyForDM);
+        return Err(DispatchError::OnlyForDM);
     }
 
     if (!config.allow_dm || options.only_in() == OnlyIn::Guild) && msg.is_private() {
-        return Err(DispatchErrorKind::OnlyForGuilds);
+        return Err(DispatchError::OnlyForGuilds);
     }
 
     #[cfg(feature = "cache")]
@@ -283,11 +283,11 @@ async fn check_discrepancy(
             if !(perms.contains(*options.required_permissions())
                 || options.owner_privilege() && config.owners.contains(&msg.author.id))
             {
-                return Err(DispatchErrorKind::LackingPermissions(*options.required_permissions()));
+                return Err(DispatchError::LackingPermissions(*options.required_permissions()));
             }
 
             if !perms.administrator() && !has_correct_roles(options, &roles, &member) {
-                return Err(DispatchErrorKind::LackingRole);
+                return Err(DispatchError::LackingRole);
             }
         }
     }
@@ -337,10 +337,10 @@ fn parse_cmd<'a>(
             try_parse(stream, map, config.by_space, |s| to_lowercase(config, s).into_owned());
 
         if config.disabled_commands.contains(&n) {
-            return Err(ParseError::Dispatch(DispatchError::new(
-                DispatchErrorKind::CommandDisabled(n.clone()),
-                n,
-            )));
+            return Err(ParseError::Dispatch {
+                error: DispatchError::CommandDisabled,
+                command_name: n,
+            });
         }
 
         if let Some((cmd, map)) = r {
@@ -350,9 +350,12 @@ fn parse_cmd<'a>(
                 stream.take_while_char(|c| c.is_whitespace());
             }
 
-            check_discrepancy(ctx, msg, config, &cmd.options)
-                .await
-                .map_err(|e| DispatchError::new(e, n))?;
+            check_discrepancy(ctx, msg, config, &cmd.options).await.map_err(|e| {
+                ParseError::Dispatch {
+                    error: e,
+                    command_name: n,
+                }
+            })?;
 
             if map.is_empty() {
                 return Ok(cmd);
@@ -386,9 +389,12 @@ fn parse_group<'a>(
                 stream.take_while_char(|c| c.is_whitespace());
             }
 
-            check_discrepancy(ctx, msg, config, &group.options)
-                .await
-                .map_err(|e| DispatchError::new(e, n))?;
+            check_discrepancy(ctx, msg, config, &group.options).await.map_err(|e| {
+                ParseError::Dispatch {
+                    error: e,
+                    command_name: n,
+                }
+            })?;
 
             if map.is_empty() {
                 return Ok((group, commands));
@@ -446,14 +452,7 @@ async fn handle_group<'a>(
 #[derive(Debug)]
 pub enum ParseError {
     UnrecognisedCommand(Option<String>),
-    Dispatch(DispatchError),
-}
-
-impl From<DispatchError> for ParseError {
-    #[inline]
-    fn from(err: DispatchError) -> Self {
-        ParseError::Dispatch(err)
-    }
+    Dispatch { error: DispatchError, command_name: String },
 }
 
 fn is_unrecognised<T>(res: &Result<T, ParseError>) -> bool {
@@ -519,25 +518,33 @@ pub async fn command(
                         }) => Some(command.options.names.get(0).copied().unwrap_or("<unknown>")),
                         Ok(Invoke::Help(name)) => Some(name), // is this correct?
                         Err(ParseError::UnrecognisedCommand(_)) => None,
-                        Err(ParseError::Dispatch(error)) => Some(error.command_name()),
+                        Err(ParseError::Dispatch {
+                            command_name, ..
+                        }) => Some(command_name),
                     }
                 }
 
                 let res = handle_group(stream, ctx, msg, config, subgroups).await;
 
                 if let Some(command_name) = command_name_if_recognised(&res) {
-                    check_discrepancy(ctx, msg, config, &group.options)
-                        .await
-                        .map_err(|e| DispatchError::new(e, command_name.to_owned()))?;
+                    check_discrepancy(ctx, msg, config, &group.options).await.map_err(|e| {
+                        ParseError::Dispatch {
+                            error: e,
+                            command_name: command_name.to_owned(),
+                        }
+                    })?;
                     return res;
                 }
 
                 let res = handle_command(stream, ctx, msg, config, commands, group).await;
 
                 if let Some(command_name) = command_name_if_recognised(&res) {
-                    check_discrepancy(ctx, msg, config, &group.options)
-                        .await
-                        .map_err(|e| DispatchError::new(e, command_name.to_owned()))?;
+                    check_discrepancy(ctx, msg, config, &group.options).await.map_err(|e| {
+                        ParseError::Dispatch {
+                            error: e,
+                            command_name: command_name.to_owned(),
+                        }
+                    })?;
                     return res;
                 }
 


### PR DESCRIPTION
Implements #876. The dispatch error hook now receives a fourth parameter with the command name.

This is a breaking change so the PR is based on the "next" branch.

I tested this by creating a little test bot that triggers almost all possible dispatch error conditions: https://pastebin.com/KNNRM1K1

Question: is that way of getting the command name correct? I found that part of the code a bit confusing https://github.com/kangalioo/serenity/blob/c82c3031f09a2207c1ffd5e42d95bc3543015edf/src/framework/standard/parse/mod.rs#L514-L549