### PR TITLE
Fix reference to kankyo::load() in e06 .env.example

### DIFF
--- a/examples/e06_sample_bot_structure/.env.example
+++ b/examples/e06_sample_bot_structure/.env.example
@@ -1,7 +1,7 @@
 # This declares an environment variable named "DISCORD_TOKEN" with the given
 # value. When calling `dotenv::dotenv()`, it will read the `.env` file and parse
 # these key-value pairs and insert them into the environment.
-# 
+#
 # Environment variables are separated by newlines and must not have space
 # around the equals sign (`=`).
 DISCORD_TOKEN=put your token here

--- a/examples/e06_sample_bot_structure/.env.example
+++ b/examples/e06_sample_bot_structure/.env.example
@@ -1,7 +1,7 @@
 # This declares an environment variable named "DISCORD_TOKEN" with the given
-# value. When calling `kankyo::load()`, it will read the `.env` file and parse
+# value. When calling `dotenv::dotenv()`, it will read the `.env` file and parse
 # these key-value pairs and insert them into the environment.
-#
+# 
 # Environment variables are separated by newlines and must not have space
 # around the equals sign (`=`).
 DISCORD_TOKEN=put your token here


### PR DESCRIPTION
`.env.example` in example 6 talks about `kankyo::load()` when kankyo is nowhere to be seen in any of the code. I changed this to `dotenv::dotenv()`, which it seems like is the correct function.