### PR TITLE
Add `USE_EXTERNAL_STICKERS` permission and audit log support for stickers.

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -841,6 +841,7 @@ impl Http {
         guild_id: u64,
         map: JsonMap,
         file: T,
+        audit_log_reason: Option<&str>,
     ) -> Result<Sticker>
     where
         T: Into<AttachmentType<'a>>,
@@ -864,7 +865,7 @@ impl Http {
                     .collect(),
                 payload_json: None,
             }),
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateSticker {
                 guild_id,
             },
@@ -1215,11 +1216,16 @@ impl Http {
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
-    pub async fn delete_sticker(&self, guild_id: u64, sticker_id: u64) -> Result<()> {
+    pub async fn delete_sticker(
+        &self,
+        guild_id: u64,
+        sticker_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteSticker {
                 guild_id,
                 sticker_id,
@@ -1848,13 +1854,14 @@ impl Http {
         guild_id: u64,
         sticker_id: u64,
         map: &JsonMap,
+        audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {
         let body = to_vec(&map)?;
         let mut value = self
             .request(Request {
                 body: Some(&body),
                 multipart: None,
-                headers: None,
+                headers: audit_log_reason.map(reason_into_header),
                 route: RouteInfo::EditSticker {
                     guild_id,
                     sticker_id,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -335,7 +335,7 @@ impl GuildId {
             None => return Err(Error::Model(ModelError::NoStickerFileSet)),
         };
 
-        let sticker = http.as_ref().create_sticker(self.0, map, file).await?;
+        let sticker = http.as_ref().create_sticker(self.0, map, file, None).await?;
 
         Ok(sticker)
     }
@@ -431,7 +431,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         sticker_id: impl Into<StickerId>,
     ) -> Result<()> {
-        http.as_ref().delete_sticker(self.0, sticker_id.into().0).await
+        http.as_ref().delete_sticker(self.0, sticker_id.into().0, None).await
     }
 
     /// Edits the current guild with new data where specified.
@@ -612,7 +612,7 @@ impl GuildId {
         f(&mut edit_sticker);
         let map = utils::hashmap_to_json_map(edit_sticker.0);
 
-        http.as_ref().edit_sticker(self.0, sticker_id.into().0, &map).await
+        http.as_ref().edit_sticker(self.0, sticker_id.into().0, &map, None).await
     }
 
     /// Edits the order of [`Role`]s

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -325,6 +325,8 @@ __impl_bitflags! {
         USE_PUBLIC_THREADS = 0b0010_0000_0000_0000_0000_0000_0000_0000_0000;
         // Allows for creating and participating in private threads.
         USE_PRIVATE_THREADS = 0b0100_0000_0000_0000_0000_0000_0000_0000_0000;
+        // Allows the usage of custom stickers from other servers.
+        USE_EXTERNAL_STICKERS = 0b1000_0000_0000_0000_0000_0000_0000_0000_0000;
     }
 }
 
@@ -359,6 +361,7 @@ generate_get_permission_names! {
     speak: "Speak",
     stream: "Stream",
     use_external_emojis: "Use External Emojis",
+    use_external_stickers: "Use External Stickers",
     use_slash_commands: "Use Slash Commands",
     use_vad: "Use Voice Activity",
     view_audit_log: "View Audit Log"
@@ -612,6 +615,14 @@ impl Permissions {
     /// [Use External Emojis]: Self::USE_EXTERNAL_EMOJIS
     pub fn use_external_emojis(self) -> bool {
         self.contains(Self::USE_EXTERNAL_EMOJIS)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
+    /// [Use External Stickers] permission.
+    ///
+    /// [Use External Stickers]: Self::USE_EXTERNAL_STICKERS
+    pub fn use_external_stickers(self) -> bool {
+        self.contains(Self::USE_EXTERNAL_STICKERS)
     }
 
     /// Shorthand for checking that the set of permissions contains the


### PR DESCRIPTION
Adds the `USE_EXTERNAL_STICKERS` permission and audit log reason for corresponding Http client methods.

This should be the last changes required in merged documentation: https://github.com/discord/discord-api-docs/pull/3128