### PR TITLE
Add thread editing

### DIFF
--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use crate::internal::prelude::*;
+
+#[derive(Debug, Clone, Default)]
+pub struct EditThread(pub HashMap<&'static str, Value>);
+
+impl EditThread {
+    /// The name of the thread.
+    ///
+    /// **Note**: Must be between 2 and 100 characters long.
+    pub fn name<D: ToString>(&mut self, name: D) -> &mut Self {
+        self.0.insert("name", Value::String(name.to_string()));
+
+        self
+    }
+
+    /// Duration in minutes to automatically archive the thread after recent activity.
+    ///
+    /// **Note**: Can only be set to 60, 1440, 4320, 10080 currently.
+    pub fn auto_archive_duration(&mut self, duration: u16) -> &mut Self {
+        self.0.insert("auto_archive_duration", Value::Number(Number::from(duration)));
+
+        self
+    }
+
+    /// The archive status of the thread.
+    ///
+    /// **Note**: A thread that is `locked` can only be unarchived if the user has the `MANAGE_THREADS` permission.
+    pub fn archived(&mut self, archived: bool) -> &mut Self {
+        self.0.insert("archived", Value::Bool(archived));
+
+        self
+    }
+
+    /// The lock status of the thread.
+    pub fn locked(&mut self, lock: bool) -> &mut Self {
+        self.0.insert("locked", Value::Bool(lock));
+
+        self
+    }
+}

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -42,6 +42,7 @@ mod edit_message;
 mod edit_profile;
 mod edit_role;
 mod edit_stage_instance;
+mod edit_thread;
 mod edit_voice_state;
 mod edit_webhook_message;
 mod execute_webhook;
@@ -66,6 +67,7 @@ pub use self::{
     edit_profile::EditProfile,
     edit_role::EditRole,
     edit_stage_instance::EditStageInstance,
+    edit_thread::EditThread,
     edit_voice_state::EditVoiceState,
     edit_webhook_message::EditWebhookMessage,
     execute_webhook::ExecuteWebhook,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -406,6 +406,20 @@ impl Http {
         .await
     }
 
+    /// Edits a thread channel in the [`GuildChannel`] given its Id.
+    pub async fn edit_thread(&self, channel_id: u64, map: &JsonMap) -> Result<GuildChannel> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditThread {
+                channel_id,
+            },
+        })
+        .await
+    }
+
     /// Creates a private thread channel in the [`GuildChannel`] given its Id.
     pub async fn create_private_thread(
         &self,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -406,20 +406,6 @@ impl Http {
         .await
     }
 
-    /// Edits a thread channel in the [`GuildChannel`] given its Id.
-    pub async fn edit_thread(&self, channel_id: u64, map: &JsonMap) -> Result<GuildChannel> {
-        let body = serde_json::to_vec(map)?;
-
-        self.fire(Request {
-            body: Some(&body),
-            headers: None,
-            route: RouteInfo::EditThread {
-                channel_id,
-            },
-        })
-        .await
-    }
-
     /// Creates a private thread channel in the [`GuildChannel`] given its Id.
     pub async fn create_private_thread(
         &self,
@@ -1569,6 +1555,20 @@ impl Http {
         }
 
         serde_json::from_value(value).map_err(From::from)
+    }
+
+    /// Edits a thread channel in the [`GuildChannel`] given its Id.
+    pub async fn edit_thread(&self, channel_id: u64, map: &JsonMap) -> Result<GuildChannel> {
+        let body = serde_json::to_vec(map)?;
+
+        self.fire(Request {
+            body: Some(&body),
+            headers: None,
+            route: RouteInfo::EditThread {
+                channel_id,
+            },
+        })
+        .await
     }
 
     /// Changes another user's voice state in a stage channel.

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1289,6 +1289,9 @@ pub enum RouteInfo<'a> {
     EditRolePosition {
         guild_id: u64,
     },
+    EditThread {
+        channel_id: u64,
+    },
     EditVoiceState {
         guild_id: u64,
         user_id: u64,
@@ -2085,6 +2088,13 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Patch,
                 Route::GuildsIdRolesId(guild_id),
                 Cow::from(Route::guild_roles(guild_id)),
+            ),
+            RouteInfo::EditThread {
+                channel_id,
+            } => (
+                LightMethod::Patch,
+                Route::ChannelsId(channel_id),
+                Cow::from(Route::channel(channel_id)),
             ),
             RouteInfo::EditVoiceState {
                 guild_id,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -20,6 +20,7 @@ use crate::builder::{
     CreateThread,
     EditChannel,
     EditMessage,
+    EditThread,
     GetMessages,
 };
 use crate::builder::{CreateStageInstance, EditStageInstance};
@@ -1032,6 +1033,23 @@ impl ChannelId {
         let map = utils::hashmap_to_json_map(instance.0);
 
         http.as_ref().edit_stage_instance(self.0, &Value::Object(map)).await
+    }
+
+    /// Edits a thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn edit_thread<F>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildChannel>
+    where
+        F: FnOnce(&mut EditThread) -> &mut EditThread,
+    {
+        let mut instance = EditThread::default();
+        f(&mut instance);
+
+        let map = utils::hashmap_to_json_map(instance.0);
+
+        http.as_ref().edit_thread(self.0, &map).await
     }
 
     /// Deletes a stage instance.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -15,6 +15,7 @@ use crate::builder::{
     CreateMessage,
     CreateThread,
     EditMessage,
+    EditThread,
     EditVoiceState,
     GetMessages,
 };
@@ -483,6 +484,18 @@ impl GuildChannel {
         F: FnOnce(&mut EditMessage) -> &mut EditMessage,
     {
         self.id.edit_message(&http, message_id, f).await
+    }
+
+    /// Edits a thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn edit_thread<F>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildChannel>
+    where
+        F: FnOnce(&mut EditThread) -> &mut EditThread,
+    {
+        self.id.edit_thread(http, f).await
     }
 
     /// Edits a voice state in a stage channel. Pass [`None`] for `user_id` to


### PR DESCRIPTION
This PR adds the `edit_thread` method to `Client`, `ChannelId`, and `GuildChannel`.

This allows the following properties of threads to be edited by this library:

* name
* auto-archive duration
* archived state
* locked state

This PR would also close #1510.