### PR TITLE
Replace the `actions-rs` GitHub actions with equivalent commands

### DIFF
--- a/.github/matchers/rust.json
+++ b/.github/matchers/rust.json
@@ -1,0 +1,44 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "cargo-common",
+            "pattern": [
+                {
+                    "regexp": "^(warning|warn|error)(\\[(\\S*)\\])?: (.*)$",
+                    "severity": 1,
+                    "message": 4,
+                    "code": 3
+                },
+                {
+                    "regexp": "^\\s+-->\\s(\\S+):(\\d+):(\\d+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
+                }
+            ]
+        },
+        {
+            "owner": "cargo-test",
+            "pattern": [
+                {
+                    "regexp": "^.*panicked\\s+at\\s+'(.*)',\\s+(.*):(\\d+):(\\d+)$",
+                    "message": 1,
+                    "file": 2,
+                    "line": 3,
+                    "column": 4
+                }
+            ]
+        },
+        {
+            "owner": "cargo-fmt",
+            "pattern": [
+                {
+                    "regexp": "^(Diff in (\\S+)) at line (\\d+):",
+                    "message": 1,
+                    "file": 2,
+                    "line": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain
-        id: tc
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain || 'stable' }}
-          profile: minimal
-          override: true
+        run: |
+          rustup install --profile minimal ${{ matrix.toolchain || 'stable' }}
+          rustup override set ${{ matrix.toolchain || 'stable' }}
+
+      - name: Add problem matchers
+        shell: bash
+        run: echo "::add-matcher::.github/matchers/rust.json"
 
       - name: Cache
         uses: Swatinem/rust-cache@v1
@@ -97,12 +98,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain (${{ env.minrust }})
-        id: tc
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.minrust }}
-          profile: minimal
-          override: true
+        run: |
+          rustup install --profile minimal ${{ env.minrust }}
+          rustup override set ${{ env.minrust }}
+
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/matchers/rust.json"
 
       - name: Cache
         uses: Swatinem/rust-cache@v1
@@ -119,12 +120,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain
-        id: tc
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+        run: |
+          rustup install --profile minimal nightly
+          rustup override set nightly
+
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/matchers/rust.json"
 
       - name: Cache
         uses: Swatinem/rust-cache@v1
@@ -145,12 +146,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain
-        id: tc
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        run: rustup install stable
+
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/matchers/rust.json"
 
       - name: Cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,12 +16,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain
-        id: tc
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+        run: |
+          rustup install --profile minimal nightly
+          rustup override set nightly
 
       - name: Cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,23 +14,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install nightly toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          profile: minimal
-          override: true
+      - name: Install toolchain
+        run: rustup install stable
+
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/matchers/rust.json"
 
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
       - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --tests
+        run: cargo clippy --workspace --tests
 
   rustfmt:
     name: Format
@@ -40,13 +34,14 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          components: rustfmt
-          profile: minimal
-          override: true
+      - name: Install toolchain
+        run: |
+          rustup install --profile minimal nightly
+          rustup override set nightly
+          rustup component add rustfmt
+
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/matchers/rust.json"
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check


### PR DESCRIPTION
The `actions-rs` GitHub actions are not really maintained and don't add
anything special compared to the plain commands.

This also adds the problem matchers from `hecrj/setup-rust-action` to
surface warnings and errors prominently in the GitHub UI.