### PR TITLE
Add ClientBuilder::get_token(&self) -> &str

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -349,7 +349,7 @@ impl<'a> Future for ClientBuilder<'a> {
             let event_handler = self.event_handler.take();
             let raw_event_handler = self.raw_event_handler.take();
             let intents = self.intents;
-            let http = Arc::new(std::mem::replace(&mut self.http, Default::default()));
+            let http = Arc::new(std::mem::take(&mut self.http));
 
             #[cfg(feature = "unstable_discord_api")]
             if http.application_id == 0 {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -149,6 +149,9 @@ impl<'a> ClientBuilder<'a> {
         self
     }
 
+    /// Gets the current token used for the [`Http`] client.
+    ///
+    /// [`Http`]: crate::http::Http 
     pub fn get_token(&self) -> &str {
         &self.http.token
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -151,7 +151,7 @@ impl<'a> ClientBuilder<'a> {
 
     /// Gets the current token used for the [`Http`] client.
     ///
-    /// [`Http`]: crate::http::Http 
+    /// [`Http`]: crate::http::Http
     pub fn get_token(&self) -> &str {
         &self.http.token
     }


### PR DESCRIPTION
This method is useful e.g. for a discord bot framework I'm writing, where the user can pass a ClientBuilder into the framework constructor. With access to the token, the framework can extract the bot user ID from the token which is needed for e.g. using bot mention as a prefix.

Anyways, I implemented this by replacing the two fields `token: Option<String>, http: Option<Http>` with just `http: Http`:
- the Http struct contains the token anyways
- removing the unneeded Option's means that get_token can return &str instead of Option<&str>