### PR TITLE
Include Discord's error explanations in Display impl

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -181,7 +181,7 @@ impl Display for Error {
                     f.write_str(&error.message)?;
                     for error in errors_iter {
                         f.write_str(", ")?;
-                        f.write_str(&error.message);
+                        f.write_str(&error.message)?;
                     }
                     f.write_str(")")?;
                 }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -171,7 +171,23 @@ impl From<InvalidHeaderValue> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Error::UnsuccessfulRequest(e) => f.write_str(&e.error.message),
+            Error::UnsuccessfulRequest(e) => {
+                f.write_str(&e.error.message)?;
+
+                // Put Discord's human readable error explanations in parantheses
+                let mut errors_iter = e.error.errors.iter();
+                if let Some(error) = errors_iter.next() {
+                    f.write_str(" (")?;
+                    f.write_str(&error.message)?;
+                    for error in errors_iter {
+                        f.write_str(", ")?;
+                        f.write_str(&error.message);
+                    }
+                    f.write_str(")")?;
+                }
+
+                Ok(())
+            },
             Error::RateLimitI64F64 => f.write_str("Error decoding a header into an i64 or f64"),
             Error::RateLimitUtf8 => f.write_str("Error decoding a header from UTF-8"),
             Error::Url(_) => f.write_str("Provided URL is incorrect."),


### PR DESCRIPTION
This PR modified the std::fmt::Display implementation for serenity::http::Error to include the [recently added](https://github.com/serenity-rs/serenity/pull/1310) [detailed explanation messages](https://discord.com/developers/docs/reference#error-messages) for unsuccessful requests.

If a list of error explanations is present in the ErrorResponse, they are put in parentheses behind the normal error message, separated by commas. Example:
```diff
-Invalid Form Body
+Invalid Form Body (parse:["users"] and users: [ids...] are mutually exclusive.)
```

I am not sure if this is the best way to format the error. List of ideas I had:
- `Invalid Form Body (parse:["users"] and users: [ids...] are mutually exclusive.)`
- `Invalid Form Body ("parse:["users"] and users: [ids...] are mutually exclusive.")`
- `Invalid Form Body` with `parse:["users"] and users: [ids...] are mutually exclusive.` returned as a source error