### PR TITLE
Guarantee the Interaction::user field

### DIFF
--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -154,12 +154,7 @@ impl ComponentInteractionFilter {
             && self.options.channel_id.map_or(true, |id| {
                 id == interaction.channel_id.as_ref().expect("expected channel id").0
             })
-            && self.options.author_id.map_or(true, |id| {
-                id == interaction
-                    .user
-                    .id
-                    .0
-            })
+            && self.options.author_id.map_or(true, |id| id == interaction.user.id.0)
             && self.options.filter.as_ref().map_or(true, |f| f(&interaction))
     }
 

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -157,8 +157,6 @@ impl ComponentInteractionFilter {
             && self.options.author_id.map_or(true, |id| {
                 id == interaction
                     .user
-                    .as_ref()
-                    .unwrap_or(&interaction.member.as_ref().expect("expected member").user)
                     .id
                     .0
             })

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -56,7 +56,6 @@ pub struct Interaction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<Member>,
     /// The `user` object for the invoking user.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: User,
     /// A continuation token for responding to the interaction.
     pub token: String,

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -51,9 +51,7 @@ pub struct Interaction {
     /// **Note**: It is only present if the interaction is triggered in a guild.
     pub member: Option<Member>,
     /// The `user` object for the invoking user.
-    ///
-    /// It is only present if the interaction is triggered in DM.
-    pub user: Option<User>,
+    pub user: User,
     /// A continuation token for responding to the interaction.
     pub token: String,
     /// Always `1`.
@@ -348,13 +346,11 @@ impl<'de> Deserialize<'de> for Interaction {
         };
 
         let user = match map.contains_key("user") {
-            true => Some(
-                map.remove("user")
+            true => map.remove("user")
                     .ok_or_else(|| DeError::custom("expected user"))
                     .and_then(User::deserialize)
                     .map_err(DeError::custom)?,
-            ),
-            false => None,
+            false => member.unwrap_or_else(|| DeError::custom("expected user or member")).user,
         };
 
         let message = match map.contains_key("message") {

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -350,7 +350,7 @@ impl<'de> Deserialize<'de> for Interaction {
                     .ok_or_else(|| DeError::custom("expected user"))
                     .and_then(User::deserialize)
                     .map_err(DeError::custom)?,
-            false => member.unwrap_or_else(|| DeError::custom("expected user or member")).user,
+            false => member.as_ref().expect("expected user or member").user.clone(),
         };
 
         let message = match map.contains_key("message") {

--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -346,10 +346,11 @@ impl<'de> Deserialize<'de> for Interaction {
         };
 
         let user = match map.contains_key("user") {
-            true => map.remove("user")
-                    .ok_or_else(|| DeError::custom("expected user"))
-                    .and_then(User::deserialize)
-                    .map_err(DeError::custom)?,
+            true => map
+                .remove("user")
+                .ok_or_else(|| DeError::custom("expected user"))
+                .and_then(User::deserialize)
+                .map_err(DeError::custom)?,
             false => member.as_ref().expect("expected user or member").user.clone(),
         };
 


### PR DESCRIPTION
This PR makes the `Interaction::user` field always present.

This has been tested