### PR TITLE
Remove old version of `time` from dependency tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,8 @@ optional = true
 version = "0.13"
 
 [dependencies.chrono]
-features = ["serde"]
+default-features = false
+features = ["clock", "serde"]
 version = "0.4.10"
 
 [dependencies.flate2]

--- a/examples/e09_create_message_builder/Cargo.toml
+++ b/examples/e09_create_message_builder/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-chrono = "0.4.10"
+chrono = { version = "0.4.10", default-features = false, features = ["clock"] }

--- a/examples/e13_parallel_loops/Cargo.toml
+++ b/examples/e13_parallel_loops/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 sys-info = "0.7"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }


### PR DESCRIPTION
chrono has a feature called `oldtime`, which adds a dependency to a 0.1 version of the time crate ([chrono docs](https://docs.rs/chrono/0.4.19/chrono/#duration)). serenity does not need it, I ran `cargo test` and `cargo check` and it worked just like before.