### PR TITLE
Replace the use of `DateTime<Utc>` with a newtype struct `Timestamp`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - no default features
           - no cache
           - no gateway
+          - time
           - unstable Discord API features
           - rustls tokio 0.2
           - native-tls tokio 0.2
@@ -44,6 +45,8 @@ jobs:
             features: default_no_backend rustls_backend simd-json
           - name: no gateway
             features: model http rustls_backend
+          - name: time
+            features: time
           - name: unstable Discord API features
             features: default unstable_discord_api
             dont-test: true
@@ -105,7 +108,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Check
-        run: cargo check --all-features
+        run: cargo check --features collector,unstable_discord_api
 
   min_versions:
     name: Check minimal versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,11 @@ version = "0.6.0"
 optional = true
 version = "0.13"
 
+[dependencies.time]
+optional = true
+version = "0.3.6"
+features = ["formatting", "parsing", "serde-well-known"]
+
 [dependencies.chrono]
 default-features = false
 features = ["clock", "serde"]

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ enough level that optional parameters can be provided at will via a JsonMap.
 - **model**: Method implementations for models, acting as helper methods over
 the HTTP functions.
 - **standard_framework**: A standard, default implementation of the Framework
+- **time**: Use the `time` crate for Discord's timestamp fields. See `serenity::model::Timestamp`.
 - **utils**: Utility functions for common use cases by users.
 - **voice**: Enables registering a voice plugin to the client, which will handle actual voice connections from Discord.
 [lavalink-rs][project:lavalink-rs] or [Songbird][project:songbird] are recommended voice plugins.

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -15,12 +15,10 @@
 //! [here]: https://discord.com/developers/docs/resources/channel#embed-object
 
 use std::collections::HashMap;
-use std::fmt::Display;
-
-use chrono::{DateTime, TimeZone};
 
 use crate::json::{self, from_number, json, Value};
 use crate::model::channel::Embed;
+use crate::model::Timestamp;
 #[cfg(feature = "utils")]
 use crate::utils::Colour;
 
@@ -305,7 +303,7 @@ impl CreateEmbed {
     }
 
     fn _timestamp(&mut self, timestamp: Timestamp) {
-        self.0.insert("timestamp", Value::from(timestamp.ts));
+        self.0.insert("timestamp", Value::from(timestamp.to_string()));
     }
 
     /// Set the title of the embed.
