### PR TITLE
Make cache Synchronous and use DashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,15 @@ version = "0.3.16"
 [dependencies.mime_guess]
 version = "2.0"
 
+[dependencies.dashmap]
+version = "4"
+features = ["serde"]
+optional = true
+
+[dependencies.parking_lot]
+version = "0.11"
+optional = true
+
 [dev-dependencies.http_crate]
 version = "0.2"
 package = "http"
@@ -179,7 +188,7 @@ default_no_backend = [
 ]
 
 builder = ["utils"]
-cache = []
+cache = ["dashmap", "parking_lot"]
 collector = ["gateway", "model"]
 client = ["http", "typemap_rev"]
 extras = []

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The following is a full list of features:
 - **cache**: The cache will store information about guilds, channels, users, and
 other data, to avoid performing REST requests. If you are low on RAM, do not
 enable this.
-- **collector**: A collector awaits events, such as receiving a message from a user or reactions on a message, and allows for responding to the events in a convenient fashion. Collectors can be configured to enforce certain critera the events must meet.
+- **collector**: A collector awaits events, such as receiving a message from a user or reactions on a message, and allows for responding to the events in a convenient fashion. Collectors can be configured to enforce certain criteria the events must meet.
 - **client**: A manager for shards and event handlers, abstracting away the
 work of handling shard events and updating the cache, if enabled.
 - **framework**: Enables the framework, which is a utility to allow simple

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ If you use the `native_tls_backend` and you are not developing on macOS or Windo
 
 # Projects extending Serenity
 
-- [lavalink-rs][project:lavalink-rs]: An interface to [Lavalink][repo:lavalink], an audio sending node based on [Lavaplayer][repo:lavaplayer]
+- [lavalink-rs][project:lavalink-rs]: An interface to [Lavalink][repo:lavalink] and [Andesite][repo:andesite], an audio sending node based on [Lavaplayer][repo:lavaplayer]
 - [Songbird][project:songbird]: An async Rust library for the Discord voice API.
 
 [`Cache`]: https://docs.rs/serenity/*/serenity/cache/struct.Cache.html
@@ -230,6 +230,7 @@ If you use the `native_tls_backend` and you are not developing on macOS or Windo
 [project:lavalink-rs]: https://gitlab.com/vicky5124/lavalink-rs/
 [project:songbird]: https://github.com/serenity-rs/songbird
 [repo:lavalink]: https://github.com/freyacodes/Lavalink
+[repo:andesite]: https://github.com/natanbc/andesite
 [repo:lavaplayer]: https://github.com/sedmelluq/lavaplayer
 [logo]: https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png
 [rust 1.48.0+ badge]: https://img.shields.io/badge/rust-1.48.0+-93450a.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ async fn ping(ctx: &Context, msg: &Message) -> CommandResult {
 }
 ```
 
-### Full Examples
+## Full Examples
 
 Full examples, detailing and explaining usage of the basic functionality of the
 library, can be found in the [`examples`] directory.

--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -570,8 +570,7 @@ async fn slow_mode(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
         } else {
             format!("Successfully set slow mode rate to `{}` seconds.", slow_mode_rate_seconds)
         }
-    } else if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx.cache)
-    {
+    } else if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx.cache) {
         format!("Current slow mode rate is `{}` seconds.", channel.slow_mode_rate.unwrap_or(0))
     } else {
         "Failed to find channel in cache.".to_string()

--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -360,7 +360,7 @@ async fn say(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
         ContentSafeOptions::default().clean_channel(false).clean_role(false)
     };
 
-    let content = content_safe(&ctx.cache, &args.rest(), &settings).await;
+    let content = content_safe(&ctx.cache, &args.rest(), &settings);
 
     msg.channel_id.say(&ctx.http, &content).await?;
 
@@ -413,7 +413,7 @@ async fn some_long_command(ctx: &Context, msg: &Message, args: Args) -> CommandR
 async fn about_role(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
     let potential_role_name = args.rest();
 
-    if let Some(guild) = msg.guild(&ctx.cache).await {
+    if let Some(guild) = msg.guild(&ctx.cache) {
         // `role_by_name()` allows us to attempt attaining a reference to a role
         // via its name.
         if let Some(role) = guild.role_by_name(potential_role_name) {
@@ -544,7 +544,6 @@ async fn am_i_admin(ctx: &Context, msg: &Message, _args: Args) -> CommandResult 
         for role in &member.roles {
             if role
                 .to_role_cached(&ctx.cache)
-                .await
                 .map_or(false, |r| r.has_permission(Permissions::ADMINISTRATOR))
             {
                 msg.channel_id.say(&ctx.http, "Yes, you are.").await?;
@@ -571,7 +570,7 @@ async fn slow_mode(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
         } else {
             format!("Successfully set slow mode rate to `{}` seconds.", slow_mode_rate_seconds)
         }
-    } else if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx.cache).await
+    } else if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx.cache)
     {
         format!("Current slow mode rate is `{}` seconds.", channel.slow_mode_rate.unwrap_or(0))
     } else {

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -24,7 +24,7 @@ use crate::json::{from_number, Value, NULL};
 /// impl EventHandler for Handler {
 ///    async fn message(&self, context: Context, msg: Message) {
 ///         if msg.content == "!createinvite" {
-///             let channel = match context.cache.guild_channel(msg.channel_id).await {
+///             let channel = match context.cache.guild_channel(msg.channel_id) {
 ///                 Some(channel) => channel,
 ///                 None => {
 ///                     let _ = msg.channel_id.say(&context, "Error creating invite").await;
@@ -91,7 +91,7 @@ impl CreateInvite {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// #     let channel = context.cache.guild_channel(81384788765712384).await.unwrap();
+    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap();
     /// #
     /// let invite = channel.create_invite(context, |i| {
     ///     i.max_age(3600)
@@ -157,7 +157,7 @@ impl CreateInvite {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// #     let channel = context.cache.guild_channel(81384788765712384).await.unwrap();
+    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap();
     /// #
     /// let invite = channel.create_invite(context, |i| {
     ///     i.temporary(true)
@@ -191,7 +191,7 @@ impl CreateInvite {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// #     let channel = context.cache.guild_channel(81384788765712384).await.unwrap();
+    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap();
     /// #
     /// let invite = channel.create_invite(context, |i| {
     ///     i.unique(true)

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -125,7 +125,7 @@ impl CreateInvite {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// #     let channel = context.cache.guild_channel(81384788765712384).await.unwrap();
+    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap();
     /// #
     /// let invite = channel.create_invite(context, |i| {
     ///     i.max_uses(5)

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -38,7 +38,7 @@ impl EditProfile {
     /// let base64 = utils::read_image("./my_image.jpg")
     ///     .expect("Failed to read image");
     ///
-    /// let mut user = context.cache.current_user().await;
+    /// let mut user = context.cache.current_user();
     /// let _ = user.edit(&context, |p| {
     ///     p.avatar(Some(&base64))
     /// }).await;

--- a/src/cache/cache_update.rs
+++ b/src/cache/cache_update.rs
@@ -1,5 +1,3 @@
-use async_trait::async_trait;
-
 use super::Cache;
 
 /// Trait used for updating the cache with a type.
@@ -105,7 +103,6 @@ use super::Cache;
 /// cache.update(&mut update_message).await;
 /// # }
 /// ```
