### PR TITLE
Add Modal Interactions and Input Text

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -381,13 +381,13 @@ impl CreateInputText {
     }
 
     /// Sets the minimum length required for the input text
-    pub fn min_values(&mut self, min: u64) -> &mut Self {
+    pub fn min_length(&mut self, min: u64) -> &mut Self {
         self.0.insert("min_length", Value::Number(Number::from(min)));
         self
     }
 
     /// Sets the maximum length required for the input text
-    pub fn max_values(&mut self, max: u64) -> &mut Self {
+    pub fn max_length(&mut self, max: u64) -> &mut Self {
         self.0.insert("max_length", Value::Number(Number::from(max)));
         self
     }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -148,6 +148,18 @@ impl CreateInteractionResponseData {
         self.0.insert("components", Value::Array(components.0));
         self
     }
+
+    /// Sets the custom id for modal interactions
+    pub fn custom_id<D: ToString>(&mut self, id: D) -> &mut Self {
+        self.0.insert("custom_id", Value::String(id.to_string()));
+        self
+    }
+
+    /// Sets the titel for modal interactions
+    pub fn title<D: ToString>(&mut self, title: D) -> &mut Self {
+        self.0.insert("title", Value::String(title.to_string()));
+        self
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -84,6 +84,7 @@ pub use self::{
         CreateActionRow,
         CreateButton,
         CreateComponents,
+        CreateInputText,
         CreateSelectMenu,
         CreateSelectMenuOption,
         CreateSelectMenuOptions,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -2260,9 +2260,7 @@ macro_rules! with_related_ids_for_event_types {
                     Interaction::ApplicationCommand(_) => None,
                     Interaction::MessageComponent(i) => Some(i.message.id),
                     Interaction::Autocomplete(i) => None,
-                    Interaction::ModalSubmit(i) => {
-                        if let Option::Some(m) = &i.message { Some(m.id) } else { None }
-                    },
+                    Interaction::ModalSubmit(i) => i.message.as_ref().map(|m| m.id).into(),
                 },
             },
             #[cfg(feature = "unstable_discord_api")]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -2260,9 +2260,7 @@ macro_rules! with_related_ids_for_event_types {
                     Interaction::ApplicationCommand(_) => None,
                     Interaction::MessageComponent(i) => Some(i.message.id),
                     Interaction::Autocomplete(i) => None,
-                    Interaction::ModalSubmit(i) => {
-                        if let Option::Some(m) = &i.message { Some(m.id) } else { None }
-                    },
+                    Interaction::ModalSubmit(i) => i.message.as_ref().map(|m| m.id),
                 },
             },
             #[cfg(feature = "unstable_discord_api")]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -2219,24 +2219,28 @@ macro_rules! with_related_ids_for_event_types {
                     Interaction::ApplicationCommand(i) => Some(i.user.id),
                     Interaction::MessageComponent(i) => Some(i.user.id),
                     Interaction::Autocomplete(i) => Some(i.user.id),
+                    Interaction::ModalSubmit(i) => Some(i.user.id),
                 },
                 guild_id: match &e.interaction {
                     Interaction::Ping(_) => None,
                     Interaction::ApplicationCommand(i) => i.guild_id.into(),
                     Interaction::MessageComponent(i) => i.guild_id.into(),
                     Interaction::Autocomplete(i) => i.guild_id.into(),
+                    Interaction::ModalSubmit(i) => i.guild_id.into(),
                 },
                 channel_id: match &e.interaction {
                     Interaction::Ping(_) => None,
                     Interaction::ApplicationCommand(i) => Some(i.channel_id),
                     Interaction::MessageComponent(i) => Some(i.channel_id),
                     Interaction::Autocomplete(i) => Some(i.channel_id),
+                    Interaction::ModalSubmit(i) => Some(i.channel_id),
                 },
                 message_id: match &e.interaction {
                     Interaction::Ping(_) => None,
                     Interaction::ApplicationCommand(_) => None,
                     Interaction::MessageComponent(i) => Some(i.message.id),
                     Interaction::Autocomplete(i) => None,
+                    Interaction::ModalSubmit(i) => Some(i.message.id),
                 },
             },
             #[cfg(feature = "unstable_discord_api")]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -2240,7 +2240,9 @@ macro_rules! with_related_ids_for_event_types {
                     Interaction::ApplicationCommand(_) => None,
                     Interaction::MessageComponent(i) => Some(i.message.id),
                     Interaction::Autocomplete(i) => None,
