### PR TITLE
Fix #[help] generating help options var name

### DIFF
--- a/command_attr/src/consts.rs
+++ b/command_attr/src/consts.rs
@@ -1,7 +1,7 @@
 pub mod suffixes {
     pub const COMMAND: &str = "COMMAND";
     pub const COMMAND_OPTIONS: &str = "COMMAND_OPTIONS";
-    pub const HELP_OPTIONS: &str = "_OPTIONS";
+    pub const HELP_OPTIONS: &str = "OPTIONS";
     pub const GROUP: &str = "GROUP";
     pub const GROUP_OPTIONS: &str = "GROUP_OPTIONS";
     pub const CHECK: &str = "CHECK";


### PR DESCRIPTION
`#[help]` macro generated name for static var help options that is not in upper snake case. For example, with function name `my_help` it would generate `MY_HELP__OPTIONS`.