### PR TITLE
Remove deprecated fields, gateway events, endpoints and traits

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -578,8 +578,7 @@ async fn slow_mode(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
             format!("Successfully set slow mode rate to `{}` seconds.", slow_mode_rate_seconds)
         }
     } else if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx.cache) {
-        #[allow(deprecated)]
-        let slow_mode_rate = channel.slow_mode_rate.unwrap_or(0);
+        let slow_mode_rate = channel.rate_limit_per_user.unwrap_or(0);
         format!("Current slow mode rate is `{}` seconds.", slow_mode_rate)
     } else {
         "Failed to find channel in cache.".to_string()

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -125,33 +125,6 @@ impl EditGuild {
         self.0.insert("owner_id", id);
     }
 
-    /// Set the voice region of the server.
-    ///
-    /// # Examples
-    ///
-    /// Setting the region to [`Region::UsWest`]:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::{http::Http, model::id::GuildId};
-    /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
-    /// #     let mut guild = GuildId(0).to_partial_guild(&http).await?;
-    /// use serenity::model::guild::Region;
-    ///
-    /// // assuming a `guild` has already been bound
-    ///
-    /// guild.edit(&http, |g| g.region(Region::UsWest)).await?;
-    /// #     Ok(())
-    /// # }
-    /// ```
-    #[deprecated(note = "Regions are now set per voice channel instead of globally.")]
-    #[allow(deprecated)]
-    pub fn region(&mut self, region: Region) -> &mut Self {
-        self.0.insert("region", Value::from(region.name().to_string()));
-        self
-    }
-
     /// Set the splash image of the guild on the invitation page.
     ///
     /// The `splash` must be base64-encoded 1024x1024 png/jpeg/gif image-data.

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -425,12 +425,6 @@ impl CacheUpdate for GuildUpdateEvent {
             guild.splash.clone_from(&self.guild.splash);
             guild.vanity_url_code.clone_from(&self.guild.vanity_url_code);
             guild.welcome_screen.clone_from(&self.guild.welcome_screen);
-
-            #[allow(deprecated)]
-            {
-                guild.region.clone_from(&self.guild.region);
-            }
-
             guild.default_message_notifications = self.guild.default_message_notifications;
             guild.max_members = self.guild.max_members;
             guild.max_presences = self.guild.max_presences;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1130,7 +1130,7 @@ mod test {
             topic: None,
             user_limit: None,
             nsfw: false,
-            slow_mode_rate: Some(0),
+            rate_limit_per_user: Some(0),
             rtc_region: None,
             video_quality_mode: None,
             message_count: None,
@@ -1154,7 +1154,6 @@ mod test {
             let mut channels = HashMap::new();
             channels.insert(ChannelId(2), channel);
 
-            #[allow(deprecated)]
             GuildCreateEvent {
                 guild: Guild {
                     id: GuildId(1),
@@ -1174,7 +1173,6 @@ mod test {
                     name: String::new(),
                     owner_id: UserId(3),
                     presences: HashMap::new(),
-                    region: String::new(),
                     roles: HashMap::new(),
                     splash: None,
                     discovery_splash: None,
@@ -1194,7 +1192,6 @@ mod test {
                     welcome_screen: None,
                     approximate_member_count: None,
                     approximate_presence_count: None,
-                    nsfw: false,
                     nsfw_level: NsfwLevel::Default,
                     max_video_channel_users: None,
                     max_presences: None,

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -801,33 +801,6 @@ async fn handle_event(
                     .await;
             });
         },
-        #[cfg(feature = "unstable_discord_api")]
-        #[allow(deprecated)]
-        DispatchEvent::Model(Event::ApplicationCommandCreate(event)) => {
-            let event_handler = Arc::clone(event_handler);
-
-            spawn_named("dispatch::event_handler::application_command_create", async move {
-                event_handler.application_command_create(context, event.application_command).await;
-            });
-        },
-        #[cfg(feature = "unstable_discord_api")]
-        #[allow(deprecated)]
-        DispatchEvent::Model(Event::ApplicationCommandUpdate(event)) => {
-            let event_handler = Arc::clone(event_handler);
-
-            spawn_named("dispatch::event_handler::application_command_update", async move {
-                event_handler.application_command_update(context, event.application_command).await;
-            });
-        },
-        #[cfg(feature = "unstable_discord_api")]
-        #[allow(deprecated)]
-        DispatchEvent::Model(Event::ApplicationCommandDelete(event)) => {
-            let event_handler = Arc::clone(event_handler);
-
-            spawn_named("dispatch::event_handler::application_command_delete", async move {
-                event_handler.application_command_delete(context, event.application_command).await;
-            });
-        },
         DispatchEvent::Model(Event::StageInstanceCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -6,7 +6,7 @@ use super::context::Context;
 use crate::client::bridge::gateway::event::*;
 use crate::json::Value;
 #[cfg(feature = "unstable_discord_api")]
-use crate::model::interactions::{application_command::ApplicationCommand, Interaction};
+use crate::model::interactions::Interaction;
 use crate::model::prelude::*;
 
 /// The core trait for handling events by serenity.
@@ -455,42 +455,6 @@ pub trait EventHandler: Send + Sync {
         _integration_id: IntegrationId,
         _guild_id: GuildId,
         _application_id: Option<ApplicationId>,
-    ) {
-    }
-
-    /// Dispatched when an application command is created.
-    ///
-    /// Provides the created application command.
-    #[cfg(feature = "unstable_discord_api")]
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    async fn application_command_create(
-        &self,
-        _ctx: Context,
-        _application_command: ApplicationCommand,
-    ) {
-    }
-
-    /// Dispatched when an application command is updated.
-    ///
-    /// Provides the updated application command.
-    #[cfg(feature = "unstable_discord_api")]
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    async fn application_command_update(
-        &self,
-        _ctx: Context,
-        _application_command: ApplicationCommand,
-    ) {
-    }
-
-    /// Dispatched when an application command is deleted.
-    ///
-    /// Provides the deleted application command.
-    #[cfg(feature = "unstable_discord_api")]
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    async fn application_command_delete(
-        &self,
-        _ctx: Context,
-        _application_command: ApplicationCommand,
     ) {
     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -590,7 +590,6 @@ impl Http {
     /// #    let http = Http::default();
     /// let map = json!({
     ///     "name": "test",
-    ///     "region": "us-west",
     /// });
     ///
     /// let _result = http.create_guild(&map).await?;
@@ -600,7 +599,6 @@ impl Http {
     ///
     /// [`Shard`]: crate::gateway::Shard
     /// [GameBridge]: https://discord.com/developers/docs/topics/gamebridge
-    /// [US West Region]: Region::UsWest
     /// [documentation on this endpoint]:
     /// https://discord.com/developers/docs/resources/guild#create-guild
     /// [whitelist]: https://discord.com/developers/docs/resources/guild#create-guild
@@ -2337,20 +2335,6 @@ impl Http {
         .await
     }
 
-    /// Gets all active threads from a channel.
-    #[deprecated(note = "Use get_guild_active_threads instead")]
-    pub async fn get_channel_active_threads(&self, channel_id: u64) -> Result<ThreadsData> {
-        self.fire(Request {
-            body: None,
-            multipart: None,
-            headers: None,
-            route: RouteInfo::GetChannelActiveThreads {
-                channel_id,
-            },
-        })
-        .await
-    }
-
     /// Gets all archived public threads from a channel.
     pub async fn get_channel_archived_public_threads(
         &self,
@@ -2726,21 +2710,6 @@ impl Http {
                 application_id: self.application_id,
                 guild_id,
                 command_id,
-            },
-        })
-        .await
-    }
-
-    /// Gets a guild embed information.
-    #[deprecated(note = "get_guild_embed was renamed to get_guild_widget")]
-    #[allow(deprecated)]
-    pub async fn get_guild_embed(&self, guild_id: u64) -> Result<GuildEmbed> {
-        self.fire(Request {
-            body: None,
-            multipart: None,
-            headers: None,
-            route: RouteInfo::GetGuildWidget {
-                guild_id,
             },
         })
         .await

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -140,12 +140,6 @@ pub enum Route {
     ///
     /// [`ChannelId`]: crate::model::id::ChannelId
     ChannelsIdThreadMembers(u64),
-    /// Route for the `/channels/:channel_id/threads/active` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdActiveThreads(u64),
     /// Route for the `/channels/:channel_id/threads/archived/public` path.
     ///
     /// The data is the relevant [`ChannelId`].
@@ -580,10 +574,6 @@ impl Route {
 
     pub fn channel_thread_members(channel_id: u64) -> String {
         api!("/channels/{}/thread-members", channel_id)
-    }
-
-    pub fn channel_active_threads(channel_id: u64) -> String {
-        api!("/channels/{}/threads/active", channel_id)
     }
 
     #[allow(clippy::let_underscore_must_use)]
@@ -1376,9 +1366,6 @@ pub enum RouteInfo<'a> {
         channel_id: u64,
     },
     GetChannelThreadMembers {
-        channel_id: u64,
-    },
-    GetChannelActiveThreads {
         channel_id: u64,
     },
     GetChannelArchivedPublicThreads {
@@ -2261,13 +2248,6 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Get,
                 Route::ChannelsIdThreadMembers(channel_id),
                 Cow::from(Route::channel_thread_members(channel_id)),
-            ),
-            RouteInfo::GetChannelActiveThreads {
-                channel_id,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdActiveThreads(channel_id),
-                Cow::from(Route::channel_active_threads(channel_id)),
             ),
             RouteInfo::GetChannelArchivedPublicThreads {
                 channel_id,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1096,18 +1096,6 @@ impl ChannelId {
         http.as_ref().remove_thread_channel_member(self.0, user_id.into()).await
     }
 
-    /// Gets all active threads of a channel.
-    ///
-    /// # Errors
-    ///
-    /// It may return an [`Error::Http`] if the bot doesn't have the
-    /// permission to get it.
-    #[deprecated(note = "Use GuildId::get_active_threads instead")]
-    pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
-        #[allow(deprecated)]
-        http.as_ref().get_channel_active_threads(self.0).await
-    }
-
     /// Gets private archived threads of a channel.
     ///
     /// # Errors

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -45,7 +45,7 @@ use crate::model::Timestamp;
 /// Represents a guild's text, news, or voice channel. Some methods are available
 /// only for voice channels and some are only available for text channels.
 /// News channels are a subset of text channels and lack slow mode hence
-/// [`Self::slow_mode_rate`] will be [`None`].
+/// [`Self::rate_limit_per_user`] will be [`None`].
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildChannel {
@@ -109,9 +109,8 @@ pub struct GuildChannel {
     /// **Note**: This is only available for text channels excluding news
     /// channels.
     #[doc(alias = "slowmode")]
-    #[deprecated(note = "will be renamed to `rate_limit_per_user` with serenity 0.11")]
-    #[serde(default, rename = "rate_limit_per_user")]
-    pub slow_mode_rate: Option<u64>,
+    #[serde(default)]
+    pub rate_limit_per_user: Option<u64>,
     /// The region override.
     ///
     /// **Note**: This is only available for voice and stage channels. [`None`]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -521,7 +521,7 @@ mod test {
                 topic: None,
                 user_limit: None,
                 nsfw: false,
-                slow_mode_rate: Some(0),
+                rate_limit_per_user: Some(0),
                 rtc_region: None,
                 video_quality_mode: None,
                 message_count: None,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)] // This is done beause it can't be used inside macro definitions.
 //! All the events this library handles.
 
 use std::convert::TryFrom;
@@ -10,7 +9,7 @@ use super::prelude::*;
 use super::utils::{emojis, roles, stickers};
 use crate::internal::prelude::*;
 #[cfg(feature = "unstable_discord_api")]
-use crate::model::interactions::{application_command::ApplicationCommand, Interaction};
+use crate::model::interactions::Interaction;
 use crate::{constants::OpCode, json::prelude::*};
 
 /// Event data for the channel creation event.
@@ -496,36 +495,6 @@ pub struct IntegrationDeleteEvent {
     pub application_id: Option<ApplicationId>,
 }
 
-#[cfg(feature = "unstable_discord_api")]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(transparent)]
-#[non_exhaustive]
-#[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-#[allow(deprecated)]
-pub struct ApplicationCommandCreateEvent {
-    pub application_command: ApplicationCommand,
-}
-
-#[cfg(feature = "unstable_discord_api")]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(transparent)]
-#[non_exhaustive]
-#[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-#[allow(deprecated)]
-pub struct ApplicationCommandUpdateEvent {
-    pub application_command: ApplicationCommand,
-}
-
-#[cfg(feature = "unstable_discord_api")]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(transparent)]
-#[non_exhaustive]
-#[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-#[allow(deprecated)]
-pub struct ApplicationCommandDeleteEvent {
-    pub application_command: ApplicationCommand,
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -813,21 +782,6 @@ pub enum Event {
     /// A guild integration was deleted
     #[cfg(feature = "unstable_discord_api")]
     IntegrationDelete(IntegrationDeleteEvent),
-    /// An application command was created
-    #[cfg(feature = "unstable_discord_api")]
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    #[allow(deprecated)]
-    ApplicationCommandCreate(ApplicationCommandCreateEvent),
-    /// An application command was updated
-    #[cfg(feature = "unstable_discord_api")]
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    #[allow(deprecated)]
-    ApplicationCommandUpdate(ApplicationCommandUpdateEvent),
-    /// An application command was deleted
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    #[cfg(feature = "unstable_discord_api")]
-    #[allow(deprecated)]
-    ApplicationCommandDelete(ApplicationCommandDeleteEvent),
     /// A stage instance was created.
     StageInstanceCreate(StageInstanceCreateEvent),
     /// A stage instance was updated.
@@ -863,7 +817,6 @@ fn gid_from_channel(c: &Channel) -> RelatedId<GuildId> {
     }
 }
 
-#[allow(deprecated)]
 macro_rules! with_related_ids_for_event_types {
     ($macro:ident) => {
         $macro! {
@@ -1203,27 +1156,6 @@ macro_rules! with_related_ids_for_event_types {
                 channel_id: Never,
                 message_id: Never,
             },
-            #[cfg(feature = "unstable_discord_api")]
-            Self::ApplicationCommandCreate, Self::ApplicationCommandCreate(e) => {
-                user_id: Never,
-                guild_id: e.application_command.guild_id.into(),
-                channel_id: Never,
-                message_id: Never,
-            },
-            #[cfg(feature = "unstable_discord_api")]
-            Self::ApplicationCommandUpdate, Self::ApplicationCommandUpdate(e) => {
-                user_id: Never,
-                guild_id: e.application_command.guild_id.into(),
-                channel_id: Never,
-                message_id: Never,
-            },
-            #[cfg(feature = "unstable_discord_api")]
-            Self::ApplicationCommandDelete, Self::ApplicationCommandDelete(e) => {
-                user_id: Never,
-                guild_id: e.application_command.guild_id.into(),
-                channel_id: Never,
-                message_id: Never,
-            },
         }
     };
 }
@@ -1343,15 +1275,6 @@ impl Event {
             Self::IntegrationUpdate(_) => EventType::IntegrationUpdate,
             #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationDelete(_) => EventType::IntegrationDelete,
-            #[cfg(feature = "unstable_discord_api")]
-            #[allow(deprecated)]
-            Self::ApplicationCommandCreate(_) => EventType::ApplicationCommandCreate,
-            #[cfg(feature = "unstable_discord_api")]
-            #[allow(deprecated)]
-            Self::ApplicationCommandUpdate(_) => EventType::ApplicationCommandUpdate,
-            #[cfg(feature = "unstable_discord_api")]
-            #[allow(deprecated)]
-            Self::ApplicationCommandDelete(_) => EventType::ApplicationCommandDelete,
             Self::StageInstanceCreate(_) => EventType::StageInstanceCreate,
             Self::StageInstanceUpdate(_) => EventType::StageInstanceUpdate,
             Self::StageInstanceDelete(_) => EventType::StageInstanceDelete,
@@ -1501,15 +1424,6 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
         EventType::IntegrationUpdate => Event::IntegrationUpdate(from_value(v)?),
         #[cfg(feature = "unstable_discord_api")]
         EventType::IntegrationDelete => Event::IntegrationDelete(from_value(v)?),
-        #[cfg(feature = "unstable_discord_api")]
-        #[allow(deprecated)]
-        EventType::ApplicationCommandCreate => Event::ApplicationCommandCreate(from_value(v)?),
-        #[cfg(feature = "unstable_discord_api")]
-        #[allow(deprecated)]
-        EventType::ApplicationCommandUpdate => Event::ApplicationCommandUpdate(from_value(v)?),
-        #[cfg(feature = "unstable_discord_api")]
-        #[allow(deprecated)]
-        EventType::ApplicationCommandDelete => Event::ApplicationCommandDelete(from_value(v)?),
         EventType::StageInstanceCreate => Event::StageInstanceCreate(from_value(v)?),
         EventType::StageInstanceUpdate => Event::StageInstanceUpdate(from_value(v)?),
         EventType::StageInstanceDelete => Event::StageInstanceDelete(from_value(v)?),
@@ -1708,24 +1622,6 @@ pub enum EventType {
     /// This maps to [`IntegrationDeleteEvent`].
     #[cfg(feature = "unstable_discord_api")]
     IntegrationDelete,
-    /// Indicator that an application command was created.
-    ///
-    /// This maps to [`ApplicationCommandCreateEvent`].
-    #[cfg(feature = "unstable_discord_api")]
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    ApplicationCommandCreate,
-    /// Indicator that an application command was updated.
-    ///
-    /// This maps to [`ApplicationCommandUpdateEvent`].
-    #[cfg(feature = "unstable_discord_api")]
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    ApplicationCommandUpdate,
-    /// Indicator that an application command was deleted.
-    ///
-    /// This maps to [`ApplicationCommandDeleteEvent`].
-    #[cfg(feature = "unstable_discord_api")]
-    #[deprecated(since = "0.10.10", note = "bots do no receive this event")]
-    ApplicationCommandDelete,
     /// Indicator that a stage instance was created.
     ///
     /// This maps to [`StageInstanceCreateEvent`].
@@ -1879,12 +1775,6 @@ impl EventType {
     const INTEGRATION_UPDATE: &'static str = "INTEGRATION_UPDATE";
     #[cfg(feature = "unstable_discord_api")]
     const INTEGRATION_DELETE: &'static str = "INTEGRATION_DELETE";
-    #[cfg(feature = "unstable_discord_api")]
-    const APPLICATION_COMMAND_CREATE: &'static str = "APPLICATION_COMMAND_CREATE";
-    #[cfg(feature = "unstable_discord_api")]
-    const APPLICATION_COMMAND_UPDATE: &'static str = "APPLICATION_COMMAND_UPDATE";
-    #[cfg(feature = "unstable_discord_api")]
-    const APPLICATION_COMMAND_DELETE: &'static str = "APPLICATION_COMMAND_DELETE";
     const STAGE_INSTANCE_CREATE: &'static str = "STAGE_INSTANCE_CREATE";
     const STAGE_INSTANCE_UPDATE: &'static str = "STAGE_INSTANCE_UPDATE";
     const STAGE_INSTANCE_DELETE: &'static str = "STAGE_INSTANCE_DELETE";
@@ -1945,15 +1835,6 @@ impl EventType {
             Self::IntegrationUpdate => Some(Self::INTEGRATION_UPDATE),
             #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationDelete => Some(Self::INTEGRATION_DELETE),
-            #[cfg(feature = "unstable_discord_api")]
-            #[allow(deprecated)]
-            Self::ApplicationCommandCreate => Some(Self::APPLICATION_COMMAND_CREATE),
-            #[cfg(feature = "unstable_discord_api")]
-            #[allow(deprecated)]
-            Self::ApplicationCommandUpdate => Some(Self::APPLICATION_COMMAND_UPDATE),
-            #[cfg(feature = "unstable_discord_api")]
-            #[allow(deprecated)]
-            Self::ApplicationCommandDelete => Some(Self::APPLICATION_COMMAND_DELETE),
             Self::StageInstanceCreate => Some(Self::STAGE_INSTANCE_CREATE),
             Self::StageInstanceUpdate => Some(Self::STAGE_INSTANCE_UPDATE),
             Self::StageInstanceDelete => Some(Self::STAGE_INSTANCE_DELETE),
@@ -2038,15 +1919,6 @@ impl<'de> Deserialize<'de> for EventType {
                     EventType::INTEGRATION_UPDATE => EventType::IntegrationUpdate,
                     #[cfg(feature = "unstable_discord_api")]
                     EventType::INTEGRATION_DELETE => EventType::IntegrationDelete,
-                    #[cfg(feature = "unstable_discord_api")]
-                    #[allow(deprecated)]
-                    EventType::APPLICATION_COMMAND_CREATE => EventType::ApplicationCommandCreate,
-                    #[cfg(feature = "unstable_discord_api")]
-                    #[allow(deprecated)]
-                    EventType::APPLICATION_COMMAND_UPDATE => EventType::ApplicationCommandUpdate,
-                    #[cfg(feature = "unstable_discord_api")]
-                    #[allow(deprecated)]
-                    EventType::APPLICATION_COMMAND_DELETE => EventType::ApplicationCommandDelete,
                     EventType::STAGE_INSTANCE_CREATE => EventType::StageInstanceCreate,
                     EventType::STAGE_INSTANCE_UPDATE => EventType::StageInstanceUpdate,
                     EventType::STAGE_INSTANCE_DELETE => EventType::StageInstanceDelete,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,6 +1,3 @@
-// FIXME: Remove after the removal of the `̀nsfw` field.
-#![allow(deprecated)]
-
 use serde::de::Error as DeError;
 #[cfg(feature = "simd-json")]
 use simd_json::StaticNode;
@@ -93,9 +90,6 @@ pub struct PartialGuild {
     /// Whether or not the user is the owner of the guild.
     #[serde(default)]
     pub owner: bool,
-    /// The region that the voice servers that the guild uses are located in.
-    #[deprecated(note = "Regions are now set per voice channel instead of globally.")]
-    pub region: String,
     /// A mapping of the guild's roles.
     #[serde(with = "roles")]
     pub roles: HashMap<RoleId, Role>,
@@ -142,12 +136,6 @@ pub struct PartialGuild {
     pub approximate_member_count: Option<u64>,
     /// Approximate number of non-offline members in this guild.
     pub approximate_presence_count: Option<u64>,
-    /// Whether or not this guild is designated as NSFW. See [`discord support article`].
-    ///
-    /// [`discord support article`]: https://support.discord.com/hc/en-us/articles/1500005389362-NSFW-Server-Designation
-    #[deprecated(note = "Removed in favor of Guild::nsfw_level.")]
-    #[serde(default)]
-    pub nsfw: bool,
     /// The guild NSFW state. See [`discord support article`].
     ///
     /// [`discord support article`]: https://support.discord.com/hc/en-us/articles/1500005389362-NSFW-Server-Designation
@@ -738,12 +726,6 @@ impl PartialGuild {
                 self.mfa_level = guild.mfa_level;
                 self.name = guild.name;
                 self.owner_id = guild.owner_id;
-
-                #[allow(deprecated)]
-                {
-                    self.region = guild.region;
-                }
-
                 self.roles = guild.roles;
                 self.splash = guild.splash;
                 self.verification_level = guild.verification_level;
@@ -1668,11 +1650,6 @@ impl<'de> Deserialize<'de> for PartialGuild {
             .ok_or_else(|| DeError::custom("expected guild owner_id"))
             .and_then(UserId::deserialize)
             .map_err(DeError::custom)?;
-        let region = map
-            .remove("region")
-            .ok_or_else(|| DeError::custom("expected guild region"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
         let roles = map
             .remove("roles")
             .ok_or_else(|| DeError::custom("expected guild roles"))
@@ -1733,12 +1710,6 @@ impl<'de> Deserialize<'de> for PartialGuild {
             .transpose()
             .map_err(DeError::custom)?
             .unwrap_or_default();
-
-        let nsfw = map
-            .remove("nsfw")
-            .ok_or_else(|| DeError::custom("expected approximate_presence_count"))
-            .and_then(bool::deserialize)
-            .map_err(DeError::custom)?;
 
         let nsfw_level = map
             .remove("nsfw_level")
@@ -1813,7 +1784,6 @@ impl<'de> Deserialize<'de> for PartialGuild {
             .and_then(stickers::deserialize)
             .map_err(DeError::custom)?;
 
-        #[allow(deprecated)]
         Ok(Self {
             application_id,
             id,
@@ -1829,7 +1799,6 @@ impl<'de> Deserialize<'de> for PartialGuild {
             name,
             owner_id,
             owner,
-            region,
             roles,
             splash,
             discovery_splash,
@@ -1846,7 +1815,6 @@ impl<'de> Deserialize<'de> for PartialGuild {
             welcome_screen,
             approximate_member_count,
             approximate_presence_count,
-            nsfw,
             nsfw_level,
             max_video_channel_users,
             max_presences,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -422,7 +422,7 @@ mod test {
                 topic: None,
                 user_limit: None,
                 nsfw: false,
-                slow_mode_rate: Some(0),
+                rate_limit_per_user: Some(0),
                 rtc_region: None,
                 video_quality_mode: None,
                 message_count: None,

--- a/src/utils/argument_convert/mod.rs
+++ b/src/utils/argument_convert/mod.rs
@@ -22,26 +22,6 @@ pub use emoji::*;
 use crate::model::prelude::*;
 use crate::prelude::*;
 
-#[deprecated(note = "Superseded by ArgumentConvert trait")]
-#[async_trait::async_trait]
-pub trait Parse: Sized {
-    /// The associated error which can be returned from parsing.
-    type Err;
-
-    /// Parses a string `s` as a command parameter of this type.
-    async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err>;
-}
-
-#[allow(deprecated)]
-#[async_trait::async_trait]
-impl<T: ArgumentConvert> Parse for T {
-    type Err = <T as ArgumentConvert>::Err;
-
-    async fn parse(ctx: &Context, msg: &Message, s: &str) -> Result<Self, Self::Err> {
-        Self::convert(ctx, msg.guild_id, Some(msg.channel_id), s).await
-    }
-}
-
 /// Parse a value from a string in context of a received message.
 ///
 /// This trait is a superset of [`std::str::FromStr`]. The

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -834,7 +834,6 @@ mod test {
             accent_colour: None,
         };
 
-        #[allow(deprecated)]
         let mut guild = Guild {
             afk_channel_id: None,
             afk_timeout: 0,
@@ -854,7 +853,6 @@ mod test {
             name: "serenity".to_string(),
             owner_id: UserId(114941315417899012),
             presences: HashMap::new(),
-            region: "Ferris Island".to_string(),
             roles: HashMap::new(),
             splash: None,
             discovery_splash: None,
@@ -873,7 +871,6 @@ mod test {
             welcome_screen: None,
             approximate_member_count: None,
             approximate_presence_count: None,
-            nsfw: false,
             nsfw_level: NsfwLevel::Default,
             max_video_channel_users: None,
             max_presences: None,
@@ -930,7 +927,7 @@ mod test {
             topic: None,
             user_limit: None,
             nsfw: false,
-            slow_mode_rate: Some(0),
+            rate_limit_per_user: Some(0),
             rtc_region: None,
             video_quality_mode: None,
             message_count: None,


### PR DESCRIPTION
* Remove `Guild::region`, `EditGuild::region`, `model::guild::Region`

  Regions are now set per voice channel instead of globally.

* Rename `GuildChannel::slow_mode_rate` field to `rate_limit_per_user`

* Remove the `Guild::nsfw` field.

  Superseded by `Guild::nsfw_level`.

* Remove `Http::get_guild_embed` and `GuildEmbed`

  Replaced by `Http::get_guild_widget` and `GuildWidget`.

* Remove the `ApplicationCommand` events for create, update & delete

  Bots no longer receive these events.

* Remove list active channel thread endpoint

  Replaced by the get active guild threads.

* Remove `utils::Parse` trait

  Replaced by `utils::ArgumentConvert` trait.