### PR TITLE
Remove unused structure in the framework

### DIFF
--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -34,12 +34,6 @@ impl UnitRatelimit {
     }
 }
 
-#[derive(Default)]
-pub(crate) struct UnitRatelimitTimes {
-    pub last_time: Option<Instant>,
-    pub set_time: Option<Instant>,
-}
-
 /// A bucket offers fine-grained control over the execution of commands.
 pub(crate) enum Bucket {
     /// The bucket will collect tickets for every invocation of a command.


### PR DESCRIPTION
## Description

This removes a structure in the buckets portion of the framework that is seemingly nowhere used, and thus serves no purpose.

## Type of Change

This removes unnecessary code in the framework.

## How Has This Been Tested?

This has been tested by verifying that no code is broken upon removal of this structure, which it hasn't.