### PR TITLE
Fix broken resolution logic for `AttachmentType::Image`

### DIFF
--- a/src/model/channel/attachment_type.rs
+++ b/src/model/channel/attachment_type.rs
@@ -4,8 +4,6 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "http")]
-use bytes::buf::Buf;
-#[cfg(feature = "http")]
 use reqwest::Client;
 #[cfg(feature = "http")]
 use tokio::{fs::File, io::AsyncReadExt};
@@ -52,10 +50,7 @@ impl<'a> AttachmentType<'a> {
             },
             AttachmentType::Image(url) => {
                 let response = client.get(url.clone()).send().await?;
-                let mut bytes = response.bytes().await?;
-                let mut picture: Vec<u8> = Vec::with_capacity(bytes.len());
-                bytes.copy_to_slice(&mut picture);
-                picture
+                response.bytes().await?.to_vec()
             },
         };
         Ok(data)


### PR DESCRIPTION
The changes introduced in #1640 included a subtle bug that resulted in url attachment data being accidentally thrown away, due to a bad copy. Specifically, `Bytes::copy_to_slice` stops after running through all the `.len()` its destination has to offer, and `Vec::with_capacity` leaves len at 0. Much simpler to just call `to_vec()` directly on the `Bytes` object since it implements `AsRef<[u8]>`, which I previously didn't know.