### PR TITLE
fix(client): Remove early return when handling collector filters

### DIFF
--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -217,17 +217,22 @@ impl ShardRunner {
 
         // Avoid the clone if there is no reacton filter.
         if !self.reaction_filters.is_empty() {
-            let reaction = Arc::new(match &event {
+            match &event {
                 Event::ReactionAdd(ref reaction_event) => {
-                    ReactionAction::Added(Arc::new(reaction_event.reaction.clone()))
+                    let reaction =
+                        Arc::new(ReactionAction::Added(Arc::new(reaction_event.reaction.clone())));
+
+                    retain(&mut self.reaction_filters, |f| f.send_reaction(&reaction));
                 },
                 Event::ReactionRemove(ref reaction_event) => {
-                    ReactionAction::Removed(Arc::new(reaction_event.reaction.clone()))
-                },
-                _ => return,
-            });
+                    let reaction = Arc::new(ReactionAction::Removed(Arc::new(
+                        reaction_event.reaction.clone(),
+                    )));
 
-            retain(&mut self.reaction_filters, |f| f.send_reaction(&reaction));
+                    retain(&mut self.reaction_filters, |f| f.send_reaction(&reaction));
+                },
+                _ => {},
+            }
         }
     }
 


### PR DESCRIPTION
### Description

Removes the early return when handling `reaction_filters` on a non-reaction event. This fixes collector filters that may run after the reaction filter but are incorrectly skipped, such as in #1369.  If using component interaction filters and there are existing reaction filters, it will return early on `Interaction Create` events and skip handling the corresponding component interaction filters.

### Tested

This has been tested by using reaction filters and ensuring it doesn't return early.