### PR TITLE
Support slash command min_value and max_value

### DIFF
--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -63,7 +63,14 @@ impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         println!("{} is connected!", ready.user.name);
 
-        let commands = ApplicationCommand::set_global_application_commands(&ctx.http, |commands| {
+        let guild_id = GuildId(
+            env::var("GUILD_ID")
+                .expect("Expected GUILD_ID in environment")
+                .parse()
+                .expect("GUILD_ID must be an integer"),
+        );
+
+        let commands = GuildId::set_application_commands(&guild_id, &ctx.http, |commands| {
             commands
                 .create_application_command(|command| {
                     command.name("ping").description("A ping command")
@@ -109,18 +116,41 @@ impl EventHandler for Handler {
                                 )
                         })
                 })
+                .create_application_command(|command| {
+                    command
+                        .name("numberinput")
+                        .description("Test command for number input")
+                        .create_option(|option| {
+                            option
+                                .name("int")
+                                .description("An integer from 5 to 10")
+                                .kind(ApplicationCommandOptionType::Integer)
+                                .min_int_value(5)
+                                .max_int_value(10)
+                                .required(true)
+                        })
+                        .create_option(|option| {
+                            option
+                                .name("number")
+                                .description("A float from -3.3 to 234.5")
+                                .kind(ApplicationCommandOptionType::Number)
+                                .min_number_value(-3.3)
+                                .max_number_value(234.5)
+                                .required(true)
+                        })
+                })
         })
         .await;
 
-        println!("I now have the following global slash commands: {:#?}", commands);
+        println!("I now have the following guild slash commands: {:#?}", commands);
 
-        let guild_command = GuildId(123456789)
-            .create_application_command(&ctx.http, |command| {
+        let guild_command =
+            ApplicationCommand::create_global_application_command(&ctx.http, |command| {
                 command.name("wonderful_command").description("An amazing command")
             })
             .await;
 
-        println!("I created the following guild command: {:#?}", guild_command);
+        println!("I created the following global slash command: {:#?}", guild_command);
     }
 }
 

--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -158,6 +158,34 @@ impl CreateApplicationCommandOption {
 
         self
     }
+
+    /// Sets the minimum permitted value for this integer option
+    pub fn min_int_value(&mut self, value: i32) -> &mut Self {
+        self.0.insert("min_value", serde_json::Value::from(value));
+
+        self
+    }
+
+    /// Sets the maximum permitted value for this integer option
+    pub fn max_int_value(&mut self, value: i32) -> &mut Self {
+        self.0.insert("max_value", serde_json::Value::from(value));
+
+        self
+    }
+
+    /// Sets the minimum permitted value for this number option
+    pub fn min_number_value(&mut self, value: f64) -> &mut Self {
+        self.0.insert("min_value", serde_json::Value::from(value));
+
+        self
+    }
+
+    /// Sets the maximum permitted value for this number option
+    pub fn max_number_value(&mut self, value: f64) -> &mut Self {
+        self.0.insert("max_value", serde_json::Value::from(value));
+
+        self
+    }
 }
 
 /// A builder for creating a new [`ApplicationCommand`].

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -957,6 +957,12 @@ pub struct ApplicationCommandOption {
     /// [`Channel`]: ApplicationCommandOptionType::Channel
     #[serde(default)]
     pub channel_types: Vec<ChannelType>,
+    /// Minimum permitted value for Integer or Number options
+    #[serde(default)]
+    pub min_value: Option<serde_json::Number>,
+    /// Maximum permitted value for Integer or Number options
+    #[serde(default)]
+    pub max_value: Option<serde_json::Number>,
 }
 
 /// An [`ApplicationCommand`] permission.


### PR DESCRIPTION
To test, I added an example command using min_value and max_value to e14_slash_command. I also made most of the commands guild commands, so they register faster and can be tested without waiting an hour.