### PR TITLE
Clarify docs for using components with webhooks

### DIFF
--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -54,7 +54,10 @@ impl EditWebhookMessage {
         self
     }
 
-    /// Sets the components of this message.
+    /// Sets the components of this message. Requires an application-owned webhook, meaning
+    /// the webhook's `kind` field is set to [`WebhookType::Application`].
+    ///
+    /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
     #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -153,7 +153,10 @@ impl<'a> ExecuteWebhook<'a> {
         self
     }
 
-    /// Creates components for this message.
+    /// Creates components for this message. Requires an application-owned webhook, meaning
+    /// the webhook's `kind` field is set to [`WebhookType::Application`].
+    ///
+    /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
     #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
@@ -166,7 +169,7 @@ impl<'a> ExecuteWebhook<'a> {
         self
     }
 
-    /// Sets the components of this message.
+    /// Sets the components of this message. Requires an application-owned webhook. See [`ExecuteWebhook::components`] for details.
     #[cfg(feature = "unstable_discord_api")]
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
         self.0.insert("components", Value::Array(components.0));


### PR DESCRIPTION
In #1758 I left out a notice in the docs about restrictions around using components with webhooks, specifically that the webhook needs to be owned by an application. This PR changes them to reflect that.