### PR TITLE
Refactor e09 to more idiomatically use the builder pattern

### DIFF
--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -1,8 +1,7 @@
-use std::{env, path::Path};
+use std::env;
 
 use serenity::{
     async_trait,
-    http::AttachmentType,
     model::{channel::Message, gateway::Ready},
     prelude::*,
 };
@@ -16,34 +15,26 @@ impl EventHandler for Handler {
             // The create message builder allows you to easily create embeds and messages
             // using a builder syntax.
             // This example will create a message that says "Hello, World!", with an embed that has
-            // a title, description, three fields, and a footer.
+            // a title, description, an image, three fields, and a footer.
             let msg = msg
                 .channel_id
                 .send_message(&ctx.http, |m| {
-                    m.content("Hello, World!");
-                    m.embed(|e| {
-                        e.title("This is a title");
-                        e.description("This is a description");
-                        e.image("attachment://ferris_eyes.png");
-                        e.fields(vec![
-                            ("This is the first field", "This is a field body", true),
-                            ("This is the second field", "Both of these fields are inline", true),
-                        ]);
-                        e.field("This is the third field", "This is not an inline field", false);
-                        e.footer(|f| {
-                            f.text("This is a footer");
-
-                            f
-                        });
-
-                        // Add a timestamp for the current time
-                        // This also accepts a rfc3339 Timestamp
-                        e.timestamp(chrono::Utc::now());
-
-                        e
-                    });
-                    m.add_file(AttachmentType::Path(Path::new("./ferris_eyes.png")));
-                    m
+                    m.content("Hello, World!")
+                        .embed(|e| {
+                            e.title("This is a title")
+                                .description("This is a description")
+                                .image("attachment://ferris_eyes.png")
+                                .fields(vec![
+                                    ("This is the first field", "This is a field body", true),
+                                    ("This is the second field", "Both fields are inline", true),
+                                ])
+                                .field("This is the third field", "This is not an inline field", false)
+                                .footer(|f| f.text("This is a footer"))
+                                // Add a timestamp for the current time
+                                // This also accepts a rfc3339 Timestamp
+                                .timestamp(chrono::Utc::now())
+                        })
+                        .add_file("./ferris_eyes.png")
                 })
                 .await;
 


### PR DESCRIPTION
We can chain calls on `CreateMessage` and `CreateEmbed` instead of calling them sequentially, and can directly return the results as well, since the closure return types match the builder function return types.