### PR TITLE
Add path to http-errors

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -174,13 +174,17 @@ impl Display for Error {
             Error::UnsuccessfulRequest(e) => {
                 f.write_str(&e.error.message)?;
 
-                // Put Discord's human readable error explanations in parantheses
+                // Put Discord's human readable error explanations in parentheses
                 let mut errors_iter = e.error.errors.iter();
                 if let Some(error) = errors_iter.next() {
                     f.write_str(" (")?;
+                    f.write_str(&error.path)?;
+                    f.write_str(": ")?;
                     f.write_str(&error.message)?;
                     for error in errors_iter {
                         f.write_str(", ")?;
+                        f.write_str(&error.path)?;
+                        f.write_str(": ")?;
                         f.write_str(&error.message)?;
                     }
                     f.write_str(")")?;


### PR DESCRIPTION
Hello!

As per issue https://github.com/serenity-rs/serenity/issues/1467 the Display-implementation of HTTP-request-related errors did at times not convey enough information.

This pull-request implements the proposed change.

`write_fmt` with `format_args!` was not chosen because apparently it is slower, however I have not benchmarked it.