### PR TITLE
Support context menus

### DIFF
--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -2,7 +2,12 @@ use std::collections::HashMap;
 
 use serde_json::{json, Value};
 
-use crate::{model::interactions::application_command::ApplicationCommandOptionType, utils};
+use crate::internal::prelude::*;
+use crate::model::interactions::application_command::{
+    ApplicationCommandOptionType,
+    ApplicationCommandType,
+};
+use crate::utils;
 
 /// A builder for creating a new [`ApplicationCommandOption`].
 ///
@@ -140,6 +145,12 @@ impl CreateApplicationCommand {
     /// **Note**: Must be between 1 and 32 lowercase characters, matching `r"^[\w-]{1,32}$"`. Two global commands of the same app cannot have the same name. Two guild-specific commands of the same app cannot have the same name.
     pub fn name<D: ToString>(&mut self, name: D) -> &mut Self {
         self.0.insert("name", Value::String(name.to_string()));
+        self
+    }
+
+    /// Specifies the type of the application command.
+    pub fn kind(&mut self, kind: ApplicationCommandType) -> &mut Self {
+        self.0.insert("type", Value::Number(Number::from(kind as u8)));
         self
     }
 

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -154,6 +154,11 @@ pub struct CommandId(pub u64);
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct CommandPermissionId(pub u64);
 
+/// An identifier for a slash command target Id. Can contain
+/// a [`UserId`] or [`MessageId`].
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct TargetId(pub u64);
+
 /// An identifier for a stage channel instance.
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct StageInstanceId(pub u64);
@@ -175,5 +180,6 @@ id_u64! {
     InteractionId;
     CommandId;
     CommandPermissionId;
+    TargetId;
     StageInstanceId;
 }

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -454,12 +454,10 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteractionData {
 
         let target = match target_id {
             Some(id) => {
-                let message_id = id.to_message_id();
-
-                if resolved.messages.contains_key(&message_id) {
+                if kind == ApplicationCommandType::Message {
                     let resolved = resolved
                         .messages
-                        .get(&message_id)
+                        .get(&id.to_message_id())
                         .expect("expected message object")
                         .to_owned();
 

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -28,6 +28,7 @@ use crate::model::interactions::InteractionType;
 use crate::model::prelude::User;
 use crate::model::utils::{
     deserialize_channels_map,
+    deserialize_messages_map,
     deserialize_options,
     deserialize_options_with_resolved,
     deserialize_partial_members_map,
@@ -382,6 +383,20 @@ pub struct ApplicationCommandInteractionData {
     /// The converted objects from the given options.
     #[serde(default)]
     pub resolved: ApplicationCommandInteractionDataResolved,
+    /// The targeted user or message, if the triggered application command type
+    /// is [`User`] or [`Message`].
+    ///
+    /// Its object data can be found in the [`resolved`] field.
+    ///
+    /// [`resolved`]: Self::resolved
+    /// [`User`]: ApplicationCommandType::User
+    /// [`Message`]: ApplicationCommandType::Message
+    pub target_id: Option<TargetId>,
+    /// The target resolved data of [`target_id`]
+    ///
+    /// [`target_id`]: Self::target_id
+    #[serde(skip_serializing)]
+    pub target: Option<ResolvedTarget>,
 }
 
 impl<'de> Deserialize<'de> for ApplicationCommandInteractionData {
@@ -418,13 +433,58 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteractionData {
             false => vec![],
         };
 
+        let target_id = match map.contains_key("target_id") {
+            true => Some(
+                map.remove("target_id")
+                    .ok_or_else(|| DeError::custom("expected resolved"))
+                    .and_then(TargetId::deserialize)
+                    .map_err(DeError::custom)?,
+            ),
+            false => None,
+        };
+
+        let target = match target_id {
+            Some(id) => {
+                let message_id = id.to_message_id();
+
+                if resolved.messages.contains_key(&message_id) {
+                    let resolved = resolved
+                        .messages
+                        .get(&message_id)
+                        .expect("expected message object")
+                        .to_owned();
+
+                    Some(ResolvedTarget::Message(resolved))
+                } else {
+                    let user_id = id.to_user_id();
+
+                    let user = resolved.users.get(&user_id).expect("expected user").to_owned();
+                    let member = resolved.members.get(&user_id).map(|m| m.to_owned());
+
+                    Some(ResolvedTarget::User(user, member))
+                }
+            },
+            None => None,
+        };
+
         Ok(Self {
             name,
             id,
             options,
             resolved,
+            target_id,
+            target,
         })
     }
+}
+
+/// The resolved value of a [`ApplicationCommandInteractionData::target_id`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum ResolvedTarget {
+    User(User, Option<PartialMember>),
+    Message(Message),
 }
 
 /// The resolved data of a command data interaction payload.
@@ -440,6 +500,8 @@ pub struct ApplicationCommandInteractionDataResolved {
     pub roles: HashMap<RoleId, Role>,
     /// The resolved partial channels.
     pub channels: HashMap<ChannelId, PartialChannel>,
+    /// The resolved messages.
+    pub messages: HashMap<MessageId, Message>,
 }
 
 impl<'de> Deserialize<'de> for ApplicationCommandInteractionDataResolved {
@@ -476,8 +538,17 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteractionDataResolved {
         let channels = match map.contains_key("channels") {
             true => map
                 .remove("channels")
-                .ok_or_else(|| DeError::custom("expected chanels"))
+                .ok_or_else(|| DeError::custom("expected channels"))
                 .and_then(deserialize_channels_map)
+                .map_err(DeError::custom)?,
+            false => HashMap::new(),
+        };
+
+        let messages = match map.contains_key("messages") {
+            true => map
+                .remove("channels")
+                .ok_or_else(|| DeError::custom("expected messages"))
+                .and_then(deserialize_messages_map)
                 .map_err(DeError::custom)?,
             false => HashMap::new(),
         };
@@ -487,6 +558,7 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteractionDataResolved {
             members,
             roles,
             channels,
+            messages,
         })
     }
 }
@@ -587,6 +659,9 @@ fn default_permission_value() -> bool {
 pub struct ApplicationCommand {
     /// The command Id.
     pub id: CommandId,
+    /// The application command kind.
+    #[serde(rename = "type")]
+    pub kind: ApplicationCommandType,
     /// The parent application Id.
     pub application_id: ApplicationId,
     /// The command guild Id, if it is a guild command.
@@ -754,6 +829,23 @@ impl ApplicationCommand {
     }
 }
 
+/// The type of an application command.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum ApplicationCommandType {
+    ChatInput = 1,
+    User = 2,
+    Message = 3,
+    Unknown = !0,
+}
+
+enum_number!(ApplicationCommandType {
+    ChatInput,
+    User,
+    Message
+});
+
 /// The parameters for an [`ApplicationCommand`].
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -819,12 +911,12 @@ pub struct ApplicationCommandPermissionData {
 impl CommandPermissionId {
     /// Converts this [`CommandPermissionId`] to [`UserId`].
     pub fn to_user_id(self) -> UserId {
-        UserId(self.0)
+        self.0.into()
     }
 
     /// Converts this [`CommandPermissionId`] to [`RoleId`].
     pub fn to_role_id(self) -> RoleId {
-        RoleId(self.0)
+        self.0.into()
     }
 }
 
@@ -860,6 +952,54 @@ impl From<CommandPermissionId> for RoleId {
 
 impl From<CommandPermissionId> for UserId {
     fn from(id: CommandPermissionId) -> Self {
+        Self(id.0)
+    }
+}
+
+impl TargetId {
+    /// Converts this [`CommandPermissionId`] to [`UserId`].
+    pub fn to_user_id(self) -> UserId {
+        self.0.into()
+    }
+
+    /// Converts this [`CommandPermissionId`] to [`MessageId`].
+    pub fn to_message_id(self) -> MessageId {
+        self.0.into()
+    }
+}
+
+impl From<MessageId> for TargetId {
+    fn from(id: MessageId) -> Self {
+        Self(id.0)
+    }
+}
+
+impl<'a> From<&'a MessageId> for TargetId {
+    fn from(id: &MessageId) -> Self {
+        Self(id.0)
+    }
+}
+
+impl From<UserId> for TargetId {
+    fn from(id: UserId) -> Self {
+        Self(id.0)
+    }
+}
+
+impl<'a> From<&'a UserId> for TargetId {
+    fn from(id: &UserId) -> Self {
+        Self(id.0)
+    }
+}
+
+impl From<TargetId> for MessageId {
+    fn from(id: TargetId) -> Self {
+        Self(id.0)
+    }
+}
+
+impl From<TargetId> for UserId {
+    fn from(id: TargetId) -> Self {
         Self(id.0)
     }
 }

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -554,7 +554,7 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteractionDataResolved {
 
         let messages = match map.contains_key("messages") {
             true => map
-                .remove("channels")
+                .remove("messages")
                 .ok_or_else(|| DeError::custom("expected messages"))
                 .and_then(deserialize_messages_map)
                 .map_err(DeError::custom)?,

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -109,6 +109,15 @@ pub fn deserialize_channels_map<'de, D: Deserializer<'de>>(
 }
 
 #[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+pub fn deserialize_messages_map<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> StdResult<HashMap<MessageId, Message>, D::Error> {
+    let map: HashMap<MessageId, Message> = Deserialize::deserialize(deserializer)?;
+
+    Ok(map)
+}
+
+#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
 pub fn deserialize_options<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<Vec<ApplicationCommandInteractionDataOption>, D::Error> {


### PR DESCRIPTION
This PR adds support to user and message context menus, which can be created with a new type of application command. See discord/discord-api-docs#3614

This has been tested.