### PR TITLE
Replace `GuildStatus` with `UnavailableGuild` in the ready event

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1213,7 +1213,7 @@ mod test {
         assert!(cache.update(&mut event).is_none());
 
         let mut guild_delete = GuildDeleteEvent {
-            guild: GuildUnavailable {
+            guild: UnavailableGuild {
                 id: GuildId(1),
                 unavailable: false,
             },

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -93,12 +93,12 @@ pub trait EventHandler: Send + Sync {
     /// If the flag is false, the bot was removed from the guild, either by being
     /// kicked or banned. If the flag is true, the guild went offline.
     ///
-    /// [`unavailable`]: GuildUnavailable::unavailable
+    /// [`unavailable`]: UnavailableGuild::unavailable
     #[cfg(feature = "cache")]
     async fn guild_delete(
         &self,
         _ctx: Context,
-        _incomplete: GuildUnavailable,
+        _incomplete: UnavailableGuild,
         _full: Option<Guild>,
     ) {
     }
@@ -111,9 +111,9 @@ pub trait EventHandler: Send + Sync {
     /// If the flag is false, the bot was removed from the guild, either by being
     /// kicked or banned. If the flag is true, the guild went offline.
     ///
-    /// [`unavailable`]: GuildUnavailable::unavailable
+    /// [`unavailable`]: UnavailableGuild::unavailable
     #[cfg(not(feature = "cache"))]
-    async fn guild_delete(&self, _ctx: Context, _incomplete: GuildUnavailable) {}
+    async fn guild_delete(&self, _ctx: Context, _incomplete: UnavailableGuild) {}
 
     // the emojis were updated.
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -264,7 +264,7 @@ impl CacheUpdate for GuildCreateEvent {
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct GuildDeleteEvent {
-    pub guild: GuildUnavailable,
+    pub guild: UnavailableGuild,
 }
 
 #[cfg(feature = "cache")]
@@ -994,24 +994,15 @@ impl CacheUpdate for ReadyEvent {
     fn update(&mut self, cache: &Cache) -> Option<()> {
         let mut ready = self.ready.clone();
 
-        for guild in ready.guilds {
-            match guild {
-                GuildStatus::Offline(unavailable) => {
-                    cache.guilds.remove(&unavailable.id);
-                    cache.unavailable_guilds.insert(unavailable.id);
-                },
-                GuildStatus::OnlineGuild(guild) => {
-                    cache.unavailable_guilds.remove(&guild.id);
-                    cache.guilds.insert(guild.id, guild);
-                },
-                GuildStatus::OnlinePartialGuild(_) => {},
-            }
+        for unavailable in ready.guilds {
+            cache.guilds.remove(&unavailable.id);
+            cache.unavailable_guilds.insert(unavailable.id);
         }
 
         // We may be removed from some guilds between disconnect and ready, so we should handle that.
         let mut guilds_to_remove = vec![];
         let ready_guilds_hashset =
-            HashSet::<GuildId>::from_iter(self.ready.guilds.iter().map(|status| status.id()));
+            HashSet::<GuildId>::from_iter(self.ready.guilds.iter().map(|status| status.id));
         let shard_data = self.ready.shard.unwrap_or([1, 1]);
         for guild_entry in cache.guilds.iter() {
             let guild = guild_entry.key();

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -488,7 +488,7 @@ pub struct Presence {
 #[non_exhaustive]
 pub struct Ready {
     pub application: PartialCurrentApplicationInfo,
-    pub guilds: Vec<GuildStatus>,
+    pub guilds: Vec<UnavailableGuild>,
     #[serde(default, with = "presences")]
     pub presences: HashMap<UserId, Presence>,
     #[serde(default, with = "private_channels")]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2946,34 +2946,12 @@ impl InviteGuild {
 
 /// Data for an unavailable guild.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct GuildUnavailable {
+pub struct UnavailableGuild {
     /// The Id of the [`Guild`] that may be unavailable.
     pub id: GuildId,
     /// Indicator of whether the guild is unavailable.
     #[serde(default)]
     pub unavailable: bool,
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
-#[serde(untagged)]
-pub enum GuildStatus {
-    OnlinePartialGuild(PartialGuild),
-    OnlineGuild(Guild),
-    Offline(GuildUnavailable),
-}
-
-#[cfg(feature = "model")]
-impl GuildStatus {
-    /// Retrieves the Id of the inner [`Guild`].
-    pub fn id(&self) -> GuildId {
-        match *self {
-            GuildStatus::Offline(offline) => offline.id,
-            GuildStatus::OnlineGuild(ref guild) => guild.id,
-            GuildStatus::OnlinePartialGuild(ref partial_guild) => partial_guild.id,
-        }
-    }
 }
 
 /// Default message notification level for a guild.


### PR DESCRIPTION
Apart from unavailable guild objects, Discord does not send partial guild
data with the ready event.

The struct `GuildUnavailable` is renamed to `UnavailableGuild` to bring
it in line with `PartialGuild`, `PartialMember` etc.

**BREAKING CHANGE:** The struct `model::guild::GuildUnavailable` is renamed to
`UnavailableGuild` and replaces `GuildStatus` in the list of unavailable
guilds in `model::gateway::Ready` for the ready event.