### PR TITLE
Change Presence::user field to handle optional fields

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -596,8 +596,6 @@ impl PresenceUser {
         })
     }
 
-    // TODO: add `to_current_user` and `into_current_user`? (converts to Option<CurrentUser>)
-
     pub(crate) fn update_with_user(&mut self, user: User) {
         self.id = user.id;
         if let Some(avatar) = user.avatar {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -603,10 +603,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user is not in
     /// the guild.
-    pub async fn roles(
-        self,
-        http: impl AsRef<Http>,
-    ) -> Result<HashMap<RoleId, Role>> {
+    pub async fn roles(self, http: impl AsRef<Http>) -> Result<HashMap<RoleId, Role>> {
         let mut roles = HashMap::new();
 
         #[allow(clippy::useless_conversion)]

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,10 +1,8 @@
 use serde::de::Error as DeError;
-
-#[cfg(feature = "cache")]
-use tracing::{error, warn};
-
 #[cfg(feature = "simd-json")]
 use simd_json::StaticNode;
+#[cfg(feature = "cache")]
+use tracing::{error, warn};
 
 #[cfg(feature = "model")]
 use crate::builder::{

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -213,7 +213,7 @@ pub fn deserialize_presences<'de, D: Deserializer<'de>>(
     let mut presences = HashMap::new();
 
     for presence in vec {
-        presences.insert(presence.user_id, presence);
+        presences.insert(presence.user.id, presence);
     }
 
     Ok(presences)


### PR DESCRIPTION
Fixes #1184.

Quoting AcdenisSK from the issue:

> The deserialization of the user object is wrong. It either expects full data for a user object, or just the user id. It doesn't account for some fields missing, which it should.

This problem was fixed by introducing a new struct `PresenceUser` that uses `Option` for all optional fields. I used `CurrentUser` as a base for the `PresenceUser` because the `CurrentUser` struct seems to have all fields that the presence user field carries.

Discord documentation for the presence object: https://discord.com/developers/docs/topics/gateway#presence-update

I'm a bit unsure about the changes to cache, so there may be stupid mistakes in there :sweat_smile:

I tested the presence deserialization and it seems to work (https://pastebin.com/6QKK6kJ1). The cache changes I did not test because I don't know how to test changes to cache like that.