### PR TITLE
Add audit log reason support to Http

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -334,11 +334,13 @@ impl Http {
         user_id: u64,
         delete_message_days: u8,
         reason: &str,
-        audit_log_reason: Option<&str>,
     ) -> Result<()> {
+        // Audit log reason and normal ban reason are mutually exclusive so we don't need the audit
+        // log reason parameter here
+
         self.wind(204, Request {
             body: None,
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::GuildBanUser {
                 delete_message_days: Some(delete_message_days),
                 reason: Some(&utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string()),
@@ -775,14 +777,10 @@ impl Http {
     }
 
     /// Deletes a private channel or a channel in a guild.
-    pub async fn delete_channel(
-        &self,
-        channel_id: u64,
-        audit_log_reason: Option<&str>,
-    ) -> Result<Channel> {
+    pub async fn delete_channel(&self, channel_id: u64) -> Result<Channel> {
         self.fire(Request {
             body: None,
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::DeleteChannel {
                 channel_id,
             },
@@ -791,15 +789,10 @@ impl Http {
     }
 
     /// Deletes an emoji from a server.
-    pub async fn delete_emoji(
-        &self,
-        guild_id: u64,
-        emoji_id: u64,
-        audit_log_reason: Option<&str>,
-    ) -> Result<()> {
+    pub async fn delete_emoji(&self, guild_id: u64, emoji_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::DeleteEmoji {
                 guild_id,
                 emoji_id,
@@ -876,15 +869,10 @@ impl Http {
     }
 
     /// Removes an integration from a guild.
-    pub async fn delete_guild_integration(
-        &self,
-        guild_id: u64,
-        integration_id: u64,
-        audit_log_reason: Option<&str>,
-    ) -> Result<()> {
+    pub async fn delete_guild_integration(&self, guild_id: u64, integration_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::DeleteGuildIntegration {
                 guild_id,
                 integration_id,
@@ -894,14 +882,10 @@ impl Http {
     }
 
     /// Deletes an invite by code.
-    pub async fn delete_invite(
-        &self,
-        code: &str,
-        audit_log_reason: Option<&str>,
-    ) -> Result<Invite> {
+    pub async fn delete_invite(&self, code: &str) -> Result<Invite> {
         self.fire(Request {
             body: None,
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::DeleteInvite {
                 code,
             },
@@ -911,15 +895,10 @@ impl Http {
 
     /// Deletes a message if created by us or we have
     /// specific permissions.
-    pub async fn delete_message(
-        &self,
-        channel_id: u64,
-        message_id: u64,
-        audit_log_reason: Option<&str>,
-    ) -> Result<()> {
+    pub async fn delete_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::DeleteMessage {
                 channel_id,
                 message_id,
@@ -929,15 +908,10 @@ impl Http {
     }
 
     /// Deletes a bunch of messages, only works for bots.
-    pub async fn delete_messages(
-        &self,
-        channel_id: u64,
-        map: &Value,
-        audit_log_reason: Option<&str>,
-    ) -> Result<()> {
+    pub async fn delete_messages(&self, channel_id: u64, map: &Value) -> Result<()> {
         self.wind(204, Request {
             body: Some(map.to_string().as_bytes()),
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::DeleteMessages {
                 channel_id,
             },
@@ -1051,15 +1025,10 @@ impl Http {
     }
 
     /// Deletes a role from a server. Can't remove the default everyone role.
-    pub async fn delete_role(
-        &self,
-        guild_id: u64,
-        role_id: u64,
-        audit_log_reason: Option<&str>,
-    ) -> Result<()> {
+    pub async fn delete_role(&self, guild_id: u64, role_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::DeleteRole {
                 guild_id,
                 role_id,
@@ -1089,14 +1058,10 @@ impl Http {
     ///       Ok(())
     /// # }
     /// ```
-    pub async fn delete_webhook(
-        &self,
-        webhook_id: u64,
-        audit_log_reason: Option<&str>,
-    ) -> Result<()> {
+    pub async fn delete_webhook(&self, webhook_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
-            headers: audit_log_reason.map(reason_into_header),
+            headers: None,
             route: RouteInfo::DeleteWebhook {
                 webhook_id,
             },

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1054,7 +1054,7 @@ impl Http {
     /// // must have set the token first.
     /// let http = Http::default();
     ///
-    /// http.delete_webhook(245037420704169985, None).await?;
+    /// http.delete_webhook(245037420704169985).await?;
     ///       Ok(())
     /// # }
     /// ```

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -133,7 +133,7 @@ impl ChannelCategory {
         f(&mut edit_channel);
         let map = serenity_utils::hashmap_to_json_map(edit_channel.0);
 
-        cache_http.http().edit_channel(self.id.0, &map).await.map(|channel| {
+        cache_http.http().edit_channel(self.id.0, &map, None).await.map(|channel| {
             let GuildChannel {
                 id,
                 guild_id,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -88,7 +88,7 @@ impl ChannelId {
 
         let map = utils::hashmap_to_json_map(invite.0);
 
-        http.as_ref().create_invite(self.0, &map).await
+        http.as_ref().create_invite(self.0, &map, None).await
     }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a
@@ -159,7 +159,7 @@ impl ChannelId {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
     pub async fn delete(self, http: impl AsRef<Http>) -> Result<Channel> {
-        http.as_ref().delete_channel(self.0).await
+        http.as_ref().delete_channel(self.0, None).await
     }
 
     /// Deletes a [`Message`] given its Id.
@@ -181,7 +181,7 @@ impl ChannelId {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        http.as_ref().delete_message(self.0, message_id.into().0).await
+        http.as_ref().delete_message(self.0, message_id.into().0, None).await
     }
 
     /// Deletes all messages by Ids from the given vector in the given channel.
@@ -221,7 +221,7 @@ impl ChannelId {
         } else {
             let map = json!({ "messages": ids });
 
-            http.as_ref().delete_messages(self.0, &map).await
+            http.as_ref().delete_messages(self.0, &map, None).await
         }
     }
 
@@ -336,7 +336,7 @@ impl ChannelId {
 
         let map = utils::hashmap_to_json_map(channel.0);
 
-        http.as_ref().edit_channel(self.0, &map).await
+        http.as_ref().edit_channel(self.0, &map, None).await
     }
 
     /// Edits a [`Message`] in the channel given its Id.
@@ -547,7 +547,7 @@ impl ChannelId {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
     pub async fn pin(self, http: impl AsRef<Http>, message_id: impl Into<MessageId>) -> Result<()> {
-        http.as_ref().pin_message(self.0, message_id.into().0).await
+        http.as_ref().pin_message(self.0, message_id.into().0, None).await
     }
 
     /// Crossposts a [`Message`].
@@ -842,7 +842,7 @@ impl ChannelId {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        http.as_ref().unpin_message(self.0, message_id.into().0).await
+        http.as_ref().unpin_message(self.0, message_id.into().0, None).await
     }
 
     /// Retrieves the channel's webhooks.
@@ -873,7 +873,7 @@ impl ChannelId {
             "name": name.to_string(),
         });
 
-        http.as_ref().create_webhook(self.0, &map).await
+        http.as_ref().create_webhook(self.0, &map, None).await
     }
 
     /// Creates a webhook with a name and an avatar.
@@ -928,7 +928,7 @@ impl ChannelId {
             "avatar": avatar
         });
 
-        http.as_ref().create_webhook(self.0, &map).await
+        http.as_ref().create_webhook(self.0, &map, None).await
     }
 
     /// Returns a future that will await one message sent in this channel.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -159,7 +159,7 @@ impl ChannelId {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
     pub async fn delete(self, http: impl AsRef<Http>) -> Result<Channel> {
-        http.as_ref().delete_channel(self.0, None).await
+        http.as_ref().delete_channel(self.0).await
     }
 
     /// Deletes a [`Message`] given its Id.
@@ -181,7 +181,7 @@ impl ChannelId {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        http.as_ref().delete_message(self.0, message_id.into().0, None).await
+        http.as_ref().delete_message(self.0, message_id.into().0).await
     }
 
     /// Deletes all messages by Ids from the given vector in the given channel.
@@ -221,7 +221,7 @@ impl ChannelId {
         } else {
             let map = json!({ "messages": ids });
 
-            http.as_ref().delete_messages(self.0, &map, None).await
+            http.as_ref().delete_messages(self.0, &map).await
         }
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -420,7 +420,7 @@ impl GuildChannel {
         f(&mut edit_channel);
         let edited = serenity_utils::hashmap_to_json_map(edit_channel.0);
 
-        *self = cache_http.http().edit_channel(self.id.0, &edited).await?;
+        *self = cache_http.http().edit_channel(self.id.0, &edited, None).await?;
 
         Ok(())
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -842,7 +842,7 @@ impl Message {
             }
         }
 
-        cache_http.http().unpin_message(self.channel_id.0, self.id.0).await
+        cache_http.http().unpin_message(self.channel_id.0, self.id.0, None).await
     }
 
     /// Tries to return author's nickname in the current channel's guild.

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -102,7 +102,7 @@ impl Emoji {
     pub async fn delete<T: AsRef<Cache> + AsRef<Http>>(&self, cache_http: T) -> Result<()> {
         match self.find_guild_id(&cache_http).await {
             Some(guild_id) => {
-                AsRef::<Http>::as_ref(&cache_http).delete_emoji(guild_id.0, self.id.0).await
+                AsRef::<Http>::as_ref(&cache_http).delete_emoji(guild_id.0, self.id.0, None).await
             },
             None => Err(Error::Model(ModelError::ItemMissing)),
         }
@@ -132,7 +132,7 @@ impl Emoji {
                 });
 
                 *self = AsRef::<Http>::as_ref(&cache_http)
-                    .edit_emoji(guild_id.0, self.id.0, &map)
+                    .edit_emoji(guild_id.0, self.id.0, &map, None)
                     .await?;
 
                 Ok(())

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -102,7 +102,7 @@ impl Emoji {
     pub async fn delete<T: AsRef<Cache> + AsRef<Http>>(&self, cache_http: T) -> Result<()> {
         match self.find_guild_id(&cache_http).await {
             Some(guild_id) => {
-                AsRef::<Http>::as_ref(&cache_http).delete_emoji(guild_id.0, self.id.0, None).await
+                AsRef::<Http>::as_ref(&cache_http).delete_emoji(guild_id.0, self.id.0).await
             },
             None => Err(Error::Model(ModelError::ItemMissing)),
         }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -107,7 +107,7 @@ impl GuildId {
             return Err(Error::ExceededLimit(reason.to_string(), 512));
         }
 
-        http.as_ref().ban_user(self.0, user.0, dmd, reason).await
+        http.as_ref().ban_user(self.0, user.0, dmd, reason, None).await
     }
 
     /// Gets a list of the guild's bans.
@@ -210,7 +210,7 @@ impl GuildId {
 
         let map = utils::hashmap_to_json_map(builder.0);
 
-        http.as_ref().create_channel(self.0, &map).await
+        http.as_ref().create_channel(self.0, &map, None).await
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.
@@ -245,7 +245,7 @@ impl GuildId {
             "image": image,
         });
 
-        http.as_ref().create_emoji(self.0, &map).await
+        http.as_ref().create_emoji(self.0, &map, None).await
     }
 
     /// Creates an integration for the guild.
@@ -270,7 +270,7 @@ impl GuildId {
             "type": kind,
         });
 
-        http.as_ref().create_guild_integration(self.0, integration_id.0, &map).await
+        http.as_ref().create_guild_integration(self.0, integration_id.0, &map, None).await
     }
 
     /// Creates a new role in the guild with the data set, if any.
@@ -294,7 +294,7 @@ impl GuildId {
         f(&mut edit_role);
         let map = utils::hashmap_to_json_map(edit_role.0);
 
-        let role = http.as_ref().create_role(self.0, &map).await?;
+        let role = http.as_ref().create_role(self.0, &map, None).await?;
 
         if let Some(position) = map.get("position").and_then(Value::as_u64) {
             self.edit_role_position(&http, role.id, position).await?;
@@ -334,7 +334,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         emoji_id: impl Into<EmojiId>,
     ) -> Result<()> {
-        http.as_ref().delete_emoji(self.0, emoji_id.into().0).await
+        http.as_ref().delete_emoji(self.0, emoji_id.into().0, None).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -353,7 +353,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        http.as_ref().delete_guild_integration(self.0, integration_id.into().0).await
+        http.as_ref().delete_guild_integration(self.0, integration_id.into().0, None).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -375,7 +375,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
     ) -> Result<()> {
-        http.as_ref().delete_role(self.0, role_id.into().0).await
+        http.as_ref().delete_role(self.0, role_id.into().0, None).await
     }
 
     /// Edits the current guild with new data where specified.
@@ -400,7 +400,7 @@ impl GuildId {
         f(&mut edit_guild);
         let map = utils::hashmap_to_json_map(edit_guild.0);
 
-        http.as_ref().edit_guild(self.0, &map).await
+        http.as_ref().edit_guild(self.0, &map, None).await
     }
 
     /// Edits an [`Emoji`]'s name in the guild.
@@ -427,7 +427,7 @@ impl GuildId {
             "name": name,
         });
 
-        http.as_ref().edit_emoji(self.0, emoji_id.into().0, &map).await
+        http.as_ref().edit_emoji(self.0, emoji_id.into().0, &map, None).await
     }
 
     /// Edits the properties of member of the guild, such as muting or
@@ -463,7 +463,7 @@ impl GuildId {
         f(&mut edit_member);
         let map = utils::hashmap_to_json_map(edit_member.0);
 
-        http.as_ref().edit_member(self.0, user_id.into().0, &map).await
+        http.as_ref().edit_member(self.0, user_id.into().0, &map, None).await
     }
 
     /// Edits the current user's nickname for the guild.
@@ -521,7 +521,7 @@ impl GuildId {
         f(&mut edit_role);
         let map = utils::hashmap_to_json_map(edit_role.0);
 
-        http.as_ref().edit_role(self.0, role_id.into().0, &map).await
+        http.as_ref().edit_role(self.0, role_id.into().0, &map, None).await
     }
 
     /// Edits the order of [`Role`]s
@@ -549,7 +549,7 @@ impl GuildId {
         role_id: impl Into<RoleId>,
         position: u64,
     ) -> Result<Vec<Role>> {
-        http.as_ref().edit_role_position(self.0, role_id.into().0, position).await
+        http.as_ref().edit_role_position(self.0, role_id.into().0, position, None).await
     }
 
     /// Edits the [`GuildWelcomeScreen`].
@@ -741,7 +741,7 @@ impl GuildId {
         user_id: impl Into<UserId>,
         reason: &str,
     ) -> Result<()> {
-        http.as_ref().kick_member_with_reason(self.0, user_id.into().0, reason).await
+        http.as_ref().kick_member_with_reason(self.0, user_id.into().0, reason, None).await
     }
 
     /// Leaves the guild.
@@ -869,7 +869,7 @@ impl GuildId {
         let mut map = JsonMap::new();
         map.insert("channel_id".to_string(), from_number(channel_id.into().0));
 
-        http.as_ref().edit_member(self.0, user_id.into().0, &map).await
+        http.as_ref().edit_member(self.0, user_id.into().0, &map, None).await
     }
 
     /// Returns the name of whatever guild this id holds.
@@ -897,7 +897,7 @@ impl GuildId {
     ) -> Result<Member> {
         let mut map = JsonMap::new();
         map.insert("channel_id".to_string(), NULL);
-        http.as_ref().edit_member(self.0, user_id.into().0, &map).await
+        http.as_ref().edit_member(self.0, user_id.into().0, &map, None).await
     }
 
     /// Gets the number of [`Member`]s that would be pruned with the given
@@ -1028,11 +1028,7 @@ impl GuildId {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn start_prune(self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
-        let map = json!({
-            "days": days,
-        });
-
-        http.as_ref().start_guild_prune(self.0, &map).await
+        http.as_ref().start_guild_prune(self.0, days as u64, None).await
     }
 
     /// Unbans a [`User`] from the guild.
@@ -1046,7 +1042,7 @@ impl GuildId {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn unban(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        http.as_ref().remove_ban(self.0, user_id.into().0).await
+        http.as_ref().remove_ban(self.0, user_id.into().0, None).await
     }
 
     /// Retrieve's the guild's vanity URL.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -107,7 +107,7 @@ impl GuildId {
             return Err(Error::ExceededLimit(reason.to_string(), 512));
         }
 
-        http.as_ref().ban_user(self.0, user.0, dmd, reason, None).await
+        http.as_ref().ban_user(self.0, user.0, dmd, reason).await
     }
 
     /// Gets a list of the guild's bans.
@@ -334,7 +334,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         emoji_id: impl Into<EmojiId>,
     ) -> Result<()> {
-        http.as_ref().delete_emoji(self.0, emoji_id.into().0, None).await
+        http.as_ref().delete_emoji(self.0, emoji_id.into().0).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -353,7 +353,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        http.as_ref().delete_guild_integration(self.0, integration_id.into().0, None).await
+        http.as_ref().delete_guild_integration(self.0, integration_id.into().0).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -375,7 +375,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
     ) -> Result<()> {
-        http.as_ref().delete_role(self.0, role_id.into().0, None).await
+        http.as_ref().delete_role(self.0, role_id.into().0).await
     }
 
     /// Edits the current guild with new data where specified.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -83,7 +83,8 @@ impl Member {
             return Ok(());
         }
 
-        match http.as_ref().add_member_role(self.guild_id.0, self.user.id.0, role_id.0).await {
+        match http.as_ref().add_member_role(self.guild_id.0, self.user.id.0, role_id.0, None).await
+        {
             Ok(()) => {
                 self.roles.push(role_id);
 
@@ -115,7 +116,7 @@ impl Member {
         builder.roles(&self.roles);
         let map = utils::hashmap_to_json_map(builder.0);
 
-        match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map).await {
+        match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await {
             Ok(member) => Ok(member.roles),
             Err(why) => {
                 self.roles.retain(|r| !role_ids.contains(r));
@@ -227,7 +228,7 @@ impl Member {
         f(&mut edit_member);
         let map = utils::hashmap_to_json_map(edit_member.0);
 
-        http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map).await
+        http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await
     }
 
     /// Retrieves the ID and position of the member's highest role in the
@@ -435,7 +436,11 @@ impl Member {
             return Ok(());
         }
 
-        match http.as_ref().remove_member_role(self.guild_id.0, self.user.id.0, role_id.0).await {
+        match http
+            .as_ref()
+            .remove_member_role(self.guild_id.0, self.user.id.0, role_id.0, None)
+            .await
+        {
             Ok(()) => {
                 self.roles.retain(|r| r.0 != role_id.0);
 
@@ -467,7 +472,7 @@ impl Member {
         builder.roles(&self.roles);
         let map = utils::hashmap_to_json_map(builder.0);
 
-        match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map).await {
+        match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await {
             Ok(member) => Ok(member.roles),
             Err(why) => {
                 self.roles.extend_from_slice(role_ids);
@@ -508,7 +513,7 @@ impl Member {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn unban(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().remove_ban(self.guild_id.0, self.user.id.0).await
+        http.as_ref().remove_ban(self.guild_id.0, self.user.id.0, None).await
     }
 }
 

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -92,7 +92,7 @@ impl Role {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
     pub async fn delete(&mut self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_role(self.guild_id.0, self.id.0).await
+        http.as_ref().delete_role(self.guild_id.0, self.id.0, None).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -92,7 +92,7 @@ impl Role {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
     pub async fn delete(&mut self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_role(self.guild_id.0, self.id.0, None).await
+        http.as_ref().delete_role(self.guild_id.0, self.id.0).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -123,7 +123,7 @@ impl Invite {
             }
         }
 
-        cache_http.http().as_ref().delete_invite(&self.code, None).await
+        cache_http.http().as_ref().delete_invite(&self.code).await
     }
 
     /// Gets the information about an invite.
@@ -323,7 +323,7 @@ impl RichInvite {
             }
         }
 
-        cache_http.http().as_ref().delete_invite(&self.code, None).await
+        cache_http.http().as_ref().delete_invite(&self.code).await
     }
 
     /// Returns a URL to use for the invite.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -90,7 +90,7 @@ impl Invite {
 
         let map = utils::hashmap_to_json_map(f(CreateInvite::default()).0);
 
-        cache_http.http().create_invite(channel_id.0, &map).await
+        cache_http.http().create_invite(channel_id.0, &map, None).await
     }
 
     /// Deletes the invite.
@@ -123,7 +123,7 @@ impl Invite {
             }
         }
 
-        cache_http.http().as_ref().delete_invite(&self.code).await
+        cache_http.http().as_ref().delete_invite(&self.code, None).await
     }
 
     /// Gets the information about an invite.
@@ -323,7 +323,7 @@ impl RichInvite {
             }
         }
 
-        cache_http.http().as_ref().delete_invite(&self.code).await
+        cache_http.http().as_ref().delete_invite(&self.code, None).await
     }
 
     /// Returns a URL to use for the invite.


### PR DESCRIPTION
A second attempt at #296.

This PR only adds audit log reason support to the Http client. Model methods like `Member::unban` or `GuildChannel::edit` still cannot be provided with an audit log reason. This was done because:
- it's unclear how the API for audit log reasons in the model type methods should be designed as to not be a hassle to 90% of use cases where no audit log reason is provided
  - add a `Option<&str>` parameter to all the methods? That's a big breaking change and requires users to litter `None` function arguments all over the place
- adding support to the Http client is the most important thing to open the door for audit log reason support; model types are just extra convenience that can be added later

I tested this by making a [small test bot](https://pastebin.com/E6UiwF11) that invokes roughly half of all modified Http functions. The audit log in the server settings shows the correct reason strings. I couldn't test the other half of Http functions because I couldn't really figure out how to invoke them easily.

Unfortunately, Discord apparently doesn't properly document which HTTP routes support an audit log reason and which don't. I was using [this table](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events) as a guideline, but probably there are some API routes where I falsely added or falsely omitted audit log support.