### PR TITLE
Add `ContextMenuCommand` message type

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1104,6 +1104,7 @@ enum_number!(MessageType {
     InlineReply,
     ApplicationCommand,
     ThreadStarterMessage,
+    ContextMenuCommand,
     GuildInviteReminder
 });
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1070,11 +1070,14 @@ pub enum MessageType {
     /// A message reply.
     InlineReply = 19,
     /// A slash command.
+    // TODO: Rename to slash command in next
     ApplicationCommand = 20,
     /// A thread start message.
     ThreadStarterMessage = 21,
     /// Server setup tips.
     GuildInviteReminder = 22,
+    /// A context menu command.
+    ContextMenuCommand = 23,
     /// An indicator that the message is of unknown type.
     Unknown = !0,
 }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1070,7 +1070,7 @@ pub enum MessageType {
     /// A message reply.
     InlineReply = 19,
     /// A slash command.
-    // TODO: Rename to slash command in next
+    // TODO: Rename to chat input command in next
     ApplicationCommand = 20,
     /// A thread start message.
     ThreadStarterMessage = 21,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1104,8 +1104,8 @@ enum_number!(MessageType {
     InlineReply,
     ApplicationCommand,
     ThreadStarterMessage,
+    GuildInviteReminder,
     ContextMenuCommand,
-    GuildInviteReminder
 });
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]


### PR DESCRIPTION
This PR adds support to context menu command message type, as per discord/discord-api-docs#3651.

Note that the message type 20, which was previously named `ApplicationCommand` will be renamed to `ChatInputCommand` in the next branch, as it is a breaking change.