### PR TITLE
Fix deserialization of Interaction's Option fields

### DIFF
--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -38,21 +38,27 @@ pub struct Interaction {
     ///
     /// [`Ping`]: self::InteractionType::Ping
     /// [`kind`]: Interaction::kind
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<InteractionData>,
     /// The message this interaction was triggered by, if
     /// it is a component.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<InteractionMessage>,
     /// The guild Id this interaction was sent from, if there is one.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
     /// The channel Id this interaction was sent from, if there is one.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub channel_id: Option<ChannelId>,
     /// The `member` data for the invoking user.
     ///
     /// **Note**: It is only present if the interaction is triggered in a guild.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<Member>,
     /// The `user` object for the invoking user.
     ///
     /// It is only present if the interaction is triggered in DM.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
     /// A continuation token for responding to the interaction.
     pub token: String,


### PR DESCRIPTION
Interaction's Deserialize implementation currently always fails because it does not handle the present-but-null values generated by the derived Serialize implementation for Option fields that equal None.