### PR TITLE
Support for Webhooks posting to threads 

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1795,6 +1795,7 @@ impl Http {
         token: &str,
         wait: bool,
         map: &JsonMap,
+        thread_id: Option<u64>,
     ) -> Result<Option<Message>> {
         let body = serde_json::to_vec(map)?;
 
@@ -1809,6 +1810,7 @@ impl Http {
                     token,
                     wait,
                     webhook_id,
+                    thread_id,
                 },
             })
             .await?;
@@ -1834,6 +1836,7 @@ impl Http {
         wait: bool,
         files: It,
         map: JsonMap,
+        thread_id: Option<u64>,
     ) -> Result<Option<Message>>
     where
         T: Into<AttachmentType<'a>>,
@@ -1897,7 +1900,7 @@ impl Http {
 
         let response = self
             .client
-            .post(&Route::webhook_with_token_optioned(webhook_id, token, wait))
+            .post(&Route::webhook_with_token_optioned(webhook_id, token, wait, thread_id))
             .multipart(multipart)
             .header(CONTENT_TYPE, HeaderValue::from_static("multipart/form-data"))
             .send()

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -902,11 +902,23 @@ impl Route {
         format!(api!("/webhooks/{}/{}"), webhook_id, token)
     }
 
-    pub fn webhook_with_token_optioned<D>(webhook_id: u64, token: D, wait: bool) -> String
+    pub fn webhook_with_token_optioned<D>(
+        webhook_id: u64,
+        token: D,
+        wait: bool,
+        thread_id: Option<u64>,
+    ) -> String
     where
         D: Display,
     {
-        format!(api!("/webhooks/{}/{}?wait={}"), webhook_id, token, wait)
+        if let Some(thread_id) = thread_id {
+            format!(
+                api!("/webhooks/{}/{}?wait={}&thread_id={}"),
+                webhook_id, token, wait, thread_id
+            )
+        } else {
+            format!(api!("/webhooks/{}/{}?wait={}"), webhook_id, token, wait)
+        }
     }
 
     pub fn webhook_message<D>(webhook_id: u64, token: D, message_id: u64) -> String
@@ -1302,6 +1314,7 @@ pub enum RouteInfo<'a> {
         token: &'a str,
         wait: bool,
         webhook_id: u64,
+        thread_id: Option<u64>,
     },
     JoinThread {
         channel_id: u64,
@@ -2116,10 +2129,11 @@ impl<'a> RouteInfo<'a> {
                 token,
                 wait,
                 webhook_id,
+                thread_id,
             } => (
                 LightMethod::Post,
                 Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook_with_token_optioned(webhook_id, token, wait)),
+                Cow::from(Route::webhook_with_token_optioned(webhook_id, token, wait, thread_id)),
             ),
             RouteInfo::GetActiveMaintenance => {
                 (LightMethod::Get, Route::None, Cow::from(Route::status_maintenances_active()))

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -50,6 +50,7 @@ pub struct GuildChannel {
     /// The unique Id of the channel.
     ///
     /// The default channel Id shares the Id of the guild and the default role.
+    /// When this channel is a thread, this Id corresponds to the thread's parent text channel instead.
     pub id: ChannelId,
     /// The bitrate of the channel.
     ///

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -301,14 +301,23 @@ impl Webhook {
         let mut execute_webhook = ExecuteWebhook::default();
         f(&mut execute_webhook);
 
-        let map = utils::hashmap_to_json_map(execute_webhook.0);
+        let map = utils::hashmap_to_json_map(execute_webhook.params);
 
-        if !execute_webhook.1.is_empty() {
+        if !execute_webhook.attachments.is_empty() {
             http.as_ref()
-                .execute_webhook_with_files(self.id.0, token, wait, execute_webhook.1.clone(), map)
+                .execute_webhook_with_files(
+                    self.id.0,
+                    token,
+                    wait,
+                    execute_webhook.attachments.clone(),
+                    map,
+                    execute_webhook.thread_id,
+                )
                 .await
         } else {
-            http.as_ref().execute_webhook(self.id.0, token, wait, &map).await
+            http.as_ref()
+                .execute_webhook(self.id.0, token, wait, &map, execute_webhook.thread_id)
+                .await
         }
     }
 


### PR DESCRIPTION
Added the `thread_id` method to the webhook builder. When called, it adds the `thread_id` query string param to the Webhook execution, in line with the [Discord documentation](https://discord.com/developers/docs/resources/webhook#execute-webhook)

```rust
// post to the guild channel
webhook.execute(&http. false, |mut w| w.content("test").username("serenity"));

// post to a specific thread in the guild channel
webhook.execute(&http. false, |mut w| w.content("test").username("serenity").thread_id(880515904499253249));
```

Additionally, added a line to the documentation for `GuildChannel.category_id` clarifying how it represents the parent text channel id when the channel is a thread. [Documentation](https://discord.com/developers/docs/topics/threads#new-thread-fields) says that the `parent_id` field is reused this way.