### PR TITLE
Guarantee the `MessageComponentInteraction::message` to not be partial

### DIFF
--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -156,7 +156,7 @@ impl ComponentInteractionFilter {
     ) -> bool {
         // TODO: On next branch, switch filter arg to &T so this as_arc() call can be removed.
         self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id.map(|g| g.0))
-            && self.options.message_id.map_or(true, |id| interaction.message.id().0 == id)
+            && self.options.message_id.map_or(true, |id| interaction.message.id.0 == id)
             && self.options.channel_id.map_or(true, |id| id == interaction.channel_id.as_ref().0)
             && self.options.author_id.map_or(true, |id| id == interaction.user.id.0)
             && self.options.filter.as_ref().map_or(true, |f| f(&interaction.as_arc()))

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -2223,7 +2223,7 @@ macro_rules! with_related_ids_for_event_types {
                 message_id: match &e.interaction {
                     Interaction::Ping(_) => None,
                     Interaction::ApplicationCommand(_) => None,
-                    Interaction::MessageComponent(i) => Some(i.message.id()),
+                    Interaction::MessageComponent(i) => Some(i.message.id),
                 },
             },
             #[cfg(feature = "unstable_discord_api")]


### PR DESCRIPTION
As per a recent discord update, the `MessageComponentInteraction::message` will not be partial for ephemeral messages anymore, and will include the full message object, see below screenshot.

![image](https://user-images.githubusercontent.com/23212967/129490670-01cc2c4d-44ca-4db2-a605-67abfb793e46.png)

Note that this is a breaking change.