### PR TITLE
Fix allowed_mentions use in Message::_reply

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -726,11 +726,16 @@ impl Message {
         }
 
         self.channel_id
-            .send_message(cache_http.http(), |mut builder| {
+            .send_message(cache_http.http(), |builder| {
                 if let Some(ping_user) = inlined {
-                    builder = builder
-                        .reference_message(self)
-                        .allowed_mentions(|f| f.replied_user(ping_user));
+                    builder.reference_message(self).allowed_mentions(|f| {
+                        f.replied_user(ping_user)
+                            // By providing allowed_mentions, Discord disabled _all_ pings by
+                            // default so we need to re-enable them
+                            .parse(crate::builder::ParseValue::Everyone)
+                            .parse(crate::builder::ParseValue::Users)
+                            .parse(crate::builder::ParseValue::Roles)
+                    });
                 }
 
                 builder.content(content)


### PR DESCRIPTION
Fixes #1236.

To control whether an inline reply pings the original message's author, the `Message::_reply` method (which `reply` and `reply_ping` are based on) uses the allowed_mentions method:

```rust
.allowed_mentions(|f| f.replied_user(ping_user));
```

However, as soon as you add the allowed_mentions attribute to a message, Discord disables _all_ pings by default and you have to re-enable them each manually to return to normal ping behavior. Therefore, this PR changes the above code snippet to:

```rust
.allowed_mentions(|f| {
    f.replied_user(ping_user)
        // By providing allowed_mentions, Discord disabled _all_ pings by
        // default so we need to re-enable them
        .parse(crate::builder::ParseValue::Everyone)
        .parse(crate::builder::ParseValue::Users)
        .parse(crate::builder::ParseValue::Roles)
});
```

I confirmed with a small test bot that `Message::reply_ping` now exhibits the expected behavior (i.e. pings within the message work).