### PR TITLE
Fix support for raw identifiers in proc macros

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -104,7 +104,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
     let _name = if !attr.is_empty() {
         parse_macro_input!(attr as Lit).to_str()
     } else {
-        fun.name.to_string()
+        fun.name.to_string_non_raw()
     };
 
     let mut options = Options::new();
@@ -622,7 +622,7 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
     let name = if !attr.is_empty() {
         parse_macro_input!(attr as Lit).to_str()
     } else {
-        group.name.to_string()
+        group.name.to_string_non_raw()
     };
 
     let mut options = GroupOptions::new();

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -54,19 +54,27 @@ impl LitExt for Lit {
 }
 
 pub trait IdentExt2: Sized {
+    fn to_string_non_raw(&self) -> String;
     fn to_uppercase(&self) -> Self;
     fn with_suffix(&self, suf: &str) -> Ident;
 }
 
 impl IdentExt2 for Ident {
     #[inline]
+    fn to_string_non_raw(&self) -> String {
+        let ident_string = self.to_string();
+        ident_string.trim_start_matches("r#").into()
+    }
+
+    #[inline]
     fn to_uppercase(&self) -> Self {
-        format_ident!("{}", self.to_string().to_uppercase())
+        // This should be valid because keywords are lowercase.
+        format_ident!("{}", self.to_string_non_raw().to_uppercase())
     }
 
     #[inline]
     fn with_suffix(&self, suffix: &str) -> Ident {
-        format_ident!("{}_{}", self.to_string().to_uppercase(), suffix)
+        format_ident!("{}_{}", self.to_uppercase(), suffix)
     }
 }
 


### PR DESCRIPTION
You can now declare commands and groups with raw identifiers and they will be referenced and used through the non-raw version of their name.

Fixes #1454