-#[async_trait]
 pub trait CacheUpdate {
     /// The return type of an update.
     ///
@@ -113,5 +110,5 @@ pub trait CacheUpdate {
     type Output;
 
     /// Updates the cache with the implementation.
-    async fn update(&mut self, _: &Cache) -> Option<Self::Output>;
+    fn update(&mut self, _: &Cache) -> Option<Self::Output>;
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -30,12 +30,19 @@
 //! [`Shard`]: crate::gateway::Shard
 //! [`http`]: crate::http
 
-use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
+use std::collections::{hash_map::RandomState, HashMap, VecDeque};
 use std::default::Default;
+use std::hash::BuildHasher;
 use std::str::FromStr;
 
-use async_trait::async_trait;
-use tokio::sync::RwLock;
+use dashmap::{
+    iter::Iter,
+    mapref::{entry::Entry, multiple::RefMulti},
+    DashMap,
+    DashSet,
+};
+use parking_lot::RwLock;
+// use tokio::sync::RwLock;
 use tracing::instrument;
 
 use crate::model::prelude::*;
@@ -45,39 +52,39 @@ mod settings;
 pub use self::cache_update::CacheUpdate;
 pub use self::settings::Settings;
 
-type MessageCache = HashMap<ChannelId, HashMap<MessageId, Message>>;
+type MessageCache = DashMap<ChannelId, DashMap<MessageId, Message>>;
 
-#[async_trait]
 pub trait FromStrAndCache: Sized {
     type Err;
 
-    async fn from_str<CRL>(cache: CRL, s: &str) -> Result<Self, Self::Err>
+    #[allow(clippy::missing_errors_doc)]
+    fn from_str<CRL>(cache: CRL, s: &str) -> Result<Self, Self::Err>
     where
         CRL: AsRef<Cache> + Send + Sync;
 }
 
-#[async_trait]
 pub trait StrExt: Sized {
-    async fn parse_cached<CRL, F: FromStrAndCache>(&self, cache: CRL) -> Result<F, F::Err>
+    #[allow(clippy::missing_errors_doc)]
+    fn parse_cached<CRL, F: FromStrAndCache>(&self, cache: CRL) -> Result<F, F::Err>
     where
         CRL: AsRef<Cache> + Send + Sync;
 }
 
-#[async_trait]
 impl StrExt for &str {
-    async fn parse_cached<CRL, F: FromStrAndCache>(&self, cache: CRL) -> Result<F, F::Err>
+    #[allow(clippy::missing_errors_doc)]
+    fn parse_cached<CRL, F: FromStrAndCache>(&self, cache: CRL) -> Result<F, F::Err>
     where
         CRL: AsRef<Cache> + Send + Sync,
     {
-        F::from_str(&cache, self).await
+        F::from_str(&cache, self)
     }
 }
 
-#[async_trait]
 impl<F: FromStr> FromStrAndCache for F {
     type Err = F::Err;
 
-    async fn from_str<CRL>(_cache: CRL, s: &str) -> Result<Self, Self::Err>
+    #[allow(clippy::missing_errors_doc)]
+    fn from_str<CRL>(_cache: CRL, s: &str) -> Result<Self, Self::Err>
     where
         CRL: AsRef<Cache> + Send + Sync,
     {
@@ -87,13 +94,18 @@ impl<F: FromStr> FromStrAndCache for F {
 
 /// Iterator given to the selector closure in [`Cache::channel_messages_field`].
 // Wrapper around a specific iterator type to allow swapping out iterators on cache design changes
-#[derive(Clone, Debug)]
-pub struct MessageIterator<'a>(std::collections::hash_map::Values<'a, MessageId, Message>);
+//
+// Clone impl waiting on this https://github.com/xacrimon/dashmap/pull/152
+//#[derive(Clone)]
+pub struct MessageIterator<'a, S: BuildHasher + Clone>(
+    Iter<'a, MessageId, Message, S, DashMap<MessageId, Message, S>>,
+);
 
-impl<'a> Iterator for MessageIterator<'a> {
-    type Item = &'a Message;
+impl<'a, S: 'a + BuildHasher + Clone> Iterator for MessageIterator<'a, S> {
+    // type Item = &'a Message;
+    type Item = RefMulti<'a, MessageId, Message, S>;
 
-    fn next(&mut self) -> Option<&'a Message> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
 
@@ -120,20 +132,20 @@ pub struct Cache {
     /// When a [`Event::GuildDelete`] or [`Event::GuildUnavailable`] is
     /// received and processed by the cache, the relevant channels are also
     /// removed from this map.
-    pub(crate) channels: RwLock<HashMap<ChannelId, GuildChannel>>,
+    pub(crate) channels: DashMap<ChannelId, GuildChannel>,
     /// A map of channel categories.
-    pub(crate) categories: RwLock<HashMap<ChannelId, ChannelCategory>>,
+    pub(crate) categories: DashMap<ChannelId, ChannelCategory>,
     /// A map of guilds with full data available. This includes data like
     /// [`Role`]s and [`Emoji`]s that are not available through the REST API.
-    pub(crate) guilds: RwLock<HashMap<GuildId, Guild>>,
-    pub(crate) messages: RwLock<MessageCache>,
+    pub(crate) guilds: DashMap<GuildId, Guild>,
+    pub(crate) messages: MessageCache,
     /// A map of users' presences. This is updated in real-time. Note that
     /// status updates are often "eaten" by the gateway, and this should not
     /// be treated as being entirely 100% accurate.
-    pub(crate) presences: RwLock<HashMap<UserId, Presence>>,
+    pub(crate) presences: DashMap<UserId, Presence>,
     /// A map of direct message channels that the current user has open with
     /// other users.
-    pub(crate) private_channels: RwLock<HashMap<ChannelId, PrivateChannel>>,
+    pub(crate) private_channels: DashMap<ChannelId, PrivateChannel>,
     /// The total number of shards being used by the bot.
     pub(crate) shard_count: RwLock<u64>,
     /// A list of guilds which are "unavailable". Refer to the documentation for
@@ -142,7 +154,7 @@ pub struct Cache {
     /// Additionally, guilds are always unavailable for bot users when a Ready
     /// is received. Guilds are "sent in" over time through the receiving of
     /// [`Event::GuildCreate`]s.
-    pub(crate) unavailable_guilds: RwLock<HashSet<GuildId>>,
+    pub(crate) unavailable_guilds: DashSet<GuildId>,
     /// The current user "logged in" and for which events are being received
     /// for.
     ///
@@ -165,13 +177,13 @@ pub struct Cache {
     /// Note, however, that users are _not_ removed from the map on removal
     /// events such as [`GuildMemberRemove`][`GuildMemberRemoveEvent`], as other
     /// structs such as members or recipients may still exist.
-    pub(crate) users: RwLock<HashMap<UserId, User>>,
+    pub(crate) users: DashMap<UserId, User>,
     /// Queue of message IDs for each channel.
     ///
     /// This is simply a vecdeque so we can keep track of the order of messages
     /// inserted into the cache. When a maximum number of messages are in a
     /// channel's cache, we can pop the front and remove that ID from the cache.
-    pub(crate) message_queue: RwLock<HashMap<ChannelId, VecDeque<MessageId>>>,
+    pub(crate) message_queue: DashMap<ChannelId, VecDeque<MessageId>>,
     /// The settings for the cache.
     settings: RwLock<Settings>,
 }
@@ -217,7 +229,7 @@ impl Cache {
     /// # use serenity::prelude::*;
     /// #
     /// # #[cfg(feature = "client")]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::thread;
     /// use std::time::Duration;
     ///
@@ -225,7 +237,7 @@ impl Cache {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, ctx: Context, _: Ready) {
+    ///     fn ready(&self, ctx: Context, _: Ready) {
     ///         // Wait some time for guilds to be received.
     ///         //
     ///         // You should keep track of this in a better fashion by tracking how
@@ -235,24 +247,26 @@ impl Cache {
     ///         //
     ///         // For demonstrative purposes we're just sleeping the thread for 5
     ///         // seconds.
-    ///         tokio::time::sleep(Duration::from_secs(5)).await;
+    ///         tokio::time::sleep(Duration::from_secs(5));
     ///
-    ///         println!("{} unknown members", ctx.cache.unknown_members().await);
+    ///         println!("{} unknown members", ctx.cache.unknown_members());
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler)?;
     ///
-    /// client.start().await?;
+    /// client.start()?;
     /// #     Ok(())
     /// # }
     /// ```
     ///
     /// [`Shard::chunk_guild`]: crate::gateway::Shard::chunk_guild
-    pub async fn unknown_members(&self) -> u64 {
+    pub fn unknown_members(&self) -> u64 {
         let mut total = 0;
 
-        for guild in self.guilds.read().await.values() {
+        for guild_entry in self.guilds.iter() {
+            let guild = guild_entry.value();
+
             let members = guild.members.len() as u64;
 
             if guild.member_count > members {
@@ -278,15 +292,15 @@ impl Cache {
     /// # use tokio::sync::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # async fn run() {
+    /// # fn run() {
     /// # let cache = Cache::default();
-    /// let amount = cache.private_channels().await.len();
+    /// let amount = cache.private_channels().len();
     ///
     /// println!("There are {} private channels", amount);
     /// # }
     /// ```
-    pub async fn private_channels(&self) -> HashMap<ChannelId, PrivateChannel> {
-        self.private_channels.read().await.clone()
+    pub fn private_channels(&self) -> DashMap<ChannelId, PrivateChannel> {
+        self.private_channels.clone()
     }
 
     /// Fetches a vector of all [`Guild`]s' Ids that are stored in the cache.
@@ -307,8 +321,8 @@ impl Cache {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, context: Context, _: Ready) {
-    ///         let guilds = context.cache.guilds().await.len();
+    ///     fn ready(&self, context: Context, _: Ready) {
+    ///         let guilds = context.cache.guilds().len();
     ///
     ///         println!("Guilds in the Cache: {}", guilds);
     ///     }
@@ -317,9 +331,9 @@ impl Cache {
     ///
     /// [`Context`]: crate::client::Context
     /// [`Shard`]: crate::gateway::Shard
-    pub async fn guilds(&self) -> Vec<GuildId> {
-        let chain = self.unavailable_guilds.read().await.clone().into_iter();
-        self.guilds.read().await.keys().cloned().chain(chain).collect()
+    pub fn guilds(&self) -> Vec<GuildId> {
+        let chain = self.unavailable_guilds.clone().into_iter();
+        self.guilds.iter().map(|i| *i.key()).chain(chain).collect()
     }
 
     /// Retrieves a [`Channel`] from the cache based on the given Id.
@@ -332,18 +346,18 @@ impl Cache {
     /// - [`GuildChannel`]: [`Self::guild_channel`] or [`Self::channels`]
     /// - [`PrivateChannel`]: [`Self::private_channel`] or [`Self::private_channels`]
     #[inline]
-    pub async fn channel<C: Into<ChannelId>>(&self, id: C) -> Option<Channel> {
-        self._channel(id.into()).await
+    pub fn channel<C: Into<ChannelId>>(&self, id: C) -> Option<Channel> {
+        self._channel(id.into())
     }
 
-    async fn _channel(&self, id: ChannelId) -> Option<Channel> {
-        if let Some(channel) = self.channels.read().await.get(&id) {
+    fn _channel(&self, id: ChannelId) -> Option<Channel> {
+        if let Some(channel) = self.channels.get(&id) {
             let channel = channel.clone();
             return Some(Channel::Guild(channel));
         }
 
-        if let Some(private_channel) = self.private_channels.read().await.get(&id).cloned() {
-            return Some(Channel::Private(private_channel));
+        if let Some(private_channel) = self.private_channels.get(&id) {
+            return Some(Channel::Private(private_channel.clone()));
         }
 
         None
@@ -360,13 +374,13 @@ impl Cache {
     ///     msgs.filter(|m| m.author.id == 8).cloned().collect::<Vec<_>>()
     /// });
     /// ```
-    pub async fn channel_messages_field<T>(
+    pub fn channel_messages_field<T>(
         &self,
         channel_id: impl Into<ChannelId>,
-        selector: impl FnOnce(MessageIterator<'_>) -> T,
+        selector: impl FnOnce(MessageIterator<'_, RandomState>) -> T,
     ) -> Option<T> {
-        let messages = self.messages.read().await;
-        let message_iter = MessageIterator(messages.get(&channel_id.into())?.values());
+        let msg = self.messages.get(&channel_id.into())?;
+        let message_iter = MessageIterator(msg.iter());
 
         Some(selector(message_iter))
     }
@@ -385,22 +399,22 @@ impl Cache {
     /// # use tokio::sync::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let cache = Cache::default();
     /// // assuming the cache is in scope, e.g. via `Context`
-    /// if let Some(guild) = cache.guild(7).await {
+    /// if let Some(guild) = cache.guild(7) {
     ///     println!("Guild name: {}", guild.name);
     /// }
     /// #   Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn guild<G: Into<GuildId>>(&self, id: G) -> Option<Guild> {
-        self._guild(id.into()).await
+    pub fn guild<G: Into<GuildId>>(&self, id: G) -> Option<Guild> {
+        self._guild(id.into())
     }
 
-    async fn _guild(&self, id: GuildId) -> Option<Guild> {
-        self.guilds.read().await.get(&id).cloned()
+    fn _guild(&self, id: GuildId) -> Option<Guild> {
+        self.guilds.get(&id).map(|i| i.clone())
     }
 
     /// This method allows to select a field of the guild instead of
@@ -410,40 +424,35 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let cache = Cache::default();
     /// // We clone only the `len()` returned `usize` instead of the entire guild or the channels.
-    /// if let Some(channel_len) = cache.guild_field(7, |guild| guild.channels.len()).await {
+    /// if let Some(channel_len) = cache.guild_field(7, |guild| guild.channels.len()) {
     ///     println!("Guild channels count: {}", channel_len);
     /// }
     /// #   Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn guild_field<Ret, Fun>(
-        &self,
-        id: impl Into<GuildId>,
-        field_selector: Fun,
-    ) -> Option<Ret>
+    pub fn guild_field<Ret, Fun>(&self, id: impl Into<GuildId>, field_selector: Fun) -> Option<Ret>
     where
         Fun: FnOnce(&Guild) -> Ret,
     {
-        self._guild_field(id.into(), field_selector).await
+        self._guild_field(id.into(), field_selector)
     }
 
-    async fn _guild_field<Ret, Fun>(&self, id: GuildId, field_accessor: Fun) -> Option<Ret>
+    fn _guild_field<Ret, Fun>(&self, id: GuildId, field_accessor: Fun) -> Option<Ret>
     where
         Fun: FnOnce(&Guild) -> Ret,
     {
-        let guilds = self.guilds.read().await;
-        let guild = guilds.get(&id)?;
+        let guild = self.guilds.get(&id)?;
 
-        Some(field_accessor(guild))
+        Some(field_accessor(&*guild))
     }
 
     /// Returns the number of cached guilds.
-    pub async fn guild_count(&self) -> usize {
-        self.guilds.read().await.len()
+    pub fn guild_count(&self) -> usize {
+        self.guilds.len()
     }
 
     /// Retrieves a reference to a [`Guild`]'s channel. Unlike [`Self::channel`],
@@ -465,12 +474,12 @@ impl Cache {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, context: Context, message: Message) {
+    ///     fn message(&self, context: Context, message: Message) {
     ///
-    ///         let channel = match context.cache.guild_channel(message.channel_id).await {
+    ///         let channel = match context.cache.guild_channel(message.channel_id) {
     ///             Some(channel) => channel,
     ///             None => {
-    ///                 let result = message.channel_id.say(&context, "Could not find guild's channel data").await;
+    ///                 let result = message.channel_id.say(&context, "Could not find guild's channel data");
     ///                 if let Err(why) = result {
     ///                     println!("Error sending message: {:?}", why);
     ///                 }
@@ -482,22 +491,22 @@ impl Cache {
     /// }
     ///
     /// # #[cfg(feature = "client")]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut client = Client::builder("token").event_handler(Handler)?;
     ///
-    /// client.start().await?;
+    /// client.start()?;
     /// #     Ok(())
     /// # }
     /// ```
     ///
     /// [`EventHandler::message`]: crate::client::EventHandler::message
     #[inline]
-    pub async fn guild_channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannel> {
-        self._guild_channel(id.into()).await
+    pub fn guild_channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannel> {
+        self._guild_channel(id.into())
     }
 
-    async fn _guild_channel(&self, id: ChannelId) -> Option<GuildChannel> {
-        self.channels.read().await.get(&id).cloned()
+    fn _guild_channel(&self, id: ChannelId) -> Option<GuildChannel> {
+        self.channels.get(&id).map(|i| i.clone())
     }
 
     /// This method allows to only clone a field of the guild channel instead of
@@ -507,17 +516,17 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let cache = Cache::default();
     /// // We clone only the `name` instead of the entire channel.
-    /// if let Some(channel_name) = cache.guild_channel_field(7, |channel| channel.name.clone()).await {
+    /// if let Some(channel_name) = cache.guild_channel_field(7, |channel| channel.name.clone()) {
     ///     println!("Guild channel name: {}", channel_name);
     /// }
     /// #   Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn guild_channel_field<Ret, Fun>(
+    pub fn guild_channel_field<Ret, Fun>(
         &self,
         id: impl Into<ChannelId>,
         field_selector: Fun,
@@ -525,21 +534,16 @@ impl Cache {
     where
         Fun: FnOnce(&GuildChannel) -> Ret,
     {
-        self._guild_channel_field(id.into(), field_selector).await
+        self._guild_channel_field(id.into(), field_selector)
     }
 
-    async fn _guild_channel_field<Ret, Fun>(
-        &self,
-        id: ChannelId,
-        field_selector: Fun,
-    ) -> Option<Ret>
+    fn _guild_channel_field<Ret, Fun>(&self, id: ChannelId, field_selector: Fun) -> Option<Ret>
     where
         Fun: FnOnce(&GuildChannel) -> Ret,
     {
-        let guild_channels = &self.channels.read().await;
-        let channel = guild_channels.get(&id)?;
+        let channel = self.channels.get(&id)?;
 
-        Some(field_selector(channel))
+        Some(field_selector(&*channel))
     }
 
     /// Retrieves a [`Guild`]'s member from the cache based on the guild's and
@@ -559,26 +563,26 @@ impl Cache {
     /// # use serenity::model::id::{ChannelId, MessageId};
     /// # use std::sync::Arc;
     /// #
-    /// # async fn run() {
+    /// # fn run() {
     /// # let http = Arc::new(Http::new_with_token("DISCORD_TOKEN"));
-    /// # let message = ChannelId(0).message(&http, MessageId(1)).await.unwrap();
+    /// # let message = ChannelId(0).message(&http, MessageId(1)).unwrap();
     /// # let cache = Cache::default();
     /// #
     /// let member = {
-    ///     let channel = match cache.guild_channel(message.channel_id).await {
+    ///     let channel = match cache.guild_channel(message.channel_id) {
     ///         Some(channel) => channel,
     ///         None => {
-    ///             if let Err(why) = message.channel_id.say(http, "Error finding channel data").await {
+    ///             if let Err(why) = message.channel_id.say(http, "Error finding channel data") {
     ///                 println!("Error sending message: {:?}", why);
     ///             }
     ///             return;
     ///         },
     ///     };
     ///
-    ///     match cache.member(channel.guild_id, message.author.id).await {
+    ///     match cache.member(channel.guild_id, message.author.id) {
     ///         Some(member) => member,
     ///         None => {
-    ///             if let Err(why) = message.channel_id.say(&http, "Error finding member data").await {
+    ///             if let Err(why) = message.channel_id.say(&http, "Error finding member data") {
     ///                 println!("Error sending message: {:?}", why);
     ///             }
     ///             return;
@@ -588,7 +592,7 @@ impl Cache {
     ///
     /// let msg = format!("You have {} roles", member.roles.len());
     ///
-    /// if let Err(why) = message.channel_id.say(&http, &msg).await {
+    /// if let Err(why) = message.channel_id.say(&http, &msg) {
     ///     println!("Error sending message: {:?}", why);
     /// }
     /// # }
@@ -597,16 +601,16 @@ impl Cache {
     /// [`EventHandler::message`]: crate::client::EventHandler::message
     /// [`members`]: crate::model::guild::Guild::members
     #[inline]
-    pub async fn member<G, U>(&self, guild_id: G, user_id: U) -> Option<Member>
+    pub fn member<G, U>(&self, guild_id: G, user_id: U) -> Option<Member>
     where
         G: Into<GuildId>,
         U: Into<UserId>,
     {
-        self._member(guild_id.into(), user_id.into()).await
+        self._member(guild_id.into(), user_id.into())
     }
 
-    async fn _member(&self, guild_id: GuildId, user_id: UserId) -> Option<Member> {
-        match self.guilds.read().await.get(&guild_id) {
+    fn _member(&self, guild_id: GuildId, user_id: UserId) -> Option<Member> {
+        match self.guilds.get(&guild_id) {
             Some(guild) => guild.members.get(&user_id).cloned(),
             None => None,
         }
@@ -619,17 +623,17 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let cache = Cache::default();
     /// // We clone only the `name` instead of the entire channel.
-    /// if let Some(Some(nick)) = cache.member_field(7, 8, |member| member.nick.clone()).await {
+    /// if let Some(Some(nick)) = cache.member_field(7, 8, |member| member.nick.clone()) {
     ///     println!("Member's nick: {}", nick);
     /// }
     /// #   Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn member_field<Ret, Fun>(
+    pub fn member_field<Ret, Fun>(
         &self,
         guild_id: impl Into<GuildId>,
         user_id: impl Into<UserId>,
@@ -638,10 +642,10 @@ impl Cache {
     where
         Fun: FnOnce(&Member) -> Ret,
     {
-        self._member_field(guild_id.into(), user_id.into(), field_selector).await
+        self._member_field(guild_id.into(), user_id.into(), field_selector)
     }
 
-    async fn _member_field<Ret, Fun>(
+    fn _member_field<Ret, Fun>(
         &self,
         guild_id: GuildId,
         user_id: UserId,
@@ -650,39 +654,38 @@ impl Cache {
     where
         Fun: FnOnce(&Member) -> Ret,
     {
-        let guilds = &self.guilds.read().await;
-        let guild = guilds.get(&guild_id)?;
+        let guild = self.guilds.get(&guild_id)?;
         let member = guild.members.get(&user_id)?;
 
         Some(field_selector(member))
     }
 
     #[inline]
-    pub async fn guild_roles(&self, guild_id: impl Into<GuildId>) -> Option<HashMap<RoleId, Role>> {
-        self._guild_roles(guild_id.into()).await
+    pub fn guild_roles(&self, guild_id: impl Into<GuildId>) -> Option<HashMap<RoleId, Role>> {
+        self._guild_roles(guild_id.into())
     }
 
-    async fn _guild_roles(&self, guild_id: GuildId) -> Option<HashMap<RoleId, Role>> {
-        self.guilds.read().await.get(&guild_id).map(|g| g.roles.clone())
+    fn _guild_roles(&self, guild_id: GuildId) -> Option<HashMap<RoleId, Role>> {
+        self.guilds.get(&guild_id).map(|g| g.roles.clone())
     }
 
     /// This method clones and returns all unavailable guilds.
     #[inline]
-    pub async fn unavailable_guilds(&self) -> HashSet<GuildId> {
-        self.unavailable_guilds.read().await.clone()
+    pub fn unavailable_guilds(&self) -> DashSet<GuildId> {
+        self.unavailable_guilds.clone()
     }
 
     /// This method returns all channels from a guild of with the given `guild_id`.
     #[inline]
-    pub async fn guild_channels(
+    pub fn guild_channels(
         &self,
         guild_id: impl Into<GuildId>,
-    ) -> Option<HashMap<ChannelId, GuildChannel>> {
-        self._guild_channels(guild_id.into()).await
+    ) -> Option<DashMap<ChannelId, GuildChannel>> {
+        self._guild_channels(guild_id.into())
     }
 
-    async fn _guild_channels(&self, guild_id: GuildId) -> Option<HashMap<ChannelId, GuildChannel>> {
-        self.guilds.read().await.get(&guild_id).map(|g| {
+    fn _guild_channels(&self, guild_id: GuildId) -> Option<DashMap<ChannelId, GuildChannel>> {
+        self.guilds.get(&guild_id).map(|g| {
             g.channels
                 .iter()
                 .filter_map(|c| match c.1 {
@@ -694,24 +697,21 @@ impl Cache {
     }
 
     /// Returns the number of guild channels in the cache.
-    pub async fn guild_channel_count(&self) -> usize {
-        self.channels.read().await.len()
+    pub fn guild_channel_count(&self) -> usize {
+        self.channels.len()
     }
 
     /// This method returns all categories from a guild of with the given `guild_id`.
     #[inline]
-    pub async fn guild_categories(
+    pub fn guild_categories(
         &self,
         guild_id: impl Into<GuildId>,
-    ) -> Option<HashMap<ChannelId, ChannelCategory>> {
-        self._guild_categories(guild_id.into()).await
+    ) -> Option<DashMap<ChannelId, ChannelCategory>> {
+        self._guild_categories(guild_id.into())
     }
 
-    async fn _guild_categories(
-        &self,
-        guild_id: GuildId,
-    ) -> Option<HashMap<ChannelId, ChannelCategory>> {
-        self.guilds.read().await.get(&guild_id).map(|g| {
+    fn _guild_categories(&self, guild_id: GuildId) -> Option<DashMap<ChannelId, ChannelCategory>> {
+        self.guilds.get(&guild_id).map(|g| {
             g.channels
                 .iter()
                 .filter_map(|c| match c.1 {
@@ -724,8 +724,8 @@ impl Cache {
 
     /// Returns the number of shards.
     #[inline]
-    pub async fn shard_count(&self) -> u64 {
-        *self.shard_count.read().await
+    pub fn shard_count(&self) -> u64 {
+        *self.shard_count.read()
     }
 
     /// Retrieves a [`Channel`]'s message from the cache based on the channel's and
@@ -745,12 +745,12 @@ impl Cache {
     /// # use tokio::sync::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Arc::new(Http::new_with_token("DISCORD_TOKEN"));
-    /// # let message = ChannelId(0).message(&http, MessageId(1)).await?;
+    /// # let message = ChannelId(0).message(&http, MessageId(1))?;
     /// # let cache = Cache::default();
     /// #
-    /// match cache.message(message.channel_id, message.id).await {
+    /// match cache.message(message.channel_id, message.id) {
     ///     Some(m) => assert_eq!(message.content, m.content),
     ///     None => println!("No message found in cache."),
     /// };
@@ -760,20 +760,18 @@ impl Cache {
     ///
     /// [`EventHandler::message`]: crate::client::EventHandler::message
     #[inline]
-    pub async fn message<C, M>(&self, channel_id: C, message_id: M) -> Option<Message>
+    pub fn message<C, M>(&self, channel_id: C, message_id: M) -> Option<Message>
     where
         C: Into<ChannelId>,
         M: Into<MessageId>,
     {
-        self._message(channel_id.into(), message_id.into()).await
+        self._message(channel_id.into(), message_id.into())
     }
 
-    async fn _message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<Message> {
+    fn _message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<Message> {
         self.messages
-            .read()
-            .await
             .get(&channel_id)
-            .and_then(|messages| messages.get(&message_id).cloned())
+            .and_then(|messages| messages.get(&message_id).map(|i| i.clone()))
     }
 
     /// Retrieves a [`PrivateChannel`] from the cache's [`Self::private_channels`]
@@ -792,26 +790,23 @@ impl Cache {
     /// # use tokio::sync::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #   let cache = Cache::default();
     /// // assuming the cache has been unlocked
     ///
-    /// if let Some(channel) = cache.private_channel(7).await {
+    /// if let Some(channel) = cache.private_channel(7) {
     ///     println!("The recipient is {}", channel.recipient);
     /// }
     /// #     Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn private_channel(
-        &self,
-        channel_id: impl Into<ChannelId>,
-    ) -> Option<PrivateChannel> {
-        self._private_channel(channel_id.into()).await
+    pub fn private_channel(&self, channel_id: impl Into<ChannelId>) -> Option<PrivateChannel> {
+        self._private_channel(channel_id.into())
     }
 
-    async fn _private_channel(&self, channel_id: ChannelId) -> Option<PrivateChannel> {
-        self.private_channels.read().await.get(&channel_id).cloned()
+    fn _private_channel(&self, channel_id: ChannelId) -> Option<PrivateChannel> {
+        self.private_channels.get(&channel_id).map(|i| i.clone())
     }
 
     /// Retrieves a [`Guild`]'s role by their Ids.
@@ -831,26 +826,26 @@ impl Cache {
     /// # use tokio::sync::RwLock;
     /// # use std::sync::Arc;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let cache = Cache::default();
     /// // assuming the cache is in scope, e.g. via `Context`
-    /// if let Some(role) = cache.role(7, 77).await {
+    /// if let Some(role) = cache.role(7, 77) {
     ///     println!("Role with Id 77 is called {}", role.name);
     /// }
     /// #     Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn role<G, R>(&self, guild_id: G, role_id: R) -> Option<Role>
+    pub fn role<G, R>(&self, guild_id: G, role_id: R) -> Option<Role>
     where
         G: Into<GuildId>,
         R: Into<RoleId>,
     {
-        self._role(guild_id.into(), role_id.into()).await
+        self._role(guild_id.into(), role_id.into())
     }
 
-    async fn _role(&self, guild_id: GuildId, role_id: RoleId) -> Option<Role> {
-        self.guilds.read().await.get(&guild_id).and_then(|g| g.roles.get(&role_id)).cloned()
+    fn _role(&self, guild_id: GuildId, role_id: RoleId) -> Option<Role> {
+        self.guilds.get(&guild_id).and_then(|g| g.roles.get(&role_id).cloned())
     }
 
     /// Returns the settings.
@@ -862,20 +857,20 @@ impl Cache {
     /// ```rust
     /// use serenity::cache::Cache;
     ///
-    /// # async fn test() {
+    /// # fn test() {
     /// let mut cache = Cache::new();
-    /// println!("Max settings: {}", cache.settings().await.max_messages);
+    /// println!("Max settings: {}", cache.settings().max_messages);
     /// # }
     /// ```
-    pub async fn settings(&self) -> Settings {
-        self.settings.read().await.clone()
+    pub fn settings(&self) -> Settings {
+        self.settings.read().clone()
     }
 
     /// Sets the maximum amount of messages per channel to cache.
     ///
     /// By default, no messages will be cached.
-    pub async fn set_max_messages(&self, max: usize) {
-        self.settings.write().await.max_messages = max;
+    pub fn set_max_messages(&self, max: usize) {
+        self.settings.write().max_messages = max;
     }
 
     /// Retrieves a [`User`] from the cache's [`Self::users`] map, if it exists.
@@ -894,72 +889,72 @@ impl Cache {
     /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// #
     /// # #[command]
-    /// # async fn test(context: &Context) -> CommandResult {
-    /// if let Some(user) = context.cache.user(7).await {
+    /// # fn test(context: &Context) -> CommandResult {
+    /// if let Some(user) = context.cache.user(7) {
     ///     println!("User with Id 7 is currently named {}", user.name);
     /// }
     /// #     Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn user<U: Into<UserId>>(&self, user_id: U) -> Option<User> {
-        self._user(user_id.into()).await
+    pub fn user<U: Into<UserId>>(&self, user_id: U) -> Option<User> {
+        self._user(user_id.into())
     }
 
-    async fn _user(&self, user_id: UserId) -> Option<User> {
-        self.users.read().await.get(&user_id).cloned()
+    fn _user(&self, user_id: UserId) -> Option<User> {
+        self.users.get(&user_id).map(|i| i.clone())
     }
 
     /// Clones all users and returns them.
     #[inline]
-    pub async fn users(&self) -> HashMap<UserId, User> {
-        self.users.read().await.clone()
+    pub fn users(&self) -> DashMap<UserId, User> {
+        self.users.clone()
     }
 
     /// Returns the amount of cached users.
     #[inline]
-    pub async fn user_count(&self) -> usize {
-        self.users.read().await.len()
+    pub fn user_count(&self) -> usize {
+        self.users.len()
     }
 
     /// Clones a category matching the `channel_id` and returns it.
     #[inline]
-    pub async fn category<C: Into<ChannelId>>(&self, channel_id: C) -> Option<ChannelCategory> {
-        self._category(channel_id.into()).await
+    pub fn category<C: Into<ChannelId>>(&self, channel_id: C) -> Option<ChannelCategory> {
+        self._category(channel_id.into())
     }
 
-    async fn _category(&self, channel_id: ChannelId) -> Option<ChannelCategory> {
-        self.categories.read().await.get(&channel_id).cloned()
+    fn _category(&self, channel_id: ChannelId) -> Option<ChannelCategory> {
+        self.categories.get(&channel_id).map(|i| i.clone())
     }
 
     /// Clones all categories and returns them.
     #[inline]
-    pub async fn categories(&self) -> HashMap<ChannelId, ChannelCategory> {
-        self.categories.read().await.clone()
+    pub fn categories(&self) -> DashMap<ChannelId, ChannelCategory> {
+        self.categories.clone()
     }
 
     /// Returns the amount of cached categories.
     #[inline]
-    pub async fn category_count(&self) -> usize {
-        self.categories.read().await.len()
+    pub fn category_count(&self) -> usize {
+        self.categories.len()
     }
 
     /// Returns the optional category ID of a channel.
     #[inline]
-    pub async fn channel_category_id(&self, channel_id: ChannelId) -> Option<ChannelId> {
-        self.categories.read().await.get(&channel_id).map(|category| category.id)
+    pub fn channel_category_id(&self, channel_id: ChannelId) -> Option<ChannelId> {
+        self.categories.get(&channel_id).map(|category| category.id)
     }
 
     /// This method clones and returns the user used by the bot.
     #[inline]
-    pub async fn current_user(&self) -> CurrentUser {
-        self.user.read().await.clone()
+    pub fn current_user(&self) -> CurrentUser {
+        self.user.read().clone()
     }
 
     /// This method returns the bot's ID.
     #[inline]
-    pub async fn current_user_id(&self) -> UserId {
-        self.user.read().await.id
+    pub fn current_user_id(&self) -> UserId {
+        self.user.read().id
     }
 
     /// This method allows to only clone a field of the current user instead of
@@ -969,20 +964,20 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let cache = Cache::default();
     /// // We clone only the `name` instead of the entire channel.
-    /// let id = cache.current_user_field(|user| user.id).await;
+    /// let id = cache.current_user_field(|user| user.id);
     /// println!("Current user's ID: {}", id);
     /// #   Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn current_user_field<Ret: Clone, Fun>(&self, field_selector: Fun) -> Ret
+    pub fn current_user_field<Ret: Clone, Fun>(&self, field_selector: Fun) -> Ret
     where
         Fun: FnOnce(&CurrentUser) -> Ret,
     {
-        let user = self.user.read().await;
+        let user = self.user.read();
 
         field_selector(&user)
     }
@@ -999,12 +994,12 @@ impl Cache {
     /// [`CacheUpdate`]: CacheUpdate
     /// [`CacheUpdate` examples]: CacheUpdate#examples
     #[instrument(skip(self, e))]
-    pub async fn update<E: CacheUpdate>(&self, e: &mut E) -> Option<E::Output> {
-        e.update(self).await
+    pub fn update<E: CacheUpdate>(&self, e: &mut E) -> Option<E::Output> {
+        e.update(self)
     }
 
-    pub(crate) async fn update_user_entry(&self, user: &User) {
-        match self.users.write().await.entry(user.id) {
+    pub(crate) fn update_user_entry(&self, user: &User) {
+        match self.users.entry(user.id) {
             Entry::Vacant(e) => {
                 e.insert(user.clone());
             },
@@ -1018,18 +1013,18 @@ impl Cache {
 impl Default for Cache {
     fn default() -> Cache {
         Cache {
-            channels: RwLock::new(HashMap::default()),
-            categories: RwLock::new(HashMap::default()),
-            guilds: RwLock::new(HashMap::default()),
-            messages: RwLock::new(HashMap::default()),
-            presences: RwLock::new(HashMap::default()),
-            private_channels: RwLock::new(HashMap::with_capacity(128)),
+            channels: DashMap::default(),
+            categories: DashMap::default(),
+            guilds: DashMap::default(),
+            messages: DashMap::default(),
+            presences: DashMap::default(),
+            private_channels: DashMap::with_capacity(128),
             settings: RwLock::new(Settings::default()),
             shard_count: RwLock::new(1),
-            unavailable_guilds: RwLock::new(HashSet::default()),
+            unavailable_guilds: DashSet::default(),
             user: RwLock::new(CurrentUser::default()),
-            users: RwLock::new(HashMap::default()),
-            message_queue: RwLock::new(HashMap::default()),
+            users: DashMap::default(),
+            message_queue: DashMap::default(),
         }
     }
 }
@@ -1046,9 +1041,9 @@ mod test {
         model::prelude::*,
     };
 
-    #[tokio::test]
+    #[test]
     #[allow(clippy::unwrap_used)]
-    async fn test_cache_messages() {
+    fn test_cache_messages() {
         let mut settings = Settings::new();
         settings.max_messages(2);
         let cache = Cache::new_with_settings(settings);
@@ -1101,26 +1096,25 @@ mod test {
         };
 
         // Check that the channel cache doesn't exist.
-        assert!(!cache.messages.read().await.contains_key(&event.message.channel_id));
+        assert!(!cache.messages.contains_key(&event.message.channel_id));
         // Add first message, none because message ID 2 doesn't already exist.
-        assert!(event.update(&cache).await.is_none());
+        assert!(event.update(&cache).is_none());
         // None, it only returns the oldest message if the cache was already full.
-        assert!(event.update(&cache).await.is_none());
+        assert!(event.update(&cache).is_none());
         // Assert there's only 1 message in the channel's message cache.
-        assert_eq!(cache.messages.read().await.get(&event.message.channel_id).unwrap().len(), 1);
+        assert_eq!(cache.messages.get(&event.message.channel_id).unwrap().len(), 1);
 
         // Add a second message, assert that channel message cache length is 2.
         event.message.id = MessageId(4);
-        assert!(event.update(&cache).await.is_none());
-        assert_eq!(cache.messages.read().await.get(&event.message.channel_id).unwrap().len(), 2);
+        assert!(event.update(&cache).is_none());
+        assert_eq!(cache.messages.get(&event.message.channel_id).unwrap().len(), 2);
 
         // Add a third message, the first should now be removed.
         event.message.id = MessageId(5);
-        assert!(event.update(&cache).await.is_some());
+        assert!(event.update(&cache).is_some());
 
         {
-            let messages = cache.messages.read().await;
-            let channel = messages.get(&event.message.channel_id).unwrap();
+            let channel = cache.messages.get(&event.message.channel_id).unwrap();
 
             assert_eq!(channel.len(), 2);
             // Check that the first message is now removed.
@@ -1156,8 +1150,8 @@ mod test {
         let mut delete = ChannelDeleteEvent {
             channel: channel.clone(),
         };
-        assert!(cache.update(&mut delete).await.is_none());
-        assert!(!cache.messages.read().await.contains_key(&delete.channel.id()));
+        assert!(cache.update(&mut delete).is_none());
+        assert!(!cache.messages.contains_key(&delete.channel.id()));
 
         // Test deletion of a guild channel's message cache when a GuildDeleteEvent
         // is received.
@@ -1218,8 +1212,8 @@ mod test {
                 },
             }
         };
-        assert!(cache.update(&mut guild_create).await.is_none());
-        assert!(cache.update(&mut event).await.is_none());
+        assert!(cache.update(&mut guild_create).is_none());
+        assert!(cache.update(&mut event).is_none());
 
         let mut guild_delete = GuildDeleteEvent {
             guild: GuildUnavailable {
@@ -1230,9 +1224,9 @@ mod test {
 
         // The guild existed in the cache, so the cache's guild is returned by the
         // update.
-        assert!(cache.update(&mut guild_delete).await.is_some());
+        assert!(cache.update(&mut guild_delete).is_some());
 
         // Assert that the channel's message cache no longer exists.
-        assert!(!cache.messages.read().await.contains_key(&ChannelId(2)));
+        assert!(!cache.messages.contains_key(&ChannelId(2)));
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1157,7 +1157,7 @@ mod test {
         // is received.
         let mut guild_create = {
             let mut channels = HashMap::new();
-            channels.insert(ChannelId(2), channel.clone());
+            channels.insert(ChannelId(2), channel);
 
             #[allow(deprecated)]
             GuildCreateEvent {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -42,7 +42,7 @@ fn update<E: CacheUpdate + fmt::Debug>(
 
 #[inline]
 #[cfg(not(feature = "cache"))]
-async fn update<E>(_cache_and_http: &Arc<CacheAndHttp>, _event: &mut E) -> Option<()> {
+fn update<E>(_cache_and_http: &Arc<CacheAndHttp>, _event: &mut E) -> Option<()> {
     None
 }
 
@@ -406,7 +406,7 @@ async fn handle_event(
 
                     event_handler.channel_update(context, old_channel, event.channel).await;
                 } else {
-                    update(&cache_and_http, &mut event).await;
+                    update(&cache_and_http, &mut event);
 
                     event_handler.channel_update(context, event.channel).await;
                 }}
@@ -597,7 +597,7 @@ async fn handle_event(
 
                     event_handler.guild_update(context, before, event.guild).await;
                 } else {
-                    update(&cache_and_http, &mut event).await;
+                    update(&cache_and_http, &mut event);
 
                     event_handler.guild_update(context, event.guild).await;
                 }}

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -33,11 +33,11 @@ use crate::CacheAndHttp;
 
 #[inline]
 #[cfg(feature = "cache")]
-async fn update<E: CacheUpdate + fmt::Debug>(
+fn update<E: CacheUpdate + fmt::Debug>(
     cache_and_http: &Arc<CacheAndHttp>,
     event: &mut E,
 ) -> Option<E::Output> {
-    cache_and_http.cache.update(event).await
+    cache_and_http.cache.update(event)
 }
 
 #[inline]
@@ -77,72 +77,72 @@ pub(crate) enum DispatchEvent {
 
 impl DispatchEvent {
     #[instrument(skip(self, cache_and_http))]
-    async fn update(&mut self, cache_and_http: &Arc<CacheAndHttp>) {
+    fn update(&mut self, cache_and_http: &Arc<CacheAndHttp>) {
         match self {
             Self::Model(Event::ChannelCreate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::ChannelDelete(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::ChannelUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildCreate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildDelete(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildEmojisUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildMemberAdd(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildMemberRemove(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildMemberUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildMembersChunk(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildRoleCreate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildRoleDelete(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildRoleUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildStickersUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::GuildUnavailable(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             // Already handled by the framework check macro
             Self::Model(Event::MessageCreate(_)) => {},
             Self::Model(Event::MessageUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::PresencesReplace(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::PresenceUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::Ready(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::UserUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             Self::Model(Event::VoiceStateUpdate(ref mut event)) => {
-                update(cache_and_http, event).await;
+                update(cache_and_http, event);
             },
             _ => (),
         }
@@ -164,33 +164,31 @@ pub(crate) fn dispatch<'rec>(
     async move {
         match (event_handler, raw_event_handler) {
             (None, None) => {
-                event.update(&cache_and_http).await;
+                event.update(&cache_and_http);
 
+                #[cfg(feature = "framework")]
                 if let DispatchEvent::Model(Event::MessageCreate(event)) = event {
-                    #[cfg(feature = "framework")]
-                    {
-                        #[cfg(not(feature = "cache"))]
-                        let context = context(data, runner_tx, shard_id, &cache_and_http.http);
-                        #[cfg(feature = "cache")]
-                        let context = context(
-                            data,
-                            runner_tx,
-                            shard_id,
-                            &cache_and_http.http,
-                            &cache_and_http.cache,
-                        );
+                    #[cfg(not(feature = "cache"))]
+                    let context = context(data, runner_tx, shard_id, &cache_and_http.http);
+                    #[cfg(feature = "cache")]
+                    let context = context(
+                        data,
+                        runner_tx,
+                        shard_id,
+                        &cache_and_http.http,
+                        &cache_and_http.cache,
+                    );
 
-                        let framework = Arc::clone(framework);
+                    let framework = Arc::clone(framework);
 
-                        tokio::spawn(async move {
-                            framework.dispatch(context, event.message).await;
-                        });
-                    }
+                    tokio::spawn(async move {
+                        framework.dispatch(context, event.message).await;
+                    });
                 }
             },
             (Some(ref h), None) => match event {
                 DispatchEvent::Model(Event::MessageCreate(mut event)) => {
-                    update(&cache_and_http, &mut event).await;
+                    update(&cache_and_http, &mut event);
 
                     #[cfg(not(feature = "cache"))]
                     let context = context(data, runner_tx, shard_id, &cache_and_http.http);
@@ -225,7 +223,7 @@ pub(crate) fn dispatch<'rec>(
                 },
             },
             (None, Some(ref rh)) => {
-                event.update(&cache_and_http).await;
+                event.update(&cache_and_http);
 
                 if let DispatchEvent::Model(event) = event {
                     let event_handler = Arc::clone(rh);
@@ -350,7 +348,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::ChannelCreate(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
             match event.channel {
                 Channel::Guild(channel) => {
                     let event_handler = Arc::clone(event_handler);
@@ -371,7 +369,7 @@ async fn handle_event(
             }
         },
         DispatchEvent::Model(Event::ChannelDelete(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
 
             match event.channel {
                 Channel::Private(_) => {},
@@ -403,8 +401,8 @@ async fn handle_event(
 
             tokio::spawn(async move {
                 feature_cache! {{
-                    let old_channel = cache_and_http.cache.as_ref().channel(event.channel.id()).await;
-                    update(&cache_and_http, &mut event).await;
+                    let old_channel = cache_and_http.cache.as_ref().channel(event.channel.id());
+                    update(&cache_and_http, &mut event);
 
                     event_handler.channel_update(context, old_channel, event.channel).await;
                 } else {
@@ -430,23 +428,20 @@ async fn handle_event(
         },
         DispatchEvent::Model(Event::GuildCreate(mut event)) => {
             #[cfg(feature = "cache")]
-            let _is_new =
-                { !cache_and_http.cache.unavailable_guilds.read().await.contains(&event.guild.id) };
+            let _is_new = { !cache_and_http.cache.unavailable_guilds.contains(&event.guild.id) };
 
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
 
             #[cfg(feature = "cache")]
             {
                 let context = context.clone();
 
-                if cache_and_http.cache.unavailable_guilds.read().await.is_empty() {
+                if cache_and_http.cache.unavailable_guilds.is_empty() {
                     let guild_amount = cache_and_http
                         .cache
                         .guilds
-                        .read()
-                        .await
                         .iter()
-                        .map(|(&id, _)| id)
+                        .map(|i| *i.key())
                         .collect::<Vec<GuildId>>();
                     let event_handler = Arc::clone(event_handler);
 
@@ -467,7 +462,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildDelete(mut event)) => {
-            let _full = update(&cache_and_http, &mut event).await;
+            let _full = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -479,7 +474,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildEmojisUpdate(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -494,7 +489,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildMemberAdd(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
 
             let event_handler = Arc::clone(event_handler);
 
@@ -503,7 +498,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildMemberRemove(mut event)) => {
-            let _member = update(&cache_and_http, &mut event).await;
+            let _member = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -515,9 +510,9 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildMemberUpdate(mut event)) => {
-            let _before = update(&cache_and_http, &mut event).await;
+            let _before = update(&cache_and_http, &mut event);
             let _after: Option<Member> = feature_cache! {{
-                cache_and_http.cache.member(event.guild_id, event.user.id).await
+                cache_and_http.cache.member(event.guild_id, event.user.id)
             } else {
                 None
             }};
@@ -535,7 +530,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildMembersChunk(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -543,7 +538,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildRoleCreate(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -551,7 +546,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildRoleDelete(mut event)) => {
-            let _role = update(&cache_and_http, &mut event).await;
+            let _role = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -563,7 +558,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildRoleUpdate(mut event)) => {
-            let _before = update(&cache_and_http, &mut event).await;
+            let _before = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -575,7 +570,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildStickersUpdate(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -583,7 +578,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::GuildUnavailable(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -596,10 +591,9 @@ async fn handle_event(
             tokio::spawn(async move {
                 feature_cache! {{
                     let before = cache_and_http.cache
-                        .guild(&event.guild.id)
-                        .await;
+                        .guild(&event.guild.id);
 
-                    update(&cache_and_http, &mut event).await;
+                    update(&cache_and_http, &mut event);
 
                     event_handler.guild_update(context, before, event.guild).await;
                 } else {
@@ -644,12 +638,12 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::MessageUpdate(mut event)) => {
-            let _before = update(&cache_and_http, &mut event).await;
+            let _before = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
                 feature_cache! {{
-                    let _after = cache_and_http.cache.message(event.channel_id, event.id).await;
+                    let _after = cache_and_http.cache.message(event.channel_id, event.id);
                     event_handler.message_update(context, _before, _after, event).await;
                 } else {
                     event_handler.message_update(context, event).await;
@@ -657,7 +651,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::PresencesReplace(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -665,7 +659,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::PresenceUpdate(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
 
             let event_handler = Arc::clone(event_handler);
 
@@ -697,7 +691,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::Ready(mut event)) => {
-            update(&cache_and_http, &mut event).await;
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -726,7 +720,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::UserUpdate(mut event)) => {
-            let _before = update(&cache_and_http, &mut event).await;
+            let _before = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
@@ -745,7 +739,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::VoiceStateUpdate(mut event)) => {
-            let _before = update(&cache_and_http, &mut event).await;
+            let _before = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -428,7 +428,7 @@ async fn handle_event(
         },
         DispatchEvent::Model(Event::GuildCreate(mut event)) => {
             #[cfg(feature = "cache")]
-            let _is_new = { !cache_and_http.cache.unavailable_guilds.contains(&event.guild.id) };
+            let _is_new = !cache_and_http.cache.unavailable_guilds.contains(&event.guild.id);
 
             update(&cache_and_http, &mut event);
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -253,14 +253,14 @@ impl StandardFramework {
 
         #[cfg(feature = "cache")]
         {
-            if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx).await {
+            if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx) {
                 let guild_id = channel.guild_id;
 
                 if self.config.blocked_guilds.contains(&guild_id) {
                     return Some(DispatchError::BlockedGuild);
                 }
 
-                let owner_id_option = ctx.cache.guild_field(guild_id, |guild| guild.owner_id).await;
+                let owner_id_option = ctx.cache.guild_field(guild_id, |guild| guild.owner_id);
 
                 if let Some(owner_id) = owner_id_option {
                     if self.config.blocked_users.contains(&owner_id) {
@@ -839,7 +839,7 @@ impl CommonOptions for &CommandOptions {
 }
 
 #[cfg(feature = "cache")]
-pub(crate) async fn has_correct_permissions(
+pub(crate) fn has_correct_permissions(
     cache: impl AsRef<Cache>,
     options: &impl CommonOptions,
     message: &Message,
@@ -873,7 +873,6 @@ pub(crate) async fn has_correct_permissions(
                     },
                 }
             })
-            .await
             .unwrap_or(false)
     }
 }

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -26,15 +26,14 @@ use uwl::Stream;
 // the author does possess them. To avoid defaulting to permissions of everyone, we fetch
 // the member from HTTP if it is missing in the guild's members list.
 #[cfg(feature = "cache")]
-async fn permissions_in(
+fn permissions_in(
     ctx: &Context,
     guild_id: GuildId,
     channel_id: ChannelId,
     member: &Member,
     roles: &HashMap<RoleId, Role>,
 ) -> Permissions {
-    if ctx.cache.guild_field(guild_id, |guild| member.user.id == guild.owner_id).await == Some(true)
-    {
+    if ctx.cache.guild_field(guild_id, |guild| member.user.id == guild.owner_id) == Some(true) {
         return Permissions::all();
     }
 
@@ -62,7 +61,7 @@ async fn permissions_in(
     }
 
     if let Some(Some(Channel::Guild(channel))) =
-        ctx.cache.guild_field(guild_id, |guild| guild.channels.get(&channel_id).cloned()).await
+        ctx.cache.guild_field(guild_id, |guild| guild.channels.get(&channel_id).cloned())
     {
         if channel.kind == ChannelType::Text {
             permissions &= !(Permissions::CONNECT
@@ -265,7 +264,6 @@ async fn check_discrepancy(
             let member = match ctx
                 .cache
                 .guild_field(guild_id, |guild| guild.members.get(&msg.author.id).cloned())
-                .await
             {
                 Some(Some(member)) => member,
                 // Member not found.
@@ -277,8 +275,8 @@ async fn check_discrepancy(
                 None => return Ok(()),
             };
             #[allow(clippy::unwrap_used)] // Allowing unwrap because should always return Some()
-            let roles = ctx.cache.guild_field(guild_id, |guild| guild.roles.clone()).await.unwrap();
-            let perms = permissions_in(ctx, guild_id, msg.channel_id, &member, &roles).await;
+            let roles = ctx.cache.guild_field(guild_id, |guild| guild.roles.clone()).unwrap();
+            let perms = permissions_in(ctx, guild_id, msg.channel_id, &member, &roles);
 
             if !(perms.contains(*options.required_permissions())
                 || options.owner_privilege() && config.owners.contains(&msg.author.id))

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -70,7 +70,7 @@ impl Bucket {
             // category.
             #[cfg(feature = "cache")]
             Self::Category(counter) => {
-                if let Some(category_id) = msg.category_id(ctx).await {
+                if let Some(category_id) = msg.category_id(ctx) {
                     counter.take(ctx, msg, category_id.0).await
                 } else {
                     None
@@ -94,7 +94,7 @@ impl Bucket {
             // category.
             #[cfg(feature = "cache")]
             Self::Category(counter) => {
-                if let Some(category_id) = msg.category_id(ctx).await {
+                if let Some(category_id) = msg.category_id(ctx) {
                     counter.give(ctx, msg, category_id.0).await
                 }
             },

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -44,7 +44,7 @@ impl<'a> Multipart<'a> {
                 } => {
                     let mut part =
                         Part::bytes(data.clone().into_owned()).file_name(filename.clone());
-                    part = part_add_mime_str(part, &filename)?;
+                    part = part_add_mime_str(part, filename)?;
 
                     multipart = multipart.part(file_name, part);
                 },
@@ -56,7 +56,7 @@ impl<'a> Multipart<'a> {
                     file.try_clone().await?.read_to_end(&mut buf).await?;
 
                     let mut part = Part::stream(buf).file_name(filename.clone());
-                    part = part_add_mime_str(part, &filename)?;
+                    part = part_add_mime_str(part, filename)?;
 
                     multipart = multipart.part(file_name, part);
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,8 @@
     clippy::unwrap_used,
     clippy::non_ascii_literal,
     clippy::missing_errors_doc,
-    clippy::let_underscore_must_use
+    clippy::let_underscore_must_use,
+    clippy::unused_async
 )]
 #![type_length_limit = "3294819"] // needed so ShardRunner::run compiles with instrument.
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -387,8 +387,8 @@ impl ChannelId {
     /// Attempts to find a [`Channel`] by its Id in the cache.
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn to_channel_cached(self, cache: impl AsRef<Cache>) -> Option<Channel> {
-        cache.as_ref().channel(self).await
+    pub fn to_channel_cached(self, cache: impl AsRef<Cache>) -> Option<Channel> {
+        cache.as_ref().channel(self)
     }
 
     /// First attempts to find a [`Channel`] by its Id in the cache,
@@ -402,7 +402,7 @@ impl ChannelId {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.channel(self).await {
+                if let Some(channel) = cache.channel(self) {
                     return Ok(channel);
                 }
             }
@@ -529,7 +529,7 @@ impl ChannelId {
     /// Returns the name of whatever channel this id holds.
     #[cfg(feature = "cache")]
     pub async fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
-        let channel = self.to_channel_cached(cache).await?;
+        let channel = self.to_channel_cached(cache)?;
 
         Some(match channel {
             Channel::Guild(channel) => channel.name().to_string(),

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -236,7 +236,6 @@ impl GuildChannel {
     /// // assuming the cache has been unlocked
     /// let channel = cache
     ///     .guild_channel(channel_id)
-    ///     .await
     ///     .ok_or(ModelError::ItemMissing)?;
     ///
     /// channel.create_permission(&http, &overwrite).await?;
@@ -276,7 +275,6 @@ impl GuildChannel {
     ///
     /// let channel = cache
     ///     .guild_channel(channel_id)
-    ///     .await
     ///     .ok_or(ModelError::ItemMissing)?;
     ///
     /// channel.create_permission(&http, &overwrite).await?;
@@ -501,7 +499,7 @@ impl GuildChannel {
     /// use serenity::model::ModelError;
     ///
     /// // assuming the cache has been unlocked
-    /// let channel = cache.guild_channel(channel_id).await.ok_or(ModelError::ItemMissing)?;
+    /// let channel = cache.guild_channel(channel_id).ok_or(ModelError::ItemMissing)?;
     ///
     /// channel.edit_voice_state(&http, user_id, |v| v.suppress(false)).await?;
     /// #   Ok(())
@@ -551,7 +549,7 @@ impl GuildChannel {
     /// use serenity::model::ModelError;
     ///
     /// // assuming the cache has been unlocked
-    /// let channel = cache.guild_channel(channel_id).await.ok_or(ModelError::ItemMissing)?;
+    /// let channel = cache.guild_channel(channel_id).ok_or(ModelError::ItemMissing)?;
     ///
     /// // Send a request to speak
     /// channel.edit_own_voice_state(&http, |v| v.request_to_speak(true)).await?;
@@ -698,12 +696,12 @@ impl GuildChannel {
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, msg: Message) {
-    ///         let channel = match context.cache.guild_channel(msg.channel_id).await {
+    ///         let channel = match context.cache.guild_channel(msg.channel_id) {
     ///             Some(channel) => channel,
     ///             None => return,
     ///         };
     ///
-    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, &msg.author).await {
+    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, &msg.author) {
     ///             println!("The user's permissions: {:?}", permissions);
     ///         }
     ///     }
@@ -732,13 +730,13 @@ impl GuildChannel {
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, mut msg: Message) {
-    ///         let channel = match context.cache.guild_channel(msg.channel_id).await {
+    ///         let channel = match context.cache.guild_channel(msg.channel_id) {
     ///             Some(channel) => channel,
     ///             None => return,
     ///         };
     ///
-    ///         let current_user_id = context.cache.current_user().await.id;
-    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, current_user_id).await {
+    ///         let current_user_id = context.cache.current_user_id();
+    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, current_user_id) {
     ///
     ///             if !permissions.contains(Permissions::ATTACH_FILES | Permissions::SEND_MESSAGES) {
     ///                 return;
@@ -994,7 +992,7 @@ impl GuildChannel {
     /// # let cache = Cache::default();
     /// # let channel = cache
     /// #    .guild_channel(ChannelId(7))
-    /// #    .await.ok_or(ModelError::ItemMissing)?;
+    /// #    .ok_or(ModelError::ItemMissing)?;
     /// // Initiate typing (assuming http is `Arc<Http>` and `channel` is bound)
     /// let typing = channel.start_typing(&http)?;
     ///

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -188,8 +188,7 @@ impl GuildChannel {
                     self.id,
                     Some(self.guild_id),
                     Permissions::CREATE_INVITE,
-                )
-                .await?;
+                )?;
             }
         }
 
@@ -324,8 +323,7 @@ impl GuildChannel {
                     self.id,
                     Some(self.guild_id),
                     Permissions::MANAGE_CHANNELS,
-                )
-                .await?;
+                )?;
             }
         }
 
@@ -430,8 +428,7 @@ impl GuildChannel {
                     self.id,
                     Some(self.guild_id),
                     Permissions::MANAGE_CHANNELS,
-                )
-                .await?;
+                )?;
             }
         }
 
@@ -609,8 +606,8 @@ impl GuildChannel {
     /// Attempts to find this channel's guild in the Cache.
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn guild(&self, cache: impl AsRef<Cache>) -> Option<Guild> {
-        cache.as_ref().guild(self.guild_id).await
+    pub fn guild(&self, cache: impl AsRef<Cache>) -> Option<Guild> {
+        cache.as_ref().guild(self.guild_id)
     }
 
     /// Gets all of the channel's invites.
@@ -782,12 +779,12 @@ impl GuildChannel {
     /// [Send Messages]: Permissions::SEND_MESSAGES
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn permissions_for_user(
+    pub fn permissions_for_user(
         &self,
         cache: impl AsRef<Cache>,
         user_id: impl Into<UserId>,
     ) -> Result<Permissions> {
-        let guild = self.guild(&cache).await.ok_or(Error::Model(ModelError::GuildNotFound))?;
+        let guild = self.guild(&cache).ok_or(Error::Model(ModelError::GuildNotFound))?;
         let member =
             guild.members.get(&user_id.into()).ok_or(Error::Model(ModelError::MemberNotFound))?;
         guild.user_permissions_in(self, member)
@@ -807,12 +804,12 @@ impl GuildChannel {
     /// be found in the [`Cache`].
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn permissions_for_role(
+    pub fn permissions_for_role(
         &self,
         cache: impl AsRef<Cache>,
         role_id: impl Into<RoleId>,
     ) -> Result<Permissions> {
-        let guild = self.guild(&cache).await.ok_or(Error::Model(ModelError::GuildNotFound))?;
+        let guild = self.guild(&cache).ok_or(Error::Model(ModelError::GuildNotFound))?;
         let role =
             guild.roles.get(&role_id.into()).ok_or(Error::Model(ModelError::RoleNotFound))?;
         guild.role_permissions_in(self, role)
@@ -957,7 +954,7 @@ impl GuildChannel {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::SEND_MESSAGES;
 
-                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req).await? {
+                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req)? {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }
@@ -1063,7 +1060,7 @@ impl GuildChannel {
     #[inline]
     pub async fn members(&self, cache: impl AsRef<Cache>) -> Result<Vec<Member>> {
         let cache = cache.as_ref();
-        let guild = cache.guild(self.guild_id).await.ok_or(ModelError::GuildNotFound)?;
+        let guild = cache.guild(self.guild_id).ok_or(ModelError::GuildNotFound)?;
 
         match self.kind {
             ChannelType::Voice | ChannelType::Stage => Ok(guild
@@ -1084,7 +1081,6 @@ impl GuildChannel {
                     .filter_map(|e| async move {
                         if self
                             .permissions_for_user(cache, e.0)
-                            .await
                             .map(|p| p.contains(Permissions::READ_MESSAGES))
                             .unwrap_or(false)
                         {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -199,6 +199,7 @@ impl Message {
     #[inline]
     pub async fn channel(&self, cache_http: impl CacheHttp) -> Result<Channel> {
         self.channel_id.to_channel(cache_http).await
+    }
 
 
     /// A util function for determining whether this message was sent by someone else, or the

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -201,7 +201,6 @@ impl Message {
         self.channel_id.to_channel(cache_http).await
     }
 
-
     /// A util function for determining whether this message was sent by someone else, or the
     /// bot.
     #[cfg(all(feature = "cache", feature = "utils"))]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -163,14 +163,13 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.author.id != cache.current_user_id().await && self.guild_id.is_some() {
+                if self.author.id != cache.current_user_id() && self.guild_id.is_some() {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
                         self.guild_id,
                         Permissions::MANAGE_MESSAGES,
-                    )
-                    .await?;
+                    )?;
                 }
             }
         }
@@ -193,15 +192,15 @@ impl Message {
     /// Returns [`None`] if the channel is not in the cache.
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn channel(&self, cache: impl AsRef<Cache>) -> Option<Channel> {
-        cache.as_ref().channel(self.channel_id).await
+    pub fn channel(&self, cache: impl AsRef<Cache>) -> Option<Channel> {
+        cache.as_ref().channel(self.channel_id)
     }
 
     /// A util function for determining whether this message was sent by someone else, or the
     /// bot.
     #[cfg(all(feature = "cache", feature = "utils"))]
-    pub async fn is_own(&self, cache: impl AsRef<Cache>) -> bool {
-        self.author.id == cache.as_ref().current_user().await.id
+    pub fn is_own(&self, cache: impl AsRef<Cache>) -> bool {
+        self.author.id == cache.as_ref().current_user().id
     }
 
     /// Deletes the message.
@@ -220,7 +219,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.author.id != cache.current_user_id().await {
+                if self.author.id != cache.current_user_id() {
                     if self.is_private() {
                         return Err(Error::Model(ModelError::NotAuthor));
                     } else {
@@ -229,8 +228,7 @@ impl Message {
                             self.channel_id,
                             self.guild_id,
                             Permissions::MANAGE_MESSAGES,
-                        )
-                        .await?;
+                        )?;
                     }
                 }
             }
@@ -259,8 +257,7 @@ impl Message {
                     self.channel_id,
                     self.guild_id,
                     Permissions::MANAGE_MESSAGES,
-                )
-                .await?;
+                )?;
             }
         }
 
@@ -291,8 +288,7 @@ impl Message {
                     self.channel_id,
                     self.guild_id,
                     Permissions::MANAGE_MESSAGES,
-                )
-                .await?;
+                )?;
             }
         }
 
@@ -341,7 +337,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.author.id != cache.current_user_id().await {
+                if self.author.id != cache.current_user_id() {
                     return Err(Error::Model(ModelError::InvalidUser));
                 }
             }
@@ -396,7 +392,7 @@ impl Message {
     /// Returns message content, but with user and role mentions replaced with
     /// names and everyone/here mentions cancelled.
     #[cfg(feature = "cache")]
-    pub async fn content_safe(&self, cache: impl AsRef<Cache>) -> String {
+    pub fn content_safe(&self, cache: impl AsRef<Cache>) -> String {
         let mut result = self.content.clone();
 
         // First replace all user mentions.
@@ -423,7 +419,7 @@ impl Message {
         for id in &self.mention_roles {
             let mention = id.mention().to_string();
 
-            if let Some(role) = id.to_role_cached(&cache).await {
+            if let Some(role) = id.to_role_cached(&cache) {
                 result = result.replace(&mention, &format!("@{}", role.name));
             } else {
                 result = result.replace(&mention, "@deleted-role");
@@ -469,8 +465,8 @@ impl Message {
     ///
     /// Requires the `cache` feature be enabled.
     #[cfg(feature = "cache")]
-    pub async fn guild(&self, cache: impl AsRef<Cache>) -> Option<Guild> {
-        cache.as_ref().guild(self.guild_id?).await
+    pub fn guild(&self, cache: impl AsRef<Cache>) -> Option<Guild> {
+        cache.as_ref().guild(self.guild_id?)
     }
 
     /// Returns a field to the [`Guild`] for the message if one is in the cache.
@@ -481,7 +477,7 @@ impl Message {
     ///
     /// Requires the `cache` feature be enabled.
     #[cfg(feature = "cache")]
-    pub async fn guild_field<Ret, Fun>(
+    pub fn guild_field<Ret, Fun>(
         &self,
         cache: impl AsRef<Cache>,
         field_accessor: Fun,
@@ -490,7 +486,7 @@ impl Message {
         Ret: Clone,
         Fun: FnOnce(&Guild) -> Ret,
     {
-        cache.as_ref().guild_field(self.guild_id?, field_accessor).await
+        cache.as_ref().guild_field(self.guild_id?, field_accessor)
     }
 
     /// True if message was sent using direct messages.
@@ -517,7 +513,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(member) = cache.member(guild_id, self.author.id).await {
+                if let Some(member) = cache.member(guild_id, self.author.id) {
                     return Ok(member);
                 }
             }
@@ -565,8 +561,7 @@ impl Message {
                         self.channel_id,
                         self.guild_id,
                         Permissions::MANAGE_MESSAGES,
-                    )
-                    .await?;
+                    )?;
                 }
             }
         }
@@ -612,11 +607,10 @@ impl Message {
                         self.channel_id,
                         self.guild_id,
                         Permissions::ADD_REACTIONS,
-                    )
-                    .await?;
+                    )?;
                 }
 
-                user_id = Some(cache.current_user().await.id);
+                user_id = Some(cache.current_user_id());
             }
         }
 
@@ -731,8 +725,7 @@ impl Message {
                         self.channel_id,
                         self.guild_id,
                         Permissions::SEND_MESSAGES,
-                    )
-                    .await?;
+                    )?;
                 }
             }
         }
@@ -778,10 +771,9 @@ impl Message {
                     self.channel_id,
                     self.guild_id,
                     Permissions::MANAGE_MESSAGES,
-                )
-                .await?;
+                )?;
 
-                if self.author.id != cache.current_user_id().await {
+                if self.author.id != cache.current_user_id() {
                     return Err(Error::Model(ModelError::NotAuthor));
                 }
             }
@@ -821,7 +813,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                return Ok(self.mentions_user_id(cache.user.read().await.id));
+                return Ok(self.mentions_user_id(cache.current_user_id()));
             }
         }
 
@@ -850,8 +842,7 @@ impl Message {
                         self.channel_id,
                         self.guild_id,
                         Permissions::MANAGE_MESSAGES,
-                    )
-                    .await?;
+                    )?;
                 }
             }
         }
@@ -925,8 +916,8 @@ impl Message {
 
     /// Retrieves the message channel's category ID if the channel has one.
     #[cfg(feature = "cache")]
-    pub async fn category_id(&self, cache: impl AsRef<Cache>) -> Option<ChannelId> {
-        cache.as_ref().channel_category_id(self.channel_id).await
+    pub fn category_id(&self, cache: impl AsRef<Cache>) -> Option<ChannelId> {
+        cache.as_ref().channel_category_id(self.channel_id)
     }
 
     pub(crate) fn check_lengths(map: &JsonMap) -> Result<()> {

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -13,8 +13,6 @@ mod reaction;
 #[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::de::{Error as DeError, Unexpected};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
@@ -564,16 +562,15 @@ mod test {
 }
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-#[async_trait]
 impl FromStrAndCache for Channel {
     type Err = ChannelParseError;
 
-    async fn from_str<C>(cache: C, s: &str) -> StdResult<Self, Self::Err>
+    fn from_str<C>(cache: C, s: &str) -> StdResult<Self, Self::Err>
     where
         C: AsRef<Cache> + Send + Sync,
     {
         match parse_channel(s) {
-            Some(x) => match ChannelId(x).to_channel_cached(&cache).await {
+            Some(x) => match ChannelId(x).to_channel_cached(&cache) {
                 Some(channel) => Ok(channel),
                 _ => Err(ChannelParseError::NotPresentInCache),
             },

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -76,7 +76,7 @@ impl Channel {
     /// # use std::sync::Arc;
     /// #
     /// #   let cache = Cache::default();
-    /// #   let channel = ChannelId(0).to_channel_cached(&cache).await.unwrap();
+    /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
     /// #
     /// match channel.guild() {
     ///     Some(guild) => {
@@ -111,7 +111,7 @@ impl Channel {
     /// # use std::sync::Arc;
     /// #
     /// #   let cache = Cache::default();
-    /// #   let channel = ChannelId(0).to_channel_cached(&cache).await.unwrap();
+    /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
     /// #
     /// match channel.private() {
     ///     Some(private) => {
@@ -146,7 +146,7 @@ impl Channel {
     /// # use std::sync::Arc;
     /// #
     /// #   let cache = Cache::default();
-    /// #   let channel = ChannelId(0).to_channel_cached(&cache).await.unwrap();
+    /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
     /// #
     /// match channel.category() {
     ///     Some(category) => {

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -366,7 +366,6 @@ impl PrivateChannel {
     /// # let http = Arc::new(Http::default());
     /// # let cache = Cache::default();
     /// # let channel = cache.private_channel(ChannelId(7))
-    /// #    .await
     /// #    .ok_or(ModelError::ItemMissing)?;
     /// // Initiate typing (assuming http is `Arc<Http>` and `channel` is bound)
     /// let typing = channel.start_typing(&http)?;

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -152,7 +152,7 @@ impl Reaction {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.user_id.is_some() && self.user_id == Some(cache.current_user().await.id) {
+                if self.user_id.is_some() && self.user_id == Some(cache.current_user().id) {
                     user_id = None;
                 }
 
@@ -162,8 +162,7 @@ impl Reaction {
                         self.channel_id,
                         self.guild_id,
                         Permissions::MANAGE_MESSAGES,
-                    )
-                    .await?;
+                    )?;
                 }
             }
         }
@@ -197,8 +196,7 @@ impl Reaction {
                     self.channel_id,
                     self.guild_id,
                     Permissions::MANAGE_MESSAGES,
-                )
-                .await?;
+                )?;
             }
         }
         cache_http
@@ -246,7 +244,7 @@ impl Reaction {
                 #[cfg(feature = "cache")]
                 {
                     if let Some(cache) = cache_http.cache() {
-                        return Ok(User::from(&cache.current_user().await));
+                        return Ok(User::from(&cache.current_user()));
                     }
                 }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -6,7 +6,6 @@ use std::mem;
 use std::{collections::HashMap, fmt};
 
 #[cfg(feature = "cache")]
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeSeq, Serializer};
@@ -51,63 +50,53 @@ impl Serialize for ChannelCreateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for ChannelCreateEvent {
     type Output = Channel;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
         match self.channel {
             Channel::Guild(ref channel) => {
                 let (guild_id, channel_id) = (channel.guild_id, channel.id);
 
                 let old_channel = cache
                     .guilds
-                    .write()
-                    .await
                     .get_mut(&guild_id)
-                    .and_then(|g| g.channels.insert(channel_id, self.channel.clone()));
+                    .and_then(|mut g| g.channels.insert(channel_id, self.channel.clone()));
 
-                cache.channels.write().await.insert(channel_id, channel.clone());
+                cache.channels.insert(channel_id, channel.clone());
 
                 old_channel
             },
             Channel::Private(ref mut channel) => {
-                if let Some(channel) = cache.private_channels.read().await.get(&channel.id) {
+                if let Some(channel) = cache.private_channels.get(&channel.id) {
                     return Some(Channel::Private(channel.clone()));
                 }
 
                 let id = {
                     let user_id = {
-                        cache.update_user_entry(&channel.recipient).await;
+                        cache.update_user_entry(&channel.recipient);
 
                         channel.recipient.id
                     };
 
-                    if let Some(u) = cache.users.read().await.get(&user_id) {
+                    if let Some(u) = cache.users.get(&user_id) {
                         channel.recipient = u.clone();
                     }
 
                     channel.id
                 };
 
-                cache
-                    .private_channels
-                    .write()
-                    .await
-                    .insert(id, channel.clone())
-                    .map(Channel::Private)
+                cache.private_channels.insert(id, channel.clone()).map(Channel::Private)
             },
             Channel::Category(ref category) => {
                 let (guild_id, channel_id) = (category.guild_id, category.id);
 
                 let old_channel = cache
                     .guilds
-                    .write()
-                    .await
                     .get_mut(&guild_id)
-                    .and_then(|g| g.channels.insert(channel_id, self.channel.clone()));
+                    .and_then(|mut g| g.channels.insert(channel_id, self.channel.clone()));
 
-                cache.categories.write().await.insert(channel_id, category.clone());
+                cache.categories.insert(channel_id, category.clone());
 
                 old_channel
             },
@@ -122,45 +111,34 @@ pub struct ChannelDeleteEvent {
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
-#[async_trait]
 impl CacheUpdate for ChannelDeleteEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
         match self.channel {
             Channel::Guild(ref channel) => {
                 let (guild_id, channel_id) = (channel.guild_id, channel.id);
 
-                cache.channels.write().await.remove(&channel_id);
+                cache.channels.remove(&channel_id);
 
-                cache
-                    .guilds
-                    .write()
-                    .await
-                    .get_mut(&guild_id)
-                    .map(|g| g.channels.remove(&channel_id));
+                cache.guilds.get_mut(&guild_id).map(|mut g| g.channels.remove(&channel_id));
             },
             Channel::Category(ref category) => {
                 let (guild_id, channel_id) = (category.guild_id, category.id);
 
-                cache.categories.write().await.remove(&channel_id);
+                cache.categories.remove(&channel_id);
 
-                cache
-                    .guilds
-                    .write()
-                    .await
-                    .get_mut(&guild_id)
-                    .map(|g| g.channels.remove(&channel_id));
+                cache.guilds.get_mut(&guild_id).map(|mut g| g.channels.remove(&channel_id));
             },
             Channel::Private(ref channel) => {
                 let id = { channel.id };
 
-                cache.private_channels.write().await.remove(&id);
+                cache.private_channels.remove(&id);
             },
         };
 
         // Remove the cached messages for the channel.
-        cache.messages.write().await.remove(&self.channel.id());
+        cache.messages.remove(&self.channel.id());
 
         None
     }
@@ -192,18 +170,17 @@ pub struct ChannelPinsUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for ChannelPinsUpdateEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
-        if let Some(channel) = cache.channels.write().await.get_mut(&self.channel_id) {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
+        if let Some(mut channel) = cache.channels.get_mut(&self.channel_id) {
             channel.last_pin_timestamp = self.last_pin_timestamp;
 
             return None;
         }
 
-        if let Some(channel) = cache.private_channels.write().await.get_mut(&self.channel_id) {
+        if let Some(mut channel) = cache.private_channels.get_mut(&self.channel_id) {
             channel.last_pin_timestamp = self.last_pin_timestamp;
 
             return None;
@@ -220,40 +197,35 @@ pub struct ChannelUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for ChannelUpdateEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
         match self.channel {
             Channel::Guild(ref channel) => {
                 let (guild_id, channel_id) = (channel.guild_id, channel.id);
 
-                cache.channels.write().await.insert(channel_id, channel.clone());
+                cache.channels.insert(channel_id, channel.clone());
 
                 cache
                     .guilds
-                    .write()
-                    .await
                     .get_mut(&guild_id)
-                    .map(|g| g.channels.insert(channel_id, self.channel.clone()));
+                    .map(|mut g| g.channels.insert(channel_id, self.channel.clone()));
             },
             Channel::Private(ref channel) => {
-                if let Some(c) = cache.private_channels.write().await.get_mut(&channel.id) {
+                if let Some(mut c) = cache.private_channels.get_mut(&channel.id) {
                     c.clone_from(channel);
                 }
             },
             Channel::Category(ref category) => {
                 let (guild_id, channel_id) = (category.guild_id, category.id);
 
-                cache.categories.write().await.insert(channel_id, category.clone());
+                cache.categories.insert(channel_id, category.clone());
 
                 cache
                     .guilds
-                    .write()
-                    .await
                     .get_mut(&guild_id)
-                    .map(|g| g.channels.insert(channel_id, self.channel.clone()));
+                    .map(|mut g| g.channels.insert(channel_id, self.channel.clone()));
             },
         }
 
@@ -299,36 +271,33 @@ pub struct GuildCreateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildCreateEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
-        cache.unavailable_guilds.write().await.remove(&self.guild.id);
+    fn update(&mut self, cache: &Cache) -> Option<()> {
+        cache.unavailable_guilds.remove(&self.guild.id);
         let mut guild = self.guild.clone();
 
         for (user_id, member) in &mut guild.members {
-            cache.update_user_entry(&member.user).await;
-            if let Some(u) = cache.user(user_id).await {
+            cache.update_user_entry(&member.user);
+            if let Some(u) = cache.user(user_id) {
                 member.user = u;
             }
         }
 
-        cache.channels.write().await.extend(guild.channels.clone().into_iter().filter_map(|c| {
-            match c.1 {
-                Channel::Guild(channel) => Some((c.0, channel)),
-                _ => None,
+        for pair in guild.channels.clone().into_iter() {
+            if let Channel::Guild(channel) = pair.1 {
+                cache.channels.insert(pair.0, channel);
             }
-        }));
+        }
 
-        cache.categories.write().await.extend(guild.channels.clone().into_iter().filter_map(|c| {
-            match c.1 {
-                Channel::Category(category) => Some((c.0, category)),
-                _ => None,
+        for pair in guild.channels.clone().into_iter() {
+            if let Channel::Category(category) = pair.1 {
+                cache.categories.insert(pair.0, category);
             }
-        }));
+        }
 
-        cache.guilds.write().await.insert(self.guild.id, guild);
+        cache.guilds.insert(self.guild.id, guild);
 
         None
     }
@@ -358,31 +327,30 @@ pub struct GuildDeleteEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildDeleteEvent {
     type Output = Guild;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        match cache.guilds.write().await.remove(&self.guild.id) {
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        match cache.guilds.remove(&self.guild.id) {
             Some(guild) => {
-                for (channel_id, channel) in &guild.channels {
+                for (channel_id, channel) in &guild.1.channels {
                     match channel {
                         Channel::Guild(_) => {
                             // Remove the channel from the cache.
-                            cache.channels.write().await.remove(channel_id);
+                            cache.channels.remove(channel_id);
 
                             // Remove the channel's cached messages.
-                            cache.messages.write().await.remove(channel_id);
+                            cache.messages.remove(channel_id);
                         },
                         Channel::Category(_) => {
                             // Remove the category from the cache
-                            cache.categories.write().await.remove(channel_id);
+                            cache.categories.remove(channel_id);
                         },
                         _ => {},
                     }
                 }
 
-                Some(guild)
+                Some(guild.1)
             },
             None => None,
         }
@@ -415,12 +383,11 @@ pub struct GuildEmojisUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildEmojisUpdateEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
-        if let Some(guild) = cache.guilds.write().await.get_mut(&self.guild_id) {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             guild.emojis.clone_from(&self.emojis);
         }
 
@@ -442,18 +409,17 @@ pub struct GuildMemberAddEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildMemberAddEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
         let user_id = self.member.user.id;
-        cache.update_user_entry(&self.member.user).await;
-        if let Some(u) = cache.user(user_id).await {
+        cache.update_user_entry(&self.member.user);
+        if let Some(u) = cache.user(user_id) {
             self.member.user = u;
         }
 
-        if let Some(guild) = cache.guilds.write().await.get_mut(&self.guild_id) {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             guild.member_count += 1;
             guild.members.insert(user_id, self.member.clone());
         }
@@ -487,12 +453,11 @@ pub struct GuildMemberRemoveEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildMemberRemoveEvent {
     type Output = Member;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        if let Some(guild) = cache.guilds.write().await.get_mut(&self.guild_id) {
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             guild.member_count -= 1;
             return guild.members.remove(&self.user.id);
         }
@@ -520,14 +485,13 @@ pub struct GuildMemberUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildMemberUpdateEvent {
     type Output = Member;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        cache.update_user_entry(&self.user).await;
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        cache.update_user_entry(&self.user);
 
-        if let Some(guild) = cache.guilds.write().await.get_mut(&self.guild_id) {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             let item = if let Some(member) = guild.members.get_mut(&self.user.id) {
                 let item = Some(member.clone());
 
@@ -581,16 +545,15 @@ pub struct GuildMembersChunkEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildMembersChunkEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
         for member in self.members.values() {
-            cache.update_user_entry(&member.user).await;
+            cache.update_user_entry(&member.user);
         }
 
-        if let Some(g) = cache.guilds.write().await.get_mut(&self.guild_id) {
+        if let Some(mut g) = cache.guilds.get_mut(&self.guild_id) {
             g.members.extend(self.members.clone());
         }
 
@@ -666,17 +629,14 @@ pub struct GuildRoleCreateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildRoleCreateEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
         cache
             .guilds
-            .write()
-            .await
             .get_mut(&self.guild_id)
-            .map(|g| g.roles.insert(self.role.id, self.role.clone()));
+            .map(|mut g| g.roles.insert(self.role.id, self.role.clone()));
 
         None
     }
@@ -721,17 +681,11 @@ pub struct GuildRoleDeleteEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildRoleDeleteEvent {
     type Output = Role;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        cache
-            .guilds
-            .write()
-            .await
-            .get_mut(&self.guild_id)
-            .and_then(|g| g.roles.remove(&self.role_id))
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        cache.guilds.get_mut(&self.guild_id).and_then(|mut g| g.roles.remove(&self.role_id))
     }
 }
 
@@ -743,12 +697,11 @@ pub struct GuildRoleUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildRoleUpdateEvent {
     type Output = Role;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        if let Some(guild) = cache.guilds.write().await.get_mut(&self.guild_id) {
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             if let Some(role) = guild.roles.get_mut(&self.role.id) {
                 return Some(mem::replace(role, self.role.clone()));
             }
@@ -798,12 +751,11 @@ pub struct GuildStickersUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildStickersUpdateEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
-        if let Some(guild) = cache.guilds.write().await.get_mut(&self.guild_id) {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             guild.stickers.clone_from(&self.stickers);
         }
 
@@ -839,13 +791,12 @@ pub struct GuildUnavailableEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildUnavailableEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
-        cache.unavailable_guilds.write().await.insert(self.guild_id);
-        cache.guilds.write().await.remove(&self.guild_id);
+    fn update(&mut self, cache: &Cache) -> Option<()> {
+        cache.unavailable_guilds.insert(self.guild_id);
+        cache.guilds.remove(&self.guild_id);
 
         None
     }
@@ -858,12 +809,11 @@ pub struct GuildUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for GuildUpdateEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
-        if let Some(guild) = cache.guilds.write().await.get_mut(&self.guild.id) {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.guild.id) {
             guild.afk_channel_id.clone_from(&self.guild.afk_channel_id);
             guild.afk_timeout = self.guild.afk_timeout;
             guild.banner.clone_from(&self.guild.banner);
@@ -927,23 +877,21 @@ pub struct MessageCreateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for MessageCreateEvent {
     /// The oldest message, if the channel's message cache was already full.
     type Output = Message;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        let max = cache.settings().await.max_messages;
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        let max = cache.settings().max_messages;
 
         if max == 0 {
             return None;
         }
 
-        let mut messages_map = cache.messages.write().await;
-        let messages = messages_map.entry(self.message.channel_id).or_insert_with(Default::default);
-        let mut message_queues = cache.message_queue.write().await;
-
-        let queue = message_queues.entry(self.message.channel_id).or_insert_with(Default::default);
+        let messages =
+            cache.messages.entry(self.message.channel_id).or_insert_with(Default::default);
+        let mut queue =
+            cache.message_queue.entry(self.message.channel_id).or_insert_with(Default::default);
 
         let mut removed_msg = None;
 
@@ -956,7 +904,7 @@ impl CacheUpdate for MessageCreateEvent {
         queue.push_back(self.message.id);
         messages.insert(self.message.id, self.message.clone());
 
-        removed_msg
+        removed_msg.map(|i| i.1)
     }
 }
 
@@ -1017,13 +965,12 @@ pub struct MessageUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for MessageUpdateEvent {
     type Output = Message;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        if let Some(messages) = cache.messages.write().await.get_mut(&self.channel_id) {
-            if let Some(message) = messages.get_mut(&self.id) {
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        if let Some(messages) = cache.messages.get_mut(&self.channel_id) {
+            if let Some(mut message) = messages.get_mut(&self.id) {
                 let item = message.clone();
 
                 if let Some(attachments) = self.attachments.clone() {
@@ -1074,21 +1021,20 @@ pub struct PresenceUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for PresenceUpdateEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
         if let Some(user) = self.presence.user.to_user() {
-            cache.update_user_entry(&user).await;
+            cache.update_user_entry(&user);
         }
 
-        if let Some(user) = cache.user(self.presence.user.id).await {
+        if let Some(user) = cache.user(self.presence.user.id) {
             self.presence.user.update_with_user(user);
         }
 
         if let Some(guild_id) = self.guild_id {
-            if let Some(guild) = cache.guilds.write().await.get_mut(&guild_id) {
+            if let Some(mut guild) = cache.guilds.get_mut(&guild_id) {
                 // If the member went offline, remove them from the presence list.
                 if self.presence.status == OnlineStatus::Offline {
                     guild.presences.remove(&self.presence.user.id);
@@ -1116,9 +1062,9 @@ impl CacheUpdate for PresenceUpdateEvent {
                 }
             }
         } else if self.presence.status == OnlineStatus::Offline {
-            cache.presences.write().await.remove(&self.presence.user.id);
+            cache.presences.remove(&self.presence.user.id);
         } else {
-            cache.presences.write().await.insert(self.presence.user.id, self.presence.clone());
+            cache.presences.insert(self.presence.user.id, self.presence.clone());
         }
 
         None
@@ -1149,20 +1095,13 @@ pub struct PresencesReplaceEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for PresencesReplaceEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
-        cache.presences.write().await.extend({
-            let mut p: HashMap<UserId, Presence> = HashMap::default();
-
-            for presence in &self.presences {
-                p.insert(presence.user.id, presence.clone());
-            }
-
-            p
-        });
+    fn update(&mut self, cache: &Cache) -> Option<()> {
+        for presence in &self.presences {
+            cache.presences.insert(presence.user.id, presence.clone());
+        }
 
         None
     }
@@ -1255,22 +1194,21 @@ pub struct ReadyEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for ReadyEvent {
     type Output = ();
 
-    async fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<()> {
         let mut ready = self.ready.clone();
 
         for guild in ready.guilds {
             match guild {
                 GuildStatus::Offline(unavailable) => {
-                    cache.guilds.write().await.remove(&unavailable.id);
-                    cache.unavailable_guilds.write().await.insert(unavailable.id);
+                    cache.guilds.remove(&unavailable.id);
+                    cache.unavailable_guilds.insert(unavailable.id);
                 },
                 GuildStatus::OnlineGuild(guild) => {
-                    cache.unavailable_guilds.write().await.remove(&guild.id);
-                    cache.guilds.write().await.insert(guild.id, guild);
+                    cache.unavailable_guilds.remove(&guild.id);
+                    cache.guilds.insert(guild.id, guild);
                 },
                 GuildStatus::OnlinePartialGuild(_) => {},
             }
@@ -1281,16 +1219,17 @@ impl CacheUpdate for ReadyEvent {
 
         for (user_id, presence) in &mut ready.presences {
             if let Some(user) = presence.user.to_user() {
-                cache.update_user_entry(&user).await;
+                cache.update_user_entry(&user);
             }
-            if let Some(user) = cache.user(user_id).await {
+            if let Some(user) = cache.user(user_id) {
                 presence.user.update_with_user(user);
             }
+
+            cache.presences.insert(*user_id, presence.clone());
         }
 
-        cache.presences.write().await.extend(ready.presences);
-        *cache.shard_count.write().await = ready.shard.map_or(1, |s| s[1]);
-        *cache.user.write().await = ready.user;
+        *cache.shard_count.write() = ready.shard.map_or(1, |s| s[1]);
+        *cache.user.write() = ready.user;
 
         None
     }
@@ -1343,12 +1282,11 @@ pub struct UserUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for UserUpdateEvent {
     type Output = CurrentUser;
 
-    async fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        let mut user = cache.user.write().await;
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        let mut user = cache.user.write();
         Some(mem::replace(&mut user, self.current_user.clone()))
     }
 }
@@ -1397,13 +1335,12 @@ pub struct VoiceStateUpdateEvent {
 }
 
 #[cfg(feature = "cache")]
-#[async_trait]
 impl CacheUpdate for VoiceStateUpdateEvent {
     type Output = VoiceState;
 
-    async fn update(&mut self, cache: &Cache) -> Option<VoiceState> {
+    fn update(&mut self, cache: &Cache) -> Option<VoiceState> {
         if let Some(guild_id) = self.guild_id {
-            if let Some(guild) = cache.guilds.write().await.get_mut(&guild_id) {
+            if let Some(mut guild) = cache.guilds.get_mut(&guild_id) {
                 if let Some(member) = &self.voice_state.member {
                     guild.members.insert(member.user.id, member.clone());
                 }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -5,7 +5,6 @@ use std::convert::TryFrom;
 use std::mem;
 use std::{collections::HashMap, fmt};
 
-#[cfg(feature = "cache")]
 use chrono::{DateTime, Utc};
 use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeSeq, Serializer};

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -629,6 +629,7 @@ impl PresenceUser {
         })
     }
 
+    #[cfg(feature = "cache")] // method is only used with the cache feature enabled 
     pub(crate) fn update_with_user(&mut self, user: User) {
         self.id = user.id;
         if let Some(avatar) = user.avatar {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -629,7 +629,7 @@ impl PresenceUser {
         })
     }
 
-    #[cfg(feature = "cache")] // method is only used with the cache feature enabled 
+    #[cfg(feature = "cache")] // method is only used with the cache feature enabled
     pub(crate) fn update_with_user(&mut self, user: User) {
         self.id = user.id;
         if let Some(avatar) = user.avatar {

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult, Write as FmtWrite};
 
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::Cache;
+#[cfg(feature = "cache")]
 use crate::http::Http;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -100,7 +100,7 @@ impl Emoji {
     #[cfg(feature = "cache")]
     #[inline]
     pub async fn delete<T: AsRef<Cache> + AsRef<Http>>(&self, cache_http: T) -> Result<()> {
-        match self.find_guild_id(&cache_http).await {
+        match self.find_guild_id(&cache_http) {
             Some(guild_id) => {
                 AsRef::<Http>::as_ref(&cache_http).delete_emoji(guild_id.0, self.id.0).await
             },
@@ -125,7 +125,7 @@ impl Emoji {
         cache_http: T,
         name: &str,
     ) -> Result<()> {
-        match self.find_guild_id(&cache_http).await {
+        match self.find_guild_id(&cache_http) {
             Some(guild_id) => {
                 let map = json!({
                     "name": name,
@@ -174,8 +174,10 @@ impl Emoji {
     /// # }
     /// ```
     #[cfg(feature = "cache")]
-    pub async fn find_guild_id(&self, cache: impl AsRef<Cache>) -> Option<GuildId> {
-        for guild in cache.as_ref().guilds.read().await.values() {
+    pub fn find_guild_id(&self, cache: impl AsRef<Cache>) -> Option<GuildId> {
+        for guild_entry in cache.as_ref().guilds.iter() {
+            let guild = guild_entry.value();
+
             if guild.emojis.contains_key(&self.id) {
                 return Some(guild.id);
             }

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -168,7 +168,7 @@ impl Emoji {
     /// # })).unwrap();
     /// #
     /// // assuming emoji has been set already
-    /// if let Some(guild_id) = emoji.find_guild_id(&cache).await {
+    /// if let Some(guild_id) = emoji.find_guild_id(&cache) {
     ///     println!("{} is owned by {}", emoji.name, guild_id);
     /// }
     /// # }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -708,8 +708,8 @@ impl GuildId {
     /// Tries to find the [`Guild`] by its Id in the cache.
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn to_guild_cached(self, cache: impl AsRef<Cache>) -> Option<Guild> {
-        cache.as_ref().guild(self).await
+    pub fn to_guild_cached(self, cache: impl AsRef<Cache>) -> Option<Guild> {
+        cache.as_ref().guild(self)
     }
 
     /// Requests [`PartialGuild`] over REST API.
@@ -894,7 +894,7 @@ impl GuildId {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(member) = cache.member(self.0, user_id).await {
+                if let Some(member) = cache.member(self.0, user_id) {
                     return Ok(member);
                 }
             }
@@ -989,8 +989,8 @@ impl GuildId {
 
     /// Returns the name of whatever guild this id holds.
     #[cfg(feature = "cache")]
-    pub async fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
-        let guild = self.to_guild_cached(&cache).await?;
+    pub fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
+        let guild = self.to_guild_cached(&cache)?;
         Some(guild.name)
     }
 
@@ -1099,8 +1099,8 @@ impl GuildId {
     /// total, consider using [`utils::shard_id`].
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
-    pub async fn shard_id(self, cache: impl AsRef<Cache>) -> u64 {
-        crate::utils::shard_id(self.0, cache.as_ref().shard_count().await)
+    pub fn shard_id(self, cache: impl AsRef<Cache>) -> u64 {
+        crate::utils::shard_id(self.0, cache.as_ref().shard_count())
     }
 
     /// Returns the Id of the shard associated with the guild.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -166,8 +166,8 @@ impl Member {
 
     /// Determines the member's colour.
     #[cfg(feature = "cache")]
-    pub async fn colour(&self, cache: impl AsRef<Cache>) -> Option<Colour> {
-        let guild_roles = cache.as_ref().guild_field(self.guild_id, |g| g.roles.clone()).await?;
+    pub fn colour(&self, cache: impl AsRef<Cache>) -> Option<Colour> {
+        let guild_roles = cache.as_ref().guild_field(self.guild_id, |g| g.roles.clone())?;
 
         let mut roles = self
             .roles
@@ -186,8 +186,8 @@ impl Member {
     /// (This returns the first channel that can be read by the member, if there isn't
     /// one returns [`None`])
     #[cfg(feature = "cache")]
-    pub async fn default_channel(&self, cache: impl AsRef<Cache>) -> Option<GuildChannel> {
-        let guild = self.guild_id.to_guild_cached(cache).await?;
+    pub fn default_channel(&self, cache: impl AsRef<Cache>) -> Option<GuildChannel> {
+        let guild = self.guild_id.to_guild_cached(cache)?;
 
         let member = guild.members.get(&self.user.id)?;
 
@@ -251,8 +251,8 @@ impl Member {
     /// position. If two or more roles have the same highest position, then the
     /// role with the lowest ID is the highest.
     #[cfg(feature = "cache")]
-    pub async fn highest_role_info(&self, cache: impl AsRef<Cache>) -> Option<(RoleId, i64)> {
-        let guild_roles = cache.as_ref().guild_field(self.guild_id, |g| g.roles.clone()).await?;
+    pub fn highest_role_info(&self, cache: impl AsRef<Cache>) -> Option<(RoleId, i64)> {
+        let guild_roles = cache.as_ref().guild_field(self.guild_id, |g| g.roles.clone())?;
 
         let mut highest = None;
 
@@ -344,14 +344,14 @@ impl Member {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = cache.guilds.read().await.get(&self.guild_id) {
+                if let Some(guild) = cache.guilds.get(&self.guild_id) {
                     let req = Permissions::KICK_MEMBERS;
 
                     if !guild.has_perms(&cache_http, req).await {
                         return Err(Error::Model(ModelError::InvalidPermissions(req)));
                     }
 
-                    guild.check_hierarchy(cache, self.user.id).await?;
+                    guild.check_hierarchy(cache, self.user.id)?;
                 }
             }
         }
@@ -409,14 +409,10 @@ impl Member {
     /// And/or returns [`ModelError::ItemMissing`] if the "default channel" of the guild is not
     /// found.
     #[cfg(feature = "cache")]
-    pub async fn permissions(
-        &self,
-        cache_http: impl CacheHttp + AsRef<Cache>,
-    ) -> Result<Permissions> {
+    pub fn permissions(&self, cache_http: impl CacheHttp + AsRef<Cache>) -> Result<Permissions> {
         let perms_opt = cache_http
             .as_ref()
-            .guild_field(self.guild_id, |guild| guild._member_permission_from_member(self))
-            .await;
+            .guild_field(self.guild_id, |guild| guild._member_permission_from_member(self));
 
         match perms_opt {
             Some(perms) => Ok(perms),
@@ -498,12 +494,11 @@ impl Member {
     ///
     /// If role data can not be found for the member, then [`None`] is returned.
     #[cfg(feature = "cache")]
-    pub async fn roles(&self, cache: impl AsRef<Cache>) -> Option<Vec<Role>> {
+    pub fn roles(&self, cache: impl AsRef<Cache>) -> Option<Vec<Role>> {
         Some(
             cache
                 .as_ref()
-                .guild_field(self.guild_id, |g| g.roles.clone())
-                .await?
+                .guild_field(self.guild_id, |g| g.roles.clone())?
                 .into_iter()
                 .map(|(_, v)| v)
                 .filter(|role| self.roles.contains(&role.id))

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "model")]
 use std::borrow::Cow;
+#[cfg(feature = "cache")]
 use std::cmp::Reverse;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -267,10 +267,10 @@ pub struct Guild {
 #[cfg(feature = "model")]
 impl Guild {
     #[cfg(feature = "cache")]
-    async fn check_hierarchy(&self, cache: impl AsRef<Cache>, other_user: UserId) -> Result<()> {
-        let current_id = cache.as_ref().current_user().await.id;
+    fn check_hierarchy(&self, cache: impl AsRef<Cache>, other_user: UserId) -> Result<()> {
+        let current_id = cache.as_ref().current_user().id;
 
-        if let Some(higher) = self.greater_member_hierarchy(&cache, other_user, current_id).await {
+        if let Some(higher) = self.greater_member_hierarchy(&cache, other_user, current_id) {
             if higher != current_id {
                 return Err(Error::Model(ModelError::Hierarchy));
             }
@@ -301,7 +301,7 @@ impl Guild {
     ///
     /// **Note**: This is very costly if used in a server with lots of channels,
     /// members, or both.
-    pub async fn default_channel_guaranteed(&self) -> Option<&GuildChannel> {
+    pub fn default_channel_guaranteed(&self) -> Option<&GuildChannel> {
         for channel in self.channels.values() {
             if let Channel::Guild(channel) = channel {
                 for member in self.members.values() {
@@ -318,7 +318,7 @@ impl Guild {
     #[cfg(feature = "cache")]
     async fn has_perms(&self, cache_http: impl CacheHttp, mut permissions: Permissions) -> bool {
         if let Some(cache) = cache_http.cache() {
-            let user_id = cache.current_user().await.id;
+            let user_id = cache.current_user().id;
 
             if let Ok(perms) = self.member_permissions(&cache_http, user_id).await {
                 permissions.remove(perms);
@@ -333,15 +333,17 @@ impl Guild {
     }
 
     #[cfg(feature = "cache")]
-    pub async fn channel_id_from_name(
+    pub fn channel_id_from_name(
         &self,
         cache: impl AsRef<Cache>,
         name: impl AsRef<str>,
     ) -> Option<ChannelId> {
         let name = name.as_ref();
-        let guild_channels = cache.as_ref().guild_channels(&self.id).await?;
+        let guild_channels = cache.as_ref().guild_channels(&self.id)?;
 
-        for (id, channel) in guild_channels.iter() {
+        for channel_entry in guild_channels.iter() {
+            let (id, channel) = channel_entry.pair();
+
             if channel.name == name {
                 return Some(*id);
             }
@@ -422,7 +424,7 @@ impl Guild {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
 
-                self.check_hierarchy(cache, user).await?;
+                self.check_hierarchy(cache, user)?;
             }
         }
 
@@ -863,7 +865,7 @@ impl Guild {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.owner_id != cache.current_user().await.id {
+                if self.owner_id != cache.current_user().id {
                     let req = Permissions::MANAGE_GUILD;
 
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
@@ -1269,17 +1271,17 @@ impl Guild {
     /// [`position`]: Role::position
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn greater_member_hierarchy(
+    pub fn greater_member_hierarchy(
         &self,
         cache: impl AsRef<Cache>,
         lhs_id: impl Into<UserId>,
         rhs_id: impl Into<UserId>,
     ) -> Option<UserId> {
-        self._greater_member_hierarchy(&cache, lhs_id.into(), rhs_id.into()).await
+        self._greater_member_hierarchy(&cache, lhs_id.into(), rhs_id.into())
     }
 
     #[cfg(feature = "cache")]
-    async fn _greater_member_hierarchy(
+    fn _greater_member_hierarchy(
         &self,
         cache: impl AsRef<Cache>,
         lhs_id: UserId,
@@ -1297,10 +1299,8 @@ impl Guild {
             return Some(rhs_id);
         }
 
-        let lhs =
-            self.members.get(&lhs_id)?.highest_role_info(&cache).await.unwrap_or((RoleId(0), 0));
-        let rhs =
-            self.members.get(&rhs_id)?.highest_role_info(&cache).await.unwrap_or((RoleId(0), 0));
+        let lhs = self.members.get(&lhs_id)?.highest_role_info(&cache).unwrap_or((RoleId(0), 0));
+        let rhs = self.members.get(&rhs_id)?.highest_role_info(&cache).unwrap_or((RoleId(0), 0));
 
         // If LHS and RHS both have no top position or have the same role ID,
         // then no one wins.
@@ -2184,8 +2184,8 @@ impl Guild {
     /// [`utils::shard_id`]: crate::utils::shard_id
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
-    pub async fn shard_id(&self, cache: impl AsRef<Cache>) -> u64 {
-        self.id.shard_id(&cache).await
+    pub fn shard_id(&self, cache: impl AsRef<Cache>) -> u64 {
+        self.id.shard_id(&cache)
     }
 
     /// Returns the Id of the shard associated with the guild.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2368,7 +2368,7 @@ impl Guild {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if let Some(guild_id) = msg.guild_id {
-    ///             if let Some(guild) = guild_id.to_guild_cached(&ctx).await {
+    ///             if let Some(guild) = guild_id.to_guild_cached(&ctx) {
     ///                 if let Some(role) = guild.role_by_name("role_name") {
     ///                     println!("{:?}", role);
     ///                 }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1486,7 +1486,7 @@ impl PartialGuild {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, msg: Message) {
     ///         if let Some(guild_id) = msg.guild_id {
-    ///             if let Some(guild) = guild_id.to_guild_cached(&context).await {
+    ///             if let Some(guild) = guild_id.to_guild_cached(&context) {
     ///                 if let Some(role) = guild.role_by_name("role_name") {
     ///                     println!("Obtained role's reference: {:?}", role);
     ///                 }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -267,15 +267,17 @@ impl PartialGuild {
     }
 
     #[cfg(feature = "cache")]
-    pub async fn channel_id_from_name(
+    pub fn channel_id_from_name(
         &self,
         cache: impl AsRef<Cache>,
         name: impl AsRef<str>,
     ) -> Option<ChannelId> {
         let name = name.as_ref();
-        let guild_channels = cache.as_ref().guild_channels(&self.id).await?;
+        let guild_channels = cache.as_ref().guild_channels(&self.id)?;
 
-        for (id, channel) in guild_channels.iter() {
+        for channel_entry in guild_channels.iter() {
+            let (id, channel) = channel_entry.pair();
+
             if channel.name == name {
                 return Some(*id);
             }
@@ -953,21 +955,17 @@ impl PartialGuild {
 
         let lhs = cache
             .as_ref()
-            .guild(self.id)
-            .await?
+            .guild(self.id)?
             .members
             .get(&lhs_id)?
             .highest_role_info(&cache)
-            .await
             .unwrap_or((RoleId(0), 0));
         let rhs = cache
             .as_ref()
-            .guild(self.id)
-            .await?
+            .guild(self.id)?
             .members
             .get(&rhs_id)?
             .highest_role_info(&cache)
-            .await
             .unwrap_or((RoleId(0), 0));
 
         // If LHS and RHS both have no top position or have the same role ID,
@@ -1138,7 +1136,7 @@ impl PartialGuild {
     #[cfg(feature = "cache")]
     async fn has_perms(&self, cache_http: impl CacheHttp, mut permissions: Permissions) -> bool {
         if let Some(cache) = cache_http.cache() {
-            let user_id = cache.current_user().await.id;
+            let user_id = cache.current_user().id;
 
             if let Ok(perms) = self.member_permissions(&cache_http, user_id).await {
                 permissions.remove(perms);
@@ -1365,8 +1363,8 @@ impl PartialGuild {
     /// [`utils::shard_id`]: crate::utils::shard_id
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
-    pub async fn shard_id(&self, cache: impl AsRef<Cache>) -> u64 {
-        self.id.shard_id(cache).await
+    pub fn shard_id(&self, cache: impl AsRef<Cache>) -> u64 {
+        self.id.shard_id(cache)
     }
 
     /// Returns the Id of the shard associated with the guild.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use async_trait::async_trait;
 #[cfg(feature = "model")]
 use serde::de::{Deserialize, Deserializer, Error as DeError};
 
@@ -187,8 +186,10 @@ impl PartialOrd for Role {
 impl RoleId {
     /// Tries to find the [`Role`] by its Id in the cache.
     #[cfg(feature = "cache")]
-    pub async fn to_role_cached(self, cache: impl AsRef<Cache>) -> Option<Role> {
-        for guild in cache.as_ref().guilds.read().await.values() {
+    pub fn to_role_cached(self, cache: impl AsRef<Cache>) -> Option<Role> {
+        for guild_entry in cache.as_ref().guilds.iter() {
+            let guild = guild_entry.value();
+
             if !guild.roles.contains_key(&self) {
                 continue;
             }
@@ -217,16 +218,15 @@ impl<'a> From<&'a Role> for RoleId {
 }
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-#[async_trait]
 impl FromStrAndCache for Role {
     type Err = RoleParseError;
 
-    async fn from_str<CRL>(cache: CRL, s: &str) -> StdResult<Self, Self::Err>
+    fn from_str<CRL>(cache: CRL, s: &str) -> StdResult<Self, Self::Err>
     where
         CRL: AsRef<Cache> + Send + Sync,
     {
         match parse_role(s) {
-            Some(x) => match RoleId(x).to_role_cached(&cache).await {
+            Some(x) => match RoleId(x).to_role_cached(&cache) {
                 Some(role) => Ok(role),
                 None => Err(RoleParseError::NotPresentInCache),
             },

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 #[cfg(feature = "model")]
 use serde::de::{Deserialize, Deserializer, Error as DeError};
 

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -83,8 +83,7 @@ impl Invite {
                     channel_id,
                     None,
                     Permissions::CREATE_INVITE,
-                )
-                .await?;
+                )?;
             }
         }
 
@@ -118,8 +117,7 @@ impl Invite {
                     self.channel.id,
                     guild_id,
                     Permissions::MANAGE_GUILD,
-                )
-                .await?;
+                )?;
             }
         }
 
@@ -222,8 +220,8 @@ impl InviteGuild {
     /// total, consider using [`utils::shard_id`].
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
-    pub async fn shard_id(&self, cache: impl AsRef<Cache>) -> u64 {
-        self.id.shard_id(&cache).await
+    pub fn shard_id(&self, cache: impl AsRef<Cache>) -> u64 {
+        self.id.shard_id(&cache)
     }
 
     /// Returns the Id of the shard associated with the guild.
@@ -318,8 +316,7 @@ impl RichInvite {
                     self.channel.id,
                     guild_id,
                     Permissions::MANAGE_GUILD,
-                )
-                .await?;
+                )?;
             }
         }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -71,7 +71,7 @@ impl CurrentUser {
     /// #
     /// # let cache = Cache::default();
     /// // assuming the cache has been unlocked
-    /// let user = cache.current_user().await;
+    /// let user = cache.current_user();
     ///
     /// match user.avatar_url() {
     ///     Some(url) => println!("{}'s avatar can be found at {}", user.name, url),
@@ -659,7 +659,7 @@ impl User {
     /// #   #[cfg(feature = "cache")]
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "~help" {
-    ///             let url = match ctx.cache.current_user().await.invite_url(&ctx, Permissions::empty()).await {
+    ///             let url = match ctx.cache.current_user().invite_url(&ctx, Permissions::empty()).await {
     ///                 Ok(v) => v,
     ///                 Err(why) => {
     ///                     println!("Error creating invite url: {:?}", why);

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -796,7 +796,7 @@ impl User {
                     #[cfg(feature = "cache")]
                     {
                         if let Some(cache) = cache_http.cache() {
-                            if let Some(member) = cache.member(guild_id, self.id).await {
+                            if let Some(member) = cache.member(guild_id, self.id) {
                                 has_role = Some(member.roles.contains(&role));
                             }
                         }
@@ -898,7 +898,7 @@ impl User {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = guild_id.to_guild_cached(cache).await {
+                if let Some(guild) = guild_id.to_guild_cached(cache) {
                     if let Some(member) = guild.members.get(&self.id) {
                         return member.nick.clone();
                     }
@@ -979,7 +979,9 @@ impl UserId {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                for channel in cache.private_channels().await.values() {
+                for channel_entry in cache.private_channels().iter() {
+                    let channel = channel_entry.value();
+
                     if channel.recipient.id == self {
                         return Ok(channel.clone());
                     }
@@ -998,7 +1000,7 @@ impl UserId {
     #[cfg(feature = "cache")]
     #[inline]
     pub async fn to_user_cached(self, cache: impl AsRef<Cache>) -> Option<User> {
-        cache.as_ref().user(self).await
+        cache.as_ref().user(self)
     }
 
     /// First attempts to find a [`User`] by its Id in the cache,
@@ -1022,7 +1024,7 @@ impl UserId {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(user) = cache.user(self).await {
+                if let Some(user) = cache.user(self) {
                     return Ok(user);
                 }
             }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -417,13 +417,13 @@ pub fn serialize_gen_map<K: Eq + Hash, S: Serializer, V: Serialize>(
 /// the permissions are not in the cache.
 #[cfg(all(feature = "cache", feature = "model"))]
 #[inline]
-pub async fn user_has_perms_cache(
+pub fn user_has_perms_cache(
     cache: impl AsRef<Cache>,
     channel_id: ChannelId,
     guild_id: Option<GuildId>,
     permissions: Permissions,
 ) -> Result<()> {
-    if match user_has_perms(cache, channel_id, guild_id, permissions).await {
+    if match user_has_perms(cache, channel_id, guild_id, permissions) {
         Err(Error::Model(err)) => err.is_cache_err(),
         result => result?,
     } {
@@ -434,7 +434,7 @@ pub async fn user_has_perms_cache(
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
-pub async fn user_has_perms(
+pub fn user_has_perms(
     cache: impl AsRef<Cache>,
     channel_id: ChannelId,
     guild_id: Option<GuildId>,
@@ -442,7 +442,7 @@ pub async fn user_has_perms(
 ) -> Result<bool> {
     let cache = cache.as_ref();
 
-    let channel = match cache.channel(channel_id).await {
+    let channel = match cache.channel(channel_id) {
         Some(channel) => channel,
         None => return Err(Error::Model(ModelError::ChannelNotFound)),
     };
@@ -465,12 +465,12 @@ pub async fn user_has_perms(
         },
     };
 
-    let guild = match cache.guild(guild_id).await {
+    let guild = match cache.guild(guild_id) {
         Some(guild) => guild,
         None => return Err(Error::Model(ModelError::GuildNotFound)),
     };
 
-    let member = match guild.members.get(&cache.current_user().await.id) {
+    let member = match guild.members.get(&cache.current_user().id) {
         Some(member) => member,
         None => return Err(Error::Model(ModelError::MemberNotFound)),
     };

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -66,7 +66,7 @@ impl Parse for Member {
     type Err = MemberParseError;
 
     async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
-        let guild = msg.guild(&ctx.cache).await.ok_or(MemberParseError::GuildNotInCache)?;
+        let guild = msg.guild(&ctx.cache).ok_or(MemberParseError::GuildNotInCache)?;
 
         let lookup_by_id = || guild.members.get(&UserId(s.parse().ok()?));
 
@@ -175,7 +175,7 @@ impl Parse for Message {
             .ok_or(MessageParseError::Malformed)?;
 
         #[cfg(feature = "cache")]
-        if let Some(msg) = ctx.cache.message(channel_id, message_id).await {
+        if let Some(msg) = ctx.cache.message(channel_id, message_id) {
             return Ok(msg);
         }
 


### PR DESCRIPTION
This PR aims to make the cache not require an asynchronous context to be used, along with removing locks for a way lower probability of a deadlock or poisoned locks, this was done by replacing `tokio::RwLock<HashMap>` with `DashMap` and `parking_lot::RwLock<...>` for other types that are neither Map nor Set.

Using parking_lot does not pull an extra dependency, as it's already a dependency of tokio. DashMap is the only new dependency, which itself doesn't depend on much.

This is a step forward to a library that depends less on tokio, so most of it features can compile to wasm, so they can be used with [wasm_plugin](https://github.com/alec-deason/wasm_plugin/) to allow for dynamic runtime functions and commands in the future.

~~Depends on https://github.com/xacrimon/dashmap/pull/152 to be merged, so `Clone` can be implemented on `Cache::MessageIterator`~~