### PR TITLE
Make the `model::guild::audit_log` module public

### DIFF
--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -1,3 +1,5 @@
+//! Audit log types for administrative actions within guilds.
+
 use std::{collections::HashMap, mem::transmute};
 
 use serde::de::{self, Deserializer};

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1,6 +1,6 @@
 //! Models relating to guilds and types that it owns.
 
-mod audit_log;
+pub mod audit_log;
 mod emoji;
 mod guild_id;
 mod guild_preview;
@@ -22,6 +22,8 @@ use tracing::error;
 #[cfg(all(feature = "model", feature = "cache"))]
 use tracing::warn;
 
+#[doc(hidden)]
+#[deprecated(note = "import the types from the `audit_log` module")]
 pub use self::audit_log::*;
 pub use self::emoji::*;
 pub use self::guild_id::*;

--- a/src/model/prelude.rs
+++ b/src/model/prelude.rs
@@ -15,6 +15,7 @@ pub use super::channel::*;
 pub use super::connection::*;
 pub use super::event::*;
 pub use super::gateway::*;
+pub use super::guild::audit_log::*;
 pub use super::guild::*;
 pub use super::id::*;
 #[cfg(feature = "unstable_discord_api")]


### PR DESCRIPTION
The `audit_log` module contains a lot of types which clutter the
`guild` module but are probably not used by most serenity users.

The types are still re-exported by the `guild` module but hidden from
the documentation.