### PR TITLE
Add `ApplicationCommand::version` field support

### DIFF
--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -154,6 +154,10 @@ pub struct CommandId(pub u64);
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct CommandPermissionId(pub u64);
 
+/// An identifier for a slash command version Id.
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct CommandVersionId(pub u64);
+
 /// An identifier for a slash command target Id. Can contain
 /// a [`UserId`] or [`MessageId`].
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
@@ -180,6 +184,7 @@ id_u64! {
     InteractionId;
     CommandId;
     CommandPermissionId;
+    CommandVersionId;
     TargetId;
     StageInstanceId;
 }

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -687,6 +687,8 @@ pub struct ApplicationCommand {
     /// the application is added to a guild.
     #[serde(default = "self::default_permission_value")]
     pub default_permission: bool,
+    /// An autoincremented version identifier updated during substantial record changes.
+    pub version: CommandVersionId,
 }
 
 impl ApplicationCommand {


### PR DESCRIPTION
This PR adds support to the `ApplicationCommand::version` field, as per discord/discord-api-docs#3524.

This has been tested.