### PR TITLE
Handle Unicode double-quote characters when parsing arguments

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -200,10 +200,7 @@ fn remove_quotes_only_if_present(s: &str) -> Option<&str> {
 }
 
 fn remove_quotes(s: &str) -> &str {
-    match remove_quotes_only_if_present(s) {
-        Some(unquoted) => unquoted,
-        None => s,
-    }
+    remove_quotes_only_if_present(s).unwrap_or(s)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -180,7 +180,7 @@ fn lex(stream: &mut Stream<'_>, delims: &[Cow<'_, str>]) -> Option<Token> {
     Some(Token::new(TokenKind::Argument, start, end))
 }
 
-fn is_quoted(s: &str) -> Option<&str> {
+fn remove_quotes_only_if_present(s: &str) -> Option<&str> {
     // A quoted argument must have both quote characters. It cannot only contain a single quote, or
     // be empty.
     if s.len() < 2 {
@@ -199,7 +199,7 @@ fn is_quoted(s: &str) -> Option<&str> {
 }
 
 fn remove_quotes(s: &str) -> &str {
-    match is_quoted(s) {
+    match remove_quotes_only_if_present(s) {
         Some(unquoted) => unquoted,
         None => s,
     }
@@ -346,7 +346,7 @@ impl Args {
             .collect::<Vec<_>>();
 
         let args = if delims.is_empty() && !message.is_empty() {
-            let kind = if is_quoted(message).is_some() {
+            let kind = if remove_quotes_only_if_present(message).is_some() {
                 TokenKind::QuotedArgument
             } else {
                 TokenKind::Argument

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -191,6 +191,7 @@ fn remove_quotes_only_if_present(s: &str) -> Option<&str> {
         return s.strip_suffix('"');
     }
 
+    // Refer to `QuoteKind` why we check for Unicode quote characters.
     if let Some(s) = s.strip_prefix('\u{201C}') {
         return s.strip_suffix('\u{201D}');
     }


### PR DESCRIPTION
## Description

This adds support for "Smart Quotes", which is a feature on operating systems by Apple that automatically substitutes `"` with `”` when typing text. While innocent for display, it causes a problem with parsing arguments of commands. An argument may comprise of multiple words or numbers that should be grouped together. The `Args` struct handles these arguments by relying on quotes to determine the beginning and end of the argument. Currently, however, it does this by simply checking whether the current character is `"`, disregarding other quotation characters like `”`. This PR remedies that by checking for either `"` or `”`, but not both, to avoid ambiguities when both are used at the same time (e.g. `"The “lazy” fox"` should parse as `The “lazy” fox`).

Fixes #1545  

## Type of Change

This is a fix to the argument parsing process to account for Unicode quote characters like `”`, which a bot may encounter if the user is running an Apple OS (MacOS or iOS) and has the "Smart Quotes" feature on.

## How Has This Been Tested?

This has been tested by ensuring the ASCII `"` character still works for existing cases, and ensuring that `”` also works, and that using both in a single argument will not cancel the other (so that, again, `"The “lazy” fox"` should parse as `The “lazy” fox`, or vice versa).