### PR TITLE
Deserialize the `GuildMembersChunkEvent` struct manually

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -10,7 +10,7 @@ use std::mem;
 use std::{collections::HashMap, fmt};
 
 use chrono::{DateTime, Utc};
-use serde::de::Error as DeError;
+use serde::de::{Error as DeError, IgnoredAny, MapAccess};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 
 use super::prelude::*;
@@ -568,61 +568,100 @@ impl CacheUpdate for GuildMembersChunkEvent {
 
 impl<'de> Deserialize<'de> for GuildMembersChunkEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "snake_case")]
+        enum Field {
+            GuildId,
+            ChunkIndex,
+            ChunkCount,
+            Members,
+            Nonce,
+            Unknown(String),
+        }
 
-        let guild_id = map
-            .get("guild_id")
-            .ok_or_else(|| DeError::custom("missing member chunk guild id"))
-            .and_then(GuildId::deserialize)
-            .map_err(DeError::custom)?;
+        struct GuildMembersChunkVisitor;
 
-        let mut members =
-            map.remove("members").ok_or_else(|| DeError::custom("missing member chunk members"))?;
+        impl<'de> Visitor<'de> for GuildMembersChunkVisitor {
+            type Value = GuildMembersChunkEvent;
 
-        let chunk_index = map
-            .get("chunk_index")
-            .ok_or_else(|| DeError::custom("missing member chunk index"))
-            .and_then(u32::deserialize)
-            .map_err(DeError::custom)?;
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("struct GuildMembersChunkEvent")
+            }
 
-        let chunk_count = map
-            .get("chunk_count")
-            .ok_or_else(|| DeError::custom("missing member chunk count"))
-            .and_then(u32::deserialize)
-            .map_err(DeError::custom)?;
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> StdResult<Self::Value, A::Error> {
+                let mut guild_id = None;
+                let mut chunk_index = None;
+                let mut chunk_count = None;
+                let mut members = None;
+                let mut nonce = None;
 
-        if let Some(members) = members.as_array_mut() {
-            let num = from_number(guild_id.0);
-
-            for member in members {
-                if let Some(map) = member.as_object_mut() {
-                    map.insert("guild_id".to_string(), num.clone());
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::GuildId => {
+                            if guild_id.is_some() {
+                                return Err(DeError::duplicate_field("guild_id"));
+                            }
+                            guild_id = Some(map.next_value()?);
+                        },
+                        Field::ChunkIndex => {
+                            if chunk_index.is_some() {
+                                return Err(DeError::duplicate_field("chunk_index"));
+                            }
+                            chunk_index = Some(map.next_value()?);
+                        },
+                        Field::ChunkCount => {
+                            if chunk_count.is_some() {
+                                return Err(DeError::duplicate_field("chunk_count"));
+                            }
+                            chunk_count = Some(map.next_value()?);
+                        },
+                        Field::Members => {
+                            if members.is_some() {
+                                return Err(DeError::duplicate_field("members"));
+                            }
+                            members = Some(map.next_value::<Vec<InterimMember>>()?);
+                        },
+                        Field::Nonce => {
+                            if nonce.is_some() {
+                                return Err(DeError::duplicate_field("nonce"));
+                            }
+                            nonce = Some(map.next_value()?);
+                        },
+                        Field::Unknown(_) => {
+                            // ignore unknown keys
+                            map.next_value::<IgnoredAny>()?;
+                        },
+                    }
                 }
+
+                let guild_id = guild_id.ok_or_else(|| DeError::missing_field("guild_id"))?;
+                let chunk_index =
+                    chunk_index.ok_or_else(|| DeError::missing_field("chunk_index"))?;
+                let chunk_count =
+                    chunk_count.ok_or_else(|| DeError::missing_field("chunk_count"))?;
+                let members = members.ok_or_else(|| DeError::missing_field("members"))?;
+
+                let members = members
+                    .into_iter()
+                    .map(|m| {
+                        let mut m = Member::from(m);
+                        m.guild_id = guild_id;
+                        (m.user.id, m)
+                    })
+                    .collect();
+
+                Ok(GuildMembersChunkEvent {
+                    guild_id,
+                    chunk_index,
+                    chunk_count,
+                    members,
+                    nonce,
+                })
             }
         }
 
-        let members = from_value::<Vec<Member>>(members)
-            .map(|members| {
-                members.into_iter().fold(HashMap::new(), |mut acc, member| {
-                    let id = member.user.id;
-
-                    acc.insert(id, member);
-
-                    acc
-                })
-            })
-            .map_err(DeError::custom)?;
-
-        let nonce =
-            map.get("nonce").and_then(|nonce| nonce.as_str()).map(|nonce| nonce.to_string());
-
-        Ok(GuildMembersChunkEvent {
-            guild_id,
-            members,
-            chunk_index,
-            chunk_count,
-            nonce,
-        })
+        const FIELDS: &[&str] = &["guild_id", "chunk_index", "chunk_count", "members", "nonce"];
+        deserializer.deserialize_struct("GuildMembersChunkEvent", FIELDS, GuildMembersChunkVisitor)
     }
 }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -60,6 +60,46 @@ pub struct Member {
     pub avatar: Option<String>,
 }
 
+/// Helper for deserialization without a `GuildId` but then later updated to the correct `GuildId`.
+///
+/// The only difference to `Member` is `#[serde(default)]` on `guild_id`.
+#[derive(Deserialize)]
+pub(crate) struct InterimMember {
+    pub deaf: bool,
+    #[serde(default)]
+    pub guild_id: GuildId,
+    pub joined_at: Option<DateTime<Utc>>,
+    pub mute: bool,
+    pub nick: Option<String>,
+    pub roles: Vec<RoleId>,
+    pub user: User,
+    #[serde(default)]
+    pub pending: bool,
+    pub premium_since: Option<DateTime<Utc>>,
+    #[cfg(feature = "unstable_discord_api")]
+    pub permissions: Option<Permissions>,
+    pub avatar: Option<String>,
+}
+
+impl From<InterimMember> for Member {
+    fn from(m: InterimMember) -> Self {
+        Self {
+            deaf: m.deaf,
+            guild_id: m.guild_id,
+            joined_at: m.joined_at,
+            mute: m.mute,
+            nick: m.nick,
+            roles: m.roles,
+            user: m.user,
+            pending: m.pending,
+            premium_since: m.premium_since,
+            #[cfg(feature = "unstable_discord_api")]
+            permissions: m.permissions,
+            avatar: m.avatar,
+        }
+    }
+}
+
 #[cfg(feature = "model")]
 impl Member {
     /// Adds a [`Role`] to the member, editing its roles in-place if the request


### PR DESCRIPTION
Instead of using `JsonMap` to inject the `GuildId` to the member data
before deserializing the member list, a serde `Visitor` is implemented to
deserialize event and the `Member`s with the help of an iterim struct.

The correct `GuildId` is assigned afterwards.