### PR TITLE
Add channel types to slash commands

### DIFF
--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -134,7 +134,7 @@ impl CreateApplicationCommandOption {
     /// If the option is a [`Channel`], it will only be able to show these types.
     ///
     /// [`Channel`]: crate::model::interactions::application_command::ApplicationCommandOptionType::Channel
-    pub fn channel_types(&mut self, channel_types: Vec<ChannelType>) -> &mut Self {
+    pub fn channel_types(&mut self, channel_types: &[ChannelType]) -> &mut Self {
         self.0.insert(
             "channel_types",
             Value::Array(

--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde_json::{json, Value};
 
 use crate::internal::prelude::*;
+use crate::model::channel::ChannelType;
 use crate::model::interactions::application_command::{
     ApplicationCommandOptionType,
     ApplicationCommandType,
@@ -126,6 +127,21 @@ impl CreateApplicationCommandOption {
         let options = self.0.entry("options").or_insert_with(|| Value::Array(Vec::new()));
         let opt_arr = options.as_array_mut().expect("Must be an array");
         opt_arr.push(Value::Object(new_option));
+
+        self
+    }
+
+    /// If an option is a Channel type, it will only be able to show these types.
+    pub fn add_channel_types(&mut self, channel_types: Vec<ChannelType>) -> &mut Self {
+        self.0.insert(
+            "channel_types",
+            Value::Array(
+                channel_types
+                    .iter()
+                    .map(|i| Value::Number(Number::from(*i as u8)))
+                    .collect::<Vec<_>>(),
+            ),
+        );
 
         self
     }

--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -131,8 +131,10 @@ impl CreateApplicationCommandOption {
         self
     }
 
-    /// If an option is a Channel type, it will only be able to show these types.
-    pub fn add_channel_types(&mut self, channel_types: Vec<ChannelType>) -> &mut Self {
+    /// If the option is a [`Channel`], it will only be able to show these types.
+    ///
+    /// [`Channel`]: crate::model::interactions::application_command::ApplicationCommandOptionType::Channel
+    pub fn channel_types(&mut self, channel_types: Vec<ChannelType>) -> &mut Self {
         self.0.insert(
             "channel_types",
             Value::Array(

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -295,6 +295,7 @@ impl Display for Channel {
 /// A representation of a type of channel.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
+#[repr(u8)]
 pub enum ChannelType {
     /// An indicator that the channel is a text [`GuildChannel`].
     Text = 0,

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -13,7 +13,7 @@ use crate::builder::{
 };
 use crate::http::Http;
 use crate::internal::prelude::{JsonMap, StdResult, Value};
-use crate::model::channel::PartialChannel;
+use crate::model::channel::{ChannelType, PartialChannel};
 use crate::model::guild::{Member, PartialMember, Role};
 use crate::model::id::{
     ApplicationId,
@@ -908,6 +908,9 @@ pub struct ApplicationCommandOption {
     /// [`SubCommandGroup`]: ApplicationCommandOptionType::SubCommandGroup
     #[serde(default)]
     pub options: Vec<ApplicationCommandOption>,
+    /// If an option is a Channel type, it will only be able to show these types.
+    #[serde(default)]
+    pub channel_types: Vec<ChannelType>,
 }
 
 /// An [`ApplicationCommand`] permission.

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -908,7 +908,9 @@ pub struct ApplicationCommandOption {
     /// [`SubCommandGroup`]: ApplicationCommandOptionType::SubCommandGroup
     #[serde(default)]
     pub options: Vec<ApplicationCommandOption>,
-    /// If an option is a Channel type, it will only be able to show these types.
+    /// If the option is a [`Channel`], it will only be able to show these types.
+    ///
+    /// [`Channel`]: ApplicationCommandOptionType::Channel
     #[serde(default)]
     pub channel_types: Vec<ChannelType>,
 }


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/commit/0a4c2fe7ff57828dbacd9f57f39331cf510c56af
Limits the channels that show up on channel type arguments in slash commands.

	modified:   src/builder/create_application_command.rs
	modified:   src/model/channel/mod.rs
	modified:   src/model/interactions/application_command.rs