### PR TITLE
Use bitshift notation for the values of Discord's bit flags

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1208,21 +1208,21 @@ pub struct MessageFlags {
 __impl_bitflags! {
     MessageFlags: u64 {
         /// This message has been published to subscribed channels (via Channel Following).
-        CROSSPOSTED = 0b0000_0000_0000_0000_0000_0000_0000_0001;
+        CROSSPOSTED = 1 << 0;
         /// This message originated from a message in another channel (via Channel Following).
-        IS_CROSSPOST = 0b0000_0000_0000_0000_0000_0000_0000_0010;
+        IS_CROSSPOST = 1 << 1;
         /// Do not include any embeds when serializing this message.
-        SUPPRESS_EMBEDS = 0b0000_0000_0000_0000_0000_0000_0000_0100;
+        SUPPRESS_EMBEDS = 1 << 2;
         /// The source message for this crosspost has been deleted (via Channel Following).
-        SOURCE_MESSAGE_DELETED = 0b0000_0000_0000_0000_0000_0000_0000_1000;
+        SOURCE_MESSAGE_DELETED = 1 << 3;
         /// This message came from the urgent message system.
-        URGENT = 0b0000_0000_0000_0000_0000_0000_0001_0000;
+        URGENT = 1 << 4;
         /// This message has an associated thread, with the same id as the message.
-        HAS_THREAD = 0b0000_0000_0000_0000_0000_0000_0010_0000;
+        HAS_THREAD = 1 << 5;
         /// This message is only visible to the user who invoked the Interaction.
-        EPHEMERAL = 0b0000_0000_0000_0000_0000_0000_0100_0000;
+        EPHEMERAL = 1 << 6;
         /// This message is an Interaction Response and the bot is "thinking".
-        LOADING = 0b0000_0000_0000_0000_0000_0000_1000_0000;
+        LOADING = 1 << 7;
     }
 }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -622,7 +622,7 @@ pub struct ThreadMemberFlags {
 __impl_bitflags! {
     ThreadMemberFlags: u64 {
         // Not documented.
-        NOTIFICATIONS = 0b0000_0000_0000_0000_0000_0000_0000_0001;
+        NOTIFICATIONS = 1 << 0;
     }
 }
 

--- a/src/model/guild/system_channel.rs
+++ b/src/model/guild/system_channel.rs
@@ -13,13 +13,13 @@ pub struct SystemChannelFlags {
 __impl_bitflags! {
     SystemChannelFlags: u64 {
         /// Suppress member join notifications.
-        SUPPRESS_JOIN_NOTIFICATIONS = 0b0000_0000_0000_0000_0000_0000_0000_0001;
+        SUPPRESS_JOIN_NOTIFICATIONS = 1 << 0;
         /// Suppress server boost notifications.
-        SUPPRESS_PREMIUM_SUBSCRIPTIONS = 0b0000_0000_0000_0000_0000_0000_0000_0010;
+        SUPPRESS_PREMIUM_SUBSCRIPTIONS = 1 << 1;
         /// Suppress server setup tips.
-        SUPPRESS_GUILD_REMINDER_NOTIFICATIONS = 0b0000_0000_0000_0000_0000_0000_0000_0100;
+        SUPPRESS_GUILD_REMINDER_NOTIFICATIONS = 1 << 2;
         /// Hide member join sticker reply buttons.
-        SUPPRESS_JOIN_NOTIFICATION_REPLIES = 0b0000_0000_0000_0000_0000_0000_0000_1000;
+        SUPPRESS_JOIN_NOTIFICATION_REPLIES = 1 << 3;
     }
 }
 

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -179,7 +179,7 @@ __impl_bitflags! {
     InteractionApplicationCommandCallbackDataFlags: u64 {
         /// Interaction message will only be visible to sender and will
         /// be quickly deleted.
-        EPHEMERAL = 0b0000_0000_0000_0000_0000_0000_0100_0000;
+        EPHEMERAL = 1 << 6;
     }
 }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -514,33 +514,33 @@ pub struct UserPublicFlags {
 __impl_bitflags! {
     UserPublicFlags: u32 {
         /// User's flag as discord employee
-        DISCORD_EMPLOYEE = 0b0000_0000_0000_0000_0000_0000_0000_0001;
+        DISCORD_EMPLOYEE = 1 << 0;
         /// User's flag as partnered server owner
-        PARTNERED_SERVER_OWNER = 0b0000_0000_0000_0000_0000_0000_0000_0010;
+        PARTNERED_SERVER_OWNER = 1 << 1;
         /// User's flag as hypesquad events
-        HYPESQUAD_EVENTS = 0b0000_0000_0000_0000_0000_0000_0000_0100;
+        HYPESQUAD_EVENTS = 1 << 2;
         /// User's flag as bug hunter level 1
-        BUG_HUNTER_LEVEL_1 = 0b0000_0000_0000_0000_0000_0000_0000_1000;
+        BUG_HUNTER_LEVEL_1 = 1 << 3;
         /// User's flag as house bravery
-        HOUSE_BRAVERY = 0b0000_0000_0000_0000_0000_0000_0100_0000;
+        HOUSE_BRAVERY = 1 << 6;
         /// User's flag as house brilliance
-        HOUSE_BRILLIANCE = 0b0000_0000_0000_0000_0000_0000_1000_0000;
+        HOUSE_BRILLIANCE = 1 << 7;
         /// User's flag as house balance
-        HOUSE_BALANCE = 0b0000_0000_0000_0000_0000_0001_0000_0000;
+        HOUSE_BALANCE = 1 << 8;
         /// User's flag as early supporter
-        EARLY_SUPPORTER = 0b0000_0000_0000_0000_0000_0010_0000_0000;
+        EARLY_SUPPORTER = 1 << 9;
         /// User's flag as team user
-        TEAM_USER = 0b0000_0000_0000_0000_0000_0100_0000_0000;
+        TEAM_USER = 1 << 10;
         /// User's flag as system
-        SYSTEM = 0b0000_0000_0000_0000_0001_0000_0000_0000;
+        SYSTEM = 1 << 12;
         /// User's flag as bug hunter level 2
-        BUG_HUNTER_LEVEL_2 = 0b0000_0000_0000_0000_0100_0000_0000_0000;
+        BUG_HUNTER_LEVEL_2 = 1 << 14;
         /// User's flag as verified bot
-        VERIFIED_BOT = 0b0000_0000_0000_0001_0000_0000_0000_0000;
+        VERIFIED_BOT = 1 << 16;
         /// User's flag as early verified bot developer
-        EARLY_VERIFIED_BOT_DEVELOPER = 0b0000_0000_0000_0010_0000_0000_0000_0000;
+        EARLY_VERIFIED_BOT_DEVELOPER = 1 << 17;
         /// User's flag as discord certified moderator
-        DISCORD_CERTIFIED_MODERATOR = 0b0000_0000_0000_0100_0000_0000_0000_0000;
+        DISCORD_CERTIFIED_MODERATOR = 1 << 18;
     }
 }
 


### PR DESCRIPTION
The bitshift notation is easier to read and follows Discord's
documentation.

It's a continuation of 0acabdf
