### PR TITLE
Remove `Install dependencies` step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libopus-dev
-
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
@@ -107,11 +101,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libopus-dev
-
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
@@ -132,11 +121,6 @@ jobs:
           toolchain: nightly
           profile: minimal
           override: true
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libopus-dev
 
       - name: Cache
         uses: Swatinem/rust-cache@v1
@@ -163,11 +147,6 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libopus-dev
 
       - name: Cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,11 +23,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libopus-dev
-
       - name: Cache
         uses: Swatinem/rust-cache@v1
 


### PR DESCRIPTION
## Description

This removes the `Install dependencies` step from all CI jobs. This is a remnant when the library included voice functionality, which was then moved over to [songbird](https://github.com/serenity-rs/songbird). The code for voice functionality in the library nowadays only serves as a bridge for an actual manager of the voice gateway (like songbird) and for sharing common code (like models) used in voice. Hence, we do not require this anymore. 

## Type of Change

This is an enhancement to the CI jobs by eliminating an unnecessary step, which was related to voice functionality that had existed in the library, but then had been moved elsewhere. 

## How Has This Been Tested?

The PR will serve as the test grounds.