### PR TITLE
Separate `Webhook::edit` into three separate methods

### DIFF
--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -23,9 +23,8 @@ use crate::model::channel::AttachmentType;
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// # let http = Http::default();
-/// let id = 245037420704169985;
-/// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-/// let webhook = http.get_webhook_with_token(id, token).await?;
+/// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+/// let webhook = http.get_webhook_from_url(url).await?;
 ///
 /// let website = Embed::fake(|e| {
 ///     e.title("The Rust Language Website")


### PR DESCRIPTION
Replace `Webhook::edit` with `Webhook::{edit_name, edit_avatar, delete_avatar}`. This lets us change the type of the `avatar` parameter to be `impl Into<AttachmentType>` instead of `Option<&str>` (which fixes #1547). Changing it to `Option<impl Into<AttachmentType>>` would still be a breaking change because passing `None` would require adding a turbofish with the concrete type. Also avoids using empty string as a sentinel value for NULL. 

Also, change documentation examples to use `Http::get_webhook_from_url` rather than `Http::get_webhook_with_token`.