### PR TITLE
Improve the download of `Attachment`s by calling `Bytes::to_vec`

### DIFF
--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -122,7 +122,7 @@ impl Attachment {
     /// [`Message`]: super::Message
     pub async fn download(&self) -> Result<Vec<u8>> {
         let reqwest = ReqwestClient::new();
-
-        Ok(reqwest.get(&self.url).send().await?.bytes().await?.into_iter().collect::<Vec<u8>>())
+        let bytes = reqwest.get(&self.url).send().await?.bytes().await?;
+        Ok(bytes.to_vec())
     }
 }


### PR DESCRIPTION
The returned `Bytes` from `reqwest` implements the `Deref` trait for `[u8]`.