### PR TITLE
Move the event deserialization of `Role` creation and update into a helper function

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -14,7 +14,7 @@ use serde::de::{Error as DeError, IgnoredAny, MapAccess};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 
 use super::prelude::*;
-use super::utils::{emojis, stickers};
+use super::utils::{emojis, roles, stickers};
 #[cfg(feature = "cache")]
 use crate::cache::{Cache, CacheUpdate};
 use crate::internal::prelude::*;
@@ -677,30 +677,8 @@ impl CacheUpdate for GuildRoleCreateEvent {
 
 impl<'de> Deserialize<'de> for GuildRoleCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
-
-        let guild_id = map
-            .remove("guild_id")
-            .ok_or_else(|| DeError::custom("expected guild_id"))
-            .and_then(GuildId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let id = *guild_id.as_u64();
-
-        if let Some(value) = map.get_mut("role") {
-            if let Some(role) = value.as_object_mut() {
-                role.insert("guild_id".to_string(), from_number(id));
-            }
-        }
-
-        let role = map
-            .remove("role")
-            .ok_or_else(|| DeError::custom("expected role"))
-            .and_then(Role::deserialize)
-            .map_err(DeError::custom)?;
-
         Ok(Self {
-            role,
+            role: roles::deserialize_event(deserializer)?,
         })
     }
 }
@@ -744,30 +722,8 @@ impl CacheUpdate for GuildRoleUpdateEvent {
 
 impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
-
-        let guild_id = map
-            .remove("guild_id")
-            .ok_or_else(|| DeError::custom("expected guild_id"))
-            .and_then(GuildId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let id = *guild_id.as_u64();
-
-        if let Some(value) = map.get_mut("role") {
-            if let Some(role) = value.as_object_mut() {
-                role.insert("guild_id".to_string(), from_number(id));
-            }
-        }
-
-        let role = map
-            .remove("role")
-            .ok_or_else(|| DeError::custom("expected role"))
-            .and_then(Role::deserialize)
-            .map_err(DeError::custom)?;
-
         Ok(Self {
-            role,
+            role: roles::deserialize_event(deserializer)?,
         })
     }
 }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -75,6 +75,48 @@ pub struct Role {
     pub tags: RoleTags,
 }
 
+/// Helper for deserialization without a `GuildId` but then later updated to the correct `GuildId`.
+///
+/// The only difference to `Role` is `#[serde(default)]` on `guild_id`.
+#[derive(Deserialize)]
+pub(crate) struct InterimRole {
+    pub id: RoleId,
+    #[serde(default)]
+    pub guild_id: GuildId,
+    #[cfg(feature = "utils")]
+    #[serde(rename = "color")]
+    pub colour: Colour,
+    #[cfg(not(feature = "utils"))]
+    #[serde(rename = "color")]
+    pub colour: u32,
+    pub hoist: bool,
+    pub managed: bool,
+    #[serde(default)]
+    pub mentionable: bool,
+    pub name: String,
+    pub permissions: Permissions,
+    pub position: i64,
+    #[serde(default)]
+    pub tags: RoleTags,
+}
+
+impl From<InterimRole> for Role {
+    fn from(r: InterimRole) -> Self {
+        Self {
+            id: r.id,
+            guild_id: r.guild_id,
+            colour: r.colour,
+            hoist: r.hoist,
+            managed: r.managed,
+            mentionable: r.mentionable,
+            name: r.name,
+            permissions: r.permissions,
+            position: r.position,
+            tags: r.tags,
+        }
+    }
+}
+
 #[cfg(feature = "model")]
 impl Role {
     /// Deletes the role.

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -240,10 +240,11 @@ pub mod private_channels {
 pub mod roles {
     use std::collections::HashMap;
 
-    use serde::Deserializer;
+    use serde::{Deserialize, Deserializer};
 
     use super::SequenceToMapVisitor;
-    use crate::model::{guild::Role, id::RoleId};
+    use crate::model::guild::{InterimRole, Role};
+    use crate::model::id::{GuildId, RoleId};
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
@@ -252,6 +253,25 @@ pub mod roles {
     }
 
     pub use super::serialize_map_values as serialize;
+
+    /// Helper to deserialize `GuildRoleCreateEvent` and `GuildRoleUpdateEvent`.
+    pub fn deserialize_event<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Role, D::Error> {
+        #[derive(Deserialize)]
+        struct Event {
+            guild_id: GuildId,
+            role: InterimRole,
+        }
+
+        let Event {
+            guild_id,
+            role,
+        } = Event::deserialize(deserializer)?;
+
+        let mut role = Role::from(role);
+        role.guild_id = guild_id;
+
+        Ok(role)
+    }
 }
 
 /// Used with `#[serde(with = "stickers")]`


### PR DESCRIPTION
This adds an utility function to deserialize the `GuildRoleCreateEvent` and
`GuildRoleUpdateEvent` structs with the help of interim structs instead of
using `JsonMap`.