### PR TITLE
Fix/remove broken links in doc comments

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -417,7 +417,7 @@ impl Cache {
     /// # Examples
     ///
     /// Getting a guild's channel via the Id of the message received through a
-    /// [`Client::on_message`] event dispatch:
+    /// [`EventHandler::message`] event dispatch:
     ///
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
@@ -445,14 +445,14 @@ impl Cache {
     ///
     /// # #[cfg(feature = "client")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
     /// # }
     /// ```
     ///
-    /// [`Client::on_message`]: ../client/struct.Client.html#method.on_message
+    /// [`EventHandler::message`]: crate::client::EventHandler::message
     #[inline]
     pub async fn guild_channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannel> {
         self._guild_channel(id.into()).await
@@ -513,7 +513,7 @@ impl Cache {
     /// # Examples
     ///
     /// Retrieving the member object of the user that posted a message, in a
-    /// [`Client::on_message`] context:
+    /// [`EventHandler::message`] context:
     ///
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
@@ -525,7 +525,7 @@ impl Cache {
     /// # let http = Arc::new(Http::new_with_token("DISCORD_TOKEN"));
     /// # let message = ChannelId(0).message(&http, MessageId(1)).await.unwrap();
     /// # let cache = Cache::default();
-    ///
+    /// #
     /// let member = {
     ///     let channel = match cache.guild_channel(message.channel_id).await {
     ///         Some(channel) => channel,
@@ -556,7 +556,7 @@ impl Cache {
     /// # }
     /// ```
     ///
-    /// [`Client::on_message`]: ../client/struct.Client.html#method.on_message
+    /// [`EventHandler::message`]: crate::client::EventHandler::message
     /// [`members`]: crate::model::guild::Guild::members
     #[inline]
     pub async fn member<G, U>(&self, guild_id: G, user_id: U) -> Option<Member>
@@ -682,7 +682,7 @@ impl Cache {
     /// #
     /// match cache.message(message.channel_id, message.id).await {
     ///     Some(m) => assert_eq!(message.content, m.content),
-    ///     None =>println!("No message found in cache."),
+    ///     None => println!("No message found in cache."),
     /// };
     /// #     Ok(())
     /// # }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -53,8 +53,7 @@ use crate::model::{
 /// leave the client to do it.
 ///
 /// This can be done by passing in the required parameters to [`Self::new`]. You can
-/// then manually handle the shard yourself and receive events via
-/// [`receive`].
+/// then manually handle the shard yourself.
 ///
 /// **Note**: You _really_ do not need to do this. Just call one of the
 /// appropriate methods on the [`Client`].
@@ -178,12 +177,6 @@ impl Shard {
     }
 
     /// Whether the shard has permanently shutdown.
-    ///
-    /// This should normally happen due to manual calling of [`shutdown`] or
-    /// [`shutdown_clean`].
-    ///
-    /// [`shutdown`]: #method.shutdown
-    /// [`shutdown_clean`]: #method.shutdown_clean
     #[inline]
     pub fn is_shutdown(&self) -> bool {
         self.shutdown

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! Serenity supports bot user authentication via the use of [`Client::builder`].
 //!
 //! Once logged in, you may add handlers to your client to dispatch [`Event`]s,
-//! such as [`Client::on_message`]. This will cause your handler to be called
+//! such as [`EventHandler::message`]. This will cause your handler to be called
 //! when a [`Event::MessageCreate`] is received. Each handler is given a
 //! [`Context`], giving information about the event. See the
 //! [client's module-level documentation].
@@ -40,7 +40,7 @@
 //! ```
 //!
 //! [`Context`]: crate::client::Context
-//! [`Client::on_message`]: client/struct.Client.html#method.on_message
+//! [`EventHandler::message`]: crate::client::EventHandler::message
 //! [`Event`]: crate::model::event::Event
 //! [`Event::MessageCreate`]: crate::model::event::Event::MessageCreate
 //! [`Shard`]: crate::gateway::Shard


### PR DESCRIPTION
This PR claims to fix all broken links detailed in [issue 998](https://github.com/serenity-rs/serenity/issues/998).

Some of the links were fixed, others were removed completely. The removals relate to methods that seem to be gone for good.

Please note that I have skipped running any tests. By doing so I'm going against the contributing guidelines. I hope it's okay given that the changes are to comments and not code.