### PR TITLE
Add Discord's new branding, css & role colours

### DIFF
--- a/src/utils/colour.rs
+++ b/src/utils/colour.rs
@@ -325,7 +325,6 @@ impl Default for Colour {
 }
 
 /// Colour constants used by Discord for their branding, role colour palette, etc.
-#[allow(dead_code)]
 pub mod colours {
     pub mod branding {
         use crate::utils::Colour;

--- a/src/utils/colour.rs
+++ b/src/utils/colour.rs
@@ -258,74 +258,63 @@ impl From<(u8, u8, u8)> for Colour {
     }
 }
 
-macro_rules! colour {
-    ($(#[$attr:meta] $constname:ident, $val:expr;)*) => {
-        impl Colour {
-            $(
-                #[$attr]
-                pub const $constname: Colour = Colour($val);
-            )*
-        }
-    }
-}
-
-colour! {
+impl Colour {
     /// Creates a new [`Colour`], setting its RGB value to `(111, 198, 226)`.
-    BLITZ_BLUE, 0x6FC6E2;
+    pub const BLITZ_BLUE: Colour = Colour(0x6FC6E2);
     /// Creates a new [`Colour`], setting its RGB value to `(52, 152, 219)`.
-    BLUE, 0x3498DB;
+    pub const BLUE: Colour = Colour(0x3498DB);
     /// Creates a new [`Colour`], setting its RGB value to `(114, 137, 218)`.
-    BLURPLE, 0x7289DA;
+    pub const BLURPLE: Colour = Colour(0x7289DA);
     /// Creates a new [`Colour`], setting its RGB value to `(32, 102, 148)`.
-    DARK_BLUE, 0x206694;
+    pub const DARK_BLUE: Colour = Colour(0x206694);
     /// Creates a new [`Colour`], setting its RGB value to `(194, 124, 14)`.
-    DARK_GOLD, 0xC27C0E;
+    pub const DARK_GOLD: Colour = Colour(0xC27C0E);
     /// Creates a new [`Colour`], setting its RGB value to `(31, 139, 76)`.
-    DARK_GREEN, 0x1F8B4C;
+    pub const DARK_GREEN: Colour = Colour(0x1F8B4C);
     /// Creates a new [`Colour`], setting its RGB value to `(96, 125, 139)`.
-    DARK_GREY, 0x607D8B;
+    pub const DARK_GREY: Colour = Colour(0x607D8B);
     /// Creates a new [`Colour`], setting its RGB value to `(173, 20, 87)`.
-    DARK_MAGENTA, 0xAD1457;
+    pub const DARK_MAGENTA: Colour = Colour(0xAD1457);
     /// Creates a new [`Colour`], setting its RGB value to `(168, 67, 0)`.
-    DARK_ORANGE, 0xA84300;
+    pub const DARK_ORANGE: Colour = Colour(0xA84300);
     /// Creates a new [`Colour`], setting its RGB value to `(113, 54, 138)`.
-    DARK_PURPLE, 0x71368A;
+    pub const DARK_PURPLE: Colour = Colour(0x71368A);
     /// Creates a new [`Colour`], setting its RGB value to `(153, 45, 34)`.
-    DARK_RED, 0x992D22;
+    pub const DARK_RED: Colour = Colour(0x992D22);
     /// Creates a new [`Colour`], setting its RGB value to `(17, 128, 106)`.
-    DARK_TEAL, 0x11806A;
+    pub const DARK_TEAL: Colour = Colour(0x11806A);
     /// Creates a new [`Colour`], setting its RGB value to `(84, 110, 122)`.
-    DARKER_GREY, 0x546E7A;
+    pub const DARKER_GREY: Colour = Colour(0x546E7A);
     /// Creates a new [`Colour`], setting its RGB value to `(250, 177, 237)`.
-    FABLED_PINK, 0xFAB1ED;
+    pub const FABLED_PINK: Colour = Colour(0xFAB1ED);
     /// Creates a new [`Colour`], setting its RGB value to `(136, 130, 196)`.
-    FADED_PURPLE, 0x8882C4;
+    pub const FADED_PURPLE: Colour = Colour(0x8882C4);
     /// Creates a new [`Colour`], setting its RGB value to `(17, 202, 128)`.
-    FOOYOO, 0x11CA80;
+    pub const FOOYOO: Colour = Colour(0x11CA80);
     /// Creates a new [`Colour`], setting its RGB value to `(241, 196, 15)`.
-    GOLD, 0xF1C40F;
+    pub const GOLD: Colour = Colour(0xF1C40F);
     /// Creates a new [`Colour`], setting its RGB value to `(186, 218, 85)`.
-    KERBAL, 0xBADA55;
+    pub const KERBAL: Colour = Colour(0xBADA55);
     /// Creates a new [`Colour`], setting its RGB value to `(151, 156, 159)`.
-    LIGHT_GREY, 0x979C9F;
+    pub const LIGHT_GREY: Colour = Colour(0x979C9F);
     /// Creates a new [`Colour`], setting its RGB value to `(149, 165, 166)`.
-    LIGHTER_GREY, 0x95A5A6;
+    pub const LIGHTER_GREY: Colour = Colour(0x95A5A6);
     /// Creates a new [`Colour`], setting its RGB value to `(233, 30, 99)`.
-    MAGENTA, 0xE91E63;
+    pub const MAGENTA: Colour = Colour(0xE91E63);
     /// Creates a new [`Colour`], setting its RGB value to `(230, 131, 151)`.
-    MEIBE_PINK, 0xE68397;
+    pub const MEIBE_PINK: Colour = Colour(0xE68397);
     /// Creates a new [`Colour`], setting its RGB value to `(230, 126, 34)`.
-    ORANGE, 0xE67E22;
+    pub const ORANGE: Colour = Colour(0xE67E22);
     /// Creates a new [`Colour`], setting its RGB value to `(155, 89, 182)`.
-    PURPLE, 0x9B59B6;
+    pub const PURPLE: Colour = Colour(0x9B59B6);
     /// Creates a new [`Colour`], setting its RGB value to `(231, 76, 60)`.
-    RED, 0xE74C3C;
+    pub const RED: Colour = Colour(0xE74C3C);
     /// Creates a new [`Colour`], setting its RGB value to `(117, 150, 255)`.
-    ROHRKATZE_BLUE, 0x7596FF;
+    pub const ROHRKATZE_BLUE: Colour = Colour(0x7596FF);
     /// Creates a new [`Colour`], setting its RGB value to `(246, 219, 216)`.
-    ROSEWATER, 0xF6DBD8;
+    pub const ROSEWATER: Colour = Colour(0xF6DBD8);
     /// Creates a new [`Colour`], setting its RGB value to `(26, 188, 156)`.
-    TEAL, 0x1ABC9C;
+    pub const TEAL: Colour = Colour(0x1ABC9C);
 }
 
 impl Default for Colour {

--- a/src/utils/colour.rs
+++ b/src/utils/colour.rs
@@ -324,6 +324,85 @@ impl Default for Colour {
     }
 }
 
+/// Colour constants used by Discord for their branding, role colour palette, etc.
+#[allow(dead_code)]
+pub mod colours {
+    pub mod branding {
+        use crate::utils::Colour;
+
+        /// Creates a new [`Colour`], setting its value to `rgb(88, 101, 242)`.
+        pub const BLURPLE: Colour = Colour(0x5865F2);
+        /// Creates a new [`Colour`], setting its value to `rgb(87, 242, 135)`.
+        pub const GREEN: Colour = Colour(0x57F287);
+        /// Creates a new [`Colour`], setting its value to `rgb(254, 231, 92)`.
+        pub const YELLOW: Colour = Colour(0xFEE75C);
+        /// Creates a new [`Colour`], setting its value to `rgb(235, 69, 158)`.
+        pub const FUCHSIA: Colour = Colour(0xEB459E);
+        /// Creates a new [`Colour`], setting its value to `rgb(237, 66, 69)`.
+        pub const RED: Colour = Colour(0xED4245);
+        /// Creates a new [`Colour`], setting its value to `rgb(255, 255, 255)`.
+        pub const WHITE: Colour = Colour(0xFFFFFF);
+        /// Creates a new [`Colour`], setting its value to `rgb(35, 39, 42)`.
+        pub const BLACK: Colour = Colour(0x23272A);
+    }
+    pub mod css {
+        use crate::utils::Colour;
+
+        /// Creates a new [`Colour`], setting its value to `hsl(139, 47.3%, 43.9%)`.
+        pub const POSITIVE: Colour = Colour(0x3BA55D);
+        /// Creates a new [`Colour`], setting its value to `hsl(38, 95.7%, 54.1%)`.
+        pub const WARNING: Colour = Colour(0xFAA81A);
+        /// Creates a new [`Colour`], setting its value to `hsl(359, 82.6%, 59.4%)`.
+        pub const DANGER: Colour = Colour(0xED4245);
+    }
+    pub mod roles {
+        use crate::utils::Colour;
+
+        /// Creates a new [`Colour`], setting its value to `rgb(153, 170, 181)`.
+        pub const DEFAULT: Colour = Colour(0x99AAB5);
+        /// Creates a new [`Colour`], setting its value to `rgb(26, 188, 156)`.
+        pub const TEAL: Colour = Colour(0x1ABC9C);
+        /// Creates a new [`Colour`], setting its value to `rgb(17, 128, 106)`.
+        pub const DARK_TEAL: Colour = Colour(0x11806A);
+        /// Creates a new [`Colour`], setting its value to `rgb(46, 204, 113)`.
+        pub const GREEN: Colour = Colour(0x2ECC71);
+        /// Creates a new [`Colour`], setting its value to `rgb(31, 139, 76)`.
+        pub const DARK_GREEN: Colour = Colour(0x1F8B4C);
+        /// Creates a new [`Colour`], setting its value to `rgb(52, 152, 219)`.
+        pub const BLUE: Colour = Colour(0x3498DB);
+        /// Creates a new [`Colour`], setting its value to `rgb(32, 102, 148)`.
+        pub const DARK_BLUE: Colour = Colour(0x206694);
+        /// Creates a new [`Colour`], setting its value to `rgb(155, 89, 182)`.
+        pub const PURPLE: Colour = Colour(0x9B59B6);
+        /// Creates a new [`Colour`], setting its value to `rgb(113, 54, 138)`.
+        pub const DARK_PURPLE: Colour = Colour(0x71368A);
+        /// Creates a new [`Colour`], setting its value to `rgb(233, 30, 99)`.
+        pub const MAGENTA: Colour = Colour(0xE91E63);
+        /// Creates a new [`Colour`], setting its value to `rgb(173, 20, 87)`.
+        pub const DARK_MAGENTA: Colour = Colour(0xAD1457);
+        /// Creates a new [`Colour`], setting its value to `rgb(241, 196, 15)`.
+        pub const GOLD: Colour = Colour(0xF1C40F);
+        /// Creates a new [`Colour`], setting its value to `rgb(194, 124, 14)`.
+        pub const DARK_GOLD: Colour = Colour(0xC27C0E);
+        /// Creates a new [`Colour`], setting its value to `rgb(230, 126, 34)`.
+        pub const ORANGE: Colour = Colour(0xE67E22);
+        /// Creates a new [`Colour`], setting its value to `rgb(168, 67, 0)`.
+        pub const DARK_ORANGE: Colour = Colour(0xA84300);
+        /// Creates a new [`Colour`], setting its value to `rgb(231, 76, 60)`.
+        pub const RED: Colour = Colour(0xE74C3C);
+        /// Creates a new [`Colour`], setting its value to `rgb(153, 45, 34)`.
+        pub const DARK_RED: Colour = Colour(0x992D22);
+        /// Creates a new [`Colour`], setting its value to `rgb(149, 165, 166)`.
+        pub const LIGHTER_GREY: Colour = Colour(0x95A5A6);
+        /// Creates a new [`Colour`], setting its value to `rgb(151, 156, 159)`.
+        pub const LIGHT_GREY: Colour = Colour(0x979C9F);
+        /// Creates a new [`Colour`], setting its value to `rgb(96, 125, 139)`.
+        pub const DARK_GREY: Colour = Colour(0x607D8B);
+        /// Creates a new [`Colour`], setting its value to `rgb(84, 110, 122)`.
+        pub const DARKER_GREY: Colour = Colour(0x546E7A);
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::u32;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,7 +11,7 @@ mod message_builder;
 pub use argument_convert::*;
 
 pub use self::{
-    colour::Colour,
+    colour::{colours, Colour},
     custom_message::CustomMessage,
     message_builder::{Content, ContentModifier, EmbedMessageBuilding, MessageBuilder},
 };


### PR DESCRIPTION
I grouped the colours by putting them into modules as a way to see where they are coming from.
This works around the different greens for **branding** `rgb(87, 242, 135)`,  **role** `rgb(46, 204, 113)`
and **positive** `hsl(139, 47.3%, 43.9%)` (positive is not an alias for branding green like #1358 stated).
Alternatively, the constants could be prefixed with `BRANDING_` / `ROLES_` and kept as associated constants of `Colour`. 

The current colour constants aren't changed beside removing the `colour!` macro.

see: #1358 

<details>
  <summary>weird flex but ok</summary>

![image](https://user-images.githubusercontent.com/2128532/136695683-deb6115f-2b5a-4bdd-aa18-a5d4d8c48681.png)
</details>