### PR TITLE
Enable compilation of builder/interaction code without a backend

### DIFF
--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -1,6 +1,8 @@
 use url::Url;
 
+#[cfg(feature = "http")]
 use crate::http::client::Http;
+#[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
@@ -64,6 +66,7 @@ impl CreateBotAuthParameters {
     /// If the user is not authorized for this endpoint.
     ///
     /// [`HttpError::UnsuccessfulRequest`]: crate::http::HttpError::UnsuccessfulRequest
+    #[cfg(feature = "http")]
     pub async fn auto_client_id(&mut self, http: impl AsRef<Http>) -> Result<&mut Self> {
         self.client_id = http.as_ref().get_current_application_info().await.map(|v| v.id)?;
         Ok(self)

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "url")]
 use url::Url;
 
 #[cfg(feature = "http")]
@@ -18,6 +19,7 @@ pub struct CreateBotAuthParameters {
 
 impl CreateBotAuthParameters {
     /// Builds the url with the provided data.
+    #[cfg(feature = "url")]
     pub fn build(self) -> String {
         let mut valid_data = vec![];
         let bits = self.permissions.bits();

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -6,9 +6,9 @@ use serde_json::Value;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
-use crate::model::interactions::InteractionApplicationCommandCallbackDataFlags;
 #[cfg(feature = "http")]
 use crate::http::AttachmentType;
+use crate::model::interactions::InteractionApplicationCommandCallbackDataFlags;
 use crate::utils;
 
 #[derive(Clone, Debug, Default)]

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -1,16 +1,21 @@
 use std::collections::HashMap;
+#[cfg(not(feature = "http"))]
+use std::marker::PhantomData;
 
 use serde_json::Value;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
 use crate::model::interactions::InteractionApplicationCommandCallbackDataFlags;
-use crate::{http::AttachmentType, utils};
+#[cfg(feature = "http")]
+use crate::http::AttachmentType;
+use crate::utils;
 
 #[derive(Clone, Debug, Default)]
 pub struct CreateInteractionResponseFollowup<'a>(
     pub HashMap<&'static str, Value>,
-    pub Vec<AttachmentType<'a>>,
+    #[cfg(feature = "http")] pub Vec<AttachmentType<'a>>,
+    #[cfg(not(feature = "http"))] PhantomData<&'a ()>,
 );
 
 impl<'a> CreateInteractionResponseFollowup<'a> {
@@ -59,12 +64,14 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Appends a file to the message.
+    #[cfg(feature = "http")]
     pub fn add_file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
         self.1.push(file.into());
         self
     }
 
     /// Appends a list of files to the message.
+    #[cfg(feature = "http")]
     pub fn add_files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
         &mut self,
         files: It,
@@ -77,6 +84,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ///
     /// Calling this multiple times will overwrite the file list.
     /// To append files, call [`Self::add_file`] or [`Self::add_files`] instead.
+    #[cfg(feature = "http")]
     pub fn files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
         &mut self,
         files: It,

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
+#[cfg(not(feature = "http"))]
+use std::marker::PhantomData;
 
 use super::CreateAllowedMentions;
 use super::CreateEmbed;
 #[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
+#[cfg(feature = "http")]
 use crate::http::AttachmentType;
 use crate::internal::prelude::*;
 use crate::model::channel::{MessageFlags, MessageReference, ReactionType};
@@ -57,7 +60,8 @@ use crate::utils;
 pub struct CreateMessage<'a>(
     pub HashMap<&'static str, Value>,
     pub Option<Vec<ReactionType>>,
-    pub Vec<AttachmentType<'a>>,
+    #[cfg(feature = "http")] pub Vec<AttachmentType<'a>>,
+    #[cfg(not(feature = "http"))] PhantomData<&'a ()>,
 );
 
 impl<'a> CreateMessage<'a> {
@@ -176,12 +180,14 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Appends a file to the message.
+    #[cfg(feature = "http")]
     pub fn add_file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
         self.2.push(file.into());
         self
     }
 
     /// Appends a list of files to the message.
+    #[cfg(feature = "http")]
     pub fn add_files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
         &mut self,
         files: It,
@@ -194,6 +200,7 @@ impl<'a> CreateMessage<'a> {
     ///
     /// Calling this multiple times will overwrite the file list.
     /// To append files, call [`Self::add_file`] or [`Self::add_files`] instead.
+    #[cfg(feature = "http")]
     pub fn files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
         &mut self,
         files: It,
@@ -259,6 +266,6 @@ impl<'a> Default for CreateMessage<'a> {
         let mut map = HashMap::new();
         map.insert("tts", Value::Bool(false));
 
-        CreateMessage(map, None, Vec::new())
+        CreateMessage(map, None, Default::default())
     }
 }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "http")]
 use bytes::buf::Buf;
