### PR TITLE
Fix return type of closure in CreateApplicationCommandPermissionsData::create_permission

### DIFF
--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -128,7 +128,9 @@ impl CreateApplicationCommandPermissionsData {
     /// Creates a permission for the interaction.
     pub fn create_permission<F>(&mut self, f: F) -> &mut Self
     where
-        F: FnOnce(&mut CreateApplicationCommandPermissionData) -> &mut Self,
+        F: FnOnce(
+            &mut CreateApplicationCommandPermissionData,
+        ) -> &mut CreateApplicationCommandPermissionData,
     {
         let mut data = CreateApplicationCommandPermissionData::default();
         f(&mut data);


### PR DESCRIPTION
The closure returned `&mut Self` (i.e. `CreateApplicationCommandPermission*s*Data`) instead of `&mut CreateApplicationCommandPermissionData` which made it impossible to use in the intended way.

(P.S. I think the name "Create…" for builders instead of "…Builder" is a bit confusing but that's a different thing 🙂)