### PR TITLE
Use ratelimiter when sending files in messages and webhooks

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -9,20 +9,19 @@ use std::{
     task::{Context as FutContext, Poll},
 };
 
-use bytes::buf::Buf;
 use futures::future::BoxFuture;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::{
-    header::{HeaderMap as Headers, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT},
+    header::{HeaderMap as Headers, HeaderValue, CONTENT_TYPE},
     StatusCode,
     Url,
 };
-use reqwest::{multipart::Part, Client, ClientBuilder, Response as ReqwestResponse};
+use reqwest::{Client, ClientBuilder, Response as ReqwestResponse};
 use serde::de::DeserializeOwned;
-use tokio::{fs::File, io::AsyncReadExt};
 use tracing::{debug, instrument, trace};
 
 use super::{
+    multipart::Multipart,
     ratelimiting::{RatelimitedRequest, Ratelimiter},
     request::Request,
     routing::RouteInfo,
@@ -32,10 +31,9 @@ use super::{
     HttpError,
 };
 use crate::constants;
-use crate::http::routing::Route;
 use crate::internal::prelude::*;
 use crate::json::json;
-use crate::json::{from_number, from_value, to_string, to_vec};
+use crate::json::{from_number, from_value, to_vec, to_value};
 use crate::model::prelude::*;
 
 /// A builder implementing [`Future`] building a [`Http`] client to perform
@@ -292,6 +290,7 @@ impl Http {
     pub async fn add_member_role(&self, guild_id: u64, user_id: u64, role_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::AddMemberRole {
                 guild_id,
@@ -320,6 +319,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GuildBanUser {
                 delete_message_days: Some(delete_message_days),
@@ -341,6 +341,7 @@ impl Http {
     pub async fn broadcast_typing(&self, channel_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::BroadcastTyping {
                 channel_id,
@@ -362,6 +363,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateChannel {
                 guild_id,
@@ -381,6 +383,7 @@ impl Http {
     pub async fn create_emoji(&self, guild_id: u64, map: &Value) -> Result<Emoji> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateEmoji {
                 guild_id,
@@ -401,6 +404,7 @@ impl Http {
     ) -> Result<Message> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateFollowupMessage {
                 application_id: self.application_id,
@@ -429,6 +433,7 @@ impl Http {
     ) -> Result<ApplicationCommand> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateGlobalApplicationCommand {
                 application_id: self.application_id,
@@ -446,6 +451,7 @@ impl Http {
     ) -> Result<Vec<ApplicationCommand>> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateGlobalApplicationCommands {
                 application_id: self.application_id,
@@ -464,6 +470,7 @@ impl Http {
     ) -> Result<Vec<ApplicationCommand>> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateGuildApplicationCommands {
                 application_id: self.application_id,
@@ -511,6 +518,7 @@ impl Http {
     pub async fn create_guild(&self, map: &Value) -> Result<PartialGuild> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateGuild,
         })
@@ -533,6 +541,7 @@ impl Http {
     ) -> Result<ApplicationCommand> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateGuildApplicationCommand {
                 application_id: self.application_id,
@@ -558,6 +567,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateGuildIntegration {
                 guild_id,
@@ -582,6 +592,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateInteractionResponse {
                 interaction_id,
@@ -606,6 +617,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateInvite {
                 channel_id,
@@ -625,6 +637,7 @@ impl Http {
 
         self.wind(204, Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreatePermission {
                 channel_id,
@@ -640,6 +653,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreatePrivateChannel,
         })
@@ -655,6 +669,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateReaction {
                 // Escape emojis like '#️⃣' that contain a hash
@@ -672,6 +687,7 @@ impl Http {
         let mut value = self
             .request(Request {
                 body: Some(&body),
+                multipart: None,
                 headers: None,
                 route: RouteInfo::CreateRole {
                     guild_id,
@@ -722,6 +738,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateWebhook {
                 channel_id,
@@ -734,6 +751,7 @@ impl Http {
     pub async fn delete_channel(&self, channel_id: u64) -> Result<Channel> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteChannel {
                 channel_id,
@@ -746,6 +764,7 @@ impl Http {
     pub async fn delete_emoji(&self, guild_id: u64, emoji_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteEmoji {
                 guild_id,
@@ -765,6 +784,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteFollowupMessage {
                 application_id: self.application_id,
@@ -781,6 +801,7 @@ impl Http {
     pub async fn delete_global_application_command(&self, command_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteGlobalApplicationCommand {
                 application_id: self.application_id,
@@ -794,6 +815,7 @@ impl Http {
     pub async fn delete_guild(&self, guild_id: u64) -> Result<PartialGuild> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteGuild {
                 guild_id,
@@ -812,6 +834,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteGuildApplicationCommand {
                 application_id: self.application_id,
@@ -826,6 +849,7 @@ impl Http {
     pub async fn delete_guild_integration(&self, guild_id: u64, integration_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteGuildIntegration {
                 guild_id,
@@ -839,6 +863,7 @@ impl Http {
     pub async fn delete_invite(&self, code: &str) -> Result<Invite> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteInvite {
                 code,
@@ -852,6 +877,7 @@ impl Http {
     pub async fn delete_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteMessage {
                 channel_id,
@@ -865,6 +891,7 @@ impl Http {
     pub async fn delete_messages(&self, channel_id: u64, map: &Value) -> Result<()> {
         self.wind(204, Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteMessages {
                 channel_id,
@@ -894,6 +921,7 @@ impl Http {
     pub async fn delete_message_reactions(&self, channel_id: u64, message_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteMessageReactions {
                 channel_id,
@@ -912,6 +940,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteMessageReactionEmoji {
                 reaction: &reaction_type.as_data(),
@@ -931,6 +960,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteOriginalInteractionResponse {
                 application_id: self.application_id,
@@ -944,6 +974,7 @@ impl Http {
     pub async fn delete_permission(&self, channel_id: u64, target_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeletePermission {
                 channel_id,
@@ -966,6 +997,7 @@ impl Http {
 
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteReaction {
                 // Escape emojis like '#️⃣' that contain a hash
@@ -982,6 +1014,7 @@ impl Http {
     pub async fn delete_role(&self, guild_id: u64, role_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteRole {
                 guild_id,
@@ -1015,6 +1048,7 @@ impl Http {
     pub async fn delete_webhook(&self, webhook_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteWebhook {
                 webhook_id,
@@ -1046,6 +1080,7 @@ impl Http {
     pub async fn delete_webhook_with_token(&self, webhook_id: u64, token: &str) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteWebhookWithToken {
                 token,
@@ -1061,6 +1096,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditChannel {
                 channel_id,
@@ -1075,6 +1111,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditEmoji {
                 guild_id,
@@ -1099,6 +1136,7 @@ impl Http {
     ) -> Result<Message> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditFollowupMessage {
                 application_id: self.application_id,
@@ -1125,6 +1163,7 @@ impl Http {
     ) -> Result<ApplicationCommand> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditGlobalApplicationCommand {
                 application_id: self.application_id,
@@ -1140,6 +1179,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditGuild {
                 guild_id,
@@ -1165,6 +1205,7 @@ impl Http {
     ) -> Result<ApplicationCommand> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommand {
                 application_id: self.application_id,
@@ -1192,6 +1233,7 @@ impl Http {
     ) -> Result<ApplicationCommandPermission> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommandPermission {
                 application_id: self.application_id,
@@ -1218,6 +1260,7 @@ impl Http {
     ) -> Result<Vec<ApplicationCommandPermission>> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommandsPermissions {
                 application_id: self.application_id,
@@ -1233,6 +1276,7 @@ impl Http {
 
         self.wind(204, Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditGuildChannels {
                 guild_id,
@@ -1247,6 +1291,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditGuildWidget {
                 guild_id,
@@ -1265,6 +1310,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditGuildWelcomeScreen {
                 guild_id,
@@ -1280,6 +1326,7 @@ impl Http {
         let mut value = self
             .request(Request {
                 body: Some(&body),
+                multipart: None,
                 headers: None,
                 route: RouteInfo::EditMember {
                     guild_id,
@@ -1310,6 +1357,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditMessage {
                 channel_id,
@@ -1329,41 +1377,19 @@ impl Http {
         map: &Value,
         new_attachments: impl IntoIterator<Item = AttachmentType<'_>>,
     ) -> Result<Message> {
-        // Note: if you need to copy this code for a new method, extract this code into a function
-        // instead and call it in here and in send_files(), to avoid duplication (see Rule Of Three)
-
-        let uri = api!("/channels/{}/messages/{}", channel_id, message_id);
-        let mut url = Url::parse(&uri).map_err(|_| Error::Url(uri))?;
-
-        if let Some(proxy) = &self.proxy {
-            url.set_host(proxy.host_str()).map_err(HttpError::Url)?;
-            url.set_scheme(proxy.scheme()).map_err(|_| HttpError::InvalidScheme)?;
-            url.set_port(proxy.port()).map_err(|_| HttpError::InvalidPort)?;
-        }
-
-        let mut multipart = reqwest::multipart::Form::new();
-
-        for (i, attachment) in new_attachments.into_iter().enumerate() {
-            multipart =
-                multipart.part(i.to_string(), attachment.into_http_form_part(&self.client).await?);
-        }
-
-        multipart = multipart.text("payload_json", serde_json::to_string(map)?);
-
-        let response = self
-            .client
-            .patch(url)
-            .header(AUTHORIZATION, HeaderValue::from_str(&self.token)?)
-            .header(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT))
-            .multipart(multipart)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            return Err(HttpError::from_response(response).await.into());
-        }
-
-        response.json::<Message>().await.map_err(From::from)
+        self.fire(Request {
+            body: None,
+            multipart: Some(Multipart {
+                files: new_attachments.into_iter().map(Into::into).collect(),
+                payload_json: map.clone(),
+            }),
+            headers: None,
+            route: RouteInfo::EditMessage {
+                channel_id,
+                message_id,
+            },
+        })
+        .await
     }
 
     /// Crossposts a message by Id.
@@ -1372,6 +1398,7 @@ impl Http {
     pub async fn crosspost_message(&self, channel_id: u64, message_id: u64) -> Result<Message> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::CrosspostMessage {
                 channel_id,
@@ -1390,6 +1417,7 @@ impl Http {
 
         self.wind(200, Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditNickname {
                 guild_id,
@@ -1407,6 +1435,7 @@ impl Http {
     ) -> Result<Message> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetOriginalInteractionResponse {
                 application_id: self.application_id,
@@ -1430,6 +1459,7 @@ impl Http {
     ) -> Result<Message> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditOriginalInteractionResponse {
                 application_id: self.application_id,
@@ -1446,6 +1476,7 @@ impl Http {
         let request = self
             .request(Request {
                 body: Some(&body),
+                multipart: None,
                 headers: None,
                 route: RouteInfo::EditProfile,
             })
@@ -1460,6 +1491,7 @@ impl Http {
         let mut value = self
             .request(Request {
                 body: Some(&body),
+                multipart: None,
                 headers: None,
                 route: RouteInfo::EditRole {
                     guild_id,
@@ -1492,6 +1524,7 @@ impl Http {
         let mut value = self
             .request(Request {
                 body: Some(&body),
+                multipart: None,
                 headers: None,
                 route: RouteInfo::EditRolePosition {
                     guild_id,
@@ -1552,6 +1585,7 @@ impl Http {
 
         self.wind(204, Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditVoiceState {
                 guild_id,
@@ -1603,6 +1637,7 @@ impl Http {
 
         self.wind(204, Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditVoiceStateMe {
                 guild_id,
@@ -1648,6 +1683,7 @@ impl Http {
     pub async fn edit_webhook(&self, webhook_id: u64, map: &Value) -> Result<Webhook> {
         self.fire(Request {
             body: Some(map.to_string().as_bytes()),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditWebhook {
                 webhook_id,
@@ -1692,6 +1728,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditWebhookWithToken {
                 token,
@@ -1764,6 +1801,7 @@ impl Http {
         let response = self
             .request(Request {
                 body: Some(&body),
+                multipart: None,
                 headers: Some(headers),
                 route: RouteInfo::ExecuteWebhook {
                     token,
@@ -1798,76 +1836,20 @@ impl Http {
     where
         T: Into<AttachmentType<'a>>,
     {
-        let mut multipart = reqwest::multipart::Form::new();
-
-        for (file_num, file) in files.into_iter().enumerate() {
-            match file.into() {
-                AttachmentType::Bytes {
-                    data,
-                    filename,
-                } => {
-                    multipart = multipart.part(
-                        file_num.to_string(),
-                        Part::bytes(data.into_owned()).file_name(filename),
-                    );
-                },
-                AttachmentType::File {
-                    file,
-                    filename,
-                } => {
-                    let mut buf = Vec::new();
-                    file.try_clone().await?.read_to_end(&mut buf).await?;
-
-                    multipart =
-                        multipart.part(file_num.to_string(), Part::stream(buf).file_name(filename));
-                },
-                AttachmentType::Path(path) => {
-                    let filename =
-                        path.file_name().map(|filename| filename.to_string_lossy().into_owned());
-                    let mut file = File::open(path).await?;
-                    let mut buf = vec![];
-                    file.read_to_end(&mut buf).await?;
-
-                    let part = match filename {
-                        Some(filename) => Part::bytes(buf).file_name(filename),
-                        None => Part::bytes(buf),
-                    };
-
-                    multipart = multipart.part(file_num.to_string(), part);
-                },
-                AttachmentType::Image(url) => {
-                    let url = Url::parse(url).map_err(|_| Error::Url(url.to_string()))?;
-                    let filename = url
-                        .path_segments()
-                        .and_then(|segments| segments.last().map(ToString::to_string))
-                        .ok_or_else(|| Error::Url(url.to_string()))?;
-                    let response = self.client.get(url).send().await?;
-                    let mut bytes = response.bytes().await?;
-                    let mut picture: Vec<u8> = vec![0; bytes.len()];
-                    bytes.copy_to_slice(&mut picture[..]);
-                    multipart = multipart.part(
-                        file_num.to_string(),
-                        Part::bytes(picture).file_name(filename.to_string()),
-                    );
-                },
-            }
-        }
-
-        multipart = multipart.text("payload_json", to_string(&map)?);
-
-        let response = self
-            .client
-            .post(&Route::webhook_with_token_optioned(webhook_id, token, wait))
-            .multipart(multipart)
-            .header(CONTENT_TYPE, HeaderValue::from_static(&"multipart/form-data"))
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            return Err(HttpError::from_response(response).await.into());
-        }
-
-        response.json::<Message>().await.map(Some).map_err(From::from)
+        self.fire(Request {
+            body: None,
+            multipart: Some(Multipart {
+                files: files.into_iter().map(Into::into).collect(),
+                payload_json: to_value(map)?,
+            }),
+            headers: None,
+            route: RouteInfo::ExecuteWebhook {
+                token,
+                wait,
+                webhook_id,
+            },
+        })
+        .await
     }
 
     /// Edits a webhook's message by Id.
@@ -1882,6 +1864,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::EditWebhookMessage {
                 token,
@@ -1901,6 +1884,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::DeleteWebhookMessage {
                 token,
@@ -1918,6 +1902,7 @@ impl Http {
         let response = self
             .request(Request {
                 body: None,
+                multipart: None,
                 headers: None,
                 route: RouteInfo::GetActiveMaintenance,
             })
@@ -1935,6 +1920,7 @@ impl Http {
     pub async fn get_bans(&self, guild_id: u64) -> Result<Vec<Ban>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetBans {
                 guild_id,
@@ -1954,6 +1940,7 @@ impl Http {
     ) -> Result<AuditLogs> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetAuditLogs {
                 action_type,
@@ -1970,6 +1957,7 @@ impl Http {
     pub async fn get_bot_gateway(&self) -> Result<BotGateway> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetBotGateway,
         })
@@ -1980,6 +1968,7 @@ impl Http {
     pub async fn get_channel_invites(&self, channel_id: u64) -> Result<Vec<RichInvite>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetChannelInvites {
                 channel_id,
@@ -2010,6 +1999,7 @@ impl Http {
     pub async fn get_channel_webhooks(&self, channel_id: u64) -> Result<Vec<Webhook>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetChannelWebhooks {
                 channel_id,
@@ -2022,6 +2012,7 @@ impl Http {
     pub async fn get_channel(&self, channel_id: u64) -> Result<Channel> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetChannel {
                 channel_id,
@@ -2034,6 +2025,7 @@ impl Http {
     pub async fn get_channels(&self, guild_id: u64) -> Result<Vec<GuildChannel>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetChannels {
                 guild_id,
@@ -2048,6 +2040,7 @@ impl Http {
     pub async fn get_current_application_info(&self) -> Result<CurrentApplicationInfo> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetCurrentApplicationInfo,
         })
@@ -2058,6 +2051,7 @@ impl Http {
     pub async fn get_current_user(&self) -> Result<CurrentUser> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetCurrentUser,
         })
@@ -2068,6 +2062,7 @@ impl Http {
     pub async fn get_emojis(&self, guild_id: u64) -> Result<Vec<Emoji>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetEmojis {
                 guild_id,
@@ -2080,6 +2075,7 @@ impl Http {
     pub async fn get_emoji(&self, guild_id: u64, emoji_id: u64) -> Result<Emoji> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetEmoji {
                 guild_id,
@@ -2093,6 +2089,7 @@ impl Http {
     pub async fn get_gateway(&self) -> Result<Gateway> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGateway,
         })
@@ -2105,6 +2102,7 @@ impl Http {
     pub async fn get_global_application_commands(&self) -> Result<Vec<ApplicationCommand>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGlobalApplicationCommands {
                 application_id: self.application_id,
@@ -2122,6 +2120,7 @@ impl Http {
     ) -> Result<ApplicationCommand> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGlobalApplicationCommand {
                 application_id: self.application_id,
@@ -2135,6 +2134,7 @@ impl Http {
     pub async fn get_guild(&self, guild_id: u64) -> Result<PartialGuild> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuild {
                 guild_id,
@@ -2147,6 +2147,7 @@ impl Http {
     pub async fn get_guild_with_counts(&self, guild_id: u64) -> Result<PartialGuild> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildWithCounts {
                 guild_id,
@@ -2164,6 +2165,7 @@ impl Http {
     ) -> Result<Vec<ApplicationCommand>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildApplicationCommands {
                 application_id: self.application_id,
@@ -2183,6 +2185,7 @@ impl Http {
     ) -> Result<ApplicationCommand> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildApplicationCommand {
                 application_id: self.application_id,
@@ -2202,6 +2205,7 @@ impl Http {
     ) -> Result<Vec<ApplicationCommandPermission>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildApplicationCommandsPermissions {
                 application_id: self.application_id,
@@ -2221,6 +2225,7 @@ impl Http {
     ) -> Result<ApplicationCommandPermission> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildApplicationCommandPermissions {
                 application_id: self.application_id,
@@ -2237,6 +2242,7 @@ impl Http {
     pub async fn get_guild_embed(&self, guild_id: u64) -> Result<GuildEmbed> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildWidget {
                 guild_id,
@@ -2249,6 +2255,7 @@ impl Http {
     pub async fn get_guild_widget(&self, guild_id: u64) -> Result<GuildWidget> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildWidget {
                 guild_id,
@@ -2261,6 +2268,7 @@ impl Http {
     pub async fn get_guild_preview(&self, guild_id: u64) -> Result<GuildPreview> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildPreview {
                 guild_id,
@@ -2273,6 +2281,7 @@ impl Http {
     pub async fn get_guild_welcome_screen(&self, guild_id: u64) -> Result<GuildWelcomeScreen> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildWelcomeScreen {
                 guild_id,
@@ -2285,6 +2294,7 @@ impl Http {
     pub async fn get_guild_integrations(&self, guild_id: u64) -> Result<Vec<Integration>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildIntegrations {
                 guild_id,
@@ -2297,6 +2307,7 @@ impl Http {
     pub async fn get_guild_invites(&self, guild_id: u64) -> Result<Vec<RichInvite>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildInvites {
                 guild_id,
@@ -2314,6 +2325,7 @@ impl Http {
 
         self.request(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildVanityUrl {
                 guild_id,
@@ -2343,6 +2355,7 @@ impl Http {
         let mut value = self
             .request(Request {
                 body: None,
+                multipart: None,
                 headers: None,
                 route: RouteInfo::GetGuildMembers {
                     after,
@@ -2379,6 +2392,7 @@ impl Http {
 
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildPruneCount {
                 days: req.days,
@@ -2393,6 +2407,7 @@ impl Http {
     pub async fn get_guild_regions(&self, guild_id: u64) -> Result<Vec<VoiceRegion>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildRegions {
                 guild_id,
@@ -2406,6 +2421,7 @@ impl Http {
         let mut value = self
             .request(Request {
                 body: None,
+                multipart: None,
                 headers: None,
                 route: RouteInfo::GetGuildRoles {
                     guild_id,
@@ -2448,6 +2464,7 @@ impl Http {
     pub async fn get_guild_webhooks(&self, guild_id: u64) -> Result<Vec<Webhook>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuildWebhooks {
                 guild_id,
@@ -2489,6 +2506,7 @@ impl Http {
 
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetGuilds {
                 after,
@@ -2508,6 +2526,7 @@ impl Http {
 
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetInvite {
                 code,
@@ -2522,6 +2541,7 @@ impl Http {
         let mut value = self
             .request(Request {
                 body: None,
+                multipart: None,
                 headers: None,
                 route: RouteInfo::GetMember {
                     guild_id,
@@ -2543,6 +2563,7 @@ impl Http {
     pub async fn get_message(&self, channel_id: u64, message_id: u64) -> Result<Message> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetMessage {
                 channel_id,
@@ -2556,6 +2577,7 @@ impl Http {
     pub async fn get_messages(&self, channel_id: u64, query: &str) -> Result<Vec<Message>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetMessages {
                 query: query.to_owned(),
@@ -2569,6 +2591,7 @@ impl Http {
     pub async fn get_pins(&self, channel_id: u64) -> Result<Vec<Message>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetPins {
                 channel_id,
@@ -2590,6 +2613,7 @@ impl Http {
 
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetReactionUsers {
                 after,
@@ -2609,6 +2633,7 @@ impl Http {
         let response = self
             .request(Request {
                 body: None,
+                multipart: None,
                 headers: None,
                 route: RouteInfo::GetUnresolvedIncidents,
             })
@@ -2629,6 +2654,7 @@ impl Http {
         let response = self
             .request(Request {
                 body: None,
+                multipart: None,
                 headers: None,
                 route: RouteInfo::GetUpcomingMaintenances,
             })
@@ -2646,6 +2672,7 @@ impl Http {
     pub async fn get_user(&self, user_id: u64) -> Result<User> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetUser {
                 user_id,
@@ -2658,6 +2685,7 @@ impl Http {
     pub async fn get_user_dm_channels(&self) -> Result<Vec<PrivateChannel>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetUserDmChannels,
         })
@@ -2668,6 +2696,7 @@ impl Http {
     pub async fn get_voice_regions(&self) -> Result<Vec<VoiceRegion>> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetVoiceRegions,
         })
@@ -2696,6 +2725,7 @@ impl Http {
     pub async fn get_webhook(&self, webhook_id: u64) -> Result<Webhook> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetWebhook {
                 webhook_id,
@@ -2727,6 +2757,7 @@ impl Http {
     pub async fn get_webhook_with_token(&self, webhook_id: u64, token: &str) -> Result<Webhook> {
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::GetWebhookWithToken {
                 token,
@@ -2750,6 +2781,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::KickMember {
                 guild_id,
@@ -2764,6 +2796,7 @@ impl Http {
     pub async fn leave_guild(&self, guild_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::LeaveGuild {
                 guild_id,
@@ -2788,41 +2821,18 @@ impl Http {
     where
         T: Into<AttachmentType<'a>>,
     {
-        let uri = api!("/channels/{}/messages", channel_id);
-        let mut url = match Url::parse(&uri) {
-            Ok(url) => url,
-            Err(_) => return Err(Error::Url(uri)),
-        };
-
-        if let Some(proxy) = &self.proxy {
-            url.set_host(proxy.host_str()).map_err(HttpError::Url)?;
-            url.set_scheme(proxy.scheme()).map_err(|_| HttpError::InvalidScheme)?;
-            url.set_port(proxy.port()).map_err(|_| HttpError::InvalidPort)?;
-        }
-
-        let mut multipart = reqwest::multipart::Form::new();
-
-        for (file_num, file) in files.into_iter().enumerate() {
-            multipart = multipart
-                .part(file_num.to_string(), file.into().into_http_form_part(&self.client).await?);
-        }
-
-        multipart = multipart.text("payload_json", to_string(&map)?);
-
-        let response = self
-            .client
-            .post(url)
-            .header(AUTHORIZATION, HeaderValue::from_str(&self.token)?)
-            .header(USER_AGENT, HeaderValue::from_static(&constants::USER_AGENT))
-            .multipart(multipart)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            return Err(HttpError::from_response(response).await.into());
-        }
-
-        response.json::<Message>().await.map_err(From::from)
+        self.fire(Request {
+            body: None,
+            multipart: Some(Multipart {
+                files: files.into_iter().map(Into::into).collect(),
+                payload_json: to_value(map)?,
+            }),
+            headers: None,
+            route: RouteInfo::CreateMessage {
+                channel_id,
+            },
+        })
+        .await
     }
 
     /// Sends a message to a channel.
@@ -2831,6 +2841,7 @@ impl Http {
 
         self.fire(Request {
             body: Some(&body),
+            multipart: None,
             headers: None,
             route: RouteInfo::CreateMessage {
                 channel_id,
@@ -2843,6 +2854,7 @@ impl Http {
     pub async fn pin_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::PinMessage {
                 channel_id,
@@ -2856,6 +2868,7 @@ impl Http {
     pub async fn remove_ban(&self, guild_id: u64, user_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::RemoveBan {
                 guild_id,
@@ -2879,6 +2892,7 @@ impl Http {
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::RemoveMemberRole {
                 guild_id,
@@ -2901,6 +2915,7 @@ impl Http {
 
         self.fire(Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::StartGuildPrune {
                 days: req.days,
@@ -2914,6 +2929,7 @@ impl Http {
     pub async fn start_integration_sync(&self, guild_id: u64, integration_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::StartIntegrationSync {
                 guild_id,
@@ -2965,6 +2981,7 @@ impl Http {
     pub async fn unpin_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
+            multipart: None,
             headers: None,
             route: RouteInfo::UnpinMessage {
                 channel_id,
@@ -3063,9 +3080,10 @@ impl Http {
     /// # }
     /// ```
     #[instrument]
-    pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
+    pub async fn request(&self, mut req: Request<'_>) -> Result<ReqwestResponse> {
         let response = if self.ratelimiter_disabled {
-            let request = req.build(&self.client, &self.token, self.proxy.as_ref())?.build()?;
+            let request =
+                req.build(&self.client, &self.token, self.proxy.as_ref()).await?.build()?;
             self.client.execute(request).await?
         } else {
             let ratelimiting_req = RatelimitedRequest::from(req);

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -33,7 +33,7 @@ use super::{
 use crate::constants;
 use crate::internal::prelude::*;
 use crate::json::json;
-use crate::json::{from_number, from_value, to_vec, to_value};
+use crate::json::{from_number, from_value, to_value, to_vec};
 use crate::model::prelude::*;
 
 /// A builder implementing [`Future`] building a [`Http`] client to perform

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -25,6 +25,7 @@
 
 pub mod client;
 pub mod error;
+pub mod multipart;
 pub mod ratelimiting;
 pub mod request;
 pub mod routing;

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -18,7 +18,7 @@ pub struct Multipart<'a> {
 }
 
 impl<'a> Multipart<'a> {
-    pub async fn to_multipart_form(&mut self, client: &Client) -> Result<Form> {
+    pub(crate) async fn to_multipart_form(&mut self, client: &Client) -> Result<Form> {
         let mut multipart = Form::new();
 
         for (file_num, file) in self.files.iter_mut().enumerate() {

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -13,8 +13,8 @@ use crate::internal::prelude::*;
 /// messages with attachments.
 #[derive(Clone, Debug)]
 pub struct Multipart<'a> {
-    pub(super) files: Vec<AttachmentType<'a>>,
-    pub(super) payload_json: Value,
+    pub files: Vec<AttachmentType<'a>>,
+    pub payload_json: Value,
 }
 
 impl<'a> Multipart<'a> {

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -1,0 +1,98 @@
+use bytes::Buf;
+use reqwest::{
+    multipart::{Form, Part},
+    Client,
+    Url,
+};
+use tokio::{fs::File, io::AsyncReadExt};
+
+use super::AttachmentType;
+use crate::internal::prelude::*;
+
+/// Holder for multipart body. Contains files and payload_json for creating
+/// messages with attachments.
+#[derive(Clone, Debug)]
+pub struct Multipart<'a> {
+    pub(super) files: Vec<AttachmentType<'a>>,
+    pub(super) payload_json: Value,
+}
+
+impl<'a> Multipart<'a> {
+    pub async fn to_multipart_form(&mut self, client: &Client) -> Result<Form> {
+        let mut multipart = Form::new();
+
+        for (file_num, file) in self.files.iter_mut().enumerate() {
+            match file {
+                AttachmentType::Bytes {
+                    data,
+                    filename,
+                } => {
+                    multipart = multipart.part(
+                        file_num.to_string(),
+                        Part::bytes(data.clone().into_owned()).file_name(filename.clone()),
+                    );
+                },
+                AttachmentType::File {
+                    file,
+                    filename,
+                } => {
+                    let mut buf = Vec::new();
+                    file.try_clone().await?.read_to_end(&mut buf).await?;
+
+                    multipart = multipart
+                        .part(file_num.to_string(), Part::stream(buf).file_name(filename.clone()));
+                },
+                AttachmentType::Path(path) => {
+                    let filename =
+                        path.file_name().map(|filename| filename.to_string_lossy().into_owned());
+                    let mut f = File::open(path).await?;
+                    let mut buf = vec![];
+                    f.read_to_end(&mut buf).await?;
+
+                    // Modify current AttachmentType as saved Bytes as to prevent
+                    // the need for another disk read when retrying
+                    *file = AttachmentType::Bytes {
+                        data: buf.clone().into(),
+                        filename: filename.clone().unwrap_or_else(String::new),
+                    };
+
+                    let part = match filename {
+                        Some(filename) => Part::bytes(buf).file_name(filename),
+                        None => Part::bytes(buf),
+                    };
+
+                    multipart = multipart.part(file_num.to_string(), part);
+                },
+                AttachmentType::Image(url) => {
+                    let url = Url::parse(url).map_err(|_| Error::Url(url.to_string()))?;
+                    let filename = url
+                        .path_segments()
+                        .and_then(|segments| segments.last().map(ToString::to_string))
+                        .ok_or_else(|| Error::Url(url.to_string()))?;
+
+                    let response = client.get(url).send().await?;
+
+                    let mut bytes = response.bytes().await?;
+                    let mut picture: Vec<u8> = vec![0; bytes.len()];
+                    bytes.copy_to_slice(&mut picture[..]);
+
+                    // Modify current AttachmentType as saved Bytes as to prevent
+                    // the need for another network request when retrying
+                    *file = AttachmentType::Bytes {
+                        data: picture.clone().into(),
+                        filename: filename.to_string(),
+                    };
+
+                    multipart = multipart.part(
+                        file_num.to_string(),
+                        Part::bytes(picture).file_name(filename.to_string()),
+                    );
+                },
+            }
+        }
+
+        multipart = multipart.text("payload_json", serde_json::to_string(&self.payload_json)?);
+
+        Ok(multipart)
+    }
+}

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -14,11 +14,13 @@ use reqwest::{
 use reqwest::{Client, RequestBuilder as ReqwestRequestBuilder};
 use tracing::instrument;
 
-use super::{routing::RouteInfo, HttpError};
+use super::{multipart::Multipart, routing::RouteInfo, HttpError};
 use crate::constants;
+use crate::internal::prelude::*;
 
 pub struct RequestBuilder<'a> {
     body: Option<&'a [u8]>,
+    multipart: Option<Multipart<'a>>,
     headers: Option<Headers>,
     route: RouteInfo<'a>,
 }
@@ -27,6 +29,7 @@ impl<'a> RequestBuilder<'a> {
     pub fn new(route_info: RouteInfo<'a>) -> Self {
         Self {
             body: None,
+            multipart: None,
             headers: None,
             route: route_info,
         }
@@ -38,6 +41,12 @@ impl<'a> RequestBuilder<'a> {
 
     pub fn body(&mut self, body: Option<&'a [u8]>) -> &mut Self {
         self.body = body;
+
+        self
+    }
+
+    pub fn multipart(&mut self, multipart: Option<Multipart<'a>>) -> &mut Self {
+        self.multipart = multipart;
 
         self
     }
@@ -58,6 +67,7 @@ impl<'a> RequestBuilder<'a> {
 #[derive(Clone, Debug)]
 pub struct Request<'a> {
     pub(super) body: Option<&'a [u8]>,
+    pub(super) multipart: Option<Multipart<'a>>,
     pub(super) headers: Option<Headers>,
     pub(super) route: RouteInfo<'a>,
 }
@@ -66,26 +76,29 @@ impl<'a> Request<'a> {
     pub fn new(builder: RequestBuilder<'a>) -> Self {
         let RequestBuilder {
             body,
+            multipart,
             headers,
             route,
         } = builder;
 
         Self {
             body,
+            multipart,
             headers,
             route,
         }
     }
 
     #[instrument(skip(token))]
-    pub fn build(
-        &'a self,
+    pub async fn build(
+        &mut self,
         client: &Client,
         token: &str,
         proxy: Option<&Url>,
-    ) -> Result<ReqwestRequestBuilder, HttpError> {
+    ) -> Result<ReqwestRequestBuilder> {
         let Request {
             body,
+            ref mut multipart,
             headers: ref request_headers,
             route: ref route_info,
         } = *self;
@@ -96,7 +109,8 @@ impl<'a> Request<'a> {
             path = Cow::Owned(path.to_mut().replace("https://discord.com/", proxy.as_str()));
         }
 
-        let mut builder = client.request(method.reqwest_method(), Url::parse(&path)?);
+        let mut builder =
+            client.request(method.reqwest_method(), Url::parse(&path).map_err(HttpError::Url)?);
 
         if let Some(ref bytes) = body {
             builder = builder.body(Vec::from(*bytes));
@@ -115,11 +129,16 @@ impl<'a> Request<'a> {
             headers.insert(CONTENT_TYPE, HeaderValue::from_static(&"application/json"));
         }
 
-        headers.insert(
-            CONTENT_LENGTH,
-            HeaderValue::from_str(&body.unwrap_or(&Vec::new()).len().to_string())
-                .map_err(HttpError::InvalidHeader)?,
-        );
+        if let Some(multipart) = multipart {
+            // Setting multipart adds the content-length header
+            builder = builder.multipart(multipart.to_multipart_form(&client).await?);
+        } else {
+            headers.insert(
+                CONTENT_LENGTH,
+                HeaderValue::from_str(&body.unwrap_or(&Vec::new()).len().to_string())
+                    .map_err(HttpError::InvalidHeader)?,
+            );
+        }
 
         if let Some(ref request_headers) = request_headers {
             headers.extend(request_headers.clone());


### PR DESCRIPTION
### Description

Uses the ratelimiter for sending multipart requests and removes duplicated code.

Minor breaking change as it changes `Request::build` to an async fn.

### Related Issues

fixes #1269 
