### PR TITLE
Deprecate `slow_mode_rate`/`rate_limit` methods and field

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -569,7 +569,7 @@ async fn am_i_admin(ctx: &Context, msg: &Message, _args: Args) -> CommandResult 
 async fn slow_mode(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
     let say_content = if let Ok(slow_mode_rate_seconds) = args.single::<u64>() {
         if let Err(why) =
-            msg.channel_id.edit(&ctx.http, |c| c.slow_mode_rate(slow_mode_rate_seconds)).await
+            msg.channel_id.edit(&ctx.http, |c| c.rate_limit_per_user(slow_mode_rate_seconds)).await
         {
             println!("Error setting channel's slow mode rate: {:?}", why);
 
@@ -579,7 +579,9 @@ async fn slow_mode(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
         }
     } else if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx.cache).await
     {
-        format!("Current slow mode rate is `{}` seconds.", channel.slow_mode_rate.unwrap_or(0))
+        #[allow(deprecated)]
+        let slow_mode_rate = channel.slow_mode_rate.unwrap_or(0);
+        format!("Current slow mode rate is `{}` seconds.", slow_mode_rate)
     } else {
         "Failed to find channel in cache.".to_string()
     };

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -76,8 +76,23 @@ impl CreateChannel {
     ///
     /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
     /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
+    #[deprecated(note = "replaced by `rate_limit_per_user`")]
     pub fn rate_limit(&mut self, limit: u64) -> &mut Self {
-        self.0.insert("rate_limit_per_user", Value::Number(Number::from(limit)));
+        self.rate_limit_per_user(limit)
+    }
+
+    /// How many seconds must a user wait before sending another message.
+    ///
+    /// Bots, or users with the [`MANAGE_MESSAGES`] and/or [`MANAGE_CHANNELS`] permissions are exempt
+    /// from this restriction.
+    ///
+    /// **Note**: Must be between 0 and 21600 seconds (360 minutes or 6 hours).
+    ///
+    /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
+    /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
+    #[doc(alias = "slowmode")]
+    pub fn rate_limit_per_user(&mut self, seconds: u64) -> &mut Self {
+        self.0.insert("rate_limit_per_user", Value::Number(Number::from(seconds)));
 
         self
     }

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -137,8 +137,23 @@ impl EditChannel {
     /// The seconds a user has to wait before sending another message.
     ///
     /// **Note**: Must be between 0 and 21600 seconds (360 minutes or 6 hours).
+    #[deprecated(note = "replaced by `rate_limit_per_user`")]
     #[inline]
     pub fn slow_mode_rate(&mut self, seconds: u64) -> &mut Self {
+        self.rate_limit_per_user(seconds)
+    }
+
+    /// How many seconds must a user wait before sending another message.
+    ///
+    /// Bots, or users with the [`MANAGE_MESSAGES`] and/or [`MANAGE_CHANNELS`] permissions are exempt
+    /// from this restriction.
+    ///
+    /// **Note**: Must be between 0 and 21600 seconds (360 minutes or 6 hours).
+    ///
+    /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
+    /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
+    #[doc(alias = "slowmode")]
+    pub fn rate_limit_per_user(&mut self, seconds: u64) -> &mut Self {
         self.0.insert("rate_limit_per_user", Value::Number(Number::from(seconds)));
 
         self

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -107,6 +107,8 @@ pub struct GuildChannel {
     ///
     /// **Note**: This is only available for text channels excluding news
     /// channels.
+    #[doc(alias = "slowmode")]
+    #[deprecated(note = "will be renamed to `rate_limit_per_user` with serenity 0.11")]
     #[serde(default, rename = "rate_limit_per_user")]
     pub slow_mode_rate: Option<u64>,
     /// The region override.


### PR DESCRIPTION
Adds the method `rate_limit_per_user` to `CreateChannel` and
`EditChannel` with a documentation alias for `slowmode`.

The `GuildChannel::slow_mode_rate` field marked with a notice about the
upcoming rename.

**DEPRECATION**: The methods `CreateChannel::rate_limit`, `EditChannel::slow_mode_rate`
and the field `GuildChannel::slow_mode_rate` are deprecated in favor of
Discord's name `rate_limit_per_user`.