### PR TITLE
Fix `Permissions` bitflags

### DIFF
--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -221,27 +221,27 @@ __impl_bitflags! {
         /// Allows for the creation of [`RichInvite`]s.
         ///
         /// [`RichInvite`]: super::invite::RichInvite
-        CREATE_INVITE = 0b0000_0000_0000_0000_0000_0000_0000_0001;
+        CREATE_INVITE = 1 << 0;
         /// Allows for the kicking of guild [member]s.
         ///
         /// [member]: super::guild::Member
-        KICK_MEMBERS = 0b0000_0000_0000_0000_0000_0000_0000_0010;
+        KICK_MEMBERS = 1 << 1;
         /// Allows the banning of guild [member]s.
         ///
         /// [member]: super::guild::Member
-        BAN_MEMBERS = 0b0000_0000_0000_0000_0000_0000_0000_0100;
+        BAN_MEMBERS = 1 << 2;
         /// Allows all permissions, bypassing channel [permission overwrite]s.
         ///
         /// [permission overwrite]: super::channel::PermissionOverwrite
-        ADMINISTRATOR = 0b0000_0000_0000_0000_0000_0000_0000_1000;
+        ADMINISTRATOR = 1 << 3;
         /// Allows management and editing of guild [channel]s.
         ///
         /// [channel]: super::channel::GuildChannel
-        MANAGE_CHANNELS = 0b0000_0000_0000_0000_0000_0000_0001_0000;
+        MANAGE_CHANNELS = 1 << 4;
         /// Allows management and editing of the [guild].
         ///
         /// [guild]: super::guild::Guild
-        MANAGE_GUILD = 0b0000_0000_0000_0000_0000_0000_0010_0000;
+        MANAGE_GUILD = 1 << 5;
         /// [`Member`]s with this permission can add new [`Reaction`]s to a
         /// [`Message`]. Members can still react using reactions already added
         /// to messages without this permission.
@@ -249,92 +249,92 @@ __impl_bitflags! {
         /// [`Member`]: super::guild::Member
         /// [`Message`]: super::channel::Message
         /// [`Reaction`]: super::channel::Reaction
-        ADD_REACTIONS = 0b0000_0000_0000_0000_0000_0000_0100_0000;
+        ADD_REACTIONS = 1 << 6;
         /// Allows viewing a guild's audit logs.
-        VIEW_AUDIT_LOG = 0b0000_0000_0000_0000_0000_0000_1000_0000;
+        VIEW_AUDIT_LOG = 1 << 7;
         /// Allows the use of priority speaking in voice channels.
-        PRIORITY_SPEAKER = 0b0000_0000_0000_0000_0000_0001_0000_0000;
+        PRIORITY_SPEAKER = 1 << 8;
         // Allows the user to go live
-        STREAM = 0b0000_0000_0000_0000_0000_0010_0000_0000;
+        STREAM = 1 << 9;
         /// Allows reading messages in a guild channel. If a user does not have
         /// this permission, then they will not be able to see the channel.
-        READ_MESSAGES = 0b0000_0000_0000_0000_0000_0100_0000_0000;
+        READ_MESSAGES = 1 << 10;
         /// Allows sending messages in a guild channel.
-        SEND_MESSAGES = 0b0000_0000_0000_0000_0000_1000_0000_0000;
+        SEND_MESSAGES = 1 << 11;
         /// Allows the sending of text-to-speech messages in a channel.
-        SEND_TTS_MESSAGES = 0b0000_0000_0000_0000_0001_0000_0000_0000;
+        SEND_TTS_MESSAGES = 1 << 12;
         /// Allows the deleting of other messages in a guild channel.
         ///
         /// **Note**: This does not allow the editing of other messages.
-        MANAGE_MESSAGES = 0b0000_0000_0000_0000_0010_0000_0000_0000;
+        MANAGE_MESSAGES = 1 << 13;
         /// Allows links from this user - or users of this role - to be
         /// embedded, with potential data such as a thumbnail, description, and
         /// page name.
-        EMBED_LINKS = 0b0000_0000_0000_0000_0100_0000_0000_0000;
+        EMBED_LINKS = 1 << 14;
         /// Allows uploading of files.
-        ATTACH_FILES = 0b0000_0000_0000_0000_1000_0000_0000_0000;
+        ATTACH_FILES = 1 << 15;
         /// Allows the reading of a channel's message history.
-        READ_MESSAGE_HISTORY = 0b0000_0000_0000_0001_0000_0000_0000_0000;
+        READ_MESSAGE_HISTORY = 1 << 16;
         /// Allows the usage of the `@everyone` mention, which will notify all
         /// users in a channel. The `@here` mention will also be available, and
         /// can be used to mention all non-offline users.
         ///
         /// **Note**: You probably want this to be disabled for most roles and
         /// users.
-        MENTION_EVERYONE = 0b0000_0000_0000_0010_0000_0000_0000_0000;
+        MENTION_EVERYONE = 1 << 17;
         /// Allows the usage of custom emojis from other guilds.
         ///
         /// This does not dictate whether custom emojis in this guild can be
         /// used in other guilds.
-        USE_EXTERNAL_EMOJIS = 0b0000_0000_0000_0100_0000_0000_0000_0000;
+        USE_EXTERNAL_EMOJIS = 1 << 18;
         /// Allows for viewing guild insights.
-        VIEW_GUILD_INSIGHTS = 0b0000_0000_0000_1000_0000_0000_0000_0000;
+        VIEW_GUILD_INSIGHTS = 1 << 19;
         /// Allows the joining of a voice channel.
-        CONNECT = 0b0000_0000_0001_0000_0000_0000_0000_0000;
+        CONNECT = 1 << 20;
         /// Allows the user to speak in a voice channel.
-        SPEAK = 0b0000_0000_0010_0000_0000_0000_0000_0000;
+        SPEAK = 1 << 21;
         /// Allows the muting of members in a voice channel.
-        MUTE_MEMBERS = 0b0000_0000_0100_0000_0000_0000_0000_0000;
+        MUTE_MEMBERS = 1 << 22;
         /// Allows the deafening of members in a voice channel.
-        DEAFEN_MEMBERS = 0b0000_0000_1000_0000_0000_0000_0000_0000;
+        DEAFEN_MEMBERS = 1 << 23;
         /// Allows the moving of members from one voice channel to another.
-        MOVE_MEMBERS = 0b0000_0001_0000_0000_0000_0000_0000_0000;
+        MOVE_MEMBERS = 1 << 24;
         /// Allows the usage of voice-activity-detection in a [voice] channel.
         ///
         /// If this is disabled, then [`Member`]s must use push-to-talk.
         ///
         /// [`Member`]: super::guild::Member
         /// [voice]: super::channel::ChannelType::Voice
-        USE_VAD = 0b0000_0010_0000_0000_0000_0000_0000_0000;
+        USE_VAD = 1 << 25;
         /// Allows members to change their own nickname in the guild.
-        CHANGE_NICKNAME = 0b0000_0100_0000_0000_0000_0000_0000_0000;
+        CHANGE_NICKNAME = 1 << 26;
         /// Allows members to change other members' nicknames.
-        MANAGE_NICKNAMES = 0b0000_1000_0000_0000_0000_0000_0000_0000;
+        MANAGE_NICKNAMES = 1 << 27;
         /// Allows management and editing of roles below their own.
-        MANAGE_ROLES = 0b0001_0000_0000_0000_0000_0000_0000_0000;
+        MANAGE_ROLES = 1 << 28;
         /// Allows management of webhooks.
-        MANAGE_WEBHOOKS = 0b0010_0000_0000_0000_0000_0000_0000_0000;
+        MANAGE_WEBHOOKS = 1 << 29;
         /// Allows management of emojis and stickers created without the use of an
         /// [`Integration`].
         ///
         /// [`Integration`]: super::guild::Integration
-        MANAGE_EMOJIS = 0b0100_0000_0000_0000_0000_0000_0000_0000;
+        MANAGE_EMOJIS = 1 << 30;
         /// Allows using slash commands.
-        USE_SLASH_COMMANDS = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+        USE_SLASH_COMMANDS = 1 << 31;
         /// Allows for requesting to speak in stage channels.
-        REQUEST_TO_SPEAK = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
+        REQUEST_TO_SPEAK = 1 << 32;
         /// Allows for deleting and archiving threads, and viewing all private threads.
-        MANAGE_THREADS = 0b0100_0000_0000_0000_0000_0000_0000_0000_0000;
+        MANAGE_THREADS = 1 << 34;
         /// Allows for creating threads.
-        CREATE_PUBLIC_THREADS = 0b1000_0000_0000_0000_0000_0000_0000_0000_0000;
+        CREATE_PUBLIC_THREADS = 1 << 35;
         /// Allows for creating private threads.
-        CREATE_PRIVATE_THREADS = 0b0001_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+        CREATE_PRIVATE_THREADS = 1 << 36;
         /// Allows the usage of custom stickers from other servers.
-        USE_EXTERNAL_STICKERS = 0b0010_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+        USE_EXTERNAL_STICKERS = 1 << 37;
         /// Allows for sending messages in threads
-        SEND_MESSAGES_IN_THREADS = 0b0100_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+        SEND_MESSAGES_IN_THREADS = 1 << 38;
         /// Allows for launching activities in a voice channel
-        START_EMBEDDED_ACTIVITIES = 0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+        START_EMBEDDED_ACTIVITIES = 1 << 39;
         /// Allows for creating and participating in public threads.
         #[deprecated(note = "This permission no longer exists")]
         USE_PUBLIC_THREADS = 0b0010_0000_0000_0000_0000_0000_0000_0000_0000;

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -287,6 +287,8 @@ __impl_bitflags! {
         /// This does not dictate whether custom emojis in this guild can be
         /// used in other guilds.
         USE_EXTERNAL_EMOJIS = 0b0000_0000_0000_0100_0000_0000_0000_0000;
+        /// Allows for viewing guild insights.
+        VIEW_GUILD_INSIGHTS = 0b0000_0000_0000_1000_0000_0000_0000_0000;
         /// Allows the joining of a voice channel.
         CONNECT = 0b0000_0000_0001_0000_0000_0000_0000_0000;
         /// Allows the user to speak in a voice channel.
@@ -312,20 +314,32 @@ __impl_bitflags! {
         MANAGE_ROLES = 0b0001_0000_0000_0000_0000_0000_0000_0000;
         /// Allows management of webhooks.
         MANAGE_WEBHOOKS = 0b0010_0000_0000_0000_0000_0000_0000_0000;
-        /// Allows management of emojis created without the use of an
+        /// Allows management of emojis and stickers created without the use of an
         /// [`Integration`].
         ///
         /// [`Integration`]: super::guild::Integration
         MANAGE_EMOJIS = 0b0100_0000_0000_0000_0000_0000_0000_0000;
-        /// Allows for requesting to speak in stage channels.
-        REQUEST_TO_SPEAK = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
         /// Allows using slash commands.
         USE_SLASH_COMMANDS = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows for requesting to speak in stage channels.
+        REQUEST_TO_SPEAK = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
         /// Allows for deleting and archiving threads, and viewing all private threads.
-        MANAGE_THREADS = 0b0001_0000_0000_0000_0000_0000_0000_0000_0000;
+        MANAGE_THREADS = 0b0100_0000_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows for creating threads.
+        CREATE_PUBLIC_THREADS = 0b1000_0000_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows for creating private threads.
+        CREATE_PRIVATE_THREADS = 0b0001_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows the usage of custom stickers from other servers.
+        USE_EXTERNAL_STICKERS = 0b0010_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows for sending messages in threads
+        SEND_MESSAGES_IN_THREADS = 0b0100_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+        /// Allows for launching activities in a voice channel
+        START_EMBEDDED_ACTIVITIES = 0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
         /// Allows for creating and participating in public threads.
+        #[deprecated(note = "This permission no longer exists")]
         USE_PUBLIC_THREADS = 0b0010_0000_0000_0000_0000_0000_0000_0000_0000;
         // Allows for creating and participating in private threads.
+        #[deprecated(note = "This permission no longer exists")]
         USE_PRIVATE_THREADS = 0b0100_0000_0000_0000_0000_0000_0000_0000_0000;
     }
 }


### PR DESCRIPTION
The `Permissions` bitflags constants had errors in them, and some permissions were missing.

I added the missing permissions and deprecated two permissions that no longer exist in the Discord API documentation.