### PR TITLE
Update serde_json for -Z minimal-versions builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = ["examples/*"]
 
 [dependencies]
 bitflags = "1.1"
-serde_json = "1"
+serde_json = "1.0.25"
 async-trait = "0.1.9"
 
 [dependencies.tracing]

--- a/voice-model/Cargo.toml
+++ b/voice-model/Cargo.toml
@@ -23,7 +23,7 @@ features = ["derive"]
 
 [dependencies.serde_json]
 features = ["raw_value"]
-version = "1"
+version = "1.0.29"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
serenity has incorrect serde version bounds. Those aren't being caught to criterion's higher `serde-json` version requirement, however if the following lines were to be removed from `voice-model/Cargo.toml` the problem would be immediately apparent when using `cargo check`.

```toml
[dev-dependencies]
criterion = "0.3"
serde_test = "1"
```

This matters because crates that use `serenity` don't use its `dev-dependencies`.