### PR TITLE
Add `ExecuteWebhook::allowed_mentions` method

### DIFF
--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use crate::json::Value;
+use super::CreateAllowedMentions;
+use crate::json::{self, Value};
 use crate::model::channel::AttachmentType;
 
 /// A builder to create the inner content of a [`Webhook`]'s execution.
@@ -133,6 +134,20 @@ impl<'a> ExecuteWebhook<'a> {
         files: It,
     ) -> &mut Self {
         self.1 = files.into_iter().map(|f| f.into()).collect();
+        self
+    }
+
+    /// Set the allowed mentions for the message.
+    pub fn allowed_mentions<F>(&mut self, f: F) -> &mut Self
+    where
+        F: FnOnce(&mut CreateAllowedMentions) -> &mut CreateAllowedMentions,
+    {
+        let mut allowed_mentions = CreateAllowedMentions::default();
+        f(&mut allowed_mentions);
+        let map = json::hashmap_to_json_map(allowed_mentions.0);
+        let allowed_mentions = Value::from(map);
+
+        self.0.insert("allowed_mentions", allowed_mentions);
         self
     }
 


### PR DESCRIPTION
Discord's docs indicate an `allowed_mentions` field on the "Execute Webhook" endpoint whose implementation was missing. A copy and paste of the same implementation used elsewhere in the code did the trick. This PR addresses #1609, at least in part.