### PR TITLE
Remove obsolete `#[cfg(feature = "utils")]` attributes on model methods

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -89,7 +89,6 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Create Invite]: Permissions::CREATE_INVITE
-    #[cfg(feature = "utils")]
     pub async fn create_invite<F>(&self, http: impl AsRef<Http>, f: F) -> Result<RichInvite>
     where
         F: FnOnce(&mut CreateInvite) -> &mut CreateInvite,
@@ -336,7 +335,6 @@ impl ChannelId {
     /// or if an invalid value is set.
     ///
     /// [Manage Channel]: Permissions::MANAGE_CHANNELS
-    #[cfg(feature = "utils")]
     #[inline]
     pub async fn edit<F>(self, http: impl AsRef<Http>, f: F) -> Result<GuildChannel>
     where
@@ -367,7 +365,6 @@ impl ChannelId {
     ///
     /// [`EditMessage`]: crate::builder::EditMessage
     /// [`the limit`]: crate::builder::EditMessage::content
-    #[cfg(feature = "utils")]
     #[inline]
     pub async fn edit_message<F>(
         self,
@@ -717,7 +714,6 @@ impl ChannelId {
     /// [Attach Files]: Permissions::ATTACH_FILES
     /// [Send Messages]: Permissions::SEND_MESSAGES
     /// [`File`]: tokio::fs::File
-    #[cfg(feature = "utils")]
     pub async fn send_files<'a, F, T, It>(
         self,
         http: impl AsRef<Http>,
@@ -759,7 +755,6 @@ impl ChannelId {
     ///
     /// [`CreateMessage`]: crate::builder::CreateMessage
     /// [Send Messages]: Permissions::SEND_MESSAGES
-    #[cfg(feature = "utils")]
     pub async fn send_message<'a, F>(self, http: impl AsRef<Http>, f: F) -> Result<Message>
     where
         for<'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -413,7 +413,6 @@ impl GuildChannel {
     /// if the current user lacks permission to edit the channel.
     ///
     /// Otherwise returns [`Error::Http`] if the current user lacks permission.
-    #[cfg(feature = "utils")]
     pub async fn edit<F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
     where
         F: FnOnce(&mut EditChannel) -> &mut EditChannel,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -202,7 +202,7 @@ impl Message {
 
     /// A util function for determining whether this message was sent by someone else, or the
     /// bot.
-    #[cfg(all(feature = "cache", feature = "utils"))]
+    #[cfg(feature = "cache")]
     pub fn is_own(&self, cache: impl AsRef<Cache>) -> bool {
         self.author.id == cache.as_ref().current_user().id
     }
@@ -764,7 +764,6 @@ impl Message {
     /// Otherwise returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    #[cfg(feature = "utils")]
     pub async fn suppress_embeds(&mut self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {


### PR DESCRIPTION
The attributes are no longer needed after `hashmap_to_json_map` was
moved into the `json` module.

Followup to #1617 