### PR TITLE
Correcting Timestamp Code

### DIFF
--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -38,7 +38,8 @@ impl EventHandler for Handler {
 
                         // Add a timestamp for the current time
                         // This also accepts a rfc3339 Timestamp
-                        e.timestamp(chrono::Utc::now());
+                        let my_timestamp = chrono::Utc::now();
+                        e.timestamp(&my_timestamp);
 
                         e
                     });


### PR DESCRIPTION
I noticed that the current code for setting a timestamp wouldn't work on Serenity v0.10.9. Thanks to anden3 on Discord, I was able to fix the code by instead making and setting a reference to a variable to get the time.