### PR TITLE
Add flags to MessageUpdateEvent

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -948,6 +948,7 @@ pub struct MessageUpdateEvent {
     pub mention_roles: Option<Vec<RoleId>>,
     pub attachments: Option<Vec<Attachment>>,
     pub embeds: Option<Vec<Embed>>,
+    pub flags: Option<MessageFlags>,
 }
 
 #[cfg(feature = "cache")]
@@ -986,6 +987,10 @@ impl CacheUpdate for MessageUpdateEvent {
 
                 if let Some(pinned) = self.pinned {
                     message.pinned = pinned;
+                }
+
+                if self.flags.is_some() {
+                    message.flags = self.flags;
                 }
 
                 return Some(item);


### PR DESCRIPTION
MessageUpdateEvent currently doesn't deserialize the flags field if
present. This is useful for checking whether the update was due to
embeds being suppressed.