### PR TITLE
fix(client): Check existing `Http` application_id when creating `Client`

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -338,9 +338,9 @@ impl<'a> Future for ClientBuilder<'a> {
             let http = Arc::new(self.http.take().unwrap());
 
             #[cfg(feature = "unstable_discord_api")]
-            self.application_id.expect(
-                "Please provide an Application Id in order to use slash commands features.",
-            );
+            if http.application_id == 0 {
+                panic!("Please provide an Application Id in order to use slash commands features.");
+            }
 
             #[cfg(feature = "voice")]
             let voice_manager = self.voice_manager.take();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -339,7 +339,7 @@ impl<'a> Future for ClientBuilder<'a> {
 
             #[cfg(feature = "unstable_discord_api")]
             if http.application_id == 0 {
-                panic!("Please provide an Application Id in order to use slash commands features.");
+                panic!("Please provide an Application Id in order to use interactions features.");
             }
 
             #[cfg(feature = "voice")]


### PR DESCRIPTION
### Description

With the `unstable_discord_api` feature enabled and when using `ClientBuilder::new_with_http`, this requires `application_id` to be provided *only* to `HttpBuilder` instead of both.  This prevents creating a second Http client that replaces the one provided with `ClientBuilder::new_with_http`. 

### Tested

Running a client with `ClientBuilder::new_with_http` works instead of panicking.