### PR TITLE
Refactor features combination `builder,unstable_discord_api`

### DIFF
--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -2,8 +2,10 @@ use std::{env, path::Path};
 
 use serenity::{
     async_trait,
-    http::AttachmentType,
-    model::{channel::Message, gateway::Ready},
+    model::{
+        channel::{AttachmentType, Message},
+        gateway::Ready,
+    },
     prelude::*,
 };
 

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -1,6 +1,8 @@
 use url::Url;
 
+#[cfg(feature = "http")]
 use crate::http::client::Http;
+#[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
@@ -64,6 +66,7 @@ impl CreateBotAuthParameters {
     /// If the user is not authorized for this endpoint.
     ///
     /// [`HttpError::UnsuccessfulRequest`]: crate::http::HttpError::UnsuccessfulRequest
+    #[cfg(feature = "http")]
     pub async fn auto_client_id(&mut self, http: impl AsRef<Http>) -> Result<&mut Self> {
         self.client_id = http.as_ref().get_current_application_info().await.map(|v| v.id)?;
         Ok(self)

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -5,8 +5,8 @@ use simd_json::Mutable;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
-use crate::http::AttachmentType;
 use crate::json::{self, from_number, Value};
+use crate::model::channel::AttachmentType;
 use crate::model::interactions::InteractionApplicationCommandCallbackDataFlags;
 
 #[derive(Clone, Debug, Default)]

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -4,7 +4,7 @@ use super::CreateAllowedMentions;
 use super::CreateEmbed;
 #[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
-use crate::http::AttachmentType;
+use crate::model::channel::AttachmentType;
 use crate::internal::prelude::*;
 use crate::json::{self, to_value};
 use crate::model::channel::{MessageReference, ReactionType};

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -4,9 +4,9 @@ use super::CreateAllowedMentions;
 use super::CreateEmbed;
 #[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
-use crate::model::channel::AttachmentType;
 use crate::internal::prelude::*;
 use crate::json::{self, to_value};
+use crate::model::channel::AttachmentType;
 use crate::model::channel::{MessageReference, ReactionType};
 use crate::model::id::StickerId;
 

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use crate::http::AttachmentType;
 use crate::internal::prelude::*;
+use crate::model::channel::AttachmentType;
 
 /// A builder to create or edit a [`Sticker`] for use via a number of model methods.
 ///

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use super::CreateEmbed;
 #[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
-use crate::http::AttachmentType;
 use crate::internal::prelude::*;
 use crate::json::{self, from_number};
+use crate::model::channel::AttachmentType;
 
 /// A builder to specify the fields to edit in an existing message.
 ///

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::http::AttachmentType;
+use crate::model::channel::AttachmentType;
 use crate::json::Value;
 
 /// A builder to create the inner content of a [`Webhook`]'s execution.

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use crate::model::channel::AttachmentType;
 use crate::json::Value;
+use crate::model::channel::AttachmentType;
 
 /// A builder to create the inner content of a [`Webhook`]'s execution.
 ///

--- a/src/model/channel/attachment_type.rs
+++ b/src/model/channel/attachment_type.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
-use tokio::fs::File;
 use std::path::{Path, PathBuf};
+
+use tokio::fs::File;
 
 /// Enum that allows a user to pass a [`Path`] or a [`File`] type to [`send_files`]
 ///

--- a/src/model/channel/attachment_type.rs
+++ b/src/model/channel/attachment_type.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
+#[cfg(not(feature = "tokio"))]
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "tokio")]
 use tokio::fs::File;
-#[cfg(not(feature = "tokio"))]
-use std::fs::File;
 
 /// Enum that allows a user to pass a [`Path`] or a [`File`] type to [`send_files`]
 ///

