### PR TITLE
Make Message::channel fall back to HTTP

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -188,13 +188,14 @@ impl Message {
         self.channel_id.crosspost(cache_http.http(), self.id.0).await
     }
 
-    /// Retrieves the related channel located in the cache.
+    /// First attempts to find a [`Channel`] by its Id in the cache,
+    /// upon failure requests it via the REST API.
     ///
-    /// Returns [`None`] if the channel is not in the cache.
-    #[cfg(feature = "cache")]
+    /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon
+    /// owning the required permissions the HTTP-request will be issued.
     #[inline]
-    pub async fn channel(&self, cache: impl AsRef<Cache>) -> Option<Channel> {
-        cache.as_ref().channel(self.channel_id).await
+    pub async fn channel(&self, cache_http: impl CacheHttp) -> Result<Channel> {
+        self.channel_id.to_channel(cache_http).await
     }
 
     /// A util function for determining whether this message was sent by someone else, or the

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -193,6 +193,10 @@ impl Message {
     ///
     /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon
     /// owning the required permissions the HTTP-request will be issued.
+    ///
+    /// # Errors
+    ///
+    /// Can return an error if the HTTP request fails.
     #[inline]
     pub async fn channel(&self, cache_http: impl CacheHttp) -> Result<Channel> {
         self.channel_id.to_channel(cache_http).await


### PR DESCRIPTION
Resolves #1452.

Changes the signature of `Message::channel` from
```rust
pub async fn channel(&self, cache: impl AsRef<Cache>) -> Option<Channel>;
```
to
```rust
pub async fn channel(&self, cache_http: impl CacheHttp) -> Result<Channel>;
```

And replaces its body with a call to `ChannelId::to_channel`, since that function already does everything we need: checking cache if cache feature is enabled and falling back to HTTP.

SInce the behavior of `Message::channel`, it may be worth considering a `Message::channel_cached` function which keeps the behavior of the current `Message::channel`. I didn't include it for now because I think most use cases don't need the old behavior specifically.