### PR TITLE
Replace levenshtein implementation with the `levenshtein` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ version = "0.6.0"
 optional = true
 version = "0.13"
 
+[dependencies.levenshtein]
+optional = true
+version = "1.0.5"
+
 [dependencies.time]
 optional = true
 version = "0.3.6"
@@ -194,7 +198,7 @@ http = []
 absolute_ratelimits = ["http"]
 model = ["builder", "http"]
 voice-model = ["serenity-voice-model"]
-standard_framework = ["framework", "uwl", "command_attr", "static_assertions"]
+standard_framework = ["framework", "uwl", "levenshtein", "command_attr", "static_assertions"]
 unstable_discord_api = []
 utils = ["base64"]
 voice = ["client", "model"]


### PR DESCRIPTION
The `levenshtein` crate is almost twice as fast as the current implementation.

A: "dwayne" B: "DuAnE"

    test benches::levenshtein          ... bench:      68 ns/iter (+/- 17)
    test benches::levenshtein_serenity ... bench:     130 ns/iter (+/- 47)

A: "levenshtein" B: "frankenstein"

    test benches::levenshtein          ... bench:     226 ns/iter (+/- 15)
    test benches::levenshtein_serenity ... bench:     385 ns/iter (+/- 79)

A: "saturday" B: "sunday"

    test benches::levenshtein          ... bench:      91 ns/iter (+/- 8)
    test benches::levenshtein_serenity ... bench:     160 ns/iter (+/- 9)

A: "xabxcdxxefxgx" B: "1ab2cd34ef5g6"

    test benches::levenshtein          ... bench:     275 ns/iter (+/- 55)
    test benches::levenshtein_serenity ... bench:     460 ns/iter (+/- 21)