### PR TITLE
Introduce internal `bitflags!` macro with serde implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [dependencies]
-bitflags = "1.1"
+bitflags = "1.3"
 serde_json = "1.0.75"
 async-trait = "0.1.9"
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -5,7 +5,6 @@ use std::fmt::Display;
 #[cfg(all(feature = "cache", feature = "model"))]
 use std::fmt::Write;
 
-use bitflags::bitflags;
 use chrono::{DateTime, Utc};
 #[cfg(feature = "simd-json")]
 use simd_json::ValueAccess;
@@ -1229,8 +1228,6 @@ bitflags! {
         const LOADING = 1 << 7;
     }
 }
-
-impl_bitflags_serde!(MessageFlags: u64);
 
 #[cfg(feature = "model")]
 impl MessageId {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,6 +1,5 @@
 //! Models pertaining to the gateway.
 
-use bitflags::bitflags;
 use url::Url;
 
 use super::prelude::*;
@@ -313,8 +312,6 @@ bitflags! {
         const EMBEDDED = 1 << 8;
     }
 }
-
-impl_bitflags_serde!(ActivityFlags: u64);
 
 /// Information about an activity's party.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -666,8 +663,6 @@ bitflags! {
         const DIRECT_MESSAGE_TYPING = 1 << 14;
     }
 }
-
-impl_bitflags_serde!(GatewayIntents: u64);
 
 #[cfg(feature = "model")]
 impl GatewayIntents {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use bitflags::bitflags;
 use chrono::{DateTime, Utc};
 
 #[cfg(feature = "model")]
@@ -660,5 +659,3 @@ bitflags! {
         const NOTIFICATIONS = 1 << 0;
     }
 }
-
-impl_bitflags_serde!(ThreadMemberFlags: u64);

--- a/src/model/guild/system_channel.rs
+++ b/src/model/guild/system_channel.rs
@@ -1,5 +1,3 @@
-use bitflags::bitflags;
-
 bitflags! {
     /// Describes a system channel flags.
     #[derive(Default)]
@@ -14,5 +12,3 @@ bitflags! {
         const SUPPRESS_JOIN_NOTIFICATION_REPLIES = 1 << 3;
     }
 }
-
-impl_bitflags_serde!(SystemChannelFlags: u64);

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -5,7 +5,6 @@ pub mod ping;
 
 use application_command::ApplicationCommandInteraction;
 use autocomplete::AutocompleteInteraction;
-use bitflags::bitflags;
 use message_component::MessageComponentInteraction;
 use ping::PingInteraction;
 use serde::de::{Deserialize, Deserializer, Error as DeError};
@@ -177,8 +176,6 @@ bitflags! {
         const EPHEMERAL = 1 << 6;
     }
 }
-
-impl_bitflags_serde!(InteractionApplicationCommandCallbackDataFlags: u64);
 
 /// Sent when a [`Message`] is a response to an [`Interaction`].
 ///

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -44,7 +44,6 @@
 #[cfg(feature = "model")]
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use bitflags::bitflags;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
@@ -220,7 +219,7 @@ pub const PRESET_VOICE: Permissions = Permissions {
     bits: Permissions::CONNECT.bits | Permissions::SPEAK.bits | Permissions::USE_VAD.bits,
 };
 
-bitflags! {
+bitflags::bitflags! {
     /// A set of permissions that can be assigned to [`User`]s and [`Role`]s via
     /// [`PermissionOverwrite`]s, roles globally in a [`Guild`], and to
     /// [`GuildChannel`]s.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -4,7 +4,6 @@ use std::fmt;
 #[cfg(feature = "model")]
 use std::fmt::Write;
 
-use bitflags::bitflags;
 #[cfg(feature = "model")]
 use futures::future::{BoxFuture, FutureExt};
 use serde::{Deserialize, Serialize};
@@ -669,8 +668,6 @@ bitflags! {
         const DISCORD_CERTIFIED_MODERATOR = 1 << 18;
     }
 }
-
-impl_bitflags_serde!(UserPublicFlags: u32);
 
 impl Default for User {
     /// Initializes a [`User`] with default values. Setting the following:


### PR DESCRIPTION
The macro forwards the generation to the `bitflags::bitflags!` macro and
implements the default (de)serialization for Discord's bitmask values.

If a different serde implementation is required then the `bitflags::bitflags!`
macro must be used directly. See `Permissions`.