### PR TITLE
Put the internal `tokio` module behind `tokio*` features

### DIFF
--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -6,4 +6,5 @@ pub mod prelude;
 #[cfg(feature = "gateway")]
 pub mod ws_impl;
 
+#[cfg(any(feature = "tokio", feature = "tokio_compat"))]
 pub mod tokio;

--- a/src/internal/tokio.rs
+++ b/src/internal/tokio.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-#[cfg(tokio_unstable)]
+#[cfg(all(tokio_unstable, not(feature = "tokio_compat")))]
 pub fn spawn_named<F, T>(name: &str, future: F) -> tokio::task::JoinHandle<T>
 where
     F: Future<Output = T> + Send + 'static,
@@ -9,7 +9,7 @@ where
     tokio::task::Builder::new().name(&*format!("serenity::{}", name)).spawn(future)
 }
 
-#[cfg(not(tokio_unstable))]
+#[cfg(any(not(tokio_unstable), feature = "tokio_compat"))]
 pub fn spawn_named<F, T>(_name: &str, future: F) -> tokio::task::JoinHandle<T>
 where
     F: Future<Output = T> + Send + 'static,


### PR DESCRIPTION
Make sure tokio's task builder is only used with tokio v1.0