### PR TITLE
Replace manual deserialization of `RoleTags`

### DIFF
--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -19,6 +19,12 @@ pub fn default_true() -> bool {
     true
 }
 
+/// Helper function for `#[serde(skip_serializing_if = "is_false")]`
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub fn is_false(v: &bool) -> bool {
+    !v
+}
+
 /// Used with `#[serde(with = "emojis")]`
 pub mod emojis {
     use std::collections::HashMap;


### PR DESCRIPTION
The (de)serialization of the `premium_subscriber` field is now handled
by a specialized serde implementation.

This also fixes the wrong serialization of `true` and `false` values.