### PR TITLE
Remove GuildChannel send_message note

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -947,8 +947,6 @@ impl GuildChannel {
 
     /// Sends a message to the channel with the given content.
     ///
-    /// **Note**: This will only work when a [`Message`] is received.
-    ///
     /// **Note**: Requires the [Send Messages] permission.
     ///
     /// # Errors


### PR DESCRIPTION
This pull request removes an inaccurate comment from the documentation for Guild Channel's send_message function.