### PR TITLE
Derive `Default` trait for all bitflags types

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1209,6 +1209,7 @@ pub struct ChannelMention {
 
 bitflags! {
     /// Describes extra features of the message.
+    #[derive(Default)]
     pub struct MessageFlags: u64 {
         /// This message has been published to subscribed channels (via Channel Following).
         const CROSSPOSTED = 1 << 0;

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -294,6 +294,7 @@ pub struct ActivityAssets {
 
 bitflags! {
     /// A set of flags defining what is in an activity's payload.
+    #[derive(Default)]
     pub struct ActivityFlags: u64 {
         /// Whether the activity is an instance activity.
         const INSTANCE = 1 << 0;
@@ -549,6 +550,7 @@ bitflags! {
     /// [gateway intent]: https://discord.com/developers/docs/topics/gateway#privileged-intents
     /// [Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
     /// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
+    #[derive(Default)]
     pub struct GatewayIntents: u64 {
         /// Enables following gateway events:
         ///
@@ -662,12 +664,6 @@ bitflags! {
         ///
         /// - TYPING_START
         const DIRECT_MESSAGE_TYPING = 1 << 14;
-    }
-}
-
-impl Default for GatewayIntents {
-    fn default() -> Self {
-        Self::empty()
     }
 }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -654,6 +654,7 @@ pub struct ThreadMember {
 
 bitflags! {
     /// Describes extra features of the message.
+    #[derive(Default)]
     pub struct ThreadMemberFlags: u64 {
         // Not documented.
         const NOTIFICATIONS = 1 << 0;

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -170,6 +170,7 @@ enum_number!(InteractionType {
 
 bitflags! {
     /// The flags for an interaction response.
+    #[derive(Default)]
     pub struct InteractionApplicationCommandCallbackDataFlags: u64 {
         /// Interaction message will only be visible to sender and will
         /// be quickly deleted.

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -230,6 +230,7 @@ bitflags! {
     /// [`PermissionOverwrite`]: super::channel::PermissionOverwrite
     /// [`Role`]: super::guild::Role
     /// [`User`]: super::user::User
+    #[derive(Default)]
     pub struct Permissions: u64 {
         /// Allows for the creation of [`RichInvite`]s.
         ///
@@ -661,12 +662,6 @@ impl Permissions {
     /// [Use VAD]: Self::USE_VAD
     pub fn use_vad(self) -> bool {
         self.contains(Self::USE_VAD)
-    }
-}
-
-impl Default for Permissions {
-    fn default() -> Self {
-        Self::empty()
     }
 }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -637,6 +637,7 @@ pub struct User {
 
 bitflags! {
     /// User's public flags
+    #[derive(Default)]
     pub struct UserPublicFlags: u32 {
         /// User's flag as discord employee
         const DISCORD_EMPLOYEE = 1 << 0;


### PR DESCRIPTION
The removed manual `Default` implementations are identical to the
derived implementation.