### PR TITLE
Move the `hashmap_to_json_map` function into the `json` module

### DIFF
--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -3,13 +3,12 @@ use std::collections::HashMap;
 #[cfg(feature = "simd-json")]
 use simd_json::Mutable;
 
-use crate::json::{from_number, json, Value};
+use crate::json::{self, from_number, json, Value};
 use crate::model::channel::ChannelType;
 use crate::model::interactions::application_command::{
     ApplicationCommandOptionType,
     ApplicationCommandType,
 };
-use crate::utils;
 
 /// A builder for creating a new [`ApplicationCommandOption`].
 ///
@@ -135,7 +134,7 @@ impl CreateApplicationCommandOption {
     /// [`SubCommandGroup`]: crate::model::interactions::application_command::ApplicationCommandOptionType::SubCommandGroup
     /// [`SubCommand`]: crate::model::interactions::application_command::ApplicationCommandOptionType::SubCommand
     pub fn add_sub_option(&mut self, sub_option: CreateApplicationCommandOption) -> &mut Self {
-        let new_option = utils::hashmap_to_json_map(sub_option.0);
+        let new_option = json::hashmap_to_json_map(sub_option.0);
         let options = self.0.entry("options").or_insert_with(|| Value::from(Vec::<Value>::new()));
         let opt_arr = options.as_array_mut().expect("Must be an array");
         opt_arr.push(Value::from(new_option));
@@ -241,7 +240,7 @@ impl CreateApplicationCommand {
     ///
     /// **Note**: Application commands can have up to 25 options.
     pub fn add_option(&mut self, option: CreateApplicationCommandOption) -> &mut Self {
-        let new_option = utils::hashmap_to_json_map(option.0);
+        let new_option = json::hashmap_to_json_map(option.0);
         let options = self.0.entry("options").or_insert_with(|| Value::from(Vec::<Value>::new()));
         let opt_arr = options.as_array_mut().expect("Must be an array");
         opt_arr.push(Value::from(new_option));
@@ -255,7 +254,7 @@ impl CreateApplicationCommand {
     pub fn set_options(&mut self, options: Vec<CreateApplicationCommandOption>) -> &mut Self {
         let new_options = options
             .into_iter()
-            .map(|f| Value::from(utils::hashmap_to_json_map(f.0)))
+            .map(|f| Value::from(json::hashmap_to_json_map(f.0)))
             .collect::<Vec<Value>>();
 
         self.0.insert("options", Value::from(new_options));
@@ -282,7 +281,7 @@ impl CreateApplicationCommands {
 
     /// Adds a new application command.
     pub fn add_application_command(&mut self, command: CreateApplicationCommand) -> &mut Self {
-        let new_data = Value::from(utils::hashmap_to_json_map(command.0));
+        let new_data = Value::from(json::hashmap_to_json_map(command.0));
 
         self.0.push(new_data);
 
@@ -296,7 +295,7 @@ impl CreateApplicationCommands {
     ) -> &mut Self {
         let new_application_command = commands
             .into_iter()
-            .map(|f| Value::from(utils::hashmap_to_json_map(f.0)))
+            .map(|f| Value::from(json::hashmap_to_json_map(f.0)))
             .collect::<Vec<Value>>();
 
         for application_command in new_application_command {

--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 #[cfg(feature = "simd-json")]
 use simd_json::Mutable;
 
-use crate::json::{from_number, Value};
+use crate::json::{self, from_number, Value};
 use crate::model::interactions::application_command::ApplicationCommandPermissionType;
-use crate::utils;
 
 /// A builder for creating several [`ApplicationCommandPermission`].
 ///
@@ -35,7 +34,7 @@ impl CreateApplicationCommandsPermissions {
         &mut self,
         application_command: CreateApplicationCommandPermissions,
     ) -> &mut Self {
-        let new_data = Value::from(utils::hashmap_to_json_map(application_command.0));
+        let new_data = Value::from(json::hashmap_to_json_map(application_command.0));
 
         self.0.push(new_data);
 
@@ -49,7 +48,7 @@ impl CreateApplicationCommandsPermissions {
     ) -> &mut Self {
         let new_application_commands = application_commands
             .into_iter()
-            .map(|f| Value::from(utils::hashmap_to_json_map(f.0)))
+            .map(|f| Value::from(json::hashmap_to_json_map(f.0)))
             .collect::<Vec<Value>>();
 
         for application_command in new_application_commands {
@@ -95,7 +94,7 @@ impl CreateApplicationCommandPermissions {
         &mut self,
         permission: CreateApplicationCommandPermissionData,
     ) -> &mut Self {
-        let new_data = utils::hashmap_to_json_map(permission.0);
+        let new_data = json::hashmap_to_json_map(permission.0);
         let permissions =
             self.0.entry("permissions").or_insert_with(|| Value::from(Vec::<Value>::new()));
 
@@ -113,7 +112,7 @@ impl CreateApplicationCommandPermissions {
     ) -> &mut Self {
         let new_permissions = permissions
             .into_iter()
-            .map(|f| Value::from(utils::hashmap_to_json_map(f.0)))
+            .map(|f| Value::from(json::hashmap_to_json_map(f.0)))
             .collect::<Vec<Value>>();
 
         self.0.insert("permissions", Value::from(new_permissions));
@@ -150,7 +149,7 @@ impl CreateApplicationCommandPermissionsData {
         &mut self,
         permission: CreateApplicationCommandPermissionData,
     ) -> &mut Self {
-        let new_data = utils::hashmap_to_json_map(permission.0);
+        let new_data = json::hashmap_to_json_map(permission.0);
         let permissions =
             self.0.entry("permissions").or_insert_with(|| Value::from(Vec::<Value>::new()));
 
@@ -168,7 +167,7 @@ impl CreateApplicationCommandPermissionsData {
     ) -> &mut Self {
         let new_permissions = permissions
             .into_iter()
-            .map(|f| Value::from(utils::hashmap_to_json_map(f.0)))
+            .map(|f| Value::from(json::hashmap_to_json_map(f.0)))
             .collect::<Vec<Value>>();
 
         self.0.insert("permissions", Value::from(new_permissions));

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
 use crate::internal::prelude::*;
-use crate::json::{from_number, Value};
+use crate::json::{self, from_number, Value};
 use crate::model::channel::ReactionType;
 use crate::model::interactions::message_component::ButtonStyle;
-use crate::utils;
 
 /// A builder for creating several [`ActionRow`]s.
 ///
@@ -103,7 +102,7 @@ impl CreateActionRow {
     pub fn build(&mut self) -> Value {
         self.0.insert("type", from_number(1_u8));
 
-        utils::hashmap_to_json_map(self.0.clone()).into()
+        json::hashmap_to_json_map(self.0.clone()).into()
     }
 }
 
@@ -173,7 +172,7 @@ impl CreateButton {
     pub fn build(mut self) -> Value {
         self.0.insert("type", from_number(2_u8));
 
-        utils::hashmap_to_json_map(self.0.clone()).into()
+        json::hashmap_to_json_map(self.0.clone()).into()
     }
 }
 
@@ -223,7 +222,7 @@ impl CreateSelectMenu {
     pub fn build(mut self) -> Value {
         self.0.insert("type", from_number(3_u8));
 
-        utils::hashmap_to_json_map(self.0.clone()).into()
+        json::hashmap_to_json_map(self.0.clone()).into()
     }
 }
 
@@ -249,7 +248,7 @@ impl CreateSelectMenuOptions {
 
     /// Adds an option.
     pub fn add_option(&mut self, option: CreateSelectMenuOption) -> &mut Self {
-        let data = utils::hashmap_to_json_map(option.0);
+        let data = json::hashmap_to_json_map(option.0);
 
         self.0.push(data.into());
 
@@ -260,7 +259,7 @@ impl CreateSelectMenuOptions {
     pub fn set_options(&mut self, options: Vec<CreateSelectMenuOption>) -> &mut Self {
         let new_options = options
             .into_iter()
-            .map(|option| utils::hashmap_to_json_map(option.0).into())
+            .map(|option| json::hashmap_to_json_map(option.0).into())
             .collect::<Vec<Value>>();
 
         for option in new_options {

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -19,10 +19,8 @@ use std::fmt::Display;
 
 use chrono::{DateTime, TimeZone};
 
-use crate::json::Value;
-use crate::json::{from_number, json};
+use crate::json::{self, from_number, json, Value};
 use crate::model::channel::Embed;
-use crate::utils;
 #[cfg(feature = "utils")]
 use crate::utils::Colour;
 
@@ -56,7 +54,7 @@ impl CreateEmbed {
 
     /// Set the author of the embed.
     pub fn set_author(&mut self, author: CreateEmbedAuthor) -> &mut Self {
-        let map = utils::hashmap_to_json_map(author.0);
+        let map = json::hashmap_to_json_map(author.0);
 
         self.0.insert("author", Value::from(map));
         self
@@ -172,7 +170,7 @@ impl CreateEmbed {
     /// Set the footer of the embed.
     pub fn set_footer(&mut self, create_embed_footer: CreateEmbedFooter) -> &mut Self {
         let footer = create_embed_footer.0;
-        let map = utils::hashmap_to_json_map(footer);
+        let map = json::hashmap_to_json_map(footer);
 
         self.0.insert("footer", Value::from(map));
         self
@@ -519,11 +517,10 @@ where
 #[cfg(test)]
 mod test {
     use super::CreateEmbed;
-    use crate::json::json;
-    use crate::json::Value;
+    use crate::json::{self, json, Value};
     use crate::{
         model::channel::{Embed, EmbedField, EmbedFooter, EmbedImage, EmbedVideo},
-        utils::{self, Colour},
+        utils::Colour,
     };
 
     #[test]
@@ -575,7 +572,7 @@ mod test {
         builder.title("still a hakase");
         builder.url("https://i.imgur.com/XfWpfCV.gif");
 
-        let built = Value::from(utils::hashmap_to_json_map(builder.0));
+        let built = Value::from(json::hashmap_to_json_map(builder.0));
 
         let obj = json!({
             "color": 0xFF0011,

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -5,13 +5,10 @@ use simd_json::Mutable;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
-use crate::json::{from_number, json, Value};
-use crate::{
-    model::interactions::{
-        InteractionApplicationCommandCallbackDataFlags,
-        InteractionResponseType,
-    },
-    utils,
+use crate::json::{self, from_number, json, Value};
+use crate::model::interactions::{
+    InteractionApplicationCommandCallbackDataFlags,
+    InteractionResponseType,
 };
 
 #[derive(Clone, Debug)]
@@ -33,7 +30,7 @@ impl CreateInteractionResponse {
     {
         let mut data = CreateInteractionResponseData::default();
         f(&mut data);
-        let map = utils::hashmap_to_json_map(data.0);
+        let map = json::hashmap_to_json_map(data.0);
         let data = Value::from(map);
 
         self.0.insert("data", data);
@@ -89,7 +86,7 @@ impl CreateInteractionResponseData {
 
     /// Adds an embed to the message.
     pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = utils::hashmap_to_json_map(embed.0);
+        let map = json::hashmap_to_json_map(embed.0);
         let embed = Value::from(map);
 
         let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
@@ -108,7 +105,7 @@ impl CreateInteractionResponseData {
     pub fn embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
         let embeds = embeds
             .into_iter()
-            .map(|embed| utils::hashmap_to_json_map(embed.0).into())
+            .map(|embed| json::hashmap_to_json_map(embed.0).into())
             .collect::<Vec<Value>>();
 
         self.0.insert("embeds", Value::from(embeds));
@@ -122,7 +119,7 @@ impl CreateInteractionResponseData {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = utils::hashmap_to_json_map(allowed_mentions.0);
+        let map = json::hashmap_to_json_map(allowed_mentions.0);
         let allowed_mentions = Value::from(map);
 
         self.0.insert("allowed_mentions", allowed_mentions);

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -5,9 +5,9 @@ use simd_json::Mutable;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
-use crate::json::{from_number, Value};
+use crate::http::AttachmentType;
+use crate::json::{self, from_number, Value};
 use crate::model::interactions::InteractionApplicationCommandCallbackDataFlags;
-use crate::{http::AttachmentType, utils};
 
 #[derive(Clone, Debug, Default)]
 pub struct CreateInteractionResponseFollowup<'a>(
@@ -99,7 +99,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
 
     /// Adds an embed to the message.
     pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = utils::hashmap_to_json_map(embed.0);
+        let map = json::hashmap_to_json_map(embed.0);
         let embed = Value::from(map);
 
         self.0
@@ -119,7 +119,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     pub fn embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
         let embeds = embeds
             .into_iter()
-            .map(|embed| utils::hashmap_to_json_map(embed.0).into())
+            .map(|embed| json::hashmap_to_json_map(embed.0).into())
             .collect::<Vec<Value>>();
 
         self.0.insert("embeds", Value::from(embeds));
@@ -133,7 +133,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = utils::hashmap_to_json_map(allowed_mentions.0);
+        let map = json::hashmap_to_json_map(allowed_mentions.0);
         let allowed_mentions = Value::from(map);
 
         self.0.insert("allowed_mentions", allowed_mentions);

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -6,10 +6,9 @@ use super::CreateEmbed;
 use crate::builder::CreateComponents;
 use crate::http::AttachmentType;
 use crate::internal::prelude::*;
-use crate::json::to_value;
+use crate::json::{self, to_value};
 use crate::model::channel::{MessageReference, ReactionType};
 use crate::model::id::StickerId;
-use crate::utils;
 
 /// A builder to specify the contents of an [`Http::send_message`] request,
 /// primarily meant for use through [`ChannelId::send_message`].
@@ -79,7 +78,7 @@ impl<'a> CreateMessage<'a> {
     }
 
     fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = utils::hashmap_to_json_map(embed.0);
+        let map = json::hashmap_to_json_map(embed.0);
         let embed = Value::from(map);
 
         let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
@@ -213,7 +212,7 @@ impl<'a> CreateMessage<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = utils::hashmap_to_json_map(allowed_mentions.0);
+        let map = json::hashmap_to_json_map(allowed_mentions.0);
         let allowed_mentions = Value::from(map);
 
         self.0.insert("allowed_mentions", allowed_mentions);

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use crate::internal::prelude::*;
+use crate::json;
 use crate::model::guild::GuildWelcomeScreenEmoji;
-use crate::utils;
 
 /// A builder to specify the fields to edit in a [`GuildWelcomeScreen`].
 ///
@@ -38,7 +38,7 @@ impl EditGuildWelcomeScreen {
     }
 
     pub fn add_welcome_channel(&mut self, channel: CreateGuildWelcomeChannel) -> &mut Self {
-        let new_data = utils::hashmap_to_json_map(channel.0);
+        let new_data = json::hashmap_to_json_map(channel.0);
 
         let channels =
             self.0.entry("welcome_channels").or_insert_with(|| Value::from(Vec::<Value>::new()));
@@ -52,7 +52,7 @@ impl EditGuildWelcomeScreen {
     pub fn set_welcome_channels(&mut self, channels: Vec<CreateGuildWelcomeChannel>) -> &mut Self {
         let new_channels = channels
             .into_iter()
-            .map(|f| Value::from(utils::hashmap_to_json_map(f.0)))
+            .map(|f| Value::from(json::hashmap_to_json_map(f.0)))
             .collect::<Vec<Value>>();
 
         self.0.insert("welcome_channels", Value::from(new_channels));

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -5,8 +5,7 @@ use simd_json::Mutable;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
-use crate::json::Value;
-use crate::utils;
+use crate::json::{self, Value};
 
 #[derive(Clone, Debug, Default)]
 pub struct EditInteractionResponse(pub HashMap<&'static str, Value>);
@@ -39,7 +38,7 @@ impl EditInteractionResponse {
 
     /// Adds an embed for the message.
     pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = utils::hashmap_to_json_map(embed.0);
+        let map = json::hashmap_to_json_map(embed.0);
         let embed = Value::from(map);
 
         let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
@@ -73,7 +72,7 @@ impl EditInteractionResponse {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = utils::hashmap_to_json_map(allowed_mentions.0);
+        let map = json::hashmap_to_json_map(allowed_mentions.0);
         let allowed_mentions = Value::from(map);
 
         self.0.insert("allowed_mentions", allowed_mentions);

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -5,8 +5,7 @@ use super::CreateEmbed;
 use crate::builder::CreateComponents;
 use crate::http::AttachmentType;
 use crate::internal::prelude::*;
-use crate::json::from_number;
-use crate::utils;
+use crate::json::{self, from_number};
 
 /// A builder to specify the fields to edit in an existing message.
 ///
@@ -45,7 +44,7 @@ impl<'a> EditMessage<'a> {
     }
 
     fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = utils::hashmap_to_json_map(embed.0);
+        let map = json::hashmap_to_json_map(embed.0);
         let embed = Value::from(map);
 
         let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::CreateAllowedMentions;
 use crate::internal::prelude::*;
-use crate::utils;
+use crate::json;
 
 /// A builder to specify the fields to edit in an existing [`Webhook`]'s message.
 ///
@@ -45,7 +45,7 @@ impl EditWebhookMessage {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = utils::hashmap_to_json_map(allowed_mentions.0);
+        let map = json::hashmap_to_json_map(allowed_mentions.0);
         let allowed_mentions = Value::from(map);
 
         self.0.insert("allowed_mentions", allowed_mentions);

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -2,10 +2,9 @@
 use crate::builder::EditChannel;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-use crate::json::from_number;
+#[cfg(feature = "model")]
+use crate::json::{self, from_number};
 use crate::model::prelude::*;
-#[cfg(all(feature = "model", feature = "utils"))]
-use crate::utils as serenity_utils;
 
 /// A category of [`GuildChannel`]s.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -119,7 +118,6 @@ impl ChannelCategory {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    #[cfg(feature = "utils")]
     pub async fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
     where
         F: FnOnce(&mut EditChannel) -> &mut EditChannel,
@@ -130,7 +128,7 @@ impl ChannelCategory {
 
         let mut edit_channel = EditChannel::default();
         f(&mut edit_channel);
-        let map = serenity_utils::hashmap_to_json_map(edit_channel.0);
+        let map = json::hashmap_to_json_map(edit_channel.0);
 
         cache_http.http().edit_channel(self.id.0, &map, None).await.map(|channel| {
             let GuildChannel {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -39,11 +39,11 @@ use crate::collector::{
 use crate::http::AttachmentType;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
+#[cfg(all(feature = "model", feature = "utils"))]
+use crate::json;
 #[cfg(feature = "model")]
 use crate::json::json;
 use crate::model::prelude::*;
-#[cfg(all(feature = "model", feature = "utils"))]
-use crate::utils;
 
 #[cfg(feature = "model")]
 impl ChannelId {
@@ -97,7 +97,7 @@ impl ChannelId {
         let mut invite = CreateInvite::default();
         f(&mut invite);
 
-        let map = utils::hashmap_to_json_map(invite.0);
+        let map = json::hashmap_to_json_map(invite.0);
 
         http.as_ref().create_invite(self.0, &map, None).await
     }
@@ -345,7 +345,7 @@ impl ChannelId {
         let mut channel = EditChannel::default();
         f(&mut channel);
 
-        let map = utils::hashmap_to_json_map(channel.0);
+        let map = json::hashmap_to_json_map(channel.0);
 
         http.as_ref().edit_channel(self.0, &map, None).await
     }
@@ -387,7 +387,7 @@ impl ChannelId {
             }
         }
 
-        let map = utils::hashmap_to_json_map(msg.0);
+        let map = json::hashmap_to_json_map(msg.0);
 
         http.as_ref()
             .edit_message_and_attachments(self.0, message_id.into().0, &Value::from(map), msg.1)
@@ -732,7 +732,7 @@ impl ChannelId {
         let mut create_message = CreateMessage::default();
         let msg = f(&mut create_message);
 
-        let map = utils::hashmap_to_json_map(msg.0.clone());
+        let map = json::hashmap_to_json_map(msg.0.clone());
 
         Message::check_lengths(&map)?;
 
@@ -767,7 +767,7 @@ impl ChannelId {
         let mut create_message = CreateMessage::default();
         let msg = f(&mut create_message);
 
-        let map = utils::hashmap_to_json_map(msg.0.clone());
+        let map = json::hashmap_to_json_map(msg.0.clone());
 
         Message::check_lengths(&map)?;
 
@@ -996,7 +996,7 @@ impl ChannelId {
         let mut instance = CreateStageInstance::default();
         f(&mut instance);
 
-        let map = utils::hashmap_to_json_map(instance.0);
+        let map = json::hashmap_to_json_map(instance.0);
 
         http.as_ref().create_stage_instance(&Value::from(map)).await
     }
@@ -1018,7 +1018,7 @@ impl ChannelId {
         let mut instance = EditStageInstance::default();
         f(&mut instance);
 
-        let map = utils::hashmap_to_json_map(instance.0);
+        let map = json::hashmap_to_json_map(instance.0);
 
         http.as_ref().edit_stage_instance(self.0, &Value::from(map)).await
     }
@@ -1035,7 +1035,7 @@ impl ChannelId {
         let mut instance = EditThread::default();
         f(&mut instance);
 
-        let map = utils::hashmap_to_json_map(instance.0);
+        let map = json::hashmap_to_json_map(instance.0);
 
         http.as_ref().edit_thread(self.0, &map).await
     }
@@ -1067,7 +1067,7 @@ impl ChannelId {
         let mut instance = CreateThread::default();
         f(&mut instance);
 
-        let map = utils::hashmap_to_json_map(instance.0);
+        let map = json::hashmap_to_json_map(instance.0);
 
         http.as_ref().create_public_thread(self.0, message_id.into().0, &map).await
     }
@@ -1089,7 +1089,7 @@ impl ChannelId {
         instance.kind(ChannelType::PrivateThread);
         f(&mut instance);
 
-        let map = utils::hashmap_to_json_map(instance.0);
+        let map = json::hashmap_to_json_map(instance.0);
 
         http.as_ref().create_private_thread(self.0, &map).await
     }

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -3,7 +3,7 @@ use crate::builder::CreateEmbed;
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
-use crate::utils;
+use crate::json;
 #[cfg(feature = "utils")]
 use crate::utils::Colour;
 
@@ -96,7 +96,7 @@ impl Embed {
     {
         let mut create_embed = CreateEmbed::default();
         f(&mut create_embed);
-        let map = utils::hashmap_to_json_map(create_embed.0);
+        let map = json::hashmap_to_json_map(create_embed.0);
 
         Value::from(map)
     }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -38,9 +38,9 @@ use crate::http::AttachmentType;
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
-#[cfg(all(feature = "model", feature = "utils"))]
-use crate::utils as serenity_utils;
-use crate::{json::from_number, model::prelude::*};
+#[cfg(feature = "model")]
+use crate::json::{self, from_number};
+use crate::model::prelude::*;
 
 /// Represents a guild's text, news, or voice channel. Some methods are available
 /// only for voice channels and some are only available for text channels.
@@ -436,7 +436,7 @@ impl GuildChannel {
 
         let mut edit_channel = EditChannel::default();
         f(&mut edit_channel);
-        let edited = serenity_utils::hashmap_to_json_map(edit_channel.0);
+        let edited = json::hashmap_to_json_map(edit_channel.0);
 
         *self = cache_http.http().edit_channel(self.id.0, &edited, None).await?;
 
@@ -604,7 +604,7 @@ impl GuildChannel {
 
         voice_state.0.insert("channel_id", Value::from(self.id.0.to_string()));
 
-        let map = serenity_utils::hashmap_to_json_map(voice_state.0);
+        let map = json::hashmap_to_json_map(voice_state.0);
 
         if let Some(id) = user_id {
             http.as_ref().edit_voice_state(self.guild_id.0, id.into().0, &map).await

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -30,6 +30,8 @@ use crate::collector::{CollectComponentInteraction, ComponentInteractionCollecto
 use crate::collector::{CollectReaction, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
+#[cfg(feature = "model")]
+use crate::json;
 use crate::json::Value;
 #[cfg(feature = "unstable_discord_api")]
 use crate::model::interactions::{message_component::ActionRow, MessageInteraction};
@@ -331,7 +333,6 @@ impl Message {
     ///
     /// [`EditMessage`]: crate::builder::EditMessage
     /// [`the limit`]: crate::builder::EditMessage::content
-    #[cfg(feature = "utils")]
     pub async fn edit<'a, F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
     where
         F: for<'b> FnOnce(&'b mut EditMessage<'a>) -> &'b mut EditMessage<'a>,
@@ -356,7 +357,7 @@ impl Message {
 
         f(&mut builder);
 
-        let map = crate::utils::hashmap_to_json_map(builder.0);
+        let map = json::hashmap_to_json_map(builder.0);
 
         *self = cache_http
             .http()
@@ -784,7 +785,7 @@ impl Message {
         let mut suppress = EditMessage::default();
         suppress.suppress_embeds(true);
 
-        let map = crate::utils::hashmap_to_json_map(suppress.0);
+        let map = json::hashmap_to_json_map(suppress.0);
 
         *self =
             cache_http.http().edit_message(self.channel_id.0, self.id.0, &Value::from(map)).await?;

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -29,9 +29,9 @@ use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
-use crate::json::json;
+use crate::json;
 #[cfg(feature = "model")]
-use crate::utils;
+use crate::json::json;
 #[cfg(all(feature = "model", feature = "unstable_discord_api"))]
 use crate::{
     builder::{
@@ -218,7 +218,7 @@ impl GuildId {
         let mut builder = CreateChannel::default();
         f(&mut builder);
 
-        let map = utils::hashmap_to_json_map(builder.0);
+        let map = json::hashmap_to_json_map(builder.0);
 
         http.as_ref().create_channel(self.0, &map, None).await
     }
@@ -302,7 +302,7 @@ impl GuildId {
     {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
-        let map = utils::hashmap_to_json_map(edit_role.0);
+        let map = json::hashmap_to_json_map(edit_role.0);
 
         let role = http.as_ref().create_role(self.0, &map, None).await?;
 
@@ -330,7 +330,7 @@ impl GuildId {
     {
         let mut create_sticker = CreateSticker::default();
         f(&mut create_sticker);
-        let map = utils::hashmap_to_json_map(create_sticker.0);
+        let map = json::hashmap_to_json_map(create_sticker.0);
 
         let file = match create_sticker.1 {
             Some(f) => f,
@@ -456,7 +456,7 @@ impl GuildId {
     {
         let mut edit_guild = EditGuild::default();
         f(&mut edit_guild);
-        let map = utils::hashmap_to_json_map(edit_guild.0);
+        let map = json::hashmap_to_json_map(edit_guild.0);
 
         http.as_ref().edit_guild(self.0, &map, None).await
     }
@@ -519,7 +519,7 @@ impl GuildId {
     {
         let mut edit_member = EditMember::default();
         f(&mut edit_member);
-        let map = utils::hashmap_to_json_map(edit_member.0);
+        let map = json::hashmap_to_json_map(edit_member.0);
 
         http.as_ref().edit_member(self.0, user_id.into().0, &map, None).await
     }
@@ -577,7 +577,7 @@ impl GuildId {
     {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
-        let map = utils::hashmap_to_json_map(edit_role.0);
+        let map = json::hashmap_to_json_map(edit_role.0);
 
         http.as_ref().edit_role(self.0, role_id.into().0, &map, None).await
     }
@@ -612,7 +612,7 @@ impl GuildId {
     {
         let mut edit_sticker = EditSticker::default();
         f(&mut edit_sticker);
-        let map = utils::hashmap_to_json_map(edit_sticker.0);
+        let map = json::hashmap_to_json_map(edit_sticker.0);
 
         http.as_ref().edit_sticker(self.0, sticker_id.into().0, &map, None).await
     }
@@ -665,7 +665,7 @@ impl GuildId {
         f(&mut map);
 
         http.as_ref()
-            .edit_guild_welcome_screen(self.0, &Value::from(utils::hashmap_to_json_map(map.0)))
+            .edit_guild_welcome_screen(self.0, &Value::from(json::hashmap_to_json_map(map.0)))
             .await
     }
 
@@ -686,7 +686,7 @@ impl GuildId {
         f(&mut map);
 
         http.as_ref()
-            .edit_guild_widget(self.0, &Value::from(utils::hashmap_to_json_map(map.0)))
+            .edit_guild_widget(self.0, &Value::from(json::hashmap_to_json_map(map.0)))
             .await
     }
 
@@ -1095,6 +1095,8 @@ impl GuildId {
     /// **Note**: When the cache is enabled, this function unlocks the cache to
     /// retrieve the total number of shards in use. If you already have the
     /// total, consider using [`utils::shard_id`].
+    ///
+    /// [`utils::shard_id`]: crate::utils::shard_id
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
     pub fn shard_id(self, cache: impl AsRef<Cache>) -> u64 {
@@ -1327,7 +1329,7 @@ impl GuildId {
             .edit_guild_application_command_permissions(
                 self.0,
                 command_id.into(),
-                &Value::from(utils::hashmap_to_json_map(map.0)),
+                &Value::from(json::hashmap_to_json_map(map.0)),
             )
             .await
     }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -16,11 +16,11 @@ use crate::cache::Cache;
 use crate::http::{CacheHttp, Http};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
+#[cfg(feature = "model")]
+use crate::json;
 #[cfg(feature = "unstable_discord_api")]
 use crate::model::permissions::Permissions;
 use crate::model::prelude::*;
-#[cfg(feature = "model")]
-use crate::utils;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use crate::utils::Colour;
 
@@ -158,7 +158,7 @@ impl Member {
 
         let mut builder = EditMember::default();
         builder.roles(&self.roles);
-        let map = utils::hashmap_to_json_map(builder.0);
+        let map = json::hashmap_to_json_map(builder.0);
 
         match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await {
             Ok(member) => Ok(member.roles),
@@ -272,7 +272,7 @@ impl Member {
     {
         let mut edit_member = EditMember::default();
         f(&mut edit_member);
-        let map = utils::hashmap_to_json_map(edit_member.0);
+        let map = json::hashmap_to_json_map(edit_member.0);
 
         http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await
     }
@@ -515,7 +515,7 @@ impl Member {
 
         let mut builder = EditMember::default();
         builder.roles(&self.roles);
-        let map = utils::hashmap_to_json_map(builder.0);
+        let map = json::hashmap_to_json_map(builder.0);
 
         match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await {
             Ok(member) => Ok(member.roles),

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -15,7 +15,7 @@ use crate::builder::{
 };
 use crate::http::Http;
 use crate::internal::prelude::StdResult;
-use crate::json::{from_number, JsonMap, Value};
+use crate::json::{self, from_number, JsonMap, Value};
 use crate::model::channel::{ChannelType, PartialChannel};
 use crate::model::guild::{Member, PartialMember, Role};
 use crate::model::id::{
@@ -38,7 +38,6 @@ use crate::model::utils::{
     deserialize_roles_map,
     deserialize_users,
 };
-use crate::utils;
 
 /// An interaction when a user invokes a slash command.
 #[derive(Clone, Debug, Serialize)]
@@ -104,7 +103,7 @@ impl ApplicationCommandInteraction {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);
 
-        let map = utils::hashmap_to_json_map(interaction_response.0);
+        let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_lengths(&map)?;
 
@@ -141,7 +140,7 @@ impl ApplicationCommandInteraction {
         let mut interaction_response = EditInteractionResponse::default();
         f(&mut interaction_response);
 
-        let map = utils::hashmap_to_json_map(interaction_response.0);
+        let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_lengths(&map)?;
 
@@ -184,7 +183,7 @@ impl ApplicationCommandInteraction {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
 
-        let map = utils::hashmap_to_json_map(interaction_response.0);
+        let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_lengths(&map)?;
 
@@ -228,7 +227,7 @@ impl ApplicationCommandInteraction {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
 
-        let map = utils::hashmap_to_json_map(interaction_response.0);
+        let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_lengths(&map)?;
 
@@ -885,7 +884,7 @@ impl ApplicationCommand {
     {
         let mut create_application_command = CreateApplicationCommand::default();
         f(&mut create_application_command);
-        utils::hashmap_to_json_map(create_application_command.0)
+        json::hashmap_to_json_map(create_application_command.0)
     }
 }
 

--- a/src/model/interactions/autocomplete.rs
+++ b/src/model/interactions/autocomplete.rs
@@ -7,14 +7,13 @@ use super::prelude::*;
 use crate::builder::CreateAutocompleteResponse;
 use crate::http::Http;
 use crate::internal::prelude::StdResult;
-use crate::json::{from_number, json, JsonMap, Value};
+use crate::json::{self, from_number, json, JsonMap, Value};
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::interactions::{
     application_command::ApplicationCommandInteractionData,
     InteractionType,
 };
 use crate::model::prelude::User;
-use crate::utils;
 
 /// An interaction recieved when the user fills in an autocomplete option
 #[derive(Clone, Debug, Serialize)]
@@ -61,7 +60,7 @@ impl AutocompleteInteraction {
     {
         let mut response = CreateAutocompleteResponse::default();
         f(&mut response);
-        let data = utils::hashmap_to_json_map(response.0);
+        let data = json::hashmap_to_json_map(response.0);
 
         // Autocomplete response type is 8
         let map = json!({

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -12,9 +12,8 @@ use crate::builder::{
     EditInteractionResponse,
 };
 use crate::http::Http;
-use crate::json::{from_number, from_value, Value};
+use crate::json::{self, from_number, from_value, Value};
 use crate::model::interactions::InteractionType;
-use crate::utils;
 
 /// An interaction triggered by a message component.
 #[derive(Clone, Debug, Serialize)]
@@ -85,7 +84,7 @@ impl MessageComponentInteraction {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);
 
-        let map = utils::hashmap_to_json_map(interaction_response.0);
+        let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_content_length(&map)?;
         Message::check_embed_length(&map)?;
@@ -123,7 +122,7 @@ impl MessageComponentInteraction {
         let mut interaction_response = EditInteractionResponse::default();
         f(&mut interaction_response);
 
-        let map = utils::hashmap_to_json_map(interaction_response.0);
+        let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_content_length(&map)?;
         Message::check_embed_length(&map)?;
@@ -167,7 +166,7 @@ impl MessageComponentInteraction {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
 
-        let map = utils::hashmap_to_json_map(interaction_response.0);
+        let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_content_length(&map)?;
         Message::check_embed_length(&map)?;
@@ -202,7 +201,7 @@ impl MessageComponentInteraction {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
 
-        let map = utils::hashmap_to_json_map(interaction_response.0);
+        let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_content_length(&map)?;
         Message::check_embed_length(&map)?;

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -14,7 +14,7 @@ use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
-use crate::utils;
+use crate::json;
 
 /// Information about an invite code.
 ///
@@ -104,7 +104,7 @@ impl Invite {
             }
         }
 
-        let map = utils::hashmap_to_json_map(f(CreateInvite::default()).0);
+        let map = json::hashmap_to_json_map(f(CreateInvite::default()).0);
 
         cache_http.http().create_invite(channel_id.0, &map, None).await
     }
@@ -235,6 +235,8 @@ impl InviteGuild {
     /// **Note**: When the cache is enabled, this function unlocks the cache to
     /// retrieve the total number of shards in use. If you already have the
     /// total, consider using [`utils::shard_id`].
+    ///
+    /// [`utils::shard_id`]: crate::utils::shard_id
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[inline]
     pub fn shard_id(&self, cache: impl AsRef<Cache>) -> u64 {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -28,10 +28,10 @@ use crate::http::GuildPagination;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
+use crate::json;
+#[cfg(feature = "model")]
 use crate::json::json;
 use crate::json::to_string;
-#[cfg(feature = "model")]
-use crate::utils;
 use crate::{internal::prelude::*, model::misc::Mentionable};
 
 /// Used with `#[serde(with|deserialize_with|serialize_with)]`
@@ -269,7 +269,7 @@ impl CurrentUser {
 
         let mut edit_profile = EditProfile(map);
         f(&mut edit_profile);
-        let map = utils::hashmap_to_json_map(edit_profile.0);
+        let map = json::hashmap_to_json_map(edit_profile.0);
 
         *self = http.as_ref().edit_profile(&map).await?;
 

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -16,13 +16,13 @@ use crate::builder::{EditWebhookMessage, ExecuteWebhook};
 use crate::http::Http;
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
+#[cfg(feature = "model")]
+use crate::json;
 use crate::json::NULL;
 #[cfg(feature = "model")]
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::ModelError;
-#[cfg(feature = "model")]
-use crate::utils;
 
 /// A representation of a type of webhook.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -310,7 +310,7 @@ impl Webhook {
         let mut execute_webhook = ExecuteWebhook::default();
         f(&mut execute_webhook);
 
-        let map = utils::hashmap_to_json_map(execute_webhook.0);
+        let map = json::hashmap_to_json_map(execute_webhook.0);
 
         if !execute_webhook.1.is_empty() {
             http.as_ref()
@@ -348,7 +348,7 @@ impl Webhook {
         let mut edit_webhook_message = EditWebhookMessage::default();
         f(&mut edit_webhook_message);
 
-        let map = utils::hashmap_to_json_map(edit_webhook_message.0);
+        let map = json::hashmap_to_json_map(edit_webhook_message.0);
 
         http.as_ref().edit_webhook_message(self.id.0, token, message_id.0, &map).await
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -19,14 +19,7 @@ pub type Color = Colour;
 
 #[cfg(feature = "cache")]
 use std::str::FromStr;
-use std::{
-    collections::HashMap,
-    ffi::OsStr,
-    fs::File,
-    hash::{BuildHasher, Hash},
-    io::Read,
-    path::Path,
-};
+use std::{ffi::OsStr, fs::File, io::Read, path::Path};
 
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
@@ -36,21 +29,6 @@ use crate::model::channel::Channel;
 #[cfg(feature = "cache")]
 use crate::model::id::{ChannelId, GuildId, RoleId, UserId};
 use crate::model::{id::EmojiId, misc::EmojiIdentifier};
-
-/// Converts a HashMap into a final [`serde_json::Map`] representation.
-pub fn hashmap_to_json_map<H, T>(map: HashMap<T, Value, H>) -> JsonMap
-where
-    H: BuildHasher,
-    T: Eq + Hash + ToString,
-{
-    let mut json_map = JsonMap::new();
-
-    for (key, value) in map {
-        json_map.insert(key.to_string(), value);
-    }
-
-    json_map
-}
 
 /// Retrieves the "code" part of an invite out of a URL.
 ///
@@ -804,6 +782,7 @@ mod test {
     #[cfg(feature = "cache")]
     #[test]
     fn test_content_safe() {
+        use std::collections::HashMap;
         use std::sync::Arc;
 
         use chrono::{DateTime, Utc};


### PR DESCRIPTION
The new `json` module is a better place for this small helper and is no longer behind the `utils` feature.

BREAKING CHANGE: Previously exported publicly under `serenity::utils`