### PR TITLE
Explicitly set rustfmt edition to match that found in Cargo.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2018"
 unstable_features = true
 use_small_heuristics = "Max"
 # Turn on once the rustfmt supporting these becomes available on rustup


### PR DESCRIPTION
Rust tools assume edition 2015, which in some cases causes them to fail when parsing certain files, for example if they contain `async` keywords. `cargo fmt` doesn't suffer from this problem since it knows what edition to use, but in my workflow I end up invoking `rustfmt` automatically through my editor, which led me to discover this.