### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -203,7 +203,7 @@ impl EventHandler for Handler {
         // data.custom_id contains the id of the component (here "animal_select")
         // and should be used to identify if a message has multiple components.
         // data.values contains the selected values from the menu
-        let animal = Animal::from_str(&mci.data.values.get(0).unwrap()).unwrap();
+        let animal = Animal::from_str(mci.data.values.get(0).unwrap()).unwrap();
 
         // Acknowledge the interaction and edit the message
         mci.create_interaction_response(&ctx, |r| {

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -140,7 +140,7 @@ impl EditRole {
             AttachmentType::Bytes {
                 data,
                 filename: _,
-            } => "data:image/png;base64,".to_string() + &base64::encode(&data.into_owned()),
+            } => "data:image/png;base64,".to_string() + &base64::encode(&data),
             AttachmentType::File {
                 file,
                 filename: _,

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -404,7 +404,7 @@ impl ShardRunner {
                     self.shard.chunk_guild(guild_id, limit, filter, nonce.as_deref()).await.is_ok()
                 },
                 ShardClientMessage::Runner(ShardRunnerMessage::Close(code, reason)) => {
-                    let reason = reason.unwrap_or_else(String::new);
+                    let reason = reason.unwrap_or_default();
                     let close = CloseFrame {
                         code: code.into(),
                         reason: Cow::from(reason),

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -109,6 +109,7 @@ impl EventFilter {
     /// Checks if the `event` passes set constraints.
     /// Constraints are optional, as it is possible to limit events to
     /// be sent by a specific user or in a specifc guild.
+    #[allow(clippy::wrong_self_convention)]
     fn is_passing_constraints(&mut self, event: &mut LazyArc<'_, Event>) -> bool {
         fn empty_or_any<T, F>(slice: &[T], f: F) -> bool
         where

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -82,6 +82,7 @@ impl<'a> From<&'a str> for Delimiter {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 enum TokenKind {
     Argument,
     QuotedArgument,

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -42,7 +42,7 @@ impl<'a> Multipart<'a> {
             if let AttachmentType::Path(_) | AttachmentType::Image(_) = file {
                 *file = AttachmentType::Bytes {
                     data: data.clone().into(),
-                    filename: filename.clone().unwrap_or_else(String::new),
+                    filename: filename.clone().unwrap_or_default(),
                 };
             }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -55,9 +55,9 @@ pub struct Member {
     pub permissions: Option<Permissions>,
     /// The guild avatar hash
     pub avatar: Option<String>,
-    /// 	When the user's timeout will expire and the user will be able to communicate in the guild again.
+    /// When the user's timeout will expire and the user will be able to communicate in the guild again.
     ///
-    /// 	Will be None or a time in the past if the user is not timed out.
+    /// Will be None or a time in the past if the user is not timed out.
     pub communication_disabled_until: Option<Timestamp>,
 }
 

--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -66,10 +66,10 @@ impl Interaction {
     /// Gets the invoked guild locale.
     pub fn guild_locale(&self) -> Option<&str> {
         match self {
-            Interaction::Ping(i) => i.guild_locale.as_ref().map(String::as_str),
-            Interaction::ApplicationCommand(i) => i.guild_locale.as_ref().map(String::as_str),
-            Interaction::MessageComponent(i) => i.guild_locale.as_ref().map(String::as_str),
-            Interaction::Autocomplete(i) => i.guild_locale.as_ref().map(String::as_str),
+            Interaction::Ping(i) => i.guild_locale.as_deref(),
+            Interaction::ApplicationCommand(i) => i.guild_locale.as_deref(),
+            Interaction::MessageComponent(i) => i.guild_locale.as_deref(),
+            Interaction::Autocomplete(i) => i.guild_locale.as_deref(),
         }
     }
 

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -4,6 +4,7 @@ use crate::{model::prelude::*, prelude::*};
 /// Error that can be returned from [`Role::convert`].
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub enum RoleParseError {
     /// When the operation was invoked outside a guild.
     NotInGuild,

--- a/src/utils/argument_convert/user.rs
+++ b/src/utils/argument_convert/user.rs
@@ -4,6 +4,7 @@ use crate::{model::prelude::*, prelude::*};
 /// Error that can be returned from [`User::convert`].
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub enum UserParseError {
     /// The provided user string failed to parse, or the parsed result cannot be found in the
     /// guild cache data.

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -995,13 +995,13 @@ impl EmbedMessageBuilding for MessageBuilder {
         self.0.push('[');
         {
             let mut c = name.into();
-            c.inner = normalize(&c.inner).replace("]", " ");
+            c.inner = normalize(&c.inner).replace(']', " ");
             self.0.push_str(&c.to_string());
         }
         self.0.push_str("](");
         {
             let mut c = url.into();
-            c.inner = normalize(&c.inner).replace(")", " ");
+            c.inner = normalize(&c.inner).replace(')', " ");
             self.0.push_str(&c.to_string());
         }
         self.0.push(')');


### PR DESCRIPTION
Only the large enum variant warning is left but that is a change to a public enum.

<details>
<summary>commit message</summary>

This fixes the following warnings:
- `clippy::needless_borrow`
- `clippy::option_as_ref_deref`
- `clippy::single_char_pattern`
- `clippy::tabs_in_doc_comments`
- `clippy::unnecessary_to_owned`
- `clippy::unwrap_or_else_default`

- allow `clippy::enum_variant_names`
- allow `clippy::wrong_self_convention`
</details>