### PR TITLE
Fix more clippy warnings

### DIFF
--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -237,7 +237,7 @@ pub struct ClosureHook {
 
 #[derive(Debug)]
 pub enum Hook {
-    Function(FunctionHook),
+    Function(Box<FunctionHook>),
     Closure(ClosureHook),
 }
 
@@ -247,7 +247,7 @@ impl Parse for Hook {
         let cooked = remove_cooked(&mut attributes);
 
         if is_function(input) {
-            parse_function_hook(input, attributes, cooked).map(Self::Function)
+            parse_function_hook(input, attributes, cooked).map(|h| Self::Function(Box::new(h)))
         } else {
             parse_closure_hook(input, attributes, cooked).map(Self::Closure)
         }

--- a/src/cache/settings.rs
+++ b/src/cache/settings.rs
@@ -10,21 +10,13 @@
 /// let mut settings = CacheSettings::new();
 /// settings.max_messages(10);
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct Settings {
     /// The maximum number of messages to store in a channel's message cache.
     ///
     /// Defaults to 0.
     pub max_messages: usize,
-}
-
-impl Default for Settings {
-    fn default() -> Self {
-        Settings {
-            max_messages: usize::default(),
-        }
-    }
 }
 
 impl Settings {

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -627,7 +627,7 @@ impl ShardRunner {
         #[cfg(feature = "voice")]
         {
             if let Ok(GatewayEvent::Dispatch(_, ref event)) = event {
-                self.handle_voice_event(&event).await;
+                self.handle_voice_event(event).await;
             }
         }
 

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -84,14 +84,14 @@ impl EventFilter {
     /// to the constraints and the limits are not reached yet.
     pub(crate) fn send_event(&mut self, event: &mut LazyArc<'_, Event>) -> bool {
         // Only events with matching types count towwards the filtered limit.
-        if !self.is_matching_event_type(&event) {
+        if !self.is_matching_event_type(event) {
             return !self.sender.is_closed();
         }
 
         if self.is_passing_constraints(event) {
             self.collected += 1;
 
-            if let Err(_) = self.sender.send(event.as_arc()) {
+            if self.sender.send(event.as_arc()).is_err() {
                 return false;
             }
         }

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -117,7 +117,7 @@ impl MessageFilter {
             if self.options.filter.as_ref().map_or(true, |f| f(&message.as_arc())) {
                 self.collected += 1;
 
-                if let Err(_) = self.sender.send(message.as_arc()) {
+                if self.sender.send(message.as_arc()).is_err() {
                     return false;
                 }
             }

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -141,19 +141,11 @@ impl ReactionAction {
     }
 
     pub fn is_added(&self) -> bool {
-        if let Self::Added(_) = &self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::Added(_))
     }
 
     pub fn is_removed(&self) -> bool {
-        if let Self::Removed(_) = &self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::Removed(_))
     }
 }
 

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -309,7 +309,7 @@ impl Ratelimit {
         }
 
         #[cfg(feature = "absolute_ratelimits")]
-        if let Some(_reset) = parse_header::<f64>(&response.headers(), "x-ratelimit-reset")? {
+        if let Some(_reset) = parse_header::<f64>(response.headers(), "x-ratelimit-reset")? {
             self.reset = Some(std::time::UNIX_EPOCH + Duration::from_secs_f64(_reset));
         }
 

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -164,11 +164,8 @@ pub(crate) async fn create_rustls_client(url: Url) -> Result<WsStream> {
 #[cfg(feature = "native_tls_backend_marker")]
 #[instrument]
 pub(crate) async fn create_native_tls_client(url: Url) -> Result<WsStream> {
-    let (stream, _) = async_tungstenite::tokio::connect_async_with_config::<Url>(
-        url.into(),
-        Some(websocket_config()),
-    )
-    .await?;
+    let (stream, _) =
+        async_tungstenite::tokio::connect_async_with_config(url, Some(websocket_config())).await?;
 
     Ok(stream)
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -930,10 +930,10 @@ mod test {
         let cache = Arc::new(Cache::default());
 
         guild.members.insert(user.id, member.clone());
-        guild.roles.insert(role.id, role.clone());
+        guild.roles.insert(role.id, role);
         cache.users.insert(user.id, user.clone());
         cache.guilds.insert(guild.id, guild.clone());
-        cache.channels.insert(channel.id, channel.clone());
+        cache.channels.insert(channel.id, channel);
 
         let with_user_mentions = "<@!100000000000000000> <@!000000000000000000> <@123> <@!123> \
         <@!123123123123123123123> <@123> <@123123123123123123> <@!invalid> \


### PR DESCRIPTION
This fixes the following warnings:
- `clippy::derivable_impls`
- `clippy::large_enum_variant`
- `clippy::match_like_matches_macro`
- `clippy::needless_borrow`
- `clippy::redundant_clone`
- `clippy::redundant_pattern_matching`
- `clippy::useless_conversion`

The remaining warnings are breaking changes and should be handled individually.