### PR TITLE
Fix the mapping of the `Change::Type` variant

### DIFF
--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -6,7 +6,7 @@ use serde::ser::{Serialize, Serializer};
 mod change;
 mod utils;
 
-pub use change::{AffectedRole, Change};
+pub use change::{AffectedRole, Change, EntityType};
 use utils::{entries, optional_string};
 
 use crate::model::prelude::*;


### PR DESCRIPTION
The field can be either a string or an integer for the type of the entity.

Follow-up to: #1746 