### PR TITLE
Cache members on more events

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -150,7 +150,9 @@ impl DispatchEvent {
             Self::Model(Event::ReactionRemoveAll(ref mut event)) => {
                 update(cache_and_http, event).await;
             },
-            // TODO: ADD CACHE_UPDATE FOR typing_start
+            Self::Model(Event::TypingStart(ref mut event)) => {
+                update(cache_and_http, event).await;
+            },
             _ => (),
         }
     }
@@ -716,7 +718,9 @@ async fn handle_event(
                 event_handler.resume(context, event).await;
             });
         },
-        DispatchEvent::Model(Event::TypingStart(event)) => {
+        DispatchEvent::Model(Event::TypingStart(mut event)) => {
+            update(&cache_and_http, &mut event).await;
+
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -141,6 +141,16 @@ impl DispatchEvent {
             Self::Model(Event::VoiceStateUpdate(ref mut event)) => {
                 update(cache_and_http, event).await;
             },
+            Self::Model(Event::ReactionAdd(ref mut event)) => {
+                update(cache_and_http, event).await;
+            },
+            Self::Model(Event::ReactionRemove(ref mut event)) => {
+                update(cache_and_http, event).await;
+            },
+            Self::Model(Event::ReactionRemoveAll(ref mut event)) => {
+                update(cache_and_http, event).await;
+            },
+            // TODO: ADD CACHE_UPDATE FOR typing_start
             _ => (),
         }
     }
@@ -662,21 +672,27 @@ async fn handle_event(
                 event_handler.presence_update(context, event).await;
             });
         },
-        DispatchEvent::Model(Event::ReactionAdd(event)) => {
+        DispatchEvent::Model(Event::ReactionAdd(mut event)) => {
+            update(&cache_and_http, &mut event).await;
+
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
                 event_handler.reaction_add(context, event.reaction).await;
             });
         },
-        DispatchEvent::Model(Event::ReactionRemove(event)) => {
+        DispatchEvent::Model(Event::ReactionRemove(mut event)) => {
+            update(&cache_and_http, &mut event).await;
+
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {
                 event_handler.reaction_remove(context, event.reaction).await;
             });
         },
-        DispatchEvent::Model(Event::ReactionRemoveAll(event)) => {
+        DispatchEvent::Model(Event::ReactionRemoveAll(mut event)) => {
+            update(&cache_and_http, &mut event).await;
+
             let event_handler = Arc::clone(event_handler);
 
             tokio::spawn(async move {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -473,7 +473,7 @@ pub struct GuildMemberUpdateEvent {
     pub deaf: bool,
     #[serde(default)]
     pub mute: bool,
-    pub avatar: Option<String>,
+    pub avatar: Option<String>, /* TODO: Remove this on next. Avatar is not directly in this payload, but as part of the user. GuildMemberUpdateEvent is public, removing would be breaking change. */
 }
 
 #[cfg(feature = "cache")]
@@ -496,7 +496,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                 member.premium_since.clone_from(&self.premium_since);
                 member.deaf.clone_from(&self.deaf);
                 member.mute.clone_from(&self.mute);
-                member.avatar.clone_from(&self.avatar);
+                member.avatar.clone_from(&self.user.avatar);
 
                 item
             } else {
@@ -516,7 +516,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     premium_since: self.premium_since,
                     #[cfg(feature = "unstable_discord_api")]
                     permissions: None,
-                    avatar: self.avatar.clone(),
+                    avatar: self.user.avatar.clone(),
                 });
             }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -473,7 +473,8 @@ pub struct GuildMemberUpdateEvent {
     pub deaf: bool,
     #[serde(default)]
     pub mute: bool,
-    pub avatar: Option<String>, /* TODO: Remove this on next. Avatar is not directly in this payload, but as part of the user. GuildMemberUpdateEvent is public, removing would be breaking change. */
+    #[deprecated(note = "This field is always `None`, use `self.user.avatar` instead")]
+    pub avatar: Option<String>,
 }
 
 #[cfg(feature = "cache")]


### PR DESCRIPTION
Hello!

This pull-request is about caching members when the necessary data is being received from various events.
So far, this pull-request caches the user+member in the `message-create` and `message-update`-event. The `message-reaction-add` and `typing-start` would also expose the member in the payload, but I would have to implement the `CacheUpdate`-trait for those events, and I do not know the semantics of the return-value of the `update`-function there.
Likewise, the `CacheUpdate` for the message-events are now not only doing a message-cache-update, but also a user/member-cache-update.
I have used similar code as in the `GuildMemberUpdateEvent` for the changes.

This also fixes an issue with the guild-member-update-event replacing the avatar by a None-value when one is available, due to an invalid deserialization.

The issue that https://github.com/serenity-rs/serenity/pull/1479 is solving by adding more intents to make the `#[required-permissions]` work would be solved with these changes differently, by having the member cached when messages are being received, and not only on GuildMember-related events or on startup (which needs the privileged `GUILD_PRESENCES`-intent).
