### PR TITLE
Add user `banner` and `accent_color` fields

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1041,7 +1041,7 @@ mod test {
                     name: "user 1".to_owned(),
                     public_flags: None,
                     banner: None,
-                    accent_color: None,
+                    accent_colour: None,
                 },
                 channel_id: ChannelId(2),
                 guild_id: Some(GuildId(1)),

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1040,6 +1040,8 @@ mod test {
                     discriminator: 1,
                     name: "user 1".to_owned(),
                     public_flags: None,
+                    banner: None,
+                    accent_color: None,
                 },
                 channel_id: ChannelId(2),
                 guild_id: Some(GuildId(1)),

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -539,6 +539,8 @@ mod test {
                     discriminator: 1,
                     name: "ab".to_string(),
                     public_flags: None,
+                    banner: None,
+                    accent_color: None,
                 },
             }
         }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -540,7 +540,7 @@ mod test {
                     name: "ab".to_string(),
                     public_flags: None,
                     banner: None,
-                    accent_color: None,
+                    accent_colour: None,
                 },
             }
         }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -444,6 +444,8 @@ mod test {
                 discriminator: 4132,
                 name: "fake".to_string(),
                 public_flags: None,
+                banner: None,
+                accent_color: None,
             };
             let member = Member {
                 deaf: false,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -445,7 +445,7 @@ mod test {
                 name: "fake".to_string(),
                 public_flags: None,
                 banner: None,
-                accent_color: None,
+                accent_colour: None,
             };
             let member = Member {
                 deaf: false,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -506,10 +506,18 @@ pub struct User {
     /// change if the username+discriminator pair becomes non-unique.
     #[serde(rename = "username")]
     pub name: String,
-    /// the public flags on a user's account
+    /// The public flags on a user's account
     pub public_flags: Option<UserPublicFlags>,
     /// Optional banner hash.
+    ///
+    /// **Note**: This will only be present if the user is fetched via Rest API,
+    /// e.g. with [`Http::get_user`].
     pub banner: Option<String>,
+    /// The user's banner color encoded as an integer representation of
+    /// hexadecimal color code
+    ///
+    /// **Note**: This will only be present if the user is fetched via Rest API,
+    /// e.g. with [`Http::get_user`].
     #[cfg(feature = "utils")]
     pub accent_color: Option<Colour>,
     #[cfg(not(feature = "utils"))]
@@ -627,6 +635,9 @@ impl User {
     /// Returns the formatted URL of the user's banner, if one exists.
     ///
     /// This will produce a WEBP image URL, or GIF if the user has a GIF banner.
+    ///
+    /// **Note**: This will only be present if the user is fetched via Rest API,
+    /// e.g. with [`Http::get_user`].
     #[inline]
     pub fn banner_url(&self) -> Option<String> {
         banner_url(self.id, self.banner.as_ref())

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -50,6 +50,8 @@ pub struct CurrentUser {
     pub name: String,
     pub verified: Option<bool>,
     pub public_flags: Option<UserPublicFlags>,
+    pub banner: Option<String>,
+    pub accent_color: Option<Colour>,
 }
 
 #[cfg(feature = "model")]
@@ -503,6 +505,9 @@ pub struct User {
     pub name: String,
     /// the public flags on a user's account
     pub public_flags: Option<UserPublicFlags>,
+    /// Optional banner hash.
+    pub banner: Option<String>,
+    pub accent_color: Option<Colour>,
 }
 
 /// User's public flags
@@ -578,6 +583,8 @@ impl Default for User {
             discriminator: 1432,
             name: "test".to_string(),
             public_flags: None,
+            banner: None,
+            accent_color: None,
         }
     }
 }
@@ -609,6 +616,14 @@ impl User {
     #[inline]
     pub fn avatar_url(&self) -> Option<String> {
         avatar_url(self.id, self.avatar.as_ref())
+    }
+
+    /// Returns the formatted URL of the user's banner, if one exists.
+    ///
+    /// This will produce a WEBP image URL, or GIF if the user has a GIF banner.
+    #[inline]
+    pub fn banner_url(&self) -> Option<String> {
+        banner_url(self.id, self.banner.as_ref())
     }
 
     /// Creates a direct message channel between the [current user] and the
@@ -1044,6 +1059,8 @@ impl From<CurrentUser> for User {
             id: user.id,
             name: user.name,
             public_flags: user.public_flags,
+            banner: user.banner,
+            accent_color: user.accent_color,
         }
     }
 }
@@ -1057,6 +1074,8 @@ impl<'a> From<&'a CurrentUser> for User {
             id: user.id,
             name: user.name.clone(),
             public_flags: user.public_flags,
+            banner: user.banner.clone(),
+            accent_color: user.accent_color,
         }
     }
 }
