### PR TITLE
Add model methods for creating public and private threads

### DIFF
--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -27,9 +27,10 @@ impl CreateThread {
 
     /// The thread type, which can be [`ChannelType::PublicThread`] or [`ChannelType::PrivateThread`].
     ///
-    /// **Note**: It defaults to [`ChannelType::PrivateThread`] in order to match the behavior when thread documentation was first published.
-    /// This is a bit of a weird default though, and thus is highly likely to change in the future,
-    /// so it is recommended to always explicitly setting it to avoid any breaking change.
+    /// **Note**: This defaults to [`ChannelType::PrivateThread`] in order to match the behavior
+    /// when thread documentation was first published. This is a bit of a weird default though,
+    /// and thus is highly likely to change in the future, so it is recommended to always
+    /// explicitly setting it to avoid any breaking change.
     ///
     /// [`ChannelType::PublicThread`]: crate::model::channel::ChannelType::PublicThread
     /// [`ChannelType::PrivateThread`]: crate::model::channel::ChannelType::PrivateThread

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1080,6 +1080,7 @@ impl ChannelId {
         F: FnOnce(&mut CreateThread) -> &mut CreateThread,
     {
         let mut instance = CreateThread::default();
+        instance.kind(ChannelType::PrivateThread);
         f(&mut instance);
 
         let map = utils::hashmap_to_json_map(instance.0);

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -10,7 +10,14 @@ use futures::stream::StreamExt;
 #[cfg(feature = "model")]
 use crate::builder::EditChannel;
 #[cfg(feature = "model")]
-use crate::builder::{CreateInvite, CreateMessage, EditMessage, EditVoiceState, GetMessages};
+use crate::builder::{
+    CreateInvite,
+    CreateMessage,
+    CreateThread,
+    EditMessage,
+    EditVoiceState,
+    GetMessages,
+};
 use crate::builder::{CreateStageInstance, EditStageInstance};
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
@@ -1263,6 +1270,39 @@ impl GuildChannel {
         }
 
         self.id.delete_stage_instance(http).await
+    }
+
+    /// Creates a public thread that is connected to a message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn create_public_thread<F>(
+        &self,
+        http: impl AsRef<Http>,
+        message_id: impl Into<MessageId>,
+        f: F,
+    ) -> Result<GuildChannel>
+    where
+        F: FnOnce(&mut CreateThread) -> &mut CreateThread,
+    {
+        self.id.create_public_thread(http, message_id, f).await
+    }
+
+    /// Creates a private thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn create_private_thread<F>(
+        &self,
+        http: impl AsRef<Http>,
+        f: F,
+    ) -> Result<GuildChannel>
+    where
+        F: FnOnce(&mut CreateThread) -> &mut CreateThread,
+    {
+        self.id.create_private_thread(http, f).await
     }
 }
 


### PR DESCRIPTION
## Description

This adds two new methods, `create_public_thread` and `create_private_thread`, on `ChannelId` and `GuildChannel`. Without these, the only possible way for one to create a thread is to make a request with the HTTP client, which has a low-level API.

This also adjusts the formatting of `CreateThread::kind`'s note.

## Type of Change

This is in an improvement to the API of the library, specifically in the models.

## How Has This Been Tested?

The methods have been tested by calling them in command code and then sending a message to the newly-created channel. Both work as expected.