### PR TITLE
Add update calls for dispatched thread events

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -846,21 +846,24 @@ async fn handle_event(
                 event_handler.stage_instance_delete(context, event.stage_instance).await;
             });
         },
-        DispatchEvent::Model(Event::ThreadCreate(event)) => {
+        DispatchEvent::Model(Event::ThreadCreate(mut event)) => {
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             spawn_named("dispatch::event_handler::thread_create", async move {
                 event_handler.thread_create(context, event.thread).await;
             });
         },
-        DispatchEvent::Model(Event::ThreadUpdate(event)) => {
+        DispatchEvent::Model(Event::ThreadUpdate(mut event)) => {
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             spawn_named("dispatch::event_handler::thread_update", async move {
                 event_handler.thread_update(context, event.thread).await;
             });
         },
-        DispatchEvent::Model(Event::ThreadDelete(event)) => {
+        DispatchEvent::Model(Event::ThreadDelete(mut event)) => {
+            update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);
 
             spawn_named("dispatch::event_handler::thread_delete", async move {


### PR DESCRIPTION
In #1465, @xMAC94x didn't add update calls to the event dispatcher for the threads. To be more clear, if a thread is created, Serenity receives an event, but doesn't properly update the cache. I think this is the solution, as it works for my needs. I took examples from how the `MessageCreate` event updates the cache.

Let me know if any changes are needed!