### PR TITLE
Add support for guild search members endpoint

### DIFF
--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -597,6 +597,7 @@ impl Route {
     pub fn guild_members_search(guild_id: u64, query: &str, limit: Option<u64>) -> String {
         let mut s = format!(api!("/guilds/{}/members/search?"), guild_id);
 
+        #[allow(clippy::let_underscore_must_use)]
         let _ = write!(s, "&query={}", query);
 
         #[allow(clippy::let_underscore_must_use)]

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -429,6 +429,7 @@ impl Route {
         api!("/channels/{}/messages/{}/reactions", channel_id, message_id)
     }
 
+    #[allow(clippy::let_underscore_must_use)]
     pub fn channel_message_reactions_list(
         channel_id: u64,
         message_id: u64,
@@ -442,7 +443,6 @@ impl Route {
         );
 
         if let Some(after) = after {
-            #[allow(clippy::let_underscore_must_use)]
             let _ = write!(uri, "&after={}", after);
         }
 
@@ -594,28 +594,26 @@ impl Route {
         format!(api!("/guilds/{}/members"), guild_id)
     }
 
+    #[allow(clippy::let_underscore_must_use)]
     pub fn guild_members_search(guild_id: u64, query: &str, limit: Option<u64>) -> String {
         let mut s = format!(api!("/guilds/{}/members/search?"), guild_id);
 
-        #[allow(clippy::let_underscore_must_use)]
         let _ = write!(s, "&query={}", query);
 
-        #[allow(clippy::let_underscore_must_use)]
         let _ = write!(s, "&limit={}", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT));
 
         s
     }
 
+    #[allow(clippy::let_underscore_must_use)]
     pub fn guild_members_optioned(guild_id: u64, after: Option<u64>, limit: Option<u64>) -> String {
         let mut s = format!(api!("/guilds/{}/members?"), guild_id);
 
         if let Some(after) = after {
-            #[allow(clippy::let_underscore_must_use)]
             let _ = write!(s, "&after={}", after);
             // should not error, ignoring
         }
 
-        #[allow(clippy::let_underscore_must_use)]
         let _ = write!(s, "&limit={}", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT));
         // should not error, ignoring
 
@@ -714,6 +712,7 @@ impl Route {
         format!(api!("/users/{}/guilds"), target)
     }
 
+    #[allow(clippy::let_underscore_must_use)]
     pub fn user_guilds_optioned<D: Display>(
         target: D,
         after: Option<u64>,
@@ -723,13 +722,11 @@ impl Route {
         let mut s = format!(api!("/users/{}/guilds?limit={}&"), target, limit);
 
         if let Some(after) = after {
-            #[allow(clippy::let_underscore_must_use)]
             let _ = write!(s, "&after={}", after);
             // should not error, ignoring
         }
 
         if let Some(before) = before {
-            #[allow(clippy::let_underscore_must_use)]
             let _ = write!(s, "&before={}", before);
             // should not error, ignoring
         }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -224,6 +224,12 @@ pub enum Route {
     ///
     /// [`GuildId`]: crate::model::id::GuildId
     GuildsIdMembersMeNick(u64),
+    /// Route for the `/guilds/:guild_id/members/search` path.
+    ///
+    /// The data is the relevant [`GuildId`].
+    ///
+    /// [`GuildId`]: crate::model::id::GuildId
+    GuildsIdMembersSearch(u64),
     /// Route for the `/guilds/:guild_id/prune` path.
     ///
     /// The data is the relevant [`GuildId`].
@@ -586,6 +592,17 @@ impl Route {
 
     pub fn guild_members(guild_id: u64) -> String {
         format!(api!("/guilds/{}/members"), guild_id)
+    }
+
+    pub fn guild_members_search(guild_id: u64, query: &str, limit: Option<u64>) -> String {
+        let mut s = format!(api!("/guilds/{}/members/search?"), guild_id);
+
+        let _ = write!(s, "&query={}", query);
+
+        #[allow(clippy::let_underscore_must_use)]
+        let _ = write!(s, "&limit={}", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT));
+
+        s
     }
 
     pub fn guild_members_optioned(guild_id: u64, after: Option<u64>, limit: Option<u64>) -> String {
@@ -1294,6 +1311,11 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         role_id: u64,
         user_id: u64,
+    },
+    SearchGuildMembers {
+        guild_id: u64,
+        query: &'a str,
+        limit: Option<u64>,
     },
     StartGuildPrune {
         days: u64,
@@ -2220,6 +2242,15 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Delete,
                 Route::GuildsIdMembersIdRolesId(guild_id),
                 Cow::from(Route::guild_member_role(guild_id, user_id, role_id)),
+            ),
+            RouteInfo::SearchGuildMembers {
+                guild_id,
+                query,
+                limit,
+            } => (
+                LightMethod::Get,
+                Route::GuildsIdMembersSearch(guild_id),
+                Cow::from(Route::guild_members_search(guild_id, query, limit)),
             ),
             RouteInfo::StartGuildPrune {
                 days,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -953,6 +953,18 @@ impl GuildId {
         http.as_ref().edit_guild_channel_positions(self.0, &Value::Array(items)).await
     }
 
+    /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname
+    /// starts with a provided string.
+    #[inline]
+    pub async fn search_members(
+        self,
+        http: impl AsRef<Http>,
+        query: &str,
+        limit: Option<u64>,
+    ) -> Result<Vec<Member>> {
+        http.as_ref().search_guild_members(self.0, query, limit).await
+    }
+
     /// Returns the Id of the shard associated with the guild.
     ///
     /// When the cache is enabled this will automatically retrieve the total

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -955,6 +955,15 @@ impl GuildId {
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname
     /// starts with a provided string.
+    ///
+    /// Optionally pass in the `limit` to limit the number of results.
+    /// Minimum value is 1, maximum and default value is 1000.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the API returns an error.
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn search_members(
         self,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2056,6 +2056,8 @@ impl Guild {
     /// Optionally pass in the `limit` to limit the number of results.
     /// Minimum value is 1, maximum and default value is 1000.
     ///
+    /// **Note**: Queries are case insensitive.
+    ///
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the API returns an error.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2030,6 +2030,18 @@ impl Guild {
         self.id.reorder_channels(&http, channels).await
     }
 
+    /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname
+    /// starts with a provided string.
+    #[inline]
+    pub async fn search_members(
+        &self,
+        http: impl AsRef<Http>,
+        query: &str,
+        limit: Option<u64>,
+    ) -> Result<Vec<Member>> {
+        http.as_ref().search_guild_members(self.id.0, query, limit).await
+    }
+
     /// Returns the Id of the shard associated with the guild.
     ///
     /// When the cache is enabled this will automatically retrieve the total

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1441,6 +1441,10 @@ impl Guild {
     ///
     /// - **username**: "zey"
     /// - **username and discriminator**: "zey#5479"
+    ///
+    /// **Note**: This will only search members that are cached. If you want to
+    /// search all members in the guild via the Http API, use
+    /// [`Self::search_members`].
     pub fn member_named(&self, name: &str) -> Option<&Member> {
         let (name, discrim) = if let Some(pos) = name.rfind('#') {
             let split = name.split_at(pos + 1);
@@ -1487,6 +1491,10 @@ impl Guild {
     /// However, since the read-locks are dropped after borrowing the name,
     /// the names might have been changed by the user, the sorted list cannot
     /// account for this.
+    ///
+    /// **Note**: This will only search members that are cached. If you want to
+    /// search all members in the guild via the Http API, use
+    /// [`Self::search_members`].
     pub async fn members_starting_with(
         &self,
         prefix: &str,
@@ -1555,6 +1563,10 @@ impl Guild {
     /// However, since the read-locks are dropped after borrowing the name,
     /// the names might have been changed by the user, the sorted list cannot
     /// account for this.
+    ///
+    /// **Note**: This will only search members that are cached. If you want to
+    /// search all members in the guild via the Http API, use
+    /// [`Self::search_members`].
     pub async fn members_containing(
         &self,
         substring: &str,
@@ -1618,6 +1630,10 @@ impl Guild {
     /// However, since the read-locks are dropped after borrowing the name,
     /// the names might have been changed by the user, the sorted list cannot
     /// account for this.
+    ///
+    /// **Note**: This will only search members that are cached. If you want to
+    /// search all members in the guild via the Http API, use
+    /// [`Self::search_members`].
     pub async fn members_username_containing(
         &self,
         substring: &str,
@@ -1676,6 +1692,10 @@ impl Guild {
     /// However, since the read-locks are dropped after borrowing the name,
     /// the names might have been changed by the user, the sorted list cannot
     /// account for this.
+    ///
+    /// **Note**: This will only search members that are cached. If you want to
+    /// search all members in the guild via the Http API, use
+    /// [`Self::search_members`].
     pub async fn members_nick_containing(
         &self,
         substring: &str,
@@ -2032,6 +2052,15 @@ impl Guild {
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname
     /// starts with a provided string.
+    ///
+    /// Optionally pass in the `limit` to limit the number of results.
+    /// Minimum value is 1, maximum and default value is 1000.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the API returns an error.
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn search_members(
         &self,
@@ -2039,7 +2068,7 @@ impl Guild {
         query: &str,
         limit: Option<u64>,
     ) -> Result<Vec<Member>> {
-        http.as_ref().search_guild_members(self.id.0, query, limit).await
+        self.id.search_members(http, query, limit).await
     }
 
     /// Returns the Id of the shard associated with the guild.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -993,6 +993,29 @@ impl PartialGuild {
         self.id.reorder_channels(&http, channels).await
     }
 
+    /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname
+    /// starts with a provided string.
+    ///
+    /// Optionally pass in the `limit` to limit the number of results.
+    /// Minimum value is 1, maximum and default value is 1000.
+    ///
+    /// **Note**: Queries are case insensitive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the API returns an error.
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    #[inline]
+    pub async fn search_members(
+        &self,
+        http: impl AsRef<Http>,
+        query: &str,
+        limit: Option<u64>,
+    ) -> Result<Vec<Member>> {
+        self.id.search_members(http, query, limit).await
+    }
+
     /// Starts a prune of [`Member`]s.
     ///
     /// See the documentation on [`GuildPrune`] for more information.


### PR DESCRIPTION
### Description

Adds support for searching guild members whose username or nickname starts with a provided query.

Documentation: https://discord.com/developers/docs/resources/guild#search-guild-members

### Tested

`Guild::search_members()` correctly returns a vec of members, and an empty vec when none are found.
