### PR TITLE
Bump MSRV to 1.51.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  minrust: 1.48.0
+  minrust: 1.51.0
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ci-badge][]][ci] [![docs-badge][]][docs] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.48.0+ badge]][rust 1.48.0+ link]
+[![ci-badge][]][ci] [![docs-badge][]][docs] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.51.0+ badge]][rust 1.51.0+ link]
 
 # serenity
 
@@ -104,7 +104,7 @@ Add the following to your `Cargo.toml` file:
 serenity = "0.10"
 ```
 
-Serenity supports a minimum of Rust 1.48.
+Serenity supports a minimum of Rust 1.51.
 
 # Features
 
@@ -231,5 +231,5 @@ If you use the `native_tls_backend` and you are not developing on macOS or Windo
 [repo:lavalink]: https://github.com/freyacodes/Lavalink
 [repo:lavaplayer]: https://github.com/sedmelluq/lavaplayer
 [logo]: https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png
-[rust 1.48.0+ badge]: https://img.shields.io/badge/rust-1.48.0+-93450a.svg?style=flat-square
-[rust 1.48.0+ link]: https://blog.rust-lang.org/2020/11/19/Rust-1.48.html
+[rust 1.51.0+ badge]: https://img.shields.io/badge/rust-1.51.0+-93450a.svg?style=flat-square
+[rust 1.51.0+ link]: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html


### PR DESCRIPTION
1.51 is still a couple versions behind current stable, so this shouldn't be burdensome, and allows use of Iterator::reduce that was stabilized in 1.51