### PR TITLE
Add `data` and `filename` methods to `AttachmentType`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -806,16 +806,13 @@ impl Http {
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
-    pub async fn create_sticker<'a, T>(
+    pub async fn create_sticker<'a>(
         &self,
         guild_id: u64,
         map: JsonMap,
-        file: T,
+        file: impl Into<AttachmentType<'a>>,
         audit_log_reason: Option<&str>,
-    ) -> Result<Sticker>
-    where
-        T: Into<AttachmentType<'a>>,
-    {
+    ) -> Result<Sticker> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -4,13 +4,7 @@ use std::fmt::Write as FmtWrite;
 use std::sync::Arc;
 
 #[cfg(feature = "model")]
-use bytes::buf::Buf;
-#[cfg(feature = "model")]
 use futures::stream::Stream;
-#[cfg(feature = "model")]
-use reqwest::Url;
-#[cfg(feature = "model")]
-use tokio::{fs::File, io::AsyncReadExt};
 
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -885,47 +879,14 @@ impl ChannelId {
         name: impl std::fmt::Display,
         avatar: impl Into<AttachmentType<'a>>,
     ) -> Result<Webhook> {
-        let name = name.to_string();
-        let avatar = avatar.into();
-
-        let avatar = match avatar {
-            AttachmentType::Bytes {
-                data,
-                filename: _,
-            } => "data:image/png;base64,".to_string() + &base64::encode(&data.into_owned()),
-            AttachmentType::File {
-                file,
-                filename: _,
-            } => {
-                let mut buf = Vec::new();
-                file.try_clone().await?.read_to_end(&mut buf).await?;
-
-                "data:image/png;base64,".to_string() + &base64::encode(&buf)
-            },
-            AttachmentType::Path(path) => {
-                let mut file = File::open(path).await?;
-                let mut buf = vec![];
-                file.read_to_end(&mut buf).await?;
-
-                "data:image/png;base64,".to_string() + &base64::encode(&buf)
-            },
-            AttachmentType::Image(url) => {
-                let url = Url::parse(url).map_err(|_| Error::Url(url.to_string()))?;
-                let response = http.as_ref().client.get(url).send().await?;
-                let mut bytes = response.bytes().await?;
-                let mut picture: Vec<u8> = vec![0; bytes.len()];
-                bytes.copy_to_slice(&mut picture[..]);
-
-                "data:image/png;base64,".to_string() + &base64::encode(&picture)
-            },
-        };
-
-        let map = crate::json::json!({
-            "name": name,
-            "avatar": avatar
+        let http = http.as_ref();
+        let data = avatar.into().data(&http.client).await?;
+        let map = json!({
+            "name": name.to_string(),
+            "avatar": format!("data:image/png;base64,{}", base64::encode(data)),
         });
 
-        http.as_ref().create_webhook(self.0, &map, None).await
+        http.create_webhook(self.0, &map, None).await
     }
 
     /// Returns a future that will await one message sent in this channel.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1183,7 +1183,6 @@ impl GuildChannel {
         avatar: impl Into<AttachmentType<'a>>,
     ) -> Result<Webhook> {
         let name = name.to_string();
-        let avatar = avatar.into();
 
         if name.len() < 2 {
             return Err(Error::Model(ModelError::NameTooShort));


### PR DESCRIPTION
This adds methods to `AttachmentType` that let other parts of the code query its contents and metadata in a unified way, and reduces code duplication. A breaking change introduced was to change the `AttachmentType::Image` variant to wrap a `reqwest::Url` rather than a `&str`, so that any url parsing errors are thrown at construction, rather than at resolution. The exception is `From<&str>`, where a failed url parse will instead construct a `Path` variant that results in a `FileNotFound` error at resolution, but I think this is fine. Also, these methods are marked `pub(crate)` since I don't expect that lib users should want to use them. It may also be worth considering if `AttachmentType` should be made `pub(crate)`, but that's another discussion.