### PR TITLE
Streamline `EventHandler` by removing redundant `guild_id` parameters

### DIFF
--- a/examples/e11_gateway_intents/src/main.rs
+++ b/examples/e11_gateway_intents/src/main.rs
@@ -3,7 +3,10 @@ use std::env;
 use serenity::{
     async_trait,
     client::bridge::gateway::GatewayIntents,
-    model::{channel::Message, event::PresenceUpdateEvent, gateway::Ready},
+    model::{
+        channel::Message,
+        gateway::{Presence, Ready},
+    },
     prelude::*,
 };
 
@@ -18,7 +21,7 @@ impl EventHandler for Handler {
 
     // As the intents set in this example, this event shall never be dispatched.
     // Try it by changing your status.
-    async fn presence_update(&self, _ctx: Context, _new_data: PresenceUpdateEvent) {
+    async fn presence_update(&self, _ctx: Context, _new_data: Presence) {
         println!("Presence Update");
     }
 

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -265,7 +265,8 @@ impl CreateEmbed {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn guild_member_addition(&self, context: Context, guild_id: GuildId, member: Member) {
+    ///     async fn guild_member_addition(&self, context: Context, member: Member) {
+    ///         let guild_id = member.guild_id;
     ///         if let Ok(guild) = guild_id.to_partial_guild(&context).await {
     ///             let channels = guild.channels(&context).await.unwrap();
     ///

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -492,7 +492,7 @@ impl ShardRunner {
                     }
                 },
                 Event::VoiceStateUpdate(ref event) => {
-                    if let Some(guild_id) = event.guild_id {
+                    if let Some(guild_id) = event.voice_state.guild_id {
                         voice_manager.state_update(guild_id, &event.voice_state).await;
                     }
                 },

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -504,7 +504,7 @@ async fn handle_event(
             let event_handler = Arc::clone(event_handler);
 
             spawn_named("dispatch::event_handler::guild_member_addition", async move {
-                event_handler.guild_member_addition(context, event.guild_id, event.member).await;
+                event_handler.guild_member_addition(context, event.member).await;
             });
         },
         DispatchEvent::Model(Event::GuildMemberRemove(mut event)) => {
@@ -552,7 +552,7 @@ async fn handle_event(
             let event_handler = Arc::clone(event_handler);
 
             spawn_named("dispatch::event_handler::guild_role_create", async move {
-                event_handler.guild_role_create(context, event.guild_id, event.role).await;
+                event_handler.guild_role_create(context, event.role).await;
             });
         },
         DispatchEvent::Model(Event::GuildRoleDelete(mut event)) => {
@@ -573,9 +573,9 @@ async fn handle_event(
 
             spawn_named("dispatch::event_handler::guild_role_update", async move {
                 feature_cache! {{
-                    event_handler.guild_role_update(context, event.guild_id, _before, event.role).await;
+                    event_handler.guild_role_update(context, _before, event.role).await;
                 } else {
-                    event_handler.guild_role_update(context, event.guild_id, event.role).await;
+                    event_handler.guild_role_update(context, event.role).await;
                 }}
             });
         },
@@ -674,7 +674,7 @@ async fn handle_event(
             let event_handler = Arc::clone(event_handler);
 
             spawn_named("dispatch::event_handler::presence_update", async move {
-                event_handler.presence_update(context, event).await;
+                event_handler.presence_update(context, event.presence).await;
             });
         },
         DispatchEvent::Model(Event::ReactionAdd(event)) => {
@@ -754,9 +754,9 @@ async fn handle_event(
 
             spawn_named("dispatch::event_handler::voice_state_update", async move {
                 feature_cache! {{
-                    event_handler.voice_state_update(context, event.guild_id, _before, event.voice_state).await;
+                    event_handler.voice_state_update(context, _before, event.voice_state).await;
                 } else {
-                    event_handler.voice_state_update(context, event.guild_id, event.voice_state).await;
+                    event_handler.voice_state_update(context, event.voice_state).await;
                 }}
             });
         },

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -139,7 +139,7 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Note: This event will not trigger unless the "guild members" privileged intent
     /// is enabled on the bot application page.
-    async fn guild_member_addition(&self, _ctx: Context, _guild_id: GuildId, _new_member: Member) {}
+    async fn guild_member_addition(&self, _ctx: Context, _new_member: Member) {}
 
     /// Dispatched when a user's membership ends by leaving, getting kicked, or being banned.
     ///
@@ -198,7 +198,7 @@ pub trait EventHandler: Send + Sync {
     /// Dispatched when a role is created.
     ///
     /// Provides the guild's id and the new role's data.
-    async fn guild_role_create(&self, _ctx: Context, _guild_id: GuildId, _new: Role) {}
+    async fn guild_role_create(&self, _ctx: Context, _new: Role) {}
 
     /// Dispatched when a role is deleted.
     ///
@@ -227,7 +227,6 @@ pub trait EventHandler: Send + Sync {
     async fn guild_role_update(
         &self,
         _ctx: Context,
-        _guild_id: GuildId,
         _old_data_if_available: Option<Role>,
         _new: Role,
     ) {
@@ -237,7 +236,7 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Provides the guild's id and the role's new data.
     #[cfg(not(feature = "cache"))]
-    async fn guild_role_update(&self, _ctx: Context, _guild_id: GuildId, _new_data: Role) {}
+    async fn guild_role_update(&self, _ctx: Context, _new_data: Role) {}
 
     /// Dispatched when the stickers are updated.
     ///
@@ -363,7 +362,7 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Note: This event will not trigger unless the "guild presences" privileged intent
     /// is enabled on the bot application page.
-    async fn presence_update(&self, _ctx: Context, _new_data: PresenceUpdateEvent) {}
+    async fn presence_update(&self, _ctx: Context, _new_data: Presence) {}
 
     /// Dispatched upon startup.
     ///
@@ -408,21 +407,14 @@ pub trait EventHandler: Send + Sync {
     /// Provides the guild's id (if available) and
     /// the old and the new state of the guild's voice channels.
     #[cfg(feature = "cache")]
-    async fn voice_state_update(
-        &self,
-        _ctx: Context,
-        _: Option<GuildId>,
-        _old: Option<VoiceState>,
-        _new: VoiceState,
-    ) {
-    }
+    async fn voice_state_update(&self, _ctx: Context, _old: Option<VoiceState>, _new: VoiceState) {}
 
     /// Dispatched when a user joins, leaves or moves to a voice channel.
     ///
     /// Provides the guild's id (if available) and
     /// the new state of the guild's voice channels.
     #[cfg(not(feature = "cache"))]
-    async fn voice_state_update(&self, _ctx: Context, _: Option<GuildId>, _: VoiceState) {}
+    async fn voice_state_update(&self, _ctx: Context, _: VoiceState) {}
 
     /// Dispatched when a guild's webhook is updated.
     ///

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -409,7 +409,6 @@ pub struct GuildIntegrationsUpdateEvent {
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildMemberAddEvent {
-    pub guild_id: GuildId,
     pub member: Member,
 }
 
@@ -424,7 +423,7 @@ impl CacheUpdate for GuildMemberAddEvent {
             self.member.user = u;
         }
 
-        if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.member.guild_id) {
             guild.member_count += 1;
             guild.members.insert(user_id, self.member.clone());
         }
@@ -435,17 +434,8 @@ impl CacheUpdate for GuildMemberAddEvent {
 
 impl<'de> Deserialize<'de> for GuildMemberAddEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let map = JsonMap::deserialize(deserializer)?;
-
-        let guild_id = map
-            .get("guild_id")
-            .ok_or_else(|| DeError::custom("missing member add guild id"))
-            .and_then(GuildId::deserialize)
-            .map_err(DeError::custom)?;
-
         Ok(GuildMemberAddEvent {
-            guild_id,
-            member: Member::deserialize(Value::from(map)).map_err(DeError::custom)?,
+            member: Member::deserialize(deserializer)?,
         })
     }
 }
@@ -629,7 +619,6 @@ impl<'de> Deserialize<'de> for GuildMembersChunkEvent {
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleCreateEvent {
-    pub guild_id: GuildId,
     pub role: Role,
 }
 
@@ -640,7 +629,7 @@ impl CacheUpdate for GuildRoleCreateEvent {
     fn update(&mut self, cache: &Cache) -> Option<()> {
         cache
             .guilds
-            .get_mut(&self.guild_id)
+            .get_mut(&self.role.guild_id)
             .map(|mut g| g.roles.insert(self.role.id, self.role.clone()));
 
         None
@@ -672,7 +661,6 @@ impl<'de> Deserialize<'de> for GuildRoleCreateEvent {
             .map_err(DeError::custom)?;
 
         Ok(Self {
-            guild_id,
             role,
         })
     }
@@ -697,7 +685,6 @@ impl CacheUpdate for GuildRoleDeleteEvent {
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleUpdateEvent {
-    pub guild_id: GuildId,
     pub role: Role,
 }
 
@@ -706,7 +693,7 @@ impl CacheUpdate for GuildRoleUpdateEvent {
     type Output = Role;
 
     fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
+        if let Some(mut guild) = cache.guilds.get_mut(&self.role.guild_id) {
             if let Some(role) = guild.roles.get_mut(&self.role.id) {
                 return Some(mem::replace(role, self.role.clone()));
             }
@@ -741,7 +728,6 @@ impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
             .map_err(DeError::custom)?;
 
         Ok(Self {
-            guild_id,
             role,
         })
     }
@@ -1021,7 +1007,6 @@ impl CacheUpdate for MessageUpdateEvent {
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct PresenceUpdateEvent {
-    pub guild_id: Option<GuildId>,
     pub presence: Presence,
 }
 
@@ -1038,7 +1023,7 @@ impl CacheUpdate for PresenceUpdateEvent {
             self.presence.user.update_with_user(user);
         }
 
-        if let Some(guild_id) = self.guild_id {
+        if let Some(guild_id) = self.presence.guild_id {
             if let Some(mut guild) = cache.guilds.get_mut(&guild_id) {
                 // If the member went offline, remove them from the presence list.
                 if self.presence.status == OnlineStatus::Offline {
@@ -1078,17 +1063,8 @@ impl CacheUpdate for PresenceUpdateEvent {
 
 impl<'de> Deserialize<'de> for PresenceUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
-
-        let guild_id = match map.remove("guild_id") {
-            Some(v) => from_value::<Option<GuildId>>(v).map_err(DeError::custom)?,
-            None => None,
-        };
-        let presence = Presence::deserialize(Value::from(map)).map_err(DeError::custom)?;
-
         Ok(Self {
-            guild_id,
-            presence,
+            presence: Presence::deserialize(deserializer)?,
         })
     }
 }
@@ -1353,7 +1329,6 @@ impl fmt::Debug for VoiceServerUpdateEvent {
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct VoiceStateUpdateEvent {
-    pub guild_id: Option<GuildId>,
     pub voice_state: VoiceState,
 }
 
@@ -1362,7 +1337,7 @@ impl CacheUpdate for VoiceStateUpdateEvent {
     type Output = VoiceState;
 
     fn update(&mut self, cache: &Cache) -> Option<VoiceState> {
-        if let Some(guild_id) = self.guild_id {
+        if let Some(guild_id) = self.voice_state.guild_id {
             if let Some(mut guild) = cache.guilds.get_mut(&guild_id) {
                 if let Some(member) = &self.voice_state.member {
                     guild.members.insert(member.user.id, member.clone());
@@ -1386,15 +1361,8 @@ impl CacheUpdate for VoiceStateUpdateEvent {
 
 impl<'de> Deserialize<'de> for VoiceStateUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let map = JsonMap::deserialize(deserializer)?;
-        let guild_id = match map.get("guild_id") {
-            Some(v) => Some(GuildId::deserialize(v).map_err(DeError::custom)?),
-            None => None,
-        };
-
         Ok(VoiceStateUpdateEvent {
-            guild_id,
-            voice_state: VoiceState::deserialize(Value::from(map)).map_err(DeError::custom)?,
+            voice_state: VoiceState::deserialize(deserializer)?,
         })
     }
 }
@@ -2039,7 +2007,7 @@ macro_rules! with_related_ids_for_event_types {
             },
             Self::GuildMemberAdd, Self::GuildMemberAdd(e) => {
                 user_id: Some(e.member.user.id),
-                guild_id: Some(e.guild_id),
+                guild_id: Some(e.member.guild_id),
                 channel_id: Never,
                 message_id: Never,
             },
@@ -2063,7 +2031,7 @@ macro_rules! with_related_ids_for_event_types {
             },
             Self::GuildRoleCreate, Self::GuildRoleCreate(e) => {
                 user_id: Never,
-                guild_id: Some(e.guild_id),
+                guild_id: Some(e.role.guild_id),
                 channel_id: Never,
                 message_id: Never,
             },
@@ -2075,7 +2043,7 @@ macro_rules! with_related_ids_for_event_types {
             },
             Self::GuildRoleUpdate, Self::GuildRoleUpdate(e) => {
                 user_id: Never,
-                guild_id: Some(e.guild_id),
+                guild_id: Some(e.role.guild_id),
                 channel_id: Never,
                 message_id: Never,
             },
@@ -2135,7 +2103,7 @@ macro_rules! with_related_ids_for_event_types {
             },
             Self::PresenceUpdate, Self::PresenceUpdate(e) => {
                 user_id: Some(e.presence.user.id),
-                guild_id: e.guild_id.into(),
+                guild_id: e.presence.guild_id.into(),
                 channel_id: Never,
                 message_id: Never,
             },
@@ -2255,7 +2223,7 @@ macro_rules! with_related_ids_for_event_types {
             },
             Self::VoiceStateUpdate, Self::VoiceStateUpdate(e) => {
                 user_id: Some(e.voice_state.user_id),
-                guild_id: e.guild_id.into(),
+                guild_id: e.voice_state.guild_id.into(),
                 channel_id: Never,
                 message_id: Never,
             },

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -651,6 +651,8 @@ pub struct Presence {
     /// The devices a user are currently active on, if available.
     #[serde(default)]
     pub client_status: Option<ClientStatus>,
+    /// The `GuildId` the presence update is coming from.
+    pub guild_id: Option<GuildId>,
     /// The user's online status.
     pub status: OnlineStatus,
     /// Data about the associated user.


### PR DESCRIPTION
This removes the `guild_id` parameter from `guild_role_create/update`,
`guild_member_addition` and `voice_state_update` which is already provided
by the `Member`, `Role` and `VoiceState` parameters.

In addition to that the `guild_id` field is moved from the
`PresenceUpdateEvent` struct to the `Presence` struct and `Presence` is
passed directly to `EventHandler::presence_update`.

Closes: #1540

https://github.com/serenity-rs/serenity/issues/1540#issuecomment-939504866 mentions `guild_stickers_update` as another candidate but i think that's impractical because the data passed is a hashmap and isn't as accessible as a single entity.