### PR TITLE
Clean up ergonomics around setting bot prefixes

### DIFF
--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -458,8 +458,9 @@ impl Configuration {
     /// let framework = StandardFramework::new().configure(|c| c
     ///     .prefix("!"));
     /// ```
-    pub fn prefix(&mut self, prefix: &str) -> &mut Self {
-        self.prefixes = if prefix.is_empty() { vec![] } else { vec![prefix.to_string()] };
+    pub fn prefix(&mut self, prefix: impl ToString) -> &mut Self {
+        let p = prefix.to_string();
+        self.prefixes = if p.is_empty() { vec![] } else { vec![p] };
 
         self
     }
@@ -488,7 +489,8 @@ impl Configuration {
         T: ToString,
         It: IntoIterator<Item = T>,
     {
-        self.prefixes = prefixes.into_iter().map(|p| p.to_string()).collect();
+        self.prefixes =
+            prefixes.into_iter().map(|p| p.to_string()).filter(|p| !p.is_empty()).collect();
 
         self
     }


### PR DESCRIPTION
`Configuration::prefix` already calls `to_string()` in its body, so to mirror the signature of `Configuration::prefixes`, I changed the parameter's type to `impl ToString` at no extra runtime cost. As well, to consolidate implementation differences, `Configuration::prefixes` now skips over empty strings in the passed-in Iterator, similar to the singular version.