### PR TITLE
Use the `bitflags!` macro instead of the undocumented macro

### DIFF
--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -362,10 +362,10 @@ impl ToTokens for Permissions {
     fn to_tokens(&self, stream: &mut TokenStream2) {
         let bits = self.0;
 
-        let path = quote!(serenity::model::permissions::Permissions);
+        let path = quote!(serenity::model::permissions::Permissions::from_bits_truncate);
 
         stream.extend(quote! {
-            #path { bits: #bits }
+            #path(#bits)
         });
     }
 }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 #[cfg(all(feature = "cache", feature = "model"))]
 use std::fmt::Write;
 
-use bitflags::__impl_bitflags;
+use bitflags::bitflags;
 use chrono::{DateTime, Utc};
 #[cfg(feature = "simd-json")]
 use simd_json::ValueAccess;
@@ -1207,30 +1207,25 @@ pub struct ChannelMention {
     pub name: String,
 }
 
-/// Describes extra features of the message.
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
-pub struct MessageFlags {
-    pub bits: u64,
-}
-
-__impl_bitflags! {
-    MessageFlags: u64 {
+bitflags! {
+    /// Describes extra features of the message.
+    pub struct MessageFlags: u64 {
         /// This message has been published to subscribed channels (via Channel Following).
-        CROSSPOSTED = 1 << 0;
+        const CROSSPOSTED = 1 << 0;
         /// This message originated from a message in another channel (via Channel Following).
-        IS_CROSSPOST = 1 << 1;
+        const IS_CROSSPOST = 1 << 1;
         /// Do not include any embeds when serializing this message.
-        SUPPRESS_EMBEDS = 1 << 2;
+        const SUPPRESS_EMBEDS = 1 << 2;
         /// The source message for this crosspost has been deleted (via Channel Following).
-        SOURCE_MESSAGE_DELETED = 1 << 3;
+        const SOURCE_MESSAGE_DELETED = 1 << 3;
         /// This message came from the urgent message system.
-        URGENT = 1 << 4;
+        const URGENT = 1 << 4;
         /// This message has an associated thread, with the same id as the message.
-        HAS_THREAD = 1 << 5;
+        const HAS_THREAD = 1 << 5;
         /// This message is only visible to the user who invoked the Interaction.
-        EPHEMERAL = 1 << 6;
+        const EPHEMERAL = 1 << 6;
         /// This message is an Interaction Response and the bot is "thinking".
-        LOADING = 1 << 7;
+        const LOADING = 1 << 7;
     }
 }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,6 +1,6 @@
 //! Models pertaining to the gateway.
 
-use bitflags::{__impl_bitflags, bitflags};
+use bitflags::bitflags;
 use url::Url;
 
 use super::prelude::*;
@@ -523,43 +523,33 @@ pub struct ActivityTimestamps {
     pub start: Option<u64>,
 }
 
-/// [Gateway Intents] will limit the events your bot will receive via the gateway.
-/// By default, all intents except [Privileged Intents] are selected.
-///
-/// # What are Intents
-///
-/// A [gateway intent] sets the types of gateway events
-/// (e.g. member joins, guild integrations, guild emoji updates, ...) the
-/// bot shall receive. Carefully picking the needed intents greatly helps
-/// the bot to scale, as less intents will result in less events to be
-/// received via the network from Discord and less processing needed for
-/// handling the data.
-///
-/// # Privileged Intents
-///
-/// The intents [`GatewayIntents::GUILD_PRESENCES`] and [`GatewayIntents::GUILD_MEMBERS`]
-/// are [Privileged Intents]. They need to be enabled in the
-/// *developer portal*.
-///
-/// **Note**:
-/// Once the bot is in 100 guilds or more, [the bot must be verified] in
-/// order to use privileged intents.
-///
-/// [gateway intent]: https://discord.com/developers/docs/topics/gateway#privileged-intents
-/// [Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
-/// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
-pub struct GatewayIntents {
-    /// The flags composing gateway intents.
+bitflags! {
+    /// [Gateway Intents] will limit the events your bot will receive via the gateway.
+    /// By default, all intents except [Privileged Intents] are selected.
     ///
-    /// # Note
-    /// Do not modify this yourself; use the provided methods.
-    /// Do the same when creating, unless you're absolutely certain that you're giving valid intents flags.
-    pub bits: u64,
-}
-
-__impl_bitflags! {
-    GatewayIntents: u64 {
+    /// # What are Intents
+    ///
+    /// A [gateway intent] sets the types of gateway events
+    /// (e.g. member joins, guild integrations, guild emoji updates, ...) the
+    /// bot shall receive. Carefully picking the needed intents greatly helps
+    /// the bot to scale, as less intents will result in less events to be
+    /// received via the network from Discord and less processing needed for
+    /// handling the data.
+    ///
+    /// # Privileged Intents
+    ///
+    /// The intents [`GatewayIntents::GUILD_PRESENCES`] and [`GatewayIntents::GUILD_MEMBERS`]
+    /// are [Privileged Intents]. They need to be enabled in the
+    /// *developer portal*.
+    ///
+    /// **Note**:
+    /// Once the bot is in 100 guilds or more, [the bot must be verified] in
+    /// order to use privileged intents.
+    ///
+    /// [gateway intent]: https://discord.com/developers/docs/topics/gateway#privileged-intents
+    /// [Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
+    /// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
+    pub struct GatewayIntents: u64 {
         /// Enables following gateway events:
         ///
         /// - GUILD_CREATE
@@ -580,7 +570,7 @@ __impl_bitflags! {
         /// - STAGE_INSTANCE_CREATE
         /// - STAGE_INSTANCE_UPDATE
         /// - STAGE_INSTANCE_DELETE
-        GUILDS = 1;
+        const GUILDS = 1;
         /// Enables following gateway events:
         ///
         /// - GUILD_MEMBER_ADD
@@ -594,37 +584,37 @@ __impl_bitflags! {
         /// Developer Portal and enable the toggle for *Privileged Intents*.
         ///
         /// This intent is also necessary to even receive the events in contains.
-        GUILD_MEMBERS = 1 << 1;
+        const GUILD_MEMBERS = 1 << 1;
         /// Enables following gateway events:
         ///
         /// - GUILD_BAN_ADD
         /// - GUILD_BAN_REMOVE
-        GUILD_BANS = 1 << 2;
+        const GUILD_BANS = 1 << 2;
         /// Enables following gateway event:
         ///
         /// - GUILD_EMOJIS_UPDATE
         /// - GUILD_STICKERS_UPDATE
-        GUILD_EMOJIS_AND_STICKERS = 1 << 3;
+        const GUILD_EMOJIS_AND_STICKERS = 1 << 3;
         /// Enables following gateway event:
         ///
         /// - GUILD_INTEGRATIONS_UPDATE
         /// - INTEGRATION_CREATE
         /// - INTEGRATION_UPDATE
         /// - INTEGRATION_DELETE
-        GUILD_INTEGRATIONS = 1 << 4;
+        const GUILD_INTEGRATIONS = 1 << 4;
         /// Enables following gateway event:
         ///
         /// - WEBHOOKS_UPDATE
-        GUILD_WEBHOOKS = 1 << 5;
+        const GUILD_WEBHOOKS = 1 << 5;
         /// Enables following gateway events:
         ///
         /// - INVITE_CREATE
         /// - INVITE_DELETE
-        GUILD_INVITES = 1 << 6;
+        const GUILD_INVITES = 1 << 6;
         /// Enables following gateway event:
         ///
         /// - VOICE_STATE_UPDATE
-        GUILD_VOICE_STATES = 1 << 7;
+        const GUILD_VOICE_STATES = 1 << 7;
         /// Enables following gateway event:
         ///
         /// - PRESENCE_UPDATE
@@ -635,43 +625,43 @@ __impl_bitflags! {
         /// Developer Portal and enable the toggle for *Privileged Intents*.
         ///
         /// This intent is also necessary to even receive the events in contains.
-        GUILD_PRESENCES = 1 << 8;
+        const GUILD_PRESENCES = 1 << 8;
         /// Enables following gateway events:
         ///
         /// - MESSAGE_CREATE
         /// - MESSAGE_UPDATE
         /// - MESSAGE_DELETE
         /// - MESSAGE_DELETE_BULK
-        GUILD_MESSAGES = 1 << 9;
+        const GUILD_MESSAGES = 1 << 9;
         /// Enables following gateway events:
         ///
         /// - MESSAGE_REACTION_ADD
         /// - MESSAGE_REACTION_REMOVE
         /// - MESSAGE_REACTION_REMOVE_ALL
         /// - MESSAGE_REACTION_REMOVE_EMOJI
-        GUILD_MESSAGE_REACTIONS = 1 << 10;
+        const GUILD_MESSAGE_REACTIONS = 1 << 10;
         /// Enable following gateway event:
         ///
         /// - TYPING_START
-        GUILD_MESSAGE_TYPING = 1 << 11;
+        const GUILD_MESSAGE_TYPING = 1 << 11;
         /// Enable following gateway events:
         ///
         /// - MESSAGE_CREATE
         /// - MESSAGE_UPDATE
         /// - MESSAGE_DELETE
         /// - CHANNEL_PINS_UPDATE
-        DIRECT_MESSAGES = 1 << 12;
+        const DIRECT_MESSAGES = 1 << 12;
         /// Enable following gateway events:
         ///
         /// - MESSAGE_REACTION_ADD
         /// - MESSAGE_REACTION_REMOVE
         /// - MESSAGE_REACTION_REMOVE_ALL
         /// - MESSAGE_REACTION_REMOVE_EMOJI
-        DIRECT_MESSAGE_REACTIONS = 1 << 13;
+        const DIRECT_MESSAGE_REACTIONS = 1 << 13;
         /// Enable following gateway event:
         ///
         /// - TYPING_START
-        DIRECT_MESSAGE_TYPING = 1 << 14;
+        const DIRECT_MESSAGE_TYPING = 1 << 14;
     }
 }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use bitflags::__impl_bitflags;
+use bitflags::bitflags;
 use chrono::{DateTime, Utc};
 
 #[cfg(feature = "model")]
@@ -652,16 +652,11 @@ pub struct ThreadMember {
     pub flags: ThreadMemberFlags,
 }
 
-/// Describes extra features of the message.
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
-pub struct ThreadMemberFlags {
-    pub bits: u64,
-}
-
-__impl_bitflags! {
-    ThreadMemberFlags: u64 {
+bitflags! {
+    /// Describes extra features of the message.
+    pub struct ThreadMemberFlags: u64 {
         // Not documented.
-        NOTIFICATIONS = 1 << 0;
+        const NOTIFICATIONS = 1 << 0;
     }
 }
 

--- a/src/model/guild/system_channel.rs
+++ b/src/model/guild/system_channel.rs
@@ -1,21 +1,17 @@
-use bitflags::__impl_bitflags;
+use bitflags::bitflags;
 
-/// Describes a system channel flags.
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Default)]
-pub struct SystemChannelFlags {
-    pub bits: u64,
-}
-
-__impl_bitflags! {
-    SystemChannelFlags: u64 {
+bitflags! {
+    /// Describes a system channel flags.
+    #[derive(Default)]
+    pub struct SystemChannelFlags: u64 {
         /// Suppress member join notifications.
-        SUPPRESS_JOIN_NOTIFICATIONS = 1 << 0;
+        const SUPPRESS_JOIN_NOTIFICATIONS = 1 << 0;
         /// Suppress server boost notifications.
-        SUPPRESS_PREMIUM_SUBSCRIPTIONS = 1 << 1;
+        const SUPPRESS_PREMIUM_SUBSCRIPTIONS = 1 << 1;
         /// Suppress server setup tips.
-        SUPPRESS_GUILD_REMINDER_NOTIFICATIONS = 1 << 2;
+        const SUPPRESS_GUILD_REMINDER_NOTIFICATIONS = 1 << 2;
         /// Hide member join sticker reply buttons.
-        SUPPRESS_JOIN_NOTIFICATION_REPLIES = 1 << 3;
+        const SUPPRESS_JOIN_NOTIFICATION_REPLIES = 1 << 3;
     }
 }
 

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -5,7 +5,7 @@ pub mod ping;
 
 use application_command::ApplicationCommandInteraction;
 use autocomplete::AutocompleteInteraction;
-use bitflags::__impl_bitflags;
+use bitflags::bitflags;
 use message_component::MessageComponentInteraction;
 use ping::PingInteraction;
 use serde::de::{Deserialize, Deserializer, Error as DeError};
@@ -168,18 +168,12 @@ enum_number!(InteractionType {
     Autocomplete,
 });
 
-/// The flags for an interaction response.
-#[derive(Clone)]
-#[non_exhaustive]
-pub struct InteractionApplicationCommandCallbackDataFlags {
-    bits: u64,
-}
-
-__impl_bitflags! {
-    InteractionApplicationCommandCallbackDataFlags: u64 {
+bitflags! {
+    /// The flags for an interaction response.
+    pub struct InteractionApplicationCommandCallbackDataFlags: u64 {
         /// Interaction message will only be visible to sender and will
         /// be quickly deleted.
-        EPHEMERAL = 1 << 6;
+        const EPHEMERAL = 1 << 6;
     }
 }
 

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -44,7 +44,7 @@
 #[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use bitflags::__impl_bitflags;
+use bitflags::bitflags;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
@@ -220,51 +220,41 @@ pub const PRESET_VOICE: Permissions = Permissions {
     bits: Permissions::CONNECT.bits | Permissions::SPEAK.bits | Permissions::USE_VAD.bits,
 };
 
-/// A set of permissions that can be assigned to [`User`]s and [`Role`]s via
-/// [`PermissionOverwrite`]s, roles globally in a [`Guild`], and to
-/// [`GuildChannel`]s.
-///
-/// [`Guild`]: super::guild::Guild
-/// [`GuildChannel`]: super::channel::GuildChannel
-/// [`PermissionOverwrite`]: super::channel::PermissionOverwrite
-/// [`Role`]: super::guild::Role
-/// [`User`]: super::user::User
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
-pub struct Permissions {
-    /// The flags making up the permissions.
+bitflags! {
+    /// A set of permissions that can be assigned to [`User`]s and [`Role`]s via
+    /// [`PermissionOverwrite`]s, roles globally in a [`Guild`], and to
+    /// [`GuildChannel`]s.
     ///
-    /// # Note
-    /// Do not modify this yourself; use the provided methods.
-    /// Do the same when creating, unless you're absolutely certain that you're giving valid permission flags.
-    pub bits: u64,
-}
-
-__impl_bitflags! {
-    Permissions: u64 {
+    /// [`Guild`]: super::guild::Guild
+    /// [`GuildChannel`]: super::channel::GuildChannel
+    /// [`PermissionOverwrite`]: super::channel::PermissionOverwrite
+    /// [`Role`]: super::guild::Role
+    /// [`User`]: super::user::User
+    pub struct Permissions: u64 {
         /// Allows for the creation of [`RichInvite`]s.
         ///
         /// [`RichInvite`]: super::invite::RichInvite
-        CREATE_INVITE = 1 << 0;
+        const CREATE_INVITE = 1 << 0;
         /// Allows for the kicking of guild [member]s.
         ///
         /// [member]: super::guild::Member
-        KICK_MEMBERS = 1 << 1;
+        const KICK_MEMBERS = 1 << 1;
         /// Allows the banning of guild [member]s.
         ///
         /// [member]: super::guild::Member
-        BAN_MEMBERS = 1 << 2;
+        const BAN_MEMBERS = 1 << 2;
         /// Allows all permissions, bypassing channel [permission overwrite]s.
         ///
         /// [permission overwrite]: super::channel::PermissionOverwrite
-        ADMINISTRATOR = 1 << 3;
+        const ADMINISTRATOR = 1 << 3;
         /// Allows management and editing of guild [channel]s.
         ///
         /// [channel]: super::channel::GuildChannel
-        MANAGE_CHANNELS = 1 << 4;
+        const MANAGE_CHANNELS = 1 << 4;
         /// Allows management and editing of the [guild].
         ///
         /// [guild]: super::guild::Guild
-        MANAGE_GUILD = 1 << 5;
+        const MANAGE_GUILD = 1 << 5;
         /// [`Member`]s with this permission can add new [`Reaction`]s to a
         /// [`Message`]. Members can still react using reactions already added
         /// to messages without this permission.
@@ -272,92 +262,92 @@ __impl_bitflags! {
         /// [`Member`]: super::guild::Member
         /// [`Message`]: super::channel::Message
         /// [`Reaction`]: super::channel::Reaction
-        ADD_REACTIONS = 1 << 6;
+        const ADD_REACTIONS = 1 << 6;
         /// Allows viewing a guild's audit logs.
-        VIEW_AUDIT_LOG = 1 << 7;
+        const VIEW_AUDIT_LOG = 1 << 7;
         /// Allows the use of priority speaking in voice channels.
-        PRIORITY_SPEAKER = 1 << 8;
+        const PRIORITY_SPEAKER = 1 << 8;
         // Allows the user to go live
-        STREAM = 1 << 9;
+        const STREAM = 1 << 9;
         /// Allows reading messages in a guild channel. If a user does not have
         /// this permission, then they will not be able to see the channel.
-        READ_MESSAGES = 1 << 10;
+        const READ_MESSAGES = 1 << 10;
         /// Allows sending messages in a guild channel.
-        SEND_MESSAGES = 1 << 11;
+        const SEND_MESSAGES = 1 << 11;
         /// Allows the sending of text-to-speech messages in a channel.
-        SEND_TTS_MESSAGES = 1 << 12;
+        const SEND_TTS_MESSAGES = 1 << 12;
         /// Allows the deleting of other messages in a guild channel.
         ///
         /// **Note**: This does not allow the editing of other messages.
-        MANAGE_MESSAGES = 1 << 13;
+        const MANAGE_MESSAGES = 1 << 13;
         /// Allows links from this user - or users of this role - to be
         /// embedded, with potential data such as a thumbnail, description, and
         /// page name.
-        EMBED_LINKS = 1 << 14;
+        const EMBED_LINKS = 1 << 14;
         /// Allows uploading of files.
-        ATTACH_FILES = 1 << 15;
+        const ATTACH_FILES = 1 << 15;
         /// Allows the reading of a channel's message history.
-        READ_MESSAGE_HISTORY = 1 << 16;
+        const READ_MESSAGE_HISTORY = 1 << 16;
         /// Allows the usage of the `@everyone` mention, which will notify all
         /// users in a channel. The `@here` mention will also be available, and
         /// can be used to mention all non-offline users.
         ///
         /// **Note**: You probably want this to be disabled for most roles and
         /// users.
-        MENTION_EVERYONE = 1 << 17;
+        const MENTION_EVERYONE = 1 << 17;
         /// Allows the usage of custom emojis from other guilds.
         ///
         /// This does not dictate whether custom emojis in this guild can be
         /// used in other guilds.
-        USE_EXTERNAL_EMOJIS = 1 << 18;
+        const USE_EXTERNAL_EMOJIS = 1 << 18;
         /// Allows for viewing guild insights.
-        VIEW_GUILD_INSIGHTS = 1 << 19;
+        const VIEW_GUILD_INSIGHTS = 1 << 19;
         /// Allows the joining of a voice channel.
-        CONNECT = 1 << 20;
+        const CONNECT = 1 << 20;
         /// Allows the user to speak in a voice channel.
-        SPEAK = 1 << 21;
+        const SPEAK = 1 << 21;
         /// Allows the muting of members in a voice channel.
-        MUTE_MEMBERS = 1 << 22;
+        const MUTE_MEMBERS = 1 << 22;
         /// Allows the deafening of members in a voice channel.
-        DEAFEN_MEMBERS = 1 << 23;
+        const DEAFEN_MEMBERS = 1 << 23;
         /// Allows the moving of members from one voice channel to another.
-        MOVE_MEMBERS = 1 << 24;
+        const MOVE_MEMBERS = 1 << 24;
         /// Allows the usage of voice-activity-detection in a [voice] channel.
         ///
         /// If this is disabled, then [`Member`]s must use push-to-talk.
         ///
         /// [`Member`]: super::guild::Member
         /// [voice]: super::channel::ChannelType::Voice
-        USE_VAD = 1 << 25;
+        const USE_VAD = 1 << 25;
         /// Allows members to change their own nickname in the guild.
-        CHANGE_NICKNAME = 1 << 26;
+        const CHANGE_NICKNAME = 1 << 26;
         /// Allows members to change other members' nicknames.
-        MANAGE_NICKNAMES = 1 << 27;
+        const MANAGE_NICKNAMES = 1 << 27;
         /// Allows management and editing of roles below their own.
-        MANAGE_ROLES = 1 << 28;
+        const MANAGE_ROLES = 1 << 28;
         /// Allows management of webhooks.
-        MANAGE_WEBHOOKS = 1 << 29;
+        const MANAGE_WEBHOOKS = 1 << 29;
         /// Allows management of emojis and stickers created without the use of an
         /// [`Integration`].
         ///
         /// [`Integration`]: super::guild::Integration
-        MANAGE_EMOJIS_AND_STICKERS = 1 << 30;
+        const MANAGE_EMOJIS_AND_STICKERS = 1 << 30;
         /// Allows using slash commands.
-        USE_SLASH_COMMANDS = 1 << 31;
+        const USE_SLASH_COMMANDS = 1 << 31;
         /// Allows for requesting to speak in stage channels.
-        REQUEST_TO_SPEAK = 1 << 32;
+        const REQUEST_TO_SPEAK = 1 << 32;
         /// Allows for deleting and archiving threads, and viewing all private threads.
-        MANAGE_THREADS = 1 << 34;
+        const MANAGE_THREADS = 1 << 34;
         /// Allows for creating threads.
-        CREATE_PUBLIC_THREADS = 1 << 35;
+        const CREATE_PUBLIC_THREADS = 1 << 35;
         /// Allows for creating private threads.
-        CREATE_PRIVATE_THREADS = 1 << 36;
+        const CREATE_PRIVATE_THREADS = 1 << 36;
         /// Allows the usage of custom stickers from other servers.
-        USE_EXTERNAL_STICKERS = 1 << 37;
+        const USE_EXTERNAL_STICKERS = 1 << 37;
         /// Allows for sending messages in threads
-        SEND_MESSAGES_IN_THREADS = 1 << 38;
+        const SEND_MESSAGES_IN_THREADS = 1 << 38;
         /// Allows for launching activities in a voice channel
-        START_EMBEDDED_ACTIVITIES = 1 << 39;
+        const START_EMBEDDED_ACTIVITIES = 1 << 39;
     }
 }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -4,7 +4,7 @@ use std::fmt;
 #[cfg(feature = "model")]
 use std::fmt::Write;
 
-use bitflags::__impl_bitflags;
+use bitflags::bitflags;
 #[cfg(feature = "model")]
 use futures::future::{BoxFuture, FutureExt};
 use serde::{Deserialize, Serialize};
@@ -635,42 +635,37 @@ pub struct User {
     pub public_flags: Option<UserPublicFlags>,
 }
 
-/// User's public flags
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct UserPublicFlags {
-    pub bits: u32,
-}
-
-__impl_bitflags! {
-    UserPublicFlags: u32 {
+bitflags! {
+    /// User's public flags
+    pub struct UserPublicFlags: u32 {
         /// User's flag as discord employee
-        DISCORD_EMPLOYEE = 1 << 0;
+        const DISCORD_EMPLOYEE = 1 << 0;
         /// User's flag as partnered server owner
-        PARTNERED_SERVER_OWNER = 1 << 1;
+        const PARTNERED_SERVER_OWNER = 1 << 1;
         /// User's flag as hypesquad events
-        HYPESQUAD_EVENTS = 1 << 2;
+        const HYPESQUAD_EVENTS = 1 << 2;
         /// User's flag as bug hunter level 1
-        BUG_HUNTER_LEVEL_1 = 1 << 3;
+        const BUG_HUNTER_LEVEL_1 = 1 << 3;
         /// User's flag as house bravery
-        HOUSE_BRAVERY = 1 << 6;
+        const HOUSE_BRAVERY = 1 << 6;
         /// User's flag as house brilliance
-        HOUSE_BRILLIANCE = 1 << 7;
+        const HOUSE_BRILLIANCE = 1 << 7;
         /// User's flag as house balance
-        HOUSE_BALANCE = 1 << 8;
+        const HOUSE_BALANCE = 1 << 8;
         /// User's flag as early supporter
-        EARLY_SUPPORTER = 1 << 9;
+        const EARLY_SUPPORTER = 1 << 9;
         /// User's flag as team user
-        TEAM_USER = 1 << 10;
+        const TEAM_USER = 1 << 10;
         /// User's flag as system
-        SYSTEM = 1 << 12;
+        const SYSTEM = 1 << 12;
         /// User's flag as bug hunter level 2
-        BUG_HUNTER_LEVEL_2 = 1 << 14;
+        const BUG_HUNTER_LEVEL_2 = 1 << 14;
         /// User's flag as verified bot
-        VERIFIED_BOT = 1 << 16;
+        const VERIFIED_BOT = 1 << 16;
         /// User's flag as early verified bot developer
-        EARLY_VERIFIED_BOT_DEVELOPER = 1 << 17;
+        const EARLY_VERIFIED_BOT_DEVELOPER = 1 << 17;
         /// User's flag as discord certified moderator
-        DISCORD_CERTIFIED_MODERATOR = 1 << 18;
+        const DISCORD_CERTIFIED_MODERATOR = 1 << 18;
     }
 }
 


### PR DESCRIPTION
The use of the `__impl_bitflags` macro was introduced at the time to help
language servers to resolve types for autocompletion. Much has changed
since then, `RLS` has been superseded by `rust-analyzer` and
`rust-analyzer` supports `local_inner_macros`.

**BREAKING CHANGE:** The `bits` field of the bitflags is now private. Use
`T::bits()` or `T::from_bits_truncate()` instead.