### PR TITLE
Clarify slash commands implementation

### DIFF
--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use serenity::{
     async_trait,
     client::bridge::gateway::GatewayIntents,
-    model::{gateway::Ready, interactions::{Interaction, InteractionResponseType, ApplicationCommand}},
+    model::{gateway::Ready, interactions::{Interaction, InteractionResponseType, ApplicationCommand, ApplicationCommandOptionType}},
     prelude::*,
 };
 
@@ -24,9 +24,59 @@ impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         println!("{} is connected!", ready.user.name);
 
-        let interactions = ApplicationCommand::get_global_application_commands(&ctx.http).await;
+        let commands = ApplicationCommand::set_global_application_commands(&ctx.http, |commands| {
+            commands
+                .create_application_command(|command| {
+                    command.name("ping").description("A ping command")
+                })
+                .create_application_command(|command| {
+                    command
+                        .name("id")
+                        .description("Get a user id")
+                        .create_option(|option| {
+                            option
+                                .name("id")
+                                .description("The user to lookup")
+                                .kind(ApplicationCommandOptionType::User)
+                                .required(false)
+                        })
+                })
+                .create_application_command(|command| {
+                    command
+                        .name("welcome")
+                        .description("Welcome a user")
+                        .create_option(|option| {
+                            option
+                                .name("user")
+                                .description("The user to welcome")
+                                .kind(ApplicationCommandOptionType::User)
+                                .required(true)
+                        })
+                        .create_option(|option| {
+                            option
+                                .name("message")
+                                .description("The message to send")
+                                .kind(ApplicationCommandOptionType::String)
+                                .required(true)
+                                .add_string_choice(
+                                    "Welcome to our cool server! Ask me if you need help",
+                                    "pizza"
+                                )
+                                .add_string_choice("Hey, do you want a coffee?", "coffee")
+                                .add_string_choice(
+                                    "Welcome to the club, you're now a good person. Well, I hope.",
+                                    "club"
+                                )
+                                .add_string_choice(
+                                    "I hope that you brought a controller to play together!",
+                                    "game"
+                                )
+                        })
+                })
+        })
+            .await;
 
-        println!("I have the following global slash command(s): {:?}", interactions);
+        println!("I have now the following global slash commands: {:#?}", commands);
     }
 }
 

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -3,7 +3,17 @@ use std::env;
 use serenity::{
     async_trait,
     client::bridge::gateway::GatewayIntents,
-    model::{gateway::Ready, interactions::{Interaction, InteractionResponseType, ApplicationCommand, ApplicationCommandOptionType}},
+    model::{
+        gateway::Ready,
+        interactions::{
+            ApplicationCommand,
+            ApplicationCommandInteractionDataOptionValue,
+            ApplicationCommandOptionType,
+            Interaction,
+            InteractionResponseType,
+            InteractionType,
+        },
+    },
     prelude::*,
 };
 
@@ -26,14 +36,14 @@ impl EventHandler for Handler {
                             .expect("Expected user object");
 
                         if let ApplicationCommandInteractionDataOptionValue::User(user, _member) =
-                        options
+                            options
                         {
                             format!("{}'s id is {}", user.tag(), user.id)
                         } else {
                             "Please provide a valid user".to_string()
                         }
                     },
-                    _ => "not implemented :(".to_string()
+                    _ => "not implemented :(".to_string(),
                 };
 
                 if let Err(why) = interaction
@@ -59,16 +69,13 @@ impl EventHandler for Handler {
                     command.name("ping").description("A ping command")
                 })
                 .create_application_command(|command| {
-                    command
-                        .name("id")
-                        .description("Get a user id")
-                        .create_option(|option| {
-                            option
-                                .name("id")
-                                .description("The user to lookup")
-                                .kind(ApplicationCommandOptionType::User)
-                                .required(true)
-                        })
+                    command.name("id").description("Get a user id").create_option(|option| {
+                        option
+                            .name("id")
+                            .description("The user to lookup")
+                            .kind(ApplicationCommandOptionType::User)
+                            .required(true)
+                    })
                 })
                 .create_application_command(|command| {
                     command
@@ -89,21 +96,21 @@ impl EventHandler for Handler {
                                 .required(true)
                                 .add_string_choice(
                                     "Welcome to our cool server! Ask me if you need help",
-                                    "pizza"
+                                    "pizza",
                                 )
                                 .add_string_choice("Hey, do you want a coffee?", "coffee")
                                 .add_string_choice(
                                     "Welcome to the club, you're now a good person. Well, I hope.",
-                                    "club"
+                                    "club",
                                 )
                                 .add_string_choice(
                                     "I hope that you brought a controller to play together!",
-                                    "game"
+                                    "game",
                                 )
                         })
                 })
         })
