### PR TITLE
Increase MSRV to 1.51

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  minrust: 1.48.0
+  minrust: 1.51.0
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ci-badge][]][ci] [![docs-badge][]][docs] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.48.0+ badge]][rust 1.48.0+ link]
+[![ci-badge][]][ci] [![docs-badge][]][docs] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.51.0+ badge]][rust 1.51.0+ link]
 
 # serenity
 
@@ -104,7 +104,7 @@ Add the following to your `Cargo.toml` file:
 serenity = "0.10"
 ```
 
-Serenity supports a minimum of Rust 1.48.
+Serenity supports a minimum of Rust 1.51.
 
 # Features
 
@@ -233,5 +233,5 @@ If you use the `native_tls_backend` and you are not developing on macOS or Windo
 [repo:lavalink]: https://github.com/freyacodes/Lavalink
 [repo:lavaplayer]: https://github.com/sedmelluq/lavaplayer
 [logo]: https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png
-[rust 1.48.0+ badge]: https://img.shields.io/badge/rust-1.48.0+-93450a.svg?style=flat-square
-[rust 1.48.0+ link]: https://blog.rust-lang.org/2020/11/19/Rust-1.48.html
+[rust 1.51.0+ badge]: https://img.shields.io/badge/rust-1.51.0+-93450a.svg?style=flat-square
+[rust 1.51.0+ link]: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.48"
+msrv = "1.51"
 cognitive-complexity-threshold = 20
 doc-valid-idents = [
     "UserAgent",


### PR DESCRIPTION
## Description

This changes the Minimum Supported Rust Version (MSRV) to 1.51. The rationale behind this, especially on the `current` branch, is due to `rustls` v0.20 being unable to be compiled on 1.48. Users are already experiencing this breakage on v0.10.9, as `reqwest` v0.10.7, which is automatically downloaded by cargo as it's the latest version, pulls `rustls` v0.20. Hence, the increase is only made official.

The version 1.51 has been chosen because it's already the MSRV on the `next` branch, in which `rustls` v0.20 compiles successfully. 

## Type of Change

This is a change in the MSRV the library supports. On regular circumstances, this PR should be targeted to `next`; however, as said in the rationale above, this change has already happened, as a result this is pardoned.

## How Has This Been Tested?

This PR will be testing grounds (for the MSRV CI job).