-                    Interaction::ModalSubmit(i) => Some(i.message.id),
+                    Interaction::ModalSubmit(i) => {
+                        if let Option::Some(m) = &i.message { Some(m.id) } else { None }
+                    },
                 },
             },
             #[cfg(feature = "unstable_discord_api")]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -2260,7 +2260,9 @@ macro_rules! with_related_ids_for_event_types {
                     Interaction::ApplicationCommand(_) => None,
                     Interaction::MessageComponent(i) => Some(i.message.id),
                     Interaction::Autocomplete(i) => None,
-                    Interaction::ModalSubmit(i) => i.message.as_ref().map(|m| m.id),
+                    Interaction::ModalSubmit(i) => {
+                        if let Option::Some(m) = &i.message { Some(m.id) } else { None }
+                    },
                 },
             },
             #[cfg(feature = "unstable_discord_api")]

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -704,7 +704,7 @@ pub struct InputText {
     pub kind: ComponentType,
     /// An identifier defined by the developer for the select menu.
     pub custom_id: String,
-    /// The Input from the user
+    /// The input from the user
     pub value: String,
 }
 

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -696,7 +696,7 @@ pub struct SelectMenuOption {
     pub default: bool,
 }
 
-/// A input text component for modal interactions
+/// An input text component for modal interactions
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InputText {
     /// The component type, it will always be [`ComponentType::InputText`].

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -526,6 +526,9 @@ impl<'de> Deserialize<'de> for ActionRowComponent {
             ComponentType::SelectMenu => serde_json::from_value::<SelectMenu>(Value::Object(map))
                 .map(ActionRowComponent::SelectMenu)
                 .map_err(DeError::custom),
+            ComponentType::InputText => serde_json::from_value::<InputText>(Value::Object(map))
+                .map(ActionRowComponent::InputText)
+                .map_err(DeError::custom),
             _ => Err(DeError::custom("Unknown component type")),
         }
     }
@@ -664,19 +667,7 @@ pub struct InputText {
     pub kind: ComponentType,
     /// An identifier defined by the developer for the select menu.
     pub custom_id: String,
-    /// The style of the input text
-    pub style: InputTextStyle,
-    /// The text that appears on top of the input text field, max 80 characters
-    pub label: String,
-    /// placeholder for the text input
-    pub placeholder: Option<String>,
-    /// Minimal length of text input
-    pub min_length: Option<u64>,
-    /// Maximal length of text input
-    pub max_length: Option<u64>,
-    /// Whether this text input is required
-    pub required: Option<bool>,
-    /// The pre-filled value
+    /// The Input from the user
     pub value: Option<String>,
 }
 

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -467,6 +467,7 @@ pub enum ComponentType {
     ActionRow = 1,
     Button = 2,
     SelectMenu = 3,
+    InputText = 4,
     Unknown = !0,
 }
 

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -656,7 +656,6 @@ pub struct SelectMenuOption {
     pub default: bool,
 }
 
-
 /// A input text component for modal interactions
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InputText {

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -423,6 +423,7 @@ impl<'de> Deserialize<'de> for Component {
             ComponentType::SelectMenu => serde_json::from_value::<SelectMenu>(Value::Object(map))
                 .map(Component::SelectMenu)
                 .map_err(DeError::custom),
+            ComponentType::InputText => unimplemented!(),
             ComponentType::Unknown => Err(DeError::custom("Unknown component type")),
         }
     }

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -668,7 +668,7 @@ pub struct InputText {
     /// An identifier defined by the developer for the select menu.
     pub custom_id: String,
     /// The Input from the user
-    pub value: Option<String>,
+    pub value: String,
 }
 
 /// The style of the input text

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -2,11 +2,13 @@ pub mod application_command;
 pub mod autocomplete;
 pub mod message_component;
 pub mod ping;
