### PR TITLE
Make GuildChannel::send_message work in threads

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -957,7 +957,9 @@ impl GuildChannel {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::SEND_MESSAGES;
 
-                if !utils::user_has_perms(&cache, self.id, Some(self.guild_id), req).await? {
+                if utils::user_has_perms(&cache, self.id, Some(self.guild_id), req).await
+                    == Ok(false)
+                {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }
             }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -957,8 +957,8 @@ impl GuildChannel {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::SEND_MESSAGES;
 
-                if utils::user_has_perms(&cache, self.id, Some(self.guild_id), req).await
-                    == Ok(false)
+                if let Ok(false) =
+                    utils::user_has_perms(&cache, self.id, Some(self.guild_id), req).await
                 {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }


### PR DESCRIPTION
When the cache feature is enabled, `GuildChannel::send_message` invokes `utils::user_has_perms` which tries to look up the thread in the channels cache. Threads are often not in cache, so it fails and throws a `model::Error::ChannelNotFound`. `send_message` lazily propagates any error, so the cache miss brings down the whole send_message invocation.

This PR fixes `send_message` to not abort the invocation if the sanity check throws an error.