### PR TITLE
Fix lifetime definitions for builders with attachments

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -357,14 +357,14 @@ impl ChannelId {
     ///
     /// [`the limit`]: crate::builder::EditMessage::content
     #[inline]
-    pub async fn edit_message<F>(
+    pub async fn edit_message<'a, F>(
         self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
         f: F,
     ) -> Result<Message>
     where
-        F: for<'a, 'b> FnOnce(&'a mut EditMessage<'b>) -> &'a mut EditMessage<'b>,
+        F: for<'b> FnOnce(&'b mut EditMessage<'a>) -> &'b mut EditMessage<'a>,
     {
         let mut msg = EditMessage::default();
         f(&mut msg);

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -460,14 +460,14 @@ impl GuildChannel {
     ///
     /// [`the limit`]: crate::builder::EditMessage::content
     #[inline]
-    pub async fn edit_message<F>(
+    pub async fn edit_message<'a, F>(
         &self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
         f: F,
     ) -> Result<Message>
     where
-        F: for<'a, 'b> FnOnce(&'a mut EditMessage<'b>) -> &'a mut EditMessage<'b>,
+        F: for<'b> FnOnce(&'b mut EditMessage<'a>) -> &'b mut EditMessage<'a>,
     {
         self.id.edit_message(&http, message_id, f).await
     }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -156,14 +156,14 @@ impl PrivateChannel {
     ///
     /// [`the limit`]: crate::builder::EditMessage::content
     #[inline]
-    pub async fn edit_message<F>(
+    pub async fn edit_message<'a, F>(
         &self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
         f: F,
     ) -> Result<Message>
     where
-        F: for<'a, 'b> FnOnce(&'a mut EditMessage<'b>) -> &'a mut EditMessage<'b>,
+        F: for<'b> FnOnce(&'b mut EditMessage<'a>) -> &'b mut EditMessage<'a>,
     {
         self.id.edit_message(&http, message_id, f).await
     }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -326,9 +326,9 @@ impl GuildId {
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    pub async fn create_sticker<F>(self, http: impl AsRef<Http>, f: F) -> Result<Sticker>
+    pub async fn create_sticker<'a, F>(self, http: impl AsRef<Http>, f: F) -> Result<Sticker>
     where
-        for<'a, 'b> F: FnOnce(&'b mut CreateSticker<'a>) -> &'b mut CreateSticker<'a>,
+        for<'b> F: FnOnce(&'b mut CreateSticker<'a>) -> &'b mut CreateSticker<'a>,
     {
         let mut create_sticker = CreateSticker::default();
         f(&mut create_sticker);

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -877,9 +877,9 @@ impl Guild {
     /// if the current user does not have permission to manage roles.
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
-    pub async fn create_sticker<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Sticker>
+    pub async fn create_sticker<'a, F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Sticker>
     where
-        for<'a, 'b> F: FnOnce(&'b mut CreateSticker<'a>) -> &'b mut CreateSticker<'a>,
+        for<'b> F: FnOnce(&'b mut CreateSticker<'a>) -> &'b mut CreateSticker<'a>,
     {
         #[cfg(feature = "cache")]
         {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -589,9 +589,9 @@ impl PartialGuild {
     /// if the current user does not have permission to manage roles.
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
-    pub async fn create_sticker<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Sticker>
+    pub async fn create_sticker<'a, F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Sticker>
     where
-        for<'a, 'b> F: FnOnce(&'b mut CreateSticker<'a>) -> &'b mut CreateSticker<'a>,
+        for<'b> F: FnOnce(&'b mut CreateSticker<'a>) -> &'b mut CreateSticker<'a>,
     {
         #[cfg(feature = "cache")]
         {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -852,9 +852,9 @@ impl User {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn direct_message<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Message>
+    pub async fn direct_message<'a, F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Message>
     where
-        for<'a, 'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
+        for<'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
     {
         self.create_dm_channel(&cache_http).await?.send_message(&cache_http.http(), f).await
     }
@@ -862,9 +862,9 @@ impl User {
     /// This is an alias of [`Self::direct_message`].
     #[allow(clippy::missing_errors_doc)]
     #[inline]
-    pub async fn dm<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Message>
+    pub async fn dm<'a, F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Message>
     where
-        for<'a, 'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
+        for<'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
     {
         self.direct_message(cache_http, f).await
     }


### PR DESCRIPTION
This constrains the lifetime used for builders that contain `AttachmentType`s to the functions, rather than on the callback itself. 

The `for<'a, 'b, ...>` syntax, alternatively called Higher-Ranked Trait Bounds, allows one to define lifetimes that may be substituted for any other lifetime, including `'static`. It is a bit magic, as the [Rustonomicon][0] says and should be avoided if possible, but it is sometimes necessary, especially in situations where we do not have a concrete lifetime to use from a function or struct.

Unfortunately, many functions that consumed builders with `AttachmentType` used HRTBs incorrectly, specifically the lifetime for the `AttachmentType`. Most people would like to add an attachment when sending a message, but because of the HRTB lifetime, it prevented them from doing so. When there is no local context, a HRTB lifetime essentially becomes `'static`. That is, this:
```rust
trait Foo<'a> {
  fn foo(&'a self);
}

fn bar<T>(b: T)
where 
  T: for<'a> Foo<'a>
{
...
}
```
is the same as:
```rust
fn bar<T>(b: T)
where 
 T: Foo<'static>
{
...
}
```

[0]: https://doc.rust-lang.org/nomicon/hrtb.html