### PR TITLE
Remove more superfluous link reference definitions

### DIFF
--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -76,7 +76,7 @@ impl CreateBotAuthParameters {
     ///
     /// **Note**: This needs to include the [`Bot`] scope.
     ///
-    /// [`Bot`]: crate::model::oauth2::OAuth2Scope::Bot
+    /// [`Bot`]: OAuth2Scope::Bot
     pub fn scopes(&mut self, scopes: &[OAuth2Scope]) -> &mut Self {
         self.scopes = scopes.to_vec();
         self

--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -9,7 +9,6 @@ use crate::model::interactions::application_command::ApplicationCommandPermissio
 /// A builder for creating several [`ApplicationCommandPermission`].
 ///
 /// [`ApplicationCommandPermission`]: crate::model::interactions::application_command::ApplicationCommandPermission
-/// [`kind`]: Self::kind
 #[derive(Clone, Debug, Default)]
 pub struct CreateApplicationCommandsPermissions(pub Vec<Value>);
 
@@ -61,7 +60,6 @@ impl CreateApplicationCommandsPermissions {
 /// A builder for creating an [`ApplicationCommandPermission`].
 ///
 /// [`ApplicationCommandPermission`]: crate::model::interactions::application_command::ApplicationCommandPermission
-/// [`kind`]: Self::kind
 #[derive(Clone, Debug, Default)]
 pub struct CreateApplicationCommandPermissions(pub HashMap<&'static str, Value>);
 
@@ -124,7 +122,6 @@ impl CreateApplicationCommandPermissions {
 /// A builder for creating several [`ApplicationCommandPermissionData`].
 ///
 /// [`ApplicationCommandPermissionData`]: crate::model::interactions::application_command::ApplicationCommandPermissionData
-/// [`kind`]: Self::kind
 #[derive(Clone, Debug, Default)]
 pub struct CreateApplicationCommandPermissionsData(pub HashMap<&'static str, Value>);
 
@@ -181,7 +178,6 @@ impl CreateApplicationCommandPermissionsData {
 /// All fields are required.
 ///
 /// [`ApplicationCommandPermissionData`]: crate::model::interactions::application_command::ApplicationCommandPermissionData
-/// [`kind`]: Self::kind
 #[derive(Clone, Debug, Default)]
 pub struct CreateApplicationCommandPermissionData(pub HashMap<&'static str, Value>);
 

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -31,9 +31,6 @@ impl CreateThread {
     /// when thread documentation was first published. This is a bit of a weird default though,
     /// and thus is highly likely to change in the future, so it is recommended to always
     /// explicitly setting it to avoid any breaking change.
-    ///
-    /// [`ChannelType::PublicThread`]: crate::model::channel::ChannelType::PublicThread
-    /// [`ChannelType::PrivateThread`]: crate::model::channel::ChannelType::PrivateThread
     pub fn kind(&mut self, kind: ChannelType) -> &mut Self {
         self.0.insert("type", from_number(kind as u8));
 

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -9,7 +9,6 @@ use crate::json;
 /// A builder which edits a user's voice state, to be used in conjunction with
 /// [`GuildChannel::edit_voice_state`].
 ///
-/// [`Member`]: crate::model::guild::Member
 /// [`GuildChannel::edit_voice_state`]: crate::model::channel::GuildChannel::edit_voice_state
 #[derive(Clone, Debug, Default)]
 pub struct EditVoiceState(pub HashMap<&'static str, Value>);

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -879,8 +879,6 @@ impl Cache {
     /// The only advantage of this method is that you can pass in anything that
     /// is indirectly a [`UserId`].
     ///
-    /// [`UserId`]: crate::model::id::UserId
-    ///
     /// # Examples
     ///
     /// Retrieve a user from the cache and print their name:
@@ -992,7 +990,6 @@ impl Cache {
     ///
     /// Refer to the [`CacheUpdate` examples].
     ///
-    /// [`CacheUpdate`]: CacheUpdate
     /// [`CacheUpdate` examples]: CacheUpdate#examples
     #[instrument(skip(self, e))]
     pub fn update<E: CacheUpdate>(&self, e: &mut E) -> Option<E::Output> {

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -9,9 +9,7 @@ use std::{
 /// variant.
 ///
 /// [`Client`]: super::Client
-/// [`Error`]: crate::Error
 /// [`Error::Client`]: crate::Error::Client
-/// [`GuildId::ban`]: crate::model::id::GuildId::ban
 #[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -136,8 +136,6 @@ impl ClientBuilder {
     /// If you have enabled the `framework`-feature (on by default), you must specify
     /// a framework via the [`Self::framework`] or [`Self::framework_arc`] method,
     /// otherwise awaiting the builder will cause a panic.
-    ///
-    /// [`Http`]: crate::http::Http
     pub fn new_with_http(http: Http) -> Self {
         Self::_new(http)
     }
@@ -151,8 +149,6 @@ impl ClientBuilder {
     }
 
     /// Gets the current token used for the [`Http`] client.
-    ///
-    /// [`Http`]: crate::http::Http
     pub fn get_token(&self) -> &str {
         &self.http.token
     }
@@ -210,7 +206,7 @@ impl ClientBuilder {
     /// Sets the settings of the cache.
     /// Refer to [`Settings`] for more information.
     ///
-    /// [`Settings`]: self::CacheSettings
+    /// [`Settings`]: CacheSettings
     #[cfg(feature = "cache")]
     pub fn cache_settings<F>(mut self, f: F) -> Self
     where
@@ -276,7 +272,7 @@ impl ClientBuilder {
     /// extra control.
     /// You can provide a clone and keep the original to manually dispatch.
     ///
-    /// [`voice_manager`]: #method.voice_manager
+    /// [`voice_manager`]: Self::voice_manager
     #[cfg(feature = "voice")]
     pub fn voice_manager_arc(
         mut self,
@@ -310,8 +306,6 @@ impl ClientBuilder {
     /// [gateway intent]: https://discord.com/developers/docs/topics/gateway#privileged-intents
     /// [Privileged intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
     /// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
-    /// [`GatewayIntents::GUILD_PRESENCES`]: crate::model::gateway::GatewayIntents::GUILD_PRESENCES
-    /// [`GatewayIntents::GUILD_MEMBERS`]: crate::model::gateway::GatewayIntents::GUILD_MEMBERS
     pub fn intents(mut self, intents: GatewayIntents) -> Self {
         self.intents = intents;
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1295,7 +1295,6 @@ async fn send_error_embed(
 /// Returns the same errors as [`ChannelId::send_message`].
 ///
 /// [`StandardFramework::help`]: crate::framework::standard::StandardFramework::help
-/// [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
 #[cfg(all(feature = "cache", feature = "http"))]
 #[allow(clippy::implicit_hasher)]
 pub async fn with_embeds(
@@ -1501,8 +1500,6 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
 /// # Errors
 ///
 /// Returns the same errors as [`ChannelId::send_message`].
-///
-/// [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
 #[cfg(all(feature = "cache", feature = "http"))]
 #[allow(clippy::implicit_hasher)]
 pub async fn plain(

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -357,7 +357,6 @@ impl ChannelId {
     /// is over the [`the limit`], containing the number of unicode code points
     /// over the limit.
     ///
-    /// [`EditMessage`]: crate::builder::EditMessage
     /// [`the limit`]: crate::builder::EditMessage::content
     #[inline]
     pub async fn edit_message<F>(
@@ -460,7 +459,6 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user does not have
     /// permission to view the channel.
     ///
-    /// [`GetMessages`]: crate::builder::GetMessages
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     pub async fn messages<F>(self, http: impl AsRef<Http>, builder: F) -> Result<Vec<Message>>
     where
@@ -747,7 +745,6 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission to
     /// send a message in this channel.
     ///
-    /// [`CreateMessage`]: crate::builder::CreateMessage
     /// [Send Messages]: Permissions::SEND_MESSAGES
     pub async fn send_message<'a, F>(self, http: impl AsRef<Http>, f: F) -> Result<Message>
     where

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -457,7 +457,6 @@ impl GuildChannel {
     /// is over the [`the limit`], containing the number of unicode code points
     /// over the limit.
     ///
-    /// [`EditMessage`]: crate::builder::EditMessage
     /// [`the limit`]: crate::builder::EditMessage::content
     #[inline]
     pub async fn edit_message<F>(
@@ -674,7 +673,6 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission to
     /// view the channel.
     ///
-    /// [`GetMessages`]: crate::builder::GetMessages
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     #[inline]
     pub async fn messages<F>(&self, http: impl AsRef<Http>, builder: F) -> Result<Vec<Message>>

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -323,7 +323,6 @@ impl Message {
     /// is over [`the limit`], containing the number of unicode code points
     /// over the limit.
     ///
-    /// [`EditMessage`]: crate::builder::EditMessage
     /// [`the limit`]: crate::builder::EditMessage::content
     pub async fn edit<'a, F>(&mut self, cache_http: impl CacheHttp, f: F) -> Result<()>
     where

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -40,8 +40,6 @@ impl PrivateChannel {
     /// Broadcasts that the current user is typing to the recipient.
     ///
     /// See [ChannelId::broadcast_typing] for more details.
-    ///
-    /// [`ChannelId::broadcast_typing`]: crate::model::channel::ChannelId::broadcast_typing
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> {
@@ -157,7 +155,6 @@ impl PrivateChannel {
     ///
     /// Returns [`Error::Http`] if the current user is not the owner of the message.
     ///
-    /// [`EditMessage`]: crate::builder::EditMessage
     /// [`the limit`]: crate::builder::EditMessage::content
     #[inline]
     pub async fn edit_message<F>(
@@ -203,8 +200,6 @@ impl PrivateChannel {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if an invalid value is set in the builder.
-    ///
-    /// [`GetMessages`]: crate::builder::GetMessages
     #[inline]
     pub async fn messages<F>(&self, http: impl AsRef<Http>, builder: F) -> Result<Vec<Message>>
     where
@@ -323,8 +318,6 @@ impl PrivateChannel {
     /// Returns a [`ModelError::MessageTooLong`] if the content of the message
     /// is over the above limit, containing the number of unicode code points
     /// over the limit.
-    ///
-    /// [`CreateMessage`]: crate::builder::CreateMessage
     #[inline]
     pub async fn send_message<'a, F>(&self, http: impl AsRef<Http>, f: F) -> Result<Message>
     where

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -548,8 +548,6 @@ pub struct ActivityTimestamps {
 /// [gateway intent]: https://discord.com/developers/docs/topics/gateway#privileged-intents
 /// [Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
 /// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
-/// [`GatewayIntents::GuildPresences`]: crate::model::gateway::GatewayIntents::GUILD_PRESENCES
-/// [`GatewayIntents::GuildMembers`]: crate::model::gateway::GatewayIntents::GUILD_MEMBERS
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct GatewayIntents {
     /// The flags composing gateway intents.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -263,8 +263,6 @@ impl Member {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks necessary permissions.
-    ///
-    /// [`EditMember`]: crate::builder::EditMember
     pub async fn edit<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Member>
     where
         F: FnOnce(&mut EditMember) -> &mut EditMember,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1121,7 +1121,6 @@ impl Guild {
     ///
     /// Returns [`Error::Http`] if the current user lacks the necessary permissions.
     ///
-    /// [`EditMember`]: crate::builder::EditMember
     /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_member<F>(

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1330,7 +1330,7 @@ impl PartialGuild {
     /// may also return [`Error::NotInRange`] if the input is
     /// not within range.
     ///
-    /// [`User`]: ../user/struct.User.html
+    /// [`User`]: crate::model::user::User
     #[inline]
     pub async fn members(
         &self,

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -122,8 +122,6 @@ impl ApplicationCommandInteraction {
     ///
     /// **Note**:   Message contents must be under 2000 unicode code points, does not work on ephemeral messages.
     ///
-    /// [`UserId`]: crate::model::id::UserId
-    ///
     /// # Errors
     ///
     /// Returns [`Error::Model`] if the edited content is too long.
@@ -975,9 +973,6 @@ pub struct ApplicationCommandPermission {
 #[non_exhaustive]
 pub struct ApplicationCommandPermissionData {
     /// The [`RoleId`] or [`UserId`], depends on `kind` value.
-    ///
-    /// [`RoleId`]: crate::model::id::RoleId
-    /// [`UserId`]: crate::model::id::UserId
     pub id: CommandPermissionId,
     /// The type of data this permissions applies to.
     #[serde(rename = "type")]

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -78,7 +78,6 @@ impl Invite {
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`]
     /// if the current user does not have the required [permission].
     ///
-    /// [`CreateInvite`]: crate::builder::CreateInvite
     /// [Create Invite]: Permissions::CREATE_INVITE
     /// [permission]: super::permissions
     #[inline]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -246,8 +246,6 @@ impl CurrentUser {
     /// # }
     /// ```
     ///
-    /// [`EditProfile`]: crate::builder::EditProfile
-    ///
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if an invalid value is set.
@@ -735,8 +733,6 @@ impl User {
     /// # Errors
     ///
     /// See [`UserId::create_dm_channel`] for what errors may be returned.
-    ///
-    /// [`UserId::create_dm_channel`]: crate::model::id::UserId::create_dm_channel
     #[inline]
     pub async fn create_dm_channel(&self, cache_http: impl CacheHttp) -> Result<PrivateChannel> {
         if self.bot {
@@ -942,8 +938,6 @@ impl User {
     /// # Errors
     ///
     /// See [`UserId::to_user`] for what errors may be returned.
-    ///
-    /// [`UserId::to_user`]: crate::model::id::UserId::to_user
     #[inline]
     pub async fn refresh(&mut self, cache_http: impl CacheHttp) -> Result<()> {
         *self = self.id.to_user(cache_http).await?;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -699,8 +699,6 @@ fn clean_users(
 /// assert_eq!("@\u{200B}everyone".to_string(), without_mention);
 /// # }
 /// ```
-///
-/// [`Cache`]: crate::cache::Cache
 #[cfg(feature = "cache")]
 pub fn content_safe(
     cache: impl AsRef<Cache>,


### PR DESCRIPTION
These are either unused or explicitly imported and are therefore already
covered by Rust's intra-doc link resolution.

Most of the link reference definitions for `Error` variants could probably also be removed
but I decided against it because these are imported via `prelude::*`.

Follow-up to: #1645 