### PR TITLE
Return EmojiIdentifierParseError as Err instead of ()

### DIFF
--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -288,12 +288,30 @@ impl EmojiIdentifier {
     }
 }
 
+#[derive(Debug)]
+#[cfg(all(feature = "model", feature = "utils"))]
+pub struct EmojiIdentifierParseError {
+    parsed_string: String,
+}
+
+#[cfg(all(feature = "model", feature = "utils"))]
+impl Display for EmojiIdentifierParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "`{}` is not a valid emoji identifier", self.parsed_string)
+    }
+}
+
+#[cfg(all(feature = "model", feature = "utils"))]
+impl StdError for EmojiIdentifierParseError {}
+
 #[cfg(all(feature = "model", feature = "utils"))]
 impl FromStr for EmojiIdentifier {
-    type Err = ();
+    type Err = EmojiIdentifierParseError;
 
-    fn from_str(s: &str) -> StdResult<Self, ()> {
-        utils::parse_emoji(s).ok_or(())
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        utils::parse_emoji(s).ok_or_else(|| EmojiIdentifierParseError {
+            parsed_string: s.to_owned(),
+        })
     }
 }
 


### PR DESCRIPTION
The [FromStr implementation](https://docs.rs/serenity/0.10.8/serenity/model/misc/struct.EmojiIdentifier.html#associatedtype.Err) for EmojiIdentifier used to return the unit type (`()`) as an error type. This makes it hard to handle in generic contexts, where it might be assumed that every error also implements std::error::Error.

This happened for example in a framework I'm writing, which uses `struct ArgumentParseError(Box<dyn Error>)` to store errors from parsing arguments via their FromStr implementation. Using EmojiIdentifier as a command parameter was not possible with this system.

This PR introduces a new type `EmojiIdentifierParseError`, which implements the Error trait. This is a breaking change, because a user-visible type has been changed.