### PR TITLE
Correctly cache guild categories on add/delete/update

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1086,7 +1086,7 @@ mod test {
             assert!(!channel.contains_key(&MessageId(3)));
         }
 
-        let guild_channel = GuildChannel {
+        let channel = Channel::Guild(GuildChannel {
             id: event.message.channel_id,
             bitrate: None,
             category_id: None,
@@ -1103,12 +1103,12 @@ mod test {
             slow_mode_rate: Some(0),
             rtc_region: None,
             video_quality_mode: None,
-        };
+        });
 
         // Add a channel delete event to the cache, the cached messages for that
         // channel should now be gone.
         let mut delete = ChannelDeleteEvent {
-            channel: Channel::Guild(guild_channel.clone()),
+            channel: channel.clone(),
         };
         assert!(cache.update(&mut delete).await.is_none());
         assert!(!cache.messages.read().await.contains_key(&delete.channel.id()));
@@ -1117,7 +1117,7 @@ mod test {
         // is received.
         let mut guild_create = {
             let mut channels = HashMap::new();
-            channels.insert(ChannelId(2), guild_channel.clone());
+            channels.insert(ChannelId(2), channel.clone());
 
             #[allow(deprecated)]
             GuildCreateEvent {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -846,8 +846,8 @@ pub(crate) async fn has_correct_permissions(
         true
     } else if let Some(guild) = message.guild(&cache).await {
         let channel = match guild.channels.get(&message.channel_id) {
-            Some(channel) => channel,
-            None => return false,
+            Some(Channel::Guild(channel)) => channel,
+            _ => return false,
         };
         let member = match guild.members.get(&message.author.id) {
             Some(member) => member,

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -61,7 +61,7 @@ async fn permissions_in(
         return Permissions::all();
     }
 
-    if let Some(Some(channel)) =
+    if let Some(Some(Channel::Guild(channel))) =
         ctx.cache.guild_field(guild_id, |guild| guild.channels.get(&channel_id).cloned()).await
     {
         if channel.kind == ChannelType::Text {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -63,8 +63,7 @@ impl CacheUpdate for ChannelCreateEvent {
                     .write()
                     .await
                     .get_mut(&guild_id)
-                    .and_then(|g| g.channels.insert(channel_id, channel.clone()))
-                    .map(Channel::Guild);
+                    .and_then(|g| g.channels.insert(channel_id, self.channel.clone()));
 
                 cache.channels.write().await.insert(channel_id, channel.clone());
 
@@ -96,12 +95,20 @@ impl CacheUpdate for ChannelCreateEvent {
                     .insert(id, channel.clone())
                     .map(Channel::Private)
             },
-            Channel::Category(ref category) => cache
-                .categories
-                .write()
-                .await
-                .insert(category.id, category.clone())
-                .map(Channel::Category),
+            Channel::Category(ref category) => {
+                let (guild_id, channel_id) = (category.guild_id, category.id);
+
+                let old_channel = cache
+                    .guilds
+                    .write()
+                    .await
+                    .get_mut(&guild_id)
+                    .and_then(|g| g.channels.insert(channel_id, self.channel.clone()));
+
+                cache.categories.write().await.insert(channel_id, category.clone());
+
+                old_channel
+            },
         }
     }
 }
@@ -132,9 +139,16 @@ impl CacheUpdate for ChannelDeleteEvent {
                     .map(|g| g.channels.remove(&channel_id));
             },
             Channel::Category(ref category) => {
-                let channel_id = category.id;
+                let (guild_id, channel_id) = (category.guild_id, category.id);
 
                 cache.categories.write().await.remove(&channel_id);
+
+                cache
+                    .guilds
+                    .write()
+                    .await
+                    .get_mut(&guild_id)
+                    .map(|g| g.channels.remove(&channel_id));
             },
             Channel::Private(ref channel) => {
                 let id = { channel.id };
@@ -220,7 +234,7 @@ impl CacheUpdate for ChannelUpdateEvent {
                     .write()
                     .await
                     .get_mut(&guild_id)
-                    .map(|g| g.channels.insert(channel_id, channel.clone()));
+                    .map(|g| g.channels.insert(channel_id, self.channel.clone()));
             },
             Channel::Private(ref channel) => {
                 if let Some(c) = cache.private_channels.write().await.get_mut(&channel.id) {
@@ -228,9 +242,16 @@ impl CacheUpdate for ChannelUpdateEvent {
                 }
             },
             Channel::Category(ref category) => {
-                if let Some(c) = cache.categories.write().await.get_mut(&category.id) {
-                    c.clone_from(category);
-                }
+                let (guild_id, channel_id) = (category.guild_id, category.id);
+
+                cache.categories.write().await.insert(channel_id, category.clone());
+
+                cache
+                    .guilds
+                    .write()
+                    .await
+                    .get_mut(&guild_id)
+                    .map(|g| g.channels.insert(channel_id, self.channel.clone()));
             },
         }
 
@@ -291,7 +312,20 @@ impl CacheUpdate for GuildCreateEvent {
             }
         }
 
-        cache.channels.write().await.extend(guild.channels.clone().into_iter());
+        cache.channels.write().await.extend(guild.channels.clone().into_iter().filter_map(|c| {
+            match c.1 {
+                Channel::Guild(channel) => Some((c.0, channel)),
+                _ => None,
+            }
+        }));
+
+        cache.categories.write().await.extend(guild.channels.clone().into_iter().filter_map(|c| {
+            match c.1 {
+                Channel::Category(category) => Some((c.0, category)),
+                _ => None,
+            }
+        }));
+
         cache.guilds.write().await.insert(self.guild.id, guild);
 
         None
@@ -329,12 +363,21 @@ impl CacheUpdate for GuildDeleteEvent {
     async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
         match cache.guilds.write().await.remove(&self.guild.id) {
             Some(guild) => {
-                for channel_id in guild.channels.keys() {
-                    // Remove the channel from the cache.
-                    cache.channels.write().await.remove(channel_id);
+                for (channel_id, channel) in &guild.channels {
+                    match channel {
+                        Channel::Guild(_) => {
+                            // Remove the channel from the cache.
+                            cache.channels.write().await.remove(channel_id);
 
-                    // Remove the channel's cached messages.
-                    cache.messages.write().await.remove(channel_id);
+                            // Remove the channel's cached messages.
+                            cache.messages.write().await.remove(channel_id);
+                        },
+                        Channel::Category(_) => {
+                            // Remove the category from the cache
+                            cache.categories.write().await.remove(channel_id);
+                        },
+                        _ => {},
+                    }
                 }
 
                 Some(guild)

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -186,8 +186,13 @@ impl Member {
         let member = guild.members.get(&self.user.id)?;
 
         for channel in guild.channels.values() {
-            if guild.user_permissions_in(channel, member).ok()?.read_messages() {
-                return Some(channel.clone());
+            match channel {
+                Channel::Guild(channel) => {
+                    if guild.user_permissions_in(channel, member).ok()?.read_messages() {
+                        return Some(channel.clone());
+                    }
+                }
+                _ => {},
             }
         }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -191,7 +191,7 @@ impl Member {
                     if guild.user_permissions_in(channel, member).ok()?.read_messages() {
                         return Some(channel.clone());
                     }
-                }
+                },
                 _ => {},
             }
         }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -48,12 +48,12 @@ pub fn serialize_emojis<S: Serializer>(
 
 pub fn deserialize_guild_channels<'de, D: Deserializer<'de>>(
     deserializer: D,
-) -> StdResult<HashMap<ChannelId, GuildChannel>, D::Error> {
-    let vec: Vec<GuildChannel> = Deserialize::deserialize(deserializer)?;
+) -> StdResult<HashMap<ChannelId, Channel>, D::Error> {
+    let vec: Vec<Channel> = Deserialize::deserialize(deserializer)?;
     let mut map = HashMap::new();
 
     for channel in vec {
-        map.insert(channel.id, channel);
+        map.insert(channel.id(), channel);
     }
 
     Ok(map)


### PR DESCRIPTION
### Description

Deserializes `Guild` channels from `GuildCreate` as `Channel` enum instead of `GuildChannel`. This also prevents the merging of guild channels and categories in `Cache::channels` when they should be separate.

Correctly updates the guild channels in the cache (e.g. when using `Message::guild(ctx)`) instead of *only* Cache::categories.

This is a breaking change as `Guild::channels` has been changed from `HashMap<ChannelId, GuildChannel>` to `HashMap<ChannelId, Channel>`. 

### Tested

Adding / Deleting channel categories correctly updates `Cache::categories`, in addition to the channels in `Cache::guild`.

### Related issues

Fixes #1404
