### PR TITLE
Fix faulty (de)serialization of `MessageFlags` and missing constants

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -7,10 +7,8 @@ use std::fmt::Write;
 #[cfg(feature = "model")]
 use std::result::Result as StdResult;
 
-#[cfg(feature = "model")]
 use bitflags::__impl_bitflags;
 use chrono::{DateTime, Utc};
-#[cfg(feature = "model")]
 use serde::{
     de::{Deserialize, Deserializer},
     ser::{Serialize, Serializer},
@@ -1218,12 +1216,10 @@ pub struct ChannelMention {
 
 /// Describes extra features of the message.
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
-#[cfg_attr(not(feature = "model"), derive(Debug, Deserialize, Serialize))]
 pub struct MessageFlags {
     pub bits: u64,
 }
 
-#[cfg(feature = "model")]
 __impl_bitflags! {
     MessageFlags: u64 {
         /// This message has been published to subscribed channels (via Channel Following).
@@ -1245,7 +1241,6 @@ __impl_bitflags! {
     }
 }
 
-#[cfg(feature = "model")]
 impl<'de> Deserialize<'de> for MessageFlags {
     fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
     where
@@ -1255,7 +1250,6 @@ impl<'de> Deserialize<'de> for MessageFlags {
     }
 }
 
-#[cfg(feature = "model")]
 impl Serialize for MessageFlags {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
     where


### PR DESCRIPTION
The `MessageFlags` (de)serialization was wrong and was missing the constants when the `model` feature was not enabled.