### PR TITLE
Add `message_id` field to audit log options for pinned/unpinned messages

### DIFF
--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -365,6 +365,9 @@ pub struct Options {
     /// Type of overwritten entity ("member" or "role").
     #[serde(default, rename = "type")]
     pub kind: Option<String>,
+    /// Message that was pinned or unpinned.
+    #[serde(default)]
+    pub message_id: Option<MessageId>,
     /// Name of the role if type is "role"
     #[serde(default)]
     pub role_name: Option<String>,


### PR DESCRIPTION
See https://github.com/discord/discord-api-docs/blob/master/docs/resources/Audit_Log.md#optional-audit-entry-info