### PR TITLE
Use Url in Activity streaming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ version = "0.1.3"
 [dependencies.url]
 optional = true
 version = "^2.1"
+features = ["serde"]
 
 [dependencies.bytes]
 optional = true

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,6 +1,7 @@
 //! Models pertaining to the gateway.
 
 use bitflags::bitflags;
+use reqwest::Url;
 use serde::de::Error as DeError;
 
 use super::prelude::*;
@@ -67,7 +68,7 @@ pub struct Activity {
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub session_id: Option<String>,
     /// The Stream URL if [`Self::kind`] is [`ActivityType::Streaming`].
-    pub url: Option<String>,
+    pub url: Option<Url>,
 }
 
 #[cfg(feature = "model")]
@@ -150,10 +151,9 @@ impl Activity {
     ///     Ok(())
     /// }
     /// ```
-    pub fn streaming<N, U>(name: N, url: U) -> Activity
+    pub fn streaming<N>(name: N, url: Url) -> Activity
     where
         N: ToString,
-        U: ToString,
     {
         Activity {
             application_id: None,
@@ -172,7 +172,7 @@ impl Activity {
             sync_id: None,
             #[cfg(feature = "unstable_discord_api")]
             session_id: None,
-            url: Some(url.to_string()),
+            url: Some(url),
         }
     }
 
@@ -405,7 +405,7 @@ impl<'de> Deserialize<'de> for Activity {
             None => None,
         };
 
-        let url = map.remove("url").and_then(|v| from_value::<String>(v).ok());
+        let url = map.remove("url").and_then(|v| from_value::<Url>(v).ok());
 
         Ok(Activity {
             application_id,
@@ -515,14 +515,7 @@ pub enum ActivityType {
     Unknown = !0,
 }
 
-enum_number!(ActivityType {
-    Playing,
-    Streaming,
-    Listening,
-    Watching,
-    Custom,
-    Competing
-});
+enum_number!(ActivityType { Playing, Streaming, Listening, Watching, Custom, Competing });
 
 impl Default for ActivityType {
     fn default() -> Self {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,8 +1,8 @@
 //! Models pertaining to the gateway.
 
 use bitflags::bitflags;
-use url::Url;
 use serde::de::Error as DeError;
+use url::Url;
 
 use super::prelude::*;
 use super::utils::*;

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -518,7 +518,14 @@ pub enum ActivityType {
     Unknown = !0,
 }
 
-enum_number!(ActivityType { Playing, Streaming, Listening, Watching, Custom, Competing });
+enum_number!(ActivityType {
+    Playing,
+    Streaming,
+    Listening,
+    Watching,
+    Custom,
+    Competing
+});
 
 impl Default for ActivityType {
     fn default() -> Self {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,5 +1,7 @@
 //! Models pertaining to the gateway.
 
+use std::convert::TryFrom;
+
 use bitflags::bitflags;
 use reqwest::Url;
 use serde::de::Error as DeError;
@@ -151,9 +153,10 @@ impl Activity {
     ///     Ok(())
     /// }
     /// ```
-    pub fn streaming<N>(name: N, url: Url) -> Activity
+    pub fn streaming<N, U>(name: N, url: U) -> Activity
     where
         N: ToString,
+        U: AsRef<str>,
     {
         Activity {
             application_id: None,
@@ -172,7 +175,7 @@ impl Activity {
             sync_id: None,
             #[cfg(feature = "unstable_discord_api")]
             session_id: None,
-            url: Some(url),
+            url: Some(Url::try_from(url.as_ref()).expect("Failed to parse url")),
         }
     }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,7 +1,5 @@
 //! Models pertaining to the gateway.
 
-use std::convert::TryFrom;
-
 use bitflags::bitflags;
 use reqwest::Url;
 use serde::de::Error as DeError;
@@ -175,7 +173,7 @@ impl Activity {
             sync_id: None,
             #[cfg(feature = "unstable_discord_api")]
             session_id: None,
-            url: Some(Url::try_from(url.as_ref()).expect("Failed to parse url")),
+            url: Some(Url::parse(url.as_ref()).expect("Failed to parse url")),
         }
     }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,7 +1,7 @@
 //! Models pertaining to the gateway.
 
 use bitflags::bitflags;
-use reqwest::Url;
+use url::Url;
 use serde::de::Error as DeError;
 
 use super::prelude::*;


### PR DESCRIPTION
This PR is *another* redo of #1349 (wow am I bad at this). I've changed Activity.url to a Url. Url serializes to and from a string, so serialization is mostly unchanged. If u attempt to deserialize an invalid url, it will error. This behavior may not be desired.

I changed U from ToString to AsRef<str>. This covers String, &str, and Url. I'm so happy rust allowed me to say "I want all of these". This should minimize breakage. I chose AsRef<str> over ToString or a TryFrom bound because it seems Url will not be adding any other TryFrom implementations. This intent might be better reflected by using Url::parse instead of Url::try_from internally. 