### PR TITLE
fix(collector): Remove collectors that have closed receivers

### DIFF
--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -140,7 +140,7 @@ impl ComponentInteractionFilter {
 
         self.filtered += 1;
 
-        self.is_within_limits()
+        self.is_within_limits() && !self.sender.is_closed()
     }
 
     /// Checks if the `interaction` passes set constraints.

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -124,7 +124,7 @@ impl MessageFilter {
 
         self.filtered += 1;
 
-        self.is_within_limits()
+        self.is_within_limits() && !self.sender.is_closed()
     }
 
     /// Checks if the `message` passes set constraints.

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -189,7 +189,7 @@ impl ReactionFilter {
 
         self.filtered += 1;
 
-        self.is_within_limits()
+        self.is_within_limits() && !self.sender.is_closed()
     }
 
     /// Checks if the `reaction` passes set constraints.


### PR DESCRIPTION
### Description

Certain collectors like the reaction collector are prone to just accumulate and may stay in the shard runner even when the collector is dropped, eating extra memory and adding overhead. Currently, collectors by default (without filter / collect limits) are only removed when it passes constraints *then* fails to send through the channel. It may still be in the shard runner even after the receiver has been closed.

This is mostly when a reaction collector goes out of scope then nobody reacts to that specific message again, with all resulting reactions failing the constraint check. Same problem may occur with the other collectors, but depends on the server activity to determine when they are cleared or not. e.g. message collector in a channel that is inactive after the collector is dropped would not be cleared when other messages are sent in other channels.

### Tested

Collectors are removed when collectors are out of scope and receives another corresponding event. For example, reaction collectors are removed when adding a new reaction to *any* message instead of just the specific message.