### PR TITLE
feat: Support sending multiple embeds in a message

### DIFF
--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -74,7 +74,32 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    /// Create an embed for the message.
+    /// Add an embed for the message.
+    pub fn add_embed<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
+    {
+        let mut embed = CreateEmbed::default();
+        f(&mut embed);
+        self._add_embed(embed)
+    }
+
+    fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
+        let map = utils::hashmap_to_json_map(embed.0);
+        let embed = Value::Object(map);
+
+        let embeds = self.0.entry("embeds").or_insert_with(|| Value::Array(Vec::new()));
+        let embeds_array = embeds.as_array_mut().expect("Embeds must be an array");
+
+        embeds_array.push(embed);
+
+        self
+    }
+
+    /// Set the embed for the message.
+    ///
+    /// **Note**: This will replace all existing embeds. Use
+    /// [`Self::add_embed()`] to add additional embeds
     pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
@@ -89,7 +114,7 @@ impl<'a> CreateMessage<'a> {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
-        self.0.insert("embed", embed);
+        self.0.insert("embeds", Value::Array(vec![embed]));
         self
     }
 

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -99,7 +99,7 @@ impl<'a> CreateMessage<'a> {
     /// Set the embed for the message.
     ///
     /// **Note**: This will replace all existing embeds. Use
-    /// [`Self::add_embed()`] to add additional embeds
+    /// [`Self::add_embed()`] to add additional embeds.
     pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
@@ -110,11 +110,23 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Set an embed for the message.
+    ///
+    /// **Note**: This will replace all existing embeds with the provided embed.
+    /// Use [`Self::set_embeds()`] to set multiple embeds at once.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
         self.0.insert("embeds", Value::Array(vec![embed]));
+        self
+    }
+
+    /// Set multiple embeds for the message.
+    pub fn set_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        for embed in embeds {
+            self._add_embed(embed);
+        }
+
         self
     }
 

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -70,7 +70,7 @@ impl EditMessage {
     /// Set the embed for the message.
     ///
     /// **Note**: This will replace all existing embeds. Use
-    /// [`Self::add_embed()`] to add additional embeds
+    /// [`Self::add_embed()`] to add additional embeds.
     pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
@@ -81,11 +81,23 @@ impl EditMessage {
     }
 
     /// Set an embed for the message.
+    ///
+    /// **Note**: This will replace all existing embeds with the provided embed.
+    /// Use [`Self::set_embeds()`] to set multiple embeds at once.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
         self.0.insert("embeds", Value::Array(vec![embed]));
+        self
+    }
+
+    /// Set multiple embeds for the message.
+    pub fn set_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        for embed in embeds {
+            self._add_embed(embed);
+        }
+
         self
     }
 

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -45,18 +45,39 @@ impl EditMessage {
         self
     }
 
-    /// Set an embed for the message.
+    /// Add an embed for the message.
+    pub fn add_embed<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
+    {
+        let mut embed = CreateEmbed::default();
+        f(&mut embed);
+        self._add_embed(embed)
+    }
+
+    fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
+        let map = utils::hashmap_to_json_map(embed.0);
+        let embed = Value::Object(map);
+
+        let embeds = self.0.entry("embeds").or_insert_with(|| Value::Array(Vec::new()));
+        let embeds_array = embeds.as_array_mut().expect("Embeds must be an array");
+
+        embeds_array.push(embed);
+
+        self
+    }
+
+    /// Set the embed for the message.
+    ///
+    /// **Note**: This will replace all existing embeds. Use
+    /// [`Self::add_embed()`] to add additional embeds
     pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {
-        let mut create_embed = CreateEmbed::default();
-        f(&mut create_embed);
-        let map = utils::hashmap_to_json_map(create_embed.0);
-        let embed = Value::Object(map);
-
-        self.0.insert("embed", embed);
-        self
+        let mut embed = CreateEmbed::default();
+        f(&mut embed);
+        self.set_embed(embed)
     }
 
     /// Set an embed for the message.
