### PR TITLE
Fix deserialisation of `PresenceUser`'s `discriminator` field

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -589,6 +589,7 @@ pub struct PresenceUser {
     pub id: UserId,
     pub avatar: Option<String>,
     pub bot: Option<bool>,
+    #[serde(deserialize_with = "deserialize_opt_u16")]
     pub discriminator: Option<u16>,
     pub email: Option<String>,
     pub mfa_enabled: Option<bool>,

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -377,7 +377,9 @@ pub fn deserialize_u16<'de, D: Deserializer<'de>>(deserializer: D) -> StdResult<
     deserializer.deserialize_any(U16Visitor)
 }
 
-pub fn deserialize_opt_u16<'de, D: Deserializer<'de>>(deserializer: D) -> StdResult<Option<u16>, D::Error> {
+pub fn deserialize_opt_u16<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> StdResult<Option<u16>, D::Error> {
     deserializer.deserialize_option(OptU16Visitor)
 }
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -377,6 +377,10 @@ pub fn deserialize_u16<'de, D: Deserializer<'de>>(deserializer: D) -> StdResult<
     deserializer.deserialize_any(U16Visitor)
 }
 
+pub fn deserialize_opt_u16<'de, D: Deserializer<'de>>(deserializer: D) -> StdResult<Option<u16>, D::Error> {
+    deserializer.deserialize_option(OptU16Visitor)
+}
+
 pub fn deserialize_u64<'de, D: Deserializer<'de>>(deserializer: D) -> StdResult<u64, D::Error> {
     deserializer.deserialize_any(U64Visitor)
 }
@@ -492,7 +496,7 @@ macro_rules! num_visitors {
                 type Value = $type;
 
                 fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
-                    formatter.write_str("identifier")
+                    formatter.write_str("number")
                 }
 
                 fn visit_str<E: DeError>(self, v: &str) -> StdResult<Self::Value, E> {
@@ -544,3 +548,37 @@ macro_rules! num_visitors {
 }
 
 num_visitors!(U16Visitor: u16, U32Visitor: u32, U64Visitor: u64);
+
+macro_rules! num_opt_visitors {
+    ($($visitor:ident: $type:ty, $visitor_impl:ident),*) => {
+        $(
+            #[derive(Debug)]
+            pub struct $visitor;
+
+            impl<'de> Visitor<'de> for $visitor {
+                type Value = Option<$type>;
+
+                fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+                    formatter.write_str("optional number")
+                }
+
+                fn visit_unit<E: DeError>(self) -> StdResult<Self::Value, E> {
+                    Ok(None)
+                }
+
+                fn visit_none<E: DeError>(self) -> StdResult<Self::Value, E> {
+                    Ok(None)
+                }
+
+                fn visit_some<D>(self, deserializer: D) -> StdResult<Self::Value, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    deserializer.deserialize_any($visitor_impl).map(Some)
+                }
+            }
+        )*
+    }
+}
+
+num_opt_visitors!(OptU16Visitor: u16, U16Visitor);


### PR DESCRIPTION
## Description

This fixes deserialisation of the `PresenceUser::discriminator` field. 

The field's value is `Option<u16>`; however, Discord sends a string and the field is not configured to deserialise strings into `u16`s, or even handle the `null` or empty case. This PR fixes that by introducing a new `OptU16Visitor` and using that to define a deserialisation function for the field. 

## Type of Change

This is a fix for one of the model types.

## How Has This Been Tested?

This has been tested by running a test bot with the `GUILD_PRESENCES` intent. With this change, deserialisation works as expected.