### PR TITLE
Add support for fetching the current user's connections

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2616,6 +2616,18 @@ impl Http {
         .await
     }
 
+    /// Gets the current user's third party connections.
+    ///
+    /// This method only works for user tokens with the `connections` OAuth2 scope.
+    pub async fn get_user_connections(&self) -> Result<Vec<Connection>> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetUserConnections,
+        })
+        .await
+    }
+
     /// Gets our DM channels.
     pub async fn get_user_dm_channels(&self) -> Result<Vec<PrivateChannel>> {
         self.fire(Request {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -286,6 +286,8 @@ pub enum Route {
     UsersMe,
     /// Route for the `/users/@me/channels` path.
     UsersMeChannels,
+    /// Route for the `/users/@me/connections` path.
+    UsersMeConnections,
     /// Route for the `/users/@me/guilds` path.
     UsersMeGuilds,
     /// Route for the `/users/@me/guilds/:guild_id` path.
@@ -682,6 +684,10 @@ impl Route {
 
     pub fn user<D: Display>(target: D) -> String {
         format!(api!("/users/{}"), target)
+    }
+
+    pub fn user_me_connections() -> &'static str {
+        api!("/users/@me/connections")
     }
 
     pub fn user_dm_channels<D: Display>(target: D) -> String {
@@ -1262,6 +1268,7 @@ pub enum RouteInfo<'a> {
     GetUser {
         user_id: u64,
     },
+    GetUserConnections,
     GetUserDmChannels,
     GetVoiceRegions,
     GetWebhook {
@@ -2150,6 +2157,11 @@ impl<'a> RouteInfo<'a> {
             RouteInfo::GetUser {
                 user_id,
             } => (LightMethod::Get, Route::UsersId, Cow::from(Route::user(user_id))),
+            RouteInfo::GetUserConnections => (
+                LightMethod::Get,
+                Route::UsersMeConnections,
+                Cow::from(Route::user_me_connections()),
+            ),
             RouteInfo::GetUserDmChannels => (
                 LightMethod::Get,
                 Route::UsersMeChannels,

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -1,0 +1,45 @@
+//! Models for user connections.
+
+use super::prelude::*;
+
+/// Information about a connection between the current user and a third party service.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Connection {
+    /// The ID of the account on the other side of this connection.
+    pub id: String,
+    /// The username of the account on the other side of this connection.
+    pub name: String,
+    /// The service that this connection represents (e.g. twitch, youtube)
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Whether this connection has been revoked and is no longer valid.
+    #[serde(default)]
+    pub revoked: bool,
+    /// A list of partial guild [`Integration`]s that use this connection.
+    #[serde(default)]
+    pub integrations: Vec<Integration>,
+    /// Whether this connection has been verified and the user has proven they own the account.
+    pub verified: bool,
+    /// Whether friend sync is enabled for this connection.
+    pub friend_sync: bool,
+    /// Whether activities related to this connection will be shown in presence updates.
+    pub show_activity: bool,
+    /// The visibility of this connection.
+    pub visibility: ConnectionVisibility,
+}
+
+/// The visibility of a user connection on a user's profile.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum ConnectionVisibility {
+    None = 0,
+    Everyone = 1,
+    Unknown = !0,
+}
+
+enum_number!(ConnectionVisibility {
+    None,
+    Everyone
+});

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -24,6 +24,7 @@ mod utils;
 
 pub mod application;
 pub mod channel;
+pub mod connection;
 pub mod error;
 pub mod event;
 pub mod gateway;

--- a/src/model/prelude.rs
+++ b/src/model/prelude.rs
@@ -12,6 +12,7 @@
 
 pub use super::application::*;
 pub use super::channel::*;
+pub use super::connection::*;
 pub use super::event::*;
 pub use super::gateway::*;
 pub use super::guild::*;


### PR DESCRIPTION
Allows fetching of the current users connections to third party services, which are shown on the profile.

This requires a user token - not a bot token - and the `connections` scope.

This should resolve #774.

Example output:
```rust
[
    Connection {
        id: "Dinnerbone#0000",
        name: "Dinnerbone#0000",
        kind: "battlenet",
        revoked: false,
        integrations: [],
        verified: true,
        friend_sync: true,
        show_activity: true,
        visibility: Everyone,
    },
    Connection {
        id: "317625",
        name: "Dinnerbone",
        kind: "github",
        revoked: false,
        integrations: [],
        verified: true,
        friend_sync: false,
        show_activity: true,
        visibility: Everyone,
    }
],
```