### PR TITLE
Fix select menu fields which might not be present

### DIFF
--- a/src/model/interactions.rs
+++ b/src/model/interactions.rs
@@ -1182,6 +1182,7 @@ pub struct ActionRow {
     #[serde(rename = "type")]
     pub kind: ComponentType,
     /// The components of this ActionRow.
+    #[serde(default)]
     pub components: Vec<Component>,
 }
 
@@ -1258,5 +1259,6 @@ pub struct SelectMenuOption {
     /// The emoji displayed on this option.
     pub emoji: Option<ReactionType>,
     /// Render this option as the default selection.
+    #[serde(default)]
     pub default: bool,
 }


### PR DESCRIPTION
This PR fixes some select menus fields, such as `default` or `components` by defaulting them as they might not be present in the Discord payload.

This has been tested.