### PR TITLE
Move Discord's snowflake de-/serialization into the `model::id` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,9 @@ optional = true
 version = "0.2"
 package = "http"
 
+[dev-dependencies.serde_test]
+version = "1"
+
 [dev-dependencies.tokio-test]
 version = "0.4"
 

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -1,9 +1,8 @@
 //! Models about OAuth2 applications.
 
 use super::{
-    id::{ApplicationId, UserId},
+    id::{snowflake, ApplicationId, UserId},
     user::User,
-    utils::*,
 };
 
 /// Partial information about the given application.
@@ -40,7 +39,7 @@ pub struct Team {
     /// The icon of the team.
     pub icon: Option<String>,
     /// The snowflake ID of the team.
-    #[serde(deserialize_with = "deserialize_u64")]
+    #[serde(with = "snowflake")]
     pub id: u64,
     /// The name of the team.
     pub name: String,
@@ -60,7 +59,7 @@ pub struct TeamMember {
     /// NOTE: Will always be ["*"] for now.
     pub permissions: Vec<String>,
     /// The ID of the team they are a member of.
-    #[serde(deserialize_with = "deserialize_u64")]
+    #[serde(with = "snowflake")]
     pub team_id: u64,
     /// The user type of the team member.
     pub user: User,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -26,7 +26,6 @@ pub use self::message::*;
 pub use self::partial_channel::*;
 pub use self::private_channel::*;
 pub use self::reaction::*;
-use super::utils::deserialize_u64;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::Cache;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
@@ -362,7 +361,7 @@ impl ChannelType {
 struct PermissionOverwriteData {
     allow: Permissions,
     deny: Permissions,
-    #[serde(serialize_with = "serialize_u64", deserialize_with = "deserialize_u64")]
+    #[serde(with = "snowflake")]
     id: u64,
     #[serde(rename = "type")]
     kind: u8,

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -3,10 +3,6 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use chrono::{DateTime, TimeZone, Utc};
-use serde::de::{Deserialize, Deserializer};
-
-use super::utils::U64Visitor;
-use crate::internal::prelude::*;
 
 macro_rules! id_u64 {
     ($($name:ident;)*) => {
@@ -64,12 +60,6 @@ macro_rules! id_u64 {
                 }
             }
 
-            impl<'de> Deserialize<'de> for $name {
-                fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-                    deserializer.deserialize_any(U64Visitor).map($name)
-                }
-            }
-
             impl From<$name> for u64 {
                 fn from(id: $name) -> u64 {
                     id.0 as u64
@@ -86,90 +76,132 @@ macro_rules! id_u64 {
 }
 
 /// An identifier for an Application.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct ApplicationId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct ApplicationId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a Channel
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct ChannelId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct ChannelId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for an Emoji
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct EmojiId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct EmojiId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a Guild
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct GuildId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct GuildId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for an Integration
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct IntegrationId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct IntegrationId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a Message
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct MessageId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct MessageId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a Role
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct RoleId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct RoleId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a User
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct UserId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct UserId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a [`Webhook`][super::webhook::Webhook]
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct WebhookId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct WebhookId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for an audit log entry.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct AuditLogEntryId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct AuditLogEntryId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for an attachment.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct AttachmentId(u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct AttachmentId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a sticker.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct StickerId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct StickerId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a sticker pack.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct StickerPackId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct StickerPackId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a sticker pack banner.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct StickerPackBannerId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct StickerPackBannerId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a SKU.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct SkuId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct SkuId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for an interaction.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct InteractionId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct InteractionId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a slash command.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct CommandId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct CommandId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a slash command permission Id. Can contain
 /// a [`RoleId`] or [`UserId`].
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct CommandPermissionId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct CommandPermissionId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a slash command version Id.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct CommandVersionId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct CommandVersionId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a slash command target Id. Can contain
 /// a [`UserId`] or [`MessageId`].
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct TargetId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct TargetId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a stage channel instance.
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct StageInstanceId(pub u64);
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct StageInstanceId(#[serde(with = "snowflake")] pub u64);
 
 id_u64! {
     AttachmentId;
@@ -195,6 +227,96 @@ id_u64! {
     StageInstanceId;
 }
 
+/// Used with `#[serde(with|deserialize_with|serialize_with)]`
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// #[derive(Deserialize, Serialize)]
+/// struct A {
+///     #[serde(with = "snowflake")]
+///     id: u64,
+/// }
+///
+/// #[derive(Deserialize)]
+/// struct B {
+///     #[serde(deserialize_with = "snowflake::deserialize")]
+///     id: u64,
+/// }
+///
+/// #[derive(Serialize)]
+/// struct C {
+///     #[serde(serialize_with = "snowflake::serialize")]
+///     id: u64,
+/// }
+/// ```
+pub(crate) mod snowflake {
+    use std::fmt;
+
+    use serde::de::{Error, MapAccess, Visitor};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+        deserializer.deserialize_any(SnowflakeVisitor)
+    }
+
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn serialize<S: Serializer>(id: &u64, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(id)
+    }
+
+    struct SnowflakeVisitor;
+
+    impl<'de> Visitor<'de> for SnowflakeVisitor {
+        type Value = u64;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("string or integer snowflake")
+        }
+
+        fn visit_u64<E: Error>(self, value: u64) -> Result<Self::Value, E> {
+            Ok(value)
+        }
+
+        fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+            value.parse().map_err(Error::custom)
+        }
+
+        // This is called when serde_json's `arbitrary_precision` feature is enabled.
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+            let id = map.next_value::<Snowflake>()?;
+            Ok(id.value)
+        }
+    }
+
+    struct Snowflake {
+        value: u64,
+    }
+
+    impl<'de> Deserialize<'de> for Snowflake {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            struct StrVisitor;
+
+            impl<'de> Visitor<'de> for StrVisitor {
+                type Value = Snowflake;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("string containing a number")
+                }
+
+                fn visit_str<E: Error>(self, s: &str) -> Result<Snowflake, E> {
+                    let value = s.parse().map_err(Error::custom)?;
+                    Ok(Snowflake {
+                        value,
+                    })
+                }
+            }
+
+            deserializer.deserialize_str(StrVisitor)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::GuildId;
@@ -206,5 +328,68 @@ mod tests {
             GuildId(175928847299117063).created_at().to_rfc3339(),
             "2016-04-30T11:18:25.796+00:00"
         );
+    }
+
+    #[test]
+    fn test_id_serde() {
+        use serde::{Deserialize, Serialize};
+        use serde_test::{assert_de_tokens, assert_tokens, Token};
+
+        use super::snowflake;
+
+        let id = GuildId(17_5928_8472_9911_7063);
+        assert_tokens(&id, &[
+            Token::NewtypeStruct {
+                name: "GuildId",
+            },
+            Token::Str("175928847299117063"),
+        ]);
+        assert_de_tokens(&id, &[
+            Token::NewtypeStruct {
+                name: "GuildId",
+            },
+            Token::U64(17_5928_8472_9911_7063),
+        ]);
+
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct S {
+            #[serde(with = "snowflake")]
+            id: u64,
+        }
+
+        let s = S {
+            id: 17_5928_8472_9911_7063,
+        };
+        assert_tokens(&s, &[
+            Token::Struct {
+                name: "S",
+                len: 1,
+            },
+            Token::Str("id"),
+            Token::Str("175928847299117063"),
+            Token::StructEnd,
+        ]);
+
+        #[derive(Debug, PartialEq, Deserialize, Serialize)]
+        struct Opt {
+            id: Option<GuildId>,
+        }
+
+        let s = Opt {
+            id: Some(GuildId(17_5928_8472_9911_7063)),
+        };
+        assert_tokens(&s, &[
+            Token::Struct {
+                name: "Opt",
+                len: 1,
+            },
+            Token::Str("id"),
+            Token::Some,
+            Token::NewtypeStruct {
+                name: "GuildId",
+            },
+            Token::Str("175928847299117063"),
+            Token::StructEnd,
+        ]);
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -55,7 +55,6 @@ pub use serenity_voice_model as voice_gateway;
 
 pub use self::error::Error as ModelError;
 pub use self::permissions::Permissions;
-use self::utils::*;
 use crate::internal::prelude::*;
 #[cfg(feature = "utils")]
 use crate::utils::Colour;

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -330,15 +330,6 @@ pub fn deserialize_opt_u16<'de, D: Deserializer<'de>>(
     deserializer.deserialize_option(OptU16Visitor)
 }
 
-pub fn deserialize_u64<'de, D: Deserializer<'de>>(deserializer: D) -> StdResult<u64, D::Error> {
-    deserializer.deserialize_any(U64Visitor)
-}
-
-#[allow(clippy::trivially_copy_pass_by_ref)]
-pub fn serialize_u64<S: Serializer>(data: &u64, ser: S) -> StdResult<S::Ok, S::Error> {
-    ser.serialize_str(&data.to_string())
-}
-
 pub fn deserialize_voice_states<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<UserId, VoiceState>, D::Error> {
@@ -529,7 +520,7 @@ macro_rules! num_visitors {
     }
 }
 
-num_visitors!(U16Visitor: u16, U64Visitor: u64);
+num_visitors!(U16Visitor: u16);
 
 macro_rules! num_opt_visitors {
     ($($visitor:ident: $type:ty, $visitor_impl:ident),*) => {


### PR DESCRIPTION
The move of the serde functions into the `model::id::snowflake` module makes
the purpose clearer and the module can be used with `#[serde(with)]`.

The `serde_test` crate is introduced to test the de-/serialization.

```
#[derive(Deserialize, Serialize)]
struct GuildId(#[serde(with = "snowflake") pub u64);

#[derive(Deserialize, Serialize)]
struct T {
    #[serde(with = "snowflake")]
    id: u64,
    #[serde(deserialize_with = "snowflake::deserialize")]
    id2: u64,
}
```

**BREAKING CHANGE:** The id is now serialized as a string and aligns with
the type in the Discord docs.