### PR TITLE
Move serde functions into modules to be used with `#[serde(with = "...")]`

### DIFF
--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -11,6 +11,7 @@ use crate::http::AttachmentType;
 #[cfg(feature = "http")]
 use crate::http::{Http, Typing};
 use crate::model::prelude::*;
+use crate::model::utils::single_recipient;
 
 /// A Direct Message text channel with another user.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -30,11 +31,7 @@ pub struct PrivateChannel {
     #[serde(rename = "type")]
     pub kind: ChannelType,
     /// The recipient to the private channel.
-    #[serde(
-        deserialize_with = "deserialize_single_recipient",
-        serialize_with = "serialize_single_recipient",
-        rename = "recipients"
-    )]
+    #[serde(with = "single_recipient", rename = "recipients")]
     pub recipient: User,
 }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -14,7 +14,7 @@ use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 
 use super::prelude::*;
-use super::utils::deserialize_emojis;
+use super::utils::{emojis, stickers};
 #[cfg(feature = "cache")]
 use crate::cache::{Cache, CacheUpdate};
 use crate::internal::prelude::*;
@@ -382,7 +382,7 @@ impl Serialize for GuildDeleteEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildEmojisUpdateEvent {
-    #[serde(serialize_with = "serialize_emojis", deserialize_with = "deserialize_emojis")]
+    #[serde(with = "emojis")]
     pub emojis: HashMap<EmojiId, Emoji>,
     pub guild_id: GuildId,
 }
@@ -750,7 +750,7 @@ impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildStickersUpdateEvent {
-    #[serde(serialize_with = "serialize_stickers", deserialize_with = "deserialize_stickers")]
+    #[serde(with = "stickers")]
     pub stickers: HashMap<StickerId, Sticker>,
     pub guild_id: GuildId,
 }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -665,17 +665,9 @@ pub struct Presence {
 pub struct Ready {
     pub application: PartialCurrentApplicationInfo,
     pub guilds: Vec<GuildStatus>,
-    #[serde(
-        default,
-        serialize_with = "serialize_presences",
-        deserialize_with = "deserialize_presences"
-    )]
+    #[serde(default, with = "presences")]
     pub presences: HashMap<UserId, Presence>,
