### PR TITLE
Mark the `model::guild::GuildStatus` enum as deprecated

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1207,6 +1207,8 @@ impl CacheUpdate for ReadyEvent {
     async fn update(&mut self, cache: &Cache) -> Option<()> {
         let mut ready = self.ready.clone();
 
+        // `GuildStatus` will by replaced by `UnavailableGuild`
+        #[allow(deprecated)]
         for guild in ready.guilds {
             match guild {
                 GuildStatus::Offline(unavailable) => {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,5 +1,8 @@
 //! Models pertaining to the gateway.
 
+// TODO: Remove after `GuildStatus` was replaced
+#![allow(deprecated)]
+
 use bitflags::bitflags;
 use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeStruct, Serializer};

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2994,6 +2994,7 @@ pub struct GuildUnavailable {
     pub unavailable: bool,
 }
 
+#[deprecated(note = "will be replaced by `UnavailableGuild` with serenity 0.11")]
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]


### PR DESCRIPTION
Apart from unavailable guild objects, Discord does not send partial guild
data with the ready event.

The enum will be replace by `model::guild::UnavailableGuild`.