### PR TITLE
Remove superfluous link reference definitions

### DIFF
--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -652,7 +652,6 @@ impl GuildId {
     /// Returns an [`Error::Http`] if some mandatory fields are not provided.
     ///
     /// [`Error::Http`]: crate::error::Error::Http
-    /// [`GuildWelcomeScreen`]: super::guild::GuildWelcomeScreen
     pub async fn edit_welcome_screen<F>(
         &self,
         http: impl AsRef<Http>,
@@ -677,7 +676,6 @@ impl GuildId {
     /// permission.
     ///
     /// [`Error::Http`]: crate::error::Error::Http
-    /// [`GuildWelcomeScreen`]: super::guild::GuildWelcomeScreen
     pub async fn edit_widget<F>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildWidget>
     where
         F: FnOnce(&mut EditGuildWidget) -> &mut EditGuildWidget,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1268,7 +1268,6 @@ impl Guild {
     /// Returns an [`Error::Http`] if some mandatory fields are not provided.
     ///
     /// [`Error::Http`]: crate::error::Error::Http
-    /// [`GuildWelcomeScreen`]: super::guild::GuildWelcomeScreen
     pub async fn edit_welcome_screen<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1288,7 +1287,6 @@ impl Guild {
     /// permission.
     ///
     /// [`Error::Http`]: crate::error::Error::Http
-    /// [`GuildWelcomeScreen`]: super::guild::GuildWelcomeScreen
     pub async fn edit_widget<F>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildWidget>
     where
         F: FnOnce(&mut EditGuildWidget) -> &mut EditGuildWidget,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -926,7 +926,6 @@ impl PartialGuild {
     /// Returns an [`Error::Http`] if some mandatory fields are not provided.
     ///
     /// [`Error::Http`]: crate::error::Error::Http
-    /// [`GuildWelcomeScreen`]: super::guild::GuildWelcomeScreen
     pub async fn edit_welcome_screen<F>(
         &self,
         http: impl AsRef<Http>,
@@ -946,7 +945,6 @@ impl PartialGuild {
     /// permission.
     ///
     /// [`Error::Http`]: crate::error::Error::Http
-    /// [`GuildWelcomeScreen`]: super::guild::GuildWelcomeScreen
     pub async fn edit_widget<F>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildWidget>
     where
         F: FnOnce(&mut EditGuildWidget) -> &mut EditGuildWidget,


### PR DESCRIPTION
These are either unused or covered by Rust's intra-doc links.