-    #[serde(
-        default,
-        serialize_with = "serialize_private_channels",
-        deserialize_with = "deserialize_private_channels"
-    )]
+    #[serde(default, with = "private_channels")]
     pub private_channels: HashMap<ChannelId, Channel>,
     pub session_id: String,
     pub shard: Option<[u64; 2]>,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -78,6 +78,7 @@ use crate::{
 use crate::{
     json::{from_number, from_value, prelude::*},
     model::prelude::*,
+    model::utils::{emojis, presences, roles, stickers},
 };
 
 /// A representation of a banning of a user.
@@ -2550,7 +2551,7 @@ impl<'de> Deserialize<'de> for Guild {
         let emojis = map
             .remove("emojis")
             .ok_or_else(|| DeError::custom("expected guild emojis"))
-            .and_then(deserialize_emojis)
+            .and_then(emojis::deserialize)
             .map_err(DeError::custom)?;
         let explicit_content_filter = map
             .remove("explicit_content_filter")
@@ -2609,7 +2610,7 @@ impl<'de> Deserialize<'de> for Guild {
         let presences = map
             .remove("presences")
             .ok_or_else(|| DeError::custom("expected guild presences"))
-            .and_then(deserialize_presences)
+            .and_then(presences::deserialize)
             .map_err(DeError::custom)?;
         let region = map
             .remove("region")
@@ -2619,7 +2620,7 @@ impl<'de> Deserialize<'de> for Guild {
         let roles = map
             .remove("roles")
             .ok_or_else(|| DeError::custom("expected guild roles"))
-            .and_then(deserialize_roles)
+            .and_then(roles::deserialize)
             .map_err(DeError::custom)?;
         let splash = match map.remove("splash") {
             Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
@@ -2780,7 +2781,7 @@ impl<'de> Deserialize<'de> for Guild {
         let stickers = map
             .remove("stickers")
             .ok_or_else(|| DeError::custom("expected guild stickers"))
-            .and_then(deserialize_stickers)
+            .and_then(stickers::deserialize)
             .map_err(DeError::custom)?;
 
         #[allow(deprecated)]

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -42,7 +42,11 @@ use crate::{
     },
     model::interactions::application_command::{ApplicationCommand, ApplicationCommandPermission},
 };
-use crate::{json::from_value, model::prelude::*};
+use crate::{
+    json::from_value,
+    model::prelude::*,
+    model::utils::{emojis, roles, stickers},
+};
 
 /// Partial information about a [`Guild`]. This does not include information
 /// like member data.
@@ -69,7 +73,7 @@ pub struct PartialGuild {
     /// The channel id that the widget will generate an invite to, or null if set to no invite
     pub widget_channel_id: Option<ChannelId>,
     /// All of the guild's custom emojis.
-    #[serde(serialize_with = "serialize_emojis", deserialize_with = "deserialize_emojis")]
+    #[serde(with = "emojis")]
     pub emojis: HashMap<EmojiId, Emoji>,
     /// Features enabled for the guild.
     ///
@@ -93,7 +97,7 @@ pub struct PartialGuild {
     #[deprecated(note = "Regions are now set per voice channel instead of globally.")]
     pub region: String,
     /// A mapping of the guild's roles.
-    #[serde(serialize_with = "serialize_roles", deserialize_with = "deserialize_roles")]
+    #[serde(with = "roles")]
     pub roles: HashMap<RoleId, Role>,
     /// An identifying hash of the guild's splash icon.
     ///
@@ -161,7 +165,7 @@ pub struct PartialGuild {
     /// The user permissions in the guild.
     pub permissions: Option<String>,
     /// All of the guild's custom stickers.
-    #[serde(serialize_with = "serialize_stickers", deserialize_with = "deserialize_stickers")]
+    #[serde(with = "stickers")]
     pub stickers: HashMap<StickerId, Sticker>,
 }
 
@@ -1639,7 +1643,7 @@ impl<'de> Deserialize<'de> for PartialGuild {
         let emojis = map
             .remove("emojis")
             .ok_or_else(|| DeError::custom("expected guild emojis"))
-            .and_then(deserialize_emojis)
+            .and_then(emojis::deserialize)
             .map_err(DeError::custom)?;
         let features = map
             .remove("features")
@@ -1678,7 +1682,7 @@ impl<'de> Deserialize<'de> for PartialGuild {
         let roles = map
             .remove("roles")
             .ok_or_else(|| DeError::custom("expected guild roles"))
-            .and_then(deserialize_roles)
+            .and_then(roles::deserialize)
             .map_err(DeError::custom)?;
         let splash = match map.remove("splash") {
             Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
@@ -1837,7 +1841,7 @@ impl<'de> Deserialize<'de> for PartialGuild {
         let stickers = map
             .remove("stickers")
             .ok_or_else(|| DeError::custom("expected guild stickers"))
-            .and_then(deserialize_stickers)
+            .and_then(stickers::deserialize)
             .map_err(DeError::custom)?;
 
         #[allow(deprecated)]

--- a/src/model/sticker/mod.rs
+++ b/src/model/sticker/mod.rs
@@ -9,7 +9,7 @@ use crate::model::prelude::*;
 use crate::model::{
     id::{GuildId, StickerId, StickerPackId},
     user::User,
-    utils::{deserialize_comma_separated_string, serialize_comma_separated_string},
+    utils::comma_separated_string,
 };
 
 pub mod sticker_id;
@@ -35,10 +35,7 @@ pub struct Sticker {
     /// For guild stickers, the Discord name of a unicode emoji representing the
     /// sticker's expression. For standard stickers, a list of
     /// related expressions.
-    #[serde(
-        serialize_with = "serialize_comma_separated_string",
-        deserialize_with = "deserialize_comma_separated_string"
-    )]
+    #[serde(with = "comma_separated_string")]
     pub tags: Vec<String>,
     /// The type of sticker.
     #[serde(rename = "type")]

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -20,30 +20,40 @@ pub fn default_true() -> bool {
     true
 }
 
-pub fn deserialize_emojis<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<EmojiId, Emoji>, D::Error> {
-    let vec: Vec<Emoji> = Deserialize::deserialize(deserializer)?;
-    let mut emojis = HashMap::new();
+/// Used with `#[serde(with = "emojis")]`
+pub mod emojis {
+    use std::collections::HashMap;
 
-    for emoji in vec {
-        emojis.insert(emoji.id, emoji);
+    use serde::ser::SerializeSeq;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    use crate::model::{guild::Emoji, id::EmojiId};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<EmojiId, Emoji>, D::Error> {
+        let vec: Vec<Emoji> = Vec::deserialize(deserializer)?;
+        let mut emojis = HashMap::with_capacity(vec.len());
+
+        for emoji in vec {
+            emojis.insert(emoji.id, emoji);
+        }
+
+        Ok(emojis)
     }
 
-    Ok(emojis)
-}
+    pub fn serialize<S: Serializer>(
+        emojis: &HashMap<EmojiId, Emoji>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(emojis.len()))?;
 
-pub fn serialize_emojis<S: Serializer>(
-    emojis: &HashMap<EmojiId, Emoji>,
-    serializer: S,
-) -> StdResult<S::Ok, S::Error> {
-    let mut seq = serializer.serialize_seq(Some(emojis.len()))?;
+        for emoji in emojis.values() {
+            seq.serialize_element(emoji)?;
+        }
 
-    for emoji in emojis.values() {
-        seq.serialize_element(emoji)?;
+        seq.end()
     }
-
-    seq.end()
 }
 
 pub fn deserialize_guild_channels<'de, D: Deserializer<'de>>(
@@ -219,30 +229,39 @@ fn loop_resolved(
     }
 }
 
-pub fn deserialize_presences<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<UserId, Presence>, D::Error> {
-    let vec: Vec<Presence> = Deserialize::deserialize(deserializer)?;
-    let mut presences = HashMap::new();
+/// Used with `#[serde(with = "presences")]`
+pub mod presences {
+    use std::collections::HashMap;
 
-    for presence in vec {
-        presences.insert(presence.user.id, presence);
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
+
+    use crate::model::{gateway::Presence, id::UserId};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<UserId, Presence>, D::Error> {
+        let vec: Vec<Presence> = Vec::deserialize(deserializer)?;
+        let mut presences = HashMap::with_capacity(vec.len());
+
+        for presence in vec {
+            presences.insert(presence.user.id, presence);
+        }
+
+        Ok(presences)
     }
 
-    Ok(presences)
-}
+    pub fn serialize<S: Serializer>(
+        presences: &HashMap<UserId, Presence>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(presences.len()))?;
 
-pub fn serialize_presences<S: Serializer>(
-    presences: &HashMap<UserId, Presence>,
-    serializer: S,
-) -> StdResult<S::Ok, S::Error> {
-    let mut seq = serializer.serialize_seq(Some(presences.len()))?;
+        for presence in presences.values() {
+            seq.serialize_element(presence)?;
+        }
 
-    for presence in presences.values() {
-        seq.serialize_element(presence)?;
+        seq.end()
     }
-
-    seq.end()
 }
 
 pub fn deserialize_buttons<'de, D: Deserializer<'de>>(
@@ -261,129 +280,162 @@ pub fn deserialize_buttons<'de, D: Deserializer<'de>>(
     Ok(buttons)
 }
 
-pub fn deserialize_private_channels<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<ChannelId, Channel>, D::Error> {
-    let vec: Vec<Channel> = Deserialize::deserialize(deserializer)?;
-    let mut private_channels = HashMap::new();
+/// Used with `#[serde(with = "private_channels")]`
+pub mod private_channels {
+    use std::collections::HashMap;
 
-    for private_channel in vec {
-        let id = match private_channel {
-            Channel::Private(ref channel) => channel.id,
-            Channel::Guild(_) => unreachable!("Guild private channel decode"),
-            Channel::Category(_) => unreachable!("Channel category private channel decode"),
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
+
+    use crate::model::{channel::Channel, id::ChannelId};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<ChannelId, Channel>, D::Error> {
+        let vec: Vec<Channel> = Vec::deserialize(deserializer)?;
+        let mut private_channels = HashMap::with_capacity(vec.len());
+
+        for private_channel in vec {
+            let id = match private_channel {
+                Channel::Private(ref channel) => channel.id,
+                Channel::Guild(_) => unreachable!("Guild private channel decode"),
+                Channel::Category(_) => unreachable!("Channel category private channel decode"),
+            };
+
+            private_channels.insert(id, private_channel);
+        }
+
+        Ok(private_channels)
+    }
+
+    pub fn serialize<S: Serializer>(
+        private_channels: &HashMap<ChannelId, Channel>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(private_channels.len()))?;
+
+        for private_channel in private_channels.values() {
+            seq.serialize_element(private_channel)?;
+        }
+
+        seq.end()
+    }
+}
+
+/// Used with `#[serde(with = "roles")]`
+pub mod roles {
+    use std::collections::HashMap;
+
+    use serde::ser::SerializeSeq;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    use crate::model::{guild::Role, id::RoleId};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<RoleId, Role>, D::Error> {
+        let vec: Vec<Role> = Vec::deserialize(deserializer)?;
+        let mut roles = HashMap::with_capacity(vec.len());
+
+        for role in vec {
+            roles.insert(role.id, role);
+        }
+
+        Ok(roles)
+    }
+
+    pub fn serialize<S: Serializer>(
+        roles: &HashMap<RoleId, Role>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(roles.len()))?;
+
+        for role in roles.values() {
+            seq.serialize_element(role)?;
+        }
+
+        seq.end()
+    }
+}
+
+/// Used with `#[serde(with = "stickers")]`
+pub mod stickers {
+    use std::collections::HashMap;
+
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
+
+    use crate::model::{id::StickerId, sticker::Sticker};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<StickerId, Sticker>, D::Error> {
+        let vec: Vec<Sticker> = Vec::deserialize(deserializer)?;
+        let mut stickers = HashMap::with_capacity(vec.len());
+
+        for sticker in vec {
+            stickers.insert(sticker.id, sticker);
+        }
+
+        Ok(stickers)
+    }
+
+    pub fn serialize<S: Serializer>(
+        stickers: &HashMap<StickerId, Sticker>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(stickers.len()))?;
+
+        for sticker in stickers.values() {
+            seq.serialize_element(sticker)?;
+        }
+
+        seq.end()
+    }
+}
+
+/// Used with `#[serde(with = "comma_separated_string")]`
+pub mod comma_separated_string {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Vec<String>, D::Error> {
+        let str_sequence = String::deserialize(deserializer)?;
+        let vec = str_sequence.split(", ").map(str::to_owned).collect();
+
+        Ok(vec)
+    }
+
+    #[allow(clippy::ptr_arg)]
+    pub fn serialize<S: Serializer>(vec: &Vec<String>, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&vec.join(", "))
+    }
+}
+
+/// Used with `#[serde(with = "single_recipient")]`
+pub mod single_recipient {
+    use serde::{de::Error, ser::SerializeSeq, Deserialize, Deserializer, Serializer};
+
+    use crate::model::user::User;
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<User, D::Error> {
+        let mut users: Vec<User> = Vec::deserialize(deserializer)?;
+
+        let user = if users.is_empty() {
+            return Err(Error::custom("Expected a single recipient"));
+        } else {
+            users.remove(0)
         };
 
-        private_channels.insert(id, private_channel);
+        Ok(user)
     }
 
-    Ok(private_channels)
-}
+    pub fn serialize<S: Serializer>(user: &User, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(1))?;
 
-pub fn serialize_private_channels<S: Serializer>(
-    private_channels: &HashMap<ChannelId, Channel>,
-    serializer: S,
-) -> StdResult<S::Ok, S::Error> {
-    let mut seq = serializer.serialize_seq(Some(private_channels.len()))?;
+        seq.serialize_element(user)?;
 
-    for private_channel in private_channels.values() {
-        seq.serialize_element(private_channel)?;
+        seq.end()
     }
-
-    seq.end()
-}
-
-pub fn deserialize_roles<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<RoleId, Role>, D::Error> {
-    let vec: Vec<Role> = Deserialize::deserialize(deserializer)?;
-    let mut roles = HashMap::new();
-
-    for role in vec {
-        roles.insert(role.id, role);
-    }
-
-    Ok(roles)
-}
-
-pub fn serialize_roles<S: Serializer>(
-    roles: &HashMap<RoleId, Role>,
-    serializer: S,
-) -> StdResult<S::Ok, S::Error> {
-    let mut seq = serializer.serialize_seq(Some(roles.len()))?;
-
-    for role in roles.values() {
-        seq.serialize_element(role)?;
-    }
-
-    seq.end()
-}
-
-pub fn deserialize_stickers<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<StickerId, Sticker>, D::Error> {
-    let vec: Vec<Sticker> = Deserialize::deserialize(deserializer)?;
-    let mut stickers = HashMap::new();
-
-    for sticker in vec {
-        stickers.insert(sticker.id, sticker);
-    }
-
-    Ok(stickers)
-}
-
-pub fn serialize_stickers<S: Serializer>(
-    stickers: &HashMap<StickerId, Sticker>,
-    serializer: S,
-) -> StdResult<S::Ok, S::Error> {
-    let mut seq = serializer.serialize_seq(Some(stickers.len()))?;
-
-    for sticker in stickers.values() {
-        seq.serialize_element(sticker)?;
-    }
-
-    seq.end()
-}
-
-pub fn deserialize_comma_separated_string<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<Vec<String>, D::Error> {
-    let str_sequence = String::deserialize(deserializer)?;
-    let vec = str_sequence.split(", ").map(str::to_owned).collect();
-
-    Ok(vec)
-}
-
-#[allow(clippy::ptr_arg)]
-pub fn serialize_comma_separated_string<S: Serializer>(
-    vec: &Vec<String>,
-    serializer: S,
-) -> StdResult<S::Ok, S::Error> {
-    serializer.serialize_str(&vec.join(", "))
-}
-
-pub fn deserialize_single_recipient<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<User, D::Error> {
-    let mut users: Vec<User> = Deserialize::deserialize(deserializer)?;
-    let user = if users.is_empty() {
-        return Err(DeError::custom("Expected a single recipient"));
-    } else {
-        users.remove(0)
-    };
-
-    Ok(user)
-}
-
-pub fn serialize_single_recipient<S: Serializer>(
-    user: &User,
-    serializer: S,
-) -> StdResult<S::Ok, S::Error> {
-    let mut seq = serializer.serialize_seq(Some(1))?;
-
-    seq.serialize_element(user)?;
-
-    seq.end()
 }
 
 pub fn deserialize_u16<'de, D: Deserializer<'de>>(deserializer: D) -> StdResult<u16, D::Error> {


### PR DESCRIPTION
Modules: emojis, comma_separated_string, presences, private_channels, roles,
         single_recipient, stickers

Before:
```rust
struct S {
    #[serde(deserialize_with = "deserialize_emojis", serialize_with = "serialize_emojis")]
    emojis: HashMap<EmojiId, Emoji>,
}

pub fn deserialize_emojis(...) -> Result<...> {}
pub fn serialize_emojis(...) -> Result<...> {}
```

After:
```rust
struct S {
    #[serde(with = "emojis")]
    emojis: HashMap<EmojiId, Emoji>,
}

pub mod emojis {
    pub fn deserialize(...) -> Result<...> {}
    pub fn serialize(...) -> Result<...> {}
}
```