### PR TITLE
add support for timeout feature

### DIFF
--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
+use std::fmt::Display;
 
 use crate::internal::prelude::*;
 use crate::model::id::{ChannelId, RoleId};
+
+use chrono::{DateTime, TimeZone};
 
 /// A builder which edits the properties of a [`Member`], to be used in
 /// conjunction with [`Member::edit`].
@@ -85,6 +88,42 @@ impl EditMember {
     pub fn disconnect_member(&mut self) -> &mut Self {
         self.0.insert("channel_id", Value::Null);
 
+        self
+    }
+
+    /// Times the user out until `time`, an ISO8601-formatted datetime string.
+    ///
+    /// Requires the [Moderate Members] permission.
+    ///
+    /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
+    pub fn communication_disabled_until<Tz>(&mut self, time: String) -> &mut Self
+    {
+        self.0.insert("communication_disabled_until", Value::String(time));
+        self
+    }
+
+    /// Times the user out until `time`.
+    ///
+    /// Requires the [Moderate Members] permission.
+    ///
+    /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
+    pub fn communication_disabled_until_datetime<Tz>(&mut self, time: DateTime<Tz>) -> &mut Self
+    where
+        Tz: TimeZone,
+        Tz::Offset: Display,
+    {
+        let timestamp = time.to_rfc3339();
+        self.0.insert("communication_disabled_until", Value::String(timestamp));
+        self
+    }
+
+    /// Allow a user to communicate, removing their timeout, if there is one.
+    ///
+    /// Requires the [Moderate Members] permission.
+    ///
+    /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
+    pub fn enable_communication(&mut self) -> &mut Self {
+        self.0.remove("communication_disabled_until");
         self
     }
 }

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -96,7 +96,7 @@ impl EditMember {
     /// Requires the [Moderate Members] permission.
     ///
     /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
-    pub fn disable_communication_until<Tz>(&mut self, time: String) -> &mut Self
+    pub fn disable_communication_until(&mut self, time: String) -> &mut Self
     {
         self.0.insert("communication_disabled_until", Value::String(time));
         self

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -98,7 +98,7 @@ impl EditMember {
     ///
     /// Requires the [Moderate Members] permission.
     ///
-    /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
+    /// [Moderate Members]: crate::model::permissions::Permissions::MODERATE_MEMBERS
     pub fn disable_communication_until(&mut self, time: String) -> &mut Self {
         self.0.insert("communication_disabled_until", Value::String(time));
         self
@@ -109,7 +109,7 @@ impl EditMember {
     /// `time` is considered invalid if it is greater than 28 days from the current time.
     /// Requires the [Moderate Members] permission.
     ///
-    /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
+    /// [Moderate Members]: crate::model::permissions::Permissions::MODERATE_MEMBERS
     pub fn disable_communication_until_datetime<Tz>(&mut self, time: DateTime<Tz>) -> &mut Self
     where
         Tz: TimeZone,
@@ -124,7 +124,7 @@ impl EditMember {
     ///
     /// Requires the [Moderate Members] permission.
     ///
-    /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
+    /// [Moderate Members]: crate::model::permissions::Permissions::MODERATE_MEMBERS
     pub fn enable_communication(&mut self) -> &mut Self {
         self.0.insert("communication_disabled_until", Value::Null);
         self

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -93,17 +93,20 @@ impl EditMember {
 
     /// Times the user out until `time`, an ISO8601-formatted datetime string.
     ///
+    ///`time` is considered invalid if it is not a valid ISO8601 timestamp or if it is greater
+    ///than 28 days from the current time.
+    ///
     /// Requires the [Moderate Members] permission.
     ///
     /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
-    pub fn disable_communication_until(&mut self, time: String) -> &mut Self
-    {
+    pub fn disable_communication_until(&mut self, time: String) -> &mut Self {
         self.0.insert("communication_disabled_until", Value::String(time));
         self
     }
 
     /// Times the user out until `time`.
     ///
+    ///`time` is considered invalid if it is greater than 28 days from the current time.
     /// Requires the [Moderate Members] permission.
     ///
     /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -123,7 +123,7 @@ impl EditMember {
     ///
     /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
     pub fn enable_communication(&mut self) -> &mut Self {
-        self.0.remove("communication_disabled_until");
+        self.0.insert("communication_disabled_until", Value::Null);
         self
     }
 }

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
+use chrono::{DateTime, TimeZone};
+
 use crate::internal::prelude::*;
 use crate::model::id::{ChannelId, RoleId};
-
-use chrono::{DateTime, TimeZone};
 
 /// A builder which edits the properties of a [`Member`], to be used in
 /// conjunction with [`Member::edit`].
@@ -93,8 +93,8 @@ impl EditMember {
 
     /// Times the user out until `time`, an ISO8601-formatted datetime string.
     ///
-    ///`time` is considered invalid if it is not a valid ISO8601 timestamp or if it is greater
-    ///than 28 days from the current time.
+    /// `time` is considered invalid if it is not a valid ISO8601 timestamp or if it is greater
+    /// than 28 days from the current time.
     ///
     /// Requires the [Moderate Members] permission.
     ///
@@ -106,7 +106,7 @@ impl EditMember {
 
     /// Times the user out until `time`.
     ///
-    ///`time` is considered invalid if it is greater than 28 days from the current time.
+    /// `time` is considered invalid if it is greater than 28 days from the current time.
     /// Requires the [Moderate Members] permission.
     ///
     /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -96,7 +96,7 @@ impl EditMember {
     /// Requires the [Moderate Members] permission.
     ///
     /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
-    pub fn communication_disabled_until<Tz>(&mut self, time: String) -> &mut Self
+    pub fn disable_communication_until<Tz>(&mut self, time: String) -> &mut Self
     {
         self.0.insert("communication_disabled_until", Value::String(time));
         self
@@ -107,7 +107,7 @@ impl EditMember {
     /// Requires the [Moderate Members] permission.
     ///
     /// [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
-    pub fn communication_disabled_until_datetime<Tz>(&mut self, time: DateTime<Tz>) -> &mut Self
+    pub fn disable_communication_until_datetime<Tz>(&mut self, time: DateTime<Tz>) -> &mut Self
     where
         Tz: TimeZone,
         Tz::Offset: Display,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -480,6 +480,7 @@ pub struct GuildMemberUpdateEvent {
     #[serde(default)]
     pub mute: bool,
     pub avatar: Option<String>,
+    pub communication_disabled_until: Option<DateTime<Utc>>,
 }
 
 #[cfg(feature = "cache")]
@@ -523,6 +524,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     #[cfg(feature = "unstable_discord_api")]
                     permissions: None,
                     avatar: self.avatar.clone(),
+                    communication_disabled_until: self.communication_disabled_until.clone(),
                 });
             }
 
@@ -1054,6 +1056,7 @@ impl CacheUpdate for PresenceUpdateEvent {
                         #[cfg(feature = "unstable_discord_api")]
                         permissions: None,
                         avatar: None,
+                        communication_disabled_until: None,
                     });
                 }
             }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -211,7 +211,8 @@ impl Member {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
+    /// Returns [`Error::Http`] if the current user lacks permission or if `time` is greater than
+    /// 28 days from the current time.
     ///
     /// [Moderate Members]: Permissions::MODERATE_MEMBERS
     pub async fn disable_communication_until_datetime(&mut self, http: impl AsRef<Http>, time: DateTime<Utc>) -> Result<()> {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -263,6 +263,28 @@ impl Member {
         http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map).await
     }
 
+    /// Allow a user to communicate, removing their timeout, if there is one.
+    ///
+    /// **Note**: Requires the [Moderate Members] permission.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    ///
+    /// [Moderate Members]: Permissions::MODERATE_MEMBERS
+    pub async fn enable_communication(&mut self, http: impl AsRef<Http>) -> Result<()> {
+        match self.guild_id.edit_member(&http, self.user.id, |member| {
+            member.enable_communication();
+            member
+        }).await {
+            Ok(_) => {
+                self.communication_disabled_until = None;
+                Ok(())
+            }
+            Err(why) => Err(why)
+        }
+    }
+
     /// Retrieves the ID and position of the member's highest role in the
     /// hierarchy, if they have one.
     ///

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -67,30 +67,6 @@ pub struct Member {
 #[cfg(feature = "model")]
 impl Member {
 
-    /// Times the user out until `time`.
-    ///
-    /// Requires the [Moderate Members] permission.
-    ///
-    /// **Note**: [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
-    ///
-    /// [Moderate Members]: Permissions::MODERATE_MEMBERS
-    pub async fn disable_communication_until_datetime(&mut self, http: impl AsRef<Http>, time: DateTime<Utc>) -> Result<()> {
-        match self.guild_id.edit_member(http, self.user.id, |member| {
-            member.disable_communication_until_datetime(time);
-            member
-        }).await {
-            Ok(_) => {
-                self.communication_disabled_until = Some(time);
-                Ok(())
-            }
-            Err(why) => Err(why)
-        }
-    }
-
     /// Adds a [`Role`] to the member, editing its roles in-place if the request
     /// was successful.
     ///
@@ -225,6 +201,30 @@ impl Member {
         }
 
         None
+    }
+
+    /// Times the user out until `time`.
+    ///
+    /// Requires the [Moderate Members] permission.
+    ///
+    /// **Note**: [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    ///
+    /// [Moderate Members]: Permissions::MODERATE_MEMBERS
+    pub async fn disable_communication_until_datetime(&mut self, http: impl AsRef<Http>, time: DateTime<Utc>) -> Result<()> {
+        match self.guild_id.edit_member(http, self.user.id, |member| {
+            member.disable_communication_until_datetime(time);
+            member
+        }).await {
+            Ok(_) => {
+                self.communication_disabled_until = Some(time);
+                Ok(())
+            }
+            Err(why) => Err(why)
+        }
     }
 
     /// Calculates the member's display name.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -58,15 +58,14 @@ pub struct Member {
     pub permissions: Option<Permissions>,
     /// The guild avatar hash
     pub avatar: Option<String>,
-    ///	When the user's timeout will expire and the user will be able to communicate in the guild again.
+    /// 	When the user's timeout will expire and the user will be able to communicate in the guild again.
     ///
-    ///	Will be None or a time in the past if the user is not timed out.
+    /// 	Will be None or a time in the past if the user is not timed out.
     pub communication_disabled_until: Option<DateTime<Utc>>,
 }
 
 #[cfg(feature = "model")]
 impl Member {
-
     /// Adds a [`Role`] to the member, editing its roles in-place if the request
     /// was successful.
     ///
@@ -97,7 +96,7 @@ impl Member {
                 self.roles.push(role_id);
 
                 Ok(())
-            }
+            },
             Err(why) => Err(why),
         }
     }
@@ -130,7 +129,7 @@ impl Member {
                 self.roles.retain(|r| !role_ids.contains(r));
 
                 Err(why)
-            }
+            },
         }
     }
 
@@ -215,16 +214,24 @@ impl Member {
     /// 28 days from the current time.
     ///
     /// [Moderate Members]: Permissions::MODERATE_MEMBERS
-    pub async fn disable_communication_until_datetime(&mut self, http: impl AsRef<Http>, time: DateTime<Utc>) -> Result<()> {
-        match self.guild_id.edit_member(http, self.user.id, |member| {
-            member.disable_communication_until_datetime(time);
-            member
-        }).await {
+    pub async fn disable_communication_until_datetime(
+        &mut self,
+        http: impl AsRef<Http>,
+        time: DateTime<Utc>,
+    ) -> Result<()> {
+        match self
+            .guild_id
+            .edit_member(http, self.user.id, |member| {
+                member.disable_communication_until_datetime(time);
+                member
+            })
+            .await
+        {
             Ok(_) => {
                 self.communication_disabled_until = Some(time);
                 Ok(())
-            }
-            Err(why) => Err(why)
+            },
+            Err(why) => Err(why),
         }
     }
 
@@ -274,15 +281,19 @@ impl Member {
     ///
     /// [Moderate Members]: Permissions::MODERATE_MEMBERS
     pub async fn enable_communication(&mut self, http: impl AsRef<Http>) -> Result<()> {
-        match self.guild_id.edit_member(&http, self.user.id, |member| {
-            member.enable_communication();
-            member
-        }).await {
+        match self
+            .guild_id
+            .edit_member(&http, self.user.id, |member| {
+                member.enable_communication();
+                member
+            })
+            .await
+        {
             Ok(_) => {
                 self.communication_disabled_until = None;
                 Ok(())
-            }
-            Err(why) => Err(why)
+            },
+            Err(why) => Err(why),
         }
     }
 
@@ -499,7 +510,7 @@ impl Member {
                 self.roles.retain(|r| r.0 != role_id.0);
 
                 Ok(())
-            }
+            },
             Err(why) => Err(why),
         }
     }
@@ -532,7 +543,7 @@ impl Member {
                 self.roles.extend_from_slice(role_ids);
 
                 Err(why)
-            }
+            },
         }
     }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -58,6 +58,10 @@ pub struct Member {
     pub permissions: Option<Permissions>,
     /// The guild avatar hash
     pub avatar: Option<String>,
+    ///	When the user's timeout will expire and the user will be able to communicate in the guild again.
+    ///
+    ///	Will be None or a time in the past if the user is not timed out.
+    pub communication_disabled_until: Option<DateTime<Utc>>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -66,6 +66,31 @@ pub struct Member {
 
 #[cfg(feature = "model")]
 impl Member {
+
+    /// Times the user out until `time`.
+    ///
+    /// Requires the [Moderate Members] permission.
+    ///
+    /// **Note**: [Moderate Members]: crate::model::permission::Permissions::MODERATE_MEMBERS
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    ///
+    /// [Moderate Members]: Permissions::MODERATE_MEMBERS
+    pub async fn disable_communication_until_datetime(&mut self, http: impl AsRef<Http>, time: DateTime<Utc>) -> Result<()> {
+        match self.guild_id.edit_member(http, self.user.id, |member| {
+            member.disable_communication_until_datetime(time);
+            member
+        }).await {
+            Ok(_) => {
+                self.communication_disabled_until = Some(time);
+                Ok(())
+            }
+            Err(why) => Err(why)
+        }
+    }
+
     /// Adds a [`Role`] to the member, editing its roles in-place if the request
     /// was successful.
     ///
@@ -96,7 +121,7 @@ impl Member {
                 self.roles.push(role_id);
 
                 Ok(())
-            },
+            }
             Err(why) => Err(why),
         }
     }
@@ -129,7 +154,7 @@ impl Member {
                 self.roles.retain(|r| !role_ids.contains(r));
 
                 Err(why)
-            },
+            }
         }
     }
 
