### PR TITLE
Support components (interactions buttons)

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -122,7 +122,27 @@ impl CreateButton {
 
     /// Sets the disabled state for the button
     pub fn emoji(&mut self, emoji: ReactionType) -> &mut Self {
-        self.0.insert("emoji", emoji.as_data().into());
+        let mut map = JsonMap::new();
+
+        match emoji {
+            ReactionType::Unicode(u) => {
+                map.insert("name".to_string(), Value::String(u));
+            },
+            ReactionType::Custom {
+                animated,
+                id,
+                name,
+            } => {
+                map.insert("animated".to_string(), Value::Bool(animated));
+                map.insert("id".to_string(), Value::String(id.to_string()));
+
+                if let Some(name) = name {
+                    map.insert("name".to_string(), Value::String(name));
+                }
+            },
+        };
+
+        self.0.insert("emoji", Value::Object(map));
         self
     }
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -5,12 +5,14 @@ use crate::model::channel::ReactionType;
 use crate::model::prelude::ButtonStyle;
 use crate::utils;
 
-/// Creates a component
+/// A builder for creating several [`ActionRow`]s.
+///
+/// [`ActionRow`]: crate::model::interactions::ActionRow
 #[derive(Clone, Debug, Default)]
 pub struct CreateComponents(pub Vec<Value>);
 
 impl CreateComponents {
-    /// Creates a new application command.
+    /// Creates an action row.
     pub fn create_action_row<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateActionRow) -> &mut CreateActionRow,
@@ -23,7 +25,7 @@ impl CreateComponents {
         self
     }
 
-    /// Adds a new interaction.
+    /// Adds an action row.
     pub fn add_action_row(&mut self, mut row: CreateActionRow) -> &mut Self {
         self.0.push(row.build());
 
@@ -107,8 +109,7 @@ impl CreateButton {
         self
     }
 
-    /// Sets the custom id of the button, it is a developer-defined
-    /// identifier.
+    /// Sets the custom id of the button, a developer-defined identifier.
     pub fn custom_id<D: ToString>(&mut self, id: D) -> &mut Self {
         self.0.insert("custom_id", Value::String(id.to_string()));
         self
@@ -120,7 +121,7 @@ impl CreateButton {
         self
     }
 
-    /// Sets the disabled state for the button
+    /// Sets emoji of the button.
     pub fn emoji(&mut self, emoji: ReactionType) -> &mut Self {
         let mut map = JsonMap::new();
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -138,7 +138,7 @@ impl CreateButton {
         self
     }
 
-    /// Sets the disabled state for the button
+    /// Sets the disabled state for the button.
     pub fn disabled(&mut self, disabled: bool) -> &mut Self {
         self.0.insert("disabled", Value::Bool(disabled));
         self

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -149,7 +149,7 @@ impl CreateButton {
 
     /// Sets the disabled state for the button
     pub fn disabled(&mut self, disabled: bool) -> &mut Self {
-        self.0.insert("url", Value::Bool(disabled));
+        self.0.insert("disabled", Value::Bool(disabled));
         self
     }
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -1,0 +1,143 @@
+use std::collections::HashMap;
+
+use super::CreateAllowedMentions;
+use super::CreateEmbed;
+use crate::http::AttachmentType;
+use crate::internal::prelude::*;
+use crate::model::channel::{MessageReference, ReactionType};
+use crate::model::prelude::ButtonStyle;
+use crate::utils;
+
+/// Creates a component
+#[derive(Clone, Debug, Default)]
+pub struct CreateComponents(pub Vec<Value>);
+
+impl CreateComponents {
+    /// Creates a new application command.
+    pub fn create_action_row<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateActionRow) -> &mut CreateActionRow,
+    {
+        let mut data = CreateActionRow::default();
+        f(&mut data);
+
+        self.add_action_row(data);
+
+        self
+    }
+
+    /// Adds a new interaction.
+    pub fn add_action_row(&mut self, mut row: CreateActionRow) -> &mut Self {
+        self.0.push(row.build());
+
+        self
+    }
+
+    /// Sets all the action rows.
+    pub fn set_action_rows(&mut self, rows: Vec<CreateActionRow>) -> &mut Self {
+        let new_rows = rows.into_iter().map(|mut f| f.build()).collect::<Vec<Value>>();
+
+        for row in new_rows {
+            self.0.push(row);
+        }
+
+        self
+    }
+}
+
+/// A builder for creating an [`ActionRow`].
+///
+/// [`ActionRow`]: crate::model::interactions::ActionRow
+#[derive(Clone, Debug, Default)]
+pub struct CreateActionRow(pub HashMap<&'static str, Value>);
+
+impl CreateActionRow {
+    /// Creates a button.
+    pub fn create_button<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateButton) -> &mut CreateButton,
+    {
+        let mut data = CreateButton::default();
+        f(&mut data);
+
+        self.add_button(data);
+
+        self
+    }
+
+    /// Adds a button.
+    pub fn add_button(&mut self, button: CreateButton) -> &mut Self {
+        let components = self.0.entry("components").or_insert_with(|| Value::Array(Vec::new()));
+        let components_array = components.as_array_mut().expect("Must be an array");
+
+        components_array.push(button.build());
+
+        self
+    }
+
+    /// Sets all the buttons.
+    pub fn set_buttons(&mut self, buttons: Vec<CreateButton>) -> &mut Self {
+        let new_components = buttons.into_iter().map(|f| f.build()).collect::<Vec<Value>>();
+
+        self.0.insert("components", Value::Array(new_components));
+
+        self
+    }
+
+    pub fn build(&mut self) -> Value {
+        self.0.insert("type", Value::Number(serde_json::Number::from(1 as u8)));
+
+        utils::hashmap_to_json_map(self.0.clone()).into()
+    }
+}
+
+/// A builder for creating an [`Button`].
+///
+/// [`ApplicationCommandPermissionData`]: crate::model::interactions::Button
+#[derive(Clone, Debug, Default)]
+pub struct CreateButton(pub HashMap<&'static str, Value>);
+
+impl CreateButton {
+    /// Sets the style of the button.
+    pub fn style(&mut self, kind: ButtonStyle) -> &mut Self {
+        self.0.insert("style", Value::Number(serde_json::Number::from(kind as u8)));
+        self
+    }
+
+    /// The label of the button.
+    pub fn label<D: ToString>(&mut self, label: D) -> &mut Self {
+        self.0.insert("label", Value::String(label.to_string()));
+        self
+    }
+
+    /// Sets the custom id of the button, it is a developer-defined
+    /// identifier.
+    pub fn custom_id<D: ToString>(&mut self, id: D) -> &mut Self {
+        self.0.insert("custom_id", Value::String(id.to_string()));
+        self
+    }
+
+    /// The url for url style button.
+    pub fn url<D: ToString>(&mut self, url: D) -> &mut Self {
+        self.0.insert("url", Value::String(url.to_string()));
+        self
+    }
+
+    /// Sets the disabled state for the button
+    pub fn emoji(&mut self, emoji: ReactionType) -> &mut Self {
+        self.0.insert("emoji", emoji.as_data().into());
+        self
+    }
+
+    /// Sets the disabled state for the button
+    pub fn disabled(&mut self, disabled: bool) -> &mut Self {
+        self.0.insert("url", Value::Bool(disabled));
+        self
+    }
+
+    pub fn build(mut self) -> Value {
+        self.0.insert("type", Value::Number(serde_json::Number::from(2 as u8)));
+
+        utils::hashmap_to_json_map(self.0.clone()).into()
+    }
+}

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -74,15 +74,6 @@ impl CreateActionRow {
         self
     }
 
-    /// Sets all the buttons.
-    pub fn set_buttons(&mut self, buttons: Vec<CreateButton>) -> &mut Self {
-        let new_components = buttons.into_iter().map(|f| f.build()).collect::<Vec<Value>>();
-
-        self.0.insert("components", Value::Array(new_components));
-
-        self
-    }
-
     pub fn build(&mut self) -> Value {
         self.0.insert("type", Value::Number(serde_json::Number::from(1 as u8)));
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -90,9 +90,9 @@ impl CreateActionRow {
     }
 }
 
-/// A builder for creating an [`Button`].
+/// A builder for creating a [`Button`].
 ///
-/// [`ApplicationCommandPermissionData`]: crate::model::interactions::Button
+/// [`Button`]: crate::model::interactions::Button
 #[derive(Clone, Debug, Default)]
 pub struct CreateButton(pub HashMap<&'static str, Value>);
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
 
-use super::CreateAllowedMentions;
-use super::CreateEmbed;
-use crate::http::AttachmentType;
 use crate::internal::prelude::*;
-use crate::model::channel::{MessageReference, ReactionType};
+use crate::model::channel::ReactionType;
 use crate::model::prelude::ButtonStyle;
 use crate::utils;
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use super::{CreateAllowedMentions, CreateEmbed};
+use crate::builder::CreateComponents;
 use crate::{
     model::interactions::{
         InteractionApplicationCommandCallbackDataFlags,
@@ -115,6 +116,19 @@ impl CreateInteractionResponseData {
     /// Sets the flags for the message.
     pub fn flags(&mut self, flags: InteractionApplicationCommandCallbackDataFlags) -> &mut Self {
         self.0.insert("flags", Value::Number(serde_json::Number::from(flags.bits())));
+        self
+    }
+
+    /// Sets the components of this message.
+    #[cfg(feature = "unstable_discord_api")]
+    pub fn components<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
+    {
+        let mut components = CreateComponents::default();
+        f(&mut components);
+
+        self.0.insert("components", Value::Array(components.0));
         self
     }
 }

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use super::{CreateAllowedMentions, CreateEmbed};
+use crate::builder::CreateComponents;
 use crate::model::interactions::InteractionApplicationCommandCallbackDataFlags;
 use crate::{http::AttachmentType, utils};
 
@@ -120,6 +121,19 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     /// Sets the flags for the response.
     pub fn flags(&mut self, flags: InteractionApplicationCommandCallbackDataFlags) -> &mut Self {
         self.0.insert("flags", Value::Number(serde_json::Number::from(flags.bits())));
+        self
+    }
+
+    /// Sets the components of this message.
+    #[cfg(feature = "unstable_discord_api")]
+    pub fn components<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
+    {
+        let mut components = CreateComponents::default();
+        f(&mut components);
+
+        self.0.insert("components", Value::Array(components.0));
         self
     }
 }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use super::CreateAllowedMentions;
 use super::CreateEmbed;
+use crate::builder::CreateComponents;
 use crate::http::AttachmentType;
 use crate::internal::prelude::*;
 use crate::model::channel::{MessageReference, ReactionType};
@@ -160,6 +161,18 @@ impl<'a> CreateMessage<'a> {
     #[allow(clippy::unwrap_used)] // allowing unwrap here because serializing MessageReference should never error
     pub fn reference_message(&mut self, reference: impl Into<MessageReference>) -> &mut Self {
         self.0.insert("message_reference", serde_json::to_value(reference.into()).unwrap());
+        self
+    }
+
+    #[cfg(feature = "unstable_discord_api")]
+    pub fn components<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
+    {
+        let mut components = CreateComponents::default();
+        f(&mut components);
+
+        self.0.insert("components", Value::Array(components.0));
         self
     }
 }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use super::CreateAllowedMentions;
 use super::CreateEmbed;
+#[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
 use crate::http::AttachmentType;
 use crate::internal::prelude::*;
@@ -164,6 +165,7 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
+    /// Sets the components of this message.
     #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use super::{CreateAllowedMentions, CreateEmbed};
-use crate::utils;
 use crate::builder::CreateComponents;
+use crate::utils;
 
 #[derive(Clone, Debug, Default)]
 pub struct EditInteractionResponse(pub HashMap<&'static str, Value>);
@@ -81,8 +81,8 @@ impl EditInteractionResponse {
     /// Sets the components of this message.
     #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
-        where
-            F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
+    where
+        F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
     {
         let mut components = CreateComponents::default();
         f(&mut components);

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::utils;
+use crate::builder::CreateComponents;
 
 #[derive(Clone, Debug, Default)]
 pub struct EditInteractionResponse(pub HashMap<&'static str, Value>);
@@ -74,6 +75,19 @@ impl EditInteractionResponse {
         let allowed_mentions = Value::Object(map);
 
         self.0.insert("allowed_mentions", allowed_mentions);
+        self
+    }
+
+    /// Sets the components of this message.
+    #[cfg(feature = "unstable_discord_api")]
+    pub fn components<F>(&mut self, f: F) -> &mut Self
+        where
+            F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
+    {
+        let mut components = CreateComponents::default();
+        f(&mut components);
+
+        self.0.insert("components", Value::Array(components.0));
         self
     }
 }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use super::CreateEmbed;
 use crate::internal::prelude::*;
 use crate::utils;
+#[cfg(feature = "unstable_discord_api")]
+use crate::builder::CreateComponents;
 
 /// A builder to specify the fields to edit in an existing message.
 ///
@@ -67,6 +69,19 @@ impl EditMessage {
             self.0.remove("flags");
         }
 
+        self
+    }
+
+    /// Sets the components of this message.
+    #[cfg(feature = "unstable_discord_api")]
+    pub fn components<F>(&mut self, f: F) -> &mut Self
+        where
+            F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
+    {
+        let mut components = CreateComponents::default();
+        f(&mut components);
+
+        self.0.insert("components", Value::Array(components.0));
         self
     }
 }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use super::CreateEmbed;
-use crate::internal::prelude::*;
-use crate::utils;
 #[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
+use crate::internal::prelude::*;
+use crate::utils;
 
 /// A builder to specify the fields to edit in an existing message.
 ///
@@ -75,8 +75,8 @@ impl EditMessage {
     /// Sets the components of this message.
     #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
-        where
-            F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
+    where
+        F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
     {
         let mut components = CreateComponents::default();
         f(&mut components);

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -76,7 +76,7 @@ pub use self::{
         CreateApplicationCommandPermissionsData,
         CreateApplicationCommandsPermissions,
     },
-    create_components::CreateComponents,
+    create_components::{CreateActionRow, CreateButton, CreateComponents},
     create_interaction_response::{CreateInteractionResponse, CreateInteractionResponseData},
     create_interaction_response_followup::CreateInteractionResponseFollowup,
     edit_interaction_response::EditInteractionResponse,

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -18,6 +18,9 @@ mod create_application_command_permission;
 mod create_allowed_mentions;
 #[cfg(feature = "unstable_discord_api")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+mod create_components;
+#[cfg(feature = "unstable_discord_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod create_interaction_response;
 #[cfg(feature = "unstable_discord_api")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
@@ -73,6 +76,7 @@ pub use self::{
         CreateApplicationCommandPermissionsData,
         CreateApplicationCommandsPermissions,
     },
+    create_components::CreateComponents,
     create_interaction_response::{CreateInteractionResponse, CreateInteractionResponseData},
     create_interaction_response_followup::CreateInteractionResponseFollowup,
     edit_interaction_response::EditInteractionResponse,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1026,7 +1026,7 @@ mod test {
                 #[cfg(feature = "unstable_discord_api")]
                 interaction: None,
                 #[cfg(feature = "unstable_discord_api")]
-                components: vec![]
+                components: vec![],
             },
         };
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1025,6 +1025,8 @@ mod test {
                 referenced_message: None,
                 #[cfg(feature = "unstable_discord_api")]
                 interaction: None,
+                #[cfg(feature = "unstable_discord_api")]
+                components: vec![]
             },
         };
 

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -2,6 +2,8 @@ use async_tungstenite::tungstenite::Message;
 use futures::channel::mpsc::{TrySendError, UnboundedSender as Sender};
 
 use super::{ChunkGuildFilter, ShardClientMessage, ShardRunnerMessage};
+#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+use crate::collector::ComponentInteractionFilter;
 #[cfg(feature = "collector")]
 use crate::collector::{MessageFilter, ReactionFilter};
 use crate::gateway::InterMessage;
@@ -258,6 +260,14 @@ impl ShardMessenger {
     pub fn set_reaction_filter(&self, collector: ReactionFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetReactionFilter(collector));
+    }
+
+    /// Sets a new filter for a component interaction collector.
+    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
+    pub fn set_component_interaction_filter(&self, collector: ComponentInteractionFilter) {
+        #[allow(clippy::let_underscore_must_use)]
+        let _ = self.send_to_shard(ShardRunnerMessage::SetComponentInteractionFilter(collector));
     }
 }
 

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -18,6 +18,8 @@ use super::{ShardClientMessage, ShardId, ShardManagerMessage, ShardRunnerMessage
 use crate::client::bridge::voice::VoiceGatewayManager;
 use crate::client::dispatch::{dispatch, DispatchEvent};
 use crate::client::{EventHandler, RawEventHandler};
+#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+use crate::collector::ComponentInteractionFilter;
 #[cfg(feature = "collector")]
 use crate::collector::{MessageFilter, ReactionAction, ReactionFilter};
 #[cfg(feature = "framework")]
@@ -26,6 +28,8 @@ use crate::gateway::{GatewayError, InterMessage, ReconnectType, Shard, ShardActi
 use crate::internal::prelude::*;
 use crate::internal::ws_impl::{ReceiverExt, SenderExt};
 use crate::model::event::{Event, GatewayEvent};
+#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+use crate::model::prelude::InteractionType;
 use crate::CacheAndHttp;
 
 /// A runner for managing a [`Shard`] and its respective WebSocket client.
@@ -48,6 +52,8 @@ pub struct ShardRunner {
     message_filters: Vec<MessageFilter>,
     #[cfg(feature = "collector")]
     reaction_filters: Vec<ReactionFilter>,
+    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    component_interaction_filters: Vec<ComponentInteractionFilter>,
 }
 
 impl ShardRunner {
@@ -72,6 +78,8 @@ impl ShardRunner {
             message_filters: Vec::new(),
             #[cfg(feature = "collector")]
             reaction_filters: Vec::new(),
+            #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+            component_interaction_filters: vec![],
         }
     }
 
@@ -228,6 +236,23 @@ impl ShardRunner {
             });
 
             retain(&mut self.reaction_filters, |f| f.send_reaction(&reaction));
+        }
+
+        // Avoid the clone if there is no interaction filter.
+        #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+        if !self.component_interaction_filters.is_empty() {
+            let interaction = Arc::new(match &event {
+                Event::InteractionCreate(ref interaction_event) => {
+                    if interaction_event.interaction.kind == InteractionType::MessageComponent {
+                        Arc::new(interaction_event.interaction.clone())
+                    } else {
+                        return;
+                    }
+                },
+                _ => return,
+            });
+
+            retain(&mut self.component_interaction_filters, |f| f.send_interaction(&interaction));
         }
     }
 
@@ -431,6 +456,14 @@ impl ShardRunner {
                 #[cfg(feature = "collector")]
                 ShardClientMessage::Runner(ShardRunnerMessage::SetReactionFilter(collector)) => {
                     self.reaction_filters.push(collector);
+
+                    true
+                },
+                #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+                ShardClientMessage::Runner(ShardRunnerMessage::SetComponentInteractionFilter(
+                    collector,
+                )) => {
+                    self.component_interaction_filters.push(collector);
 
                     true
                 },

--- a/src/client/bridge/gateway/shard_runner_message.rs
+++ b/src/client/bridge/gateway/shard_runner_message.rs
@@ -1,5 +1,7 @@
 use async_tungstenite::tungstenite::Message;
 
+#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+use crate::collector::ComponentInteractionFilter;
 #[cfg(feature = "collector")]
 use crate::collector::{MessageFilter, ReactionFilter};
 use crate::model::{
@@ -67,4 +69,8 @@ pub enum ShardRunnerMessage {
     #[cfg(feature = "collector")]
     #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     SetReactionFilter(ReactionFilter),
+    /// Sends a new filter for component interactions to the shard.
+    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
+    SetComponentInteractionFilter(ComponentInteractionFilter),
 }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -8,6 +8,8 @@ use typemap_rev::TypeMap;
 pub use crate::cache::Cache;
 #[cfg(feature = "gateway")]
 use crate::client::bridge::gateway::ShardMessenger;
+#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+use crate::collector::ComponentInteractionFilter;
 #[cfg(feature = "collector")]
 use crate::collector::{MessageFilter, ReactionFilter};
 #[cfg(feature = "gateway")]
@@ -399,6 +401,15 @@ impl Context {
     #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub async fn set_reaction_filter(&self, filter: ReactionFilter) {
         self.shard.set_reaction_filter(filter);
+    }
+
+    /// Sets a new `filter` for the shard to check if an interaction event shall be
+    /// sent back to `filter`'s paired receiver.
+    #[inline]
+    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
+    pub async fn set_component_interaction_filter(&self, filter: ComponentInteractionFilter) {
+        self.shard.set_component_interaction_filter(filter);
     }
 }
 

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -1,0 +1,343 @@
+use std::{
+    boxed::Box,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context as FutContext, Poll},
+    time::Duration,
+};
+
+use futures::{
+    future::BoxFuture,
+    stream::{Stream, StreamExt},
+};
+use tokio::sync::mpsc::{
+    unbounded_channel,
+    UnboundedReceiver as Receiver,
+    UnboundedSender as Sender,
+};
+#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
+use tokio::time::{delay_for as sleep, Delay as Sleep};
+#[cfg(feature = "tokio")]
+use tokio::time::{sleep, Sleep};
+
+use crate::client::bridge::gateway::ShardMessenger;
+use crate::model::interactions::Interaction;
+
+macro_rules! impl_component_interaction_collector {
+    ($($name:ident;)*) => {
+        $(
+            impl<'a> $name<'a> {
+                /// Limits how many interactions will attempt to be filtered.
+                ///
+                /// The filter checks whether the message has been sent
+                /// in the right guild, channel, and by the right author.
+                pub fn filter_limit(mut self, limit: u32) -> Self {
+                    self.filter.as_mut().unwrap().filter_limit = Some(limit);
+
+                    self
+                }
+
+                /// Limits how many interactions can be collected.
+                ///
+                /// An interaction is considered *collected*, if the interaction
+                /// passes all the requirements.
+                pub fn collect_limit(mut self, limit: u32) -> Self {
+                    self.filter.as_mut().unwrap().collect_limit = Some(limit);
+
+                    self
+                }
+
+                /// Sets a filter function where interactions passed to the function must
+                /// return `true`, otherwise the interaction won't be collected.
+                /// This is the last instance to pass for an interaction to count as *collected*.
+                ///
+                /// This function is intended to be an interaction filter.
+                pub fn filter<F: Fn(&Arc<Interaction>) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
+                    self.filter.as_mut().unwrap().filter = Some(Arc::new(function));
+
+                    self
+                }
+
+                /// Sets the required author ID of an interaction.
+                /// If an interaction is not triggered by a user with this ID, it won't be received.
+                pub fn author_id(mut self, author_id: impl Into<u64>) -> Self {
+                    self.filter.as_mut().unwrap().author_id = Some(author_id.into());
+
+                    self
+                }
+
+                /// Sets the message on which the interaction must occur.
+                /// If an interaction is not on a message with this ID, it won't be received.
+                pub fn message_id(mut self, message_id: impl Into<u64>) -> Self {
+                    self.filter.as_mut().unwrap().message_id = Some(message_id.into());
+
+                    self
+                }
+
+                /// Sets the guild in which the interaction must occur.
+                /// If an interaction is not on a message with this guild ID, it won't be received.
+                pub fn guild_id(mut self, guild_id: impl Into<u64>) -> Self {
+                    self.filter.as_mut().unwrap().guild_id = Some(guild_id.into());
+
+                    self
+                }
+
+                /// Sets the channel on which the interaction must occur.
+                /// If an interaction is not on a message with this channel ID, it won't be received.
+                pub fn channel_id(mut self, channel_id: impl Into<u64>) -> Self {
+                    self.filter.as_mut().unwrap().channel_id = Some(channel_id.into());
+
+                    self
+                }
+
+                /// Sets a `duration` for how long the collector shall receive
+                /// interactions.
+                pub fn timeout(mut self, duration: Duration) -> Self {
+                    self.timeout = Some(Box::pin(sleep(duration)));
+
+                    self
+                }
+            }
+        )*
+    }
+}
+
+/// Filters events on the shard's end and sends them to the collector.
+#[derive(Clone, Debug)]
+pub struct ComponentInteractionFilter {
+    filtered: u32,
+    collected: u32,
+    options: FilterOptions,
+    sender: Sender<Arc<Interaction>>,
+}
+
+impl ComponentInteractionFilter {
+    /// Creates a new filter
+    fn new(options: FilterOptions) -> (Self, Receiver<Arc<Interaction>>) {
+        let (sender, receiver) = unbounded_channel();
+
+        let filter = Self {
+            filtered: 0,
+            collected: 0,
+            sender,
+            options,
+        };
+
+        (filter, receiver)
+    }
+
+    /// Sends an `interaction` to the consuming collector if the `interaction` conforms
+    /// to the constraints and the limits are not reached yet.
+    pub(crate) fn send_interaction(&mut self, interaction: &Arc<Interaction>) -> bool {
+        if self.is_passing_constraints(&interaction) {
+            self.collected += 1;
+
+            if self.sender.send(Arc::clone(interaction)).is_err() {
+                return false;
+            }
+        }
+
+        self.filtered += 1;
+
+        self.is_within_limits()
+    }
+
+    /// Checks if the `interaction` passes set constraints.
+    /// Constraints are optional, as it is possible to limit interactions to
+    /// be sent by a specific author or in a specifc guild.
+    fn is_passing_constraints(&self, interaction: &Arc<Interaction>) -> bool {
+        self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id.map(|g| g.0))
+            && self.options.message_id.map_or(true, |id| {
+                id == interaction.message.as_ref().expect("expected message id").id.0
+            })
+            && self.options.channel_id.map_or(true, |id| {
+                id == interaction.channel_id.as_ref().expect("expected channel id").0
+            })
+            && self.options.author_id.map_or(true, |id| {
+                id == interaction
+                    .user
+                    .as_ref()
+                    .unwrap_or(&interaction.member.as_ref().expect("expected member").user)
+                    .id
+                    .0
+            })
+            && self.options.filter.as_ref().map_or(true, |f| f(&interaction))
+    }
+
+    /// Checks if the filter is within set receive and collect limits.
+    /// An interaction is considered *received* even when it does not meet the
+    /// constraints.
+    fn is_within_limits(&self) -> bool {
+        self.options.filter_limit.map_or(true, |limit| self.filtered < limit)
+            && self.options.collect_limit.map_or(true, |limit| self.collected < limit)
+    }
+}
+
+#[derive(Clone)]
+struct FilterOptions {
+    filter_limit: Option<u32>,
+    collect_limit: Option<u32>,
+    filter: Option<Arc<dyn Fn(&Arc<Interaction>) -> bool + 'static + Send + Sync>>,
+    channel_id: Option<u64>,
+    guild_id: Option<u64>,
+    author_id: Option<u64>,
+    message_id: Option<u64>,
+}
+
+impl std::fmt::Debug for FilterOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReactionFilter")
+            .field("collect_limit", &self.collect_limit)
+            .field("filter", &"Option<Arc<dyn Fn(&Arc<Reaction>) -> bool + 'static + Send + Sync>>")
+            .field("channel_id", &self.channel_id)
+            .field("guild_id", &self.guild_id)
+            .field("author_id", &self.author_id)
+            .finish()
+    }
+}
+
+impl Default for FilterOptions {
+    fn default() -> Self {
+        Self {
+            filter_limit: None,
+            collect_limit: None,
+            filter: None,
+            channel_id: None,
+            guild_id: None,
+            author_id: None,
+            message_id: None,
+        }
+    }
+}
+
+// Implement the common setters for all component interaction collector types.
+// This avoids using a trait that the user would need to import in
+// order to use any of these methods.
+impl_component_interaction_collector! {
+    CollectComponentInteraction;
+    ComponentInteractionCollectorBuilder;
+}
+
+pub struct ComponentInteractionCollectorBuilder<'a> {
+    filter: Option<FilterOptions>,
+    shard: Option<ShardMessenger>,
+    timeout: Option<Pin<Box<Sleep>>>,
+    fut: Option<BoxFuture<'a, ComponentInteractionCollector>>,
+}
+
+impl<'a> ComponentInteractionCollectorBuilder<'a> {
+    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
+        Self {
+            filter: Some(FilterOptions::default()),
+            shard: Some(shard_messenger.as_ref().clone()),
+            timeout: None,
+            fut: None,
+        }
+    }
+}
+
+impl<'a> Future for ComponentInteractionCollectorBuilder<'a> {
+    type Output = ComponentInteractionCollector;
+    #[allow(clippy::unwrap_used)]
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let shard_messenger = self.shard.take().unwrap();
+            let (filter, receiver) = ComponentInteractionFilter::new(self.filter.take().unwrap());
+            let timeout = self.timeout.take();
+
+            self.fut = Some(Box::pin(async move {
+                shard_messenger.set_component_interaction_filter(filter);
+
+                ComponentInteractionCollector {
+                    receiver: Box::pin(receiver),
+                    timeout,
+                }
+            }))
+        }
+
+        self.fut.as_mut().unwrap().as_mut().poll(ctx)
+    }
+}
+
+pub struct CollectComponentInteraction<'a> {
+    filter: Option<FilterOptions>,
+    shard: Option<ShardMessenger>,
+    timeout: Option<Pin<Box<Sleep>>>,
+    fut: Option<BoxFuture<'a, Option<Arc<Interaction>>>>,
+}
+
+impl<'a> CollectComponentInteraction<'a> {
+    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
+        Self {
+            filter: Some(FilterOptions::default()),
+            shard: Some(shard_messenger.as_ref().clone()),
+            timeout: None,
+            fut: None,
+        }
+    }
+}
+
+impl<'a> Future for CollectComponentInteraction<'a> {
+    type Output = Option<Arc<Interaction>>;
+    #[allow(clippy::unwrap_used)]
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            let shard_messenger = self.shard.take().unwrap();
+            let (filter, receiver) = ComponentInteractionFilter::new(self.filter.take().unwrap());
+            let timeout = self.timeout.take();
+
+            self.fut = Some(Box::pin(async move {
+                shard_messenger.set_component_interaction_filter(filter);
+
+                ComponentInteractionCollector {
+                    receiver: Box::pin(receiver),
+                    timeout,
+                }
+                .next()
+                .await
+            }))
+        }
+
+        self.fut.as_mut().unwrap().as_mut().poll(ctx)
+    }
+}
+
+/// A component interaction collector receives interactions matching a the given filter for a
+/// set duration.
+pub struct ComponentInteractionCollector {
+    receiver: Pin<Box<Receiver<Arc<Interaction>>>>,
+    timeout: Option<Pin<Box<Sleep>>>,
+}
+
+impl ComponentInteractionCollector {
+    /// Stops collecting, this will implicitly be done once the
+    /// collector drops.
+    /// In case the drop does not appear until later, it is preferred to
+    /// stop the collector early.
+    pub fn stop(mut self) {
+        self.receiver.close();
+    }
+}
+
+impl Stream for ComponentInteractionCollector {
+    type Item = Arc<Interaction>;
+    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(ref mut timeout) = self.timeout {
+            match timeout.as_mut().poll(ctx) {
+                Poll::Ready(_) => {
+                    return Poll::Ready(None);
+                },
+                Poll::Pending => (),
+            }
+        }
+
+        self.receiver.as_mut().poll_recv(ctx)
+    }
+}
+
+impl Drop for ComponentInteractionCollector {
+    fn drop(&mut self) {
+        self.receiver.close();
+    }
+}

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,8 +1,12 @@
 //! Collectors will receive events from the contextual shard, check if the
 //! filter lets them pass, and collects if the receive, collect, or time limits
 //! are not reached yet.
