### PR TITLE
Add support to (Partial)Guild::nsfw_level

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1131,6 +1131,7 @@ mod test {
                     approximate_member_count: None,
                     approximate_presence_count: None,
                     nsfw: false,
+                    nsfw_level: NsfwLevel::Default,
                     max_video_channel_users: None,
                     max_presences: None,
                     max_members: None,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,3 +1,6 @@
+// FIXME: Remove after the removal of the `̀nsfw` field.
+#![allow(deprecated)]
+
 use serde::de::Error as DeError;
 #[cfg(feature = "cache")]
 use tracing::{error, warn};
@@ -136,7 +139,13 @@ pub struct PartialGuild {
     /// Whether or not this guild is designated as NSFW. See [`discord support article`].
     ///
     /// [`discord support article`]: https://support.discord.com/hc/en-us/articles/1500005389362-NSFW-Server-Designation
+    #[deprecated(note = "Removed in favor of Guild::nsfw_level.")]
+    #[serde(default)]
     pub nsfw: bool,
+    /// The guild NSFW state. See [`discord support article`].
+    ///
+    /// [`discord support article`]: https://support.discord.com/hc/en-us/articles/1500005389362-NSFW-Server-Designation
+    pub nsfw_level: NsfwLevel,
     /// The maximum amount of users in a video channel.
     pub max_video_channel_users: Option<u64>,
     /// The maximum number of presences for the guild. The default value is currently 25000.
@@ -1576,6 +1585,12 @@ impl<'de> Deserialize<'de> for PartialGuild {
             .and_then(bool::deserialize)
             .map_err(DeError::custom)?;
 
+        let nsfw_level = map
+            .remove("nsfw_level")
+            .ok_or_else(|| DeError::custom("expected nsfw_level"))
+            .and_then(NsfwLevel::deserialize)
+            .map_err(DeError::custom)?;
+
         let max_video_channel_users = match map.contains_key("max_video_channel_users") {
             true => Some(
                 map.remove("max_video_channel_users")
@@ -1686,6 +1701,7 @@ impl<'de> Deserialize<'de> for PartialGuild {
             approximate_member_count,
             approximate_presence_count,
             nsfw,
+            nsfw_level,
             max_video_channel_users,
             max_presences,
             max_members,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -865,6 +865,7 @@ mod test {
             approximate_member_count: None,
             approximate_presence_count: None,
             nsfw: false,
+            nsfw_level: NsfwLevel::Default,
             max_video_channel_users: None,
             max_presences: None,
             max_members: None,


### PR DESCRIPTION
This PR adds support to the `nsfw_level` field on `Guild` and `PartialGuild` structures, as per discord/discord-api-docs#2976. It also deprecates the `nsfw` field.

This has been tested.