### PR TITLE
Add a simple dashboard example.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,4 +222,4 @@ jobs:
       - name: 'Build example 14'
         run: cargo build -p e14_slash_commands
       - name: 'Build example 15'
-        run: cargo build -p e14_simple_dashboard
+        run: cargo build -p e15_simple_dashboard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,3 +221,5 @@ jobs:
         run: cargo build -p e13_parallel_loops
       - name: 'Build example 14'
         run: cargo build -p e14_slash_commands
+      - name: 'Build example 15'
+        run: cargo build -p e14_simple_dashboard

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ members = [
     "examples/e11_gateway_intents",
     "examples/e12_global_data",
     "examples/e13_parallel_loops",
-    "examples/e14_slash_commands"
+    "examples/e14_slash_commands",
+    "examples/e15_simple_dashboard"
 ]
 
 [dependencies]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -286,3 +286,41 @@ args = ["make", "run_example", "e13_parallel_loops"]
 [tasks.dev_build_13]
 command = "cargo"
 args = ["make", "build_example", "e13_parallel_loops"]
+
+[tasks.14]
+alias = "run_14"
+
+[tasks.run_14]
+command = "cargo"
+args = ["make", "run_example_release", "e14_slash_commands"]
+
+[tasks.build_14]
+command = "cargo"
+args = ["make", "build_example_release", "e14_slash_commands"]
+
+[tasks.dev_run_14]
+command = "cargo"
+args = ["make", "run_example", "e14_slash_commands"]
+
+[tasks.dev_build_14]
+command = "cargo"
+args = ["make", "build_example", "e14_slash_commands"]
+
+[tasks.15]
+alias = "run_15"
+
+[tasks.run_15]
+command = "cargo"
+args = ["make", "run_example_release", "e15_simple_dashboard"]
+
+[tasks.build_15]
+command = "cargo"
+args = ["make", "build_example_release", "e15_simple_dashboard"]
+
+[tasks.dev_run_15]
+command = "cargo"
+args = ["make", "run_example", "e15_simple_dashboard"]
+
+[tasks.dev_build_15]
+command = "cargo"
+args = ["make", "build_example", "e15_simple_dashboard"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,43 +7,51 @@ All examples have documentation for new concepts, and try to explain any new
 concepts. Examples should be completed in order, so as not to miss any
 documentation.
 
+If you are looking for voice examples, they can be found in [songbird's repository](https://github.com/serenity-rs/songbird/tree/current/examples/serenity) and on [lavalink-rs](https://gitlab.com/vicky5124/lavalink-rs/-/tree/master/examples)
+
 To provide a token for them to use, you need to set the `DISCORD_TOKEN`
 environmental variable to the Bot token.\
 If you don't like environment tokens, you can hardcode your token in instead.\
 TIP: A valid token starts with M, N or O and has 2 dots.
 
-### Running Examples
+## Running Examples
 
 To run an example, you have various options:
 
 1. [cargo-make](https://lib.rs/crates/cargo-make)
+
 - Clone the repository: `git clone https://github.com/serenity-rs/serenity.git`
 - CD into the serenity folder: `cd serenity`
 - Run `cargo make 1`, where 1 is the number of the example you wish to run; these are:
-```
- 1 => Basic Ping Bot: A bare minimum serenity application.
- 2 => Transparent Guild Sharding: How to use sharding and shared cache.
- 3 => Structure Utilities: Simple usage of the utils feature.
- 4 => Message Builder: A demonstration of the message builder utility, to generate messages safely.
- 5 => Command Framework: The main example, where it's demonstrated how to use serenity's command framework,
-      along with most of its utilities.
-      This example also shows how to share data between events and commands, using `Context.data`
- 6 => Simple Bot Stucture: An example showing the recommended file structure to use.
- 7 => Env Logging: How to use the tracing crate along with serenity.
- 8 => Shard Manager: How to get started with using the shard manager.
- 9 => Create Message Builder: How to send embeds and files.
-10 => Collectors: How to use the collectors feature to wait for messages and reactions.
-11 => Gateway Intents: How to use intents to limit the events the bot will receive.
-12 => Global Data: How to use the client data to share data between commands and events safely.
-13 => Parallel Loops: How to run tasks in a loop with context access.
-      Additionally, show how to send a message to a specific channel.
-```
+
+    ```
+    1 => Basic Ping Bot: A bare minimum serenity application.
+    2 => Transparent Guild Sharding: How to use sharding and shared cache.
+    3 => Structure Utilities: Simple usage of the utils feature.
+    4 => Message Builder: A demonstration of the message builder utility, to generate messages safely.
+    5 => Command Framework: The main example, where it's demonstrated how to use serenity's command framework,
+    along with most of its utilities.
+    This example also shows how to share data between events and commands, using `Context.data`
+    6 => Simple Bot Stucture: An example showing the recommended file structure to use.
+    7 => Env Logging: How to use the tracing crate along with serenity.
+    8 => Shard Manager: How to get started with using the shard manager.
+    9 => Create Message Builder: How to send embeds and files.
+    10 => Collectors: How to use the collectors feature to wait for messages and reactions.
+    11 => Gateway Intents: How to use intents to limit the events the bot will receive.
+    12 => Global Data: How to use the client data to share data between commands and events safely.
+    13 => Parallel Loops: How to run tasks in a loop with context access.
+    Additionally, show how to send a message to a specific channel.
+    14 => Slash Commands: How to use the low level slash command API.
+    15 => Simple Dashboard: A simple dashboard to control and monitor the bot with `rillrate`.
+    ```
 
 2. Manually running:
+
 - Clone the repository: `git clone https://github.com/serenity-rs/serenity.git`
 - Run the example of choice, selected using the `-p` flag: `cargo run --release -p e01_basic_ping_bot `
 
 3. Copy Paste:
+
 - Copy the contents of the example into your local binary project\
 (created via `cargo new test-project --bin`)\
 and ensuring that the contents of the `Cargo.toml` file
@@ -58,6 +66,8 @@ clarified.
 ### Contributing
 
 If you add a new example also add it to the following files:
+
 - `.github/workflows/ci.yml`
 - `Makefile.toml`
 - `examples/README.md`
+- `Cargo.toml` -> `workspace.members`

--- a/examples/e15_simple_dashboard/Cargo.toml
+++ b/examples/e15_simple_dashboard/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rillrate = "0.37"
+rillrate = "0.38"
+
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tracing-log = "0.1"
+
 webbrowser = "0.5"
 
 [dependencies.serenity]

--- a/examples/e15_simple_dashboard/Cargo.toml
+++ b/examples/e15_simple_dashboard/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "e15_simple_dashboard"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rillrate = "0.37"
+tracing = "0.1"
+tracing-subscriber = "0.2"
+tracing-log = "0.1"
+webbrowser = "0.5"
+
+[dependencies.serenity]
+path = "../../"
+
+[dependencies.tokio]
+version = "1"
+features = ["full"]
+
+[dependencies.reqwest]
+version = "0.11"
+default-features = false
+features = ["json", "rustls-tls"]
+
+[features]
+post-ping = []

--- a/examples/e15_simple_dashboard/Cargo.toml
+++ b/examples/e15_simple_dashboard/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rillrate = "0.38"
+rillrate = "0.39"
 
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/examples/e15_simple_dashboard/Makefile.toml
+++ b/examples/e15_simple_dashboard/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -1,0 +1,501 @@
+//! This example shows how you can use `rillrate` to create a web dashboard for your bot!
+//!
+//! This example is considered advanced and requires the knowledge of other examples.
+//! Example 5 is needed for the Gateway latency and Framework usage.
+//! Example 7 is needed because tracing is being used.
+//! Example 12 is needed because global data and atomic are used.
+//! Example 13 is needed for the parallel loops that are running to update data from the
+//! dashboard.
+
+// be lazy, import all macros globally!
+#[macro_use]
+extern crate tracing;
+
+use std::env;
+use std::error::Error;
+use std::sync::{atomic::*, Arc};
+use std::time::Instant;
+use std::collections::HashMap;
+
+use serenity::async_trait;
+use serenity::client::{
+    bridge::gateway::{ShardId, ShardManager},
+    Client, Context, EventHandler,
+};
+use serenity::framework::standard::{
+    macros::{command, group, hook},
+    CommandResult, StandardFramework,
+};
+use serenity::model::prelude::*;
+use serenity::prelude::*;
+
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration};
+
+use rillrate::pulse::PulseSpec;
+use rillrate::table::{Row, Col};
+use rillrate::range::{Label, Range};
+use rillrate::*;
+
+// Name used to group dashboards.
+// You could have multiple packages for different applications, such as a package for the bot
+// dashboards, and another package for a web server running alongside the bot.
+const PACKAGE: &str = "Bot Dashboards";
+// Dashboards are a part inside of package, they can be used to group different types of
+// dashboards that you may want to use, like a dashboard for system status, another dashboard
+// for cache status, and another one to configure features or trigger actions on the bot.
+const DASHBOARD_STATS: &str = "Statistics";
+const DASHBOARD_CONFIG: &str = "Config Dashboard";
+// This are collapsable menus inside the dashboard, you can use them to group specific sets
+// of data inside the same dashboard.
+// If you are using constants for this, make sure they don't end in _GROUP or _COMMAND, because
+// serenity's command framework uses these internally.
+const GROUP_LATENCY: &str = "1 - Discord Latency";
+const GROUP_COMMAND_COUNT: &str = "2 - Command Trigger Count";
+const GROUP_CONF: &str = "1 - Switch Command Configuration";
+// All of the 3 configurable namescapes are sorted alphabetically.
+
+#[derive(Debug, Clone)]
+struct CommandUsageValue {
+    index: usize,
+    use_count: usize,
+}
+
+struct Components {
+    data_switch: AtomicBool,
+    double_link_value: AtomicU8,
+    ws_ping_history: Pulse,
+    get_ping_history: Pulse,
+    #[cfg(feature = "post-ping")]
+    post_ping_history: Pulse,
+    command_usage_table: Table,
+    command_usage_values: Mutex<HashMap<&'static str, CommandUsageValue>>,
+}
+
+struct RillRateComponents;
+
+impl TypeMapKey for RillRateComponents {
+    // RillRate component types have internal mutability, so we don't need RwLock nor Mutex!
+    // We do still want to Arc the type so it can be cloned out of `ctx.data`.
+    // If you wanna bind data between RillRate and the bot that doesn't have Atomics, use fields
+    // that use RwLock or Mutex, rather than making the enirety of Components one of them, like
+    // it's being done with `command_usage_values` this will make it considerably less likely
+    // to deadlock.
+    type Value = Arc<Components>;
+}
+
+struct ShardManagerContainer;
+
+impl TypeMapKey for ShardManagerContainer {
+    type Value = Arc<Mutex<ShardManager>>;
+}
+
+#[group]
+#[commands(ping, switch)]
+struct General;
+
+struct Handler;
+
+#[async_trait]
+impl EventHandler for Handler {
+    async fn ready(&self, _ctx: Context, ready: Ready) {
+        info!("{} is connected!", ready.user.name);
+    }
+
+    async fn cache_ready(&self, ctx: Context, _guilds: Vec<GuildId>) {
+        info!("Cache is ready!");
+
+        let switch = Switch::new(
+            [PACKAGE, DASHBOARD_CONFIG, GROUP_CONF, "Toggle Switch"],
+            "Switch Me and run the `~switch` command!",
+        );
+        let switch_instance = switch.clone();
+
+        let ctx_clone = ctx.clone();
+
+        tokio::spawn(async move {
+            // There's currently no way to read the current data stored on RillRate types,
+            // so we use our own external method of storage, in this case since a switch is
+            // essentially just a boolean, we use an AtomicBool, stored on the same
+            // Components structure.
+            let components = {
+                let data_read = ctx_clone.data.read().await;
+                data_read.get::<RillRateComponents>().unwrap().clone()
+            };
+
+            switch.sync_callback(move |envelope| {
+                if let Some(action) = envelope.action {
+                    debug!("Switch action: {:?}", action);
+
+                    // Here we toggle our internal state for the switch.
+                    components.data_switch.swap(action, Ordering::Relaxed);
+
+                    // If you click the switch, it won't turn on by itself, it will just send an
+                    // event about it's new status.
+                    // We need to manually set the switch to that status.
+                    // If we do it at the end, we can make sure the switch switches it's status
+                    // only if the action was successful.
+                    switch_instance.apply(action);
+                }
+
+                Ok(())
+            });
+        });
+
+        let default_values = {
+            let mut values = vec![];
+            for i in u8::MIN..=u8::MAX {
+                if i % 32 == 0 {
+                    values.push(i.to_string())
+                }
+            }
+            values
+        };
+
+        // You are also able to have different actions in different components interact with
+        // the same data.
+        // In this example, we have a Selector with preset data, and a Slider for more fine
+        // grain control of the value.
+        let selector = Selector::new(
+            [PACKAGE, DASHBOARD_CONFIG, GROUP_CONF, "Value Selector"],
+            "Select from a preset of values!",
+            default_values,
+        );
+        let selector_instance = selector.clone();
+
+        let slider = Slider::new(
+            [PACKAGE, DASHBOARD_CONFIG, GROUP_CONF, "Value Slider"],
+            "Or slide me for more fine grain control!",
+            u8::MIN as f64,
+            u8::MAX as f64,
+            2.0,
+        );
+        let slider_instance = slider.clone();
+
+        let ctx_clone = ctx.clone();
+
+        tokio::spawn(async move {
+            let components = {
+                let data_read = ctx_clone.data.read().await;
+                data_read.get::<RillRateComponents>().unwrap().clone()
+            };
+
+            selector.sync_callback(move |envelope| {
+                let mut value: Option<u8> = None;
+
+                if let Some(action) = envelope.action {
+                    debug!("Values action (selector): {:?}", action);
+                    value = action.map(|val| val.parse().unwrap());
+                }
+
+                if let Some(val) = value {
+                    components.double_link_value.swap(val, Ordering::Relaxed);
+
+                    // This is the selector callback, yet we are switching the data from the
+                    // slider, this is to make sure both fields share the same look in the
+                    // dashboard.
+                    slider_instance.apply(val as f64);
+                }
+
+                // the sync_callback() closure wants a Result value returned.
+                Ok(())
+            });
+        });
+
+        let ctx_clone = ctx.clone();
+
+        tokio::spawn(async move {
+            let components = {
+                let data_read = ctx_clone.data.read().await;
+                data_read.get::<RillRateComponents>().unwrap().clone()
+            };
+
+            // Because sync_callback() waits for an action to happen to it's component,
+            // we cannot have both in the same thread, rather we need to listen to them in
+            // parallel, but still have both modify the same value in the end.
+            slider.sync_callback(move |envelope| {
+                let mut value: Option<u8> = None;
+
+                if let Some(action) = envelope.action {
+                    debug!("Values action (slider): {:?}", action);
+                    value = Some(action as u8);
+                }
+
+                if let Some(val) = value {
+                    components.double_link_value.swap(val, Ordering::Relaxed);
+
+                    selector_instance.apply(Some(val.to_string()));
+                }
+
+                Ok(())
+            });
+        });
+
+        let ctx_clone = ctx.clone();
+
+        tokio::spawn(async move {
+            let components = {
+                let data_read = ctx_clone.data.read().await;
+                data_read.get::<RillRateComponents>().unwrap().clone()
+            };
+
+            loop {
+                // Get the REST GET latency by counting how long it takes to do a GET request.
+                let get_latency = {
+                    let now = Instant::now();
+                    // `let _` to supress any errors. If they are a timeout, that will  be
+                    // reflected in the plotted graph.
+                    let _ = reqwest::get("https://discordapp.com/api/v6/gateway").await;
+                    now.elapsed().as_millis() as f64
+                };
+
+                // POST Request is feature gated because discord doesn't like bots doing repeated
+                // tasks in short time periods, as they are considered API abuse; this is specially
+                // true on bigger bots. If you still wanna see this function though, compile the
+                // code adding `--features post-ping` to the command.
+                //
+                // Get the REST POST latency by posting a message to #testing.
+                //
+                // If you don't want to spam, use the DM channel of some random bot, or use some
+                // other kind of POST request such as reacting to a message, or creating an invite.
+                // Be aware that if the http request fails, the latency returned may be incorrect.
+                #[cfg(feature = "post-ping")]
+                let post_latency = {
+                    let now = Instant::now();
+                    let _ = ChannelId(381926291785383946)
+                        .say(&ctx_clone, "Latency Test")
+                        .await;
+                    now.elapsed().as_millis() as f64
+                };
+
+                // Get the Gateway Heartbeat latency.
+                // See example 5 for more information about the ShardManager latency.
+                let ws_latency = {
+                    let data_read = ctx.data.read().await;
+                    let shard_manager = data_read.get::<ShardManagerContainer>().unwrap();
+
+                    let manager = shard_manager.lock().await;
+                    let runners = manager.runners.lock().await;
+
+                    let runner = runners.get(&ShardId(ctx.shard_id)).unwrap();
+
+                    if let Some(duration) = runner.latency {
+                        duration.as_millis() as f64
+                    } else {
+                        f64::NAN // effectively 0.0ms, it won't display on the graph.
+                    }
+                };
+
+                components.ws_ping_history.push(ws_latency);
+                components.get_ping_history.push(get_latency);
+                #[cfg(feature = "post-ping")]
+                components.post_ping_history.push(post_latency);
+
+                // Update every heartbeat, when the ws latency also updates.
+                sleep(Duration::from_millis(42500)).await;
+            }
+        });
+    }
+}
+
+#[hook]
+async fn before_hook(ctx: &Context, _: &Message, cmd_name: &str) -> bool {
+    let components = {
+        let data_read = ctx.data.read().await;
+        data_read.get::<RillRateComponents>().unwrap().clone()
+    };
+
+    let command_count_value = {
+        let mut count_write = components.command_usage_values.lock().await;
+        let mut command_count_value = count_write.get_mut(cmd_name).unwrap();
+        command_count_value.use_count += 1;
+        command_count_value.clone()
+    };
+
+    components.command_usage_table.set_cell(Row(command_count_value.index as u64), Col(1), command_count_value.use_count);
+
+    info!("Running command {}", cmd_name);
+
+    true
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    env::set_var(
+        "RUST_LOG",
+        // TODO: If you are going to copy this to your crate, update the crate name in the string
+        // with the name of the create you are using it with.
+        // This are the recommended log settings for rillrate, otherwise be prepared to be spammed
+        // with a ton of events.
+        "info,e15_simple_dashboard=trace,meio=warn,rate_core=warn,rill_engine=warn",
+    );
+
+    // Increase compatibility with tracing and the log crate macros used by RillRate.
+    // Some weird things get logged without this if you use tracing.
+    tracing_log::LogTracer::init()?;
+    // Since we use tracing_log, we need to use a different way of subscribing to tracing events
+    // than shown in example 7.
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    // Start a server on `http://0.0.0.0:6361/`
+    // Currently the port is not configurable, but it will be soon enough; thankfully it's not a
+    // common port, so it will be fine for most users.
+    rillrate::install("serenity")?;
+
+    // Because you probably ran this without looking at the source :P
+    let _ = webbrowser::open("http://localhost:6361");
+
+    let framework = StandardFramework::new()
+        .configure(|c| c.prefix("~"))
+        .before(before_hook)
+        .group(&GENERAL_GROUP);
+
+    let token = env::var("DISCORD_TOKEN")?;
+
+    let mut client = Client::builder(token)
+        .event_handler(Handler)
+        .framework(framework)
+        .await?;
+
+    {
+        let mut data = client.data.write().await;
+
+        data.insert::<ShardManagerContainer>(Arc::clone(&client.shard_manager));
+
+        // These 3 Pulse are the graphs used to plot the latency overtime.
+        let ws_ping_tracer = Pulse::new(
+            [PACKAGE, DASHBOARD_STATS, GROUP_LATENCY, "Websocket Ping Time"],
+            PulseSpec {
+                // The seconds of data to retain, this is 30 minutes.
+                retain: 1800,
+                // Column value range
+                range: Range {
+                    min: Some(0.0),
+                    max: Some(200.0),
+                },
+                // Label used along the values on the column.
+                label: Label {
+                    caption: "ms".to_string(),
+                    divisor: 1.0,
+                },
+            },
+        );
+
+        let get_ping_tracer = Pulse::new(
+            [PACKAGE, DASHBOARD_STATS, GROUP_LATENCY, "GET Ping Time"],
+            PulseSpec {
+                retain: 1800,
+                range: Range {
+                    min: Some(0.0),
+                    max: Some(200.0),
+                },
+                label: Label {
+                    caption: "ms".to_string(),
+                    divisor: 1.0,
+                },
+            },
+        );
+
+        #[cfg(feature = "post-ping")]
+        let post_ping_tracer = Pulse::new(
+            [PACKAGE, DASHBOARD_STATS, GROUP_LATENCY, "POST Ping Time"],
+            PulseSpec {
+                retain: 1800,
+                range: Range {
+                    min: Some(0.0),
+                    max: Some(500.0),
+                },
+                label: Label {
+                    caption: "ms".to_string(),
+                    divisor: 1.0,
+                },
+            },
+        );
+
+        let command_usage_table = Table::new(
+            [PACKAGE, DASHBOARD_STATS, GROUP_COMMAND_COUNT, "Command Usage"],
+            vec![(Col(0), "Command Name"), (Col(1), "Number of Uses")],
+        );
+
+        let mut command_usage_values = HashMap::new();
+
+        // Iterate over the commands of the General grop and add them to the table.
+        for (idx, i) in GENERAL_GROUP.options.commands.iter().enumerate() {
+            command_usage_table.add_row(Row(idx as u64));
+            command_usage_table.set_cell(Row(idx as u64), Col(0), i.options.names[0]);
+            command_usage_table.set_cell(Row(idx as u64), Col(1), 0);
+            command_usage_values.insert(i.options.names[0], CommandUsageValue {
+                index: idx,
+                use_count: 0,
+            });
+        }
+
+        data.insert::<RillRateComponents>(Arc::new(Components {
+            ws_ping_history: ws_ping_tracer,
+            get_ping_history: get_ping_tracer,
+            #[cfg(feature = "post-ping")]
+            post_ping_history: post_ping_tracer,
+            data_switch: AtomicBool::new(false),
+            double_link_value: AtomicU8::new(0),
+            command_usage_table,
+            command_usage_values: Mutex::new(command_usage_values),
+        }));
+    }
+
+    client.start().await?;
+
+    Ok(())
+}
+
+/// You can use this command to read the current value of the Switch, Slider and Selector.
+#[command]
+async fn switch(ctx: &Context, msg: &Message) -> CommandResult {
+    let components = {
+        let data_read = ctx.data.read().await;
+        data_read.get::<RillRateComponents>().unwrap().clone()
+    };
+
+    msg.reply(
+        ctx,
+        format!(
+            "The switch is {} and the current value is {}",
+            if components.data_switch.load(Ordering::Relaxed) {
+                "ON"
+            } else {
+                "OFF"
+            },
+            components.double_link_value.load(Ordering::Relaxed),
+        ),
+    )
+        .await?;
+
+    Ok(())
+}
+
+#[command]
+#[aliases("latency", "pong")]
+async fn ping(ctx: &Context, msg: &Message) -> CommandResult {
+    let latency = {
+        let data_read = ctx.data.read().await;
+        let shard_manager = data_read.get::<ShardManagerContainer>().unwrap();
+
+        let manager = shard_manager.lock().await;
+        let runners = manager.runners.lock().await;
+
+        let runner = runners.get(&ShardId(ctx.shard_id)).unwrap();
+
+        if let Some(duration) = runner.latency {
+            format!("{:.2}ms", duration.as_millis())
+        } else {
+            "?ms".to_string()
+        }
+    };
+
+    msg.reply(ctx, &format!("The shard latency is {}", latency))
+        .await?;
+
+    Ok(())
+}

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -329,7 +329,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     env::set_var(
         "RUST_LOG",
         // TODO: If you are going to copy this to your crate, update the crate name in the string
-        // with the name of the create you are using it with.
+        // with the name of the crate you are using it with.
         // This are the recommended log settings for rillrate, otherwise be prepared to be spammed
         // with a ton of events.
         "info,e15_simple_dashboard=trace,meio=warn,rate_core=warn,rill_engine=warn",


### PR DESCRIPTION
This PR adds an example for a bot dashboard, using RillRate

	modified:   .github/workflows/ci.yml
	modified:   Cargo.toml
	modified:   Makefile.toml
	modified:   examples/README.md
	new file:   examples/e15_simple_dashboard/Cargo.toml
	new file:   examples/e15_simple_dashboard/Makefile.toml
	new file:   examples/e15_simple_dashboard/example video.mp4
	new file:   examples/e15_simple_dashboard/src/main.rs