### PR TITLE
Suppress deprecation warning for the use of `Region`

### DIFF
--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -143,6 +143,7 @@ impl EditGuild {
     /// # }
     /// ```
     #[deprecated(note = "Regions are now set per voice channel instead of globally.")]
+    #[allow(deprecated)]
     pub fn region(&mut self, region: Region) -> &mut Self {
         self.0.insert("region", Value::String(region.name().to_string()));
         self


### PR DESCRIPTION
This supresses the deprecation warning for serenity's use of `Region`
and not the warning if the user is using `EditGuild::region`.

Follow-up to: #1673