### PR TITLE
Support more integer types for min_value / max_value

### DIFF
--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 #[cfg(feature = "simd-json")]
 use simd_json::Mutable;
 
-use crate::json::{self, from_number, json, Value};
+use crate::json::{self, from_number, json, ToNumber, Value};
 use crate::model::channel::ChannelType;
 use crate::model::interactions::application_command::{
     ApplicationCommandOptionType,
@@ -155,15 +155,15 @@ impl CreateApplicationCommandOption {
     }
 
     /// Sets the minimum permitted value for this integer option
-    pub fn min_int_value(&mut self, value: i32) -> &mut Self {
-        self.0.insert("min_value", from_number(value));
+    pub fn min_int_value(&mut self, value: impl ToNumber) -> &mut Self {
+        self.0.insert("min_value", value.to_number());
 
         self
     }
 
     /// Sets the maximum permitted value for this integer option
-    pub fn max_int_value(&mut self, value: i32) -> &mut Self {
-        self.0.insert("max_value", from_number(value));
+    pub fn max_int_value(&mut self, value: impl ToNumber) -> &mut Self {
+        self.0.insert("max_value", value.to_number());
 
         self
     }

--- a/src/json.rs
+++ b/src/json.rs
@@ -19,8 +19,6 @@ pub type Value = simd_json::OwnedValue;
 pub use serde_json::json;
 #[cfg(not(feature = "simd-json"))]
 pub use serde_json::Error as JsonError;
-#[cfg(not(feature = "simd-json"))]
-use serde_json::Number;
 #[cfg(feature = "simd-json")]
 pub use simd_json::json;
 #[cfg(feature = "simd-json")]
@@ -140,20 +138,26 @@ where
     Ok(simd_json::serde::to_owned_value(value)?)
 }
 
+pub trait ToNumber {
+    fn to_number(self) -> Value;
+}
+
 #[cfg(not(feature = "simd-json"))]
-pub(crate) fn from_number<T>(n: T) -> Value
-where
-    serde_json::Number: From<T>,
-{
-    Value::Number(Number::from(n))
+impl<T: Into<serde_json::Number>> ToNumber for T {
+    fn to_number(self) -> Value {
+        Value::Number(self.into())
+    }
 }
 
 #[cfg(feature = "simd-json")]
-pub(crate) fn from_number<T>(n: T) -> Value
-where
-    Value: From<T>,
-{
-    Value::from(n)
+impl<T: Into<Value>> ToNumber for T {
+    fn to_number(self) -> Value {
+        self.into()
+    }
+}
+
+pub(crate) fn from_number(n: impl ToNumber) -> Value {
+    n.to_number()
 }
 
 pub mod prelude {


### PR DESCRIPTION
Previously, `u32`, `u64` and `i64` could not be used for the min-/max value bounds on slash command integer parameters. This PR changes the parameter type for `CreateApplicationCommandOption::{min_value, max_value}` from `i32` to `impl ToNumber`. `ToNumber` is a new trait equivalent to `Into<serde_json::Number>` but with support for simd_json too.