### PR TITLE
New audit log models

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -18,7 +18,7 @@ use std::{
 use serenity::prelude::*;
 use serenity::{
     async_trait,
-    client::bridge::gateway::{ShardId, ShardManager, GatewayIntents},
+    client::bridge::gateway::{GatewayIntents, ShardId, ShardManager},
     framework::standard::{
         buckets::{LimitedFor, RevertBucket},
         help_commands,

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -492,21 +492,21 @@ impl<'de> Deserialize<'de> for AuditLogs {
                             }
 
                             audit_log_entries = Some(map.next_value::<Vec<AuditLogEntry>>()?);
-                        }
+                        },
                         Ok(Some(Field::Webhooks)) => {
                             if webhooks.is_some() {
                                 return Err(de::Error::duplicate_field("webhooks"));
                             }
 
                             webhooks = Some(map.next_value::<Vec<Webhook>>()?);
-                        }
+                        },
                         Ok(Some(Field::Users)) => {
                             if users.is_some() {
                                 return Err(de::Error::duplicate_field("users"));
                             }
 
                             users = Some(map.next_value::<Vec<User>>()?);
-                        }
+                        },
                         Ok(None) => break, // No more keys
                         Err(e) => {
                             if e.to_string().contains("unknown field") {
@@ -519,7 +519,7 @@ impl<'de> Deserialize<'de> for AuditLogs {
                             } else {
                                 return Err(e);
                             }
-                        }
+                        },
                     }
                 }
 
@@ -532,7 +532,11 @@ impl<'de> Deserialize<'de> for AuditLogs {
                 let webhooks = webhooks.ok_or_else(|| de::Error::missing_field("webhooks"))?;
                 let users = users.ok_or_else(|| de::Error::missing_field("users"))?;
 
-                Ok(AuditLogs { entries, webhooks, users })
+                Ok(AuditLogs {
+                    entries,
+                    webhooks,
+                    users,
+                })
             }
         }
 

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -35,6 +35,9 @@ pub enum Action {
     Emoji(ActionEmoji),
     Message(ActionMessage),
     Integration(ActionIntegration),
+    StageInstance(ActionStageInstance),
+    Sticker(ActionSticker),
+    Thread(ActionThread),
 }
 
 impl Action {
@@ -52,6 +55,9 @@ impl Action {
             Action::Emoji(ref x) => x.num(),
             Action::Message(ref x) => x.num(),
             Action::Integration(ref x) => x.num(),
+            Action::StageInstance(ref x) => x.num(),
+            Action::Sticker(ref x) => x.num(),
+            Action::Thread(ref x) => x.num(),
         }
     }
 }
@@ -241,6 +247,63 @@ impl ActionIntegration {
     }
 }
 
+#[derive(Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum ActionStageInstance {
+    Create = 83,
+    Update = 84,
+    Delete = 85,
+}
+
+impl ActionStageInstance {
+    pub fn num(&self) -> u8 {
+        match *self {
+            ActionStageInstance::Create => 83,
+            ActionStageInstance::Update => 84,
+            ActionStageInstance::Delete => 85,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum ActionSticker {
+    Create = 90,
+    Update = 91,
+    Delete = 92,
+}
+
+impl ActionSticker {
+    pub fn num(&self) -> u8 {
+        match *self {
+            ActionSticker::Create => 90,
+            ActionSticker::Update => 91,
+            ActionSticker::Delete => 92,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum ActionThread {
+    Create = 110,
+    Update = 111,
+    Delete = 112,
+}
+
+impl ActionThread {
+    pub fn num(&self) -> u8 {
+        match *self {
+            ActionThread::Create => 110,
+            ActionThread::Update => 111,
+            ActionThread::Delete => 112,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Change {
     #[serde(rename = "key")]
@@ -378,6 +441,9 @@ mod action_handler {
                     60..=62 => Action::Emoji(unsafe { transmute(value) }),
                     72..=75 => Action::Message(unsafe { transmute(value) }),
                     80..=82 => Action::Integration(unsafe { transmute(value) }),
+                    83..=85 => Action::StageInstance(unsafe { transmute(value) }),
+                    90..=92 => Action::Sticker(unsafe { transmute(value) }),
+                    110..=112 => Action::Thread(unsafe { transmute(value) }),
                     _ => return Err(E::custom(format!("Unexpected action number: {}", value))),
                 })
             }
@@ -426,21 +492,21 @@ impl<'de> Deserialize<'de> for AuditLogs {
                             }
 
                             audit_log_entries = Some(map.next_value::<Vec<AuditLogEntry>>()?);
-                        },
+                        }
                         Ok(Some(Field::Webhooks)) => {
                             if webhooks.is_some() {
                                 return Err(de::Error::duplicate_field("webhooks"));
                             }
 
                             webhooks = Some(map.next_value::<Vec<Webhook>>()?);
-                        },
+                        }
                         Ok(Some(Field::Users)) => {
                             if users.is_some() {
                                 return Err(de::Error::duplicate_field("users"));
                             }
 
                             users = Some(map.next_value::<Vec<User>>()?);
-                        },
+                        }
                         Ok(None) => break, // No more keys
                         Err(e) => {
                             if e.to_string().contains("unknown field") {
@@ -453,7 +519,7 @@ impl<'de> Deserialize<'de> for AuditLogs {
                             } else {
                                 return Err(e);
                             }
-                        },
+                        }
                     }
                 }
 
@@ -466,11 +532,7 @@ impl<'de> Deserialize<'de> for AuditLogs {
                 let webhooks = webhooks.ok_or_else(|| de::Error::missing_field("webhooks"))?;
                 let users = users.ok_or_else(|| de::Error::missing_field("users"))?;
 
-                Ok(AuditLogs {
-                    entries,
-                    webhooks,
-                    users,
-                })
+                Ok(AuditLogs { entries, webhooks, users })
             }
         }
 


### PR DESCRIPTION
#1466 
Discord has added 3 new audit log models: `STAGE_INSTANCE`, `STICKER` & `THREAD`, which isn't supported by Serenity's audit log interface yet. 
This pull request adds these new model into Serenity (Three new enum variants for `Action`, and three new action enums).