-            .await;
+        .await;
 
         println!("I have now the following global slash commands: {:#?}", commands);
     }
@@ -115,8 +122,10 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
     // The Application Id is usually the Bot User Id.
-    let application_id: u64 =
-        env::var("APPLICATION_ID").expect("Expected an application id in the environment").parse().expect("application id is not a valid id");
+    let application_id: u64 = env::var("APPLICATION_ID")
+        .expect("Expected an application id in the environment")
+        .parse()
+        .expect("application id is not a valid id");
 
     // Build our client.
     let mut client = Client::builder(token)

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -112,7 +112,7 @@ impl EventHandler for Handler {
         })
         .await;
 
-        println!("I have now the following global slash commands: {:#?}", commands);
+        println!("I now have the following global slash commands: {:#?}", commands);
     }
 }
 

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -62,6 +62,7 @@ impl EventHandler for Handler {
                             println!("Cannot respond to slash command: {}", why);
                         }
                     },
+                    _ => {},
                 }
             }
         }

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -121,6 +121,14 @@ impl EventHandler for Handler {
         .await;
 
         println!("I now have the following global slash commands: {:#?}", commands);
+
+        let guild_command = GuildId(123456789)
+            .create_application_command(&ctx.http, |command| {
+                command.name("wonderful_command").description("An amazing command")
+            })
+            .await;
+
+        println!("I created the following guild command: {:#?}", guild_command);
     }
 }
 

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -5,6 +5,7 @@ use serenity::{
     client::bridge::gateway::GatewayIntents,
     model::{
         gateway::Ready,
+        id::GuildId,
         interactions::{
             ApplicationCommand,
             ApplicationCommandInteractionDataOptionValue,

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -10,6 +10,7 @@ use serenity::{
             ApplicationCommandInteractionDataOptionValue,
             ApplicationCommandOptionType,
             Interaction,
+            InteractionData,
             InteractionResponseType,
             InteractionType,
         },
@@ -24,37 +25,43 @@ impl EventHandler for Handler {
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
         if interaction.kind == InteractionType::ApplicationCommand {
             if let Some(data) = interaction.data.as_ref() {
-                let content = match data.name.as_str() {
-                    "ping" => "Hey, I'm alive!".to_string(),
-                    "id" => {
-                        let options = data
-                            .options
-                            .get(0)
-                            .expect("Expected user option")
-                            .resolved
-                            .as_ref()
-                            .expect("Expected user object");
+                match data {
+                    InteractionData::ApplicationCommand(data) => {
+                        let content = match data.name.as_str() {
+                            "ping" => "Hey, I'm alive!".to_string(),
+                            "id" => {
+                                let options = data
+                                    .options
+                                    .get(0)
+                                    .expect("Expected user option")
+                                    .resolved
+                                    .as_ref()
+                                    .expect("Expected user object");
 
-                        if let ApplicationCommandInteractionDataOptionValue::User(user, _member) =
-                            options
+                                if let ApplicationCommandInteractionDataOptionValue::User(
+                                    user,
+                                    _member,
+                                ) = options
+                                {
+                                    format!("{}'s id is {}", user.tag(), user.id)
+                                } else {
+                                    "Please provide a valid user".to_string()
+                                }
+                            },
+                            _ => "not implemented :(".to_string(),
+                        };
+
+                        if let Err(why) = interaction
+                            .create_interaction_response(&ctx.http, |response| {
+                                response
+                                    .kind(InteractionResponseType::ChannelMessageWithSource)
+                                    .interaction_response_data(|message| message.content(content))
+                            })
+                            .await
                         {
-                            format!("{}'s id is {}", user.tag(), user.id)
-                        } else {
-                            "Please provide a valid user".to_string()
+                            println!("Cannot respond to slash command: {}", why);
                         }
                     },
-                    _ => "not implemented :(".to_string(),
-                };
-
-                if let Err(why) = interaction
-                    .create_interaction_response(&ctx.http, |response| {
-                        response
-                            .kind(InteractionResponseType::ChannelMessageWithSource)
-                            .interaction_response_data(|message| message.content(content))
-                    })
-                    .await
-                {
-                    println!("Cannot respond to slash command: {}", why);
                 }
             }
         }

--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -54,7 +54,7 @@ impl CreateApplicationCommandOption {
         self
     }
 
-    /// Interaction commands can optionally have a limited
+    /// Application commands can optionally have a limited
     /// number of integer or string choices.
     ///
     /// **Note**: There can be no more than 10 choices set.
@@ -114,7 +114,7 @@ impl CreateApplicationCommandOption {
 pub struct CreateApplicationCommand(pub HashMap<&'static str, Value>);
 
 impl CreateApplicationCommand {
-    /// Specify the name of the Interaction.
+    /// Specify the name of the application command.
     ///
     /// **Note**: Must be between 1 and 32 characters long,
     /// and cannot start with a space.
@@ -133,7 +133,7 @@ impl CreateApplicationCommand {
         self
     }
 
-    /// Specify the description of the Interaction.
+    /// Specify the description of the application command.
     ///
     /// **Note**: Must be between 1 and 100 characters long.
     pub fn description<D: ToString>(&mut self, description: D) -> &mut Self {
@@ -141,9 +141,9 @@ impl CreateApplicationCommand {
         self
     }
 
-    /// Create an interaction option for the interaction.
+    /// Create an application command option for the application command.
     ///
-    /// **Note**: Interactions can only have up to 10 options.
+    /// **Note**: Application commands can only have up to 10 options.
     pub fn create_option<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateApplicationCommandOption) -> &mut CreateApplicationCommandOption,
@@ -153,9 +153,9 @@ impl CreateApplicationCommand {
         self.add_option(data)
     }
 
-    /// Add an interaction option for the interaction.
+    /// Add an application command option for the application command.
     ///
-    /// **Note**: Interactions can only have up to 10 options.
+    /// **Note**: Application commands can only have up to 10 options.
     pub fn add_option(&mut self, option: CreateApplicationCommandOption) -> &mut Self {
         let new_option = utils::hashmap_to_json_map(option.0);
         let options = self.0.entry("options").or_insert_with(|| Value::Array(Vec::new()));
@@ -165,9 +165,9 @@ impl CreateApplicationCommand {
         self
     }
 
-    /// Sets all the interaction options for the interaction.
+    /// Sets all the application command options for the application command.
     ///
-    /// **Note**: Interactions can only have up to 10 options.
+    /// **Note**: Application commands can only have up to 10 options.
     pub fn set_options(&mut self, options: Vec<CreateApplicationCommandOption>) -> &mut Self {
         let new_options = options
             .into_iter()
@@ -196,8 +196,8 @@ impl CreateApplicationCommands {
     }
 
     /// Adds a new application command.
-    pub fn add_application_command(&mut self, interaction: CreateApplicationCommand) -> &mut Self {
-        let new_data = Value::Object(utils::hashmap_to_json_map(interaction.0));
+    pub fn add_application_command(&mut self, command: CreateApplicationCommand) -> &mut Self {
+        let new_data = Value::Object(utils::hashmap_to_json_map(command.0));
 
         self.0.push(new_data);
 
@@ -207,9 +207,9 @@ impl CreateApplicationCommands {
     /// Sets all the application commands.
     pub fn set_application_commands(
         &mut self,
-        interactions: Vec<CreateApplicationCommand>,
+        commands: Vec<CreateApplicationCommand>,
     ) -> &mut Self {
-        let new_application_command = interactions
+        let new_application_command = commands
             .into_iter()
             .map(|f| Value::Object(utils::hashmap_to_json_map(f.0)))
             .collect::<Vec<Value>>();

--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -83,7 +83,7 @@ impl CreateApplicationCommandPermissions {
         let mut data = CreateApplicationCommandPermissionData::default();
         f(&mut data);
 
-        self.add_permission(data);
+        self.add_permissions(data);
 
         self
     }

--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -73,8 +73,8 @@ impl CreateApplicationCommandPermissions {
         self
     }
 
-    /// Creates permissions(s) for the application command.
-    pub fn create_permission<F>(&mut self, f: F) -> &mut Self
+    /// Creates permissions for the application command.
+    pub fn create_permissions<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(
             &mut CreateApplicationCommandPermissionData,
@@ -88,8 +88,8 @@ impl CreateApplicationCommandPermissions {
         self
     }
 
-    /// Adds permission(s) for the application command.
-    pub fn add_permission(
+    /// Adds permission for the application command.
+    pub fn add_permissions(
         &mut self,
         permission: CreateApplicationCommandPermissionData,
     ) -> &mut Self {
@@ -103,7 +103,7 @@ impl CreateApplicationCommandPermissions {
         self
     }
 
-    /// Sets permission(s) for the application command.
+    /// Sets permissions for the application command.
     pub fn set_permissions(
         &mut self,
         permissions: Vec<CreateApplicationCommandPermissionData>,
@@ -157,7 +157,7 @@ impl CreateApplicationCommandPermissionsData {
         self
     }
 
-    /// Sets a permission for the application command.
+    /// Sets permissions for the application command.
     pub fn set_permissions(
         &mut self,
         permissions: Vec<CreateApplicationCommandPermissionData>,

--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -28,7 +28,7 @@ impl CreateApplicationCommandsPermissions {
         self
     }
 
-    /// Adds a new interaction.
+    /// Adds a new application command.
     pub fn add_application_command(
         &mut self,
         application_command: CreateApplicationCommandPermissions,
@@ -40,7 +40,7 @@ impl CreateApplicationCommandsPermissions {
         self
     }
 
-    /// Sets all the interactions.
+    /// Sets all the application commands.
     pub fn set_application_commands(
         &mut self,
         application_commands: Vec<CreateApplicationCommandPermissions>,
@@ -73,7 +73,7 @@ impl CreateApplicationCommandPermissions {
         self
     }
 
-    /// Creates a new permission for the interaction.
+    /// Creates permissions(s) for the application command.
     pub fn create_permission<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(
@@ -88,7 +88,7 @@ impl CreateApplicationCommandPermissions {
         self
     }
 
-    /// Adds a permission for the interaction.
+    /// Adds permission(s) for the application command.
     pub fn add_permission(
         &mut self,
         permission: CreateApplicationCommandPermissionData,
@@ -103,7 +103,7 @@ impl CreateApplicationCommandPermissions {
         self
     }
 
-    /// Sets all the permissions for the interaction.
+    /// Sets permission(s) for the application command.
     pub fn set_permissions(
         &mut self,
         permissions: Vec<CreateApplicationCommandPermissionData>,
@@ -127,7 +127,7 @@ impl CreateApplicationCommandPermissions {
 pub struct CreateApplicationCommandPermissionsData(pub HashMap<&'static str, Value>);
 
 impl CreateApplicationCommandPermissionsData {
-    /// Creates a permission for the interaction.
+    /// Creates a permission for the application command.
     pub fn create_permission<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(
@@ -142,7 +142,7 @@ impl CreateApplicationCommandPermissionsData {
         self
     }
 
-    /// Adds a permission.
+    /// Adds a permission for the application command.
     pub fn add_permission(
         &mut self,
         permission: CreateApplicationCommandPermissionData,
@@ -157,7 +157,7 @@ impl CreateApplicationCommandPermissionsData {
         self
     }
 
-    /// Sets all the permissions for the interaction.
+    /// Sets a permission for the application command.
     pub fn set_permissions(
         &mut self,
         permissions: Vec<CreateApplicationCommandPermissionData>,
@@ -199,7 +199,12 @@ impl CreateApplicationCommandPermissionData {
         self
     }
 
-    /// Sets the permission.
+    /// Sets the permission for the [`ApplicationCommandPermissionData`].
+    ///
+    /// **Note**: Setting it to `false` will only grey the application command in the
+    /// list, it will not fully hide it to the user.
+    ///
+    /// [`ApplicationCommandPermissionData`]: crate::model::interaction::ApplicationCommandPermissionData
     pub fn permission(&mut self, permission: bool) -> &mut Self {
         self.0.insert("permission", Value::Bool(permission));
         self

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -422,7 +422,8 @@ pub trait EventHandler: Send + Sync {
     ) {
     }
 
-    /// Dispatched when a user used a slash command.
+    /// Dispatched when an interaction is created (e.g a slash command was used
+    /// or a button was clicked).
     ///
     /// Provides the created interaction.
     #[cfg(feature = "unstable_discord_api")]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -88,7 +88,7 @@ impl<'a> HttpBuilder<'a> {
         Self::_new().token(token)
     }
 
-    /// Sets the application_id to use slash commands.
+    /// Sets the application_id to use interactions.
     #[cfg(feature = "unstable_discord_api")]
     pub fn application_id(mut self, application_id: u64) -> Self {
         self.application_id = Some(application_id);
@@ -175,7 +175,7 @@ impl<'a> Future for HttpBuilder<'a> {
             #[cfg(feature = "unstable_discord_api")]
             let application_id = self
                 .application_id
-                .expect("Expected application Id in order to use slash commands");
+                .expect("Expected application Id in order to use interacions features");
 
             let client = self.client.take().unwrap_or_else(|| {
                 let builder = configure_client_backend(Client::builder());

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1698,7 +1698,7 @@ pub enum Event {
     VoiceServerUpdate(VoiceServerUpdateEvent),
     /// A webhook for a [channel][`GuildChannel`] was updated in a [`Guild`].
     WebhookUpdate(WebhookUpdateEvent),
-    /// A user used a slash command.
+    /// An interaction was created.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     InteractionCreate(InteractionCreateEvent),
@@ -2053,7 +2053,7 @@ pub enum EventType {
     ///
     /// This maps to [`WebhookUpdateEvent`].
     WebhookUpdate,
-    /// Indicator that a slash command was received.
+    /// Indicator that an interaction was created.
     ///
     /// This maps to [`InteractionCreateEvent`].
     #[cfg(feature = "unstable_discord_api")]

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1169,13 +1169,10 @@ impl GuildId {
         http.as_ref().create_guild_application_command(self.0, &Value::Object(map)).await
     }
 
-    /// Same as [`create_application_command`], but allows to create more
-    /// than one command per call.
-    ///
-    /// [`create_application_command`]: Self::create_application_command
+    /// Overrides all guild application commands.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub async fn create_application_commands<F>(
+    pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
         f: F,
@@ -1220,13 +1217,10 @@ impl GuildId {
             .await
     }
 
-    /// Same as [`create_application_command_permission`] but allows to create
-    /// more than one permission per call.
-    ///
-    /// [`create_application_command_permission`]: Self::create_application_command_permission
+    /// Overrides all application commands permissions.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub async fn create_application_commands_permissions<F>(
+    pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
         f: F,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -634,13 +634,12 @@ impl Guild {
         self.id.create_application_command(http, f).await
     }
 
-    /// Same as [`create_application_command`], but allows to create more
-    /// than one command per call.
+    /// Overrides all guild application commands.
     ///
     /// [`create_application_command`]: Self::create_application_command
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub async fn create_application_commands<F>(
+    pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
         f: F,
@@ -648,7 +647,7 @@ impl Guild {
     where
         F: FnOnce(&mut CreateApplicationCommands) -> &mut CreateApplicationCommands,
     {
-        self.id.create_application_commands(http, f).await
+        self.id.set_application_commands(http, f).await
     }
 
     /// Creates a guild specific [`ApplicationCommandPermission`].
@@ -672,13 +671,10 @@ impl Guild {
         self.id.create_application_command_permission(http, command_id, f).await
     }
 
-    /// Same as [`create_application_command_permission`] but allows to create
-    /// more than one permission per call.
-    ///
-    /// [`create_application_command_permission`]: Self::create_application_command_permission
+    /// Overrides all application commands permissions.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub async fn create_application_commands_permissions<F>(
+    pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
         f: F,
@@ -688,7 +684,7 @@ impl Guild {
             &mut CreateApplicationCommandsPermissions,
         ) -> &mut CreateApplicationCommandsPermissions,
     {
-        self.id.create_application_commands_permissions(http, f).await
+        self.id.set_application_commands_permissions(http, f).await
     }
 
     /// Get all guild application commands.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -383,13 +383,12 @@ impl PartialGuild {
         self.id.create_application_command(http, f).await
     }
 
-    /// Same as [`create_application_command`], but allows to create more
-    /// than one command per call.
+    /// Overrides all guild application commands.
     ///
     /// [`create_application_command`]: Self::create_application_command
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub async fn create_application_commands<F>(
+    pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
         f: F,
@@ -397,7 +396,7 @@ impl PartialGuild {
     where
         F: FnOnce(&mut CreateApplicationCommands) -> &mut CreateApplicationCommands,
     {
-        self.id.create_application_commands(http, f).await
+        self.id.set_application_commands(http, f).await
     }
 
     /// Creates a guild specific [`ApplicationCommandPermission`].
@@ -427,7 +426,7 @@ impl PartialGuild {
     /// [`create_application_command_permission`]: Self::create_application_command_permission
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
-    pub async fn create_application_commands_permissions<F>(
+    pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
         f: F,
@@ -437,7 +436,7 @@ impl PartialGuild {
             &mut CreateApplicationCommandsPermissions,
         ) -> &mut CreateApplicationCommandsPermissions,
     {
-        self.id.create_application_commands_permissions(http, f).await
+        self.id.set_application_commands_permissions(http, f).await
     }
 
     /// Get all guild application commands.

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -762,13 +762,15 @@ impl ApplicationCommand {
     ///
     /// When a created [`ApplicationCommand`] is used, the [`InteractionCreate`] event will be emitted.
     ///
-    /// **Note**: Global commands may take up to an hour to become available.
+    /// **Note**: Global commands may take up to an hour to be updated in the user slash commands
+    /// list. If an outdated command data is sent by a user, discord will consider it as an error
+    /// and then will instantly update that command.
     ///
     /// As such, it is recommended that guild application commands be used for testing purposes.
     ///
     /// # Examples
     ///
-    /// Create a simple ping command
+    /// Create a simple ping command:
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
@@ -778,15 +780,15 @@ impl ApplicationCommand {
     /// # let http = Arc::new(Http::default());
     /// use serenity::model::{interactions::ApplicationCommand, id::ApplicationId};
     ///
-    /// let _ = ApplicationCommand::create_global_application_command(&http, |a| {
-    ///    a.name("ping")
+    /// let _ = ApplicationCommand::create_global_application_command(&http, |command| {
+    ///    command.name("ping")
     ///     .description("A simple ping command")
     /// })
     /// .await;
     /// # }
     /// ```
     ///
-    /// Create a command that echoes what is inserted
+    /// Create a command that echoes what is inserted:
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
@@ -799,12 +801,12 @@ impl ApplicationCommand {
     ///     id::ApplicationId
     /// };
     ///
-    /// let _ = ApplicationCommand::create_global_application_command(&http, |a| {
-    ///    a.name("echo")
-    ///     .description("What is said is echoed")
-    ///     .create_option(|o| {
-    ///         o.name("to_say")
-    ///          .description("What will be echoed")
+    /// let _ = ApplicationCommand::create_global_application_command(&http, |command| {
+    ///    command.name("echo")
+    ///     .description("Makes the bot send a message")
+    ///     .create_option(|option| {
+    ///         option.name("message")
+    ///          .description("The message to send")
     ///          .kind(ApplicationCommandOptionType::String)
     ///          .required(true)
     ///     })
@@ -838,11 +840,10 @@ impl ApplicationCommand {
         http.as_ref().create_global_application_command(&Value::Object(map)).await
     }
 
-    /// Same as [`create_global_application_command`] but allows
-    /// to create more than one global command per call.
+    /// Overrides all global application commands.
     ///
     /// [`create_global_application_command`]: Self::create_global_application_command
-    pub async fn create_global_application_commands<F>(
+    pub async fn set_global_application_commands<F>(
         http: impl AsRef<Http>,
         f: F,
     ) -> Result<Vec<ApplicationCommand>>

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -19,8 +19,8 @@ use crate::utils;
 
 /// Information about an interaction.
 ///
-/// An interaction is sent when a user invokes a slash command and is the same
-/// for slash commands and other future interaction types.
+/// An interaction is sent when a user invokes a slash command, clicks a button,
+/// or other future interaction types.
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct Interaction {


### PR DESCRIPTION
This PR clarifies the slash commands and interaction implementation by improving the documentation and renames confusing `create(_global)_application_commands(_permissions)` methods to `set(_global)_application_commands(_permissions)`.

This has been tested.