### PR TITLE
Allow sending files when creating and editing followup messages

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -518,7 +518,7 @@ impl Http {
             body: None,
             multipart: Some(Multipart {
                 files: files.into_iter().map(Into::into).collect(),
-                payload_json: Some(to_value(map)?),
+                payload_json: Some(map.clone()),
                 fields: vec![],
             }),
             headers: None,
@@ -1393,7 +1393,7 @@ impl Http {
             body: None,
             multipart: Some(Multipart {
                 files: new_attachments.into_iter().map(Into::into).collect(),
-                payload_json: Some(to_value(map)?),
+                payload_json: Some(map.clone()),
                 fields: vec![],
             }),
             headers: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1375,6 +1375,37 @@ impl Http {
         .await
     }
 
+    /// Edits a follow-up message and its attachments for an interaction.
+    ///
+    /// Refer to Discord's [docs] for Edit Webhook Message for field information.
+    ///
+    /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    pub async fn edit_followup_message_and_attachments(
+        &self,
+        interaction_token: &str,
+        message_id: u64,
+        map: &Value,
+        new_attachments: impl IntoIterator<Item = AttachmentType<'_>>,
+    ) -> Result<Message> {
+        self.fire(Request {
+            body: None,
+            multipart: Some(Multipart {
+                files: new_attachments.into_iter().map(Into::into).collect(),
+                payload_json: Some(to_value(map)?),
+                fields: vec![],
+            }),
+            headers: None,
+            route: RouteInfo::EditFollowupMessage {
+                application_id: self.application_id,
+                interaction_token,
+                message_id,
+            },
+        })
+        .await
+    }
+
     /// Edits a global command.
     ///
     /// Updates will be available in all guilds after 1 hour.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -503,6 +503,33 @@ impl Http {
         .await
     }
 
+    /// Create a follow-up message with attachments for an Interaction.
+    ///
+    /// Functions the same as [`Self::execute_webhook`]
+    #[cfg(feature = "unstable_discord_api")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
+    pub async fn create_followup_message_with_files(
+        &self,
+        interaction_token: &str,
+        map: &Value,
+        files: impl IntoIterator<Item = AttachmentType<'_>>,
+    ) -> Result<Message> {
+        self.fire(Request {
+            body: None,
+            multipart: Some(Multipart {
+                files: files.into_iter().map(Into::into).collect(),
+                payload_json: Some(to_value(map)?),
+                fields: vec![],
+            }),
+            headers: None,
+            route: RouteInfo::CreateFollowupMessage {
+                application_id: self.application_id,
+                interaction_token,
+            },
+        })
+        .await
+    }
+
     /// Creates a new global command.
     ///
     /// New global commands will be available in all guilds after 1 hour.

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -233,9 +233,20 @@ impl ApplicationCommandInteraction {
 
         Message::check_lengths(&map)?;
 
-        http.as_ref()
-            .edit_followup_message(&self.token, message_id.into().into(), &Value::from(map))
-            .await
+        let message_id = message_id.into().into();
+
+        if interaction_response.1.is_empty() {
+            http.as_ref().edit_followup_message(&self.token, message_id, &Value::from(map)).await
+        } else {
+            http.as_ref()
+                .edit_followup_message_and_attachments(
+                    &self.token,
+                    message_id,
+                    &Value::from(map),
+                    interaction_response.1,
+                )
+                .await
+        }
     }
 
     /// Deletes a followup message.

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -189,7 +189,17 @@ impl ApplicationCommandInteraction {
 
         Message::check_lengths(&map)?;
 
-        http.as_ref().create_followup_message(&self.token, &Value::from(map)).await
+        if interaction_response.1.is_empty() {
+            http.as_ref().create_followup_message(&self.token, &Value::from(map)).await
+        } else {
+            http.as_ref()
+                .create_followup_message_with_files(
+                    &self.token,
+                    &Value::from(map),
+                    interaction_response.1,
+                )
+                .await
+        }
     }
 
     /// Edits a followup response to the response sent.


### PR DESCRIPTION
## Description

This adds the ability to send attachments when creating and editing followup messages to an interaction. The code for specifying attachments in the followup message builder already exists, just the act itself of sending those to Discord's API wasn't implemented.

Fixes #1441 

## Type of Change

This is both an enhancement and a fix to the HTTP client and builder code regarding followup messages.

## How Has This Been Tested?

This has been tested by specifying attachments to post when creating, and then editing, the followup message. Both attempts were successful.