### PR TITLE
Fix panic in `ReactionType` deserialization

### DIFF
--- a/tests/test_reaction.rs
+++ b/tests/test_reaction.rs
@@ -81,3 +81,34 @@ fn str_fromstr() {
     let emoji_str = "<:somestuff:1234";
     ReactionType::from_str(emoji_str).unwrap_err();
 }
+
+#[test]
+fn json_to_reaction_type() {
+    let s = r#"{"name": "foo", "id": "1"}"#;
+    let value = serde_json::from_str(s).unwrap();
+    assert!(matches!(value, ReactionType::Custom { .. }));
+    if let ReactionType::Custom {
+        name, ..
+    } = value
+    {
+        assert_eq!(name.as_deref(), Some("foo"));
+    }
+
+    let s = r#"{"name": null, "id": "1"}"#;
+    let value = serde_json::from_str(s).unwrap();
+    assert!(matches!(value, ReactionType::Custom { .. }));
+
+    let s = r#"{"id": "1"}"#;
+    let value = serde_json::from_str(s).unwrap();
+    assert!(matches!(value, ReactionType::Custom { .. }));
+
+    let s = r#"{"name": "foo"}"#;
+    let value = serde_json::from_str(s).unwrap();
+    assert!(matches!(value, ReactionType::Unicode(_)));
+    if let ReactionType::Unicode(value) = value {
+        assert_eq!(value, "foo");
+    }
+
+    let s = r#"{"name": null}"#;
+    assert!(serde_json::from_str::<ReactionType>(s).is_err());
+}


### PR DESCRIPTION
This changes the deserialization to catch the case of the JSON value
containing only `{"name": null}`.