### PR TITLE
Allow `clippy::unwrap_used` for tests globally

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1043,7 +1043,6 @@ mod test {
     };
 
     #[test]
-    #[allow(clippy::unwrap_used)]
     fn test_cache_messages() {
         let mut settings = Settings::new();
         settings.max_messages(2);

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3839,7 +3839,6 @@ mod test {
     #[test]
     fn test_webhook_parsing() {
         let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-        #[allow(clippy::unwrap_used)]
         let url = Url::parse(url).unwrap();
         assert!(parse_webhook_url(&url).is_ok());
     }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -215,7 +215,6 @@ impl StdError for Error {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod test {
     use http_crate::response::Builder;
     use reqwest::ResponseBuilderExt;

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -416,7 +416,6 @@ mod tests {
 
     type Result<T> = StdResult<T, Box<dyn StdError>>;
 
-    #[allow(clippy::unwrap_used)]
     fn headers() -> HeaderMap {
         let pairs = &[
             (HeaderName::from_static("x-ratelimit-limit"), HeaderValue::from_static("5")),
@@ -442,7 +441,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::float_cmp, clippy::unwrap_used)]
+    #[allow(clippy::float_cmp)]
     fn test_parse_header_good() -> Result<()> {
         let headers = headers();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
     clippy::let_underscore_must_use,
     clippy::unused_async
 )]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
 #![type_length_limit = "3294819"] // needed so ShardRunner::run compiles with instrument.
 
 #[macro_use]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -3360,7 +3360,6 @@ mod test {
         }
 
         #[test]
-        #[allow(clippy::unwrap_used)]
         fn member_named_username() {
             let guild = gen();
             let lhs = guild.member_named("test#1432").unwrap().display_name();
@@ -3369,7 +3368,6 @@ mod test {
         }
 
         #[test]
-        #[allow(clippy::unwrap_used)]
         fn member_named_nickname() {
             let guild = gen();
             let lhs = guild.member_named("aaaa").unwrap().display_name();

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -408,7 +408,6 @@ mod test {
         use crate::utils::Colour;
 
         #[test]
-        #[allow(clippy::unwrap_used)]
         fn test_mention() {
             let channel = Channel::Guild(GuildChannel {
                 bitrate: None,
@@ -489,7 +488,6 @@ mod test {
         }
 
         #[test]
-        #[allow(clippy::unwrap_used)]
         fn parse_mentions() {
             assert_eq!("<@1234>".parse::<UserId>().unwrap(), UserId(1234));
             assert_eq!("<@&1234>".parse::<RoleId>().unwrap(), RoleId(1234));

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1267,7 +1267,6 @@ fn tag(name: &str, discriminator: u16) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod test {
     #[test]
     fn test_discriminator_serde() {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -733,7 +733,7 @@ pub fn content_safe(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::non_ascii_literal)]
+#[allow(clippy::non_ascii_literal)]
 mod test {
     use super::*;
     #[cfg(feature = "cache")]


### PR DESCRIPTION
With this change, you no longer have to take care to annotate the test code.