@@ -64,7 +85,7 @@ impl EditMessage {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
 
-        self.0.insert("embed", embed);
+        self.0.insert("embeds", Value::Array(vec![embed]));
         self
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,6 +3,9 @@
 /// The maximum length of the textual size of an embed.
 pub const EMBED_MAX_LENGTH: usize = 6000;
 
+/// The maximum number of embeds in a message.
+pub const EMBED_MAX_COUNT: usize = 10;
+
 /// The gateway version used by the library. The gateway URI is retrieved via
 /// the REST API.
 pub const GATEWAY_VERSION: u8 = 8;

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -348,10 +348,7 @@ impl Message {
             builder.content(&self.content);
         }
 
-        let embeds: Vec<_> = self
-            .embeds
-            .iter()
-            .map(|e| CreateEmbed::from(e.clone())).collect();
+        let embeds: Vec<_> = self.embeds.iter().map(|e| CreateEmbed::from(e.clone())).collect();
         builder.set_embeds(embeds);
 
         f(&mut builder);

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -348,13 +348,11 @@ impl Message {
             builder.content(&self.content);
         }
 
-        if let Some(embed) = self.embeds.get(0) {
-            let embed = CreateEmbed::from(embed.clone());
-            builder.embed(|e| {
-                *e = embed;
-                e
-            });
-        }
+        let embeds: Vec<_> = self
+            .embeds
+            .iter()
+            .map(|e| CreateEmbed::from(e.clone())).collect();
+        builder.set_embeds(embeds);
 
         f(&mut builder);
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -937,53 +937,59 @@ impl Message {
     }
 
     pub(crate) fn check_embed_length(map: &JsonMap) -> Result<()> {
-        let embed = match map.get("embed") {
-            Some(&Value::Object(ref value)) => value,
+        let embeds = match map.get("embeds") {
+            Some(&Value::Array(ref value)) => value,
             _ => return Ok(()),
         };
 
-        let mut total: usize = 0;
+        if embeds.len() > 10 {
+            return Err(Error::Model(ModelError::EmbedAmount));
+        }
 
-        if let Some(&Value::Object(ref author)) = embed.get("author") {
-            if let Some(&Value::Object(ref name)) = author.get("name") {
-                total += name.len();
+        for embed in embeds {
+            let mut total: usize = 0;
+
+            if let Some(&Value::Object(ref author)) = embed.get("author") {
+                if let Some(&Value::Object(ref name)) = author.get("name") {
+                    total += name.len();
+                }
             }
-        }
 
-        if let Some(&Value::String(ref description)) = embed.get("description") {
-            total += description.len();
-        }
+            if let Some(&Value::String(ref description)) = embed.get("description") {
+                total += description.len();
+            }
 
-        if let Some(&Value::Array(ref fields)) = embed.get("fields") {
-            for field_as_value in fields {
-                if let Value::Object(ref field) = *field_as_value {
-                    if let Some(&Value::String(ref field_name)) = field.get("name") {
-                        total += field_name.len();
-                    }
+            if let Some(&Value::Array(ref fields)) = embed.get("fields") {
+                for field_as_value in fields {
+                    if let Value::Object(ref field) = *field_as_value {
+                        if let Some(&Value::String(ref field_name)) = field.get("name") {
+                            total += field_name.len();
+                        }
 
-                    if let Some(&Value::String(ref field_value)) = field.get("value") {
-                        total += field_value.len();
+                        if let Some(&Value::String(ref field_value)) = field.get("value") {
+                            total += field_value.len();
+                        }
                     }
                 }
             }
-        }
 
-        if let Some(&Value::Object(ref footer)) = embed.get("footer") {
-            if let Some(&Value::String(ref text)) = footer.get("text") {
-                total += text.len();
+            if let Some(&Value::Object(ref footer)) = embed.get("footer") {
+                if let Some(&Value::String(ref text)) = footer.get("text") {
+                    total += text.len();
+                }
+            }
+
+            if let Some(&Value::String(ref title)) = embed.get("title") {
+                total += title.len();
+            }
+
+            if total > constants::EMBED_MAX_LENGTH {
+                let overflow = total - constants::EMBED_MAX_LENGTH;
+                return Err(Error::Model(ModelError::EmbedTooLarge(overflow)));
             }
         }
 
-        if let Some(&Value::String(ref title)) = embed.get("title") {
-            total += title.len();
-        }
-
-        if total <= constants::EMBED_MAX_LENGTH {
-            Ok(())
-        } else {
-            let overflow = total - constants::EMBED_MAX_LENGTH;
-            Err(Error::Model(ModelError::EmbedTooLarge(overflow)))
-        }
+        Ok(())
     }
 }
 

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -69,6 +69,8 @@ pub enum Error {
     /// When attempting to delete a number of days' worth of messages that is
     /// not allowed.
     DeleteMessageDaysAmount(u8),
+    /// When attempting to send a message with over 10 embeds.
+    EmbedAmount,
     /// Indicates that the textual content of an embed exceeds the maximum
     /// length.
     EmbedTooLarge(usize),
@@ -184,6 +186,7 @@ impl Display for Error {
         match self {
             Error::BulkDeleteAmount => f.write_str("Too few/many messages to bulk delete."),
             Error::DeleteMessageDaysAmount(_) => f.write_str("Invalid delete message days."),
+            Error::EmbedAmount => f.write_str("Too many embeds in a message."),
             Error::EmbedTooLarge(_) => f.write_str("Embed too large."),
             Error::GuildNotFound => f.write_str("Guild not found in the cache."),
             Error::RoleNotFound => f.write_str("Role not found in the cache."),


### PR DESCRIPTION
### Description

Documentation: https://github.com/discord/discord-api-docs/pull/3105

Adds support for multiple embeds per message (up to 10). Preserves previous behavior where `CreateMessage::embed()` just replaces the existing embed, but uses the new `embeds` field as an array instead of the now deprecated `embed` in the json params.

### Tested

Message successfully send with 10 embeds.