### PR TITLE
Remove workaround for serde_json's `arbitrary_precision` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 
 [dependencies]
 bitflags = "1.1"
-serde_json = "1"
+serde_json = "1.0.75"
 async-trait = "0.1.9"
 
 [dependencies.simd-json]

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -253,8 +253,8 @@ id_u64! {
 pub(crate) mod snowflake {
     use std::fmt;
 
-    use serde::de::{Error, MapAccess, Visitor};
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::de::{Error, Visitor};
+    use serde::{Deserializer, Serializer};
 
     pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
         deserializer.deserialize_any(SnowflakeVisitor)
@@ -280,39 +280,6 @@ pub(crate) mod snowflake {
 
         fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
             value.parse().map_err(Error::custom)
-        }
-
-        // This is called when serde_json's `arbitrary_precision` feature is enabled.
-        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-            let id = map.next_value::<Snowflake>()?;
-            Ok(id.value)
-        }
-    }
-
-    struct Snowflake {
-        value: u64,
-    }
-
-    impl<'de> Deserialize<'de> for Snowflake {
-        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-            struct StrVisitor;
-
-            impl<'de> Visitor<'de> for StrVisitor {
-                type Value = Snowflake;
-
-                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    formatter.write_str("string containing a number")
-                }
-
-                fn visit_str<E: Error>(self, s: &str) -> Result<Snowflake, E> {
-                    let value = s.parse().map_err(Error::custom)?;
-                    Ok(Snowflake {
-                        value,
-                    })
-                }
-            }
-
-            deserializer.deserialize_str(StrVisitor)
         }
     }
 }


### PR DESCRIPTION
In the past `serde_json` would call `Visitor::visit_map` for all numbers
when its `arbitrary_precision` feature is activated.
Since `serde_json` v1.0.75 that method is only called for 128bit numbers.


Original issue: #527
Fix in `serde_json`: https://github.com/serde-rs/json/pull/848