### PR TITLE
Add missing method for converting to a ModalSubmitInteraction

### DIFF
--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -113,6 +113,14 @@ impl Interaction {
             _ => None,
         }
     }
+
+    /// Converts this to a [`ModalSubmitInteraction`]
+    pub fn modal_submit(self) -> Option<ModalSubmitInteraction> {
+        match self {
+            Interaction::ModalSubmit(i) => Some(i),
+            _ => None,
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for Interaction {


### PR DESCRIPTION
While working with the new Modal features, I noticed that the method for converting an `Interaction` to a `ModalSubmitInteraction` was missing. Here's a PR to address this, please let me know if I need to modify anything in my code or PR.