### PR TITLE
Fix broken GuildChannel `await_reply` functionality

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1100,44 +1100,44 @@ impl GuildChannel {
         }
     }
 
-    /// Returns a future that will await one message by this guild.
+    /// Returns a future that will await one message by this guild channel.
     #[cfg(feature = "collector")]
     #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
     ) -> CollectReply<'a> {
-        CollectReply::new(shard_messenger).guild_id(self.id.0)
+        CollectReply::new(shard_messenger).channel_id(self.id.0)
     }
 
-    /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this guild.
+    /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this guild channel.
     #[cfg(feature = "collector")]
     #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
     ) -> MessageCollectorBuilder<'a> {
-        MessageCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
+        MessageCollectorBuilder::new(shard_messenger).channel_id(self.id.0)
     }
 
-    /// Await a single reaction by this guild.
+    /// Await a single reaction by this guild channel.
     #[cfg(feature = "collector")]
     #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
     ) -> CollectReaction<'a> {
-        CollectReaction::new(shard_messenger).guild_id(self.id.0)
+        CollectReaction::new(shard_messenger).channel_id(self.id.0)
     }
 
-    /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this guild.
+    /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this guild channel.
     #[cfg(feature = "collector")]
     #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
     ) -> ReactionCollectorBuilder<'a> {
-        ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
+        ReactionCollectorBuilder::new(shard_messenger).channel_id(self.id.0)
     }
 
     /// Creates a webhook with only a name.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -83,10 +83,10 @@ impl Channel {
     /// #   let channel = ChannelId(0).to_channel_cached(&cache).await.unwrap();
     /// #
     /// match channel.guild() {
-    ///     Some(guild) => {
-    ///         println!("It's a guild named {}!", guild.name);
+    ///     Some(guild_channel) => {
+    ///         println!("It's a guild channel named {}!", guild_channel.name);
     ///     },
-    ///     None => { println!("It's not a guild!"); },
+    ///     None => { println!("It's not in a guild!"); },
     /// }
     /// # }
     /// ```


### PR DESCRIPTION
Currently `GuildChannel#await_reply` seems to await a reply from a *guild* that matches the `GuildChannel` id, which does not make sense... 

This PR also fixes an example for `Channel.guild()` where `GuildChannel#name` should be the `GuildChannel` name, not the guild name as the example suggests. 