### PR TITLE
Remove `#[doc(cfg(...))]` attributes

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -9,22 +9,17 @@ mod create_channel;
 mod create_embed;
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod create_application_command;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod create_application_command_permission;
 
 mod bot_auth_parameters;
 mod create_allowed_mentions;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod create_components;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod create_interaction_response;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod create_interaction_response_followup;
 mod create_invite;
 mod create_message;
@@ -35,7 +30,6 @@ mod edit_guild;
 mod edit_guild_welcome_screen;
 mod edit_guild_widget;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 mod edit_interaction_response;
 mod edit_member;
 mod edit_message;
@@ -74,7 +68,6 @@ pub use self::{
     get_messages::GetMessages,
 };
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 pub use self::{
     create_application_command::{
         CreateApplicationCommand,

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -248,7 +248,6 @@ impl ShardMessenger {
     /// Sets a new filter for an event collector.
     #[inline]
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn set_event_filter(&self, collector: EventFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetEventFilter(collector));
@@ -257,7 +256,6 @@ impl ShardMessenger {
     /// Sets a new filter for a message collector.
     #[inline]
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn set_message_filter(&self, collector: MessageFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetMessageFilter(collector));
@@ -265,7 +263,6 @@ impl ShardMessenger {
 
     /// Sets a new filter for a reaction collector.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn set_reaction_filter(&self, collector: ReactionFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetReactionFilter(collector));
@@ -273,7 +270,6 @@ impl ShardMessenger {
 
     /// Sets a new filter for a component interaction collector.
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
     pub fn set_component_interaction_filter(&self, collector: ComponentInteractionFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetComponentInteractionFilter(collector));

--- a/src/client/bridge/gateway/shard_runner_message.rs
+++ b/src/client/bridge/gateway/shard_runner_message.rs
@@ -63,18 +63,14 @@ pub enum ShardRunnerMessage {
     SetStatus(OnlineStatus),
     /// Sends a new filter for events to the shard.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     SetEventFilter(EventFilter),
     /// Sends a new filter for messages to the shard.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     SetMessageFilter(MessageFilter),
     /// Sends a new filter for reactions to the shard.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     SetReactionFilter(ReactionFilter),
     /// Sends a new filter for component interactions to the shard.
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
     SetComponentInteractionFilter(ComponentInteractionFilter),
 }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -389,7 +389,6 @@ impl Context {
     /// sent back to `filter`'s paired receiver.
     #[inline]
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub async fn set_message_filter(&self, filter: MessageFilter) {
         self.shard.set_message_filter(filter);
     }
@@ -398,7 +397,6 @@ impl Context {
     /// sent back to `filter`'s paired receiver.
     #[inline]
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub async fn set_reaction_filter(&self, filter: ReactionFilter) {
         self.shard.set_reaction_filter(filter);
     }
@@ -407,7 +405,6 @@ impl Context {
     /// sent back to `filter`'s paired receiver.
     #[inline]
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
     pub async fn set_component_interaction_filter(&self, filter: ComponentInteractionFilter) {
         self.shard.set_component_interaction_filter(filter);
     }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -428,28 +428,24 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Provides the created interaction.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn interaction_create(&self, _ctx: Context, _interaction: Interaction) {}
 
     /// Dispatched when a guild integration is created.
     ///
     /// Provides the created integration.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn integration_create(&self, _ctx: Context, _integration: Integration) {}
 
     /// Dispatched when a guild integration is updated.
     ///
     /// Provides the updated integration.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn integration_update(&self, _ctx: Context, _integration: Integration) {}
 
     /// Dispatched when a guild integration is deleted.
     ///
     /// Provides the integration's id, the id of the guild it belongs to, and its associated application id
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn integration_delete(
         &self,
         _ctx: Context,
@@ -463,7 +459,6 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Provides the created application command.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn application_command_create(
         &self,
         _ctx: Context,
@@ -475,7 +470,6 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Provides the updated application command.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn application_command_update(
         &self,
         _ctx: Context,
@@ -487,7 +481,6 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Provides the deleted application command.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     async fn application_command_delete(
         &self,
         _ctx: Context,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -447,7 +447,6 @@ impl Http {
     ///
     /// Functions the same as [`Self::execute_webhook`]
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_followup_message(
         &self,
         interaction_token: &str,
@@ -476,7 +475,6 @@ impl Http {
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_global_application_command(
         &self,
         map: &Value,
@@ -493,7 +491,6 @@ impl Http {
 
     /// Creates new global application commands.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_global_application_commands(
         &self,
         map: &Value,
@@ -510,7 +507,6 @@ impl Http {
 
     /// Creates new guild application commands.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_guild_application_commands(
         &self,
         guild_id: u64,
@@ -579,7 +575,6 @@ impl Http {
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_guild_application_command(
         &self,
         guild_id: u64,
@@ -627,7 +622,6 @@ impl Http {
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#interaction-interaction-response
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_interaction_response(
         &self,
         interaction_id: u64,
@@ -823,7 +817,6 @@ impl Http {
 
     /// Deletes a follow-up message for an interaction.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_followup_message(
         &self,
         interaction_token: &str,
@@ -843,7 +836,6 @@ impl Http {
 
     /// Deletes a global command.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_global_application_command(&self, command_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
@@ -870,7 +862,6 @@ impl Http {
 
     /// Deletes a guild command.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_guild_application_command(
         &self,
         guild_id: u64,
@@ -990,7 +981,6 @@ impl Http {
 
     /// Deletes the initial interaction response.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_original_interaction_response(
         &self,
         interaction_token: &str,
@@ -1168,7 +1158,6 @@ impl Http {
     ///
     /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_followup_message(
         &self,
         interaction_token: &str,
@@ -1195,7 +1184,6 @@ impl Http {
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_global_application_command(
         &self,
         command_id: u64,
@@ -1234,7 +1222,6 @@ impl Http {
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_guild_application_command(
         &self,
         guild_id: u64,
@@ -1261,7 +1248,6 @@ impl Http {
     ///
     /// [documentation]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_guild_application_command_permissions(
         &self,
         guild_id: u64,
@@ -1288,7 +1274,6 @@ impl Http {
     ///
     /// [documentation]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_guild_application_commands_permissions(
         &self,
         guild_id: u64,
@@ -1445,7 +1430,6 @@ impl Http {
 
     /// Gets the initial interaction response.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_original_interaction_response(
         &self,
         interaction_token: &str,
@@ -1467,7 +1451,6 @@ impl Http {
     ///
     /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_original_interaction_response(
         &self,
         interaction_token: &str,
@@ -2311,7 +2294,6 @@ impl Http {
 
     /// Fetches all of the global commands for your application.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_global_application_commands(&self) -> Result<Vec<ApplicationCommand>> {
         self.fire(Request {
             body: None,
@@ -2325,7 +2307,6 @@ impl Http {
 
     /// Fetches a global commands for your application by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_global_application_command(
         &self,
         command_id: u64,
@@ -2367,7 +2348,6 @@ impl Http {
 
     /// Fetches all of the guild commands for your application for a specific guild.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_guild_application_commands(
         &self,
         guild_id: u64,
@@ -2385,7 +2365,6 @@ impl Http {
 
     /// Fetches a guild command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_guild_application_command(
         &self,
         guild_id: u64,
@@ -2405,7 +2384,6 @@ impl Http {
 
     /// Fetches all of the guild commands permissions for your application for a specific guild.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_guild_application_commands_permissions(
         &self,
         guild_id: u64,
@@ -2423,7 +2401,6 @@ impl Http {
 
     /// Gives the guild command permission for your application for a specific guild.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_guild_application_command_permissions(
         &self,
         guild_id: u64,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -374,7 +374,6 @@ pub enum Route {
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     WebhooksApplicationId(u64),
     /// Route for the `/interactions/:interaction_id` path.
     ///
@@ -382,7 +381,6 @@ pub enum Route {
     ///
     /// [`InteractionId`]: crate::model::id::InteractionId
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     InteractionsId(u64),
     /// Route for the `/applications/:application_id` path.
     ///
@@ -390,7 +388,6 @@ pub enum Route {
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationsIdCommands(u64),
     /// Route for the `/applications/:application_id/commands/:command_id` path.
     ///
@@ -398,7 +395,6 @@ pub enum Route {
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationsIdCommandsId(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id` path.
     ///
@@ -406,7 +402,6 @@ pub enum Route {
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationsIdGuildsIdCommands(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id/commands/permissions` path.
     ///
@@ -414,7 +409,6 @@ pub enum Route {
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationsIdGuildsIdCommandsPermissions(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id/commands/:command_id/permissions` path.
     ///
@@ -422,7 +416,6 @@ pub enum Route {
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationsIdGuildsIdCommandIdPermissions(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id` path.
     ///
@@ -430,7 +423,6 @@ pub enum Route {
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationsIdGuildsIdCommandsId(u64),
     /// Route for the `/stage-instances` path.
     ///
@@ -927,7 +919,6 @@ impl Route {
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn webhook_original_interaction_response<D: Display>(
         application_id: u64,
         token: D,
@@ -936,7 +927,6 @@ impl Route {
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn webhook_followup_message<D: Display>(
         application_id: u64,
         token: D,
@@ -946,31 +936,26 @@ impl Route {
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn webhook_followup_messages<D: Display>(application_id: u64, token: D) -> String {
         format!(api!("/webhooks/{}/{}"), application_id, token)
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn interaction_response<D: Display>(application_id: u64, token: D) -> String {
         format!(api!("/interactions/{}/{}/callback"), application_id, token)
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn application_command(application_id: u64, command_id: u64) -> String {
         format!(api!("/applications/{}/commands/{}"), application_id, command_id)
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn application_commands(application_id: u64) -> String {
         format!(api!("/applications/{}/commands"), application_id)
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn application_guild_command(
         application_id: u64,
         guild_id: u64,
@@ -983,7 +968,6 @@ impl Route {
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn application_guild_command_permissions(
         application_id: u64,
         guild_id: u64,
@@ -996,13 +980,11 @@ impl Route {
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn application_guild_commands(application_id: u64, guild_id: u64) -> String {
         format!(api!("/applications/{}/guilds/{}/commands"), application_id, guild_id)
     }
 
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub fn application_guild_commands_permissions(application_id: u64, guild_id: u64) -> String {
         format!(api!("/applications/{}/guilds/{}/commands/permissions"), application_id, guild_id)
     }
@@ -1048,30 +1030,25 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     CreateFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     CreateGlobalApplicationCommand {
         application_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     CreateGlobalApplicationCommands {
         application_id: u64,
     },
     CreateGuild,
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     CreateGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     CreateGuildApplicationCommands {
         application_id: u64,
         guild_id: u64,
@@ -1081,7 +1058,6 @@ pub enum RouteInfo<'a> {
         integration_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     CreateInteractionResponse {
         interaction_id: u64,
         interaction_token: &'a str,
@@ -1119,14 +1095,12 @@ pub enum RouteInfo<'a> {
         emoji_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     DeleteFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
         message_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     DeleteGlobalApplicationCommand {
         application_id: u64,
         command_id: u64,
@@ -1135,7 +1109,6 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     DeleteGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
@@ -1165,7 +1138,6 @@ pub enum RouteInfo<'a> {
         reaction: &'a str,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     DeleteOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
@@ -1207,14 +1179,12 @@ pub enum RouteInfo<'a> {
         emoji_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     EditFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
         message_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     EditGlobalApplicationCommand {
         application_id: u64,
         command_id: u64,
@@ -1223,21 +1193,18 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     EditGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
         command_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     EditGuildApplicationCommandPermission {
         application_id: u64,
         guild_id: u64,
         command_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     EditGuildApplicationCommandsPermissions {
         application_id: u64,
         guild_id: u64,
@@ -1270,13 +1237,11 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     GetOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     EditOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
@@ -1389,12 +1354,10 @@ pub enum RouteInfo<'a> {
     },
     GetGateway,
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     GetGlobalApplicationCommands {
         application_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     GetGlobalApplicationCommand {
         application_id: u64,
         command_id: u64,
@@ -1406,26 +1369,22 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     GetGuildApplicationCommands {
         application_id: u64,
         guild_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     GetGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
         command_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     GetGuildApplicationCommandsPermissions {
         application_id: u64,
         guild_id: u64,
     },
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     GetGuildApplicationCommandPermissions {
         application_id: u64,
         guild_id: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,6 @@ pub mod cache;
 #[cfg(feature = "client")]
 pub mod client;
 #[cfg(feature = "collector")]
-#[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
 pub mod collector;
 #[cfg(feature = "framework")]
 pub mod framework;

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -945,7 +945,6 @@ impl ChannelId {
 
     /// Returns a future that will await one message sent in this channel.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -955,7 +954,6 @@ impl ChannelId {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this channel.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -965,7 +963,6 @@ impl ChannelId {
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -975,7 +972,6 @@ impl ChannelId {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this channel.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1125,7 +1125,6 @@ impl GuildChannel {
 
     /// Returns a future that will await one message by this guild channel.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1135,7 +1134,6 @@ impl GuildChannel {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this guild channel.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1145,7 +1143,6 @@ impl GuildChannel {
 
     /// Await a single reaction by this guild channel.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1155,7 +1152,6 @@ impl GuildChannel {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this guild channel.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -127,11 +127,9 @@ pub struct Message {
     ///
     /// [`Interaction`]: crate::model::interactions::Interaction
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub interaction: Option<MessageInteraction>,
     /// The components of this message
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     #[serde(default)]
     pub components: Vec<ActionRow>,
 }
@@ -878,7 +876,6 @@ impl Message {
 
     /// Await a single reaction on this message.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -888,7 +885,6 @@ impl Message {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions on this message.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -898,7 +894,6 @@ impl Message {
 
     /// Await a single component interaction on this message.
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
     pub fn await_component_interaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -908,7 +903,6 @@ impl Message {
 
     /// Returns a stream builder which can be awaited to obtain a stream of component interactions on this message.
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable_discord_api", feature = "collector"))))]
     pub fn await_component_interactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1382,7 +1382,6 @@ pub struct WebhookUpdateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct InteractionCreateEvent {
@@ -1390,7 +1389,6 @@ pub struct InteractionCreateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl<'de> Deserialize<'de> for InteractionCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         Ok(Self {
@@ -1400,7 +1398,6 @@ impl<'de> Deserialize<'de> for InteractionCreateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl Serialize for InteractionCreateEvent {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
     where
@@ -1411,7 +1408,6 @@ impl Serialize for InteractionCreateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct IntegrationCreateEvent {
@@ -1419,7 +1415,6 @@ pub struct IntegrationCreateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl<'de> Deserialize<'de> for IntegrationCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let integration = Integration::deserialize(deserializer)?;
@@ -1431,7 +1426,6 @@ impl<'de> Deserialize<'de> for IntegrationCreateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct IntegrationUpdateEvent {
@@ -1439,7 +1433,6 @@ pub struct IntegrationUpdateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl<'de> Deserialize<'de> for IntegrationUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let integration = Integration::deserialize(deserializer)?;
@@ -1451,7 +1444,6 @@ impl<'de> Deserialize<'de> for IntegrationUpdateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct IntegrationDeleteEvent {
@@ -1461,7 +1453,6 @@ pub struct IntegrationDeleteEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommandCreateEvent {
@@ -1469,7 +1460,6 @@ pub struct ApplicationCommandCreateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl<'de> Deserialize<'de> for ApplicationCommandCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let application_command = ApplicationCommand::deserialize(deserializer)?;
@@ -1481,7 +1471,6 @@ impl<'de> Deserialize<'de> for ApplicationCommandCreateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommandUpdateEvent {
@@ -1489,7 +1478,6 @@ pub struct ApplicationCommandUpdateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl<'de> Deserialize<'de> for ApplicationCommandUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let application_command = ApplicationCommand::deserialize(deserializer)?;
@@ -1501,7 +1489,6 @@ impl<'de> Deserialize<'de> for ApplicationCommandUpdateEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommandDeleteEvent {
@@ -1509,7 +1496,6 @@ pub struct ApplicationCommandDeleteEvent {
 }
 
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 impl<'de> Deserialize<'de> for ApplicationCommandDeleteEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let application_command = ApplicationCommand::deserialize(deserializer)?;
@@ -1858,31 +1844,24 @@ pub enum Event {
     WebhookUpdate(WebhookUpdateEvent),
     /// An interaction was created.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     InteractionCreate(InteractionCreateEvent),
     /// A guild integration was created
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     IntegrationCreate(IntegrationCreateEvent),
     /// A guild integration was updated
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     IntegrationUpdate(IntegrationUpdateEvent),
     /// A guild integration was deleted
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     IntegrationDelete(IntegrationDeleteEvent),
     /// An application command was created
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationCommandCreate(ApplicationCommandCreateEvent),
     /// An application command was updated
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationCommandUpdate(ApplicationCommandUpdateEvent),
     /// An application command was deleted
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationCommandDelete(ApplicationCommandDeleteEvent),
     /// A stage instance was created.
     StageInstanceCreate(StageInstanceCreateEvent),
@@ -2733,43 +2712,36 @@ pub enum EventType {
     ///
     /// This maps to [`InteractionCreateEvent`].
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     InteractionCreate,
     /// Indicator that an integration was created.
     ///
     /// This maps to [`IntegrationCreateEvent`].
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     IntegrationCreate,
     /// Indicator that an integration was created.
     ///
     /// This maps to [`IntegrationUpdateEvent`].
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     IntegrationUpdate,
     /// Indicator that an integration was created.
     ///
     /// This maps to [`IntegrationDeleteEvent`].
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     IntegrationDelete,
     /// Indicator that an application command was created.
     ///
     /// This maps to [`ApplicationCommandCreateEvent`].
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationCommandCreate,
     /// Indicator that an application command was updated.
     ///
     /// This maps to [`ApplicationCommandUpdateEvent`].
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationCommandUpdate,
     /// Indicator that an application command was deleted.
     ///
     /// This maps to [`ApplicationCommandDeleteEvent`].
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     ApplicationCommandDelete,
     /// Indicator that a stage instance was created.
     ///
@@ -2916,25 +2888,18 @@ impl EventType {
     const VOICE_STATE_UPDATE: &'static str = "VOICE_STATE_UPDATE";
     const WEBHOOKS_UPDATE: &'static str = "WEBHOOKS_UPDATE";
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     const INTERACTION_CREATE: &'static str = "INTERACTION_CREATE";
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     const INTEGRATION_CREATE: &'static str = "INTEGRATION_CREATE";
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     const INTEGRATION_UPDATE: &'static str = "INTEGRATION_UPDATE";
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     const INTEGRATION_DELETE: &'static str = "INTEGRATION_DELETE";
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     const APPLICATION_COMMAND_CREATE: &'static str = "APPLICATION_COMMAND_CREATE";
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     const APPLICATION_COMMAND_UPDATE: &'static str = "APPLICATION_COMMAND_UPDATE";
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     const APPLICATION_COMMAND_DELETE: &'static str = "APPLICATION_COMMAND_DELETE";
     const STAGE_INSTANCE_CREATE: &'static str = "STAGE_INSTANCE_CREATE";
     const STAGE_INSTANCE_UPDATE: &'static str = "STAGE_INSTANCE_UPDATE";

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -58,13 +58,11 @@ pub struct Activity {
     /// The sync ID of the activity. Mainly used by the Spotify activity
     /// type which uses this parameter to store the track ID.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub sync_id: Option<String>,
     /// The session ID of the activity. Reserved for specific activity
     /// types, such as the Activity that is transmitted when a user is
     /// listening to Spotify.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub session_id: Option<String>,
     /// The Stream URL if [`Self::kind`] is [`ActivityType::Streaming`].
     pub url: Option<String>,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1108,7 +1108,6 @@ impl GuildId {
 
     /// Returns a future that will await one message sent in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1118,7 +1117,6 @@ impl GuildId {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1128,7 +1126,6 @@ impl GuildId {
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1138,7 +1135,6 @@ impl GuildId {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1157,7 +1153,6 @@ impl GuildId {
     /// [`ApplicationCommand`]: crate::model::interactions::application_command::ApplicationCommand
     /// [`create_global_application_command`]: crate::model::interactions::application_command::ApplicationCommand::create_global_application_command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1172,7 +1167,6 @@ impl GuildId {
 
     /// Overrides all guild application commands.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1194,7 +1188,6 @@ impl GuildId {
     ///
     /// [`ApplicationCommandPermission`]: crate::model::interactions::application_command::ApplicationCommandPermission
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1220,7 +1213,6 @@ impl GuildId {
 
     /// Overrides all application commands permissions.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1241,7 +1233,6 @@ impl GuildId {
 
     /// Get all guild application commands.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands(
         &self,
         http: impl AsRef<Http>,
@@ -1251,7 +1242,6 @@ impl GuildId {
 
     /// Get a specific guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -1262,7 +1252,6 @@ impl GuildId {
 
     /// Edit guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1280,7 +1269,6 @@ impl GuildId {
 
     /// Delete guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -1291,7 +1279,6 @@ impl GuildId {
 
     /// Get all guild application commands permissions only.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -1301,7 +1288,6 @@ impl GuildId {
 
     /// Get permissions for specific guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -55,7 +55,6 @@ pub struct Member {
     ///
     /// [`Interaction`]: crate::model::interactions::Interaction
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub permissions: Option<Permissions>,
     /// The guild avatar hash
     pub avatar: Option<String>,
@@ -589,7 +588,6 @@ pub struct PartialMember {
     ///
     /// [`Interaction`]: crate::model::interactions::Interaction
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub permissions: Option<Permissions>,
 }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -630,7 +630,6 @@ impl Guild {
     ///
     /// [`ApplicationCommand`]: crate::model::interactions::application_command::ApplicationCommand
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn create_application_command<F>(
@@ -648,7 +647,6 @@ impl Guild {
     ///
     /// [`create_application_command`]: Self::create_application_command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
@@ -666,7 +664,6 @@ impl Guild {
     ///
     /// [`ApplicationCommandPermission`]: crate::model::interactions::application_command::ApplicationCommandPermission
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -683,7 +680,6 @@ impl Guild {
 
     /// Overrides all application commands permissions.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -699,7 +695,6 @@ impl Guild {
 
     /// Get all guild application commands.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands(
         &self,
         http: impl AsRef<Http>,
@@ -709,7 +704,6 @@ impl Guild {
 
     /// Get a specific guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -720,7 +714,6 @@ impl Guild {
 
     /// Edit guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -735,7 +728,6 @@ impl Guild {
 
     /// Delete guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -746,7 +738,6 @@ impl Guild {
 
     /// Get all guild application commands permissions only.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -756,7 +747,6 @@ impl Guild {
 
     /// Get permissions for specific guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -2298,7 +2288,6 @@ impl Guild {
 
     /// Returns a future that will await one message sent in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -2308,7 +2297,6 @@ impl Guild {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -2318,7 +2306,6 @@ impl Guild {
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -2328,7 +2315,6 @@ impl Guild {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -369,7 +369,6 @@ impl PartialGuild {
     ///
     /// [`ApplicationCommand`]: crate::model::interactions::application_command::ApplicationCommand
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn create_application_command<F>(
@@ -387,7 +386,6 @@ impl PartialGuild {
     ///
     /// [`create_application_command`]: Self::create_application_command
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
@@ -405,7 +403,6 @@ impl PartialGuild {
     ///
     /// [`ApplicationCommandPermission`]: crate::model::interactions::application_command::ApplicationCommandPermission
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -425,7 +422,6 @@ impl PartialGuild {
     ///
     /// [`create_application_command_permission`]: Self::create_application_command_permission
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -441,7 +437,6 @@ impl PartialGuild {
 
     /// Get all guild application commands.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands(
         &self,
         http: impl AsRef<Http>,
@@ -451,7 +446,6 @@ impl PartialGuild {
 
     /// Get a specific guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -462,7 +456,6 @@ impl PartialGuild {
 
     /// Edit guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -477,7 +470,6 @@ impl PartialGuild {
 
     /// Delete guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -488,7 +480,6 @@ impl PartialGuild {
 
     /// Get all guild application commands permissions only.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -498,7 +489,6 @@ impl PartialGuild {
 
     /// Get permissions for specific guild application command by its Id.
     #[cfg(feature = "unstable_discord_api")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -1425,7 +1415,6 @@ impl PartialGuild {
 
     /// Returns a future that will await one message sent in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1435,7 +1424,6 @@ impl PartialGuild {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1445,7 +1433,6 @@ impl PartialGuild {
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -1455,7 +1442,6 @@ impl PartialGuild {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -31,7 +31,6 @@ pub mod gateway;
 pub mod guild;
 pub mod id;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 pub mod interactions;
 pub mod invite;
 pub mod misc;

--- a/src/model/prelude.rs
+++ b/src/model/prelude.rs
@@ -18,7 +18,6 @@ pub use super::gateway::*;
 pub use super::guild::*;
 pub use super::id::*;
 #[cfg(feature = "unstable_discord_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable_discord_api")))]
 pub use super::interactions::*;
 pub use super::invite::*;
 pub use super::misc::*;

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -909,7 +909,6 @@ impl User {
 
     /// Returns a future that will await one message by this user.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reply<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -919,7 +918,6 @@ impl User {
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this user.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_replies<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -929,7 +927,6 @@ impl User {
 
     /// Await a single reaction by this user.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reaction<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,
@@ -939,7 +936,6 @@ impl User {
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this user.
     #[cfg(feature = "collector")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "collector")))]
     pub fn await_reactions<'a>(
         &self,
         shard_messenger: &'a impl AsRef<ShardMessenger>,


### PR DESCRIPTION
## Description

This removes all uses of the `#[doc(cfg(...))]` attribute. The purpose of this attribute was to tell `rustdoc` to add an annotation, which would inform users what features an item (module, struct, trait, method, etc.) needed. However, in the latest Nightly, [this attribute is implicit when `#![feature(doc_cfg)]` is enabled](https://github.com/rust-lang/rust/pull/89596). Thus, our usage of this attribute is unnecessary and we can remove it.

## Type of Change

This is an enhancement to the library's code by removing clutter, which is related to documentation.

## How Has This Been Tested?

This has been tested by ensuring existing annotations haven't been removed.