--- a/src/model/channel/attachment_type.rs
+++ b/src/model/channel/attachment_type.rs
@@ -1,0 +1,80 @@
+use std::borrow::Cow;
+use tokio::fs::File;
+use std::path::{Path, PathBuf};
+
+/// Enum that allows a user to pass a [`Path`] or a [`File`] type to [`send_files`]
+///
+/// [`send_files`]: crate::model::id::ChannelId::send_files
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum AttachmentType<'a> {
+    /// Indicates that the [`AttachmentType`] is a byte slice with a filename.
+    Bytes { data: Cow<'a, [u8]>, filename: String },
+    /// Indicates that the [`AttachmentType`] is a [`File`]
+    File { file: &'a File, filename: String },
+    /// Indicates that the [`AttachmentType`] is a [`Path`]
+    Path(&'a Path),
+    /// Indicates that the [`AttachmentType`] is an image URL.
+    Image(&'a str),
+}
+
+impl<'a> From<(&'a [u8], &str)> for AttachmentType<'a> {
+    fn from(params: (&'a [u8], &str)) -> AttachmentType<'a> {
+        AttachmentType::Bytes {
+            data: Cow::Borrowed(params.0),
+            filename: params.1.to_string(),
+        }
+    }
+}
+
+impl<'a> From<&'a str> for AttachmentType<'a> {
+    /// Constructs an [`AttachmentType`] from a string.
+    /// This string may refer to the path of a file on disk, or the http url to an image on the internet.
+    fn from(s: &'a str) -> AttachmentType<'_> {
+        if s.starts_with("http://") || s.starts_with("https://") {
+            AttachmentType::Image(s)
+        } else {
+            AttachmentType::Path(Path::new(s))
+        }
+    }
+}
+
+impl<'a> From<&'a Path> for AttachmentType<'a> {
+    fn from(path: &'a Path) -> AttachmentType<'_> {
+        AttachmentType::Path(path)
+    }
+}
+
+impl<'a> From<&'a PathBuf> for AttachmentType<'a> {
+    fn from(pathbuf: &'a PathBuf) -> AttachmentType<'_> {
+        AttachmentType::Path(pathbuf.as_path())
+    }
+}
+
+impl<'a> From<(&'a File, &str)> for AttachmentType<'a> {
+    fn from(f: (&'a File, &str)) -> AttachmentType<'a> {
+        AttachmentType::File {
+            file: f.0,
+            filename: f.1.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use super::AttachmentType;
+
+    #[test]
+    fn test_attachment_type() {
+        assert!(matches!(
+            AttachmentType::from(Path::new("./dogs/corgis/kona.png")),
+            AttachmentType::Path(_)
+        ));
+        assert!(matches!(
+            AttachmentType::from(Path::new("./cats/copycat.png")),
+            AttachmentType::Path(_)
+        ));
+    }
+}

--- a/src/model/channel/attachment_type.rs
+++ b/src/model/channel/attachment_type.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "tokio")]
 use tokio::fs::File;
+#[cfg(not(feature = "tokio"))]
+use std::fs::File;
 
 /// Enum that allows a user to pass a [`Path`] or a [`File`] type to [`send_files`]
 ///

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -30,7 +30,7 @@ use crate::collector::{
     ReactionCollectorBuilder,
 };
 #[cfg(feature = "model")]
-use crate::http::AttachmentType;
+use crate::model::channel::AttachmentType;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(all(feature = "model", feature = "utils"))]

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -30,13 +30,13 @@ use crate::collector::{
     ReactionCollectorBuilder,
 };
 #[cfg(feature = "model")]
-use crate::model::channel::AttachmentType;
-#[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(all(feature = "model", feature = "utils"))]
 use crate::json;
 #[cfg(feature = "model")]
 use crate::json::json;
+#[cfg(feature = "model")]
+use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
 
 #[cfg(feature = "model")]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -33,7 +33,7 @@ use crate::collector::{
     ReactionCollectorBuilder,
 };
 #[cfg(feature = "model")]
-use crate::http::AttachmentType;
+use crate::model::channel::AttachmentType;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(all(feature = "cache", feature = "model"))]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -33,13 +33,13 @@ use crate::collector::{
     ReactionCollectorBuilder,
 };
 #[cfg(feature = "model")]
-use crate::model::channel::AttachmentType;
-#[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::json::{self, from_number};
+#[cfg(feature = "model")]
+use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
 
 /// Represents a guild's text, news, or voice channel. Some methods are available

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -9,6 +9,7 @@ mod message;
 mod partial_channel;
 mod private_channel;
 mod reaction;
+mod attachment_type;
 
 #[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};
@@ -18,6 +19,7 @@ use serde::de::{Error as DeError, Unexpected};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 pub use self::attachment::*;
+pub use self::attachment_type::*;
 pub use self::channel_category::*;
 pub use self::channel_id::*;
 pub use self::embed::*;

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -1,6 +1,7 @@
 //! Models relating to channels and types within channels.
 
 mod attachment;
+mod attachment_type;
 mod channel_category;
 mod channel_id;
 mod embed;
