### PR TITLE
Improvements to embed methods on EditMessage

### DIFF
--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -74,16 +74,6 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    /// Add an embed for the message.
-    pub fn add_embed<F>(&mut self, f: F) -> &mut Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
-        self._add_embed(embed)
-    }
-
     fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
@@ -96,33 +86,64 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    /// Set the embed for the message.
+    /// Add an embed for the message.
+    ///
+    /// **Note**: This will keep all existing embeds. Use [`Self::set_embed()`] to replace existing
+    /// embeds.
+    pub fn add_embed<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
+    {
+        let mut embed = CreateEmbed::default();
+        f(&mut embed);
+        self._add_embed(embed)
+    }
+
+    /// Add multiple embeds for the message.
+    ///
+    /// **Note**: This will keep all existing embeds. Use [`Self::set_embeds()`] to replace existing
+    /// embeds.
+    pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        for embed in embeds {
+            self._add_embed(embed);
+        }
+
+        self
+    }
+
+    /// Set an embed for the message.
+    ///
+    /// Equivalent to [`Self::set_embed()`].
     ///
     /// **Note**: This will replace all existing embeds. Use
-    /// [`Self::add_embed()`] to add additional embeds.
+    /// [`Self::add_embed()`] to add an additional embed.
     pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {
         let mut embed = CreateEmbed::default();
         f(&mut embed);
-        self.set_embed(embed)
+        self.0.insert("embeds", Value::Array(Vec::new()));
+        self._add_embed(embed)
     }
 
     /// Set an embed for the message.
     ///
-    /// **Note**: This will replace all existing embeds with the provided embed.
-    /// Use [`Self::set_embeds()`] to set multiple embeds at once.
+    /// Equivalent to [`Self::embed()`].
+    ///
+    /// **Note**: This will replace all existing embeds.
+    /// Use [`Self::add_embed()`] to add an additional embed.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = utils::hashmap_to_json_map(embed.0);
-        let embed = Value::Object(map);
-
-        self.0.insert("embeds", Value::Array(vec![embed]));
-        self
+        self.0.insert("embeds", Value::Array(Vec::new()));
+        self._add_embed(embed)
     }
 
     /// Set multiple embeds for the message.
+    ///
+    /// **Note**: This will replace all existing embeds. Use [`Self::add_embeds()`] to keep existing
+    /// embeds.
     pub fn set_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        self.0.insert("embeds", Value::Array(Vec::new()));
         for embed in embeds {
             self._add_embed(embed);
         }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -45,16 +45,6 @@ impl EditMessage {
         self
     }
 
-    /// Add an embed for the message.
-    pub fn add_embed<F>(&mut self, f: F) -> &mut Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
-        self._add_embed(embed)
-    }
-
     fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
@@ -67,33 +57,64 @@ impl EditMessage {
         self
     }
 
-    /// Set the embed for the message.
+    /// Add an embed for the message.
+    ///
+    /// **Note**: This will keep all existing embeds. Use [`Self::set_embed()`] to replace existing
+    /// embeds.
+    pub fn add_embed<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
+    {
+        let mut embed = CreateEmbed::default();
+        f(&mut embed);
+        self._add_embed(embed)
+    }
+
+    /// Add multiple embeds for the message.
+    ///
+    /// **Note**: This will keep all existing embeds. Use [`Self::set_embeds()`] to replace existing
+    /// embeds.
+    pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        for embed in embeds {
+            self._add_embed(embed);
+        }
+
+        self
+    }
+
+    /// Set an embed for the message.
+    ///
+    /// Equivalent to [`Self::set_embed()`].
     ///
     /// **Note**: This will replace all existing embeds. Use
-    /// [`Self::add_embed()`] to add additional embeds.
+    /// [`Self::add_embed()`] to add an additional embed.
     pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {
         let mut embed = CreateEmbed::default();
         f(&mut embed);
-        self.set_embed(embed)
+        self.0.remove("embeds");
+        self._add_embed(embed)
     }
 
     /// Set an embed for the message.
     ///
-    /// **Note**: This will replace all existing embeds with the provided embed.
-    /// Use [`Self::set_embeds()`] to set multiple embeds at once.
+    /// Equivalent to [`Self::embed()`].
+    ///
+    /// **Note**: This will replace all existing embeds.
+    /// Use [`Self::add_embed()`] to add an additional embed.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = utils::hashmap_to_json_map(embed.0);
-        let embed = Value::Object(map);
-
-        self.0.insert("embeds", Value::Array(vec![embed]));
-        self
+        self.0.remove("embeds");
+        self._add_embed(embed)
     }
 
     /// Set multiple embeds for the message.
+    ///
+    /// **Note**: This will replace all existing embeds. Use [`Self::add_embeds()`] to keep existing
+    /// embeds.
     pub fn set_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        self.0.remove("embeds");
         for embed in embeds {
             self._add_embed(embed);
         }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -94,7 +94,7 @@ impl EditMessage {
     {
         let mut embed = CreateEmbed::default();
         f(&mut embed);
-        self.0.remove("embeds");
+        self.0.insert("embeds", Value::Array(Vec::new()));
         self._add_embed(embed)
     }
 
@@ -105,7 +105,7 @@ impl EditMessage {
     /// **Note**: This will replace all existing embeds.
     /// Use [`Self::add_embed()`] to add an additional embed.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        self.0.remove("embeds");
+        self.0.insert("embeds", Value::Array(Vec::new()));
         self._add_embed(embed)
     }
 
@@ -114,7 +114,7 @@ impl EditMessage {
     /// **Note**: This will replace all existing embeds. Use [`Self::add_embeds()`] to keep existing
     /// embeds.
     pub fn set_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
-        self.0.remove("embeds");
+        self.0.insert("embeds", Value::Array(Vec::new()));
         for embed in embeds {
             self._add_embed(embed);
         }


### PR DESCRIPTION
- Make embed methods not depend on each other
- Add add_embeds method
- Change set_embeds to actually _set_ embeds, not _add_ them
- Expand embed method documentation to explain differences to each other

I tested the embed(), set_embed(), and set_embeds() methods in a personal bot