### PR TITLE
Add get_ methods for many ClientBuilder fields

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -239,6 +239,7 @@ impl<'a> ClientBuilder<'a> {
     pub fn get_cache_settings(&self) -> &CacheSettings {
         // unwrap() is ok because cache_settings will only ever be None in the middle of being
         // .await'ed
+        #[allow(clippy::unwrap_used)]
         self.cache_settings.as_ref().unwrap()
     }
 


### PR DESCRIPTION
Specifically: application_id, type map, cache update timeout, cache_settings, framework, voice_manager, intents, event_handler, raw_event_handler. These methods are in line with the existing `get_token`

Why: my bot framework for serenity ([poise](https://github.com/kangalioo/poise/)) registers itself as an event handler in a ClientBuilder provided by the user. If the user has registered their own event handlers, the framework needs to store them in order to forward events to it.