### PR TITLE
Remove unused `#[serde(deserialize_with = "..")]` attribute

### DIFF
--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -121,8 +121,6 @@ pub struct PartialGuild {
     #[serde(default)]
     pub premium_tier: PremiumTier,
     /// The total number of users currently boosting this server.
-    // In some cases Discord returns `null` rather than 0.
-    #[serde(deserialize_with = "deserialize_u64_or_zero")]
     pub premium_subscription_count: u64,
     /// The guild's banner, if it has one.
     pub banner: Option<String>,


### PR DESCRIPTION
The attribute has not been used since the manual implementation of the
deserialization and the method was removed.

See e544671 and 5df4c6d
