### PR TITLE
Fix embed in interaction follow-up messages

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -84,8 +84,8 @@ impl CreateInteractionResponseData {
         self.set_embed(embed)
     }
 
-    /// Set an embed for the message.
-    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
+    /// Adds an embed to the message.
+    pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
@@ -95,6 +95,20 @@ impl CreateInteractionResponseData {
             embeds.push(embed);
         }
 
+        self
+    }
+
+    /// Sets a list of embeds to include in the message.
+    ///
+    /// Calling this multiple times will overwrite the embed list.
+    /// To append embeds, call [`Self::add_embed`] instead.
+    pub fn embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
+        let embeds = embeds
+            .into_iter()
+            .map(|embed| utils::hashmap_to_json_map(embed.0).into())
+            .collect();
+        
+        self.0.insert("embeds", Value::Array(embeds));
         self
     }
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -75,7 +75,7 @@ impl CreateInteractionResponseData {
     }
 
     /// Create an embed for the message.
-    pub fn embed<F>(&mut self, f: F) -> &mut Self
+    pub fn create_embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -81,7 +81,7 @@ impl CreateInteractionResponseData {
     {
         let mut embed = CreateEmbed::default();
         f(&mut embed);
-        self.set_embed(embed)
+        self.add_embed(embed)
     }
 
     /// Adds an embed to the message.

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -103,11 +103,9 @@ impl CreateInteractionResponseData {
     /// Calling this multiple times will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
     pub fn embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
-        let embeds = embeds
-            .into_iter()
-            .map(|embed| utils::hashmap_to_json_map(embed.0).into())
-            .collect();
-        
+        let embeds =
+            embeds.into_iter().map(|embed| utils::hashmap_to_json_map(embed.0).into()).collect();
+
         self.0.insert("embeds", Value::Array(embeds));
         self
     }

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -91,15 +91,21 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     {
         let mut embed = CreateEmbed::default();
         f(&mut embed);
-        self.set_embed(embed)
+        self.add_embed(embed)
     }
 
-    /// Set an embed for the message.
-    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
+    /// Adds an embed to the message.
+    pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
-        self.0.insert("embed", embed);
+        self.0
+            .entry("embeds")
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+            .unwrap()
+            .push(embed);
+
         self
     }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -85,7 +85,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Create an embed for the message.
-    pub fn embed<F>(&mut self, f: F) -> &mut Self
+    pub fn create_embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -108,6 +108,20 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
 
         self
     }
+    
+    /// Sets a list of embeds to include in the message.
+    ///
+    /// Calling this multiple times will overwrite the embed list.
+    /// To append embeds, call [`Self::add_embed`] instead.
+    pub fn embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
+        let embeds = embeds
+            .into_iter()
+            .map(|embed| utils::hashmap_to_json_map(embed.0).into())
+            .collect();
+        
+        self.0.insert("embeds", Value::Array(embeds));
+        self
+    }
 
     /// Set the allowed mentions for the message.
     pub fn allowed_mentions<F>(&mut self, f: F) -> &mut Self

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -108,17 +108,15 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
 
         self
     }
-    
+
     /// Sets a list of embeds to include in the message.
     ///
     /// Calling this multiple times will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
     pub fn embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
-        let embeds = embeds
-            .into_iter()
-            .map(|embed| utils::hashmap_to_json_map(embed.0).into())
-            .collect();
-        
+        let embeds =
+            embeds.into_iter().map(|embed| utils::hashmap_to_json_map(embed.0).into()).collect();
+
         self.0.insert("embeds", Value::Array(embeds));
         self
     }


### PR DESCRIPTION
Currently, interaction follow-up messages don't work at all. Discord's API for follow-up messages expects a field called `embeds` which can be "array of up to 10 embed objects", however the current version of the library sends a field called `embed` which is a single, optional embed object.

This PR changes the follow-up message builder to support multiple embeds, also fixing how the embeds are sent to Discord in the process. Additionally, `CreateInteractionResponseFollowup::set_embed` is being renamed to `add_embed` to reflect the change.

~~Since this is a breaking change, I'm targeting `next`. Let me know if I should change `add_embed` back to `set_embed` and target `current` instead to fix it on the current version of the library.~~ Targeting 'current' now since it's locked behind the `unstable_discord_api` feature anyway.

References:
 - [Create Followup Message](https://discord.com/developers/docs/interactions/slash-commands#create-followup-message)
 - [Execute Webhook](https://discord.com/developers/docs/resources/webhook#execute-webhook) ('Create Followup Message' follows this format)