@@ -451,7 +476,7 @@ impl Member {
                 self.roles.retain(|r| r.0 != role_id.0);
 
                 Ok(())
-            },
+            }
             Err(why) => Err(why),
         }
     }
@@ -484,7 +509,7 @@ impl Member {
                 self.roles.extend_from_slice(role_ids);
 
                 Err(why)
-            },
+            }
         }
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -3222,6 +3222,7 @@ mod test {
                 #[cfg(feature = "unstable_discord_api")]
                 permissions: None,
                 avatar: None,
+                communication_disabled_until: None,
             }
         }
 

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -458,6 +458,7 @@ mod test {
                 #[cfg(feature = "unstable_discord_api")]
                 permissions: None,
                 avatar: None,
+                communication_disabled_until: None,
             };
 
             assert_eq!(ChannelId(1).mention().to_string(), "<#1>");

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -358,6 +358,9 @@ __impl_bitflags! {
         SEND_MESSAGES_IN_THREADS = 1 << 38;
         /// Allows for launching activities in a voice channel
         START_EMBEDDED_ACTIVITIES = 1 << 39;
+        /// Allows for timing out users to prevent them from sending or reacting to messages in
+        /// chat and threads, and from speaking in voice and stage channels.
+        MODERATE_MEMBERS = 1 << 40;
         /// Allows for creating and participating in public threads.
         #[deprecated(note = "This permission no longer exists")]
         USE_PUBLIC_THREADS = 0b0010_0000_0000_0000_0000_0000_0000_0000_0000;

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -110,6 +110,7 @@ impl<'de> Deserialize<'de> for VoiceState {
             #[cfg(feature = "unstable_discord_api")]
             permissions: Option<Permissions>,
             avatar: Option<String>,
+            communication_disabled_until: Option<DateTime<Utc>>,
         }
 
         struct VoiceStateVisitor;
@@ -186,6 +187,7 @@ impl<'de> Deserialize<'de> for VoiceState {
                                     #[cfg(feature = "unstable_discord_api")]
                                     permissions: partial_member.permissions,
                                     avatar: partial_member.avatar,
+                                    communication_disabled_until: partial_member.communication_disabled_until,
                                 });
                             }
                         },

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -187,7 +187,8 @@ impl<'de> Deserialize<'de> for VoiceState {
                                     #[cfg(feature = "unstable_discord_api")]
                                     permissions: partial_member.permissions,
                                     avatar: partial_member.avatar,
-                                    communication_disabled_until: partial_member.communication_disabled_until,
+                                    communication_disabled_until: partial_member
+                                        .communication_disabled_until,
                                 });
                             }
                         },

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -888,6 +888,7 @@ mod test {
             #[cfg(feature = "unstable_discord_api")]
             permissions: None,
             avatar: None,
+            communication_disabled_until: None,
         };
 
         let role = Role {


### PR DESCRIPTION
Hello. Discord released a new feature recently allowing moderators/admins to time out users for a specified amount of time. Timing out a user requires a [new permission](https://discord.com/developers/docs/topics/permissions#permissions) and is part of the [Modify Guild Member](https://discord.com/developers/docs/resources/guild#modify-guild-member) API.

Thank you for your time reading and reviewing this pull request. I am happy to address any issues if you find that there are any.