### PR TITLE
Add Cache::channel_messages_field

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -352,7 +352,7 @@ impl Cache {
 
     /// This method allows to extract specific data from the cached messages of a channel by
     /// providing a `selector` closure picking what you want to extract from the messages
-    /// iterator of a given channell.
+    /// iterator of a given channel.
     ///
     /// ```rust,no_run
     /// # let cache: serenity::cache::Cache = todo!();

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -86,6 +86,23 @@ impl<F: FromStr> FromStrAndCache for F {
     }
 }
 
+/// Iterator given to the selector closure in [`Cache::channel_messages_field`].
+// Wrapper around a specific iterator type to allow swapping out iterators on cache design changes
+#[derive(Clone, Debug)]
+pub struct MessageIterator<'a>(std::collections::hash_map::Values<'a, MessageId, Message>);
+
+impl<'a> Iterator for MessageIterator<'a> {
+    type Item = &'a Message;
+
+    fn next(&mut self) -> Option<&'a Message> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
 /// A cache containing data received from [`Shard`]s.
 ///
 /// Using the cache allows to avoid REST API requests via the [`http`] module
@@ -331,6 +348,28 @@ impl Cache {
         }
 
         None
+    }
+
+    /// This method allows to extract specific data from the cached messages of a channel by
+    /// providing a `selector` closure picking what you want to extract from the messages
+    /// iterator of a given channell.
+    ///
+    /// ```rust,no_run
+    /// # let cache: serenity::cache::Cache = todo!();
+    /// // Find all messages by user ID 8 in channel ID 7
+    /// let messages_by_user = cache.channel_messages_field(7, |msgs| {
+    ///     msgs.filter(|m| m.author.id == 8).cloned().collect::<Vec<_>>()
+    /// });
+    /// ```
+    pub async fn channel_messages_field<T>(
+        &self,
+        channel_id: impl Into<ChannelId>,
+        selector: impl FnOnce(MessageIterator<'_>) -> T,
+    ) -> Option<T> {
+        let messages = self.messages.read().await;
+        let message_iter = MessageIterator(messages.get(&channel_id.into())?.values());
+
+        Some(selector(message_iter))
     }
 
     /// Clones an entire guild from the cache based on the given `id`.


### PR DESCRIPTION
Sparked by [a discussion](https://discord.com/channels/381880193251409931/673965002805477386/860914066183553035) in the serenity Discord server, this PR adds a new method to Cache:

```rust
pub async fn channel_messages_field<T>(
    &self,
    channel_id: impl Into<ChannelId>,
    selector: impl FnOnce(MessageIterator<'_>) -> T,
) -> Option<T> 
```

The new method makes it possible to access cached messages for a channel, for example to collect messages by a specific user:
```rust
let messages_by_user = cache.channel_messages_field(7, |msgs| {
    msgs.filter(|m| m.author.id == 8).cloned().collect::<Vec<_>>()
});
```

The Iterator type passed to the closure is `MessageIterator`, a new type which wraps `std::collections::hash_map::Values`. Passing `MessageIterator` instead of the concrete `std::collections::hash_map::Values` makes it possible to swap out the actual iterator type in the future when cache implementation details change.

I tested the new method with a [small test bot](https://pastebin.com/VdmSpVuL).