### PR TITLE
Remove shutdown and is_shutdown from Gateway::Shard

### DIFF
--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -88,8 +88,6 @@ pub struct Shard {
     seq: u64,
     session_id: Option<String>,
     shard_info: [u64; 2],
-    /// Whether the shard has permanently shutdown.
-    shutdown: bool,
     stage: ConnectionStage,
     /// Instant of when the shard was started.
     // This acts as a timeout to determine if the shard has - for some reason -
@@ -154,7 +152,6 @@ impl Shard {
         let session_id = None;
 
         Ok(Shard {
-            shutdown: false,
             client,
             current_presence,
             heartbeat_instants,
@@ -175,18 +172,6 @@ impl Shard {
     #[inline]
     pub fn current_presence(&self) -> &CurrentPresence {
         &self.current_presence
-    }
-
-    /// Whether the shard has permanently shutdown.
-    ///
-    /// This should normally happen due to manual calling of [`shutdown`] or
-    /// [`shutdown_clean`].
-    ///
-    /// [`shutdown`]: #method.shutdown
-    /// [`shutdown_clean`]: #method.shutdown_clean
-    #[inline]
-    pub fn is_shutdown(&self) -> bool {
-        self.shutdown
     }
 
     /// Retrieves the heartbeat instants of the shard.


### PR DESCRIPTION
This PR is my opinionated attempt at addressing [Issue 1413](https://github.com/serenity-rs/serenity/issues/1413). It removes the private field `shutdown` and the public method `is_shutdown` from `Gateway::Shard`.

The [contributing guidelines](https://github.com/serenity-rs/serenity/blob/current/CONTRIBUTING.md) say:

> Please post an issue prior to dedicating a large amount of time on a PR so it can be determined if the change is something that the community wants.

This didn't take a large amount of time. Please reject these changes if they aren't what the community wants. 