### PR TITLE
Add support to set a single child builder for several parent builders

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -32,6 +32,14 @@ impl CreateComponents {
         self
     }
 
+    /// Set a single action row.
+    /// Calling this will overwrite all action rows.
+    pub fn set_action_row(&mut self, mut row: CreateActionRow) -> &mut Self {
+        self.0 = vec![row.build()];
+
+        self
+    }
+
     /// Sets all the action rows.
     pub fn set_action_rows(&mut self, rows: Vec<CreateActionRow>) -> &mut Self {
         let new_rows = rows.into_iter().map(|mut f| f.build()).collect::<Vec<Value>>();

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -99,6 +99,15 @@ impl CreateInteractionResponseData {
         self
     }
 
+    /// Adds multiple embeds for the message.
+    pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        for embed in embeds {
+            self.add_embed(embed);
+        }
+
+        self
+    }
+
     /// Sets a single embed to include in the message
     ///
     /// Calling this will overwrite the embed list.

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -76,7 +76,7 @@ impl CreateInteractionResponseData {
     }
 
     /// Create an embed for the message.
-    pub fn create_embed<F>(&mut self, f: F) -> &mut Self
+    pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {
@@ -103,7 +103,7 @@ impl CreateInteractionResponseData {
     ///
     /// Calling this will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
-    pub fn embed(&mut self, embed: CreateEmbed) -> &mut Self {
+    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
         self.0.insert("embeds", Value::Array(vec![embed]));
@@ -115,7 +115,7 @@ impl CreateInteractionResponseData {
     ///
     /// Calling this multiple times will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
-    pub fn embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
+    pub fn set_embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
         let embeds =
             embeds.into_iter().map(|embed| utils::hashmap_to_json_map(embed.0).into()).collect();
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -99,6 +99,18 @@ impl CreateInteractionResponseData {
         self
     }
 
+    /// Sets a single embed to include in the message
+    ///
+    /// Calling this will overwrite the embed list.
+    /// To append embeds, call [`Self::add_embed`] instead.
+    pub fn embed(&mut self, embed: CreateEmbed) -> &mut Self {
+        let map = utils::hashmap_to_json_map(embed.0);
+        let embed = Value::Object(map);
+        self.0.insert("embeds", Value::Array(vec![embed]));
+
+        self
+    }
+
     /// Sets a list of embeds to include in the message.
     ///
     /// Calling this multiple times will overwrite the embed list.

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -86,7 +86,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Create an embed for the message.
-    pub fn create_embed<F>(&mut self, f: F) -> &mut Self
+    pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {
@@ -114,7 +114,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ///
     /// Calling this will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
-    pub fn embed(&mut self, embed: CreateEmbed) -> &mut Self {
+    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         let map = utils::hashmap_to_json_map(embed.0);
         let embed = Value::Object(map);
         self.0.insert("embeds", Value::Array(vec![embed]));
@@ -126,7 +126,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ///
     /// Calling this multiple times will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
-    pub fn embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
+    pub fn set_embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
         let embeds =
             embeds.into_iter().map(|embed| utils::hashmap_to_json_map(embed.0).into()).collect();
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -110,6 +110,18 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         self
     }
 
+    /// Sets a single embed to include in the message
+    ///
+    /// Calling this will overwrite the embed list.
+    /// To append embeds, call [`Self::add_embed`] instead.
+    pub fn embed(&mut self, embed: CreateEmbed) -> &mut Self {
+        let map = utils::hashmap_to_json_map(embed.0);
+        let embed = Value::Object(map);
+        self.0.insert("embeds", Value::Array(vec![embed]));
+
+        self
+    }
+
     /// Sets a list of embeds to include in the message.
     ///
     /// Calling this multiple times will overwrite the embed list.

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -110,6 +110,15 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         self
     }
 
+    /// Adds multiple embeds to the message.
+    pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        for embed in embeds {
+            self.add_embed(embed);
+        }
+
+        self
+    }
+
     /// Sets a single embed to include in the message
     ///
     /// Calling this will overwrite the embed list.

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -26,7 +26,7 @@ impl EditInteractionResponse {
     }
 
     /// Creates an embed for the message.
-    pub fn create_embed<F>(&mut self, f: F) -> &mut Self
+    pub fn embed<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -49,6 +49,27 @@ impl EditInteractionResponse {
         self
     }
 
+    /// Adds multiple embeds to the message.
+    pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        for embed in embeds {
+            self.add_embed(embed);
+        }
+
+        self
+    }
+
+    /// Sets a single embed to include in the message
+    ///
+    /// Calling this will overwrite the embed list.
+    /// To append embeds, call [`Self::add_embed`] instead.
+    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
+        let map = utils::hashmap_to_json_map(embed.0);
+        let embed = Value::Object(map);
+        self.0.insert("embeds", Value::Array(vec![embed]));
+
+        self
+    }
+
     /// Sets the embeds for the message.
     ///
     /// **Note**: You can only have up to 10 embeds per message.


### PR DESCRIPTION
- Implement a simple 'embed' function for 'CreateInteractionResponseData' and 'CreateInteractionResponseFollowup' builders, similar to 'set_embed' for 'CreateMessage' builder
- Implement a simple 'set_action_row' function for 'CreateComponents' builder, similar to 'set_embed' for 'CreateMessage' builder