### PR TITLE
Update to `reqwest` v0.11.7 and `async-tungstenite` v0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ version = "1.0.13"
 default-features = false
 features = ["json", "multipart", "stream"]
 optional = true
-version = "0.11"
+version = "0.11.7"
 
 # Tokio v0.2
 [dependencies.reqwest_compat]
@@ -102,7 +102,7 @@ version = "1.1"
 default-features = false
 features = ["tokio-runtime"]
 optional = true
-version = "0.15"
+version = "0.16"
 
 # Tokio v0.2
 [dependencies.async-tungstenite_compat]


### PR DESCRIPTION
Both crates are updated to use `rustls` v0.20