### PR TITLE
Move `GuildWelcomeScreen` and dependant types into a separate module

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -13,12 +13,12 @@ mod partial_guild;
 mod premium_tier;
 mod role;
 mod system_channel;
+mod welcome_screen;
 
 use chrono::{DateTime, Utc};
 #[cfg(feature = "model")]
 use futures::stream::StreamExt;
 use serde::de::Error as DeError;
-use serde::{Serialize, Serializer};
 #[cfg(feature = "simd-json")]
 use simd_json::StaticNode;
 #[cfg(feature = "model")]
@@ -36,6 +36,7 @@ pub use self::partial_guild::*;
 pub use self::premium_tier::*;
 pub use self::role::*;
 pub use self::system_channel::*;
+pub use self::welcome_screen::*;
 use super::utils::*;
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -2860,99 +2861,6 @@ pub enum GuildContainer {
     Guild(PartialGuild),
     /// A guild's id, which can be used to search the cache for a guild.
     Id(GuildId),
-}
-
-/// Information relating to a guild's welcome screen.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct GuildWelcomeScreen {
-    /// The server description shown in the welcome screen.
-    pub description: Option<String>,
-    /// The channels shown in the welcome screen.
-    ///
-    /// **Note**: There can only be only up to 5 channels.
-    pub welcome_channels: Vec<GuildWelcomeChannel>,
-}
-
-/// A channel shown in the [`GuildWelcomeScreen`].
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct GuildWelcomeChannel {
-    /// The channel Id.
-    pub channel_id: ChannelId,
-    /// The description shown for the channel.
-    pub description: String,
-    /// The emoji shown, if there is one.
-    pub emoji: Option<GuildWelcomeChannelEmoji>,
-}
-
-impl<'de> Deserialize<'de> for GuildWelcomeChannel {
-    fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Helper {
-            channel_id: ChannelId,
-            description: String,
-            emoji_id: Option<EmojiId>,
-            emoji_name: Option<String>,
-        }
-        let Helper {
-            channel_id,
-            description,
-            emoji_id,
-            emoji_name,
-        } = Helper::deserialize(deserializer)?;
-
-        let emoji = match (emoji_id, emoji_name) {
-            (Some(id), Some(name)) => Some(GuildWelcomeChannelEmoji::Custom {
-                id,
-                name,
-            }),
-            (None, Some(name)) => Some(GuildWelcomeChannelEmoji::Unicode(name)),
-            _ => None,
-        };
-
-        Ok(Self {
-            channel_id,
-            description,
-            emoji,
-        })
-    }
-}
-
-impl Serialize for GuildWelcomeChannel {
-    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeStruct;
-
-        let mut s = serializer.serialize_struct("GuildWelcomeChannel", 4)?;
-        s.serialize_field("channel_id", &self.channel_id)?;
-        s.serialize_field("description", &self.description)?;
-        let (emoji_id, emoji_name) = match &self.emoji {
-            Some(GuildWelcomeChannelEmoji::Custom {
-                id,
-                name,
-            }) => (Some(id), Some(name)),
-            Some(GuildWelcomeChannelEmoji::Unicode(name)) => (None, Some(name)),
-            None => (None, None),
-        };
-        s.serialize_field("emoji_id", &emoji_id)?;
-        s.serialize_field("emoji_name", &emoji_name)?;
-        s.end()
-    }
-}
-
-/// A [`GuildWelcomeScreen`] emoji.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[non_exhaustive]
-pub enum GuildWelcomeChannelEmoji {
-    /// A custom emoji.
-    Custom { id: EmojiId, name: String },
-    /// A unicode emoji.
-    Unicode(String),
 }
 
 /// A [`Guild`] embed.

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::model::id::{ChannelId, EmojiId};
+
+/// Information relating to a guild's welcome screen.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GuildWelcomeScreen {
+    /// The server description shown in the welcome screen.
+    pub description: Option<String>,
+    /// The channels shown in the welcome screen.
+    ///
+    /// **Note**: There can only be only up to 5 channels.
+    pub welcome_channels: Vec<GuildWelcomeChannel>,
+}
+
+/// A channel shown in the [`GuildWelcomeScreen`].
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct GuildWelcomeChannel {
+    /// The channel Id.
+    pub channel_id: ChannelId,
+    /// The description shown for the channel.
+    pub description: String,
+    /// The emoji shown, if there is one.
+    pub emoji: Option<GuildWelcomeChannelEmoji>,
+}
+
+impl<'de> Deserialize<'de> for GuildWelcomeChannel {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Helper {
+            channel_id: ChannelId,
+            description: String,
+            emoji_id: Option<EmojiId>,
+            emoji_name: Option<String>,
+        }
+        let Helper {
+            channel_id,
+            description,
+            emoji_id,
+            emoji_name,
+        } = Helper::deserialize(deserializer)?;
+
+        let emoji = match (emoji_id, emoji_name) {
+            (Some(id), Some(name)) => Some(GuildWelcomeChannelEmoji::Custom {
+                id,
+                name,
+            }),
+            (None, Some(name)) => Some(GuildWelcomeChannelEmoji::Unicode(name)),
+            _ => None,
+        };
+
+        Ok(Self {
+            channel_id,
+            description,
+            emoji,
+        })
+    }
+}
+
+impl Serialize for GuildWelcomeChannel {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut s = serializer.serialize_struct("GuildWelcomeChannel", 4)?;
+        s.serialize_field("channel_id", &self.channel_id)?;
+        s.serialize_field("description", &self.description)?;
+        let (emoji_id, emoji_name) = match &self.emoji {
+            Some(GuildWelcomeChannelEmoji::Custom {
+                id,
+                name,
+            }) => (Some(id), Some(name)),
+            Some(GuildWelcomeChannelEmoji::Unicode(name)) => (None, Some(name)),
+            None => (None, None),
+        };
+        s.serialize_field("emoji_id", &emoji_id)?;
+        s.serialize_field("emoji_name", &emoji_name)?;
+        s.end()
+    }
+}
+
+/// A [`GuildWelcomeScreen`] emoji.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum GuildWelcomeChannelEmoji {
+    /// A custom emoji.
+    Custom { id: EmojiId, name: String },
+    /// A unicode emoji.
+    Unicode(String),
+}


### PR DESCRIPTION
It slices off a bit of the enormous `guild/mod.rs` file.