### PR TITLE
Change the data mapping of `AuditLogs`

### DIFF
--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -7,7 +7,7 @@ mod change;
 mod utils;
 
 pub use change::{AffectedRole, Change, EntityType};
-use utils::{entries, optional_string};
+use utils::{optional_string, users, webhooks};
 
 use crate::model::prelude::*;
 
@@ -203,10 +203,12 @@ pub enum ActionThread {
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct AuditLogs {
-    #[serde(with = "entries", rename = "audit_log_entries")]
-    pub entries: HashMap<AuditLogEntryId, AuditLogEntry>,
-    pub webhooks: Vec<Webhook>,
-    pub users: Vec<User>,
+    #[serde(rename = "audit_log_entries")]
+    pub entries: Vec<AuditLogEntry>,
+    #[serde(with = "users")]
+    pub users: HashMap<UserId, User>,
+    #[serde(with = "webhooks")]
+    pub webhooks: HashMap<WebhookId, Webhook>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/model/guild/audit_log/utils.rs
+++ b/src/model/guild/audit_log/utils.rs
@@ -1,17 +1,36 @@
-/// Used with `#[serde(with = "entries")]`
-pub mod entries {
+/// Used with `#[serde(with = "users")]`
+pub mod users {
     use std::collections::HashMap;
 
     use serde::Deserializer;
 
-    use crate::model::guild::AuditLogEntry;
-    use crate::model::id::AuditLogEntryId;
+    use crate::model::id::UserId;
+    use crate::model::user::User;
     use crate::model::utils::SequenceToMapVisitor;
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
-    ) -> Result<HashMap<AuditLogEntryId, AuditLogEntry>, D::Error> {
-        deserializer.deserialize_seq(SequenceToMapVisitor::new(|e: &AuditLogEntry| e.id))
+    ) -> Result<HashMap<UserId, User>, D::Error> {
+        deserializer.deserialize_seq(SequenceToMapVisitor::new(|u: &User| u.id))
+    }
+
+    pub use crate::model::utils::serialize_map_values as serialize;
+}
+
+/// Used with `#[serde(with = "webhooks")]`
+pub mod webhooks {
+    use std::collections::HashMap;
+
+    use serde::Deserializer;
+
+    use crate::model::id::WebhookId;
+    use crate::model::utils::SequenceToMapVisitor;
+    use crate::model::webhook::Webhook;
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<WebhookId, Webhook>, D::Error> {
+        deserializer.deserialize_seq(SequenceToMapVisitor::new(|h: &Webhook| h.id))
     }
 
     pub use crate::model::utils::serialize_map_values as serialize;


### PR DESCRIPTION
The `entries` are now mapped as `Vec` to keep the order as returned by
the Discord API (newest first). The fields `users` and `webhooks` are
mapped as `HashMap<ID, ENTITY>` to lookup the entities that are
referenced by the audit log entries.

**BREAKING CHANGE:**
- The field `AuditLogs::entries` is changed to `Vec<AuditLogEntry>`.
- The fields `users` and `webhooks` are changed to `HashMap<ENTITY_ID, ENTITY>`.