### PR TITLE
fix(model): Make Embed::colour an Option

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -359,7 +359,10 @@ impl From<Embed> for CreateEmbed {
     /// Some values - such as Proxy URLs - are not preserved.
     fn from(embed: Embed) -> Self {
         let mut b = CreateEmbed::default();
-        b.colour(embed.colour);
+
+        if let Some(colour) = embed.colour {
+            b.colour(colour);
+        }
 
         if let Some(author) = embed.author {
             b.author(move |a| {
@@ -519,7 +522,7 @@ mod test {
     fn test_from_embed() {
         let embed = Embed {
             author: None,
-            colour: Colour::new(0xFF0011),
+            colour: Some(Colour::new(0xFF0011)),
             description: Some("This is a test description".to_string()),
             fields: vec![
                 EmbedField {

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -24,8 +24,8 @@ pub struct Embed {
     pub author: Option<EmbedAuthor>,
     /// The colour code of the embed.
     #[cfg(feature = "utils")]
-    #[serde(default, rename = "color")]
-    pub colour: Colour,
+    #[serde(rename = "color")]
+    pub colour: Option<Colour>,
     /// The colour code of the embed.
     #[cfg(not(feature = "utils"))]
     #[serde(default, rename = "color")]


### PR DESCRIPTION
### Description

Prevents changing embed colours to black when editing a message.

When an embed colour isn't provided when creating a message, the API returns messages with colour as undefined for default colour. The colour field has the `#[serde(default)]`  attribute which changes that into a 0 instead.

https://github.com/serenity-rs/serenity/blob/7a7e8cce663b004b289077e628bca10ddf4e6d52/src/model/channel/embed.rs#L27-L28

### Tested

Editing a message containing an embed no longer changes it's colour.
