### PR TITLE
Remove unused `NeverFails` error type

### DIFF
--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -650,22 +650,6 @@ impl<'a> TryFrom<&'a str> for ReactionType {
     }
 }
 
-// TODO: Change this to `!` once it becomes stable.
-#[derive(Debug)]
-pub enum NeverFails {}
-
-impl Display for NeverFails {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "never fails")
-    }
-}
-
-impl StdError for NeverFails {
-    fn description(&self) -> &str {
-        "never fails"
-    }
-}
-
 impl FromStr for ReactionType {
     type Err = ReactionConversionError;
 


### PR DESCRIPTION
The error type is no longer used since 6aee47b93d7fdead6eb9e4b3cc7269fd0fc45619