### PR TITLE
Clarify interaction docs

### DIFF
--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -422,7 +422,8 @@ pub trait EventHandler: Send + Sync {
     ) {
     }
 
-    /// Dispatched when a user used a slash command.
+    /// Dispatched when an interaction is created (e.g a slash command was used
+    /// or a button was clicked).
     ///
     /// Provides the created interaction.
     #[cfg(feature = "unstable_discord_api")]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -88,7 +88,7 @@ impl<'a> HttpBuilder<'a> {
         Self::_new().token(token)
     }
 
-    /// Sets the application_id to use slash commands.
+    /// Sets the application_id to use interactions.
     #[cfg(feature = "unstable_discord_api")]
     pub fn application_id(mut self, application_id: u64) -> Self {
         self.application_id = Some(application_id);
@@ -175,7 +175,7 @@ impl<'a> Future for HttpBuilder<'a> {
             #[cfg(feature = "unstable_discord_api")]
             let application_id = self
                 .application_id
-                .expect("Expected application Id in order to use slash commands");
+                .expect("Expected application Id in order to use interaction features");
 
             let client = self.client.take().unwrap_or_else(|| {
                 let builder = configure_client_backend(Client::builder());

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1696,7 +1696,7 @@ pub enum Event {
     VoiceServerUpdate(VoiceServerUpdateEvent),
     /// A webhook for a [channel][`GuildChannel`] was updated in a [`Guild`].
     WebhookUpdate(WebhookUpdateEvent),
-    /// A user used a slash command.
+    /// An interaction was created.
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     InteractionCreate(InteractionCreateEvent),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -2051,7 +2051,7 @@ pub enum EventType {
     ///
     /// This maps to [`WebhookUpdateEvent`].
     WebhookUpdate,
-    /// Indicator that a slash command was received.
+    /// Indicator that an interaction was created.
     ///
     /// This maps to [`InteractionCreateEvent`].
     #[cfg(feature = "unstable_discord_api")]

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -19,8 +19,8 @@ use crate::utils;
 
 /// Information about an interaction.
 ///
-/// An interaction is sent when a user invokes a slash command and is the same
-/// for slash commands and other future interaction types.
+/// An interaction is sent when a user invokes a slash command, clicks a button,
+/// or other future interaction types.
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct Interaction {


### PR DESCRIPTION
Minor changes to adjust slash command specific wording to include buttons and other interactions.  Prevents confusion that certain things are *only* for slash commands when they actually include other interactions.