### PR TITLE
Perform owner check when calculating permissions for a member

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1757,10 +1757,14 @@ impl Guild {
     /// Helper function that's used for getting a [`Member`]'s permissions.
     #[cfg(feature = "cache")]
     pub(crate) fn _member_permission_from_member(&self, member: &Member) -> Permissions {
+        if member.user.id == self.owner_id {
+            return Permissions::all();
+        }
+
         let everyone = match self.roles.get(&RoleId(self.id.0)) {
             Some(everyone) => everyone,
             None => {
-                error!("@everyone role ({}) missing in '{}'", self.id, self.name,);
+                error!("@everyone role ({}) missing in '{}'", self.id, self.name);
 
                 return Permissions::empty();
             },


### PR DESCRIPTION
## Description

This adds a simple check that will return `Permissions::all` when the member's ID is equal to the ID of the guild owner.

This check is already done in `_member_permissions`, but it is only executed when `member_permissions` is called. This would cause a method like `Member::permissions` to return the wrong permissions when the `Member` data belonged to the guild owner, because it depends on `_member_permission_from_member`, which did not have the same check as `_member_permissions`.

## Type of Change

This is a fix to permission-calculation code, which is found in the `model` module.

## How Has This Been Tested?

It hasn't been, but theoretically should work.