### PR TITLE
Replace instances of `tokio::spawn` with `spawn_named`

### DIFF
--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -25,6 +25,7 @@ use crate::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
 use crate::internal::prelude::*;
+use crate::internal::tokio::spawn_named;
 use crate::CacheAndHttp;
 
 /// A manager for handling the status of shards by starting them, restarting
@@ -140,7 +141,7 @@ impl ShardManager {
             intents: opt.intents,
         };
 
-        tokio::spawn(async move {
+        spawn_named("shard_queuer::run", async move {
             shard_queuer.run().await;
         });
 

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -35,6 +35,7 @@ use crate::framework::Framework;
 use crate::gateway::ConnectionStage;
 use crate::gateway::{InterMessage, Shard};
 use crate::internal::prelude::*;
+use crate::internal::tokio::spawn_named;
 use crate::CacheAndHttp;
 
 const WAIT_BETWEEN_BOOTS_IN_SECONDS: u64 = 5;
@@ -208,7 +209,7 @@ impl ShardQueuer {
             stage: ConnectionStage::Disconnected,
         };
 
-        tokio::spawn(async move {
+        spawn_named("shard_queuer::stop", async move {
             #[allow(clippy::let_underscore_must_use)]
             let _ = runner.run().await;
             debug!("[ShardRunner {:?}] Stopping", runner.shard.shard_info());

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -22,6 +22,7 @@ use crate::cache::{Cache, CacheUpdate};
 use crate::framework::Framework;
 use crate::gateway::InterMessage;
 use crate::http::Http;
+use crate::internal::tokio::spawn_named;
 #[cfg(feature = "cache")]
 use crate::model::id::GuildId;
 use crate::model::{
@@ -179,7 +180,7 @@ pub(crate) fn dispatch<'rec>(
 
                         let framework = Arc::clone(framework);
 
-                        tokio::spawn(async move {
+                        spawn_named("framework::dispatch::message", async move {
                             framework.dispatch(context, event.message).await;
                         });
                     }
@@ -212,7 +213,7 @@ pub(crate) fn dispatch<'rec>(
 
                         let framework = Arc::clone(framework);
 
-                        tokio::spawn(async move {
+                        spawn_named("framework::dispatch::message", async move {
                             framework.dispatch(context, event.message).await;
                         });
                     }
@@ -253,7 +254,7 @@ pub(crate) fn dispatch<'rec>(
 
                             let framework = Arc::clone(framework);
 
-                            tokio::spawn(async move {
+                            spawn_named("framework::dispatch::message", async move {
                                 framework.dispatch(context, message).await;
                             });
                         } else {
@@ -290,7 +291,7 @@ pub(crate) fn dispatch<'rec>(
 
                             let framework = Arc::clone(framework);
                             let message = event.message;
-                            tokio::spawn(async move {
+                            spawn_named("framework::dispatch::message", async move {
                                 framework.dispatch(context, message).await;
                             });
                         }
@@ -318,7 +319,7 @@ async fn dispatch_message(
 
     let event_handler = Arc::clone(event_handler);
 
-    tokio::spawn(async move {
+    spawn_named("event_handler::dispatch::message", async move {
         event_handler.message(context, message).await;
     });
 }
@@ -342,7 +343,7 @@ async fn handle_event(
         DispatchEvent::Client(ClientEvent::ShardStageUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::shard_stage_update", async move {
                 event_handler.shard_stage_update(context, event).await;
             });
         },
@@ -352,14 +353,14 @@ async fn handle_event(
                 Channel::Guild(channel) => {
                     let event_handler = Arc::clone(event_handler);
 
-                    tokio::spawn(async move {
+                    spawn_named("event_handler::dispatch::channel_create", async move {
                         event_handler.channel_create(context, &channel).await;
                     });
                 },
                 Channel::Category(channel) => {
                     let event_handler = Arc::clone(event_handler);
 
-                    tokio::spawn(async move {
+                    spawn_named("event_handler::dispatch::category_create", async move {
                         event_handler.category_create(context, &channel).await;
                     });
                 },
@@ -375,14 +376,14 @@ async fn handle_event(
                 Channel::Guild(channel) => {
                     let event_handler = Arc::clone(event_handler);
 
-                    tokio::spawn(async move {
+                    spawn_named("event_handler::dispatch::channel_delete", async move {
                         event_handler.channel_delete(context, &channel).await;
                     });
                 },
                 Channel::Category(channel) => {
                     let event_handler = Arc::clone(event_handler);
 
-                    tokio::spawn(async move {
+                    spawn_named("event_handler::dispatch::category_delete", async move {
                         event_handler.category_delete(context, &channel).await;
                     });
                 },
@@ -391,14 +392,14 @@ async fn handle_event(
         DispatchEvent::Model(Event::ChannelPinsUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::channel_pins_update", async move {
                 event_handler.channel_pins_update(context, event).await;
             });
         },
         DispatchEvent::Model(Event::ChannelUpdate(mut event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::channel_update", async move {
                 feature_cache! {{
                     let old_channel = cache_and_http.cache.as_ref().channel(event.channel.id()).await;
                     update(&cache_and_http, &mut event).await;
@@ -414,14 +415,14 @@ async fn handle_event(
         DispatchEvent::Model(Event::GuildBanAdd(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_ban_addition", async move {
                 event_handler.guild_ban_addition(context, event.guild_id, event.user).await;
             });
         },
         DispatchEvent::Model(Event::GuildBanRemove(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_ban_removal", async move {
                 event_handler.guild_ban_removal(context, event.guild_id, event.user).await;
             });
         },
@@ -447,7 +448,7 @@ async fn handle_event(
                         .collect::<Vec<GuildId>>();
                     let event_handler = Arc::clone(event_handler);
 
-                    tokio::spawn(async move {
+                    spawn_named("event_handler::dispatch::cache_ready", async move {
                         event_handler.cache_ready(context, guild_amount).await;
                     });
                 }
@@ -455,7 +456,7 @@ async fn handle_event(
 
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_create", async move {
                 feature_cache! {{
                     event_handler.guild_create(context, event.guild, _is_new).await;
                 } else {
@@ -467,7 +468,7 @@ async fn handle_event(
             let _full = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_delete", async move {
                 feature_cache! {{
                     event_handler.guild_delete(context, event.guild, _full).await;
                 } else {
@@ -479,14 +480,14 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_emojis_update", async move {
                 event_handler.guild_emojis_update(context, event.guild_id, event.emojis).await;
             });
         },
         DispatchEvent::Model(Event::GuildIntegrationsUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_integrations_update", async move {
                 event_handler.guild_integrations_update(context, event.guild_id).await;
             });
         },
@@ -495,7 +496,7 @@ async fn handle_event(
 
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_member_addition", async move {
                 event_handler.guild_member_addition(context, event.guild_id, event.member).await;
             });
         },
@@ -503,7 +504,7 @@ async fn handle_event(
             let _member = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_member_removal", async move {
                 feature_cache! {{
                     event_handler.guild_member_removal(context, event.guild_id, event.user, _member).await;
                 } else {
@@ -521,7 +522,7 @@ async fn handle_event(
 
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_member_update", async move {
                 feature_cache! {{
                     if let Some(after) = _after {
                         event_handler.guild_member_update(context, _before, after).await;
@@ -535,7 +536,7 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_members_chunk", async move {
                 event_handler.guild_members_chunk(context, event).await;
             });
         },
@@ -543,7 +544,7 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_role_create", async move {
                 event_handler.guild_role_create(context, event.guild_id, event.role).await;
             });
         },
@@ -551,7 +552,7 @@ async fn handle_event(
             let _role = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_role_delete", async move {
                 feature_cache! {{
                     event_handler.guild_role_delete(context, event.guild_id, event.role_id, _role).await;
                 } else {
@@ -563,7 +564,7 @@ async fn handle_event(
             let _before = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_role_update", async move {
                 feature_cache! {{
                     event_handler.guild_role_update(context, event.guild_id, _before, event.role).await;
                 } else {
@@ -575,14 +576,14 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_unavailable", async move {
                 event_handler.guild_unavailable(context, event.guild_id).await;
             });
         },
         DispatchEvent::Model(Event::GuildUpdate(mut event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::guild_update", async move {
                 feature_cache! {{
                     let before = cache_and_http.cache
                         .guild(&event.guild.id)
@@ -601,14 +602,14 @@ async fn handle_event(
         DispatchEvent::Model(Event::InviteCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::invite_create", async move {
                 event_handler.invite_create(context, event).await;
             });
         },
         DispatchEvent::Model(Event::InviteDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::invite_delete", async move {
                 event_handler.invite_delete(context, event).await;
             });
         },
@@ -617,7 +618,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::MessageDeleteBulk(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::message_delete_bulk", async move {
                 event_handler
                     .message_delete_bulk(context, event.channel_id, event.ids, event.guild_id)
                     .await;
@@ -626,7 +627,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::MessageDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::message_delete", async move {
                 event_handler
                     .message_delete(context, event.channel_id, event.message_id, event.guild_id)
                     .await;
@@ -636,7 +637,7 @@ async fn handle_event(
             let _before = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::message_update", async move {
                 feature_cache! {{
                     let _after = cache_and_http.cache.message(event.channel_id, event.id).await;
                     event_handler.message_update(context, _before, _after, event).await;
@@ -649,7 +650,7 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::presence_replace", async move {
                 event_handler.presence_replace(context, event.presences).await;
             });
         },
@@ -658,28 +659,28 @@ async fn handle_event(
 
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::presence_update", async move {
                 event_handler.presence_update(context, event).await;
             });
         },
         DispatchEvent::Model(Event::ReactionAdd(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::reaction_add", async move {
                 event_handler.reaction_add(context, event.reaction).await;
             });
         },
         DispatchEvent::Model(Event::ReactionRemove(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::reaction_remove", async move {
                 event_handler.reaction_remove(context, event.reaction).await;
             });
         },
         DispatchEvent::Model(Event::ReactionRemoveAll(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::remove_all", async move {
                 event_handler
                     .reaction_remove_all(context, event.channel_id, event.message_id)
                     .await;
@@ -689,28 +690,28 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::ready", async move {
                 event_handler.ready(context, event.ready).await;
             });
         },
         DispatchEvent::Model(Event::Resumed(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::resume", async move {
                 event_handler.resume(context, event).await;
             });
         },
         DispatchEvent::Model(Event::TypingStart(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::typing_start", async move {
                 event_handler.typing_start(context, event).await;
             });
         },
         DispatchEvent::Model(Event::Unknown(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::unknown", async move {
                 event_handler.unknown(context, event.kind, event.value).await;
             });
         },
@@ -718,7 +719,7 @@ async fn handle_event(
             let _before = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::user_update", async move {
                 feature_cache! {{
                     event_handler.user_update(context, _before.expect("missing old user"), event.current_user).await;
                 } else {
@@ -729,7 +730,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::VoiceServerUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::voice_server_update", async move {
                 event_handler.voice_server_update(context, event).await;
             });
         },
@@ -737,7 +738,7 @@ async fn handle_event(
             let _before = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::voice_state_update", async move {
                 feature_cache! {{
                     event_handler.voice_state_update(context, event.guild_id, _before, event.voice_state).await;
                 } else {
@@ -748,7 +749,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::WebhookUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::webhook_update", async move {
                 event_handler.webhook_update(context, event.guild_id, event.channel_id).await;
             });
         },
@@ -756,7 +757,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::InteractionCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::interaction_create", async move {
                 event_handler.interaction_create(context, event.interaction).await;
             });
         },
@@ -764,7 +765,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::IntegrationCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::integration_create", async move {
                 event_handler.integration_create(context, event.integration).await;
             });
         },
@@ -772,7 +773,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::IntegrationUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::integration_update", async move {
                 event_handler.integration_update(context, event.integration).await;
             });
         },
@@ -780,7 +781,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::IntegrationDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::integration_delete", async move {
                 event_handler
                     .integration_delete(context, event.id, event.guild_id, event.application_id)
                     .await;
@@ -790,7 +791,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::ApplicationCommandCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::application_command_create", async move {
                 event_handler.application_command_create(context, event.application_command).await;
             });
         },
@@ -798,7 +799,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::ApplicationCommandUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::application_command_update", async move {
                 event_handler.application_command_update(context, event.application_command).await;
             });
         },
@@ -806,70 +807,70 @@ async fn handle_event(
         DispatchEvent::Model(Event::ApplicationCommandDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::application_command_delete", async move {
                 event_handler.application_command_delete(context, event.application_command).await;
             });
         },
         DispatchEvent::Model(Event::StageInstanceCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::stage_instance_create", async move {
                 event_handler.stage_instance_create(context, event.stage_instance).await;
             });
         },
         DispatchEvent::Model(Event::StageInstanceUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::stage_instance_update", async move {
                 event_handler.stage_instance_update(context, event.stage_instance).await;
             });
         },
         DispatchEvent::Model(Event::StageInstanceDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::stage_instance_delete", async move {
                 event_handler.stage_instance_delete(context, event.stage_instance).await;
             });
         },
         DispatchEvent::Model(Event::ThreadCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::thread_create", async move {
                 event_handler.thread_create(context, event.thread).await;
             });
         },
         DispatchEvent::Model(Event::ThreadUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::thread_update", async move {
                 event_handler.thread_update(context, event.thread).await;
             });
         },
         DispatchEvent::Model(Event::ThreadDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::thread_delete", async move {
                 event_handler.thread_delete(context, event.thread).await;
             });
         },
         DispatchEvent::Model(Event::ThreadListSync(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::thread_list_sync", async move {
                 event_handler.thread_list_sync(context, event).await;
             });
         },
         DispatchEvent::Model(Event::ThreadMemberUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::thread_member_update", async move {
                 event_handler.thread_member_update(context, event.member).await;
             });
         },
         DispatchEvent::Model(Event::ThreadMembersUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            tokio::spawn(async move {
+            spawn_named("event_handler::dispatch::thread_members_update", async move {
                 event_handler.thread_members_update(context, event).await;
             });
         },

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -180,7 +180,7 @@ pub(crate) fn dispatch<'rec>(
 
                         let framework = Arc::clone(framework);
 
-                        spawn_named("framework::dispatch::message", async move {
+                        spawn_named("dispatch::framework::message", async move {
                             framework.dispatch(context, event.message).await;
                         });
                     }
@@ -213,7 +213,7 @@ pub(crate) fn dispatch<'rec>(
 
                         let framework = Arc::clone(framework);
 
-                        spawn_named("framework::dispatch::message", async move {
+                        spawn_named("dispatch::framework::message", async move {
                             framework.dispatch(context, event.message).await;
                         });
                     }
@@ -254,7 +254,7 @@ pub(crate) fn dispatch<'rec>(
 
                             let framework = Arc::clone(framework);
 
-                            spawn_named("framework::dispatch::message", async move {
+                            spawn_named("dispatch::framework::message", async move {
                                 framework.dispatch(context, message).await;
                             });
                         } else {
@@ -291,7 +291,7 @@ pub(crate) fn dispatch<'rec>(
 
                             let framework = Arc::clone(framework);
                             let message = event.message;
-                            spawn_named("framework::dispatch::message", async move {
+                            spawn_named("dispatch::framework::message", async move {
                                 framework.dispatch(context, message).await;
                             });
                         }
@@ -319,7 +319,7 @@ async fn dispatch_message(
 
     let event_handler = Arc::clone(event_handler);
 
-    spawn_named("event_handler::dispatch::message", async move {
+    spawn_named("dispatch::event_handler::message", async move {
         event_handler.message(context, message).await;
     });
 }
@@ -343,7 +343,7 @@ async fn handle_event(
         DispatchEvent::Client(ClientEvent::ShardStageUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::shard_stage_update", async move {
+            spawn_named("dispatch::event_handler::shard_stage_update", async move {
                 event_handler.shard_stage_update(context, event).await;
             });
         },
@@ -353,14 +353,14 @@ async fn handle_event(
                 Channel::Guild(channel) => {
                     let event_handler = Arc::clone(event_handler);
 
-                    spawn_named("event_handler::dispatch::channel_create", async move {
+                    spawn_named("dispatch::event_handler::channel_create", async move {
                         event_handler.channel_create(context, &channel).await;
                     });
                 },
                 Channel::Category(channel) => {
                     let event_handler = Arc::clone(event_handler);
 
-                    spawn_named("event_handler::dispatch::category_create", async move {
+                    spawn_named("dispatch::event_handler::category_create", async move {
                         event_handler.category_create(context, &channel).await;
                     });
                 },
@@ -376,14 +376,14 @@ async fn handle_event(
                 Channel::Guild(channel) => {
                     let event_handler = Arc::clone(event_handler);
 
-                    spawn_named("event_handler::dispatch::channel_delete", async move {
+                    spawn_named("dispatch::event_handler::channel_delete", async move {
                         event_handler.channel_delete(context, &channel).await;
                     });
                 },
                 Channel::Category(channel) => {
                     let event_handler = Arc::clone(event_handler);
 
-                    spawn_named("event_handler::dispatch::category_delete", async move {
+                    spawn_named("dispatch::event_handler::category_delete", async move {
                         event_handler.category_delete(context, &channel).await;
                     });
                 },
@@ -392,14 +392,14 @@ async fn handle_event(
         DispatchEvent::Model(Event::ChannelPinsUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::channel_pins_update", async move {
+            spawn_named("dispatch::event_handler::channel_pins_update", async move {
                 event_handler.channel_pins_update(context, event).await;
             });
         },
         DispatchEvent::Model(Event::ChannelUpdate(mut event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::channel_update", async move {
+            spawn_named("dispatch::event_handler::channel_update", async move {
                 feature_cache! {{
                     let old_channel = cache_and_http.cache.as_ref().channel(event.channel.id()).await;
                     update(&cache_and_http, &mut event).await;
@@ -415,14 +415,14 @@ async fn handle_event(
         DispatchEvent::Model(Event::GuildBanAdd(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_ban_addition", async move {
+            spawn_named("dispatch::event_handler::guild_ban_addition", async move {
                 event_handler.guild_ban_addition(context, event.guild_id, event.user).await;
             });
         },
         DispatchEvent::Model(Event::GuildBanRemove(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_ban_removal", async move {
+            spawn_named("dispatch::event_handler::guild_ban_removal", async move {
                 event_handler.guild_ban_removal(context, event.guild_id, event.user).await;
             });
         },
@@ -448,7 +448,7 @@ async fn handle_event(
                         .collect::<Vec<GuildId>>();
                     let event_handler = Arc::clone(event_handler);
 
-                    spawn_named("event_handler::dispatch::cache_ready", async move {
+                    spawn_named("dispatch::event_handler::cache_ready", async move {
                         event_handler.cache_ready(context, guild_amount).await;
                     });
                 }
@@ -456,7 +456,7 @@ async fn handle_event(
 
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_create", async move {
+            spawn_named("dispatch::event_handler::guild_create", async move {
                 feature_cache! {{
                     event_handler.guild_create(context, event.guild, _is_new).await;
                 } else {
@@ -468,7 +468,7 @@ async fn handle_event(
             let _full = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_delete", async move {
+            spawn_named("dispatch::event_handler::guild_delete", async move {
                 feature_cache! {{
                     event_handler.guild_delete(context, event.guild, _full).await;
                 } else {
@@ -480,14 +480,14 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_emojis_update", async move {
+            spawn_named("dispatch::event_handler::guild_emojis_update", async move {
                 event_handler.guild_emojis_update(context, event.guild_id, event.emojis).await;
             });
         },
         DispatchEvent::Model(Event::GuildIntegrationsUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_integrations_update", async move {
+            spawn_named("dispatch::event_handler::guild_integrations_update", async move {
                 event_handler.guild_integrations_update(context, event.guild_id).await;
             });
         },
@@ -496,7 +496,7 @@ async fn handle_event(
 
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_member_addition", async move {
+            spawn_named("dispatch::event_handler::guild_member_addition", async move {
                 event_handler.guild_member_addition(context, event.guild_id, event.member).await;
             });
         },
@@ -504,7 +504,7 @@ async fn handle_event(
             let _member = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_member_removal", async move {
+            spawn_named("dispatch::event_handler::guild_member_removal", async move {
                 feature_cache! {{
                     event_handler.guild_member_removal(context, event.guild_id, event.user, _member).await;
                 } else {
@@ -522,7 +522,7 @@ async fn handle_event(
 
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_member_update", async move {
+            spawn_named("dispatch::event_handler::guild_member_update", async move {
                 feature_cache! {{
                     if let Some(after) = _after {
                         event_handler.guild_member_update(context, _before, after).await;
@@ -536,7 +536,7 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_members_chunk", async move {
+            spawn_named("dispatch::event_handler::guild_members_chunk", async move {
                 event_handler.guild_members_chunk(context, event).await;
             });
         },
@@ -544,7 +544,7 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_role_create", async move {
+            spawn_named("dispatch::event_handler::guild_role_create", async move {
                 event_handler.guild_role_create(context, event.guild_id, event.role).await;
             });
         },
@@ -552,7 +552,7 @@ async fn handle_event(
             let _role = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_role_delete", async move {
+            spawn_named("dispatch::event_handler::guild_role_delete", async move {
                 feature_cache! {{
                     event_handler.guild_role_delete(context, event.guild_id, event.role_id, _role).await;
                 } else {
@@ -564,7 +564,7 @@ async fn handle_event(
             let _before = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_role_update", async move {
+            spawn_named("dispatch::event_handler::guild_role_update", async move {
                 feature_cache! {{
                     event_handler.guild_role_update(context, event.guild_id, _before, event.role).await;
                 } else {
@@ -576,14 +576,14 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_unavailable", async move {
+            spawn_named("dispatch::event_handler::guild_unavailable", async move {
                 event_handler.guild_unavailable(context, event.guild_id).await;
             });
         },
         DispatchEvent::Model(Event::GuildUpdate(mut event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::guild_update", async move {
+            spawn_named("dispatch::event_handler::guild_update", async move {
                 feature_cache! {{
                     let before = cache_and_http.cache
                         .guild(&event.guild.id)
@@ -602,14 +602,14 @@ async fn handle_event(
         DispatchEvent::Model(Event::InviteCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::invite_create", async move {
+            spawn_named("dispatch::event_handler::invite_create", async move {
                 event_handler.invite_create(context, event).await;
             });
         },
         DispatchEvent::Model(Event::InviteDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::invite_delete", async move {
+            spawn_named("dispatch::event_handler::invite_delete", async move {
                 event_handler.invite_delete(context, event).await;
             });
         },
@@ -618,7 +618,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::MessageDeleteBulk(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::message_delete_bulk", async move {
+            spawn_named("dispatch::event_handler::message_delete_bulk", async move {
                 event_handler
                     .message_delete_bulk(context, event.channel_id, event.ids, event.guild_id)
                     .await;
@@ -627,7 +627,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::MessageDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::message_delete", async move {
+            spawn_named("dispatch::event_handler::message_delete", async move {
                 event_handler
                     .message_delete(context, event.channel_id, event.message_id, event.guild_id)
                     .await;
@@ -637,7 +637,7 @@ async fn handle_event(
             let _before = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::message_update", async move {
+            spawn_named("dispatch::event_handler::message_update", async move {
                 feature_cache! {{
                     let _after = cache_and_http.cache.message(event.channel_id, event.id).await;
                     event_handler.message_update(context, _before, _after, event).await;
@@ -650,7 +650,7 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::presence_replace", async move {
+            spawn_named("dispatch::event_handler::presence_replace", async move {
                 event_handler.presence_replace(context, event.presences).await;
             });
         },
@@ -659,28 +659,28 @@ async fn handle_event(
 
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::presence_update", async move {
+            spawn_named("dispatch::event_handler::presence_update", async move {
                 event_handler.presence_update(context, event).await;
             });
         },
         DispatchEvent::Model(Event::ReactionAdd(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::reaction_add", async move {
+            spawn_named("dispatch::event_handler::reaction_add", async move {
                 event_handler.reaction_add(context, event.reaction).await;
             });
         },
         DispatchEvent::Model(Event::ReactionRemove(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::reaction_remove", async move {
+            spawn_named("dispatch::event_handler::reaction_remove", async move {
                 event_handler.reaction_remove(context, event.reaction).await;
             });
         },
         DispatchEvent::Model(Event::ReactionRemoveAll(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::remove_all", async move {
+            spawn_named("dispatch::event_handler::remove_all", async move {
                 event_handler
                     .reaction_remove_all(context, event.channel_id, event.message_id)
                     .await;
@@ -690,28 +690,28 @@ async fn handle_event(
             update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::ready", async move {
+            spawn_named("dispatch::event_handler::ready", async move {
                 event_handler.ready(context, event.ready).await;
             });
         },
         DispatchEvent::Model(Event::Resumed(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::resume", async move {
+            spawn_named("dispatch::event_handler::resume", async move {
                 event_handler.resume(context, event).await;
             });
         },
         DispatchEvent::Model(Event::TypingStart(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::typing_start", async move {
+            spawn_named("dispatch::event_handler::typing_start", async move {
                 event_handler.typing_start(context, event).await;
             });
         },
         DispatchEvent::Model(Event::Unknown(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::unknown", async move {
+            spawn_named("dispatch::event_handler::unknown", async move {
                 event_handler.unknown(context, event.kind, event.value).await;
             });
         },
@@ -719,7 +719,7 @@ async fn handle_event(
             let _before = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::user_update", async move {
+            spawn_named("dispatch::event_handler::user_update", async move {
                 feature_cache! {{
                     event_handler.user_update(context, _before.expect("missing old user"), event.current_user).await;
                 } else {
@@ -730,7 +730,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::VoiceServerUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::voice_server_update", async move {
+            spawn_named("dispatch::event_handler::voice_server_update", async move {
                 event_handler.voice_server_update(context, event).await;
             });
         },
@@ -738,7 +738,7 @@ async fn handle_event(
             let _before = update(&cache_and_http, &mut event).await;
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::voice_state_update", async move {
+            spawn_named("dispatch::event_handler::voice_state_update", async move {
                 feature_cache! {{
                     event_handler.voice_state_update(context, event.guild_id, _before, event.voice_state).await;
                 } else {
@@ -749,7 +749,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::WebhookUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::webhook_update", async move {
+            spawn_named("dispatch::event_handler::webhook_update", async move {
                 event_handler.webhook_update(context, event.guild_id, event.channel_id).await;
             });
         },
@@ -757,7 +757,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::InteractionCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::interaction_create", async move {
+            spawn_named("dispatch::event_handler::interaction_create", async move {
                 event_handler.interaction_create(context, event.interaction).await;
             });
         },
@@ -765,7 +765,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::IntegrationCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::integration_create", async move {
+            spawn_named("dispatch::event_handler::integration_create", async move {
                 event_handler.integration_create(context, event.integration).await;
             });
         },
@@ -773,7 +773,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::IntegrationUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::integration_update", async move {
+            spawn_named("dispatch::event_handler::integration_update", async move {
                 event_handler.integration_update(context, event.integration).await;
             });
         },
@@ -781,7 +781,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::IntegrationDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::integration_delete", async move {
+            spawn_named("dispatch::event_handler::integration_delete", async move {
                 event_handler
                     .integration_delete(context, event.id, event.guild_id, event.application_id)
                     .await;
@@ -791,7 +791,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::ApplicationCommandCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::application_command_create", async move {
+            spawn_named("dispatch::event_handler::application_command_create", async move {
                 event_handler.application_command_create(context, event.application_command).await;
             });
         },
@@ -799,7 +799,7 @@ async fn handle_event(
         DispatchEvent::Model(Event::ApplicationCommandUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::application_command_update", async move {
+            spawn_named("dispatch::event_handler::application_command_update", async move {
                 event_handler.application_command_update(context, event.application_command).await;
             });
         },
@@ -807,70 +807,70 @@ async fn handle_event(
         DispatchEvent::Model(Event::ApplicationCommandDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::application_command_delete", async move {
+            spawn_named("dispatch::event_handler::application_command_delete", async move {
                 event_handler.application_command_delete(context, event.application_command).await;
             });
         },
         DispatchEvent::Model(Event::StageInstanceCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::stage_instance_create", async move {
+            spawn_named("dispatch::event_handler::stage_instance_create", async move {
                 event_handler.stage_instance_create(context, event.stage_instance).await;
             });
         },
         DispatchEvent::Model(Event::StageInstanceUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::stage_instance_update", async move {
+            spawn_named("dispatch::event_handler::stage_instance_update", async move {
                 event_handler.stage_instance_update(context, event.stage_instance).await;
             });
         },
         DispatchEvent::Model(Event::StageInstanceDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::stage_instance_delete", async move {
+            spawn_named("dispatch::event_handler::stage_instance_delete", async move {
                 event_handler.stage_instance_delete(context, event.stage_instance).await;
             });
         },
         DispatchEvent::Model(Event::ThreadCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::thread_create", async move {
+            spawn_named("dispatch::event_handler::thread_create", async move {
                 event_handler.thread_create(context, event.thread).await;
             });
         },
         DispatchEvent::Model(Event::ThreadUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::thread_update", async move {
+            spawn_named("dispatch::event_handler::thread_update", async move {
                 event_handler.thread_update(context, event.thread).await;
             });
         },
         DispatchEvent::Model(Event::ThreadDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::thread_delete", async move {
+            spawn_named("dispatch::event_handler::thread_delete", async move {
                 event_handler.thread_delete(context, event.thread).await;
             });
         },
         DispatchEvent::Model(Event::ThreadListSync(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::thread_list_sync", async move {
+            spawn_named("dispatch::event_handler::thread_list_sync", async move {
                 event_handler.thread_list_sync(context, event).await;
             });
         },
         DispatchEvent::Model(Event::ThreadMemberUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::thread_member_update", async move {
+            spawn_named("dispatch::event_handler::thread_member_update", async move {
                 event_handler.thread_member_update(context, event.member).await;
             });
         },
         DispatchEvent::Model(Event::ThreadMembersUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
-            spawn_named("event_handler::dispatch::thread_members_update", async move {
+            spawn_named("dispatch::event_handler::thread_members_update", async move {
                 event_handler.thread_members_update(context, event).await;
             });
         },

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 use futures::future::BoxFuture;
 
 use crate::client::Context;
+use crate::internal::tokio::spawn_named;
 use crate::model::channel::Message;
 
 type Check = for<'fut> fn(&'fut Context, &'fut Message) -> BoxFuture<'fut, bool>;
@@ -205,7 +206,7 @@ impl TicketCounter {
                             let ctx = ctx.clone();
                             let msg = msg.clone();
 
-                            tokio::spawn(async move {
+                            spawn_named("buckets::delay_action", async move {
                                 delay_action(&ctx, &msg).await;
                             });
                         }
@@ -253,7 +254,7 @@ impl TicketCounter {
                     let ctx = ctx.clone();
                     let msg = msg.clone();
 
-                    tokio::spawn(async move {
+                    spawn_named("buckets::delay_action", async move {
                         delay_action(&ctx, &msg).await;
                     });
                 }

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -9,6 +9,7 @@ use tokio::{
     time::Duration,
 };
 
+use crate::internal::tokio::spawn_named;
 use crate::{error::Result, http::Http};
 
 /// A struct to start typing in a [`Channel`] for an indefinite period of time.
@@ -68,7 +69,7 @@ impl Typing {
     pub fn start(http: Arc<Http>, channel_id: u64) -> Result<Self> {
         let (sx, mut rx) = oneshot::channel();
 
-        tokio::spawn(async move {
+        spawn_named("typing::start", async move {
             loop {
                 match rx.try_recv() {
                     Ok(_) | Err(TryRecvError::Closed) => break,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -5,3 +5,5 @@ pub mod prelude;
 
 #[cfg(feature = "gateway")]
 pub mod ws_impl;
+
+pub mod tokio;

--- a/src/internal/tokio.rs
+++ b/src/internal/tokio.rs
@@ -1,0 +1,13 @@
+pub fn spawn_named<T>(
+    name: &str,
+    future: impl std::future::Future<Output = T> + Send + 'static,
+) -> tokio::task::JoinHandle<T>
+where
+    T: Send + 'static,
+{
+    #[cfg(tokio_unstable)]
+    return tokio::task::Builder::new().name(format!("serenity::{}", name)).spawn(future);
+
+    #[cfg(not(tokio_unstable))]
+    tokio::spawn(future)
+}

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -448,5 +448,5 @@ pub enum InviteTargetType {
 enum_number!(InviteTargetType {
     Normal,
     Stream,
-    EmmbeddedApplication,
+    EmmbeddedApplication
 });

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -448,5 +448,5 @@ pub enum InviteTargetType {
 enum_number!(InviteTargetType {
     Normal,
     Stream,
-    EmmbeddedApplication
+    EmmbeddedApplication,
 });


### PR DESCRIPTION
This PR replaces calls to `tokio::spawn` with an internal function called `spawn_named`. This is to assign names to tasks spawned by the library. For use with https://github.com/tokio-rs/console.