### PR TITLE
Replace deserialization helper functions with the required types

### DIFF
--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -32,16 +32,7 @@ use crate::model::id::{
 use crate::model::interactions::InteractionType;
 use crate::model::prelude::User;
 #[cfg(feature = "unstable_discord_api")]
-use crate::model::utils::{
-    deserialize_attachments_map,
-    deserialize_channels_map,
-    deserialize_messages_map,
-    deserialize_options,
-    deserialize_options_with_resolved,
-    deserialize_partial_members_map,
-    deserialize_roles_map,
-    deserialize_users,
-};
+use crate::model::utils::deserialize_options_with_resolved;
 
 /// An interaction when a user invokes a slash command.
 #[derive(Clone, Debug, Serialize)]
@@ -578,42 +569,42 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteractionDataResolved {
 
         let members = map
             .remove("members")
-            .map(deserialize_partial_members_map)
+            .map(HashMap::deserialize)
             .transpose()
             .map_err(DeError::custom)?
             .unwrap_or_default();
 
         let users = map
             .remove("users")
-            .map(deserialize_users)
+            .map(HashMap::deserialize)
             .transpose()
             .map_err(DeError::custom)?
             .unwrap_or_default();
 
         let roles = map
             .remove("roles")
-            .map(deserialize_roles_map)
+            .map(HashMap::deserialize)
             .transpose()
             .map_err(DeError::custom)?
             .unwrap_or_default();
 
         let channels = map
             .remove("channels")
-            .map(deserialize_channels_map)
+            .map(HashMap::deserialize)
             .transpose()
             .map_err(DeError::custom)?
             .unwrap_or_default();
 
         let messages = map
             .remove("messages")
-            .map(deserialize_messages_map)
+            .map(HashMap::deserialize)
             .transpose()
             .map_err(DeError::custom)?
             .unwrap_or_default();
 
         let attachments = map
             .remove("attachments")
-            .map(deserialize_attachments_map)
+            .map(HashMap::deserialize)
             .transpose()
             .map_err(DeError::custom)?
             .unwrap_or_default();
@@ -681,7 +672,7 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteractionDataOption {
 
         let options = map
             .remove("options")
-            .map(deserialize_options)
+            .map(Vec::deserialize)
             .transpose()
             .map_err(DeError::custom)?
             .unwrap_or_default();

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -54,55 +54,6 @@ pub fn deserialize_members<'de, D: Deserializer<'de>>(
 }
 
 #[cfg(feature = "unstable_discord_api")]
-pub fn deserialize_partial_members_map<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<UserId, PartialMember>, D::Error> {
-    HashMap::deserialize(deserializer)
-}
-
-#[cfg(feature = "unstable_discord_api")]
-pub fn deserialize_users<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<UserId, User>, D::Error> {
-    HashMap::deserialize(deserializer)
-}
-
-#[cfg(feature = "unstable_discord_api")]
-pub fn deserialize_roles_map<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<RoleId, Role>, D::Error> {
-    HashMap::deserialize(deserializer)
-}
-
-#[cfg(feature = "unstable_discord_api")]
-pub fn deserialize_channels_map<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<ChannelId, PartialChannel>, D::Error> {
-    HashMap::deserialize(deserializer)
-}
-
-#[cfg(feature = "unstable_discord_api")]
-pub fn deserialize_messages_map<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<MessageId, Message>, D::Error> {
-    HashMap::deserialize(deserializer)
-}
-
-#[cfg(feature = "unstable_discord_api")]
-pub fn deserialize_attachments_map<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<AttachmentId, Attachment>, D::Error> {
-    HashMap::deserialize(deserializer)
-}
-
-#[cfg(feature = "unstable_discord_api")]
-pub fn deserialize_options<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<Vec<ApplicationCommandInteractionDataOption>, D::Error> {
-    Vec::deserialize(deserializer)
-}
-
-#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_options_with_resolved<'de, D: Deserializer<'de>>(
     deserializer: D,
     resolved: &ApplicationCommandInteractionDataResolved,


### PR DESCRIPTION
The rust compiler is able to infer the hashmap/vec types.