### PR TITLE
Fix the `EmojiId` serialization in the `ReactionType` serialization

### DIFF
--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -403,7 +403,7 @@ impl Serialize for ReactionType {
                 let mut map = serializer.serialize_map(Some(3))?;
 
                 map.serialize_entry("animated", &animated)?;
-                map.serialize_entry("id", &id.0)?;
+                map.serialize_entry("id", &id)?;
                 map.serialize_entry("name", &name)?;
 
                 map.end()


### PR DESCRIPTION
Use the `Serialize` implementation of the ID type instead of its u64
value.