### PR TITLE
Perf!: remove async in http builder

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -163,6 +163,7 @@ impl HttpBuilder {
     }
 
     /// Use the given configuration to build the `Http` client.
+    #[allow(clippy::unwrap_used)]
     pub fn build(self) -> Http {
         let token = self.token.unwrap();
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -39,8 +39,8 @@ use crate::model::interactions::application_command::{
 };
 use crate::model::prelude::*;
 
-/// A builder implementing [`Future`] building a [`Http`] client to perform
-/// requests to Discord's HTTP API. If you do not need to use a proxy or do not
+/// A builder for the underlying [`Http`] client that performs requests
+/// to Discord's HTTP API. If you do not need to use a proxy or do not
 /// need to disable the rate limiter, you can use [`Http::new`] or
 /// [`Http::new_with_token`] instead.
 ///
@@ -50,13 +50,12 @@ use crate::model::prelude::*;
 ///
 /// ```rust
 /// # use serenity::http::HttpBuilder;
-/// # async fn run() {
+/// # fn run() {
 /// let http = HttpBuilder::new("token")
 ///     .proxy("http://127.0.0.1:3000")
 ///     .expect("Invalid proxy URL")
 ///     .ratelimiter_disabled(true)
-///     .await
-///     .expect("Error creating Http");
+///     .build();
 /// # }
 /// ```
 pub struct HttpBuilder {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3,14 +3,10 @@ use std::{
     borrow::Cow,
     collections::BTreeMap,
     fmt,
-    future::Future,
-    pin::Pin,
     str::FromStr,
     sync::Arc,
-    task::{Context as FutContext, Poll},
 };
 
-use futures::future::BoxFuture;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::{
     header::{HeaderMap as Headers, HeaderValue, CONTENT_TYPE},

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,11 +1,5 @@
 #![allow(clippy::missing_errors_doc)]
-use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-    fmt,
-    str::FromStr,
-    sync::Arc,
-};
+use std::{borrow::Cow, collections::BTreeMap, fmt, str::FromStr, sync::Arc};
 
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::{


### PR DESCRIPTION
# Summary
Previously, the `HttpBuilder` implemented the `Future` trait so that it may be constructed with `async`-`await`. However, this necessitated an extra heap allocation since the underlying future was stored inside a pinned `Box`. This issue may be resolved by wrapping the resultant `Http` client in a [`Ready` struct](https://doc.rust-lang.org/std/future/fn.ready.html) instead, thereby avoiding the heap allocation altogether.

However, I figured that since the `Http` client is already available for consumption, then `async`-`await` is unnecessary. That is, a synchronous builder is sufficient and less costly. This PR implements my proposal to remove the unnecessary extra work performed by the code below:

https://github.com/serenity-rs/serenity/blob/5a700f7ea40fc89ff1c5550e673dd37a3b739f06/src/http/client.rs#L198-L208

# Breaking Changes
Since `HttpBuilder` no longer implements `Future`, then the old example no longer works:

```rust
let http = HttpBuilder::new("token")
    .proxy("http://127.0.0.1:3000")
    .expect("Invalid proxy URL")
    .ratelimiter_disabled(true)
    .await
    .expect("Error creating Http");
```

Instead, we must now use the explicit `build` method:

```rust
let http = HttpBuilder::new("token")
    .proxy("http://127.0.0.1:3000")
    .expect("Invalid proxy URL")
    .ratelimiter_disabled(true)
    .build();
```

Note, however, that the current implementation panics when the client is built with invalid parameters (as did the old `Future` implementation). Eventually, we may add a fallible `try_build` method to avoid panicking, but that addition is beyond the scope of this PR since it may require the addition of an error enum.

Anyway, if there are any issues with these changes, please do let me know. In the event that I miss updating some documentation, I will gladly address them. Thanks!