### PR TITLE
Change matches where the match expression is a bool to be more idiomatic

### DIFF
--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -38,14 +38,12 @@ impl<'de> Deserialize<'de> for DiscordJsonError {
             .and_then(String::deserialize)
             .map_err(DeError::custom)?;
 
-        let errors = match map.contains_key("errors") {
-            true => map
-                .remove("errors")
-                .ok_or_else(|| DeError::custom("expected errors"))
-                .and_then(deserialize_errors)
-                .map_err(DeError::custom)?,
-            false => vec![],
-        };
+        let errors = map
+            .remove("errors")
+            .map(deserialize_errors)
+            .transpose()
+            .map_err(DeError::custom)?
+            .unwrap_or_default();
 
         Ok(Self {
             code,

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -59,25 +59,14 @@ impl<'de> Deserialize<'de> for Reaction {
             .and_then(ReactionType::deserialize)
             .map_err(DeError::custom)?;
 
-        let user_id = match map.contains_key("user_id") {
-            true => Some(
-                map.remove("user_id")
-                    .ok_or_else(|| DeError::custom("expected user_id"))
-                    .and_then(UserId::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let user_id =
+            map.remove("user_id").map(UserId::deserialize).transpose().map_err(DeError::custom)?;
 
-        let guild_id = match map.contains_key("guild_id") {
-            true => Some(
-                map.remove("guild_id")
-                    .ok_or_else(|| DeError::custom("expected guild_id"))
-                    .and_then(GuildId::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let guild_id = map
+            .remove("guild_id")
+            .map(GuildId::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
         if let Some(id) = guild_id {
             if let Some(member) = map.get_mut("member") {
@@ -87,15 +76,11 @@ impl<'de> Deserialize<'de> for Reaction {
             }
         }
 
-        let member = match map.contains_key("member") {
-            true => Some(
-                map.remove("member")
-                    .ok_or_else(|| DeError::custom("expected member"))
-                    .and_then(PartialMember::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let member = map
+            .remove("member")
+            .map(PartialMember::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
         Ok(Self {
             channel_id,

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -416,14 +416,12 @@ impl<'de> Deserialize<'de> for Activity {
 
         let url = map.remove("url").and_then(|v| from_value::<Url>(v).ok());
 
-        let buttons = match map.contains_key("buttons") {
-            true => map
-                .remove("buttons")
-                .ok_or_else(|| DeError::custom("expected buttons"))
-                .and_then(deserialize_buttons)
-                .map_err(DeError::custom)?,
-            false => vec![],
-        };
+        let buttons = map
+            .remove("buttons")
+            .map(deserialize_buttons)
+            .transpose()
+            .map_err(DeError::custom)?
+            .unwrap_or_default();
 
         Ok(Activity {
             application_id,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2670,60 +2670,37 @@ impl<'de> Deserialize<'de> for Guild {
             .and_then(String::deserialize)
             .map_err(DeError::custom)?;
 
-        let welcome_screen = match map.contains_key("welcome_screen") {
-            true => Some(
-                map.remove("welcome_screen")
-                    .ok_or_else(|| DeError::custom("expected welcome_screen"))
-                    .and_then(GuildWelcomeScreen::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let welcome_screen = map
+            .remove("welcome_screen")
+            .map(GuildWelcomeScreen::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
-        let approximate_member_count = match map.contains_key("approximate_member_count") {
-            true => Some(
-                map.remove("approximate_member_count")
-                    .ok_or_else(|| DeError::custom("expected approximate_member_count"))
-                    .and_then(u64::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let approximate_member_count = map
+            .remove("approximate_member_count")
+            .map(u64::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
-        let approximate_presence_count = match map.contains_key("approximate_presence_count") {
-            true => Some(
-                map.remove("approximate_presence_count")
-                    .ok_or_else(|| DeError::custom("expected approximate_presence_count"))
-                    .and_then(u64::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let approximate_presence_count = map
+            .remove("approximate_presence_count")
+            .map(u64::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
-        let max_video_channel_users = match map.contains_key("max_video_channel_users") {
-            true => Some(
-                map.remove("max_video_channel_users")
-                    .ok_or_else(|| DeError::custom("expected max_video_channel_users"))
-                    .and_then(u64::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let max_video_channel_users = map
+            .remove("max_video_channel_users")
+            .map(u64::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
         let max_presences = match map.remove("max_presences") {
             Some(v) => Option::<u64>::deserialize(v).map_err(DeError::custom)?,
             None => None,
         };
 
-        let max_members = match map.contains_key("max_members") {
-            true => Some(
-                map.remove("max_members")
-                    .ok_or_else(|| DeError::custom("expected max_members"))
-                    .and_then(u64::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let max_members =
+            map.remove("max_members").map(u64::deserialize).transpose().map_err(DeError::custom)?;
 
         let discovery_splash = match map.remove("discovery_splash") {
             Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1721,34 +1721,24 @@ impl<'de> Deserialize<'de> for PartialGuild {
             None => None,
         };
 
-        let approximate_member_count = match map.contains_key("approximate_member_count") {
-            true => Some(
-                map.remove("approximate_member_count")
-                    .ok_or_else(|| DeError::custom("expected approximate_member_count"))
-                    .and_then(u64::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let approximate_member_count = map
+            .remove("approximate_member_count")
+            .map(u64::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
-        let approximate_presence_count = match map.contains_key("approximate_presence_count") {
-            true => Some(
-                map.remove("approximate_presence_count")
-                    .ok_or_else(|| DeError::custom("expected approximate_presence_count"))
-                    .and_then(u64::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let approximate_presence_count = map
+            .remove("approximate_presence_count")
+            .map(u64::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
-        let owner = match map.contains_key("owner") {
-            true => map
-                .remove("owner")
-                .ok_or_else(|| DeError::custom("expected owner"))
-                .and_then(bool::deserialize)
-                .map_err(DeError::custom)?,
-            false => false,
-        };
+        let owner = map
+            .remove("owner")
+            .map(bool::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?
+            .unwrap_or_default();
 
         let nsfw = map
             .remove("nsfw")
@@ -1762,30 +1752,19 @@ impl<'de> Deserialize<'de> for PartialGuild {
             .and_then(NsfwLevel::deserialize)
             .map_err(DeError::custom)?;
 
-        let max_video_channel_users = match map.contains_key("max_video_channel_users") {
-            true => Some(
-                map.remove("max_video_channel_users")
-                    .ok_or_else(|| DeError::custom("expected max_video_channel_users"))
-                    .and_then(u64::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let max_video_channel_users = map
+            .remove("max_video_channel_users")
+            .map(u64::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
         let max_presences = match map.remove("max_presences") {
             Some(v) => Option::<u64>::deserialize(v).map_err(DeError::custom)?,
             None => None,
         };
 
-        let max_members = match map.contains_key("max_members") {
-            true => Some(
-                map.remove("max_members")
-                    .ok_or_else(|| DeError::custom("expected max_members"))
-                    .and_then(u64::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let max_members =
+            map.remove("max_members").map(u64::deserialize).transpose().map_err(DeError::custom)?;
 
         let discovery_splash = match map.remove("discovery_splash") {
             Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
@@ -1828,15 +1807,11 @@ impl<'de> Deserialize<'de> for PartialGuild {
             None => None,
         };
 
-        let welcome_screen = match map.contains_key("welcome_screen") {
-            true => Some(
-                map.remove("welcome_screen")
-                    .ok_or_else(|| DeError::custom("expected welcome_screen"))
-                    .and_then(GuildWelcomeScreen::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let welcome_screen = map
+            .remove("welcome_screen")
+            .map(GuildWelcomeScreen::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
         let stickers = map
             .remove("stickers")

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -250,25 +250,14 @@ impl<'de> Deserialize<'de> for RoleTags {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
 
-        let bot_id = match map.contains_key("bot_id") {
-            true => Some(
-                map.remove("bot_id")
-                    .ok_or_else(|| DeError::custom("expected bot_id"))
-                    .and_then(UserId::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let bot_id =
+            map.remove("bot_id").map(UserId::deserialize).transpose().map_err(DeError::custom)?;
 
-        let integration_id = match map.contains_key("integration_id") {
-            true => Some(
-                map.remove("integration_id")
-                    .ok_or_else(|| DeError::custom("expected integration_id"))
-                    .and_then(IntegrationId::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let integration_id = map
+            .remove("integration_id")
+            .map(IntegrationId::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
         let premium_subscriber = map.contains_key("premium_subscriber");
 

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -315,15 +315,11 @@ impl<'de> Deserialize<'de> for MessageComponentInteraction {
             .and_then(MessageComponentInteractionData::deserialize)
             .map_err(DeError::custom)?;
 
-        let guild_id = match map.contains_key("guild_id") {
-            true => Some(
-                map.remove("guild_id")
-                    .ok_or_else(|| DeError::custom("expected guild_id"))
-                    .and_then(GuildId::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let guild_id = map
+            .remove("guild_id")
+            .map(GuildId::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
 
         let channel_id = map
             .remove("channel_id")
@@ -331,24 +327,15 @@ impl<'de> Deserialize<'de> for MessageComponentInteraction {
             .and_then(ChannelId::deserialize)
             .map_err(DeError::custom)?;
 
-        let member = match map.contains_key("member") {
-            true => Some(
-                map.remove("member")
-                    .ok_or_else(|| DeError::custom("expected member"))
-                    .and_then(Member::deserialize)
-                    .map_err(DeError::custom)?,
-            ),
-            false => None,
-        };
+        let member =
+            map.remove("member").map(Member::deserialize).transpose().map_err(DeError::custom)?;
 
-        let user = match map.contains_key("user") {
-            true => map
-                .remove("user")
-                .ok_or_else(|| DeError::custom("expected user"))
-                .and_then(User::deserialize)
-                .map_err(DeError::custom)?,
-            false => member.as_ref().expect("expected user or member").user.clone(),
-        };
+        let user =
+            map.remove("user").map(User::deserialize).transpose().map_err(DeError::custom)?;
+
+        let user = user
+            .or(member.as_ref().map(|m| m.user.clone()))
+            .ok_or_else(|| DeError::custom("expected user or member"))?;
 
         let message = map
             .remove("message")


### PR DESCRIPTION
This changes the deserialization pattern of `match map.contains_key(key)` followed by
`map.remove(key).ok_or_else(|| "expected key"). ...` if the key exists.

Before
```rust
let value: Option<X> = match map.contains_key("value") {
    true => map
        .remove("value")
        .ok_or_else(|| DeError::custom("expected value"))
        .and_then(deserialize_value)
        .map_err(DeError::custom)?,
    false => None,
};
```

After
```rust
let value: Option<X> = map
    .remove("value")
    .map(deserialize_value)
    .transpose()
    .map_err(DeError::custom)?;
```