### PR TITLE
Basic forum channels

### DIFF
--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -43,7 +43,7 @@ macro_rules! feature_cache {
 }
 
 macro_rules! enum_number {
-    ($name:ident { $($variant:ident $(,)? )* }) => {
+    ($name:ident { $($(#[$attr:meta])? $variant:ident $(,)? )* }) => {
         impl $name {
             #[inline]
             pub fn num(&self) -> u64 {
@@ -80,7 +80,7 @@ macro_rules! enum_number {
                         // Rust does not come with a simple way of converting a
                         // number to an enum, so use a big `match`.
                         match value {
-                            $( v if v == $name::$variant as u64 => Ok($name::$variant), )*
+                            $( $(#[$attr])? v if v == $name::$variant as u64 => Ok($name::$variant), )*
                             _ => {
                                 tracing::warn!("Unknown {} value: {}", stringify!($name), value);
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -329,6 +329,7 @@ pub enum ChannelType {
     /// An indicator that the channel is a stage [`GuildChannel`].
     Stage = 13,
     /// An indicator that the channel is a forum [`GuildChannel`].
+    #[cfg(feature = "unstable_discord_api")]
     Forum = 15,
     /// An indicator that the channel is of unknown type.
     Unknown = !0,
@@ -345,6 +346,7 @@ enum_number!(ChannelType {
     PublicThread,
     PrivateThread,
     Stage,
+    #[cfg(feature = "unstable_discord_api")]
     Forum,
 });
 
@@ -362,6 +364,7 @@ impl ChannelType {
             ChannelType::PublicThread => "public_thread",
             ChannelType::PrivateThread => "private_thread",
             ChannelType::Stage => "stage",
+            #[cfg(feature = "unstable_discord_api")]
             ChannelType::Forum => "forum",
             ChannelType::Unknown => "unknown",
         }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -328,6 +328,8 @@ pub enum ChannelType {
     PrivateThread = 12,
     /// An indicator that the channel is a stage [`GuildChannel`].
     Stage = 13,
+    /// An indicator that the channel is a forum (haha discord not documenting features go brr)
+    Forum = 15,
     /// An indicator that the channel is of unknown type.
     Unknown = !0,
 }
@@ -342,7 +344,8 @@ enum_number!(ChannelType {
     NewsThread,
     PublicThread,
     PrivateThread,
-    Stage
+    Stage,
+    Forum
 });
 
 impl ChannelType {
@@ -359,6 +362,7 @@ impl ChannelType {
             ChannelType::PublicThread => "public_thread",
             ChannelType::PrivateThread => "private_thread",
             ChannelType::Stage => "stage",
+            ChannelType::Forum => "forum",
             ChannelType::Unknown => "unknown",
         }
     }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -253,7 +253,7 @@ impl<'de> Deserialize<'de> for Channel {
         };
 
         match kind {
-            0 | 2 | 5 | 6 | 10 | 11 | 12 | 13 => {
+            0 | 2 | 5 | 6 | 10 | 11 | 12 | 13 | 15 => {
                 serde_json::from_value::<GuildChannel>(Value::Object(v))
                     .map(Channel::Guild)
                     .map_err(DeError::custom)
@@ -322,13 +322,13 @@ pub enum ChannelType {
     Store = 6,
     /// An indicator that the channel is a news thread [`GuildChannel`].
     NewsThread = 10,
-    /// An indicator that the channel is a news thread [`GuildChannel`].
+    /// An indicator that the channel is a public thread [`GuildChannel`].
     PublicThread = 11,
-    /// An indicator that the channel is a news thread [`GuildChannel`].
+    /// An indicator that the channel is a private thread [`GuildChannel`].
     PrivateThread = 12,
     /// An indicator that the channel is a stage [`GuildChannel`].
     Stage = 13,
-    /// An indicator that the channel is a forum (haha discord not documenting features go brr)
+    /// An indicator that the channel is a forum [`GuildChannel`].
     Forum = 15,
     /// An indicator that the channel is of unknown type.
     Unknown = !0,
@@ -345,7 +345,7 @@ enum_number!(ChannelType {
     PublicThread,
     PrivateThread,
     Stage,
-    Forum
+    Forum,
 });
 
 impl ChannelType {


### PR DESCRIPTION
This PR adds rudimentary support for Discord's experimental forum channels. This is needed because serenity currently fails to cache guilds with forum channels due to the unknown channel type, which can break bots.

As seen in the list of commits, the changes are:
- Added forum channel type
- Handle forum channel type in deserialization
- Skip invalid channel when caching - caching should be resilient against Discord adding new channel types in the feature
- Gate forum channels behind unstable_discord_api - forum channels are still experimental