### PR TITLE
Rename `ApplicationCommand` message type to `ChatInputCommand`

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1092,11 +1092,13 @@ pub enum MessageType {
     /// A message reply.
     InlineReply = 19,
     /// A slash command.
-    ApplicationCommand = 20,
+    SlashCommand = 20,
     /// A thread start message.
     ThreadStarterMessage = 21,
     /// Server setup tips.
     GuildInviteReminder = 22,
+    /// A context menu command.
+    ContextMenuCommand = 23,
     /// An indicator that the message is of unknown type.
     Unknown = !0,
 }
@@ -1121,9 +1123,10 @@ enum_number!(MessageType {
     GuildDiscoveryGracePeriodFinalWarning
     ThreadCreated,
     InlineReply,
-    ApplicationCommand,
+    SlashCommand,
     ThreadStarterMessage,
-    GuildInviteReminder
+    GuildInviteReminder,
+    ContextMenuCommand,
 });
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1092,7 +1092,7 @@ pub enum MessageType {
     /// A message reply.
     InlineReply = 19,
     /// A slash command.
-    SlashCommand = 20,
+    ChatInputCommand = 20,
     /// A thread start message.
     ThreadStarterMessage = 21,
     /// Server setup tips.
@@ -1123,7 +1123,7 @@ enum_number!(MessageType {
     GuildDiscoveryGracePeriodFinalWarning
     ThreadCreated,
     InlineReply,
-    SlashCommand,
+    ChatInputCommand,
     ThreadStarterMessage,
     GuildInviteReminder,
     ContextMenuCommand,


### PR DESCRIPTION
This PR renames the `ApplicationCommand` message type to `ChatInputCommand`, as per discord/discord-api-docs#3651.

This is a breaking change.