### PR TITLE
Add `GenericId` snowflake type for unspecific entities in audit logs

### DIFF
--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -268,8 +268,8 @@ pub struct Options {
     #[serde(default, with = "option_u64_handler")]
     pub count: Option<u64>,
     /// Id of the overwritten entity
-    #[serde(default, with = "option_u64_handler")]
-    pub id: Option<u64>,
+    #[serde(default)]
+    pub id: Option<GenericId>,
     /// Type of overwritten entity ("member" or "role").
     #[serde(default, rename = "type")]
     pub kind: Option<String>,

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -92,6 +92,12 @@ pub struct ChannelId(#[serde(with = "snowflake")] pub u64);
 )]
 pub struct EmojiId(#[serde(with = "snowflake")] pub u64);
 
+/// An identifier for an unspecific entity.
+#[derive(
+    Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
+)]
+pub struct GenericId(#[serde(with = "snowflake")] pub u64);
+
 /// An identifier for a Guild
 #[derive(
     Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
@@ -207,6 +213,7 @@ id_u64! {
     ApplicationId;
     ChannelId;
     EmojiId;
+    GenericId;
     GuildId;
     IntegrationId;
     MessageId;


### PR DESCRIPTION
It's not the only usage for such a type. 
It will also be used in a following PR that replaces the `Change` struct with an enum with different variants for the keys.

**BREAKING CHANGE:** The field `id` of the optional audit entry info type
`model::guild::Options` changed to `Option<GenericId>`.