### PR TITLE
feat: Add support for per guild avatars

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1333,6 +1333,20 @@ impl Http {
         .await
     }
 
+    /// Edits the current member for the provided [`Guild`] via its Id.
+    pub async fn edit_member_me(&self, guild_id: u64, map: &JsonMap) -> Result<Member> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditMemberMe {
+                guild_id,
+            },
+        })
+        .await
+    }
+
     /// Edits the current user's nickname for the provided [`Guild`] via its Id.
     ///
     /// Pass [`None`] to reset the nickname.
@@ -1343,7 +1357,7 @@ impl Http {
         self.wind(200, Request {
             body: Some(&body),
             headers: None,
-            route: RouteInfo::EditNickname {
+            route: RouteInfo::EditMemberMe {
                 guild_id,
             },
         })

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -212,6 +212,12 @@ pub enum Route {
     ///
     /// [`GuildId`]: crate::model::id::GuildId
     GuildsIdMembersIdRolesId(u64),
+    /// Route for the `/guilds/:guild_id/members/@me` path.
+    ///
+    /// The data is the relevant [`GuildId`].
+    ///
+    /// [`GuildId`]: crate::model::id::GuildId
+    GuildsIdMembersMe(u64),
     /// Route for the `/guilds/:guild_id/members/@me/nick` path.
     ///
     /// The data is the relevant [`GuildId`].
@@ -596,6 +602,10 @@ impl Route {
         // should not error, ignoring
 
         s
+    }
+
+    pub fn guild_member_me(guild_id: u64) -> String {
+        format!(api!("/guilds/{}/members/@me"), guild_id)
     }
 
     pub fn guild_nickname(guild_id: u64) -> String {
@@ -1052,6 +1062,9 @@ pub enum RouteInfo<'a> {
     CrosspostMessage {
         channel_id: u64,
         message_id: u64,
+    },
+    EditMemberMe {
+        guild_id: u64,
     },
     EditNickname {
         guild_id: u64,
@@ -1737,6 +1750,13 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Patch,
                 Route::ChannelsIdMessagesId(LightMethod::Patch, channel_id),
                 Cow::from(Route::channel_message(channel_id, message_id)),
+            ),
+            RouteInfo::EditMemberMe {
+                guild_id,
+            } => (
+                LightMethod::Patch,
+                Route::GuildsIdMembersMe(guild_id),
+                Cow::from(Route::guild_member_me(guild_id)),
             ),
             RouteInfo::EditNickname {
                 guild_id,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -470,7 +470,6 @@ pub struct GuildMemberUpdateEvent {
     pub deaf: bool,
     #[serde(default)]
     pub mute: bool,
-    pub avatar: Option<String>,
 }
 
 #[cfg(feature = "cache")]
@@ -493,7 +492,6 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                 member.premium_since.clone_from(&self.premium_since);
                 member.deaf.clone_from(&self.deaf);
                 member.mute.clone_from(&self.mute);
-                member.avatar.clone_from(&self.avatar);
 
                 item
             } else {
@@ -513,7 +511,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     premium_since: self.premium_since,
                     #[cfg(feature = "unstable_discord_api")]
                     permissions: None,
-                    avatar: self.avatar.clone(),
+                    avatar: None,
                 });
             }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -470,6 +470,7 @@ pub struct GuildMemberUpdateEvent {
     pub deaf: bool,
     #[serde(default)]
     pub mute: bool,
+    pub avatar: Option<String>,
 }
 
 #[cfg(feature = "cache")]
@@ -492,6 +493,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                 member.premium_since.clone_from(&self.premium_since);
                 member.deaf.clone_from(&self.deaf);
                 member.mute.clone_from(&self.mute);
+                member.avatar.clone_from(&self.avatar);
 
                 item
             } else {
@@ -511,6 +513,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     premium_since: self.premium_since,
                     #[cfg(feature = "unstable_discord_api")]
                     permissions: None,
+                    avatar: self.avatar.clone(),
                 });
             }
 
@@ -1036,6 +1039,7 @@ impl CacheUpdate for PresenceUpdateEvent {
                         premium_since: None,
                         #[cfg(feature = "unstable_discord_api")]
                         permissions: None,
+                        avatar: None,
                     });
                 }
             }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -54,6 +54,8 @@ pub struct Member {
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub permissions: Option<Permissions>,
+    /// The guild avatar hash
+    pub avatar: Option<String>,
 }
 
 #[cfg(feature = "model")]