+pub mod modal;
 
 use application_command::ApplicationCommandInteraction;
 use autocomplete::AutocompleteInteraction;
 use bitflags::__impl_bitflags;
 use message_component::MessageComponentInteraction;
+use modal::ModalSubmitInteraction;
 use ping::PingInteraction;
 use serde::de::{Deserialize, Deserializer, Error as DeError};
 use serde::ser::{Serialize, Serializer};
@@ -21,8 +23,7 @@ pub enum Interaction {
     ApplicationCommand(ApplicationCommandInteraction),
     MessageComponent(MessageComponentInteraction),
     Autocomplete(AutocompleteInteraction),
-    // TODO This should probably become a new struct
-    ModalSubmit(MessageComponentInteraction),
+    ModalSubmit(ModalSubmitInteraction),
 }
 
 impl Interaction {
@@ -133,8 +134,8 @@ impl<'de> Deserialize<'de> for Interaction {
                     .map_err(DeError::custom)
             },
             InteractionType::ModalSubmit => {
-                serde_json::from_value::<MessageComponentInteraction>(Value::Object(map))
-                    .map(Interaction::MessageComponent)
+                serde_json::from_value::<ModalSubmitInteraction>(Value::Object(map))
+                    .map(Interaction::ModalSubmit)
                     .map_err(DeError::custom)
             },
             InteractionType::Unknown => Err(DeError::custom("Unknown interaction type")),
@@ -156,7 +157,7 @@ impl Serialize for Interaction {
                 MessageComponentInteraction::serialize(i, serializer)
             },
             Interaction::Autocomplete(i) => AutocompleteInteraction::serialize(i, serializer),
-            Interaction::ModalSubmit(i) => MessageComponentInteraction::serialize(i, serializer),
+            Interaction::ModalSubmit(i) => ModalSubmitInteraction::serialize(i, serializer),
         }
     }
 }

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -78,6 +78,7 @@ impl Interaction {
             Interaction::ApplicationCommand(i) => i.guild_locale.as_ref().map(String::as_str),
             Interaction::MessageComponent(i) => i.guild_locale.as_ref().map(String::as_str),
             Interaction::Autocomplete(i) => i.guild_locale.as_ref().map(String::as_str),
+            Interaction::ModalSubmit(i) => i.guild_locale.as_ref().map(String::as_str),
         }
     }
 

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -44,7 +44,7 @@ impl Interaction {
             Interaction::ApplicationCommand(_) => InteractionType::ApplicationCommand,
             Interaction::MessageComponent(_) => InteractionType::MessageComponent,
             Interaction::Autocomplete(_) => InteractionType::Autocomplete,
-            Interaction::ModalSubmit(_) => InteractionType::Autocomplete,
+            Interaction::ModalSubmit(_) => InteractionType::ModalSubmit,
         }
     }
 

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -156,9 +156,7 @@ impl Serialize for Interaction {
                 MessageComponentInteraction::serialize(i, serializer)
             },
             Interaction::Autocomplete(i) => AutocompleteInteraction::serialize(i, serializer),
-            Interaction::ModalSubmit(i) => {
-                MessageComponentInteraction::serialize(i, serializer)
-            },
+            Interaction::ModalSubmit(i) => MessageComponentInteraction::serialize(i, serializer),
         }
     }
 }

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -158,6 +158,7 @@ pub enum InteractionType {
     ApplicationCommand = 2,
     MessageComponent = 3,
     Autocomplete = 4,
+    ModalSubmit = 5,
     Unknown = !0,
 }
 
@@ -224,4 +225,5 @@ pub enum InteractionResponseType {
     DeferredUpdateMessage = 6,
     UpdateMessage = 7,
     Autocomplete = 8,
+    Modal = 9,
 }

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -1,8 +1,8 @@
 pub mod application_command;
 pub mod autocomplete;
 pub mod message_component;
-pub mod ping;
 pub mod modal;
