### PR TITLE
Fix missing field `pack_id` decode error

### DIFF
--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -9,7 +9,7 @@ pub struct Sticker {
     /// The unique ID given to this sticker.
     pub id: StickerId,
     /// The unique ID of the pack the sticker is from.
-    pub pack_id: StickerPackId,
+    pub pack_id: Option<StickerPackId>,
     /// The name of the sticker.
     pub name: String,
     /// Description of the sticker


### PR DESCRIPTION
Have been getting some errors saying ```"missing field `pack_id`"```
Discord [defines](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-structure) `pack_id` as optional. Changing pack_id to be `Option<StickerPackId>` seems to have resolved the issue