@@ -1120,6 +1139,15 @@ fn default_avatar_url(discriminator: u16) -> String {
 #[cfg(feature = "model")]
 fn static_avatar_url(user_id: UserId, hash: Option<&String>) -> Option<String> {
     hash.map(|hash| cdn!("/avatars/{}/{}.webp?size=1024", user_id, hash))
+}
+
+#[cfg(feature = "model")]
+fn banner_url(user_id: UserId, hash: Option<&String>) -> Option<String> {
+    hash.map(|hash| {
+        let ext = if hash.starts_with("a_") { "gif" } else { "webp" };
+
+        cdn!("/banners/{}/{}.{}?size=1024", user_id.0, hash, ext)
+    })
 }
 
 #[cfg(feature = "model")]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -52,9 +52,9 @@ pub struct CurrentUser {
     pub public_flags: Option<UserPublicFlags>,
     pub banner: Option<String>,
     #[cfg(feature = "utils")]
-    pub accent_color: Option<Colour>,
+    pub accent_colour: Option<Colour>,
     #[cfg(not(feature = "utils"))]
-    pub accent_color: Option<u32>,
+    pub accent_colour: Option<u32>,
 }
 
 #[cfg(feature = "model")]
@@ -513,15 +513,17 @@ pub struct User {
     /// **Note**: This will only be present if the user is fetched via Rest API,
     /// e.g. with [`Http::get_user`].
     pub banner: Option<String>,
-    /// The user's banner color encoded as an integer representation of
-    /// hexadecimal color code
+    /// The user's banner colour encoded as an integer representation of
+    /// hexadecimal colour code
     ///
     /// **Note**: This will only be present if the user is fetched via Rest API,
     /// e.g. with [`Http::get_user`].
     #[cfg(feature = "utils")]
-    pub accent_color: Option<Colour>,
+    #[serde(rename = "accent_color")]
+    pub accent_colour: Option<Colour>,
     #[cfg(not(feature = "utils"))]
-    pub accent_color: Option<u32>,
+    #[serde(rename = "accent_color")]
+    pub accent_colour: Option<u32>,
 }
 
 /// User's public flags
@@ -598,7 +600,7 @@ impl Default for User {
             name: "test".to_string(),
             public_flags: None,
             banner: None,
-            accent_color: None,
+            accent_colour: None,
         }
     }
 }
@@ -1077,7 +1079,7 @@ impl From<CurrentUser> for User {
             name: user.name,
             public_flags: user.public_flags,
             banner: user.banner,
-            accent_color: user.accent_color,
+            accent_colour: user.accent_colour,
         }
     }
 }
@@ -1092,7 +1094,7 @@ impl<'a> From<&'a CurrentUser> for User {
             name: user.name.clone(),
             public_flags: user.public_flags,
             banner: user.banner.clone(),
-            accent_color: user.accent_color,
+            accent_colour: user.accent_colour,
         }
     }
 }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -51,7 +51,10 @@ pub struct CurrentUser {
     pub verified: Option<bool>,
     pub public_flags: Option<UserPublicFlags>,
     pub banner: Option<String>,
+    #[cfg(feature = "utils")]
     pub accent_color: Option<Colour>,
+    #[cfg(not(feature = "utils"))]
+    pub accent_color: Option<u32>,
 }
 
 #[cfg(feature = "model")]
@@ -507,7 +510,10 @@ pub struct User {
     pub public_flags: Option<UserPublicFlags>,
     /// Optional banner hash.
     pub banner: Option<String>,
+    #[cfg(feature = "utils")]
     pub accent_color: Option<Colour>,
+    #[cfg(not(feature = "utils"))]
+    pub accent_color: Option<u32>,
 }
 
 /// User's public flags

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -248,7 +248,7 @@ fn dummy_message() -> Message {
             name: String::new(),
             public_flags: None,
             banner: None,
-            accent_color: None,
+            accent_colour: None,
         },
         channel_id: ChannelId::default(),
         content: String::new(),

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -247,6 +247,8 @@ fn dummy_message() -> Message {
             discriminator: 0x0000,
             name: String::new(),
             public_flags: None,
+            banner: None,
+            accent_color: None,
         },
         channel_id: ChannelId::default(),
         content: String::new(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -856,6 +856,8 @@ mod test {
             discriminator: 0000,
             name: "Crab".to_string(),
             public_flags: None,
+            banner: None,
+            accent_color: None,
         };
 
         #[allow(deprecated)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -857,7 +857,7 @@ mod test {
             name: "Crab".to_string(),
             public_flags: None,
             banner: None,
-            accent_color: None,
+            accent_colour: None,
         };
 
         #[allow(deprecated)]


### PR DESCRIPTION
### Description

Adds support for new user profile banner and accent_color.

Relevant documentation: https://github.com/discord/discord-api-docs/pull/3448

### Tested

Fetching a user correctly has the banner hash and accent_color deserialized as a Colour struct.