### PR TITLE
Support more options for querying invites

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3075,8 +3075,8 @@ impl Http {
     /// * `expiration` - Whether to include information about when the invite expires.
     /// * `event_id` - An optional server event ID to include with the invite.
     ///
-    /// More information about these arguments can be found on Discord's API documentation:
-    /// https://discord.com/developers/docs/resources/invite#get-invite
+    /// More information about these arguments can be found on Discord's
+    /// [API documentation](https://discord.com/developers/docs/resources/invite#get-invite).
     pub async fn get_invite(
         &self,
         mut code: &str,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3066,7 +3066,24 @@ impl Http {
     }
 
     /// Gets information about a specific invite.
-    pub async fn get_invite(&self, mut code: &str, stats: bool) -> Result<Invite> {
+    ///
+    /// # Arguments
+    ///
+    /// * `code` - The invite code.
+    /// * `member_counts` - Whether to include information about the current number
+    /// of members in the server that the invite belongs to.
+    /// * `expiration` - Whether to include information about when the invite expires.
+    /// * `event_id` - An optional server event ID to include with the invite.
+    ///
+    /// More information about these arguments can be found on Discord's API documentation:
+    /// https://discord.com/developers/docs/resources/invite#get-invite
+    pub async fn get_invite(
+        &self,
+        mut code: &str,
+        member_counts: bool,
+        expiration: bool,
+        event_id: Option<u64>,
+    ) -> Result<Invite> {
         #[cfg(feature = "utils")]
         {
             code = utils::parse_invite(code);
@@ -3078,7 +3095,9 @@ impl Http {
             headers: None,
             route: RouteInfo::GetInvite {
                 code,
-                stats,
+                member_counts,
+                expiration,
+                event_id,
             },
         })
         .await

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -832,8 +832,23 @@ impl Route {
         api!("/invites/{}", code)
     }
 
-    pub fn invite_optioned(code: &str, stats: bool) -> String {
-        api!("/invites/{}?with_counts={}", code, stats)
+    pub fn invite_optioned(
+        code: &str,
+        member_counts: bool,
+        expiration: bool,
+        event_id: Option<u64>,
+    ) -> String {
+        let event_config = match event_id {
+            Some(id) => &format!("&event_id={}", id),
+            None => "",
+        };
+        api!(
+            "/invites/{}?with_counts={}&with_expiration={}{}",
+            code,
+            member_counts,
+            expiration,
+            event_config
+        )
     }
 
     pub fn oauth2_application_current() -> &'static str {
@@ -1477,7 +1492,9 @@ pub enum RouteInfo<'a> {
     },
     GetInvite {
         code: &'a str,
-        stats: bool,
+        member_counts: bool,
+        expiration: bool,
+        event_id: Option<u64>,
     },
     GetMember {
         guild_id: u64,
@@ -2523,11 +2540,13 @@ impl<'a> RouteInfo<'a> {
             ),
             RouteInfo::GetInvite {
                 code,
-                stats,
+                member_counts,
+                expiration,
+                event_id,
             } => (
                 LightMethod::Get,
                 Route::InvitesCode,
-                Cow::from(Route::invite_optioned(code, stats)),
+                Cow::from(Route::invite_optioned(code, member_counts, expiration, event_id)),
             ),
             RouteInfo::GetMember {
                 guild_id,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -838,16 +838,15 @@ impl Route {
         expiration: bool,
         event_id: Option<u64>,
     ) -> String {
-        let event_config = match event_id {
-            Some(id) => &format!("&event_id={}", id),
-            None => "",
-        };
         api!(
             "/invites/{}?with_counts={}&with_expiration={}{}",
             code,
             member_counts,
             expiration,
-            event_config
+            match event_id {
+                Some(id) => format!("&event_id={}", id),
+                None => "".to_string(),
+            }
         )
     }
 

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -149,8 +149,8 @@ impl Invite {
     /// * `expiration` - Whether to include information about when the invite expires.
     /// * `event_id` - An optional server event ID to include with the invite.
     ///
-    /// More information about these arguments can be found on Discord's API documentation:
-    /// https://discord.com/developers/docs/resources/invite#get-invite
+    /// More information about these arguments can be found on Discord's
+    /// [API documentation](https://discord.com/developers/docs/resources/invite#get-invite).
     ///
     /// # Errors
     ///

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -139,14 +139,31 @@ impl Invite {
         cache_http.http().as_ref().delete_invite(&self.code).await
     }
 
-    /// Gets the information about an invite.
+    /// Gets information about an invite.
+    ///
+    /// # Arguments
+    ///
+    /// * `code` - The invite code.
+    /// * `member_counts` - Whether to include information about the current number
+    /// of members in the server that the invite belongs to.
+    /// * `expiration` - Whether to include information about when the invite expires.
+    /// * `event_id` - An optional server event ID to include with the invite.
+    ///
+    /// More information about these arguments can be found on Discord's API documentation:
+    /// https://discord.com/developers/docs/resources/invite#get-invite
     ///
     /// # Errors
     ///
     /// May return an [`Error::Http`] if the invite is invalid.
     /// Can also return an [`Error::Json`] if there is an error
     /// deserializing the API response.
-    pub async fn get(http: impl AsRef<Http>, code: &str, stats: bool) -> Result<Invite> {
+    pub async fn get(
+        http: impl AsRef<Http>,
+        code: &str,
+        member_counts: bool,
+        expiration: bool,
+        event_id: Option<u64>,
+    ) -> Result<Invite> {
         let mut invite = code;
 
         #[cfg(feature = "utils")]
@@ -154,7 +171,7 @@ impl Invite {
             invite = crate::utils::parse_invite(invite);
         }
 
-        http.as_ref().get_invite(invite, stats).await
+        http.as_ref().get_invite(invite, member_counts, expiration, event_id).await
     }
 
     /// Returns a URL to use for the invite.


### PR DESCRIPTION
As I outlined in #1712, there's a few possible ways to handle the new parameters Discord is offering; I've just gone with the one I personally favor, but am happy to change it.

Fixes #1712