### PR TITLE
Change the return type of `Route::stage_instances` to `&'static str`

### DIFF
--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1031,8 +1031,8 @@ impl Route {
         api!("/applications/{}/guilds/{}/commands/permissions", application_id, guild_id)
     }
 
-    pub fn stage_instances() -> String {
-        api!("/stage-instances").to_string()
+    pub fn stage_instances() -> &'static str {
+        api!("/stage-instances")
     }
 
     pub fn stage_instance(channel_id: u64) -> String {


### PR DESCRIPTION
Functions without parameters should return the static string directly.

**BREAKING CHANGE:** The function `Route::stage_instances` now returns
a `&'static str` instead of a `String`.