@@ -468,49 +466,6 @@ impl CreateEmbedFooter {
     pub fn text<S: ToString>(&mut self, text: S) -> &mut Self {
         self.0.insert("text", Value::from(text.to_string()));
         self
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct Timestamp {
-    pub ts: String,
-}
-
-impl From<String> for Timestamp {
-    fn from(ts: String) -> Self {
-        Self {
-            ts,
-        }
-    }
-}
-
-impl<'a> From<&'a str> for Timestamp {
-    fn from(ts: &'a str) -> Self {
-        Self {
-            ts: ts.to_string(),
-        }
-    }
-}
-
-impl<Tz: TimeZone> From<DateTime<Tz>> for Timestamp
-where
-    Tz::Offset: Display,
-{
-    fn from(dt: DateTime<Tz>) -> Self {
-        Self {
-            ts: dt.to_rfc3339(),
-        }
-    }
-}
-
-impl<'a, Tz: TimeZone> From<&'a DateTime<Tz>> for Timestamp
-where
-    Tz::Offset: Display,
-{
-    fn from(dt: &'a DateTime<Tz>) -> Self {
-        Self {
-            ts: dt.to_rfc3339(),
-        }
     }
 }
 

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -1,12 +1,10 @@
 use std::collections::HashMap;
-use std::fmt::Display;
-
-use chrono::{DateTime, TimeZone};
 
 use crate::{internal::prelude::*, json::from_number};
 use crate::{
     json::NULL,
     model::id::{ChannelId, RoleId},
+    model::Timestamp,
 };
 
 /// A builder which edits the properties of a [`Member`], to be used in
@@ -114,13 +112,8 @@ impl EditMember {
     ///
     /// [Moderate Members]: crate::model::permissions::Permissions::MODERATE_MEMBERS
     #[doc(alias = "timeout")]
-    pub fn disable_communication_until_datetime<Tz>(&mut self, time: DateTime<Tz>) -> &mut Self
-    where
-        Tz: TimeZone,
-        Tz::Offset: Display,
-    {
-        let timestamp = time.to_rfc3339();
-        self.0.insert("communication_disabled_until", Value::String(timestamp));
+    pub fn disable_communication_until_datetime(&mut self, time: Timestamp) -> &mut Self {
+        self.0.insert("communication_disabled_until", Value::String(time.to_string()));
         self
     }
 

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 
-use chrono::{DateTime, Utc};
-
-use super::create_embed::Timestamp;
 use crate::internal::prelude::*;
 use crate::json;
+use crate::model::Timestamp;
 
 /// A builder which edits a user's voice state, to be used in conjunction with
 /// [`GuildChannel::edit_voice_state`].
@@ -34,9 +32,9 @@ impl EditVoiceState {
     /// [Request to Speak]: crate::model::permissions::Permissions::REQUEST_TO_SPEAK
     pub fn request_to_speak(&mut self, request: bool) -> &mut Self {
         if request {
-            self.request_to_speak_timestamp(Some(&Utc::now()));
+            self.request_to_speak_timestamp(Some(Timestamp::now()));
         } else {
-            self.request_to_speak_timestamp(None::<&DateTime<Utc>>);
+            self.request_to_speak_timestamp(None::<Timestamp>);
         }
 
         self
@@ -53,7 +51,7 @@ impl EditVoiceState {
         timestamp: Option<T>,
     ) -> &mut Self {
         if let Some(timestamp) = timestamp {
-            self.0.insert("request_to_speak_timestamp", Value::from(timestamp.into().ts));
+            self.0.insert("request_to_speak_timestamp", Value::from(timestamp.into().to_string()));
         } else {
             self.0.insert("request_to_speak_timestamp", json::NULL);
         }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -49,7 +49,7 @@ pub use self::{
     create_allowed_mentions::CreateAllowedMentions,
     create_allowed_mentions::ParseValue,
     create_channel::CreateChannel,
-    create_embed::{CreateEmbed, CreateEmbedAuthor, CreateEmbedFooter, Timestamp},
+    create_embed::{CreateEmbed, CreateEmbedAuthor, CreateEmbedFooter},
     create_invite::CreateInvite,
     create_message::CreateMessage,
     create_stage_instance::CreateStageInstance,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1032,8 +1032,6 @@ impl Default for Cache {
 mod test {
     use std::collections::HashMap;
 
-    use chrono::{DateTime, Utc};
-
     use crate::json::from_number;
     use crate::{
         cache::{Cache, CacheUpdate, Settings},
@@ -1047,10 +1045,7 @@ mod test {
         let cache = Cache::new_with_settings(settings);
 
         // Test inserting one message into a channel's message cache.
-        let datetime =
-            DateTime::parse_from_str("1983 Apr 13 12:09:14.274 +0000", "%Y %b %d %H:%M:%S%.3f %z")
-                .unwrap()
-                .with_timezone(&Utc);
+        let datetime = Timestamp::now();
         let mut event = MessageCreateEvent {
             message: Message {
                 id: MessageId(3),

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -3,7 +3,6 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[cfg(feature = "model")]
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
 #[cfg(feature = "cache")]
 use futures::stream::StreamExt;
 
@@ -41,6 +40,7 @@ use crate::json::{self, from_number};
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
+use crate::model::Timestamp;
 
 /// Represents a guild's text, news, or voice channel. Some methods are available
 /// only for voice channels and some are only available for text channels.
@@ -78,7 +78,7 @@ pub struct GuildChannel {
     /// The timestamp of the time a pin was most recently made.
     ///
     /// **Note**: This is only available for text channels.
-    pub last_pin_timestamp: Option<DateTime<Utc>>,
+    pub last_pin_timestamp: Option<Timestamp>,
     /// The name of the channel.
     pub name: String,
     /// Permission overwrites for [`Member`]s and for [`Role`]s.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -5,7 +5,6 @@ use std::fmt::Display;
 #[cfg(all(feature = "cache", feature = "model"))]
 use std::fmt::Write;
 
-use chrono::{DateTime, Utc};
 #[cfg(feature = "simd-json")]
 use simd_json::ValueAccess;
 
@@ -33,6 +32,7 @@ use crate::{
     model::{
         id::{ApplicationId, ChannelId, GuildId, MessageId},
         sticker::StickerItem,
+        timestamp::Timestamp,
     },
 };
 
@@ -53,7 +53,7 @@ pub struct Message {
     /// The content of the message.
     pub content: String,
     /// The timestamp of the last time the message was updated, if it was.
-    pub edited_timestamp: Option<DateTime<Utc>>,
+    pub edited_timestamp: Option<Timestamp>,
     /// Array of embeds sent with the message.
     pub embeds: Vec<Embed>,
     /// The Id of the [`Guild`] that the message was sent in. This value will
@@ -98,7 +98,7 @@ pub struct Message {
     #[serde(default)]
     pub reactions: Vec<MessageReaction>,
     /// Initial message creation timestamp, calculated from its Id.
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: Timestamp,
     /// Indicator of whether the command is to be played back via
     /// text-to-speech.
     ///
@@ -369,7 +369,7 @@ impl Message {
                     format!("{} pinned a message to this channel. See all the pins.", self.author);
             },
             MessageType::MemberJoin => {
-                let sec = self.timestamp.timestamp() as usize;
+                let sec = self.timestamp.unix_timestamp() as usize;
                 let chosen = constants::JOIN_MESSAGES[sec % constants::JOIN_MESSAGES.len()];
 
                 self.content = if chosen.contains("$user") {

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -14,7 +14,6 @@ mod reaction;
 #[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use chrono::{DateTime, Utc};
 use serde::de::{Error as DeError, Unexpected};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
@@ -37,6 +36,7 @@ use crate::http::CacheHttp;
 use crate::internal::is_false;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use crate::model::misc::ChannelParseError;
+use crate::model::Timestamp;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use crate::utils::parse_channel;
 use crate::{json::prelude::*, model::prelude::*};
@@ -472,14 +472,14 @@ pub struct ThreadMetadata {
     /// **Note**: It can currently only be set to 60, 1440, 4320, 10080.
     pub auto_archive_duration: Option<u64>,
     /// Timestamp when the thread's archive status was last changed, used for calculating recent activity.
-    pub archive_timestamp: Option<DateTime<Utc>>,
+    pub archive_timestamp: Option<Timestamp>,
     /// When a thread is locked, only users with `MANAGE_THREADS` permission can unarchive it.
     #[serde(default)]
     pub locked: bool,
     /// Timestamp when the thread was created.
     ///
     /// **Note**: only populated for threads created after 2022-01-09
-    pub create_timestamp: Option<DateTime<Utc>>,
+    pub create_timestamp: Option<Timestamp>,
     /// Whether non-moderators can add other non-moderators to a thread.
     ///
     /// **Note**: Only available on private threads.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -2,8 +2,6 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[cfg(feature = "model")]
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
-
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditMessage, GetMessages};
 #[cfg(feature = "http")]
@@ -12,6 +10,7 @@ use crate::http::{Http, Typing};
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
 use crate::model::utils::single_recipient;
+use crate::model::Timestamp;
 
 /// A Direct Message text channel with another user.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24,7 +23,7 @@ pub struct PrivateChannel {
     /// The Id of the last message sent.
     pub last_message_id: Option<MessageId>,
     /// Timestamp of the last time a [`Message`] was pinned.
-    pub last_pin_timestamp: Option<DateTime<Utc>>,
+    pub last_pin_timestamp: Option<Timestamp>,
     /// Indicator of the type of channel this is.
     ///
     /// This should always be [`ChannelType::Private`].

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -4,7 +4,6 @@
 use std::convert::TryFrom;
 use std::{collections::HashMap, fmt};
 
-use chrono::{DateTime, Utc};
 use serde::de::{Error as DeError, IgnoredAny, MapAccess};
 
 use super::prelude::*;
@@ -40,7 +39,7 @@ pub struct ChannelDeleteEvent {
 pub struct ChannelPinsUpdateEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
-    pub last_pin_timestamp: Option<DateTime<Utc>>,
+    pub last_pin_timestamp: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -111,10 +110,10 @@ pub struct GuildMemberRemoveEvent {
 pub struct GuildMemberUpdateEvent {
     pub guild_id: GuildId,
     pub nick: Option<String>,
-    pub joined_at: DateTime<Utc>,
+    pub joined_at: Timestamp,
     pub roles: Vec<RoleId>,
     pub user: User,
-    pub premium_since: Option<DateTime<Utc>>,
+    pub premium_since: Option<Timestamp>,
     #[serde(default)]
     pub pending: bool,
     #[serde(default)]
@@ -122,7 +121,7 @@ pub struct GuildMemberUpdateEvent {
     #[serde(default)]
     pub mute: bool,
     pub avatar: Option<String>,
-    pub communication_disabled_until: Option<DateTime<Utc>>,
+    pub communication_disabled_until: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -346,8 +345,8 @@ pub struct MessageUpdateEvent {
     pub nonce: Option<String>,
     pub tts: Option<bool>,
     pub pinned: Option<bool>,
-    pub timestamp: Option<DateTime<Utc>>,
-    pub edited_timestamp: Option<DateTime<Utc>>,
+    pub timestamp: Option<Timestamp>,
+    pub edited_timestamp: Option<Timestamp>,
     pub author: Option<User>,
     pub mention_everyone: Option<bool>,
     pub mentions: Option<Vec<User>>,

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -1,6 +1,5 @@
-use chrono::{DateTime, Utc};
-
 use super::*;
+use crate::model::Timestamp;
 
 /// Various information about integrations.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17,7 +16,7 @@ pub struct Integration {
     pub kind: String,
     pub name: String,
     pub role_id: Option<RoleId>,
-    pub synced_at: Option<DateTime<Utc>>,
+    pub synced_at: Option<Timestamp>,
     pub syncing: Option<bool>,
     pub user: Option<User>,
     pub enable_emoticons: Option<bool>,

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -4,8 +4,6 @@ use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use chrono::{DateTime, Utc};
-
 #[cfg(feature = "model")]
 use crate::builder::EditMember;
 #[cfg(feature = "cache")]
@@ -19,6 +17,7 @@ use crate::json;
 #[cfg(feature = "unstable_discord_api")]
 use crate::model::permissions::Permissions;
 use crate::model::prelude::*;
+use crate::model::Timestamp;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use crate::utils::Colour;
 
@@ -31,7 +30,7 @@ pub struct Member {
     /// The unique Id of the guild that the member is a part of.
     pub guild_id: GuildId,
     /// Timestamp representing the date when the member joined.
-    pub joined_at: Option<DateTime<Utc>>,
+    pub joined_at: Option<Timestamp>,
     /// Indicator of whether the member can speak in voice channels.
     pub mute: bool,
     /// The member's nickname, if present.
@@ -46,7 +45,7 @@ pub struct Member {
     #[serde(default)]
     pub pending: bool,
     /// Timestamp representing the date since the member is boosting the guild.
-    pub premium_since: Option<DateTime<Utc>>,
+    pub premium_since: Option<Timestamp>,
     /// The total permissions of the member in a channel, including overrides.
     ///
     /// This is only [`Some`] when returned in an [`Interaction`] object.
@@ -59,7 +58,7 @@ pub struct Member {
     /// 	When the user's timeout will expire and the user will be able to communicate in the guild again.
     ///
     /// 	Will be None or a time in the past if the user is not timed out.
-    pub communication_disabled_until: Option<DateTime<Utc>>,
+    pub communication_disabled_until: Option<Timestamp>,
 }
 
 /// Helper for deserialization without a `GuildId` but then later updated to the correct `GuildId`.
@@ -70,14 +69,14 @@ pub(crate) struct InterimMember {
     pub deaf: bool,
     #[serde(default)]
     pub guild_id: GuildId,
-    pub joined_at: Option<DateTime<Utc>>,
+    pub joined_at: Option<Timestamp>,
     pub mute: bool,
     pub nick: Option<String>,
     pub roles: Vec<RoleId>,
     pub user: User,
     #[serde(default)]
     pub pending: bool,
-    pub premium_since: Option<DateTime<Utc>>,
+    pub premium_since: Option<Timestamp>,
     #[cfg(feature = "unstable_discord_api")]
     pub permissions: Option<Permissions>,
     pub avatar: Option<String>,
@@ -260,7 +259,7 @@ impl Member {
     pub async fn disable_communication_until_datetime(
         &mut self,
         http: impl AsRef<Http>,
-        time: DateTime<Utc>,
+        time: Timestamp,
     ) -> Result<()> {
         match self
             .guild_id
@@ -667,7 +666,7 @@ pub struct PartialMember {
     #[serde(default)]
     pub deaf: bool,
     /// Timestamp representing the date when the member joined.
-    pub joined_at: Option<DateTime<Utc>>,
+    pub joined_at: Option<Timestamp>,
     /// Indicator of whether the member can speak in voice channels
     #[serde(default)]
     pub mute: bool,
@@ -681,7 +680,7 @@ pub struct PartialMember {
     #[serde(default)]
     pub pending: bool,
     /// Timestamp representing the date since the member is boosting the guild.
-    pub premium_since: Option<DateTime<Utc>>,
+    pub premium_since: Option<Timestamp>,
     /// The unique Id of the guild that the member is a part of.
     pub guild_id: Option<GuildId>,
     /// Attached User struct.
@@ -712,7 +711,7 @@ pub struct ThreadMember {
     /// The id of the user.
     pub user_id: Option<UserId>,
     /// The time the current user last joined the thread.
-    pub join_timestamp: DateTime<Utc>,
+    pub join_timestamp: Timestamp,
     /// Any user-thread settings, currently only used for notifications
     pub flags: ThreadMemberFlags,
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -15,7 +15,6 @@ mod role;
 mod system_channel;
 mod welcome_screen;
 
-use chrono::{DateTime, Utc};
 #[cfg(feature = "model")]
 use futures::stream::StreamExt;
 use serde::de::Error as DeError;
@@ -80,6 +79,7 @@ use crate::{
     json::{from_number, from_value, prelude::*},
     model::prelude::*,
     model::utils::{emojis, presences, roles, stickers},
+    model::Timestamp,
 };
 
 /// A representation of a banning of a user.
@@ -160,7 +160,7 @@ pub struct Guild {
     /// that of the default channel (typically `#general`).
     pub id: GuildId,
     /// The date that the current user joined the guild.
-    pub joined_at: DateTime<Utc>,
+    pub joined_at: Timestamp,
     /// Indicator of whether the guild is considered "large" by Discord.
     pub large: bool,
     /// The number of members in the guild.
@@ -2576,7 +2576,7 @@ impl<'de> Deserialize<'de> for Guild {
         let joined_at = map
             .remove("joined_at")
             .ok_or_else(|| DeError::custom("expected guild joined_at"))
-            .and_then(DateTime::deserialize)
+            .and_then(Timestamp::deserialize)
             .map_err(DeError::custom)?;
         let large = map
             .remove("large")
@@ -3139,8 +3139,6 @@ mod test {
     mod model {
         use std::collections::*;
 
-        use chrono::prelude::*;
-
         use crate::model::prelude::*;
 
         fn gen_user() -> User {
@@ -3148,9 +3146,7 @@ mod test {
         }
 
         fn gen_member() -> Member {
-            #[allow(clippy::zero_prefixed_literal)]
-            let dt: DateTime<Utc> =
-                FixedOffset::east(5 * 3600).ymd(2016, 11, 08).and_hms(0, 0, 0).with_timezone(&Utc);
+            let dt = Timestamp::now();
 
             let vec1 = Vec::new();
             let u = gen_user();
@@ -3180,9 +3176,7 @@ mod test {
             let hm2 = HashMap::new();
             let vec1 = Vec::new();
 
-            #[allow(clippy::zero_prefixed_literal)]
-            let dt: DateTime<Utc> =
-                FixedOffset::east(5 * 3600).ymd(2016, 11, 08).and_hms(0, 0, 0).with_timezone(&Utc);
+            let dt = Timestamp::now();
 
             let mut hm3 = HashMap::new();
             let hm4 = HashMap::new();

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -2,16 +2,15 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use chrono::{DateTime, TimeZone, Utc};
+use super::Timestamp;
 
 macro_rules! id_u64 {
     ($($name:ident;)*) => {
         $(
             impl $name {
                 /// Retrieves the time that the Id was created at.
-                pub fn created_at(&self) -> DateTime<Utc> {
-                    const DISCORD_EPOCH: u64 = 1_420_070_400_000;
-                    Utc.timestamp_millis(((self.0 >> 22) + DISCORD_EPOCH) as i64)
+                pub fn created_at(&self) -> Timestamp {
+                    Timestamp::from_discord_id(self.0)
                 }
 
                 /// Immutably borrow inner Id.
@@ -297,10 +296,9 @@ mod tests {
     #[test]
     fn test_created_at() {
         // The id is from discord's snowflake docs
-        assert_eq!(
-            GuildId(175928847299117063).created_at().to_rfc3339(),
-            "2016-04-30T11:18:25.796+00:00"
-        );
+        let id = GuildId(175928847299117063);
+        assert_eq!(id.created_at().unix_timestamp(), 1462015105);
+        assert_eq!(id.created_at().to_string(), "2016-04-30T11:18:25.796Z");
     }
 
     #[test]

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -1,7 +1,5 @@
 //! Models for server and channel invites.
 
-use chrono::{DateTime, Utc};
-
 use super::prelude::*;
 #[cfg(all(feature = "cache", feature = "model"))]
 use super::{utils as model_utils, Permissions};
@@ -15,6 +13,7 @@ use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::json;
+use crate::model::Timestamp;
 
 /// Information about an invite code.
 ///
@@ -57,7 +56,7 @@ pub struct Invite {
 
     // /// The expiration date of this invite, returned from `Http::get_invite` when
     // /// `with_expiration` is true.
-    // pub expires_at: Option<DateTime<Utc>>,
+    // pub expires_at: Option<Timestamp>,
     /// The Stage instance data if there is a public Stage instance in the Stage
     /// channel this invite is for.
     pub stage_instance: Option<InviteStageInstance>,
@@ -284,7 +283,7 @@ pub struct RichInvite {
     /// The unique code for the invite.
     pub code: String,
     /// When the invite was created.
-    pub created_at: DateTime<Utc>,
+    pub created_at: Timestamp,
     /// A representation of the minimal amount of information needed about the
     /// [`Guild`] being invited to.
     pub guild: Option<InviteGuild>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -21,6 +21,7 @@
 
 #[macro_use]
 mod utils;
+mod timestamp;
 
 pub mod application;
 pub mod channel;
@@ -52,6 +53,7 @@ use serde::de::Visitor;
 use serde::{Deserialize, Deserializer};
 #[cfg(feature = "voice-model")]
 pub use serenity_voice_model as voice_gateway;
+pub use timestamp::Timestamp;
 
 pub use self::error::Error as ModelError;
 pub use self::permissions::Permissions;

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -1,0 +1,184 @@
+use std::fmt;
+use std::ops::Deref;
+
+#[cfg(not(feature = "time"))]
+use chrono::{DateTime, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "time")]
+use time::format_description::well_known::Rfc3339;
+#[cfg(feature = "time")]
+use time::serde::rfc3339;
+#[cfg(feature = "time")]
+use time::{Duration, OffsetDateTime};
+
+/// Discord's epoch starts at "2015-01-01T00:00:00+00:00"
+const DISCORD_EPOCH: u64 = 1_420_070_400_000;
+
+/// Representation of a Unix timestamp.
+///
+/// The struct implements the `std::fmt::Display` trait to format the underlying type as
+/// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
+///
+/// ```
+/// # use serenity::model::id::GuildId;
+/// # use serenity::model::Timestamp;
+/// #
+/// let timestamp: Timestamp = GuildId(175928847299117063).created_at();
+/// assert_eq!(timestamp.unix_timestamp(), 1462015105);
+/// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
+/// ```
+#[cfg(not(feature = "time"))]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct Timestamp(DateTime<Utc>);
+
+/// Representation of a Unix timestamp.
+///
+/// The struct implements the `std::fmt::Display` trait to format the underlying type as
+/// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
+///
+/// ```
+/// # use serenity::model::id::GuildId;
+/// # use serenity::model::Timestamp;
+/// #
+/// let timestamp: Timestamp = GuildId(175928847299117063).created_at();
+/// assert_eq!(timestamp.unix_timestamp(), 1462015105);
+/// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
+/// ```
+#[cfg(feature = "time")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct Timestamp(#[serde(with = "rfc3339")] OffsetDateTime);
+
+#[cfg(feature = "time")]
+impl Timestamp {
+    pub(crate) fn from_discord_id(id: u64) -> Timestamp {
+        let ns = Duration::milliseconds(((id >> 22) + DISCORD_EPOCH) as i64).whole_nanoseconds();
+        // This can't fail because of the bit shifting
+        // `(u64::MAX >> 22) + DISCORD_EPOCH` = 5818116911103 = "Wed May 15 2154 07:35:11 GMT+0000"
+        Self(OffsetDateTime::from_unix_timestamp_nanos(ns).expect("can't fail"))
+    }
+
+    /// Create a new `Timestamp` with the current date and time in UTC.
+    pub fn now() -> Self {
+        Self(OffsetDateTime::now_utc())
+    }
+
+    /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
+    pub fn unix_timestamp(&self) -> i64 {
+        self.0.unix_timestamp()
+    }
+
+    fn parse(input: &str) -> Result<Timestamp, ParseError> {
+        OffsetDateTime::parse(input, &Rfc3339).map(Self).map_err(|_| ParseError)
+    }
+}
+
+#[cfg(not(feature = "time"))]
+impl Timestamp {
+    pub(crate) fn from_discord_id(id: u64) -> Timestamp {
+        Self(Utc.timestamp_millis(((id >> 22) + DISCORD_EPOCH) as i64))
+    }
+
+    /// Create a new `Timestamp` with the current date and time in UTC.
+    pub fn now() -> Self {
+        Self(Utc::now())
+    }
+
+    /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
+    pub fn unix_timestamp(&self) -> i64 {
+        self.0.timestamp()
+    }
+
+    fn parse(input: &str) -> Result<Timestamp, ParseError> {
+        DateTime::parse_from_rfc3339(input)
+            .map(|d| Self(d.with_timezone(&Utc)))
+            .map_err(|_| ParseError)
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseError;
+
+impl std::error::Error for ParseError {}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("invalid rfc3339 string")
+    }
+}
+
+#[cfg(feature = "time")]
+impl fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = self.0.format(&Rfc3339).map_err(|_| fmt::Error)?;
+        f.write_str(&s)
+    }
+}
+
+#[cfg(not(feature = "time"))]
+impl fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use chrono::SecondsFormat;
+        let s = self.0.to_rfc3339_opts(SecondsFormat::Millis, true);
+        f.write_str(&s)
+    }
+}
+
+#[cfg(not(feature = "time"))]
+impl Deref for Timestamp {
+    type Target = DateTime<Utc>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "time")]
+impl Deref for Timestamp {
+    type Target = OffsetDateTime;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<String> for Timestamp {
+    /// Parses an RFC 3339 date and time string such as `2016-04-30T11:18:25.796Z`.
+    ///
+    /// Panics on invalid value.
+    fn from(s: String) -> Self {
+        #[allow(clippy::unwrap_used)]
+        Timestamp::parse(&s).unwrap()
+    }
+}
+
+impl<'a> From<&'a str> for Timestamp {
+    /// Parses an RFC 3339 date and time string such as `2016-04-30T11:18:25.796Z`.
+    ///
+    /// Panics on invalid value.
+    fn from(s: &'a str) -> Self {
+        #[allow(clippy::unwrap_used)]
+        Timestamp::parse(s).unwrap()
+    }
+}
+
+impl From<&Timestamp> for Timestamp {
+    fn from(ts: &Timestamp) -> Self {
+        *ts
+    }
+}
+
+#[cfg(not(feature = "time"))]
+impl<Tz: TimeZone> From<DateTime<Tz>> for Timestamp {
+    fn from(dt: DateTime<Tz>) -> Self {
+        Self(dt.with_timezone(&Utc))
+    }
+}
+
+#[cfg(feature = "time")]
+impl From<OffsetDateTime> for Timestamp {
+    fn from(dt: OffsetDateTime) -> Self {
+        Self(dt)
+    }
+}

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -97,6 +97,7 @@ impl Timestamp {
     }
 }
 
+/// Signifies the failure to parse the `Timestamp` from an RFC 3339 string.
 #[derive(Debug)]
 pub struct ParseError;
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -716,9 +716,6 @@ impl Default for User {
 
 use std::hash::{Hash, Hasher};
 
-#[cfg(feature = "model")]
-use chrono::{DateTime, Utc};
-
 impl PartialEq for User {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
@@ -773,7 +770,7 @@ impl User {
 
     /// Retrieves the time that this user was created at.
     #[inline]
-    pub fn created_at(&self) -> DateTime<Utc> {
+    pub fn created_at(&self) -> Timestamp {
         self.id.created_at()
     }
 

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -2,7 +2,6 @@
 
 use std::fmt;
 
-use chrono::{DateTime, Utc};
 use serde::de::{self, Deserialize, Deserializer, IgnoredAny, MapAccess, Visitor};
 
 use super::{
@@ -12,6 +11,7 @@ use super::{
 };
 #[cfg(feature = "unstable_discord_api")]
 use crate::model::permissions::Permissions;
+use crate::model::Timestamp;
 
 /// Information about an available voice region.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -49,7 +49,7 @@ pub struct VoiceState {
     /// When unsuppressed, non-bot users will have this set to the current time.
     /// Bot users will be set to [`None`]. When suppressed, the user will have
     /// their [`Self::request_to_speak_timestamp`] removed.
-    pub request_to_speak_timestamp: Option<DateTime<Utc>>,
+    pub request_to_speak_timestamp: Option<Timestamp>,
 }
 
 impl fmt::Debug for VoiceState {
@@ -97,18 +97,18 @@ impl<'de> Deserialize<'de> for VoiceState {
         #[non_exhaustive]
         struct PartialMember {
             deaf: bool,
-            joined_at: Option<DateTime<Utc>>,
+            joined_at: Option<Timestamp>,
             mute: bool,
             nick: Option<String>,
             roles: Vec<RoleId>,
             user: User,
             #[serde(default)]
             pending: bool,
-            premium_since: Option<DateTime<Utc>>,
+            premium_since: Option<Timestamp>,
             #[cfg(feature = "unstable_discord_api")]
             permissions: Option<Permissions>,
             avatar: Option<String>,
-            communication_disabled_until: Option<DateTime<Utc>>,
+            communication_disabled_until: Option<Timestamp>,
         }
 
         struct VoiceStateVisitor;

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -1,7 +1,6 @@
-use chrono::{DateTime, Utc};
-
 use crate::json::NULL;
 use crate::model::prelude::*;
+use crate::model::Timestamp;
 
 /// A builder for constructing a personal [`Message`] instance.
 /// This can be useful for emitting a manual [`dispatch`] to the framework,
@@ -79,8 +78,8 @@ impl CustomMessage {
     ///
     /// If not used, the default value is [`None`] (not all messages are edited).
     #[inline]
-    pub fn edited_timestamp(&mut self, timestamp: DateTime<Utc>) -> &mut Self {
-        self.msg.edited_timestamp = Some(timestamp);
+    pub fn edited_timestamp<T: Into<Timestamp>>(&mut self, timestamp: T) -> &mut Self {
+        self.msg.edited_timestamp = Some(timestamp.into());
 
         self
     }
@@ -193,8 +192,8 @@ impl CustomMessage {
     ///
     /// If not used, the default value is the current local time.
     #[inline]
-    pub fn timestamp(&mut self, timestamp: DateTime<Utc>) -> &mut Self {
-        self.msg.timestamp = timestamp;
+    pub fn timestamp<T: Into<Timestamp>>(&mut self, timestamp: T) -> &mut Self {
+        self.msg.timestamp = timestamp.into();
 
         self
     }
@@ -266,7 +265,7 @@ fn dummy_message() -> Message {
         reactions: Vec::new(),
         tts: false,
         webhook_id: None,
-        timestamp: Utc::now(),
+        timestamp: Timestamp::now(),
         activity: None,
         application: None,
         message_reference: None,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -821,8 +821,6 @@ mod test {
         use std::collections::HashMap;
         use std::sync::Arc;
 
-        use chrono::{DateTime, Utc};
-
         use crate::model::{prelude::*, user::User, Permissions};
 
         let user = User {
@@ -848,12 +846,7 @@ mod test {
             features: Vec::new(),
             icon: None,
             id: GuildId(381880193251409931),
-            joined_at: DateTime::parse_from_str(
-                "1983 Apr 13 12:09:14.274 +0000",
-                "%Y %b %d %H:%M:%S%.3f %z",
-            )
-            .unwrap()
-            .with_timezone(&Utc),
+            joined_at: Timestamp::now(),
             large: false,
             member_count: 1,
             members: HashMap::new(),


### PR DESCRIPTION
Adds support for using the `time` crate for Discord's timestamp fields
and the builders instead of `chrono`.

The `Timestamp` newtype avoids all the needed `#[cfg(feature)]` and `#[serde(with)]` attributes on every field.

The main difference between `chrono` and `time` is that `time` returns a result while `chrono` might panic or just return a malformed formatted string.

`time` as default implementation would bump the MSRV to 1.53 or if optional, only if it's enabled.

**BREAKING CHANGE:** `DateTime<Utc>` fields and `builder::Timestamp` are
replaced by `model::Timestamp`.