### PR TITLE
Improve the usage of the `cdn!` macro

### DIFF
--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -214,7 +214,7 @@ impl Emoji {
     #[inline]
     pub fn url(&self) -> String {
         let extension = if self.animated { "gif" } else { "png" };
-        format!(cdn!("/emojis/{}.{}"), self.id, extension)
+        cdn!("/emojis/{}.{}", self.id, extension)
     }
 }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -435,9 +435,7 @@ impl Guild {
 
     /// Returns the formatted URL of the guild's banner image, if one exists.
     pub fn banner_url(&self) -> Option<String> {
-        self.banner
-            .as_ref()
-            .map(|banner| format!(cdn!("/banners/{}/{}.webp?size=1024"), self.id, banner))
+        self.banner.as_ref().map(|banner| cdn!("/banners/{}/{}.webp?size=1024", self.id, banner))
     }
 
     /// Retrieves a list of [`Ban`]s for the guild.
@@ -1391,7 +1389,7 @@ impl Guild {
         self.icon.as_ref().map(|icon| {
             let ext = if icon.starts_with("a_") { "gif" } else { "webp" };
 
-            format!(cdn!("/icons/{}/{}.{}"), self.id, icon, ext)
+            cdn!("/icons/{}/{}.{}", self.id, icon, ext)
         })
     }
 
@@ -2275,9 +2273,7 @@ impl Guild {
 
     /// Returns the formatted URL of the guild's splash image, if one exists.
     pub fn splash_url(&self) -> Option<String> {
-        self.splash
-            .as_ref()
-            .map(|splash| format!(cdn!("/splashes/{}/{}.webp?size=4096"), self.id, splash))
+        self.splash.as_ref().map(|splash| cdn!("/splashes/{}/{}.webp?size=4096", self.id, splash))
     }
 
     /// Starts an integration sync for the given integration Id.
@@ -3012,7 +3008,7 @@ impl GuildInfo {
         self.icon.as_ref().map(|icon| {
             let ext = if icon.starts_with("a_") { "gif" } else { "webp" };
 
-            format!(cdn!("/icons/{}/{}.{}"), self.id, icon, ext)
+            cdn!("/icons/{}/{}.{}", self.id, icon, ext)
         })
     }
 }
@@ -3039,9 +3035,7 @@ impl From<u64> for GuildContainer {
 impl InviteGuild {
     /// Returns the formatted URL of the guild's splash image, if one exists.
     pub fn splash_url(&self) -> Option<String> {
-        self.splash
-            .as_ref()
-            .map(|splash| format!(cdn!("/splashes/{}/{}.webp?size=4096"), self.id, splash))
+        self.splash.as_ref().map(|splash| cdn!("/splashes/{}/{}.webp?size=4096", self.id, splash))
     }
 }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1236,12 +1236,12 @@ impl PartialGuild {
 
     /// Returns a formatted URL of the guild's icon, if the guild has an icon.
     pub fn icon_url(&self) -> Option<String> {
-        self.icon.as_ref().map(|icon| format!(cdn!("/icons/{}/{}.webp"), self.id, icon))
+        self.icon.as_ref().map(|icon| cdn!("/icons/{}/{}.webp", self.id, icon))
     }
 
     /// Returns a formatted URL of the guild's banner, if the guild has a banner.
     pub fn banner_url(&self) -> Option<String> {
-        self.banner.as_ref().map(|banner| format!(cdn!("/banners/{}/{}.webp"), self.id, banner))
+        self.banner.as_ref().map(|banner| cdn!("/banners/{}/{}.webp", self.id, banner))
     }
 
     /// Gets all [`Emoji`]s of this guild via HTTP.
@@ -1451,9 +1451,7 @@ impl PartialGuild {
     /// Returns the formatted URL of the guild's splash image, if one exists.
     #[inline]
     pub fn splash_url(&self) -> Option<String> {
-        self.splash
-            .as_ref()
-            .map(|splash| format!(cdn!("/splashes/{}/{}.webp?size=4096"), self.id, splash))
+        self.splash.as_ref().map(|splash| cdn!("/splashes/{}/{}.webp?size=4096", self.id, splash))
     }
 
     /// Starts an integration sync for the given integration Id.

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -286,10 +286,9 @@ pub struct EmojiIdentifier {
 impl EmojiIdentifier {
     /// Generates a URL to the emoji's image.
     pub fn url(&self) -> String {
-        match self.animated {
-            true => format!(cdn!("/emojis/{}.gif"), self.id),
-            false => format!(cdn!("/emojis/{}.png"), self.id),
-        }
+        let ext = if self.animated { "gif" } else { "png" };
+
+        cdn!("/emojis/{}.{}", self.id, ext)
     }
 }
 


### PR DESCRIPTION
The macro supports string interpolation for additional parameters.