### PR TITLE
Move token parse and validate functions into the `utils::token` module

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -14,11 +14,6 @@ use std::{
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
-    /// When the token provided is invalid. This is returned when validating a
-    /// token through the [`validate_token`] function.
-    ///
-    /// [`validate_token`]: super::validate_token
-    InvalidToken,
     /// When a shard has completely failed to reboot after resume and/or
     /// reconnect attempts.
     ShardBootFailure,
@@ -30,7 +25,6 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Error::InvalidToken => f.write_str("The provided token was invalid"),
             Error::ShardBootFailure => f.write_str("Failed to (re-)boot a shard"),
             Error::Shutdown => f.write_str("The clients shards shutdown"),
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -71,7 +71,6 @@ use crate::internal::prelude::*;
 use crate::model::gateway::GatewayIntents;
 #[cfg(feature = "unstable_discord_api")]
 use crate::model::id::ApplicationId;
-use crate::model::id::UserId;
 pub use crate::CacheAndHttp;
 
 /// A builder implementing [`Future`] building a [`Client`] to interact with Discord.
@@ -997,85 +996,4 @@ impl Client {
 
         Ok(())
     }
-}
-
-/// Validates that a token is likely in a valid format.
-///
-/// This performs the following checks on a given token:
-///
-/// - At least one character long;
-/// - Contains 3 parts (split by the period char `'.'`);
-/// - The second part of the token is at least 6 characters long;
-/// - The token does not contain any whitespace prior to or after the token.
-///
-/// # Examples
-///
-/// Validate that a token is valid and that a number of invalid tokens are
-/// actually invalid:
-///
-/// ```rust,no_run
-/// use serenity::client::validate_token;
-///
-/// // ensure a valid token is in fact valid:
-/// assert!(validate_token("Mjg4NzYwMjQxMzYzODc3ODg4.C_ikow.j3VupLBuE1QWZng3TMGH0z_UAwg").is_ok());
-///
-/// // helpful to prevent typos
-/// assert!(validate_token("Njg4NzYwMjQxMzYzODc3ODg4.C_ikow.j3VupLBuE1QWZng3TMGH0z_UAwg").is_err());
-/// ```
-///
-/// # Errors
-///
-/// Returns a [`ClientError::InvalidToken`] when one of the above checks fail.
-/// The type of failure is not specified.
-pub fn validate_token(token: impl AsRef<str>) -> Result<()> {
-    if parse_token(token.as_ref()).is_some() {
-        Ok(())
-    } else {
-        Err(Error::Client(ClientError::InvalidToken))
-    }
-}
-
-/// Part of the data contained within a Discord bot token. Returned by [`parse_token`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TokenComponents {
-    pub bot_user_id: UserId,
-    pub creation_time: chrono::NaiveDateTime,
-}
-
-/// Verifies that the token adheres to the Discord token format and extracts the bot user ID and the
-/// token generation timestamp
-pub fn parse_token(token: impl AsRef<str>) -> Option<TokenComponents> {
-    // The token consists of three base64-encoded parts
-    let mut parts = token.as_ref().split('.');
-    let base64_config = base64::Config::new(base64::CharacterSet::UrlSafe, true);
-
-    // First part must be a base64-encoded stringified user ID
-    let user_id = base64::decode_config(parts.next()?, base64_config).ok()?;
-    let user_id = UserId(std::str::from_utf8(&user_id).ok()?.parse().ok()?);
-
-    // Second part must be a base64-encoded token generation timestamp
-    let timestamp_base64 = parts.next()?;
-    // The base64-encoded timestamp must be at least 6 characters
-    if timestamp_base64.len() < 6 {
-        return None;
-    }
-    let timestamp_bytes = base64::decode_config(timestamp_base64, base64_config).ok()?;
-    let mut timestamp = 0;
-    for byte in timestamp_bytes {
-        timestamp *= 256;
-        timestamp += byte as u64;
-    }
-    // Some timestamps are based on the Discord epoch. Convert to Unix epoch
-    if timestamp < 1293840000 {
-        timestamp += 1293840000;
-    }
-    let timestamp = chrono::NaiveDateTime::from_timestamp_opt(timestamp as i64, 0)?;
-
-    // Third part is a base64-encoded HMAC that's not interesting on its own
-    let _ = base64::decode_config(parts.next()?, base64_config).ok()?;
-
-    Some(TokenComponents {
-        bot_user_id: user_id,
-        creation_time: timestamp,
-    })
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,12 +9,16 @@ mod content_safe;
 mod custom_message;
 mod message_builder;
 
+pub mod token;
+
 #[cfg(all(feature = "client", feature = "cache"))]
 pub use argument_convert::*;
 #[cfg(feature = "cache")]
 pub use content_safe::*;
 use reqwest::Url;
 
+#[doc(inline)]
+pub use self::token::{parse as parse_token, validate as validate_token};
 pub use self::{
     colour::{colours, Colour},
     custom_message::CustomMessage,

--- a/src/utils/token.rs
+++ b/src/utils/token.rs
@@ -1,0 +1,82 @@
+//! Utilities to parse and validate Discord tokens.
+
+use std::fmt;
+use std::str;
+
+use crate::model::id::UserId;
+
+/// Validates that a token is likely in a valid format.
+///
+/// This performs the following checks on a given token:
+///
+/// - Is not empty;
+/// - Contains 3 parts (split by the period char `'.'`);
+/// - The second part of the token is at least 6 characters long;
+///
+/// # Examples
+///
+/// Validate that a token is valid and that a number of malformed tokens are
+/// actually invalid:
+///
+/// ```
+/// use serenity::utils::token::validate;
+///
+/// // ensure a valid token is in fact a valid format:
+/// assert!(validate("Mjg4NzYwMjQxMzYzODc3ODg4.C_ikow.j3VupLBuE1QWZng3TMGH0z_UAwg").is_ok());
+///
+/// assert!(validate("Mjg4NzYwMjQxMzYzODc3ODg4").is_err());
+/// assert!(validate("").is_err());
+/// ```
+///
+/// # Errors
+///
+/// Returns a [`InvalidToken`] when one of the above checks fail.
+/// The type of failure is not specified.
+pub fn validate(token: impl AsRef<str>) -> Result<(), InvalidToken> {
+    parse(token).map(|_| ()).ok_or(InvalidToken)
+}
+
+/// Error that can be return by [`validate`].
+#[derive(Debug)]
+pub struct InvalidToken;
+
+impl std::error::Error for InvalidToken {}
+
+impl fmt::Display for InvalidToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("The provided token was invalid")
+    }
+}
+
+/// Verifies that the token adheres to the Discord token format and extracts the bot user ID and
+/// the token generation unix timestamp.
+pub fn parse(token: impl AsRef<str>) -> Option<(UserId, i64)> {
+    // The token consists of three base64-encoded parts
+    let mut parts = token.as_ref().split('.');
+
+    // First part must be a base64-encoded stringified user ID
+    let user_id = base64::decode_config(parts.next()?, base64::URL_SAFE).ok()?;
+    let user_id = UserId(str::from_utf8(&user_id).ok()?.parse().ok()?);
+
+    // Second part must be a base64-encoded token generation timestamp
+    let timestamp = parts.next()?;
+    // The base64-encoded timestamp must be at least 6 characters
+    if timestamp.len() < 6 {
+        return None;
+    }
+    let timestamp_bytes = base64::decode_config(timestamp, base64::URL_SAFE).ok()?;
+    let mut timestamp = 0;
+    for byte in timestamp_bytes {
+        timestamp *= 256;
+        timestamp += byte as i64;
+    }
+    // Some timestamps are based on the Discord epoch. Convert to Unix epoch
+    if timestamp < 1_293_840_000 {
+        timestamp += 1_293_840_000;
+    }
+
+    // Third part is a base64-encoded HMAC that's not interesting on its own
+    base64::decode_config(parts.next()?, base64::URL_SAFE).ok()?;
+
+    Some((user_id, timestamp))
+}


### PR DESCRIPTION
The `validate_token` and `parse_token` functions are not used by the
`client` module and are not tied to it beside the `InvalidToken` enum
variant in the client error.

The `utils::token::parse` function is also streamlined by returning an optional
tuple `(UserId, i64)` for the bot use ID and the unix timestamp. This removes
the dependency on `chrono` and brings it in line with the other `parse_*`
functions in the `utils` module.

**BREAKING CHANGES:**
- `client::validate_token` and `client::parse_token` functions are moved
  into the `utils::token` module and renamed to `validate` and `parse`.
- The `utils::token::parse` function now returns `Option<(UserId, i64)>`.
- The `ClientError::InvalidToken` enum variant is removed.