### PR TITLE
Refactor `GuildWelcomeChannel` and dependant types

### DIFF
--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::internal::prelude::*;
 use crate::json;
-use crate::model::guild::GuildWelcomeScreenEmoji;
+use crate::model::guild::GuildWelcomeChannelEmoji;
 
 /// A builder to specify the fields to edit in a [`GuildWelcomeScreen`].
 ///
@@ -83,15 +83,19 @@ impl CreateGuildWelcomeChannel {
     }
 
     /// The emoji shown for the channel.
-    pub fn emoji(&mut self, emoji: GuildWelcomeScreenEmoji) -> &mut Self {
+    pub fn emoji(&mut self, emoji: GuildWelcomeChannelEmoji) -> &mut Self {
         match emoji {
-            GuildWelcomeScreenEmoji::Unicode(name) => {
-                self.0.insert("emoji_name", Value::from(name))
+            GuildWelcomeChannelEmoji::Unicode(name) => {
+                self.0.insert("emoji_name", Value::from(name));
             },
-            GuildWelcomeScreenEmoji::Custom(id) => {
-                self.0.insert("emoji_id", Value::from(id.to_string()))
+            GuildWelcomeChannelEmoji::Custom {
+                id,
+                name,
+            } => {
+                self.0.insert("emoji_id", Value::from(id.to_string()));
+                self.0.insert("emoji_name", Value::from(name));
             },
-        };
+        }
 
         self
     }


### PR DESCRIPTION
Rename `GuildWelcomeScreenEmoji` to `GuildWelcomeChannelEmoji` to make
the relation to `GuildWelcomeChannel` clear.

Change the `GuildWelcomeChannelEmoji::Custom` enum variant into a struct
to reflect that Discord sends the ID and name for custom emojis.

Use a interim struct and the `Serializer` API for (de)serialization
instead of using `JsonMap`.

**BREAKING CHANGE:** The enum `GuildWelcomeScreenEmoji` is renamed to
`GuildWelcomeChannelEmoji` and its `Custom` variant is now a struct variant
defined as `Custom { id: EmojiId, name: String }`.