### PR TITLE
CI: attempt to fix nightly builds in `next` branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "0.3.7"
 optional = true
 
 [dependencies.serde]
-version = "1.0.103"
+version = "1.0.130"
 features = ["derive"]
 
 [dependencies.uwl]
@@ -153,7 +153,7 @@ version = "0.3.16"
 version = "2.0"
 
 [dependencies.dashmap]
-version = "4"
+version = "4.0.2"
 features = ["serde"]
 optional = true
 


### PR DESCRIPTION
# The Problem
Currently, the `next` branch's nightly builds fail due to its inability to compile the `dashmap` crate. According to the GitHub Actions logs, it turns out that this is due to xacrimon/dashmap#133, where it was [discovered that `serde` unexpectedly introduced a semver-breaking change in a patch release](https://github.com/xacrimon/dashmap/issues/133#issuecomment-758326449). A patch was quickly issued for `dashmap@4.0.2`.

Now, this alone should fix the issue. Though, I would later find out while investigating the logs that `dashmap` had been pinned to `4.0.0`. Looking at the `Cargo.toml`, Cargo should have pulled in the latest patch of `dashmap` (see the dependency declaration below).

https://github.com/serenity-rs/serenity/blob/7e0b1d3d98956b4f26637645ed43ea9fea65ef43/Cargo.toml#L155-L158

Indeed, this is the case except for nightly builds. I went through the Git blames and found that #1222 made it so that the nightly builds only pulled in the "minimal version" of dependencies. Details of this nightly feature may be found at rust-lang/cargo#4100. Attached below is the workflow configuration in question:

https://github.com/serenity-rs/serenity/blob/7e0b1d3d98956b4f26637645ed43ea9fea65ef43/.github/workflows/ci.yml#L93

In effect, the invocation to `cargo update -Z minimal-versions` must have pinned `dashmap` to the buggy `4.0.0`, hence the compilation failures.

# Possible Courses of Action
1. Manually bump up the dependency declarations. This is the approach I took with this PR, which also happens to be the most conservative.
2. Explicitly use patch-only semver ranges for all dependencies via [tilde requirements](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements).
3. Revert the invocation to `cargo update -Z minimal-versions` so that CI will always pull in the latest semver-compatible dependencies.