@@ -510,6 +512,24 @@ impl Member {
     pub async fn unban(&self, http: impl AsRef<Http>) -> Result<()> {
         http.as_ref().remove_ban(self.guild_id.0, self.user.id.0).await
     }
+
+    /// Returns the formatted URL of the member's per guild avatar, if one exists.
+    ///
+    /// This will produce a WEBP image URL, or GIF if the member has a GIF avatar.
+    #[inline]
+    pub fn avatar_url(&self) -> Option<String> {
+        avatar_url(self.guild_id, self.user.id, self.avatar.as_ref())
+    }
+
+    /// Retrieves the URL to the current member's avatar, falling back to the
+    /// user's avatar, then default avatar if needed.
+    ///
+    /// This will call [`Self::avatar_url`] first, and if that returns [`None`], it
+    /// then falls back to [`Self::user::face()`].
+    #[inline]
+    pub fn face(&self) -> String {
+        self.avatar_url().unwrap_or_else(|| self.user.face())
+    }
 }
 
 impl Display for Member {
@@ -565,4 +585,13 @@ pub struct PartialMember {
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub permissions: Option<Permissions>,
+}
+
+#[cfg(feature = "model")]
+fn avatar_url(guild_id: GuildId, user_id: UserId, hash: Option<&String>) -> Option<String> {
+    hash.map(|hash| {
+        let ext = if hash.starts_with("a_") { "gif" } else { "webp" };
+
+        cdn!("/guilds/{}/users/{}/avatars/{}.{}?size=1024", guild_id.0, user_id.0, hash, ext)
+    })
 }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -524,8 +524,8 @@ impl Member {
     /// Retrieves the URL to the current member's avatar, falling back to the
     /// user's avatar, then default avatar if needed.
     ///
-    /// This will call [`Self::avatar_url`] first, and if that returns [`None`], it
-    /// then falls back to [`Self::user::face()`].
+    /// This will call [`Self::avatar_url`] first, and if that returns [`None`],
+    /// it then falls back to [`User::face()`].
     #[inline]
     pub fn face(&self) -> String {
         self.avatar_url().unwrap_or_else(|| self.user.face())

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -3095,6 +3095,7 @@ mod test {
                 premium_since: None,
                 #[cfg(feature = "unstable_discord_api")]
                 permissions: None,
+                avatar: None,
             }
         }
 

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -447,6 +447,7 @@ mod test {
                 premium_since: None,
                 #[cfg(feature = "unstable_discord_api")]
                 permissions: None,
+                avatar: None,
             };
 
             assert_eq!(ChannelId(1).mention().to_string(), "<#1>");

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -109,6 +109,7 @@ impl<'de> Deserialize<'de> for VoiceState {
             premium_since: Option<DateTime<Utc>>,
             #[cfg(feature = "unstable_discord_api")]
             permissions: Option<Permissions>,
+            avatar: Option<String>,
         }
 
         struct VoiceStateVisitor;
@@ -184,6 +185,7 @@ impl<'de> Deserialize<'de> for VoiceState {
                                     premium_since: partial_member.premium_since,
                                     #[cfg(feature = "unstable_discord_api")]
                                     permissions: partial_member.permissions,
+                                    avatar: partial_member.avatar,
                                 });
                             }
                         },

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -885,6 +885,7 @@ mod test {
             premium_since: None,
             #[cfg(feature = "unstable_discord_api")]
             permissions: None,
+            avatar: None,
         };
 
         let role = Role {


### PR DESCRIPTION
### Description

Documentation: https://github.com/discord/discord-api-docs/pull/3081 (not merged yet)

Adds an additional `avatar` field on member in addition to helper methods like `Member::face()`.

Also adds support for the new `/guilds/:guild_id/members/@me` endpoint. It currently only supports changing the current member nickname so no builder or anything added for it yet, just `edit_member_me()` added to Http client.

### Tested

`Member::face()` fetches the user's avatar if there isn't a member avatar set, and correctly fetches the guild avatar if there is one set.