### PR TITLE
Clean up Clippy errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,9 +30,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # TODO(https://github.com/serenity-rs/serenity/issues/1423): Clippy currently fails with
-          # all features enabled. Re-add `--workspace` here once that's fixed.
-          args: --tests
+          args: --workspace --tests
 
   rustfmt:
     name: Format

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1170,6 +1170,12 @@ impl GuildId {
     }
 
     /// Overrides all guild application commands.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same possible errors as [`set_global_application_commands`].
+    ///
+    /// [`set_global_application_commands`]: crate::model::interactions::application_command::ApplicationCommand::set_global_application_commands
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands<F>(
@@ -1192,6 +1198,13 @@ impl GuildId {
     /// **Note**: It will update instantly.
     ///
     /// [`ApplicationCommandPermission`]: crate::model::interactions::application_command::ApplicationCommandPermission
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_application_command_permission<F>(
@@ -1218,6 +1231,13 @@ impl GuildId {
     }
 
     /// Overrides all application commands permissions.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands_permissions<F>(
@@ -1239,6 +1259,13 @@ impl GuildId {
     }
 
     /// Get all guild application commands.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands(
@@ -1249,6 +1276,13 @@ impl GuildId {
     }
 
     /// Get a specific guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command(
@@ -1260,6 +1294,13 @@ impl GuildId {
     }
 
     /// Edit guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_application_command<F>(
@@ -1278,6 +1319,13 @@ impl GuildId {
     }
 
     /// Delete guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_application_command(
@@ -1289,6 +1337,13 @@ impl GuildId {
     }
 
     /// Get all guild application commands permissions only.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands_permissions(
@@ -1299,6 +1354,13 @@ impl GuildId {
     }
 
     /// Get permissions for specific guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command_permissions(

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -646,6 +646,13 @@ impl Guild {
     /// Overrides all guild application commands.
     ///
     /// [`create_application_command`]: Self::create_application_command
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands<F>(
@@ -664,6 +671,13 @@ impl Guild {
     /// **Note**: It will update instantly.
     ///
     /// [`ApplicationCommandPermission`]: crate::model::interactions::application_command::ApplicationCommandPermission
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_application_command_permission<F>(
@@ -681,6 +695,13 @@ impl Guild {
     }
 
     /// Overrides all application commands permissions.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands_permissions<F>(
@@ -697,6 +718,13 @@ impl Guild {
     }
 
     /// Get all guild application commands.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands(
@@ -707,6 +735,13 @@ impl Guild {
     }
 
     /// Get a specific guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command(
@@ -718,6 +753,13 @@ impl Guild {
     }
 
     /// Edit guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_application_command<F>(
@@ -733,6 +775,13 @@ impl Guild {
     }
 
     /// Delete guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_application_command(
@@ -744,6 +793,13 @@ impl Guild {
     }
 
     /// Get all guild application commands permissions only.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands_permissions(
@@ -754,6 +810,13 @@ impl Guild {
     }
 
     /// Get permissions for specific guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command_permissions(

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -386,6 +386,13 @@ impl PartialGuild {
     /// Overrides all guild application commands.
     ///
     /// [`create_application_command`]: Self::create_application_command
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands<F>(
@@ -404,6 +411,13 @@ impl PartialGuild {
     /// **Note**: It will update instantly.
     ///
     /// [`ApplicationCommandPermission`]: crate::model::interactions::application_command::ApplicationCommandPermission
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_application_command_permission<F>(
@@ -424,6 +438,13 @@ impl PartialGuild {
     /// more than one permission per call.
     ///
     /// [`create_application_command_permission`]: Self::create_application_command_permission
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands_permissions<F>(
@@ -440,6 +461,13 @@ impl PartialGuild {
     }
 
     /// Get all guild application commands.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands(
@@ -450,6 +478,13 @@ impl PartialGuild {
     }
 
     /// Get a specific guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command(
@@ -461,6 +496,13 @@ impl PartialGuild {
     }
 
     /// Edit guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_application_command<F>(
@@ -476,6 +518,13 @@ impl PartialGuild {
     }
 
     /// Delete guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_application_command(
@@ -487,6 +536,13 @@ impl PartialGuild {
     }
 
     /// Get all guild application commands permissions only.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands_permissions(
@@ -497,6 +553,13 @@ impl PartialGuild {
     }
 
     /// Get permissions for specific guild application command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     #[cfg(feature = "unstable_discord_api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command_permissions(

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -800,6 +800,13 @@ impl ApplicationCommand {
     /// Overrides all global application commands.
     ///
     /// [`create_global_application_command`]: Self::create_global_application_command
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn set_global_application_commands<F>(
         http: impl AsRef<Http>,
         f: F,
@@ -815,6 +822,13 @@ impl ApplicationCommand {
     }
 
     /// Edits a global command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_global_application_command<F>(
         http: impl AsRef<Http>,
         command_id: CommandId,
@@ -828,6 +842,13 @@ impl ApplicationCommand {
     }
 
     /// Gets all global commands.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_global_application_commands(
         http: impl AsRef<Http>,
     ) -> Result<Vec<ApplicationCommand>> {
@@ -835,6 +856,13 @@ impl ApplicationCommand {
     }
 
     /// Gets a global command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_global_application_command(
         http: impl AsRef<Http>,
         command_id: CommandId,
@@ -843,6 +871,13 @@ impl ApplicationCommand {
     }
 
     /// Deletes a global command by its Id.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn delete_global_application_command(
         http: impl AsRef<Http>,
         command_id: CommandId,


### PR DESCRIPTION
This fixes some of the errors preventing `cargo clippy --workspace --tests` (#1423).

I think this is the right thing to do? With the previous code, if the server sent something like a user ID that cannot be parsed to a `u64` or did not correspond to a known user, a panic would occur. With the new code, if the servers sends something like that the code will not panic and instead `options.resolved` will be left as `None`.

The only remaining error class is [missing_errors_doc](https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc). I'm not sure what to do about this. I was looking at the error handling code and for all the cases I checked there is no specific error handling so if anything goes wrong you just get `Error::Http`. Should I just copy and paste a generic message like "If there is an error, it will be either [`Error::Http`] or [`Error::Json`]." for those cases?