### PR TITLE
Change methods on `Http` to take `&JsonMap` instead of `JsonMap`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2143,7 +2143,7 @@ impl Http {
         token: &str,
         wait: bool,
         files: It,
-        map: JsonMap,
+        map: &JsonMap,
     ) -> Result<Option<Message>>
     where
         T: Into<AttachmentType<'a>>,
@@ -3430,7 +3430,7 @@ impl Http {
         &self,
         channel_id: u64,
         files: It,
-        map: JsonMap,
+        map: &JsonMap,
     ) -> Result<Message>
     where
         T: Into<AttachmentType<'a>>,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -732,7 +732,7 @@ impl ChannelId {
 
         Message::check_lengths(&map)?;
 
-        http.as_ref().send_files(self.0, files, map).await
+        http.as_ref().send_files(self.0, files, &map).await
     }
 
     /// Sends a message to the channel.
@@ -769,7 +769,7 @@ impl ChannelId {
         let message = if msg.2.is_empty() {
             http.as_ref().send_message(self.0, &Value::from(map)).await?
         } else {
-            http.as_ref().send_files(self.0, msg.2.clone(), map).await?
+            http.as_ref().send_files(self.0, msg.2.clone(), &map).await?
         };
 
         if let Some(reactions) = msg.1.clone() {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -314,7 +314,7 @@ impl Webhook {
 
         if !execute_webhook.1.is_empty() {
             http.as_ref()
-                .execute_webhook_with_files(self.id.0, token, wait, execute_webhook.1.clone(), map)
+                .execute_webhook_with_files(self.id.0, token, wait, execute_webhook.1.clone(), &map)
                 .await
         } else {
             http.as_ref().execute_webhook(self.id.0, token, wait, &map).await


### PR DESCRIPTION
The `Http::send_files` and `Http::execute_webhook_with_files` are the only existing methods that take ownership of the `JsonMap` passed into them instead of borrowing it, so I change the signatures. This is of course a breaking change, but not a large one.