### PR TITLE
Add get guild active threads

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2040,7 +2040,20 @@ impl Http {
         .await
     }
 
+    /// Gets all active threads from a guild.
+    pub async fn get_guild_active_threads(&self, guild_id: u64) -> Result<ThreadsData> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetGuildActiveThreads {
+                guild_id,
+            },
+        })
+        .await
+    }
+
     /// Gets all active threads from a channel.
+    #[deprecated(note = "Use get_guild_active_threads instead")]
     pub async fn get_channel_active_threads(&self, channel_id: u64) -> Result<ThreadsData> {
         self.fire(Request {
             body: None,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -338,6 +338,12 @@ pub enum Route {
     ///
     /// [`GuildId`]: crate::model::id::GuildId
     GuildsIdWelcomeScreen(u64),
+    /// Route for the `/guilds/:guild_id/threads/active` path.
+    ///
+    /// The data is the relevant [`GuildId`].
+    ///
+    /// [`GuildId`]: crate::model::id::GuildId
+    GuildsIdThreadsActive,
     /// Route for the `/invites/:code` path.
     InvitesCode,
     /// Route for the `/users/:user_id` path.
@@ -811,6 +817,10 @@ impl Route {
 
     pub fn guild_welcome_screen(guild_id: u64) -> String {
         format!(api!("/guilds/{}/welcome-screen"), guild_id)
+    }
+
+    pub fn guild_threads_active(guild_id: u64) -> String {
+        format!(api!("/guilds/{}/threads/active"), guild_id)
     }
 
     pub fn guilds() -> &'static str {
@@ -1419,6 +1429,9 @@ pub enum RouteInfo<'a> {
         command_id: u64,
     },
     GetGuildWidget {
+        guild_id: u64,
+    },
+    GetGuildActiveThreads {
         guild_id: u64,
     },
     GetGuildPreview {
@@ -2220,6 +2233,13 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Get,
                 Route::ChannelsIdMeJoindedArchivedPrivateThreads(channel_id),
                 Cow::from(Route::channel_joined_private_threads(channel_id, before, limit)),
+            ),
+            RouteInfo::GetGuildActiveThreads {
+                guild_id,
+            } => (
+                LightMethod::Get,
+                Route::GuildsIdThreadsActive,
+                Cow::from(Route::guild_threads_active(guild_id)),
             ),
             RouteInfo::JoinThread {
                 channel_id,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1143,6 +1143,7 @@ impl ChannelId {
     ///
     /// It may return an [`Error::Http`] if the bot doesn't have the
     /// permission to get it.
+    #[deprecated(note = "Use GuildId::get_active_threads instead")]
     pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
         http.as_ref().get_channel_active_threads(self.0).await
     }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -483,6 +483,7 @@ pub struct ThreadsData {
     /// A thread member for each returned thread the current user has joined.
     pub members: Vec<ThreadMember>,
     /// Whether there are potentially additional threads that could be returned on a subsequent call.
+    #[serde(default)]
     pub has_more: bool,
 }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1343,6 +1343,16 @@ impl GuildId {
     pub fn widget_image_url(&self, style: GuildWidgetStyle) -> String {
         format!(api!("/guilds/{}/widget.png?style={}"), self.0.to_string(), style.to_string())
     }
+
+    /// Gets the guild active threads.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if there is an error in the deserialization, or
+    /// if the bot issuing the request is not in the guild.
+    pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
+        http.as_ref().get_guild_active_threads(self.0).await
+    }
 }
 
 impl From<PartialGuild> for GuildId {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2334,6 +2334,16 @@ impl Guild {
     ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
+
+    /// Gets the guild active threads.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if there is an error in the deserialization, or
+    /// if the bot issuing the request is not in the guild.
+    pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
+        self.id.get_active_threads(http).await
+    }
 }
 
 impl<'de> Deserialize<'de> for Guild {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1462,6 +1462,16 @@ impl PartialGuild {
     ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
+
+    /// Gets the guild active threads.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if there is an error in the deserialization, or
+    /// if the bot issuing the request is not in the guild.
+    pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
+        self.id.get_active_threads(http).await
+    }
 }
 
 impl<'de> Deserialize<'de> for PartialGuild {


### PR DESCRIPTION
This pr adds support to the get guild active threads method, as per discord/discord-api-docs#3502. It also deprecates the get channel active threads method.

This has been tested.