### PR TITLE
Change back "category_id" to "parent_id"

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1124,7 +1124,7 @@ mod test {
         let channel = Channel::Guild(GuildChannel {
             id: event.message.channel_id,
             bitrate: None,
-            category_id: None,
+            parent_id: None,
             guild_id: event.message.guild_id.unwrap(),
             kind: ChannelType::Text,
             last_message_id: None,

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -16,8 +16,7 @@ pub struct ChannelCategory {
     /// Guild Id this category belongs to.
     pub guild_id: GuildId,
     /// If this category belongs to another category.
-    #[serde(rename = "parent_id")]
-    pub category_id: Option<ChannelId>,
+    pub parent_id: Option<ChannelId>,
     /// The position of this category.
     pub position: i64,
     /// Indicator of the type of channel this is.
@@ -137,7 +136,7 @@ impl ChannelCategory {
             let GuildChannel {
                 id,
                 guild_id,
-                category_id,
+                parent_id,
                 position,
                 kind,
                 name,
@@ -149,7 +148,7 @@ impl ChannelCategory {
             *self = ChannelCategory {
                 id,
                 guild_id,
-                category_id,
+                parent_id,
                 position,
                 kind,
                 name,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -48,9 +48,10 @@ pub struct GuildChannel {
     ///
     /// **Note**: This is only available for voice and stage channels.
     pub bitrate: Option<u64>,
-    /// Whether this guild channel belongs in a category.
-    #[serde(rename = "parent_id")]
-    pub category_id: Option<ChannelId>,
+    /// The Id of the parent category for a channel, or of the parent text channel for a thread. 
+    ///
+    /// **Note**: This is only available for channels in a category and thread channels.
+    pub parent_id: Option<ChannelId>,
     /// The Id of the guild the channel is located in.
     ///
     /// If this matches with the [`id`], then this is the default text channel.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -18,10 +18,7 @@ use crate::cache::Cache;
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
 use crate::collector::{
-    CollectReaction,
-    CollectReply,
-    MessageCollectorBuilder,
-    ReactionCollectorBuilder,
+    CollectReaction, CollectReply, MessageCollectorBuilder, ReactionCollectorBuilder,
 };
 #[cfg(feature = "model")]
 use crate::http::AttachmentType;
@@ -48,7 +45,7 @@ pub struct GuildChannel {
     ///
     /// **Note**: This is only available for voice and stage channels.
     pub bitrate: Option<u64>,
-    /// The Id of the parent category for a channel, or of the parent text channel for a thread. 
+    /// The Id of the parent category for a channel, or of the parent text channel for a thread.
     ///
     /// **Note**: This is only available for channels in a category and thread channels.
     pub parent_id: Option<ChannelId>,
@@ -1091,7 +1088,7 @@ impl GuildChannel {
                     })
                     .collect::<Vec<Member>>()
                     .await)
-            },
+            }
             _ => Err(Error::from(ModelError::InvalidChannelType)),
         }
     }
@@ -1274,9 +1271,8 @@ pub struct PartialGuildChannel {
     pub id: ChannelId,
     /// The channel guild Id.
     pub guild_id: GuildId,
-    /// The channel category Id.
-    #[serde(rename = "parent_id")]
-    pub category_id: ChannelId,
+    /// The channel category Id,  or the parent text channel Id for a thread.
+    pub parent_id: ChannelId,
     /// The channel type.
     #[serde(rename = "type")]
     pub kind: ChannelType,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -18,7 +18,10 @@ use crate::cache::Cache;
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
 use crate::collector::{
-    CollectReaction, CollectReply, MessageCollectorBuilder, ReactionCollectorBuilder,
+    CollectReaction,
+    CollectReply,
+    MessageCollectorBuilder,
+    ReactionCollectorBuilder,
 };
 #[cfg(feature = "model")]
 use crate::http::AttachmentType;
@@ -1088,7 +1091,7 @@ impl GuildChannel {
                     })
                     .collect::<Vec<Member>>()
                     .await)
-            }
+            },
             _ => Err(Error::from(ModelError::InvalidChannelType)),
         }
     }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -490,7 +490,7 @@ mod test {
             GuildChannel {
                 id: ChannelId(1),
                 bitrate: None,
-                category_id: None,
+                parent_id: None,
                 guild_id: GuildId(2),
                 kind: ChannelType::Text,
                 last_message_id: None,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -136,7 +136,7 @@ impl Display for Mention {
             MentionableImpl::Role(id) => f.write_fmt(format_args!("<@&{}>", id.0)),
             MentionableImpl::Emoji(id, animated) => {
                 f.write_fmt(format_args!("<{}:_:{}>", if animated { "a" } else { "" }, id.0,))
-            }
+            },
         }
     }
 }
@@ -309,8 +309,9 @@ impl FromStr for EmojiIdentifier {
     type Err = EmojiIdentifierParseError;
 
     fn from_str(s: &str) -> StdResult<Self, Self::Err> {
-        utils::parse_emoji(s)
-            .ok_or_else(|| EmojiIdentifierParseError { parsed_string: s.to_owned() })
+        utils::parse_emoji(s).ok_or_else(|| EmojiIdentifierParseError {
+            parsed_string: s.to_owned(),
+        })
     }
 }
 

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -136,7 +136,7 @@ impl Display for Mention {
             MentionableImpl::Role(id) => f.write_fmt(format_args!("<@&{}>", id.0)),
             MentionableImpl::Emoji(id, animated) => {
                 f.write_fmt(format_args!("<{}:_:{}>", if animated { "a" } else { "" }, id.0,))
-            },
+            }
         }
     }
 }
@@ -309,9 +309,8 @@ impl FromStr for EmojiIdentifier {
     type Err = EmojiIdentifierParseError;
 
     fn from_str(s: &str) -> StdResult<Self, Self::Err> {
-        utils::parse_emoji(s).ok_or_else(|| EmojiIdentifierParseError {
-            parsed_string: s.to_owned(),
-        })
+        utils::parse_emoji(s)
+            .ok_or_else(|| EmojiIdentifierParseError { parsed_string: s.to_owned() })
     }
 }
 
@@ -407,7 +406,7 @@ mod test {
         async fn test_mention() {
             let channel = Channel::Guild(GuildChannel {
                 bitrate: None,
-                category_id: None,
+                parent_id: None,
                 guild_id: GuildId(1),
                 kind: ChannelType::Text,
                 id: ChannelId(4),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -906,7 +906,7 @@ mod test {
         let channel = GuildChannel {
             id: ChannelId(111880193700067777),
             bitrate: None,
-            category_id: None,
+            parent_id: None,
             guild_id: guild.id,
             kind: ChannelType::Text,
             last_message_id: None,


### PR DESCRIPTION
With the addition of threads, this field can refer to either the category of a channel or the text channel the thread was created in.

This is a breaking change.