### PR TITLE
Add three new `ActivityFlags` and use bitshift notation

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -477,17 +477,20 @@ bitflags! {
     #[derive(Deserialize, Serialize)]
     pub struct ActivityFlags: u64 {
         /// Whether the activity is an instance activity.
-        const INSTANCE = 0b001;
+        const INSTANCE = 1 << 0;
         /// Whether the activity is joinable.
-        const JOIN = 0b010;
+        const JOIN = 1 << 1;
         /// Whether the activity can be spectated.
-        const SPECTATE = 0b011;
+        const SPECTATE = 1 << 2;
         /// Whether a request can be sent to join the user's party.
-        const JOIN_REQUEST = 0b100;
+        const JOIN_REQUEST = 1 << 3;
         /// Whether the activity can be synced.
-        const SYNC = 0b101;
+        const SYNC = 1 << 4;
         /// Whether the activity can be played.
-        const PLAY = 0b110;
+        const PLAY = 1 << 5;
+        const PARTY_PRIVACY_FRIENDS = 1 << 6;
+        const PARTY_PRIVACY_VOICE_CHANNEL = 1 << 7;
+        const EMBEDDED = 1 << 8;
     }
 }
 


### PR DESCRIPTION
New Flags: `PARTY_PRIVACY_FRIENDS`, `PARTY_PRIVACY_VOICE_CHANNEL`, `EMBEDDED`

The bitshift notation is easier to read and follows Discord's documentation.

Edit: [Discord's documentation commit](https://github.com/discord/discord-api-docs/commit/9114a1bcb882619f1c42dd1c577f22a80e82b125)