### PR TITLE
Format code blocks in doc comments

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -832,9 +832,7 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
 /// use std::pin::Pin;
 ///
 /// fn foo(n: i32) -> Pin<Box<dyn std::future::Future<Output = i32>>> {
-///     Box::pin(async move {
-///         n + 4
-///     })
+///     Box::pin(async move { n + 4 })
 /// }
 /// ```
 ///
@@ -844,20 +842,14 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
 /// ```rust,no_run
 /// # #![feature(async_closure)]
 /// #
-/// async move |x: i32| {
-///     x * 2 + 4
-/// }
+/// async move |x: i32| x * 2 + 4
 /// # ;
 /// ```
 ///
 /// is changed to:
 ///
 /// ```rust,no_run
-/// |x: i32| {
-///     Box::pin(async move {
-///         x * 2 + 4
-///     })
-/// }
+/// |x: i32| Box::pin(async move { x * 2 + 4 })
 /// # ;
 /// ```
 ///
@@ -872,9 +864,7 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
 /// use std::pin::Pin;
 ///
 /// fn foo<'fut>(n: &'fut i32) -> Pin<Box<dyn std::future::Future<Output = i32> + 'fut>> {
-///     Box::pin(async move {
-///         *n + 4
-///     })
+///     Box::pin(async move { *n + 4 })
 /// }
 /// ```
 ///

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -114,11 +114,7 @@ impl CreateChannel {
     ///     kind: PermissionOverwriteType::Member(UserId(1234)),
     /// }];
     ///
-    /// guild.create_channel(http, |c| {
-    ///     c.name("my_new_cool_channel")
-    ///     .permissions(permissions)
-    /// })
-    /// .await?;
+    /// guild.create_channel(http, |c| c.name("my_new_cool_channel").permissions(permissions)).await?;
     /// #    Ok(())
     /// # }
     /// ```

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -222,8 +222,8 @@ impl CreateEmbed {
     /// ```rust,no_run
     /// # #[cfg(feature = "client")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// use serenity::prelude::*;
     /// use serenity::model::channel::Message;
+    /// use serenity::prelude::*;
     ///
     /// struct Handler;
     ///
@@ -231,14 +231,14 @@ impl CreateEmbed {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, mut msg: Message) {
     ///         if msg.content == "~embed" {
-    ///             let _ = msg.channel_id.send_message(&context.http, |m| {
-    ///                 m.embed(|e| {
-    ///                     e.title("hello").timestamp("2004-06-08T16:04:23")
-    ///                 });
+    ///             let _ = msg
+    ///                 .channel_id
+    ///                 .send_message(&context.http, |m| {
+    ///                     m.embed(|e| e.title("hello").timestamp("2004-06-08T16:04:23"));
     ///
-    ///                 m
-    ///             })
-    ///             .await;
+    ///                     m
+    ///                 })
+    ///                 .await;
     ///         }
     ///     }
     /// }
@@ -257,9 +257,9 @@ impl CreateEmbed {
     /// ```rust,no_run
     /// # #[cfg(all(feature = "cache", feature = "client"))]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// use serenity::prelude::*;
     /// use serenity::model::guild::Member;
     /// use serenity::model::id::GuildId;
+    /// use serenity::prelude::*;
     ///
     /// struct Handler;
     ///
@@ -267,31 +267,27 @@ impl CreateEmbed {
     /// impl EventHandler for Handler {
     ///     async fn guild_member_addition(&self, context: Context, guild_id: GuildId, member: Member) {
     ///         if let Ok(guild) = guild_id.to_partial_guild(&context).await {
-    ///             let channels = guild.channels(&context)
-    ///                 .await
-    ///                 .unwrap();
+    ///             let channels = guild.channels(&context).await.unwrap();
     ///
-    ///             let channel_search = channels.values()
-    ///                 .find(|c| c.name == "join-log");
+    ///             let channel_search = channels.values().find(|c| c.name == "join-log");
     ///
     ///             if let Some(channel) = channel_search {
     ///                 let user = &member.user;
     ///
-    ///                 let _ = channel.send_message(&context, |m| {
-    ///                     m.embed(|e| {
-    ///                         e.author(|a| {
-    ///                             a.icon_url(&user.face()).name(&user.name)
-    ///                         });
-    ///                         e.title("Member Join");
+    ///                 let _ = channel
+    ///                     .send_message(&context, |m| {
+    ///                         m.embed(|e| {
+    ///                             e.author(|a| a.icon_url(&user.face()).name(&user.name));
+    ///                             e.title("Member Join");
     ///
-    ///                         if let Some(ref joined_at) = member.joined_at {
-    ///                             e.timestamp(joined_at);
-    ///                         }
+    ///                             if let Some(ref joined_at) = member.joined_at {
+    ///                                 e.timestamp(joined_at);
+    ///                             }
     ///
-    ///                         e
+    ///                             e
+    ///                         })
     ///                     })
-    ///                 })
-    ///                 .await;
+    ///                     .await;
     ///             }
     ///         }
     ///     }

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -26,7 +26,7 @@ use crate::model::invite::InviteTargetType;
 ///
 /// #[serenity::async_trait]
 /// impl EventHandler for Handler {
-///    async fn message(&self, context: Context, msg: Message) {
+///     async fn message(&self, context: Context, msg: Message) {
 ///         if msg.content == "!createinvite" {
 ///             let channel = match context.cache.guild_channel(msg.channel_id).await {
 ///                 Some(channel) => channel,
@@ -36,19 +36,16 @@ use crate::model::invite::InviteTargetType;
 ///                 },
 ///             };
 ///
-///             let creation = channel.create_invite(&context, |i| {
-///                 i.max_age(3600).max_uses(10)
-///             })
-///             .await;
+///             let creation =
+///                 channel.create_invite(&context, |i| i.max_age(3600).max_uses(10)).await;
 ///
 ///             let invite = match creation {
 ///                 Ok(invite) => invite,
 ///                 Err(why) => {
 ///                     println!("Err creating invite: {:?}", why);
-///                     if let Err(why) = msg
-///                         .channel_id
-///                         .say(&context, "Error creating invite")
-///                         .await {
+///                     if let Err(why) =
+///                         msg.channel_id.say(&context, "Error creating invite").await
+///                     {
 ///                         println!("Err sending err msg: {:?}", why);
 ///                     }
 ///

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -169,11 +169,7 @@ impl EditChannel {
     ///     kind: PermissionOverwriteType::Member(UserId(1234)),
     /// }];
     ///
-    /// channel.edit(http, |c| {
-    ///     c.name("my_edited_cool_channel")
-    ///     .permissions(permissions)
-    /// })
-    /// .await?;
+    /// channel.edit(http, |c| c.name("my_edited_cool_channel").permissions(permissions)).await?;
     /// #    Ok(())
     /// # }
     /// ```

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -61,10 +61,7 @@ impl EditGuild {
     ///
     /// let base64_icon = utils::read_image("./guild_icon.png")?;
     ///
-    /// guild.edit(&http, |mut g| {
-    ///     g.icon(Some(&base64_icon))
-    /// })
-    /// .await?;
+    /// guild.edit(&http, |mut g| g.icon(Some(&base64_icon))).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -141,10 +138,7 @@ impl EditGuild {
     ///
     /// // assuming a `guild` has already been bound
     ///
-    /// guild.edit(&http, |g| {
-    ///     g.region(Region::UsWest)
-    /// })
-    /// .await?;
+    /// guild.edit(&http, |g| g.region(Region::UsWest)).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -276,10 +270,7 @@ impl EditGuild {
     ///
     /// // assuming a `guild` has already been bound
     ///
-    /// let edit = guild.edit(&http, |g| {
-    ///     g.verification_level(VerificationLevel::High)
-    /// })
-    /// .await;
+    /// let edit = guild.edit(&http, |g| g.verification_level(VerificationLevel::High)).await;
     ///
     /// if let Err(why) = edit {
     ///     println!("Error setting verification level: {:?}", why);
@@ -313,10 +304,14 @@ impl EditGuild {
     ///
     /// // assuming a `guild` has already been bound
     ///
-    /// let edit = guild.edit(&http, |g| {
-    ///     g.system_channel_flags(SystemChannelFlags::SUPPRESS_JOIN_NOTIFICATIONS | SystemChannelFlags::SUPPRESS_GUILD_REMINDER_NOTIFICATIONS)
-    /// })
-    /// .await;
+    /// let edit = guild
+    ///     .edit(&http, |g| {
+    ///         g.system_channel_flags(
+    ///             SystemChannelFlags::SUPPRESS_JOIN_NOTIFICATIONS
+    ///                 | SystemChannelFlags::SUPPRESS_GUILD_REMINDER_NOTIFICATIONS,
+    ///         )
+    ///     })
+    ///     .await;
     ///
     /// if let Err(why) = edit {
     ///     println!("Error setting verification level: {:?}", why);

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -23,10 +23,7 @@ use crate::utils;
 /// # #[command]
 /// # async fn example(ctx: &Context) -> CommandResult {
 /// # let mut message = ChannelId(7).message(&ctx, MessageId(8)).await?;
-/// message.edit(ctx, |m| {
-///     m.content("hello")
-/// })
-/// .await?;
+/// message.edit(ctx, |m| m.content("hello")).await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -35,13 +35,10 @@ impl EditProfile {
     ///
     /// // assuming a `context` has been bound
     ///
-    /// let base64 = utils::read_image("./my_image.jpg")
-    ///     .expect("Failed to read image");
+    /// let base64 = utils::read_image("./my_image.jpg").expect("Failed to read image");
     ///
     /// let mut user = context.cache.current_user().await;
-    /// let _ = user.edit(&context, |p| {
-    ///     p.avatar(Some(&base64))
-    /// }).await;
+    /// let _ = user.edit(&context, |p| p.avatar(Some(&base64))).await;
     /// #     }
     /// # }
     /// # }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -29,9 +29,7 @@ use crate::model::{guild::Role, Permissions};
 /// #
 /// // assuming a `channel_id` and `guild_id` has been bound
 ///
-/// let role = guild_id.create_role(&http, |r| {
-///     r.hoist(true).mentionable(true).name("a test role")
-/// });
+/// let role = guild_id.create_role(&http, |r| r.hoist(true).mentionable(true).name("a test role"));
 /// ```
 ///
 /// [`PartialGuild::create_role`]: crate::model::guild::PartialGuild::create_role

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -37,14 +37,16 @@ use crate::http::AttachmentType;
 /// let resources = Embed::fake(|e| {
 ///     e.title("Rust Resources")
 ///         .description("A few resources to help with learning Rust")
-///         .colour(0xDEA584).field("The Rust Book", "A comprehensive resource for Rust.", false)
+///         .colour(0xDEA584)
+///         .field("The Rust Book", "A comprehensive resource for Rust.", false)
 ///         .field("Rust by Example", "A collection of Rust examples", false)
 /// });
 ///
-/// webhook.execute(&http, false, |w| {
-///     w.content("Here's some information on Rust:").embeds(vec![website, resources])
-/// })
-/// .await?;
+/// webhook
+///     .execute(&http, false, |w| {
+///         w.content("Here's some information on Rust:").embeds(vec![website, resources])
+///     })
+///     .await?;
 /// #     Ok(())
 /// # }
 /// ```
@@ -71,10 +73,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// #
     /// let avatar_url = "https://i.imgur.com/KTs6whd.jpg";
     ///
-    /// webhook.execute(&http, false, |w| {
-    ///     w.avatar_url(avatar_url).content("Here's a webhook")
-    /// })
-    /// .await?;
+    /// webhook.execute(&http, false, |w| w.avatar_url(avatar_url).content("Here's a webhook")).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -99,10 +98,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # let http = Http::default();
     /// # let webhook = http.get_webhook_with_token(0, "").await?;
     /// #
-    /// let execution = webhook.execute(&http, false, |w| {
-    ///     w.content("foo")
-    /// })
-    /// .await;
+    /// let execution = webhook.execute(&http, false, |w| w.content("foo")).await;
     ///
     /// if let Err(why) = execution {
     ///     println!("Err sending webhook: {:?}", why);
@@ -173,10 +169,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # let http = Http::default();
     /// # let webhook = http.get_webhook_with_token(0, "").await?;
     /// #
-    /// let execution = webhook.execute(&http, false, |w| {
-    ///     w.content("hello").tts(true)
-    /// })
-    /// .await;
+    /// let execution = webhook.execute(&http, false, |w| w.content("hello").tts(true)).await;
     ///
     /// if let Err(why) = execution {
     ///     println!("Err sending webhook: {:?}", why);
@@ -202,10 +195,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # let http = Http::default();
     /// # let webhook = http.get_webhook_with_token(0, "").await?;
     /// #
-    /// let execution = webhook.execute(&http, false, |w| {
-    ///     w.content("hello").username("hakase")
-    /// })
-    /// .await;
+    /// let execution = webhook.execute(&http, false, |w| w.content("hello").username("hakase")).await;
     ///
     /// if let Err(why) = execution {
     ///     println!("Err sending webhook: {:?}", why);

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -35,10 +35,9 @@ use crate::model::id::MessageId;
 /// // you can then pass it into a function which retrieves messages:
 /// let channel_id = ChannelId(81384788765712384);
 ///
-/// let _messages = channel_id.messages(&http, |retriever| {
-///     retriever.after(MessageId(158339864557912064)).limit(25)
-/// })
-/// .await?;
+/// let _messages = channel_id
+///     .messages(&http, |retriever| retriever.after(MessageId(158339864557912064)).limit(25))
+///     .await?;
 /// #     Ok(())
 /// # }
 /// ```

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -467,11 +467,13 @@ impl Cache {
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, message: Message) {
-    ///
     ///         let channel = match context.cache.guild_channel(message.channel_id).await {
     ///             Some(channel) => channel,
     ///             None => {
-    ///                 let result = message.channel_id.say(&context, "Could not find guild's channel data").await;
+    ///                 let result = message
+    ///                     .channel_id
+    ///                     .say(&context, "Could not find guild's channel data")
+    ///                     .await;
     ///                 if let Err(why) = result {
     ///                     println!("Error sending message: {:?}", why);
     ///                 }

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -50,27 +50,29 @@ use crate::CacheAndHttp;
 /// # #[cfg(feature = "framework")]
 /// # async fn run() -> Result<(), Box<dyn Error>> {
 /// #
-/// use tokio::sync::{Mutex, RwLock};
-/// use serenity::client::bridge::gateway::{ShardManager, ShardManagerOptions, GatewayIntents};
-/// use serenity::client::{EventHandler, RawEventHandler};
-/// use serenity::http::Http;
-/// use serenity::CacheAndHttp;
-/// use serenity::prelude::*;
-/// use serenity::framework::{Framework, StandardFramework};
-/// use std::sync::Arc;
 /// use std::env;
+/// use std::sync::Arc;
+///
+/// use serenity::client::bridge::gateway::{GatewayIntents, ShardManager, ShardManagerOptions};
+/// use serenity::client::{EventHandler, RawEventHandler};
+/// use serenity::framework::{Framework, StandardFramework};
+/// use serenity::http::Http;
+/// use serenity::prelude::*;
+/// use serenity::CacheAndHttp;
+/// use tokio::sync::{Mutex, RwLock};
 ///
 /// struct Handler;
 ///
-/// impl EventHandler for Handler { }
-/// impl RawEventHandler for Handler { }
+/// impl EventHandler for Handler {}
+/// impl RawEventHandler for Handler {}
 ///
 /// # let cache_and_http = Arc::new(CacheAndHttp::default());
 /// # let http = &cache_and_http.http;
 /// let gateway_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 /// let data = Arc::new(RwLock::new(TypeMap::new()));
 /// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
-/// let framework = Arc::new(Box::new(StandardFramework::new()) as Box<dyn Framework + 'static + Send + Sync>);
+/// let framework =
+///     Arc::new(Box::new(StandardFramework::new()) as Box<dyn Framework + 'static + Send + Sync>);
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data: &data,
@@ -217,13 +219,14 @@ impl ShardManager {
     /// concept is the same)_
     ///
     /// ```rust,no_run
+    /// use std::env;
+    ///
     /// use serenity::client::bridge::gateway::ShardId;
     /// use serenity::client::{Client, EventHandler};
-    /// use std::env;
     ///
     /// struct Handler;
     ///
-    /// impl EventHandler for Handler { }
+    /// impl EventHandler for Handler {}
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -88,7 +88,12 @@ impl ShardMessenger {
     /// #
     /// use serenity::model::id::GuildId;
     ///
-    /// shard.chunk_guild(GuildId(81384788765712384), Some(20), ChunkGuildFilter::Query("do".to_owned()), Some("request"));
+    /// shard.chunk_guild(
+    ///     GuildId(81384788765712384),
+    ///     Some(20),
+    ///     ChunkGuildFilter::Query("do".to_owned()),
+    ///     Some("request"),
+    /// );
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -563,7 +563,7 @@ pub struct Client {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// struct Handler;
     ///
-    /// impl EventHandler for Handler { }
+    /// impl EventHandler for Handler {}
     ///
     /// let token = std::env::var("DISCORD_TOKEN")?;
     /// let mut client = Client::builder(&token).event_handler(Handler).await?;
@@ -587,12 +587,13 @@ pub struct Client {
     ///
     /// ```rust,no_run
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// use serenity::client::{Client, EventHandler};
     /// use std::time::Duration;
+    ///
+    /// use serenity::client::{Client, EventHandler};
     ///
     /// struct Handler;
     ///
-    /// impl EventHandler for Handler { }
+    /// impl EventHandler for Handler {}
     ///
     /// let token = std::env::var("DISCORD_TOKEN")?;
     /// let mut client = Client::builder(&token).event_handler(Handler).await?;

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -33,9 +33,9 @@
 //!
 //! ```rust,no_run
 //! use serenity::client::{Client, Context, EventHandler};
-//! use serenity::model::channel::Message;
 //! use serenity::framework::standard::macros::{command, group};
-//! use serenity::framework::standard::{StandardFramework, CommandResult};
+//! use serenity::framework::standard::{CommandResult, StandardFramework};
+//! use serenity::model::channel::Message;
 //!
 //! #[command]
 //! async fn about(ctx: &Context, msg: &Message) -> CommandResult {

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -83,14 +83,14 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 ///
 /// impl EventHandler for Handler {}
 ///
-/// use serenity::Client;
 /// use serenity::framework::StandardFramework;
 /// use serenity::model::id::UserId;
+/// use serenity::Client;
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// let token = std::env::var("DISCORD_BOT_TOKEN")?;
-/// let framework = StandardFramework::new()
-///     .configure(|c| c.on_mention(Some(UserId(5))).prefix("~"));
+/// let framework =
+///     StandardFramework::new().configure(|c| c.on_mention(Some(UserId(5))).prefix("~"));
 ///
 /// let mut client = Client::builder(&token).event_handler(Handler).framework(framework).await?;
 /// #     Ok(())
@@ -193,11 +193,11 @@ impl Configuration {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// use serenity::model::id::ChannelId;
     /// use serenity::framework::StandardFramework;
+    /// use serenity::model::id::ChannelId;
     ///
-    /// let framework = StandardFramework::new().configure(|c| c
-    ///     .allowed_channels(vec![ChannelId(7), ChannelId(77)].into_iter().collect()));
+    /// let framework = StandardFramework::new()
+    ///     .configure(|c| c.allowed_channels(vec![ChannelId(7), ChannelId(77)].into_iter().collect()));
     /// ```
     pub fn allowed_channels(&mut self, channels: HashSet<ChannelId>) -> &mut Self {
         self.allowed_channels = channels;
@@ -215,11 +215,11 @@ impl Configuration {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// use serenity::model::id::GuildId;
     /// use serenity::framework::StandardFramework;
+    /// use serenity::model::id::GuildId;
     ///
-    /// let framework = StandardFramework::new().configure(|c| c
-    ///     .blocked_guilds(vec![GuildId(7), GuildId(77)].into_iter().collect()));
+    /// let framework = StandardFramework::new()
+    ///     .configure(|c| c.blocked_guilds(vec![GuildId(7), GuildId(77)].into_iter().collect()));
     /// ```
     pub fn blocked_guilds(&mut self, guilds: HashSet<GuildId>) -> &mut Self {
         self.blocked_guilds = guilds;
@@ -239,11 +239,11 @@ impl Configuration {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// use serenity::model::id::UserId;
     /// use serenity::framework::StandardFramework;
+    /// use serenity::model::id::UserId;
     ///
-    /// let framework = StandardFramework::new().configure(|c| c
-    ///     .blocked_users(vec![UserId(7), UserId(77)].into_iter().collect()));
+    /// let framework = StandardFramework::new()
+    ///     .configure(|c| c.blocked_users(vec![UserId(7), UserId(77)].into_iter().collect()));
     /// ```
     pub fn blocked_users(&mut self, users: HashSet<UserId>) -> &mut Self {
         self.blocked_users = users;
@@ -260,11 +260,11 @@ impl Configuration {
     /// Ignore a set of commands, assuming they exist:
     ///
     /// ```rust,no_run
-    /// use serenity::framework::StandardFramework;
     /// use serenity::client::Context;
-    /// use serenity::model::channel::Message;
+    /// use serenity::framework::standard::macros::{command, group};
     /// use serenity::framework::standard::CommandResult;
-    /// use serenity::framework::standard::macros::{group, command};
+    /// use serenity::framework::StandardFramework;
+    /// use serenity::model::channel::Message;
     ///
     /// #[command]
     /// async fn ping(ctx: &Context, msg: &Message) -> CommandResult {
@@ -278,9 +278,8 @@ impl Configuration {
     ///
     /// let disabled = vec!["ping"].into_iter().map(|x| x.to_string()).collect();
     ///
-    /// let framework = StandardFramework::new()
-    ///     .group(&PENG_GROUP)
-    ///     .configure(|c| c.disabled_commands(disabled));
+    /// let framework =
+    ///     StandardFramework::new().group(&PENG_GROUP).configure(|c| c.disabled_commands(disabled));
     /// ```
     #[inline]
     pub fn disabled_commands(&mut self, commands: HashSet<String>) -> &mut Self {
@@ -317,14 +316,13 @@ impl Configuration {
     /// # use serenity::prelude::*;
     /// use serenity::framework::StandardFramework;
     ///
-    /// let framework = StandardFramework::new()
-    ///     .configure(|c| c.dynamic_prefix(|_, msg| Box::pin(async move {
-    ///         Some(if msg.channel_id.0 % 5 == 0 {
-    ///             "!"
-    ///         } else {
-    ///             "*"
-    ///         }.to_string())
-    ///     })));
+    /// let framework = StandardFramework::new().configure(|c| {
+    ///     c.dynamic_prefix(|_, msg| {
+    ///         Box::pin(
+    ///             async move { Some(if msg.channel_id.0 % 5 == 0 { "!" } else { "*" }.to_string()) },
+    ///         )
+    ///     })
+    /// });
     /// ```
     ///
     /// This will only use the prefix `"!"` or `"*"` depending on channel ID,
@@ -334,8 +332,8 @@ impl Configuration {
     /// # use serenity::prelude::*;
     /// use serenity::framework::StandardFramework;
     ///
-    /// let framework = StandardFramework::new()
-    ///     .configure(|c| c
+    /// let framework = StandardFramework::new().configure(|c| {
+    ///     c
     ///        .dynamic_prefix(|_, msg| Box::pin(async move {
     ///             Some(if msg.channel_id.0 % 5 == 0 {
     ///                 "!"
@@ -345,7 +343,7 @@ impl Configuration {
     ///         }))
     ///         // This disables the default prefix "~"
     ///         .prefix("")
-    ///     );
+    /// });
     /// ```
     ///
     /// [`Context::data`]: crate::client::Context::data
@@ -412,19 +410,20 @@ impl Configuration {
     /// Create a HashSet in-place:
     ///
     /// ```rust,no_run
-    /// use serenity::model::id::UserId;
     /// use serenity::framework::StandardFramework;
+    /// use serenity::model::id::UserId;
     ///
-    /// let framework = StandardFramework::new().configure(|c| c
-    ///     .owners(vec![UserId(7), UserId(77)].into_iter().collect()));
+    /// let framework = StandardFramework::new()
+    ///     .configure(|c| c.owners(vec![UserId(7), UserId(77)].into_iter().collect()));
     /// ```
     ///
     /// Create a HashSet beforehand:
     ///
     /// ```rust,no_run
-    /// use serenity::model::id::UserId;
     /// use std::collections::HashSet;
+    ///
     /// use serenity::framework::StandardFramework;
+    /// use serenity::model::id::UserId;
     ///
     /// let mut set = HashSet::new();
     /// set.insert(UserId(7));
@@ -455,8 +454,7 @@ impl Configuration {
     /// ```rust,no_run
     /// use serenity::framework::StandardFramework;
     ///
-    /// let framework = StandardFramework::new().configure(|c| c
-    ///     .prefix("!"));
+    /// let framework = StandardFramework::new().configure(|c| c.prefix("!"));
     /// ```
     pub fn prefix(&mut self, prefix: impl ToString) -> &mut Self {
         let p = prefix.to_string();
@@ -480,8 +478,7 @@ impl Configuration {
     /// ```rust,no_run
     /// use serenity::framework::StandardFramework;
     ///
-    /// let framework = StandardFramework::new().configure(|c| c
-    ///     .prefixes(vec!["!", ">", "+"]));
+    /// let framework = StandardFramework::new().configure(|c| c.prefixes(vec!["!", ">", "+"]));
     /// ```
     #[inline]
     pub fn prefixes<T, It>(&mut self, prefixes: It) -> &mut Self
@@ -520,8 +517,7 @@ impl Configuration {
     /// ```rust,no_run
     /// use serenity::framework::StandardFramework;
     ///
-    /// let framework = StandardFramework::new().configure(|c| c
-    ///     .delimiter(", "));
+    /// let framework = StandardFramework::new().configure(|c| c.delimiter(", "));
     /// ```
     pub fn delimiter<I: Into<Delimiter>>(&mut self, delimiter: I) -> &mut Self {
         self.delimiters.clear();
@@ -542,8 +538,7 @@ impl Configuration {
     /// ```rust,no_run
     /// use serenity::framework::StandardFramework;
     ///
-    /// let framework = StandardFramework::new().configure(|c| c
-    ///     .delimiters(vec![", ", " "]));
+    /// let framework = StandardFramework::new().configure(|c| c.delimiters(vec![", ", " "]));
     /// ```
     pub fn delimiters<T, It>(&mut self, delimiters: It) -> &mut Self
     where

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -6,19 +6,20 @@
 //! embeds:
 //!
 //! ```rust,no_run
-//! use serenity::framework::standard::{
-//!     StandardFramework,
-//!     help_commands,
-//!     Args,
-//!     HelpOptions,
-//!     CommandGroup,
-//!     CommandResult,
-//! };
-//! use serenity::framework::standard::macros::help;
-//! use serenity::model::prelude::{Message, UserId};
-//! use serenity::client::{EventHandler, Context, Client};
 //! use std::collections::HashSet;
 //! use std::env;
+//!
+//! use serenity::client::{Client, Context, EventHandler};
+//! use serenity::framework::standard::macros::help;
+//! use serenity::framework::standard::{
+//!     help_commands,
+//!     Args,
+//!     CommandGroup,
+//!     CommandResult,
+//!     HelpOptions,
+//!     StandardFramework,
+//! };
+//! use serenity::model::prelude::{Message, UserId};
 //!
 //! struct Handler;
 //!
@@ -26,12 +27,12 @@
 //!
 //! #[help]
 //! async fn my_help(
-//!    context: &Context,
-//!    msg: &Message,
-//!    args: Args,
-//!    help_options: &'static HelpOptions,
-//!    groups: &[&'static CommandGroup],
-//!    owners: HashSet<UserId>
+//!     context: &Context,
+//!     msg: &Message,
+//!     args: Args,
+//!     help_options: &'static HelpOptions,
+//!     groups: &[&'static CommandGroup],
+//!     owners: HashSet<UserId>,
 //! ) -> CommandResult {
 //! #  #[cfg(all(feature = "cache", feature = "http"))]
 //! # {
@@ -43,8 +44,7 @@
 //! # Ok(())
 //! }
 //!
-//! let framework = StandardFramework::new()
-//!     .help(&MY_HELP);
+//! let framework = StandardFramework::new().help(&MY_HELP);
 //! ```
 //!
 //! The same can be accomplished with no embeds by substituting `with_embeds`
@@ -1270,9 +1270,18 @@ async fn send_error_embed(
 /// ```rust,no_run
 /// # use serenity::prelude::*;
 /// use std::{collections::HashSet, hash::BuildHasher};
-/// use serenity::{framework::standard::{Args, CommandGroup, CommandResult,
-///     StandardFramework, macros::help, HelpOptions,
-///     help_commands::*}, model::prelude::*,
+///
+/// use serenity::{
+///     framework::standard::{
+///         help_commands::*,
+///         macros::help,
+///         Args,
+///         CommandGroup,
+///         CommandResult,
+///         HelpOptions,
+///         StandardFramework,
+///     },
+///     model::prelude::*,
 /// };
 ///
 /// #[help]
@@ -1282,14 +1291,13 @@ async fn send_error_embed(
 ///     args: Args,
 ///     help_options: &'static HelpOptions,
 ///     groups: &[&'static CommandGroup],
-///     owners: HashSet<UserId>
+///     owners: HashSet<UserId>,
 /// ) -> CommandResult {
 ///     let _ = with_embeds(context, msg, args, &help_options, groups, owners).await;
 ///     Ok(())
 /// }
 ///
-/// let framwork = StandardFramework::new()
-///     .help(&MY_HELP);
+/// let framwork = StandardFramework::new().help(&MY_HELP);
 /// ```
 ///
 /// [`StandardFramework::help`]: crate::framework::standard::StandardFramework::help
@@ -1472,9 +1480,18 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
 /// ```rust,no_run
 /// # use serenity::prelude::*;
 /// use std::{collections::HashSet, hash::BuildHasher};
-/// use serenity::{framework::standard::{Args, CommandGroup, CommandResult,
-///     StandardFramework, macros::help, HelpOptions,
-///     help_commands::*}, model::prelude::*,
+///
+/// use serenity::{
+///     framework::standard::{
+///         help_commands::*,
+///         macros::help,
+///         Args,
+///         CommandGroup,
+///         CommandResult,
+///         HelpOptions,
+///         StandardFramework,
+///     },
+///     model::prelude::*,
 /// };
 ///
 /// #[help]
@@ -1484,14 +1501,13 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
 ///     args: Args,
 ///     help_options: &'static HelpOptions,
 ///     groups: &[&'static CommandGroup],
-///     owners: HashSet<UserId>
+///     owners: HashSet<UserId>,
 /// ) -> CommandResult {
 ///     let _ = plain(context, msg, args, &help_options, groups, owners).await;
 ///     Ok(())
 /// }
 ///
-/// let framework = StandardFramework::new()
-///     .help(&MY_HELP);
+/// let framework = StandardFramework::new().help(&MY_HELP);
 /// ```
 #[cfg(all(feature = "cache", feature = "http"))]
 #[allow(clippy::implicit_hasher)]

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -143,15 +143,12 @@ impl StandardFramework {
     /// # use serenity::prelude::EventHandler;
     /// # struct Handler;
     /// # impl EventHandler for Handler {}
-    /// use serenity::Client;
     /// use serenity::framework::StandardFramework;
+    /// use serenity::Client;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let framework = StandardFramework::new()
-    ///     .configure(|c| c
-    ///         .with_whitespace(true)
-    ///         .prefix("~"));
+    /// let framework = StandardFramework::new().configure(|c| c.with_whitespace(true).prefix("~"));
     ///
     /// let mut client = Client::builder(&token).event_handler(Handler).framework(framework).await?;
     /// #     Ok(())
@@ -180,7 +177,7 @@ impl StandardFramework {
     ///
     /// ```rust,no_run
     /// use serenity::framework::standard::macros::command;
-    /// use serenity::framework::standard::{StandardFramework, CommandResult};
+    /// use serenity::framework::standard::{CommandResult, StandardFramework};
     ///
     /// #[command]
     /// // Registers the bucket `basic` to this command.
@@ -190,9 +187,8 @@ impl StandardFramework {
     /// }
     ///
     /// # async fn run() {
-    /// let framework = StandardFramework::new()
-    ///     .bucket("basic", |b| b.delay(2).time_span(10).limit(3))
-    ///     .await;
+    /// let framework =
+    ///     StandardFramework::new().bucket("basic", |b| b.delay(2).time_span(10).limit(3)).await;
     /// # }
     /// ```
     #[inline]
@@ -420,12 +416,18 @@ impl StandardFramework {
     /// #[hook]
     /// async fn dispatch_error_hook(context: &Context, msg: &Message, error: DispatchError) {
     ///     match error {
-    ///         DispatchError::NotEnoughArguments { min, given } => {
+    ///         DispatchError::NotEnoughArguments {
+    ///             min,
+    ///             given,
+    ///         } => {
     ///             let s = format!("Need {} arguments, but only got {}.", min, given);
     ///
     ///             let _ = msg.channel_id.say(&context, &s).await;
     ///         },
-    ///         DispatchError::TooManyArguments { max, given } => {
+    ///         DispatchError::TooManyArguments {
+    ///             max,
+    ///             given,
+    ///         } => {
     ///             let s = format!("Max arguments allowed is {}, but got {}.", max, given);
     ///
     ///             let _ = msg.channel_id.say(&context, &s).await;
@@ -434,8 +436,7 @@ impl StandardFramework {
     ///     }
     /// }
     ///
-    /// let framework = StandardFramework::new()
-    ///     .on_dispatch_error(dispatch_error_hook);
+    /// let framework = StandardFramework::new().on_dispatch_error(dispatch_error_hook);
     /// ```
     pub fn on_dispatch_error(mut self, f: DispatchHook) -> Self {
         self.dispatch = Some(f);
@@ -468,8 +469,7 @@ impl StandardFramework {
     ///     println!("Running command {}", cmd_name);
     ///     true
     /// }
-    /// let framework = StandardFramework::new()
-    ///     .before(before_hook);
+    /// let framework = StandardFramework::new().before(before_hook);
     /// ```
     ///
     /// Using before to prevent command usage:
@@ -494,8 +494,7 @@ impl StandardFramework {
     ///     true
     /// }
     ///
-    /// let framework = StandardFramework::new()
-    ///     .before(before_hook);
+    /// let framework = StandardFramework::new().before(before_hook);
     /// ```
     pub fn before(mut self, f: BeforeHook) -> Self {
         self.before = Some(f);
@@ -525,8 +524,7 @@ impl StandardFramework {
     ///     }
     /// }
     ///
-    /// let framework = StandardFramework::new()
-    ///     .after(after_hook);
+    /// let framework = StandardFramework::new().after(after_hook);
     /// ```
     pub fn after(mut self, f: AfterHook) -> Self {
         self.after = Some(f);
@@ -547,14 +545,18 @@ impl StandardFramework {
     /// use serenity::framework::StandardFramework;
     ///
     /// #[hook]
-    /// async fn unrecognised_command_hook(_: &Context, msg: &Message, unrecognised_command_name: &str) {
-    ///     println!("A user named {:?} tried to executute an unknown command: {}",
+    /// async fn unrecognised_command_hook(
+    ///     _: &Context,
+    ///     msg: &Message,
+    ///     unrecognised_command_name: &str,
+    /// ) {
+    ///     println!(
+    ///         "A user named {:?} tried to executute an unknown command: {}",
     ///         msg.author.name, unrecognised_command_name
     ///     );
     /// }
     ///
-    /// let framework = StandardFramework::new()
-    ///     .unrecognised_command(unrecognised_command_hook);
+    /// let framework = StandardFramework::new().unrecognised_command(unrecognised_command_hook);
     /// ```
     pub fn unrecognised_command(mut self, f: UnrecognisedHook) -> Self {
         self.unrecognised_command = Some(f);
@@ -579,8 +581,7 @@ impl StandardFramework {
     ///     println!("Received a generic message: {:?}", msg.content);
     /// }
     ///
-    /// let framework = StandardFramework::new()
-    ///     .normal_message(normal_message_hook);
+    /// let framework = StandardFramework::new().normal_message(normal_message_hook);
     /// ```
     pub fn normal_message(mut self, f: NormalMessageHook) -> Self {
         self.normal_message = Some(f);

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -110,9 +110,10 @@ impl Shard {
     /// then listening for events:
     ///
     /// ```rust,no_run
+    /// use std::sync::Arc;
+    ///
     /// use serenity::gateway::Shard;
     /// use tokio::sync::Mutex;
-    /// use std::sync::Arc;
     /// #
     /// # use serenity::http::Http;
     /// # use serenity::client::bridge::gateway::GatewayIntents;
@@ -704,7 +705,14 @@ impl Shard {
     /// #
     /// use serenity::model::id::GuildId;
     ///
-    /// shard.chunk_guild(GuildId(81384788765712384), Some(20), ChunkGuildFilter::Query("do".to_owned()), Some("request")).await?;
+    /// shard
+    ///     .chunk_guild(
+    ///         GuildId(81384788765712384),
+    ///         Some(20),
+    ///         ChunkGuildFilter::Query("do".to_owned()),
+    ///         Some("request"),
+    ///     )
+    ///     .await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1065,7 +1065,7 @@ impl Http {
     /// let http = Http::default();
     ///
     /// http.delete_webhook(245037420704169985).await?;
-    ///       Ok(())
+    /// Ok(())
     /// # }
     /// ```
     pub async fn delete_webhook(&self, webhook_id: u64) -> Result<()> {

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -49,12 +49,13 @@ impl Attachment {
     /// ```rust,no_run
     /// # #[cfg(feature = "client")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::io::Write;
+    /// use std::path::Path;
+    ///
     /// use serenity::model::prelude::*;
     /// use serenity::prelude::*;
     /// use tokio::fs::File;
     /// use tokio::io::AsyncWriteExt;
-    /// use std::io::Write;
-    /// use std::path::Path;
     ///
     /// struct Handler;
     ///
@@ -66,7 +67,8 @@ impl Attachment {
     ///                 Ok(content) => content,
     ///                 Err(why) => {
     ///                     println!("Error downloading attachment: {:?}", why);
-    ///                     let _ = message.channel_id.say(&context, "Error downloading attachment").await;
+    ///                     let _ =
+    ///                         message.channel_id.say(&context, "Error downloading attachment").await;
     ///
     ///                     return;
     ///                 },
@@ -88,7 +90,10 @@ impl Attachment {
     ///                 return;
     ///             }
     ///
-    ///             let _ = message.channel_id.say(&context, &format!("Saved {:?}", attachment.filename)).await;
+    ///             let _ = message
+    ///                 .channel_id
+    ///                 .say(&context, &format!("Saved {:?}", attachment.filename))
+    ///                 .await;
     ///         }
     ///     }
     ///

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -514,17 +514,13 @@ impl ChannelId {
     /// # async fn run() {
     /// # let channel_id = ChannelId::default();
     /// # let ctx = Http::default();
-    /// use serenity::model::channel::MessagesIter;
     /// use serenity::futures::StreamExt;
+    /// use serenity::model::channel::MessagesIter;
     ///
     /// let mut messages = channel_id.messages_iter(&ctx).boxed();
     /// while let Some(message_result) = messages.next().await {
     ///     match message_result {
-    ///         Ok(message) => println!(
-    ///             "{} said \"{}\".",
-    ///             message.author.name,
-    ///             message.content,
-    ///         ),
+    ///         Ok(message) => println!("{} said \"{}\".", message.author.name, message.content,),
     ///         Err(error) => eprintln!("Uh oh! Error: {}", error),
     ///     }
     /// }
@@ -677,10 +673,7 @@ impl ChannelId {
     ///
     /// let paths = vec!["/path/to/file.jpg", "path/to/file2.jpg"];
     ///
-    /// let _ = channel_id.send_files(&http, paths, |m| {
-    ///     m.content("a file")
-    /// })
-    /// .await;
+    /// let _ = channel_id.send_files(&http, paths, |m| m.content("a file")).await;
     /// # }
     /// ```
     ///
@@ -702,10 +695,7 @@ impl ChannelId {
     ///
     /// let files = vec![(&f1, "my_file.jpg"), (&f2, "my_file2.jpg")];
     ///
-    /// let _ = channel_id.send_files(&http, files, |m| {
-    ///     m.content("a file")
-    /// })
-    /// .await;
+    /// let _ = channel_id.send_files(&http, files, |m| m.content("a file")).await;
     /// #    Ok(())
     /// # }
     /// ```
@@ -1337,17 +1327,13 @@ impl<H: AsRef<Http>> MessagesIter<H> {
     /// # async fn run() {
     /// # let channel_id = ChannelId::default();
     /// # let ctx = Http::default();
-    /// use serenity::model::channel::MessagesIter;
     /// use serenity::futures::StreamExt;
+    /// use serenity::model::channel::MessagesIter;
     ///
     /// let mut messages = MessagesIter::<Http>::stream(&ctx, channel_id).boxed();
     /// while let Some(message_result) = messages.next().await {
     ///     match message_result {
-    ///         Ok(message) => println!(
-    ///             "{} said \"{}\"",
-    ///             message.author.name,
-    ///             message.content,
-    ///         ),
+    ///         Ok(message) => println!("{} said \"{}\"", message.author.name, message.content,),
     ///         Err(error) => eprintln!("Uh oh! Error: {}", error),
     ///     }
     /// }

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -82,9 +82,11 @@ impl Embed {
     /// use serenity::model::channel::Embed;
     ///
     /// let embed = Embed::fake(|e| {
-    ///     e.title("Embed title")
-    ///         .description("Making a basic embed")
-    ///         .field("A field", "Has some content.", false)
+    ///     e.title("Embed title").description("Making a basic embed").field(
+    ///         "A field",
+    ///         "Has some content.",
+    ///         false,
+    ///     )
     /// });
     /// ```
     #[inline]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -231,23 +231,17 @@ impl GuildChannel {
     /// #     let cache = Cache::default();
     /// #     let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
-    /// use serenity::model::channel::{
-    ///     PermissionOverwrite,
-    ///     PermissionOverwriteType,
-    /// };
+    /// use serenity::model::channel::{PermissionOverwrite, PermissionOverwriteType};
     /// use serenity::model::{ModelError, Permissions};
     /// let allow = Permissions::SEND_MESSAGES;
     /// let deny = Permissions::SEND_TTS_MESSAGES | Permissions::ATTACH_FILES;
     /// let overwrite = PermissionOverwrite {
-    ///     allow: allow,
-    ///     deny: deny,
+    ///     allow,
+    ///     deny,
     ///     kind: PermissionOverwriteType::Member(user_id),
     /// };
     /// // assuming the cache has been unlocked
-    /// let channel = cache
-    ///     .guild_channel(channel_id)
-    ///     .await
-    ///     .ok_or(ModelError::ItemMissing)?;
+    /// let channel = cache.guild_channel(channel_id).await.ok_or(ModelError::ItemMissing)?;
     ///
     /// channel.create_permission(&http, &overwrite).await?;
     /// #   Ok(())
@@ -270,24 +264,18 @@ impl GuildChannel {
     /// #   let cache = Cache::default();
     /// #   let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
-    /// use serenity::model::channel::{
-    ///     PermissionOverwrite,
-    ///     PermissionOverwriteType,
-    /// };
-    /// use serenity::model::{ModelError, Permissions, channel::Channel};
+    /// use serenity::model::channel::{PermissionOverwrite, PermissionOverwriteType};
+    /// use serenity::model::{channel::Channel, ModelError, Permissions};
     ///
     /// let allow = Permissions::SEND_MESSAGES;
     /// let deny = Permissions::SEND_TTS_MESSAGES | Permissions::ATTACH_FILES;
     /// let overwrite = PermissionOverwrite {
-    ///     allow: allow,
-    ///     deny: deny,
+    ///     allow,
+    ///     deny,
     ///     kind: PermissionOverwriteType::Member(user_id),
     /// };
     ///
-    /// let channel = cache
-    ///     .guild_channel(channel_id)
-    ///     .await
-    ///     .ok_or(ModelError::ItemMissing)?;
+    /// let channel = cache.guild_channel(channel_id).await.ok_or(ModelError::ItemMissing)?;
     ///
     /// channel.create_permission(&http, &overwrite).await?;
     /// #     Ok(())
@@ -715,8 +703,8 @@ impl GuildChannel {
     /// channel:
     ///
     /// ```rust,no_run
-    /// use serenity::prelude::*;
     /// use serenity::model::prelude::*;
+    /// use serenity::prelude::*;
     /// struct Handler;
     ///
     /// #[serenity::async_trait]
@@ -727,14 +715,15 @@ impl GuildChannel {
     ///             None => return,
     ///         };
     ///
-    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, &msg.author).await {
+    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, &msg.author).await
+    ///         {
     ///             println!("The user's permissions: {:?}", permissions);
     ///         }
     ///     }
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -746,9 +735,9 @@ impl GuildChannel {
     /// for demonstrative purposes):
     ///
     /// ```rust,no_run
-    /// use serenity::prelude::*;
-    /// use serenity::model::prelude::*;
     /// use serenity::model::channel::Channel;
+    /// use serenity::model::prelude::*;
+    /// use serenity::prelude::*;
     /// use tokio::fs::File;
     ///
     /// struct Handler;
@@ -762,8 +751,9 @@ impl GuildChannel {
     ///         };
     ///
     ///         let current_user_id = context.cache.current_user().await.id;
-    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, current_user_id).await {
-    ///
+    ///         if let Ok(permissions) =
+    ///             channel.permissions_for_user(&context.cache, current_user_id).await
+    ///         {
     ///             if !permissions.contains(Permissions::ATTACH_FILES | Permissions::SEND_MESSAGES) {
     ///                 return;
     ///             }
@@ -777,17 +767,19 @@ impl GuildChannel {
     ///                 },
     ///             };
     ///
-    ///             let _ = msg.channel_id.send_files(&context.http, vec![(&file, "cat.png")], |mut m| {
-    ///                 m.content("here's a cat");
-    ///                 m
-    ///             })
-    ///             .await;
+    ///             let _ = msg
+    ///                 .channel_id
+    ///                 .send_files(&context.http, vec![(&file, "cat.png")], |mut m| {
+    ///                     m.content("here's a cat");
+    ///                     m
+    ///                 })
+    ///                 .await;
     ///         }
     ///     }
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -86,7 +86,9 @@ impl Channel {
     ///     Some(guild_channel) => {
     ///         println!("It's a guild channel named {}!", guild_channel.name);
     ///     },
-    ///     None => { println!("It's not in a guild!"); },
+    ///     None => {
+    ///         println!("It's not in a guild!");
+    ///     },
     /// }
     /// # }
     /// ```
@@ -121,7 +123,9 @@ impl Channel {
     ///     Some(private) => {
     ///         println!("It's a private channel with {}!", &private.recipient);
     ///     },
-    ///     None => { println!("It's not a private channel!"); },
+    ///     None => {
+    ///         println!("It's not a private channel!");
+    ///     },
     /// }
     /// # }
     /// ```
@@ -156,7 +160,9 @@ impl Channel {
     ///     Some(category) => {
     ///         println!("It's a category named {}!", category.name);
     ///     },
-    ///     None => { println!("It's not a category!"); },
+    ///     None => {
+    ///         println!("It's not a category!");
+    ///     },
     /// }
     /// #
     /// # }

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -20,10 +20,10 @@ use super::Permissions;
 /// ```rust,no_run
 /// # #[cfg(all(feature = "client", feature = "model"))]
 /// # async fn run() -> Result<(), Box<std::error::Error>> {
-/// use serenity::prelude::*;
 /// use serenity::model::prelude::*;
-/// use serenity::Error;
 /// use serenity::model::ModelError;
+/// use serenity::prelude::*;
+/// use serenity::Error;
 ///
 /// struct Handler;
 ///

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -84,12 +84,12 @@ impl Activity {
     /// Create a command that sets the current activity:
     ///
     /// ```rust,no_run
-    /// use serenity::model::gateway::Activity;
-    /// use serenity::model::channel::Message;
-    /// # #[cfg(feature = "framework")]
-    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
     /// # #[cfg(feature = "client")]
     /// use serenity::client::Context;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{macros::command, Args, CommandResult};
+    /// use serenity::model::channel::Message;
+    /// use serenity::model::gateway::Activity;
     ///
     /// # #[cfg(feature = "framework")]
     /// #[command]
@@ -136,12 +136,12 @@ impl Activity {
     /// Create a command that sets the current streaming status:
     ///
     /// ```rust,no_run
-    /// use serenity::model::gateway::Activity;
-    /// use serenity::model::channel::Message;
-    /// # #[cfg(feature = "framework")]
-    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
     /// # #[cfg(feature = "client")]
     /// use serenity::client::Context;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{macros::command, Args, CommandResult};
+    /// use serenity::model::channel::Message;
+    /// use serenity::model::gateway::Activity;
     ///
     /// # #[cfg(feature = "framework")]
     /// #[command]
@@ -190,12 +190,12 @@ impl Activity {
     /// Create a command that sets the current listening status:
     ///
     /// ```rust,no_run
-    /// use serenity::model::gateway::Activity;
-    /// use serenity::model::channel::Message;
-    /// # #[cfg(feature = "framework")]
-    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
     /// # #[cfg(feature = "client")]
     /// use serenity::client::Context;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{macros::command, Args, CommandResult};
+    /// use serenity::model::channel::Message;
+    /// use serenity::model::gateway::Activity;
     ///
     /// # #[cfg(feature = "framework")]
     /// #[command]
@@ -241,12 +241,12 @@ impl Activity {
     /// Create a command that sets the current cometing status:
     ///
     /// ```rust,no_run
-    /// use serenity::model::gateway::Activity;
-    /// use serenity::model::channel::Message;
-    /// # #[cfg(feature = "framework")]
-    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
     /// # #[cfg(feature = "client")]
     /// use serenity::client::Context;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{macros::command, Args, CommandResult};
+    /// use serenity::model::channel::Message;
+    /// use serenity::model::gateway::Activity;
     ///
     /// # #[cfg(feature = "framework")]
     /// #[command]
@@ -292,12 +292,12 @@ impl Activity {
     /// Create a command that sets the current cometing status:
     ///
     /// ```rust,no_run
-    /// use serenity::model::gateway::Activity;
-    /// use serenity::model::channel::Message;
-    /// # #[cfg(feature = "framework")]
-    /// use serenity::framework::standard::{Args, CommandResult, macros::command};
     /// # #[cfg(feature = "client")]
     /// use serenity::client::Context;
+    /// # #[cfg(feature = "framework")]
+    /// use serenity::framework::standard::{macros::command, Args, CommandResult};
+    /// use serenity::model::channel::Message;
+    /// use serenity::model::gateway::Activity;
     ///
     /// # #[cfg(feature = "framework")]
     /// #[command]

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -86,7 +86,7 @@ impl Emoji {
     /// // assuming emoji has been set already
     /// match emoji.delete(&ctx).await {
     ///     Ok(()) => println!("Emoji deleted."),
-    ///     Err(_) => println!("Could not delete emoji.")
+    ///     Err(_) => println!("Could not delete emoji."),
     /// }
     /// #    Ok(())
     /// # }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -50,8 +50,8 @@ impl GuildId {
     /// Ban a member and remove all messages they've sent in the last 4 days:
     ///
     /// ```rust,no_run
-    /// use serenity::model::id::UserId;
     /// use serenity::model::id::GuildId;
+    /// use serenity::model::id::UserId;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # use serenity::http::Http;
@@ -184,13 +184,14 @@ impl GuildId {
     /// Create a voice channel in a guild with the name `test`:
     ///
     /// ```rust,no_run
-    /// use serenity::model::id::GuildId;
     /// use serenity::model::channel::ChannelType;
+    /// use serenity::model::id::GuildId;
     ///
     /// # async fn run() {
     /// # use serenity::http::Http;
     /// # let http = Http::default();
-    /// let _channel = GuildId(7).create_channel(&http, |c| c.name("test").kind(ChannelType::Voice)).await;
+    /// let _channel =
+    ///     GuildId(7).create_channel(&http, |c| c.name("test").kind(ChannelType::Voice)).await;
     /// # }
     /// ```
     ///
@@ -828,17 +829,13 @@ impl GuildId {
     /// # async fn run() {
     /// # let guild_id = GuildId::default();
     /// # let ctx = Http::default();
-    /// use serenity::model::guild::MembersIter;
     /// use serenity::futures::StreamExt;
+    /// use serenity::model::guild::MembersIter;
     ///
     /// let mut members = guild_id.members_iter(&ctx).boxed();
     /// while let Some(member_result) = members.next().await {
     ///     match member_result {
-    ///         Ok(member) => println!(
-    ///             "{} is {}",
-    ///             member,
-    ///             member.display_name(),
-    ///         ),
+    ///         Ok(member) => println!("{} is {}", member, member.display_name(),),
     ///         Err(error) => eprintln!("Uh oh!  Error: {}", error),
     ///     }
     /// }
@@ -1523,17 +1520,13 @@ impl<H: AsRef<Http>> MembersIter<H> {
     /// # async fn run() {
     /// # let guild_id = GuildId::default();
     /// # let ctx = Http::default();
-    /// use serenity::model::guild::MembersIter;
     /// use serenity::futures::StreamExt;
+    /// use serenity::model::guild::MembersIter;
     ///
     /// let mut members = MembersIter::<Http>::stream(&ctx, guild_id).boxed();
     /// while let Some(member_result) = members.next().await {
     ///     match member_result {
-    ///         Ok(member) => println!(
-    ///             "{} is {}",
-    ///             member,
-    ///             member.display_name(),
-    ///         ),
+    ///         Ok(member) => println!("{} is {}", member, member.display_name(),),
     ///         Err(error) => eprintln!("Uh oh!  Error: {}", error),
     ///     }
     /// }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1465,7 +1465,7 @@ impl PartialGuild {
     ///     }
     /// }
     ///
-    /// let mut client =Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #    Ok(())

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -735,11 +735,13 @@ impl ApplicationCommand {
     /// #
     /// # async fn run() {
     /// # let http = Arc::new(Http::default());
-    /// use serenity::model::{interactions::application_command::ApplicationCommand, id::ApplicationId};
+    /// use serenity::model::{
+    ///     id::ApplicationId,
+    ///     interactions::application_command::ApplicationCommand,
+    /// };
     ///
     /// let _ = ApplicationCommand::create_global_application_command(&http, |command| {
-    ///    command.name("ping")
-    ///     .description("A simple ping command")
+    ///     command.name("ping").description("A simple ping command")
     /// })
     /// .await;
     /// # }
@@ -754,18 +756,17 @@ impl ApplicationCommand {
     /// # async fn run() {
     /// # let http = Arc::new(Http::default());
     /// use serenity::model::{
+    ///     id::ApplicationId,
     ///     interactions::application_command::{ApplicationCommand, ApplicationCommandOptionType},
-    ///     id::ApplicationId
     /// };
     ///
     /// let _ = ApplicationCommand::create_global_application_command(&http, |command| {
-    ///    command.name("echo")
-    ///     .description("Makes the bot send a message")
-    ///     .create_option(|option| {
-    ///         option.name("message")
-    ///          .description("The message to send")
-    ///          .kind(ApplicationCommandOptionType::String)
-    ///          .required(true)
+    ///     command.name("echo").description("Makes the bot send a message").create_option(|option| {
+    ///         option
+    ///             .name("message")
+    ///             .description("The message to send")
+    ///             .kind(ApplicationCommandOptionType::String)
+    ///             .required(true)
     ///     })
     /// })
     /// .await;

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -75,7 +75,7 @@ impl CurrentUser {
     ///
     /// match user.avatar_url() {
     ///     Some(url) => println!("{}'s avatar can be found at {}", user.name, url),
-    ///     None => println!("{} does not have an avatar set.", user.name)
+    ///     None => println!("{} does not have an avatar set.", user.name),
     /// }
     /// # }
     /// ```
@@ -238,8 +238,11 @@ impl CurrentUser {
     ///     },
     /// };
     ///
-    /// assert_eq!(url, "https://discordapp.com/api/oauth2/authorize? \
-    ///                  client_id=249608697955745802&scope=bot");
+    /// assert_eq!(
+    ///     url,
+    ///     "https://discordapp.com/api/oauth2/authorize? \
+    ///                  client_id=249608697955745802&scope=bot"
+    /// );
     /// # }
     /// ```
     ///
@@ -255,7 +258,8 @@ impl CurrentUser {
     /// use serenity::model::Permissions;
     ///
     /// // assuming the user has been bound
-    /// let permissions = Permissions::READ_MESSAGES | Permissions::SEND_MESSAGES | Permissions::EMBED_LINKS;
+    /// let permissions =
+    ///     Permissions::READ_MESSAGES | Permissions::SEND_MESSAGES | Permissions::EMBED_LINKS;
     /// let url = match user.invite_url(&http, permissions).await {
     ///     Ok(v) => v,
     ///     Err(why) => {
@@ -265,9 +269,11 @@ impl CurrentUser {
     ///     },
     /// };
     ///
-    /// assert_eq!(url,
-    /// "https://discordapp.
-    /// com/api/oauth2/authorize?client_id=249608697955745802&scope=bot&permissions=19456");
+    /// assert_eq!(
+    ///     url,
+    ///     "https://discordapp.
+    /// com/api/oauth2/authorize?client_id=249608697955745802&scope=bot&permissions=19456"
+    /// );
     /// # }
     /// ```
     ///
@@ -301,8 +307,8 @@ impl CurrentUser {
     /// # async fn run() {
     /// #     let user = CurrentUser::default();
     /// #     let http = Http::default();
-    /// use serenity::model::Permissions;
     /// use serenity::model::oauth2::OAuth2Scope;
+    /// use serenity::model::Permissions;
     ///
     /// let scopes = vec![OAuth2Scope::Bot, OAuth2Scope::ApplicationsCommands];
     ///
@@ -316,8 +322,11 @@ impl CurrentUser {
     ///     },
     /// };
     ///
-    /// assert_eq!(url, "https://discordapp.com/api/oauth2/authorize? \
-    ///                  client_id=249608697955745802&scope=bot%20applications.commands");
+    /// assert_eq!(
+    ///     url,
+    ///     "https://discordapp.com/api/oauth2/authorize? \
+    ///                  client_id=249608697955745802&scope=bot%20applications.commands"
+    /// );
     /// # }
     /// ```
     /// # Errors
@@ -361,7 +370,7 @@ impl CurrentUser {
     ///
     /// match user.static_avatar_url() {
     ///     Some(url) => println!("{}'s static avatar can be found at {}", user.name, url),
-    ///     None => println!("Could not get static avatar for {}.", user.name)
+    ///     None => println!("Could not get static avatar for {}.", user.name),
     /// }
     /// # }
     /// ```
@@ -657,7 +666,13 @@ impl User {
     /// #   #[cfg(feature = "cache")]
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "~help" {
-    ///             let url = match ctx.cache.current_user().await.invite_url(&ctx, Permissions::empty()).await {
+    ///             let url = match ctx
+    ///                 .cache
+    ///                 .current_user()
+    ///                 .await
+    ///                 .invite_url(&ctx, Permissions::empty())
+    ///                 .await
+    ///             {
     ///                 Ok(v) => v,
     ///                 Err(why) => {
     ///                     println!("Error creating invite url: {:?}", why);
@@ -666,15 +681,9 @@ impl User {
     ///                 },
     ///             };
     ///
-    ///             let help = format!(
-    ///                 "Helpful info here. Invite me with this link: <{}>",
-    ///                 url,
-    ///             );
+    ///             let help = format!("Helpful info here. Invite me with this link: <{}>", url,);
     ///
-    ///             let dm = msg.author.direct_message(&ctx, |m| {
-    ///                 m.content(&help)
-    ///             })
-    ///             .await;
+    ///             let dm = msg.author.direct_message(&ctx, |m| m.content(&help)).await;
     ///
     ///             match dm {
     ///                 Ok(_) => {
@@ -691,7 +700,7 @@ impl User {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     /// #     Ok(())
     /// # }
     /// # }
@@ -853,8 +862,8 @@ impl User {
     /// # use serenity::prelude::*;
     /// # use serenity::model::prelude::*;
     /// #
-    /// use serenity::utils::MessageBuilder;
     /// use serenity::utils::ContentModifier::Bold;
+    /// use serenity::utils::MessageBuilder;
     ///
     /// struct Handler;
     ///
@@ -871,7 +880,7 @@ impl User {
     ///         }
     ///     }
     /// }
-    /// let mut client =Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token").event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -232,11 +232,12 @@ impl Webhook {
     ///
     /// let mut webhook = http.get_webhook_with_token(id, token).await?;
     ///
-    /// webhook.execute(&http, false, |mut w| {
-    ///     w.content("test");
-    ///     w
-    /// })
-    /// .await?;
+    /// webhook
+    ///     .execute(&http, false, |mut w| {
+    ///         w.content("test");
+    ///         w
+    ///     })
+    ///     .await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -258,20 +259,23 @@ impl Webhook {
     ///
     /// let embed = Embed::fake(|mut e| {
     ///     e.title("Rust's website");
-    ///     e.description("Rust is a systems programming language that runs
+    ///     e.description(
+    ///         "Rust is a systems programming language that runs
     ///                    blazingly fast, prevents segfaults, and guarantees
-    ///                    thread safety.");
+    ///                    thread safety.",
+    ///     );
     ///     e.url("https://rust-lang.org");
     ///     e
     /// });
     ///
-    /// webhook.execute(&http, false, |mut w| {
-    ///     w.content("test");
-    ///     w.username("serenity");
-    ///     w.embeds(vec![embed]);
-    ///     w
-    /// })
-    /// .await?;
+    /// webhook
+    ///     .execute(&http, false, |mut w| {
+    ///         w.content("test");
+    ///         w.username("serenity");
+    ///         w.embeds(vec![embed]);
+    ///         w
+    ///     })
+    ///     .await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1020,8 +1020,8 @@ impl EmbedMessageBuilding for MessageBuilder {
 /// Create a new Content type which describes a bold-italic "text":
 ///
 /// ```rust,no_run
-/// use serenity::utils::ContentModifier::{Bold, Italic};
 /// use serenity::utils::Content;
+/// use serenity::utils::ContentModifier::{Bold, Italic};
 /// let content: Content = Bold + Italic + "text";
 /// ```
 #[non_exhaustive]


### PR DESCRIPTION
The latest rustfmt nightly respects the `format_code_in_doc_comments`
option in the `rustfmt.toml`