+pub mod ping;
 
 use application_command::ApplicationCommandInteraction;
 use autocomplete::AutocompleteInteraction;

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -21,6 +21,8 @@ pub enum Interaction {
     ApplicationCommand(ApplicationCommandInteraction),
     MessageComponent(MessageComponentInteraction),
     Autocomplete(AutocompleteInteraction),
+    // TODO This should probably become a new struct
+    ModalSubmit(MessageComponentInteraction),
 }
 
 impl Interaction {
@@ -31,6 +33,7 @@ impl Interaction {
             Interaction::ApplicationCommand(i) => i.id,
             Interaction::MessageComponent(i) => i.id,
             Interaction::Autocomplete(i) => i.id,
+            Interaction::ModalSubmit(i) => i.id,
         }
     }
 
@@ -41,6 +44,7 @@ impl Interaction {
             Interaction::ApplicationCommand(_) => InteractionType::ApplicationCommand,
             Interaction::MessageComponent(_) => InteractionType::MessageComponent,
             Interaction::Autocomplete(_) => InteractionType::Autocomplete,
+            Interaction::ModalSubmit(_) => InteractionType::Autocomplete,
         }
     }
 
@@ -51,6 +55,7 @@ impl Interaction {
             Interaction::ApplicationCommand(i) => i.application_id,
             Interaction::MessageComponent(i) => i.application_id,
             Interaction::Autocomplete(i) => i.application_id,
+            Interaction::ModalSubmit(i) => i.application_id,
         }
     }
 
@@ -61,6 +66,7 @@ impl Interaction {
             Interaction::ApplicationCommand(i) => i.token.as_str(),
             Interaction::MessageComponent(i) => i.token.as_str(),
             Interaction::Autocomplete(i) => i.token.as_str(),
+            Interaction::ModalSubmit(i) => i.token.as_str(),
         }
     }
 
@@ -126,6 +132,11 @@ impl<'de> Deserialize<'de> for Interaction {
                     .map(Interaction::Autocomplete)
                     .map_err(DeError::custom)
             },
+            InteractionType::ModalSubmit => {
+                serde_json::from_value::<MessageComponentInteraction>(Value::Object(map))
+                    .map(Interaction::MessageComponent)
+                    .map_err(DeError::custom)
+            },
             InteractionType::Unknown => Err(DeError::custom("Unknown interaction type")),
         }
     }
@@ -145,6 +156,9 @@ impl Serialize for Interaction {
                 MessageComponentInteraction::serialize(i, serializer)
             },
             Interaction::Autocomplete(i) => AutocompleteInteraction::serialize(i, serializer),
+            Interaction::ModalSubmit(i) => {
+                MessageComponentInteraction::serialize(i, serializer)
+            },
         }
     }
 }
@@ -167,6 +181,7 @@ enum_number!(InteractionType {
     MessageComponent,
     ApplicationCommand,
     Autocomplete,
+    ModalSubmit,
 });
 
 /// The flags for an interaction response.

--- a/src/model/interactions/modal.rs
+++ b/src/model/interactions/modal.rs
@@ -1,6 +1,7 @@
 use serde::de::Error as DeError;
 use serde::Serialize;
 
+use super::message_component::ActionRow;
 use super::prelude::*;
 use crate::builder::{
     CreateInteractionResponse,
@@ -384,8 +385,8 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ModalSubmitInteractionData {
-    /// The custom id of the component.
+    /// The custom id of the modal
     pub custom_id: String,
     /// The components.
-    pub components: Vec<serde_json::Value>, // TODO
+    pub components: Vec<ActionRow>,
 }

--- a/src/model/interactions/modal.rs
+++ b/src/model/interactions/modal.rs
@@ -349,11 +349,15 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
             false => member.as_ref().expect("expected user or member").user.clone(),
         };
 
-        let message = map
-            .remove("message")
-            .ok_or_else(|| DeError::custom("expected message"))
-            .and_then(Message::deserialize)
-            .map_err(DeError::custom)?;
+        let message = match map.contains_key("message") {
+            true => Some(
+                map.remove("message")
+                    .ok_or_else(|| DeError::custom("expected message"))
+                    .and_then(Message::deserialize)
+                    .map_err(DeError::custom)?,
+            ),
+            false => None,
+        };
 
         let token = map
             .remove("token")

