### PR TITLE
Prevent CI clippy errors

### DIFF
--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -385,6 +385,7 @@ mod test {
         use crate::utils::Colour;
 
         #[tokio::test]
+        #[allow(clippy::unwrap_used)]
         async fn test_mention() {
             let channel = Channel::Guild(GuildChannel {
                 bitrate: None,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -756,7 +756,7 @@ pub async fn content_safe(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::non_ascii_literal)]
 mod test {
     use super::*;
     #[cfg(feature = "cache")]
@@ -803,7 +803,6 @@ mod test {
     }
 
     #[cfg(feature = "cache")]
-    #[allow(clippy::non_ascii_literal)]
     #[tokio::test]
     async fn test_content_safe() {
         use std::{collections::HashMap, sync::Arc};


### PR DESCRIPTION
For quite some time now, every CI Lint failed because of two clippy errors. This fixes it.

Details:
`src/model/misc.rs:388` - Allowing `unwrap_used` is required because `#[tokio::test]` adds an unwrap when it expands (see [entry.rs](https://docs.rs/tokio-macros/1.2.0/src/tokio_macros/entry.rs.html#329)).
` src/utils/mod.rs` - Allowing `non_ascii_literal` for `test_content_safe` does nothing, nor does allowing it for both responsible strings. Adding a block around them and declaring them inside doesn't work either. Moving the allow attribute to the upper mod (`utils::test`) works, and despite broadening the scope of allowance, it's still very limited.