### PR TITLE
Remove the unused function names from the colour macro

### DIFF
--- a/src/utils/colour.rs
+++ b/src/utils/colour.rs
@@ -1,17 +1,6 @@
 // Disable this lint to avoid it wanting to change `0xABCDEF` to `0xAB_CDEF`.
 #![allow(clippy::unreadable_literal)]
 
-macro_rules! colour {
-    ($(#[$attr:meta] $constname:ident, $name:ident, $val:expr;)*) => {
-        impl Colour {
-            $(
-                #[$attr]
-                pub const $constname: Colour = Colour($val);
-            )*
-        }
-    }
-}
-
 /// A utility struct to help with working with the basic representation of a
 /// colour. This is particularly useful when working with a [`Role`]'s colour,
 /// as the API works with an integer value instead of an RGB value.
@@ -269,63 +258,74 @@ impl From<(u8, u8, u8)> for Colour {
     }
 }
 
+macro_rules! colour {
+    ($(#[$attr:meta] $constname:ident, $val:expr;)*) => {
+        impl Colour {
+            $(
+                #[$attr]
+                pub const $constname: Colour = Colour($val);
+            )*
+        }
+    }
+}
+
 colour! {
     /// Creates a new [`Colour`], setting its RGB value to `(111, 198, 226)`.
-    BLITZ_BLUE, blitz_blue, 0x6FC6E2;
+    BLITZ_BLUE, 0x6FC6E2;
     /// Creates a new [`Colour`], setting its RGB value to `(52, 152, 219)`.
-    BLUE, blue, 0x3498DB;
+    BLUE, 0x3498DB;
     /// Creates a new [`Colour`], setting its RGB value to `(114, 137, 218)`.
-    BLURPLE, blurple, 0x7289DA;
+    BLURPLE, 0x7289DA;
     /// Creates a new [`Colour`], setting its RGB value to `(32, 102, 148)`.
-    DARK_BLUE, dark_blue, 0x206694;
+    DARK_BLUE, 0x206694;
     /// Creates a new [`Colour`], setting its RGB value to `(194, 124, 14)`.
-    DARK_GOLD, dark_gold, 0xC27C0E;
+    DARK_GOLD, 0xC27C0E;
     /// Creates a new [`Colour`], setting its RGB value to `(31, 139, 76)`.
-    DARK_GREEN, dark_green, 0x1F8B4C;
+    DARK_GREEN, 0x1F8B4C;
     /// Creates a new [`Colour`], setting its RGB value to `(96, 125, 139)`.
-    DARK_GREY, dark_grey, 0x607D8B;
+    DARK_GREY, 0x607D8B;
     /// Creates a new [`Colour`], setting its RGB value to `(173, 20, 87)`.
-    DARK_MAGENTA, dark_magenta, 0xAD1457;
+    DARK_MAGENTA, 0xAD1457;
     /// Creates a new [`Colour`], setting its RGB value to `(168, 67, 0)`.
-    DARK_ORANGE, dark_orange, 0xA84300;
+    DARK_ORANGE, 0xA84300;
     /// Creates a new [`Colour`], setting its RGB value to `(113, 54, 138)`.
-    DARK_PURPLE, dark_purple, 0x71368A;
+    DARK_PURPLE, 0x71368A;
     /// Creates a new [`Colour`], setting its RGB value to `(153, 45, 34)`.
-    DARK_RED, dark_red, 0x992D22;
+    DARK_RED, 0x992D22;
     /// Creates a new [`Colour`], setting its RGB value to `(17, 128, 106)`.
-    DARK_TEAL, dark_teal, 0x11806A;
+    DARK_TEAL, 0x11806A;
     /// Creates a new [`Colour`], setting its RGB value to `(84, 110, 122)`.
-    DARKER_GREY, darker_grey, 0x546E7A;
+    DARKER_GREY, 0x546E7A;
     /// Creates a new [`Colour`], setting its RGB value to `(250, 177, 237)`.
-    FABLED_PINK, fabled_pink, 0xFAB1ED;
+    FABLED_PINK, 0xFAB1ED;
     /// Creates a new [`Colour`], setting its RGB value to `(136, 130, 196)`.
-    FADED_PURPLE, faded_purple, 0x8882C4;
+    FADED_PURPLE, 0x8882C4;
     /// Creates a new [`Colour`], setting its RGB value to `(17, 202, 128)`.
-    FOOYOO, fooyoo, 0x11CA80;
+    FOOYOO, 0x11CA80;
     /// Creates a new [`Colour`], setting its RGB value to `(241, 196, 15)`.
-    GOLD, gold, 0xF1C40F;
+    GOLD, 0xF1C40F;
     /// Creates a new [`Colour`], setting its RGB value to `(186, 218, 85)`.
-    KERBAL, kerbal, 0xBADA55;
+    KERBAL, 0xBADA55;
     /// Creates a new [`Colour`], setting its RGB value to `(151, 156, 159)`.
-    LIGHT_GREY, light_grey, 0x979C9F;
+    LIGHT_GREY, 0x979C9F;
     /// Creates a new [`Colour`], setting its RGB value to `(149, 165, 166)`.
-    LIGHTER_GREY, lighter_grey, 0x95A5A6;
+    LIGHTER_GREY, 0x95A5A6;
     /// Creates a new [`Colour`], setting its RGB value to `(233, 30, 99)`.
-    MAGENTA, magenta, 0xE91E63;
+    MAGENTA, 0xE91E63;
     /// Creates a new [`Colour`], setting its RGB value to `(230, 131, 151)`.
-    MEIBE_PINK, meibe_pink, 0xE68397;
+    MEIBE_PINK, 0xE68397;
     /// Creates a new [`Colour`], setting its RGB value to `(230, 126, 34)`.
-    ORANGE, orange, 0xE67E22;
+    ORANGE, 0xE67E22;
     /// Creates a new [`Colour`], setting its RGB value to `(155, 89, 182)`.
-    PURPLE, purple, 0x9B59B6;
+    PURPLE, 0x9B59B6;
     /// Creates a new [`Colour`], setting its RGB value to `(231, 76, 60)`.
-    RED, red, 0xE74C3C;
+    RED, 0xE74C3C;
     /// Creates a new [`Colour`], setting its RGB value to `(117, 150, 255)`.
-    ROHRKATZE_BLUE, rohrkatze_blue, 0x7596FF;
+    ROHRKATZE_BLUE, 0x7596FF;
     /// Creates a new [`Colour`], setting its RGB value to `(246, 219, 216)`.
-    ROSEWATER, rosewater, 0xF6DBD8;
+    ROSEWATER, 0xF6DBD8;
     /// Creates a new [`Colour`], setting its RGB value to `(26, 188, 156)`.
-    TEAL, teal, 0x1ABC9C;
+    TEAL, 0x1ABC9C;
 }
 
 impl Default for Colour {


### PR DESCRIPTION
It's a leftover of removing deprecated functions.

I also moved it close to its usage.