--- a/src/model/interactions/modal.rs
+++ b/src/model/interactions/modal.rs
@@ -1,0 +1,391 @@
+use serde::de::Error as DeError;
+use serde::Serialize;
+
+use super::prelude::*;
+use crate::builder::{
+    CreateInteractionResponse,
+    CreateInteractionResponseFollowup,
+    EditInteractionResponse,
+};
+use crate::http::Http;
+use crate::model::interactions::InteractionType;
+use crate::utils;
+
+/// An interaction triggered by a message component.
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
+pub struct ModalSubmitInteraction {
+    /// Id of the interaction.
+    pub id: InteractionId,
+    /// Id of the application this interaction is for.
+    pub application_id: ApplicationId,
+    /// The type of interaction.
+    #[serde(rename = "type")]
+    pub kind: InteractionType,
+    /// The data of the interaction which was triggered.
+    pub data: ModalSubmitInteractionData,
+    /// The message this interaction was triggered by, if
+    /// it is a component.
+    pub message: Message,
+    /// The guild Id this interaction was sent from, if there is one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guild_id: Option<GuildId>,
+    /// The channel Id this interaction was sent from.
+    pub channel_id: ChannelId,
+    /// The `member` data for the invoking user.
+    ///
+    /// **Note**: It is only present if the interaction is triggered in a guild.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member: Option<Member>,
+    /// The `user` object for the invoking user.
+    pub user: User,
+    /// A continuation token for responding to the interaction.
+    pub token: String,
+    /// Always `1`.
+    pub version: u8,
+}
+
+//FIXME documentation
+impl ModalSubmitInteraction {
+    /// Gets the interaction response.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if there is no interaction response.
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    pub async fn get_interaction_response(&self, http: impl AsRef<Http>) -> Result<Message> {
+        http.as_ref().get_original_interaction_response(&self.token).await
+    }
+
+    /// Creates a response to the interaction received.
+    ///
+    /// **Note**: Message contents must be under 2000 unicode code points.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Model`] if the message content is too long.
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Model`]: crate::error::Error::Model
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
+    pub async fn create_interaction_response<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut CreateInteractionResponse) -> &mut CreateInteractionResponse,
+    {
+        let mut interaction_response = CreateInteractionResponse::default();
+        f(&mut interaction_response);
+
+        let map = utils::hashmap_to_json_map(interaction_response.0);
+
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
+
+        http.as_ref().create_interaction_response(self.id.0, &self.token, &Value::Object(map)).await
+    }
+
+    /// Edits the initial interaction response.
+    ///
+    /// `application_id` will usually be the bot's [`UserId`], except in cases of bots being very old.
+    ///
+    /// Refer to Discord's docs for Edit Webhook Message for field information.
+    ///
+    /// **Note**:   Message contents must be under 2000 unicode code points, does not work on ephemeral messages.
+    ///
+    /// [`UserId`]: crate::model::id::UserId
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Model`] if the edited content is too long.
+    /// May also return [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error deserializing the response.
+    ///
+    /// [`Error::Model`]: crate::error::Error::Model
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
+    pub async fn edit_original_interaction_response<F>(
+        &self,
+        http: impl AsRef<Http>,
+        f: F,
+    ) -> Result<Message>
+    where
+        F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse,
+    {
+        let mut interaction_response = EditInteractionResponse::default();
+        f(&mut interaction_response);
+
+        let map = utils::hashmap_to_json_map(interaction_response.0);
+
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
+
+        http.as_ref().edit_original_interaction_response(&self.token, &Value::Object(map)).await
+    }
+
+    /// Deletes the initial interaction response.
+    ///
+    /// # Errors
+    ///
+    /// May return [`Error::Http`] if the API returns an error.
+    /// Such as if the response was already deleted.
+    pub async fn delete_original_interaction_response(&self, http: impl AsRef<Http>) -> Result<()> {
+        http.as_ref().delete_original_interaction_response(&self.token).await
+    }
+
+    /// Creates a followup response to the response sent.
+    ///
+    /// **Note**: Message contents must be under 2000 unicode code points.
+    ///
+    /// # Errors
+    ///
+    /// Will return [`Error::Model`] if the content is too long.
+    /// May also return [`Error::Http`] if the API returns an error,
+    /// or a [`Error::Json`] if there is an error in deserializing the response.
+    ///
+    /// [`Error::Model`]: crate::error::Error::Model
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
+    pub async fn create_followup_message<'a, F>(
+        &self,
+        http: impl AsRef<Http>,
+        f: F,
+    ) -> Result<Message>
+    where
+        for<'b> F: FnOnce(
+            &'b mut CreateInteractionResponseFollowup<'a>,
+        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
+    {
+        let mut interaction_response = CreateInteractionResponseFollowup::default();
+        f(&mut interaction_response);
+
+        let map = utils::hashmap_to_json_map(interaction_response.0);
+
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
+
+        http.as_ref().create_followup_message(&self.token, &Value::Object(map)).await
+    }
+
+    /// Edits a followup response to the response sent.
+    ///
+    /// **Note**: Message contents must be under 2000 unicode code points.
+    ///
+    /// # Errors
+    ///
+    /// Will return [`Error::Model`] if the content is too long.
+    /// May also return [`Error::Http`] if the API returns an error,
+    /// or a [`Error::Json`] if there is an error in deserializing the response.
+    ///
+    /// [`Error::Model`]: crate::error::Error::Model
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
+    pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
+        &self,
+        http: impl AsRef<Http>,
+        message_id: M,
+        f: F,
+    ) -> Result<Message>
+    where
+        for<'b> F: FnOnce(
+            &'b mut CreateInteractionResponseFollowup<'a>,
+        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
+    {
+        let mut interaction_response = CreateInteractionResponseFollowup::default();
+        f(&mut interaction_response);
+
+        let map = utils::hashmap_to_json_map(interaction_response.0);
+
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
+
+        http.as_ref()
+            .edit_followup_message(&self.token, message_id.into().into(), &Value::Object(map))
+            .await
+    }
+
+    /// Deletes a followup message.
+    ///
+    /// # Errors
+    ///
+    /// May return [`Error::Http`] if the API returns an error.
+    /// Such as if the response was already deleted.
+    pub async fn delete_followup_message<M: Into<MessageId>>(
+        &self,
+        http: impl AsRef<Http>,
+        message_id: M,
+    ) -> Result<()> {
+        http.as_ref().delete_followup_message(&self.token, message_id.into().into()).await
+    }
+    /// Helper function to defer an interaction
+    ///
+    /// # Errors
+    ///
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
+    pub async fn defer(&self, http: impl AsRef<Http>) -> Result<()> {
+        self.create_interaction_response(http, |f| {
+            f.kind(InteractionResponseType::DeferredUpdateMessage)
+        })
+        .await
+    }
+}
+
+impl<'de> Deserialize<'de> for ModalSubmitInteraction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        let mut map = JsonMap::deserialize(deserializer)?;
+
+        let id = map.get("guild_id").and_then(|x| x.as_str()).and_then(|x| x.parse::<u64>().ok());
+
+        if let Some(guild_id) = id {
+            if let Some(member) = map.get_mut("member").and_then(|x| x.as_object_mut()) {
+                member.insert("guild_id".to_string(), Value::Number(Number::from(guild_id)));
+            }
+
+            if let Some(data) = map.get_mut("data") {
+                if let Some(resolved) = data.get_mut("resolved") {
+                    if let Some(roles) = resolved.get_mut("roles") {
+                        if let Some(values) = roles.as_object_mut() {
+                            for value in values.values_mut() {
+                                value
+                                    .as_object_mut()
+                                    .expect("couldn't deserialize message component")
+                                    .insert(
+                                        "guild_id".to_string(),
+                                        Value::String(guild_id.to_string()),
+                                    );
+                            }
+                        }
+                    }
+
+                    if let Some(channels) = resolved.get_mut("channels") {
+                        if let Some(values) = channels.as_object_mut() {
+                            for value in values.values_mut() {
+                                value
+                                    .as_object_mut()
+                                    .expect(
+                                        "couldn't deserialize the message component interaction",
+                                    )
+                                    .insert(
+                                        "guild_id".to_string(),
+                                        Value::String(guild_id.to_string()),
+                                    );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let id = map
+            .remove("id")
+            .ok_or_else(|| DeError::custom("expected id"))
+            .and_then(InteractionId::deserialize)
+            .map_err(DeError::custom)?;
+
+        let application_id = map
+            .remove("application_id")
+            .ok_or_else(|| DeError::custom("expected application id"))
+            .and_then(ApplicationId::deserialize)
+            .map_err(DeError::custom)?;
+
+        let kind = map
+            .remove("type")
+            .ok_or_else(|| DeError::custom("expected type"))
+            .and_then(InteractionType::deserialize)
+            .map_err(DeError::custom)?;
+
+        let data = map
+            .remove("data")
+            .ok_or_else(|| DeError::custom("expected data"))
+            .and_then(ModalSubmitInteractionData::deserialize)
+            .map_err(DeError::custom)?;
+
+        let guild_id = match map.contains_key("guild_id") {
+            true => Some(
+                map.remove("guild_id")
+                    .ok_or_else(|| DeError::custom("expected guild_id"))
+                    .and_then(GuildId::deserialize)
+                    .map_err(DeError::custom)?,
+            ),
+            false => None,
+        };
+
+        let channel_id = map
+            .remove("channel_id")
+            .ok_or_else(|| DeError::custom("expected channel_id"))
+            .and_then(ChannelId::deserialize)
+            .map_err(DeError::custom)?;
+
+        let member = match map.contains_key("member") {
+            true => Some(
+                map.remove("member")
+                    .ok_or_else(|| DeError::custom("expected member"))
+                    .and_then(Member::deserialize)
+                    .map_err(DeError::custom)?,
+            ),
+            false => None,
+        };
+
+        let user = match map.contains_key("user") {
+            true => map
+                .remove("user")
+                .ok_or_else(|| DeError::custom("expected user"))
+                .and_then(User::deserialize)
+                .map_err(DeError::custom)?,
+            false => member.as_ref().expect("expected user or member").user.clone(),
+        };
+
+        let message = map
+            .remove("message")
+            .ok_or_else(|| DeError::custom("expected message"))
+            .and_then(Message::deserialize)
+            .map_err(DeError::custom)?;
+
+        let token = map
+            .remove("token")
+            .ok_or_else(|| DeError::custom("expected token"))
+            .and_then(String::deserialize)
+            .map_err(DeError::custom)?;
+
+        let version = map
+            .remove("version")
+            .ok_or_else(|| DeError::custom("expected version"))
+            .and_then(u8::deserialize)
+            .map_err(DeError::custom)?;
+
+        Ok(Self {
+            id,
+            application_id,
+            kind,
+            data,
+            message,
+            guild_id,
+            channel_id,
+            member,
+            user,
+            token,
+            version,
+        })
+    }
+}
+
+/// A message component interaction data, provided by [`MessageComponentInteraction::data`]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ModalSubmitInteractionData {
+    /// The custom id of the component.
+    pub custom_id: String,
+    /// The components.
+    pub components: Vec<serde_json::Value>, // TODO
+}

--- a/src/model/interactions/modal.rs
+++ b/src/model/interactions/modal.rs
@@ -25,9 +25,11 @@ pub struct ModalSubmitInteraction {
     pub kind: InteractionType,
     /// The data of the interaction which was triggered.
     pub data: ModalSubmitInteractionData,
-    /// The message this interaction was triggered by, if
-    /// it is a component.
-    pub message: Message,
+    /// The message this interaction was triggered by
+    /// **Note**: Does not exist if the modal interaction originates from
+    /// an application command interaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<Message>,
     /// The guild Id this interaction was sent from, if there is one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,

--- a/src/model/interactions/modal.rs
+++ b/src/model/interactions/modal.rs
@@ -408,7 +408,7 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
     }
 }
 
-/// A message component interaction data, provided by [`ModalSubmitInteraction::data`]
+/// A modal submit interaction data, provided by [`ModalSubmitInteraction::data`]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ModalSubmitInteractionData {


### PR DESCRIPTION
Modals are out of beta

This PR adds modal interactions and input text options.

# Docs
Modals: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-modal
Text Input: https://discord.com/developers/docs/interactions/message-components#text-inputs

### TODO

- [x]  Add modal interactions
- [x]  Add input text
- [x]  Add input text builder
- [x]  Finish ModalSubmitInteractions
- [x]  Testing: https://github.com/pascalharp/serenity_modal_testing
- [x]  Fix merge conflicts