### PR TITLE
Specify MSRV for clippy and use stable toolchain for the lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         id: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy
           profile: minimal
           override: true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,4 @@
+msrv = "1.48"
 cognitive-complexity-threshold = 20
 doc-valid-idents = [
     "UserAgent",


### PR DESCRIPTION
I think it's more stable to switch to stable for clippy. :)
And specifying the MSRV for clippy would also disable lints that require compiler features above the MSRV.