### PR TITLE
Simplify tracing_subscriber initialization in the examples

### DIFF
--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -22,7 +22,6 @@ use serenity::{
     prelude::*,
 };
 use tracing::{error, info};
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 pub struct ShardManagerContainer;
 
@@ -57,10 +56,7 @@ async fn main() {
     //
     // In this case, a good default is setting the environment variable
     // `RUST_LOG` to debug`.
-    let subscriber =
-        FmtSubscriber::builder().with_env_filter(EnvFilter::from_default_env()).finish();
-
-    tracing::subscriber::set_global_default(subscriber).expect("Failed to start the logger");
+    tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 

--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -55,7 +55,7 @@ async fn main() {
     // Initialize the logger to use environment variables.
     //
     // In this case, a good default is setting the environment variable
-    // `RUST_LOG` to debug`.
+    // `RUST_LOG` to `debug`.
     tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");

--- a/examples/e15_simple_dashboard/Cargo.toml
+++ b/examples/e15_simple_dashboard/Cargo.toml
@@ -10,7 +10,6 @@ rillrate = "0.39"
 
 tracing = "0.1"
 tracing-subscriber = "0.2"
-tracing-log = "0.1"
 
 webbrowser = "0.5"
 

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -335,15 +335,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         "info,e15_simple_dashboard=trace,meio=warn,rate_core=warn,rill_engine=warn",
     );
 
-    // Increase compatibility with tracing and the log crate macros used by RillRate.
-    // Some weird things get logged without this if you use tracing.
-    tracing_log::LogTracer::init()?;
-    // Since we use tracing_log, we need to use a different way of subscribing to tracing events
-    // than shown in example 7.
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+    // Initialize the logger to use environment variables.
+    //
+    // In this case, a good default is setting the environment variable
+    // `RUST_LOG` to debug`.
+    tracing_subscriber::fmt::init();
 
     // Start a server on `http://0.0.0.0:6361/`
     // Currently the port is not configurable, but it will be soon enough; thankfully it's not a

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -338,7 +338,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // Initialize the logger to use environment variables.
     //
     // In this case, a good default is setting the environment variable
-    // `RUST_LOG` to debug`.
+    // `RUST_LOG` to `debug`, but for production, use the variable defined above.
     tracing_subscriber::fmt::init();
 
     // Start a server on `http://0.0.0.0:6361/`


### PR DESCRIPTION
The default features of `tracing_subscriber` already initialize `tracing` with
`tracing_log` and the env filter when `tracing_subscriber::fmt::init()` is used.

See [EnvFilter] & [LogTrace] init

[EnvFilter]: https://github.com/tokio-rs/tracing/blob/tracing-subscriber-0.2.24/tracing-subscriber/src/fmt/mod.rs#L1074-L1107
[LogTrace]: https://github.com/tokio-rs/tracing/blob/tracing-subscriber-0.2.24/tracing-subscriber/src/util.rs#L41-L70