+#[cfg(feature = "unstable_discord_api")]
+pub mod component_interaction_collector;
 pub mod message_collector;
 pub mod reaction_collector;
 
+#[cfg(feature = "unstable_discord_api")]
+pub use component_interaction_collector::*;
 pub use message_collector::*;
 pub use reaction_collector::*;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2824,6 +2824,8 @@ impl Http {
     pub async fn send_message(&self, channel_id: u64, map: &Value) -> Result<Message> {
         let body = serde_json::to_vec(map)?;
 
+        dbg!(&map);
+
         self.fire(Request {
             body: Some(&body),
             headers: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2824,8 +2824,6 @@ impl Http {
     pub async fn send_message(&self, channel_id: u64, map: &Value) -> Result<Message> {
         let body = serde_json::to_vec(map)?;
 
-        dbg!(&map);
-
         self.fire(Request {
             body: Some(&body),
             headers: None,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -126,6 +126,11 @@ pub struct Message {
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub interaction: Option<MessageInteraction>,
+    /// The components of this message
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    #[serde(default)]
+    pub components: Vec<Component>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -22,6 +22,8 @@ use crate::builder::{CreateEmbed, EditMessage};
 use crate::cache::Cache;
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
+#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+use crate::collector::{CollectComponentInteraction, ComponentInteractionCollectorBuilder};
 #[cfg(feature = "collector")]
 use crate::collector::{CollectReaction, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
@@ -896,6 +898,26 @@ impl Message {
         shard_messenger: &'a impl AsRef<ShardMessenger>,
     ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
+    }
+
+    /// Await a single component interaction on this message.
+    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
+    pub fn await_component_interaction<'a>(
+        &self,
+        shard_messenger: &'a impl AsRef<ShardMessenger>,
+    ) -> CollectComponentInteraction<'a> {
+        CollectComponentInteraction::new(shard_messenger).message_id(self.id.0)
+    }
+
+    /// Returns a stream builder which can be awaited to obtain a stream of component interactions on this message.
+    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
+    pub fn await_component_interactions<'a>(
+        &self,
+        shard_messenger: &'a impl AsRef<ShardMessenger>,
+    ) -> ComponentInteractionCollectorBuilder<'a> {
+        ComponentInteractionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 
     /// Retrieves the message channel's category ID if the channel has one.

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -317,26 +317,6 @@ impl<'de> Deserialize<'de> for Interaction {
             }
         };
 
-        // if map.contains_key("data") {
-        //     match kind {
-        //         InteractionType::ApplicationCommand => {
-        //             data = InteractionData::ApplicationCommand(map
-        //                 .remove("data")
-        //                 .ok_or_else(|| DeError::custom("expected data"))
-        //                 .and_then(ApplicationCommandInteractionData::deserialize)
-        //                 .map_err(DeError::custom)?);
-        //         }
-        //         InteractionType::MessageComponent => {
-        //             data = InteractionData::MessageComponent(map
-        //                 .remove("data")
-        //                 .ok_or_else(|| DeError::custom("expected data"))
-        //                 .and_then(MessageComponent::deserialize)
-        //                 .map_err(DeError::custom)?);
-        //         }
-        //         _ => {}
-        //     }
-        // }
-
         let guild_id = match map.contains_key("guild_id") {
             true => Some(
                 map.remove("guild_id")

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -789,7 +789,7 @@ pub enum InteractionResponseType {
     ChannelMessageWithSource = 4,
     DeferredChannelMessageWithSource = 5,
     DeferredUpdateMessage = 6,
-    UpdateMessage = 7
+    UpdateMessage = 7,
 }
 
 /// The flags for an interaction response.

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -2,7 +2,7 @@
 
 use bitflags::__impl_bitflags;
 use serde::de::{Deserialize, Deserializer, Error as DeError};
-use serde::ser::{Serialize, SerializeStruct, Serializer};
+use serde::ser::{Serialize, Serializer};
 use serde_json::{Map, Number, Value};
 
 use super::prelude::*;
@@ -788,6 +788,8 @@ pub enum InteractionResponseType {
     Pong = 1,
     ChannelMessageWithSource = 4,
     DeferredChannelMessageWithSource = 5,
+    DeferredUpdateMessage = 6,
+    UpdateMessage = 7
 }
 
 /// The flags for an interaction response.

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -60,7 +60,6 @@ pub struct Interaction {
     pub version: u8,
 }
 
-
 impl Interaction {
     /// Gets the interaction response.
     ///
@@ -90,8 +89,8 @@ impl Interaction {
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_interaction_response<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
-        where
-            F: FnOnce(&mut CreateInteractionResponse) -> &mut CreateInteractionResponse,
+    where
+        F: FnOnce(&mut CreateInteractionResponse) -> &mut CreateInteractionResponse,
     {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);
@@ -128,8 +127,8 @@ impl Interaction {
         http: impl AsRef<Http>,
         f: F,
     ) -> Result<Message>
-        where
-            F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse,
+    where
+        F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse,
     {
         let mut interaction_response = EditInteractionResponse::default();
         f(&mut interaction_response);
@@ -170,8 +169,8 @@ impl Interaction {
         http: impl AsRef<Http>,
         f: F,
     ) -> Result<Message>
-        where
-                for<'b> F: FnOnce(
+    where
+        for<'b> F: FnOnce(
             &'b mut CreateInteractionResponseFollowup<'a>,
         ) -> &'b mut CreateInteractionResponseFollowup<'a>,
     {
@@ -205,8 +204,8 @@ impl Interaction {
         message_id: M,
         f: F,
     ) -> Result<Message>
-        where
-                for<'b> F: FnOnce(
+    where
+        for<'b> F: FnOnce(
             &'b mut CreateInteractionResponseFollowup<'a>,
         ) -> &'b mut CreateInteractionResponseFollowup<'a>,
     {

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -31,12 +31,12 @@ pub struct Interaction {
     /// The type of interaction.
     #[serde(rename = "type")]
     pub kind: InteractionType,
-    /// The data of the command which was triggered, if there is one.
+    /// The data of the interaction which was triggered.
     ///
-    /// **Note**: It is always present if the interaction [`kind`] is
-    /// [`ApplicationCommand`].
+    /// **Note**: It is always present if the interaction [`kind`] is not
+    /// [`Ping`].
     ///
-    /// [`ApplicationCommand`]: self::InteractionType::ApplicationCommand
+    /// [`Ping`]: self::InteractionType::Ping
     /// [`kind`]: Interaction::kind
     pub data: Option<InteractionData>,
     /// The message this interaction was triggered by, if
@@ -255,6 +255,7 @@ enum_number!(InteractionType {
     ApplicationCommand
 });
 
+/// The [`Interaction::data`] field.
 #[derive(Clone, Debug, Deserialize)]
 pub enum InteractionData {
     ApplicationCommand(ApplicationCommandInteractionData),
@@ -275,6 +276,7 @@ impl Serialize for InteractionData {
     }
 }
 
+/// A message component data, provided by [`Interaction::data`]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageComponent {
@@ -1036,6 +1038,7 @@ impl From<CommandPermissionId> for UserId {
     }
 }
 
+/// A component.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Component {
@@ -1092,6 +1095,7 @@ enum_number!(ComponentType {
     Button
 });
 
+/// An action row.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ActionRow {
     /// The type of component this ActionRow is.
@@ -1101,9 +1105,10 @@ pub struct ActionRow {
     pub components: Vec<Component>,
 }
 
+/// A button component.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Button {
-    /// The component type.
+    /// The component type, it will always be [`ComponentType::Button`].
     #[serde(rename = "type")]
     pub kind: ComponentType,
     /// The button style.

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -273,5 +273,7 @@ fn dummy_message() -> Message {
         referenced_message: None,
         #[cfg(feature = "unstable_discord_api")]
         interaction: None,
+        #[cfg(feature = "unstable_discord_api")]
+        components: vec![],
     }
 }


### PR DESCRIPTION
This PR adds support to components, as per discord/discord-api-docs#3007 (see https://discord.com/developers/docs/interactions/message-components).

Others relevant PRs: discord/discord-api-docs#3012, https://github.com/discord/discord-api-docs/commit/06218a9ea23cb66082568bb4436724f083f605b8

This has been tested.