### PR TITLE
Mark the `model::guild::Region` enum as deprecated

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -3073,6 +3073,7 @@ enum_number!(MfaLevel {
 /// The name of a region that a voice server can be located in.
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 #[non_exhaustive]
+#[deprecated(note = "Regions are now set per voice channel instead of globally.")]
 pub enum Region {
     #[serde(rename = "amsterdam")]
     Amsterdam,


### PR DESCRIPTION
Regions are now set per voice channel instead of globally.

[#1306] marked the field and the builder method but missed deprecating the `Region` enum.


[#1306]: https://github.com/serenity-rs/serenity/pull/1306