### PR TITLE
Add support for adding attachments in message edits

### DIFF
--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::CreateEmbed;
 use crate::utils;
-use crate::{internal::prelude::*, json::from_number};
+use crate::{http::AttachmentType, internal::prelude::*, json::from_number};
 
 /// A builder to specify the fields to edit in an existing message.
 ///
@@ -31,9 +31,9 @@ use crate::{internal::prelude::*, json::from_number};
 ///
 /// [`Message`]: crate::model::channel::Message
 #[derive(Clone, Debug, Default)]
-pub struct EditMessage(pub HashMap<&'static str, Value>);
+pub struct EditMessage<'a>(pub HashMap<&'static str, Value>, pub Vec<AttachmentType<'a>>);
 
-impl EditMessage {
+impl<'a> EditMessage<'a> {
     /// Set the content of the message.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
@@ -76,6 +76,14 @@ impl EditMessage {
             self.0.remove("flags");
         }
 
+        self
+    }
+
+    /// Add a new attachment for the message.
+    ///
+    /// This can be called multiple times.
+    pub fn attachment(&mut self, attachment: impl Into<AttachmentType<'a>>) -> &mut Self {
+        self.1.push(attachment.into());
         self
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1329,7 +1329,8 @@ impl Http {
         map: &Value,
         new_attachments: impl IntoIterator<Item = AttachmentType<'_>>,
     ) -> Result<Message> {
-        // TODO: Avoid duplication with send_files()?
+        // Note: if you need to copy this code for a new method, extract this code into a function
+        // instead and call it in here and in send_files(), to avoid duplication (see Rule Of Three)
 
         let uri = api!("/channels/{}/messages/{}", channel_id, message_id);
         let mut url = Url::parse(&uri).map_err(|_| Error::Url(uri))?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1319,6 +1319,52 @@ impl Http {
         .await
     }
 
+    /// Edits a message and its attachments by Id.
+    ///
+    /// **Note**: Only the author of a message can modify it.
+    pub async fn edit_message_and_attachments(
+        &self,
+        channel_id: u64,
+        message_id: u64,
+        map: &Value,
+        new_attachments: impl IntoIterator<Item = AttachmentType<'_>>,
+    ) -> Result<Message> {
+        // TODO: Avoid duplication with send_files()?
+
+        let uri = api!("/channels/{}/messages/{}", channel_id, message_id);
+        let mut url = Url::parse(&uri).map_err(|_| Error::Url(uri))?;
+
+        if let Some(proxy) = &self.proxy {
+            url.set_host(proxy.host_str()).map_err(HttpError::Url)?;
+            url.set_scheme(proxy.scheme()).map_err(|_| HttpError::InvalidScheme)?;
+            url.set_port(proxy.port()).map_err(|_| HttpError::InvalidPort)?;
+        }
+
+        let mut multipart = reqwest::multipart::Form::new();
+
+        for (i, attachment) in new_attachments.into_iter().enumerate() {
+            multipart =
+                multipart.part(i.to_string(), attachment.into_http_form_part(&self.client).await?);
+        }
+
+        multipart = multipart.text("payload_json", serde_json::to_string(map)?);
+
+        let response = self
+            .client
+            .patch(url)
+            .header(AUTHORIZATION, HeaderValue::from_str(&self.token)?)
+            .header(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT))
+            .multipart(multipart)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(HttpError::from_response(response).await.into());
+        }
+
+        response.json::<Message>().await.map_err(From::from)
+    }
+
     /// Crossposts a message by Id.
     ///
     /// **Note**: Only available on announcements channels.
@@ -2756,56 +2802,8 @@ impl Http {
         let mut multipart = reqwest::multipart::Form::new();
 
         for (file_num, file) in files.into_iter().enumerate() {
-            match file.into() {
-                AttachmentType::Bytes {
-                    data,
-                    filename,
-                } => {
-                    multipart = multipart.part(
-                        file_num.to_string(),
-                        Part::bytes(data.into_owned()).file_name(filename),
-                    );
-                },
-                AttachmentType::File {
-                    file,
-                    filename,
-                } => {
-                    let mut buf = Vec::new();
-                    file.try_clone().await?.read_to_end(&mut buf).await?;
-
-                    multipart =
-                        multipart.part(file_num.to_string(), Part::stream(buf).file_name(filename));
-                },
-                AttachmentType::Path(path) => {
-                    let filename =
-                        path.file_name().map(|filename| filename.to_string_lossy().into_owned());
-                    let mut file = File::open(path).await?;
-                    let mut buf = vec![];
-                    file.read_to_end(&mut buf).await?;
-
-                    let part = match filename {
-                        Some(filename) => Part::bytes(buf).file_name(filename),
-                        None => Part::bytes(buf),
-                    };
-
-                    multipart = multipart.part(file_num.to_string(), part);
-                },
-                AttachmentType::Image(url) => {
-                    let url = Url::parse(url).map_err(|_| Error::Url(url.to_string()))?;
-                    let filename = url
-                        .path_segments()
-                        .and_then(|segments| segments.last().map(ToString::to_string))
-                        .ok_or_else(|| Error::Url(url.to_string()))?;
-                    let response = self.client.get(url).send().await?;
-                    let mut bytes = response.bytes().await?;
-                    let mut picture: Vec<u8> = vec![0; bytes.len()];
-                    bytes.copy_to_slice(&mut picture[..]);
-                    multipart = multipart.part(
-                        file_num.to_string(),
-                        Part::bytes(picture).file_name(filename.to_string()),
-                    );
-                },
-            }
+            multipart = multipart
+                .part(file_num.to_string(), file.into().into_http_form_part(&self.client).await?);
         }
 
         multipart = multipart.text("payload_json", to_string(&map)?);

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -194,6 +194,58 @@ pub enum AttachmentType<'a> {
     Image(&'a str),
 }
 
+impl AttachmentType<'_> {
+    pub(crate) async fn into_http_form_part(
+        self,
+        client: &reqwest::Client,
+    ) -> Result<reqwest::multipart::Part, crate::Error> {
+        use bytes::buf::Buf;
+        use tokio::io::AsyncReadExt;
+
+        Ok(match self {
+            AttachmentType::Bytes {
+                data,
+                filename,
+            } => reqwest::multipart::Part::bytes(data.into_owned()).file_name(filename),
+            AttachmentType::File {
+                file,
+                filename,
+            } => {
+                let mut buf = Vec::new();
+                file.try_clone().await?.read_to_end(&mut buf).await?;
+
+                reqwest::multipart::Part::stream(buf).file_name(filename)
+            },
+            AttachmentType::Path(path) => {
+                let filename =
+                    path.file_name().map(|filename| filename.to_string_lossy().into_owned());
+                let mut file = File::open(path).await?;
+                let mut buf = vec![];
+                file.read_to_end(&mut buf).await?;
+
+                match filename {
+                    Some(filename) => reqwest::multipart::Part::bytes(buf).file_name(filename),
+                    None => reqwest::multipart::Part::bytes(buf),
+                }
+            },
+            AttachmentType::Image(url) => {
+                let url =
+                    reqwest::Url::parse(url).map_err(|_| crate::Error::Url(url.to_string()))?;
+                let filename = url
+                    .path_segments()
+                    .and_then(|segments| segments.last().map(ToString::to_string))
+                    .ok_or_else(|| crate::Error::Url(url.to_string()))?;
+                let response = client.get(url).send().await?;
+                let mut bytes = response.bytes().await?;
+                let mut picture: Vec<u8> = vec![0; bytes.len()];
+                bytes.copy_to_slice(&mut picture[..]);
+
+                reqwest::multipart::Part::bytes(picture).file_name(filename.to_string())
+            },
+        })
+    }
+}
+
 impl<'a> From<(&'a [u8], &str)> for AttachmentType<'a> {
     fn from(params: (&'a [u8], &str)) -> AttachmentType<'a> {
         AttachmentType::Bytes {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -365,7 +365,7 @@ impl ChannelId {
         f: F,
     ) -> Result<Message>
     where
-        F: FnOnce(&mut EditMessage) -> &mut EditMessage,
+        F: for<'a, 'b> FnOnce(&'a mut EditMessage<'b>) -> &'a mut EditMessage<'b>,
     {
         let mut msg = EditMessage::default();
         f(&mut msg);
@@ -378,7 +378,9 @@ impl ChannelId {
 
         let map = utils::hashmap_to_json_map(msg.0);
 
-        http.as_ref().edit_message(self.0, message_id.into().0, &Value::from(map)).await
+        http.as_ref()
+            .edit_message_and_attachments(self.0, message_id.into().0, &Value::from(map), msg.1)
+            .await
     }
 
     /// Attempts to find a [`Channel`] by its Id in the cache.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -450,7 +450,7 @@ impl GuildChannel {
         f: F,
     ) -> Result<Message>
     where
-        F: FnOnce(&mut EditMessage) -> &mut EditMessage,
+        F: for<'a, 'b> FnOnce(&'a mut EditMessage<'b>) -> &'a mut EditMessage<'b>,
     {
         self.id.edit_message(&http, message_id, f).await
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -324,7 +324,7 @@ impl Message {
     #[cfg(feature = "utils")]
     pub async fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
     where
-        F: FnOnce(&mut EditMessage) -> &mut EditMessage,
+        F: for<'a, 'b> FnOnce(&'a mut EditMessage<'b>) -> &'a mut EditMessage<'b>,
     {
         #[cfg(feature = "cache")]
         {
@@ -353,8 +353,15 @@ impl Message {
 
         let map = crate::utils::hashmap_to_json_map(builder.0);
 
-        *self =
-            cache_http.http().edit_message(self.channel_id.0, self.id.0, &Value::from(map)).await?;
+        *self = cache_http
+            .http()
+            .edit_message_and_attachments(
+                self.channel_id.0,
+                self.id.0,
+                &Value::from(map),
+                builder.1,
+            )
+            .await?;
 
         Ok(())
     }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -170,7 +170,7 @@ impl PrivateChannel {
         f: F,
     ) -> Result<Message>
     where
-        F: FnOnce(&mut EditMessage) -> &mut EditMessage,
+        F: for<'a, 'b> FnOnce(&'a mut EditMessage<'b>) -> &'a mut EditMessage<'b>,
     {
         self.id.edit_message(&http, message_id, f).await
     }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,6 +1,8 @@
 use serde::de::Error as DeError;
 #[cfg(feature = "simd-json")]
 use simd_json::StaticNode;
+#[cfg(feature = "simd-json")]
+use simd_json::StaticNode;
 #[cfg(feature = "cache")]
 use tracing::{error, warn};
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,8 +1,6 @@
 use serde::de::Error as DeError;
 #[cfg(feature = "simd-json")]
 use simd_json::StaticNode;
-#[cfg(feature = "simd-json")]
-use simd_json::StaticNode;
 #[cfg(feature = "cache")]
 use tracing::{error, warn};
 


### PR DESCRIPTION
This PR makes it possible to add new attachments to a message when editing it.

This PR:
- creates a new method `Http::edit_message_and_attachments` (that method is to `edit_message` what `send_files` is to `send_message`)
  - there's a lot of duplication between that new method and `Http::edit_message_and_attachments` and `Http::send_files`, but I don't know enough about serenity's http design to improve the situation
- changes calls of `Http::edit_message` to `Http::edit_message_and_attachments` where appropriate
- creates a new method `EditMessage::attachment` to add a new attachment
- adds a new field to `EditMessage` which stores new attachments (breaking change) 
- adds a lifetime parameter to `EditMessage` (breaking change)
- moves the `AttachmentType` serialization into an HTTP form part into a function to avoid code duplication

Here are [the Discord docs](https://discord.com/developers/docs/resources/channel#edit-message) for the message edit request.

The code was tested with a [small test bot](https://pastebin.com/fHeffUu2).