### PR TITLE
Remove the unused `Component` enum

### DIFF
--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -164,8 +164,6 @@ pub enum Error {
     NotAuthor,
     /// Indicates that the webhook token is missing.
     NoTokenSet,
-    /// Indicates that the component type cannot be used in this context.
-    InvalidComponentType,
     /// When attempting to delete a built in nitro sticker instead of a guild
     /// sticker.
     DeleteNitroSticker,
@@ -203,7 +201,6 @@ impl Display for Error {
             Error::ChannelNotFound => f.write_str("Channel not found in the cache."),
             Error::Hierarchy => f.write_str("Role hierarchy prevents this action."),
             Error::InvalidChannelType => f.write_str("The channel cannot perform the action."),
-            Error::InvalidComponentType => f.write_str("The component cannot perform this action."),
             Error::InvalidPermissions(_) => f.write_str("Invalid permissions."),
             Error::InvalidUser => f.write_str("The current user cannot perform the action."),
             Error::ItemMissing => f.write_str("The required item is missing from the cache."),


### PR DESCRIPTION
The `Component` enum is no longer used since the type of `Message::components`
was changed to `Vec<ActionRow>` in 2b2006c.

Also, the `From`/`TryFrom` implementations and doc comment don't make clear
what the potential use case of the enum is.