@@ -9,7 +10,6 @@ mod message;
 mod partial_channel;
 mod private_channel;
 mod reaction;
-mod attachment_type;
 
 #[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditMessage, GetMessages};
 #[cfg(feature = "model")]
-use crate::http::AttachmentType;
+use crate::model::channel::AttachmentType;
 #[cfg(feature = "http")]
 use crate::http::{Http, Typing};
 use crate::model::prelude::*;

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -6,10 +6,10 @@ use chrono::{DateTime, Utc};
 
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditMessage, GetMessages};
-#[cfg(feature = "model")]
-use crate::model::channel::AttachmentType;
 #[cfg(feature = "http")]
 use crate::http::{Http, Typing};
+#[cfg(feature = "model")]
+use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
 use crate::model::utils::single_recipient;
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -32,6 +32,9 @@ use crate::internal::prelude::*;
 use crate::json;
 #[cfg(feature = "model")]
 use crate::json::json;
+#[cfg(feature = "model")]
+use crate::json::prelude::*;
+use crate::model::prelude::*;
 #[cfg(all(feature = "model", feature = "unstable_discord_api"))]
 use crate::{
     builder::{
@@ -42,9 +45,6 @@ use crate::{
     },
     model::interactions::application_command::{ApplicationCommand, ApplicationCommandPermission},
 };
-#[cfg(feature = "model")]
-use crate::json::prelude::*;
-use crate::model::prelude::*;
 
 #[cfg(feature = "model")]
 impl GuildId {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -42,7 +42,9 @@ use crate::{
     },
     model::interactions::application_command::{ApplicationCommand, ApplicationCommandPermission},
 };
-use crate::{json::prelude::*, model::prelude::*};
+#[cfg(feature = "model")]
+use crate::json::prelude::*;
+use crate::model::prelude::*;
 
 #[cfg(feature = "model")]
 impl GuildId {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -10,7 +10,7 @@ use serde::{Serialize, Serializer};
 
 #[cfg(feature = "model")]
 use crate::builder::EditMember;
-#[cfg(all(feature = "cache"))]
+#[cfg(feature = "cache")]
 use crate::cache::Cache;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -6,13 +6,15 @@ use serde::{Deserialize, Deserializer};
 use simd_json::ValueAccess;
 
 use super::prelude::*;
+use crate::builder::CreateApplicationCommand;
+#[cfg(feature = "http")]
 use crate::builder::{
-    CreateApplicationCommand,
     CreateApplicationCommands,
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     EditInteractionResponse,
 };
+#[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::StdResult;
 use crate::json::{self, from_number, JsonMap, Value};
@@ -29,6 +31,7 @@ use crate::model::id::{
 };
 use crate::model::interactions::InteractionType;
 use crate::model::prelude::User;
+#[cfg(feature = "unstable_discord_api")]
 use crate::model::utils::{
     deserialize_channels_map,
     deserialize_messages_map,
@@ -70,6 +73,7 @@ pub struct ApplicationCommandInteraction {
     pub version: u8,
 }
 
+#[cfg(feature = "http")]
 impl ApplicationCommandInteraction {
     /// Gets the interaction response.
     ///
@@ -615,6 +619,7 @@ pub struct ApplicationCommandInteractionDataOption {
     pub focused: bool,
 }
 
+#[cfg(feature = "unstable_discord_api")]
 impl<'de> Deserialize<'de> for ApplicationCommandInteractionDataOption {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
@@ -704,6 +709,7 @@ pub struct ApplicationCommand {
     pub version: CommandVersionId,
 }
 
+#[cfg(feature = "http")]
 impl ApplicationCommand {
     /// Creates a global [`ApplicationCommand`],
     /// overriding an existing one with the same name if it exists.
@@ -876,7 +882,9 @@ impl ApplicationCommand {
     ) -> Result<()> {
         http.as_ref().delete_global_application_command(command_id.into()).await
     }
+}
 
+impl ApplicationCommand {
     #[inline]
     pub(crate) fn build_application_command<F>(f: F) -> JsonMap
     where

--- a/src/model/interactions/autocomplete.rs
+++ b/src/model/interactions/autocomplete.rs
@@ -9,7 +9,9 @@ use crate::builder::CreateAutocompleteResponse;
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::StdResult;
-use crate::json::{self, from_number, json, JsonMap, Value};
+#[cfg(feature = "http")]
+use crate::json::{self, json};
+use crate::json::{from_number, JsonMap, Value};
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::interactions::{
     application_command::ApplicationCommandInteractionData,

--- a/src/model/interactions/autocomplete.rs
+++ b/src/model/interactions/autocomplete.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Deserializer};
 use simd_json::ValueAccess;
 
 use super::prelude::*;
+#[cfg(feature = "http")]
 use crate::builder::CreateAutocompleteResponse;
+#[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::StdResult;
 use crate::json::{self, from_number, json, JsonMap, Value};
@@ -46,6 +48,7 @@ pub struct AutocompleteInteraction {
     pub version: u8,
 }
 
+#[cfg(feature = "http")]
 impl AutocompleteInteraction {
     /// Creates a response to an autocomplete interaction.
     ///

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -14,7 +14,9 @@ use crate::builder::{
 };
 #[cfg(feature = "http")]
 use crate::http::Http;
-use crate::json::{self, from_number, from_value, Value};
+#[cfg(feature = "http")]
+use crate::json;
+use crate::json::{from_number, from_value, Value};
 use crate::model::interactions::InteractionType;
 
 /// An interaction triggered by a message component.

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -6,11 +6,13 @@ use serde::{Serialize, Serializer};
 use simd_json::ValueAccess;
 
 use super::prelude::*;
+#[cfg(feature = "http")]
 use crate::builder::{
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     EditInteractionResponse,
 };
+#[cfg(feature = "http")]
 use crate::http::Http;
 use crate::json::{self, from_number, from_value, Value};
 use crate::model::interactions::InteractionType;
@@ -49,6 +51,7 @@ pub struct MessageComponentInteraction {
     pub version: u8,
 }
 
+#[cfg(feature = "http")]
 impl MessageComponentInteraction {
     /// Gets the interaction response.
     ///

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -12,7 +12,7 @@ use super::prelude::*;
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
 use crate::internal::prelude::*;
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 use crate::model::interactions::application_command::*;
 
 pub fn default_true() -> bool {
@@ -49,49 +49,49 @@ pub fn deserialize_members<'de, D: Deserializer<'de>>(
     deserializer.deserialize_seq(SequenceToMapVisitor::new(|member: &Member| member.user.id))
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_partial_members_map<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<UserId, PartialMember>, D::Error> {
     HashMap::deserialize(deserializer)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_users<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<UserId, User>, D::Error> {
     HashMap::deserialize(deserializer)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_roles_map<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<RoleId, Role>, D::Error> {
     HashMap::deserialize(deserializer)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_channels_map<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<ChannelId, PartialChannel>, D::Error> {
     HashMap::deserialize(deserializer)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_messages_map<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<MessageId, Message>, D::Error> {
     HashMap::deserialize(deserializer)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_options<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<Vec<ApplicationCommandInteractionDataOption>, D::Error> {
     Vec::deserialize(deserializer)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_options_with_resolved<'de, D: Deserializer<'de>>(
     deserializer: D,
     resolved: &ApplicationCommandInteractionDataResolved,
@@ -105,7 +105,7 @@ pub fn deserialize_options_with_resolved<'de, D: Deserializer<'de>>(
     Ok(options)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 fn try_resolve(
     value: &Value,
     kind: ApplicationCommandOptionType,
@@ -166,7 +166,7 @@ fn try_resolve(
     }
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 fn loop_resolved(
     options: &mut ApplicationCommandInteractionDataOption,
     resolved: &ApplicationCommandInteractionDataResolved,

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -17,8 +17,7 @@ use crate::http::Http;
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
-use crate::json;
-use crate::json::NULL;
+use crate::json::{self, NULL};
 #[cfg(feature = "model")]
 use crate::model::prelude::*;
 #[cfg(feature = "model")]


### PR DESCRIPTION
similar to https://github.com/serenity-rs/serenity/pull/1548, this PR makes `builder,unstable_discord_api` work.
`check --no-default-features --features "builder unstable_discord_api"`

Moves `AttachmentType` from http to model. It is _breaking_ for direct `AttachmentType` imports.

currently introduces this warning. Moving it into the feature flag or adding a `allow` could resolve it, but not sure which is better.

```
warning: associated function is never used: `build_application_command`
   --> ./serenity/src/model/interactions/application_command.rs:906:19
    |
906 |     pub(crate) fn build_application_command<F>(f: F) -> Map<String, Value>
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

```