### PR TITLE
Update to dashmap 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ version = "0.3.16"
 version = "2.0"
 
 [dependencies.dashmap]
-version = "4.0.2"
+version = "5.0"
 features = ["serde"]
 optional = true
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -95,8 +95,7 @@ impl<F: FromStr> FromStrAndCache for F {
 /// Iterator given to the selector closure in [`Cache::channel_messages_field`].
 // Wrapper around a specific iterator type to allow swapping out iterators on cache design changes
 //
-// Clone impl waiting on this https://github.com/xacrimon/dashmap/pull/152
-//#[derive(Clone)]
+#[derive(Clone)]
 pub struct MessageIterator<'a, S: BuildHasher + Clone>(
     Iter<'a, MessageId, Message, S, DashMap<MessageId, Message, S>>,
 );


### PR DESCRIPTION
Additionally, bring back the `Clone` trait to `MessageIterator`

	modified:   Cargo.toml
	modified:   src/cache/mod.rs