### PR TITLE
Express all example crates as workspace members with a wildcard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,7 @@ edition = "2018"
 include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 
 [workspace]
-members = [
-    "examples/e01_basic_ping_bot",
-    "examples/e02_transparent_guild_sharding",
-    "examples/e03_struct_utilities",
-    "examples/e04_message_builder",
-    "examples/e05_command_framework",
-    "examples/e06_sample_bot_structure",
-    "examples/e07_env_logging",
-    "examples/e08_shard_manager",
-    "examples/e09_create_message_builder",
-    "examples/e10_collectors",
-    "examples/e11_gateway_intents",
-    "examples/e12_global_data",
-    "examples/e13_parallel_loops",
-    "examples/e14_slash_commands",
-    "examples/e15_simple_dashboard",
-    "examples/e16_sqlite_database",
-    "examples/e17_message_components"
-]
+members = ["examples/*"]
 
 [dependencies]
 bitflags = "1.1"

--- a/examples/README.md
+++ b/examples/README.md
@@ -73,4 +73,3 @@ If you add a new example also add it to the following files:
 - `.github/workflows/ci.yml`
 - `Makefile.toml`
 - `examples/README.md`
-- `Cargo.toml` -> `workspace.members`


### PR DESCRIPTION
This reduces the maintenance burden when adding or removing examples.