+#[cfg(feature = "http")]
 use reqwest::Url;
+#[cfg(feature = "http")]
 use tokio::{fs::File, io::AsyncReadExt};
 
+#[cfg(feature = "http")]
 use crate::http::{AttachmentType, Http};
 use crate::internal::prelude::*;
 use crate::model::{guild::Role, Permissions};
@@ -130,6 +134,7 @@ impl EditRole {
     ///
     /// May error if the icon is a URL and the HTTP request fails, or if the icon is a file
     /// on a path that doesn't exist.
+    #[cfg(feature = "http")]
     pub async fn icon<'a>(
         &mut self,
         http: impl AsRef<Http>,

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -4,6 +4,7 @@ use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer};
 
 use super::prelude::*;
+#[cfg(feature = "model")]
 use crate::builder::{
     CreateApplicationCommand,
     CreateApplicationCommands,
@@ -11,6 +12,7 @@ use crate::builder::{
     CreateInteractionResponseFollowup,
     EditInteractionResponse,
 };
+#[cfg(feature = "model")]
 use crate::http::Http;
 use crate::internal::prelude::{JsonMap, StdResult, Value};
 use crate::model::channel::{ChannelType, PartialChannel};
@@ -35,6 +37,7 @@ use crate::model::utils::{
     deserialize_roles_map,
     deserialize_users,
 };
+#[cfg(feature = "model")]
 use crate::utils;
 
 /// An interaction when a user invokes a slash command.
@@ -72,6 +75,7 @@ pub struct ApplicationCommandInteraction {
     pub locale: String,
 }
 
+#[cfg(feature = "model")]
 impl ApplicationCommandInteraction {
     /// Gets the interaction response.
     ///
@@ -757,6 +761,7 @@ pub struct ApplicationCommand {
     pub version: CommandVersionId,
 }
 
+#[cfg(feature = "model")]
 impl ApplicationCommand {
     /// Creates a global [`ApplicationCommand`],
     /// overriding an existing one with the same name if it exists.

--- a/src/model/interactions/autocomplete.rs
+++ b/src/model/interactions/autocomplete.rs
@@ -1,9 +1,12 @@
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer};
+#[cfg(feature = "model")]
 use serde_json::json;
 
 use super::prelude::*;
+#[cfg(feature = "model")]
 use crate::builder::CreateAutocompleteResponse;
+#[cfg(feature = "model")]
 use crate::http::Http;
 use crate::internal::prelude::{JsonMap, StdResult, Value};
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
@@ -12,6 +15,7 @@ use crate::model::interactions::{
     InteractionType,
 };
 use crate::model::prelude::User;
+#[cfg(feature = "model")]
 use crate::utils;
 
 /// An interaction received when the user fills in an autocomplete option
@@ -49,6 +53,7 @@ pub struct AutocompleteInteraction {
     pub locale: String,
 }
 
+#[cfg(feature = "model")]
 impl AutocompleteInteraction {
     /// Creates a response to an autocomplete interaction.
     ///

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -4,13 +4,16 @@ use serde::de::Error as DeError;
 use serde::{Serialize, Serializer};
 
 use super::prelude::*;
+#[cfg(feature = "model")]
 use crate::builder::{
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     EditInteractionResponse,
 };
+#[cfg(feature = "model")]
 use crate::http::Http;
 use crate::model::interactions::InteractionType;
+#[cfg(feature = "model")]
 use crate::utils;
 
 /// An interaction triggered by a message component.
@@ -51,6 +54,7 @@ pub struct MessageComponentInteraction {
     pub locale: String,
 }
 
+#[cfg(feature = "model")]
 impl MessageComponentInteraction {
     /// Gets the interaction response.
     ///

--- a/src/model/interactions/modal.rs
+++ b/src/model/interactions/modal.rs
@@ -3,13 +3,16 @@ use serde::Serialize;
 
 use super::message_component::ActionRow;
 use super::prelude::*;
+#[cfg(feature = "model")]
 use crate::builder::{
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     EditInteractionResponse,
 };
+#[cfg(feature = "model")]
 use crate::http::Http;
 use crate::model::interactions::InteractionType;
+#[cfg(feature = "model")]
 use crate::utils;
 
 /// An interaction triggered by a modal submit.
@@ -52,6 +55,7 @@ pub struct ModalSubmitInteraction {
     pub locale: String,
 }
 
+#[cfg(feature = "model")]
 impl ModalSubmitInteraction {
     /// Gets the interaction response.
     ///

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -466,6 +466,7 @@ mod test {
             };
 
             assert_eq!(ChannelId(1).mention().to_string(), "<#1>");
+            #[cfg(feature = "model")]
             assert_eq!(channel.mention().to_string(), "<#4>");
             assert_eq!(emoji.mention().to_string(), "<:omitted:5>");
             assert_eq!(member.mention().to_string(), "<@6>");
@@ -475,6 +476,7 @@ mod test {
             assert_eq!(user.id.mention().to_string(), "<@6>");
         }
 
+        #[cfg(feature = "model")]
         #[test]
         #[allow(clippy::unwrap_used)]
         fn parse_mentions() {

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -11,7 +11,7 @@ use super::prelude::*;
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
 use crate::internal::prelude::*;
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 use crate::model::interactions::application_command::*;
 
 pub fn default_true() -> bool {
@@ -84,7 +84,7 @@ pub fn deserialize_members<'de, D: Deserializer<'de>>(
     Ok(members)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_partial_members_map<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<UserId, PartialMember>, D::Error> {
@@ -93,7 +93,7 @@ pub fn deserialize_partial_members_map<'de, D: Deserializer<'de>>(
     Ok(map)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_users<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<UserId, User>, D::Error> {
@@ -102,7 +102,7 @@ pub fn deserialize_users<'de, D: Deserializer<'de>>(
     Ok(map)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_roles_map<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<RoleId, Role>, D::Error> {
@@ -111,7 +111,7 @@ pub fn deserialize_roles_map<'de, D: Deserializer<'de>>(
     Ok(map)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_channels_map<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<ChannelId, PartialChannel>, D::Error> {
@@ -120,7 +120,7 @@ pub fn deserialize_channels_map<'de, D: Deserializer<'de>>(
     Ok(map)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_messages_map<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<MessageId, Message>, D::Error> {
@@ -129,7 +129,7 @@ pub fn deserialize_messages_map<'de, D: Deserializer<'de>>(
     Ok(map)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_options<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<Vec<ApplicationCommandInteractionDataOption>, D::Error> {
@@ -139,7 +139,7 @@ pub fn deserialize_options<'de, D: Deserializer<'de>>(
     Ok(options)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_options_with_resolved<'de, D: Deserializer<'de>>(
     deserializer: D,
     resolved: &ApplicationCommandInteractionDataResolved,
@@ -154,7 +154,7 @@ pub fn deserialize_options_with_resolved<'de, D: Deserializer<'de>>(
     Ok(options)
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 fn try_resolve(
     value: &Value,
     kind: ApplicationCommandOptionType,
@@ -215,7 +215,7 @@ fn try_resolve(
     }
 }
 
-#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "unstable_discord_api")]
 fn loop_resolved(
     options: &mut ApplicationCommandInteractionDataOption,
     resolved: &ApplicationCommandInteractionDataResolved,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,7 +9,8 @@ mod message_builder;
 
 #[cfg(all(feature = "client", feature = "cache"))]
 pub use argument_convert::*;
-use reqwest::Url;
+#[cfg(feature = "url")]
+use url::Url;
 
 pub use self::{
     colour::{colours, Colour},
@@ -433,7 +434,7 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
     args
 }
 
-/// Parses the id and token from a webhook url. Expects a [`reqwest::Url`] object rather than a [`&str`].
+/// Parses the id and token from a webhook url. Expects a [`url::Url`] object rather than a [`&str`].
 ///
 /// # Examples
 ///
@@ -447,6 +448,7 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
 /// assert_eq!(id, 245037420704169985);
 /// assert_eq!(token, "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV");
 /// ```
+#[cfg(feature = "url")]
 pub fn parse_webhook(url: &Url) -> Option<(u64, &str)> {
     let path = url.path().strip_prefix("/api/webhooks/")?;
     let split_idx = path.find('/')?;
@@ -832,6 +834,7 @@ mod test {
         assert_eq!(parsed, ["a", "b c", "d", "e f", "g"]);
     }
 
+    #[cfg(feature = "url")]
     #[test]
     fn test_webhook_parser() {
         let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV".parse().unwrap();


### PR DESCRIPTION
I have a somewhat odd use case. I wanted to create an Interactions webhook receiver using Cloudflare Workers. Their platform does not support native executables; rather you get a web-ish JS/WASM environment. This means bringing your own networking tools isn't in the cards, as there is no interface to use.

Still, I didn't want to reinvent the wheel and re-type (the parts I needed out of) the Discord API. Instead, I wanted to use the existing types provided by Serenity, even if I couldn't actually use the HTTP or gateway code (I didn't need those for this project). However, I found that selecting just the features I wanted, i.e. `builder` and `unstable_discord_api`, would result in compiler errors throughout the code. I worked through those and added (in my eyes) appropriate feature gates to ensure no change to existing users, while enabling my intended configuration to compile without error.

In future, I would like to perhaps explore the possibility of using Reqwest's support for the Fetch API and a manual rewrite of the WebSocket code to enable the full feature set of Serenity in an environment like that.