### PR TITLE
Adds the necessary derive traits to use match with UserPublicFlags struct

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -496,7 +496,7 @@ pub struct User {
 }
 
 /// User's public flags
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UserPublicFlags {
     pub bits: u32,
 }


### PR DESCRIPTION
`match` requires that any variable or constant that is used derives from at least PartialEq and Eq.  Before it did not derive from these traits, so the following was invalid:

```rust
match user.public_flags {
    UserPublicFlags::HOUSE_BRAVERY => "Bravery",
    // and so on
    _ => "None",
}
```