### PR TITLE
Make the crate compilable with minimal dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ package = "async-tungstenite"
 default-features = false
 features = ["tokio-runtime"]
 optional = true
-version = "0.9"
+version = "0.9.2"
 
 [dependencies.typemap_rev]
 optional = true

--- a/voice-model/Cargo.toml
+++ b/voice-model/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1"
-enum_primitive = "0.1"
-serde_repr = "0.1"
+enum_primitive = "0.1.1"
+serde_repr = "0.1.5"
 
 [dependencies.serde]
 version = "1"


### PR DESCRIPTION
Dependency specifications in the current `Cargo.toml`s in this repo is too loose, and the crate can fail to compile even when all the dependencies are within versions specified in `Cargo.toml`s.
To test this, you can generate `Cargo.lock` with `cargo +nightly update -Z minimal-versions` and try to run `cargo test --all-features`.

This commit bumps dependencies to make the crate compile with any `Cargo.lock` that satisfies `Cargo.toml`.
In order to prevent unintended side effects, used lower versions as possible.

Intended changes are below:

* Remove `num` v0.0.1 (pulled from `enum_premitive` v0.1.0).
* Bump `quote` v0.6.3 to v1.0.9 (pulled from `serde_repr` v0.1.0).
* Bump `async-tungstenite` v0.9.0 to v0.9.2 (pulled from `serenity`).