### PR TITLE
Provide parsing of RFC 3339 strings for `model::Timestamp`

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -21,7 +21,6 @@
 
 #[macro_use]
 mod utils;
-mod timestamp;
 
 pub mod application;
 pub mod channel;
@@ -39,6 +38,7 @@ pub mod oauth2;
 pub mod permissions;
 pub mod prelude;
 pub mod sticker;
+pub mod timestamp;
 pub mod user;
 pub mod voice;
 pub mod webhook;


### PR DESCRIPTION
This makes the `timestamp` module and the `Timestamp::parse` functions
public and adds a `FromStr` implementation.