### PR TITLE
Add avatar field to member update event

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -470,6 +470,7 @@ pub struct GuildMemberUpdateEvent {
     pub deaf: bool,
     #[serde(default)]
     pub mute: bool,
+    pub avatar: Option<String>,
 }
 
 #[cfg(feature = "cache")]
@@ -492,6 +493,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                 member.premium_since.clone_from(&self.premium_since);
                 member.deaf.clone_from(&self.deaf);
                 member.mute.clone_from(&self.mute);
+                member.avatar.clone_from(&self.avatar);
 
                 item
             } else {
@@ -511,7 +513,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     premium_since: self.premium_since,
                     #[cfg(feature = "unstable_discord_api")]
                     permissions: None,
-                    avatar: None,
+                    avatar: self.avatar.clone(),
                 });
             }
 


### PR DESCRIPTION
#### Description

Correctly updates cache when a member updates their per-guild avatar.  

#### Tested

This is currently **not documented** but tested that it works (same documentation as #1391).  The `guild_member_update` correctly has the avatar field on members with a server avatar.