### PR TITLE
Impl from owned Datetime for Timestamp

### DIFF
--- a/examples/e09_create_message_builder/Cargo.toml
+++ b/examples/e09_create_message_builder/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+chrono = { version = "0.4.10", features = ["serde"]}

--- a/examples/e09_create_message_builder/Cargo.toml
+++ b/examples/e09_create_message_builder/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-chrono = { version = "0.4.10", features = ["serde"]}
+chrono = "0.4.10"

--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -36,6 +36,10 @@ impl EventHandler for Handler {
                             f
                         });
 
+                        // Add a timestamp for the current time
+                        // This also accepts a rfc3339 Timestamp
+                        e.timestamp(chrono::Utc::now());
+
                         e
                     });
                     m.add_file(AttachmentType::Path(Path::new("./ferris_eyes.png")));

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -494,6 +494,17 @@ impl<'a> From<&'a str> for Timestamp {
     }
 }
 
+impl<Tz: TimeZone> From<DateTime<Tz>> for Timestamp
+where
+    Tz::Offset: Display,
+{
+    fn from(dt: DateTime<Tz>) -> Self {
+        Self {
+            ts: dt.to_rfc3339(),
+        }
+    }
+}
+
 impl<'a, Tz: TimeZone> From<&'a DateTime<Tz>> for Timestamp
 where
     Tz::Offset: Display,


### PR DESCRIPTION
### Description

Allows passing an owned value into `CreateEmbed::timestamp()`

### Tested

Example has been updated to use an owned Timestamp which works correctly. Prior to this change it would need to be borrowed.