### PR TITLE
Check for discrepancies in default commands of groups

### DIFF
--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -413,10 +413,14 @@ async fn handle_command<'a>(
             command,
         }),
         Err(err) => match group.options.default_command {
-            Some(command) => Ok(Invoke::Command {
-                group,
-                command,
-            }),
+            Some(command) => {
+                check_discrepancy(ctx, msg, config, &command.options).await?;
+
+                Ok(Invoke::Command {
+                    group,
+                    command,
+                })
+            },
             None => Err(err),
         },
     }


### PR DESCRIPTION
## Description

This adds an unaccounted for check for discrepancies to default commands, which would result in default commands, for example, ignoring to check permissions of a user before executing.

Fixes #1530 

## Type of Change

This is a fix to the framework, specifically to the behaviour of default commands.

## How Has This Been Tested?

This has been tested with a command with `#[required_permissions("ADMINISTRATOR")]` by two users. One that had `ADMINISTRATOR` permissions, and one that did not. With this change, the command only executed for the user with `ADMINISTRATOR`, as it is intended.