### PR TITLE
refactor: make collector builders synchronous

### DIFF
--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -141,7 +141,7 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
         .collect_limit(5u32)
         .timeout(Duration::from_secs(10))
     // Build the collector.
-        .await;
+        .build();
 
     // Let's acquire borrow HTTP to send a message inside the `async move`.
     let http = &ctx.http;
@@ -173,7 +173,8 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
         .add_event_type(EventType::MessageUpdate)
         .timeout(Duration::from_secs(20));
     // Only collect MessageUpdate events for the 5 MessageIds we're interested in.
-    let mut collector = collected.iter().fold(builder, |b, msg| b.add_message_id(msg.id)).await?;
+    let mut collector =
+        collected.iter().fold(builder, |b, msg| b.add_message_id(msg.id)).build()?;
 
     let _ = msg.reply(ctx, "Edit each of those 5 messages in 20 seconds").await;
     let mut edited = HashSet::new();

--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -217,7 +217,7 @@ impl EventHandler for Handler {
         // Wait for multiple interactions
 
         let mut cib =
-            m.await_component_interactions(&ctx).timeout(Duration::from_secs(60 * 3)).await;
+            m.await_component_interactions(&ctx).timeout(Duration::from_secs(60 * 3)).build();
 
         while let Some(mci) = cib.next().await {
             let sound = Sound::from_str(&mci.data.custom_id).unwrap();

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -217,6 +217,7 @@ impl ComponentInteractionCollectorBuilder {
         }
     }
 
+    /// Use the given configuration to build the [`ComponentInteractionCollector`].
     #[allow(clippy::unwrap_used)]
     pub fn build(self) -> ComponentInteractionCollector {
         let shard_messenger = self.shard.unwrap();

--- a/src/collector/error.rs
+++ b/src/collector/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
     ///     EventCollectorBuilder::new(&ctx)
     ///         .add_event_type(EventType::GuildCreate)
     ///         .add_user_id(UserId::default())
-    ///         .await,
+    ///         .build(),
     ///     Err(SerenityError::Collector(CollectorError::InvalidEventIdFilters)),
     /// ));
     /// # });

--- a/src/collector/error.rs
+++ b/src/collector/error.rs
@@ -19,7 +19,6 @@ pub enum Error {
     /// # use serenity::{prelude::*, collector::{CollectorError, EventCollectorBuilder}, model::prelude::*};
     /// # let (sender, _) = futures::channel::mpsc::unbounded();
     /// # let ctx = serenity::client::bridge::gateway::ShardMessenger::new(sender);
-    /// # tokio_test::block_on(async move {
     /// assert!(matches!(
     ///     EventCollectorBuilder::new(&ctx)
     ///         .add_event_type(EventType::GuildCreate)
@@ -27,7 +26,6 @@ pub enum Error {
     ///         .build(),
     ///     Err(SerenityError::Collector(CollectorError::InvalidEventIdFilters)),
     /// ));
-    /// # });
     /// ```
     /// [EventCollectorBuilder]: crate::collector::EventCollectorBuilder
     InvalidEventIdFilters,

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -266,7 +266,7 @@ impl EventCollectorBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if the filter option validation fails.
+    /// Returns [`Error::Collector`] if the filter option validation fails.
     #[allow(clippy::unwrap_used)]
     pub fn build(self) -> Result<EventCollector> {
         let shard_messenger = self.shard.unwrap();

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -262,6 +262,11 @@ impl EventCollectorBuilder {
         self
     }
 
+    /// Use the given configuration to build the [`EventCollector`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the filter option validation fails.
     #[allow(clippy::unwrap_used)]
     pub fn build(self) -> Result<EventCollector> {
         let shard_messenger = self.shard.unwrap();

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use futures::{future::BoxFuture, stream::Stream};
+use futures::stream::Stream;
 use tokio::sync::mpsc::{
     unbounded_channel,
     UnboundedReceiver as Receiver,
@@ -157,21 +157,19 @@ struct FilterOptions {
 }
 
 /// Future building a stream of events.
-pub struct EventCollectorBuilder<'a> {
+pub struct EventCollectorBuilder {
     filter: Option<FilterOptions>,
     shard: Option<ShardMessenger>,
     timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'a, Result<EventCollector>>>,
 }
 
-impl<'a> EventCollectorBuilder<'a> {
+impl EventCollectorBuilder {
     /// A future that builds an [`EventCollector`] based on the settings.
     pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
         Self {
             filter: Some(FilterOptions::default()),
             shard: Some(shard_messenger.as_ref().clone()),
             timeout: None,
-            fut: None,
         }
     }
 
@@ -263,31 +261,19 @@ impl<'a> EventCollectorBuilder<'a> {
 
         self
     }
-}
 
-impl<'a> Future for EventCollectorBuilder<'a> {
-    type Output = Result<EventCollector>;
     #[allow(clippy::unwrap_used)]
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            let shard_messenger = self.shard.take().unwrap();
-            let (filter, receiver) = match EventFilter::new(self.filter.take().unwrap()) {
-                Ok(ret) => ret,
-                Err(err) => return Poll::Ready(Err(err)),
-            };
-            let timeout = self.timeout.take();
+    pub fn build(self) -> Result<EventCollector> {
+        let shard_messenger = self.shard.unwrap();
+        let (filter, receiver) = EventFilter::new(self.filter.unwrap())?;
+        let timeout = self.timeout;
 
-            self.fut = Some(Box::pin(async move {
-                shard_messenger.set_event_filter(filter);
+        shard_messenger.set_event_filter(filter);
 
-                Ok(EventCollector {
-                    receiver: Box::pin(receiver),
-                    timeout,
-                })
-            }))
-        }
-
-        self.fut.as_mut().unwrap().as_mut().poll(ctx)
+        Ok(EventCollector {
+            receiver: Box::pin(receiver),
+            timeout,
+        })
     }
 }
 
@@ -336,22 +322,22 @@ mod test {
     use super::*;
     use crate::client::bridge::gateway::ShardMessenger;
 
-    #[tokio::test]
-    async fn test_no_event_types() {
+    #[test]
+    fn test_no_event_types() {
         let (sender, _) = unbounded();
         let msg = ShardMessenger::new(sender);
         assert!(matches!(
-            EventCollectorBuilder::new(&msg).await,
+            EventCollectorBuilder::new(&msg).build(),
             Err(Error::Collector(CollectorError::NoEventTypes))
         ));
         assert!(matches!(
-            EventCollectorBuilder::new(&msg).add_channel_id(ChannelId::default()).await,
+            EventCollectorBuilder::new(&msg).add_channel_id(ChannelId::default()).build(),
             Err(Error::Collector(CollectorError::NoEventTypes))
         ));
     }
 
-    #[tokio::test]
-    async fn test_build_with_single_id_filter() {
+    #[test]
+    fn test_build_with_single_id_filter() {
         let (sender, _) = unbounded();
         let msg = ShardMessenger::new(sender);
 
@@ -359,7 +345,7 @@ mod test {
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::GuildCreate)
                 .add_user_id(UserId::default())
-                .await,
+                .build(),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
         assert!(matches!(
@@ -367,7 +353,7 @@ mod test {
                 .add_event_type(EventType::GuildCreate)
                 .add_event_type(EventType::GuildRoleCreate)
                 .add_user_id(UserId::default())
-                .await,
+                .build(),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
 
@@ -375,7 +361,7 @@ mod test {
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::GuildBanAdd)
                 .add_user_id(UserId::default())
-                .await,
+                .build(),
             Ok(_)
         ));
         assert!(matches!(
@@ -383,13 +369,13 @@ mod test {
                 .add_event_type(EventType::GuildBanAdd)
                 .add_event_type(EventType::GuildCreate)
                 .add_user_id(UserId::default())
-                .await,
+                .build(),
             Ok(_)
         ));
     }
 
-    #[tokio::test]
-    async fn test_build_with_multiple_id_filters() {
+    #[test]
+    fn test_build_with_multiple_id_filters() {
         let (sender, _) = unbounded();
         let msg = ShardMessenger::new(sender);
 
@@ -398,20 +384,20 @@ mod test {
                 .add_event_type(EventType::UserUpdate)
                 .add_user_id(UserId::default())
                 .add_guild_id(GuildId::default())
-                .await,
+                .build(),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
         assert!(matches!(
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::UserUpdate)
                 .add_user_id(UserId::default())
-                .await,
+                .build(),
             Ok(_)
         ));
     }
 
-    #[tokio::test]
-    async fn test_build_with_multiple_event_types() {
+    #[test]
+    fn test_build_with_multiple_event_types() {
         let (sender, _) = unbounded();
         let msg = ShardMessenger::new(sender);
 
@@ -422,7 +408,7 @@ mod test {
                 .add_event_type(EventType::GuildCreate)
                 .add_event_type(EventType::GuildMemberAdd)
                 .add_user_id(UserId::default())
-                .await,
+                .build(),
             Ok(_)
         ));
         // But if none of the events have that ID type, that's an error.
@@ -431,7 +417,7 @@ mod test {
                 .add_event_type(EventType::GuildCreate)
                 .add_event_type(EventType::UserUpdate)
                 .add_channel_id(ChannelId::default())
-                .await,
+                .build(),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
     }

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -26,7 +26,7 @@ use crate::{client::bridge::gateway::ShardMessenger, collector::LazyArc, model::
 macro_rules! impl_message_collector {
     ($($name:ident;)*) => {
         $(
-            impl<'a> $name<'a> {
+            impl $name {
                 /// Limits how many messages will attempt to be filtered.
                 ///
                 /// The filter checks whether the message has been sent
@@ -163,21 +163,19 @@ impl_message_collector! {
 }
 
 /// Future building a stream of messages.
-pub struct MessageCollectorBuilder<'a> {
+pub struct MessageCollectorBuilder {
     filter: Option<FilterOptions>,
     shard: Option<ShardMessenger>,
     timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'a, MessageCollector>>,
 }
 
-impl<'a> MessageCollectorBuilder<'a> {
+impl MessageCollectorBuilder {
     /// A future that builds a [`MessageCollector`] based on the settings.
     pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
         Self {
             filter: Some(FilterOptions::default()),
             shard: Some(shard_messenger.as_ref().clone()),
             timeout: None,
-            fut: None,
         }
     }
 
@@ -191,39 +189,30 @@ impl<'a> MessageCollectorBuilder<'a> {
 
         self
     }
-}
 
-impl<'a> Future for MessageCollectorBuilder<'a> {
-    type Output = MessageCollector;
     #[allow(clippy::unwrap_used)]
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            let shard_messenger = self.shard.take().unwrap();
-            let (filter, receiver) = MessageFilter::new(self.filter.take().unwrap());
-            let timeout = self.timeout.take();
+    pub fn build(self) -> MessageCollector {
+        let shard_messenger = self.shard.unwrap();
+        let (filter, receiver) = MessageFilter::new(self.filter.unwrap());
+        let timeout = self.timeout;
 
-            self.fut = Some(Box::pin(async move {
-                shard_messenger.set_message_filter(filter);
+        shard_messenger.set_message_filter(filter);
 
-                MessageCollector {
-                    receiver: Box::pin(receiver),
-                    timeout,
-                }
-            }))
+        MessageCollector {
+            receiver: Box::pin(receiver),
+            timeout,
         }
-
-        self.fut.as_mut().unwrap().as_mut().poll(ctx)
     }
 }
 
-pub struct CollectReply<'a> {
+pub struct CollectReply {
     filter: Option<FilterOptions>,
     shard: Option<ShardMessenger>,
     timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'a, Option<Arc<Message>>>>,
+    fut: Option<BoxFuture<'static, Option<Arc<Message>>>>,
 }
 
-impl<'a> CollectReply<'a> {
+impl CollectReply {
     pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
         Self {
             filter: Some(FilterOptions::default()),
@@ -234,7 +223,7 @@ impl<'a> CollectReply<'a> {
     }
 }
 
-impl<'a> Future for CollectReply<'a> {
+impl Future for CollectReply {
     type Output = Option<Arc<Message>>;
     #[allow(clippy::unwrap_used)]
     fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -190,6 +190,7 @@ impl MessageCollectorBuilder {
         self
     }
 
+    /// Use the given configuration to build the [`MessageCollector`].
     #[allow(clippy::unwrap_used)]
     pub fn build(self) -> MessageCollector {
         let shard_messenger = self.shard.unwrap();

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -28,7 +28,7 @@ use crate::model::interactions::modal::ModalSubmitInteraction;
 macro_rules! impl_modal_interaction_collector {
     ($($name:ident;)*) => {
         $(
-            impl<'a> $name<'a> {
+            impl $name {
                 /// Limits how many interactions will attempt to be filtered.
                 ///
                 /// The filter checks whether the message has been sent
@@ -205,55 +205,44 @@ impl_modal_interaction_collector! {
     ModalInteractionCollectorBuilder;
 }
 
-pub struct ModalInteractionCollectorBuilder<'a> {
+pub struct ModalInteractionCollectorBuilder {
     filter: Option<FilterOptions>,
     shard: Option<ShardMessenger>,
     timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'a, ModalInteractionCollector>>,
 }
 
-impl<'a> ModalInteractionCollectorBuilder<'a> {
+impl ModalInteractionCollectorBuilder {
     pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
         Self {
             filter: Some(FilterOptions::default()),
             shard: Some(shard_messenger.as_ref().clone()),
             timeout: None,
-            fut: None,
         }
     }
-}
 
-impl<'a> Future for ModalInteractionCollectorBuilder<'a> {
-    type Output = ModalInteractionCollector;
     #[allow(clippy::unwrap_used)]
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            let shard_messenger = self.shard.take().unwrap();
-            let (filter, receiver) = ModalInteractionFilter::new(self.filter.take().unwrap());
-            let timeout = self.timeout.take();
+    pub fn build(self) -> ModalInteractionCollector {
+        let shard_messenger = self.shard.unwrap();
+        let (filter, receiver) = ModalInteractionFilter::new(self.filter.unwrap());
+        let timeout = self.timeout;
 
-            self.fut = Some(Box::pin(async move {
-                shard_messenger.set_modal_interaction_filter(filter);
+        shard_messenger.set_modal_interaction_filter(filter);
 
-                ModalInteractionCollector {
-                    receiver: Box::pin(receiver),
-                    timeout,
-                }
-            }))
+        ModalInteractionCollector {
+            receiver: Box::pin(receiver),
+            timeout,
         }
-
-        self.fut.as_mut().unwrap().as_mut().poll(ctx)
     }
 }
 
-pub struct CollectModalInteraction<'a> {
+pub struct CollectModalInteraction {
     filter: Option<FilterOptions>,
     shard: Option<ShardMessenger>,
     timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'a, Option<Arc<ModalSubmitInteraction>>>>,
+    fut: Option<BoxFuture<'static, Option<Arc<ModalSubmitInteraction>>>>,
 }
 
-impl<'a> CollectModalInteraction<'a> {
+impl CollectModalInteraction {
     pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
         Self {
             filter: Some(FilterOptions::default()),
@@ -264,7 +253,7 @@ impl<'a> CollectModalInteraction<'a> {
     }
 }
 
-impl<'a> Future for CollectModalInteraction<'a> {
+impl Future for CollectModalInteraction {
     type Output = Option<Arc<ModalSubmitInteraction>>;
     #[allow(clippy::unwrap_used)]
     fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -220,6 +220,7 @@ impl ModalInteractionCollectorBuilder {
         }
     }
 
+    /// Use the given configuration to build the [`ModalInteractionCollector`].
     #[allow(clippy::unwrap_used)]
     pub fn build(self) -> ModalInteractionCollector {
         let shard_messenger = self.shard.unwrap();

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -313,6 +313,7 @@ impl ReactionCollectorBuilder {
         }
     }
 
+    /// Use the given configuration to build the [`ReactionCollector`].
     #[allow(clippy::unwrap_used)]
     pub fn build(self) -> ReactionCollector {
         let shard_messenger = self.shard.unwrap();

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -31,7 +31,7 @@ use crate::{
 macro_rules! impl_reaction_collector {
     ($($name:ident;)*) => {
         $(
-            impl<'a> $name<'a> {
+            impl $name {
                 /// Limits how many messages will attempt to be filtered.
                 ///
                 /// The filter checks whether the message has been sent
@@ -298,55 +298,44 @@ impl_reaction_collector! {
     ReactionCollectorBuilder;
 }
 
-pub struct ReactionCollectorBuilder<'a> {
+pub struct ReactionCollectorBuilder {
     filter: Option<FilterOptions>,
     shard: Option<ShardMessenger>,
     timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'a, ReactionCollector>>,
 }
 
-impl<'a> ReactionCollectorBuilder<'a> {
+impl ReactionCollectorBuilder {
     pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
         Self {
             filter: Some(FilterOptions::default()),
             shard: Some(shard_messenger.as_ref().clone()),
             timeout: None,
-            fut: None,
         }
     }
-}
 
-impl<'a> Future for ReactionCollectorBuilder<'a> {
-    type Output = ReactionCollector;
     #[allow(clippy::unwrap_used)]
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            let shard_messenger = self.shard.take().unwrap();
-            let (filter, receiver) = ReactionFilter::new(self.filter.take().unwrap());
-            let timeout = self.timeout.take();
+    pub fn build(self) -> ReactionCollector {
+        let shard_messenger = self.shard.unwrap();
+        let (filter, receiver) = ReactionFilter::new(self.filter.unwrap());
+        let timeout = self.timeout;
 
-            self.fut = Some(Box::pin(async move {
-                shard_messenger.set_reaction_filter(filter);
+        shard_messenger.set_reaction_filter(filter);
 
-                ReactionCollector {
-                    receiver: Box::pin(receiver),
-                    timeout,
-                }
-            }))
+        ReactionCollector {
+            receiver: Box::pin(receiver),
+            timeout,
         }
-
-        self.fut.as_mut().unwrap().as_mut().poll(ctx)
     }
 }
 
-pub struct CollectReaction<'a> {
+pub struct CollectReaction {
     filter: Option<FilterOptions>,
     shard: Option<ShardMessenger>,
     timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'a, Option<Arc<ReactionAction>>>>,
+    fut: Option<BoxFuture<'static, Option<Arc<ReactionAction>>>>,
 }
 
-impl<'a> CollectReaction<'a> {
+impl CollectReaction {
     pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
         Self {
             filter: Some(FilterOptions::default()),
@@ -357,7 +346,7 @@ impl<'a> CollectReaction<'a> {
     }
 }
 
-impl<'a> Future for CollectReaction<'a> {
+impl Future for CollectReaction {
     type Output = Option<Arc<ReactionAction>>;
     #[allow(clippy::unwrap_used)]
     fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -888,37 +888,31 @@ impl ChannelId {
 
     /// Returns a future that will await one message sent in this channel.
     #[cfg(feature = "collector")]
-    pub fn await_reply<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReply<'a> {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
         CollectReply::new(shard_messenger).channel_id(self.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this channel.
     #[cfg(feature = "collector")]
-    pub fn await_replies<'a>(
+    pub fn await_replies(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> MessageCollectorBuilder {
         MessageCollectorBuilder::new(shard_messenger).channel_id(self.0)
     }
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReaction<'a> {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
         CollectReaction::new(shard_messenger).channel_id(self.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this channel.
     #[cfg(feature = "collector")]
-    pub fn await_reactions<'a>(
+    pub fn await_reactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollectorBuilder {
         ReactionCollectorBuilder::new(shard_messenger).channel_id(self.0)
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1105,37 +1105,31 @@ impl GuildChannel {
 
     /// Returns a future that will await one message by this guild channel.
     #[cfg(feature = "collector")]
-    pub fn await_reply<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReply<'a> {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
         CollectReply::new(shard_messenger).channel_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this guild channel.
     #[cfg(feature = "collector")]
-    pub fn await_replies<'a>(
+    pub fn await_replies(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> MessageCollectorBuilder {
         MessageCollectorBuilder::new(shard_messenger).channel_id(self.id.0)
     }
 
     /// Await a single reaction by this guild channel.
     #[cfg(feature = "collector")]
-    pub fn await_reaction<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReaction<'a> {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
         CollectReaction::new(shard_messenger).channel_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this guild channel.
     #[cfg(feature = "collector")]
-    pub fn await_reactions<'a>(
+    pub fn await_reactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollectorBuilder {
         ReactionCollectorBuilder::new(shard_messenger).channel_id(self.id.0)
     }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -877,55 +877,52 @@ impl Message {
 
     /// Await a single reaction on this message.
     #[cfg(feature = "collector")]
-    pub fn await_reaction<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReaction<'a> {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
         CollectReaction::new(shard_messenger).message_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions on this message.
     #[cfg(feature = "collector")]
-    pub fn await_reactions<'a>(
+    pub fn await_reactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollectorBuilder {
         ReactionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 
     /// Await a single component interaction on this message.
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    pub fn await_component_interaction<'a>(
+    pub fn await_component_interaction(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectComponentInteraction<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> CollectComponentInteraction {
         CollectComponentInteraction::new(shard_messenger).message_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of component interactions on this message.
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    pub fn await_component_interactions<'a>(
+    pub fn await_component_interactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ComponentInteractionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ComponentInteractionCollectorBuilder {
         ComponentInteractionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 
     /// Await a single modal submit interaction on this message.
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    pub fn await_modal_interaction<'a>(
+    pub fn await_modal_interaction(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectModalInteraction<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> CollectModalInteraction {
         CollectModalInteraction::new(shard_messenger).message_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of modal submit interactions on this message.
     #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-    pub fn await_modal_interactions<'a>(
+    pub fn await_modal_interactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ModalInteractionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ModalInteractionCollectorBuilder {
         ModalInteractionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1242,37 +1242,31 @@ impl GuildId {
 
     /// Returns a future that will await one message sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReply<'a> {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
         CollectReply::new(shard_messenger).guild_id(self.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_replies<'a>(
+    pub fn await_replies(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> MessageCollectorBuilder {
         MessageCollectorBuilder::new(shard_messenger).guild_id(self.0)
     }
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReaction<'a> {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
         CollectReaction::new(shard_messenger).guild_id(self.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reactions<'a>(
+    pub fn await_reactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollectorBuilder {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.0)
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2447,37 +2447,31 @@ impl Guild {
 
     /// Returns a future that will await one message sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReply<'a> {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
         CollectReply::new(shard_messenger).guild_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_replies<'a>(
+    pub fn await_replies(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> MessageCollectorBuilder {
         MessageCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReaction<'a> {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
         CollectReaction::new(shard_messenger).guild_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reactions<'a>(
+    pub fn await_reactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollectorBuilder {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1541,37 +1541,31 @@ impl PartialGuild {
 
     /// Returns a future that will await one message sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReply<'a> {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
         CollectReply::new(shard_messenger).guild_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_replies<'a>(
+    pub fn await_replies(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> MessageCollectorBuilder {
         MessageCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 
     /// Await a single reaction in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReaction<'a> {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
         CollectReaction::new(shard_messenger).guild_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reactions<'a>(
+    pub fn await_reactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollectorBuilder {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1049,37 +1049,31 @@ impl User {
 
     /// Returns a future that will await one message by this user.
     #[cfg(feature = "collector")]
-    pub fn await_reply<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReply<'a> {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
         CollectReply::new(shard_messenger).author_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this user.
     #[cfg(feature = "collector")]
-    pub fn await_replies<'a>(
+    pub fn await_replies(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> MessageCollectorBuilder {
         MessageCollectorBuilder::new(shard_messenger).author_id(self.id.0)
     }
 
     /// Await a single reaction by this user.
     #[cfg(feature = "collector")]
-    pub fn await_reaction<'a>(
-        &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> CollectReaction<'a> {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
         CollectReaction::new(shard_messenger).author_id(self.id.0)
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this user.
     #[cfg(feature = "collector")]
-    pub fn await_reactions<'a>(
+    pub fn await_reactions(
         &self,
-        shard_messenger: &'a impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollectorBuilder {
         ReactionCollectorBuilder::new(shard_messenger).author_id(self.id.0)
     }
 }


### PR DESCRIPTION
This removes the `Future` implementations for `ComponentInteractionCollectorBuilder`, `EventCollectorBuilder`, `MessageCollectorBuilder`, `ModalInteractionCollectorBuilder` and `ReactionCollectorBuilder` and replaces it with a synchronous build method because there is nothing that requires it to be async.

Because the code inside some macros needed to be changed from `impl<'a> $name<'a>` to `impl $name`, this also changes the `BoxFuture` of related structs to be static, making them owned types.

Related PRs: #1538, #1566