### PR TITLE
Remove tokio 0.2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
           - no gateway
           - time
           - unstable Discord API features
-          - rustls tokio 0.2
-          - native-tls tokio 0.2
           - simd-json
 
         include:
@@ -46,12 +44,6 @@ jobs:
             features: time
           - name: unstable Discord API features
             features: default unstable_discord_api
-            dont-test: true
-          - name: rustls tokio 0.2
-            features: default_tokio_0_2
-            dont-test: true
-          - name: native-tls tokio 0.2
-            features: default_native_tls_tokio_0_2
             dont-test: true
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,14 +74,6 @@ features = ["json", "multipart", "stream"]
 optional = true
 version = "0.11.7"
 
-# Tokio v0.2
-[dependencies.reqwest_compat]
-package = "reqwest"
-default-features = false
-features = ["json", "stream"]
-optional = true
-version = "0.10"
-
 [dependencies.serenity-voice-model]
 path = "./voice-model"
 version = "0.1.1"
@@ -97,14 +89,6 @@ features = ["tokio-runtime"]
 optional = true
 version = "0.16"
 
-# Tokio v0.2
-[dependencies.async-tungstenite_compat]
-package = "async-tungstenite"
-default-features = false
-features = ["tokio-runtime"]
-optional = true
-version = "0.9.2"
-
 [dependencies.typemap_rev]
 optional = true
 version = "0.1.3"
@@ -113,24 +97,11 @@ version = "0.1.3"
 optional = true
 version = "1.0"
 
-[dependencies.bytes_compat]
-package = "bytes"
-optional = true
-version = "0.5"
-
 [dependencies.tokio]
 version = "1"
 default-features = true
 optional = true
 features = ["fs", "macros", "rt", "sync", "time"]
-
-# Tokio v0.2
-[dependencies.tokio_compat]
-package = "tokio"
-version = "0.2"
-optional = true
-default-features = true
-features = ["fs", "macros", "rt-core", "sync", "time", "stream"]
 
 [dependencies.futures]
 version = "0.3"
@@ -169,11 +140,6 @@ version = "0.4"
 # Defaults with different backends
 default = ["default_no_backend", "rustls_backend"]
 default_native_tls = ["default_no_backend", "native_tls_backend"]
-default_tokio_0_2 = ["default_no_backend", "rustls_tokio_0_2_backend"]
-default_native_tls_tokio_0_2 = [
-    "default_no_backend",
-    "native_tls_tokio_0_2_backend",
-]
 
 # Serenity requires a backend, this picks all default features without a backend.
 default_no_backend = [
@@ -216,13 +182,6 @@ rustls_backend = [
     "rustls_backend_marker",
     "bytes",
 ]
-rustls_tokio_0_2_backend = [
-    "reqwest_compat/rustls-tls",
-    "async-tungstenite_compat/tokio-rustls",
-    "tokio_compat",
-    "bytes_compat",
-    "rustls_backend_marker",
-]
 # Marks that a Rustls backend is active
 rustls_backend_marker = []
 
@@ -232,13 +191,6 @@ native_tls_backend = [
     "async-tungstenite/tokio-native-tls",
     "tokio",
     "bytes",
-    "native_tls_backend_marker",
-]
-native_tls_tokio_0_2_backend = [
-    "reqwest_compat/native-tls",
-    "async-tungstenite_compat/tokio-native-tls",
-    "tokio_compat",
-    "bytes_compat",
     "native_tls_backend_marker",
 ]
 # Marks that a Native TLS backend is active

--- a/README.md
+++ b/README.md
@@ -123,9 +123,7 @@ The default features are: `builder`, `cache`, `client`, `framework`, `gateway`,
 
 There are these alternative default features, they require to set `default-features = false`:
 
-- **default_tokio_0_2**: Uses the default backend with `tokio` version `0.2`.
 - **default_native_tls**: Uses `native_tls_backend` instead of the default `rustls_backend`.
-- **default_native_tls_tokio_0_2**: Uses `native_tls_backend` with `tokio` version `0.2`.
 - **default_no_backend**: Excludes the default backend, pick your own backend instead.
 
 If you are unsure which to pick, use the default features by not setting `default-features = false`.
@@ -168,11 +166,6 @@ one if you do not use the default features:
 TLS implementation.
 - **native_tls_backend**: Uses SChannel on Windows, Secure Transport on macOS,
 and OpenSSL on other platforms.
-
-If you need to use `tokio` version `0.2` use the backends below:
-
-- **rustls_tokio_0_2_backend**: Combines **rustls_backend** with `tokio` version `0.2`.
-- **native_tls_tokio_0_2_backend**: Combines **native_tls_backend** with `tokio` version `0.2`.
 
 If you want all of the default features except for `cache` for example, you can
 list all but that:

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -8,11 +8,7 @@ use futures::{
     StreamExt,
 };
 use tokio::sync::{Mutex, RwLock};
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::delay_for as sleep;
-#[cfg(feature = "tokio")]
-use tokio::time::sleep;
-use tokio::time::{timeout, Duration, Instant};
+use tokio::time::{sleep, timeout, Duration, Instant};
 use tracing::{debug, info, instrument, warn};
 use typemap_rev::TypeMap;
 

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -16,9 +16,6 @@ use tokio::sync::mpsc::{
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::{delay_for as sleep, Delay as Sleep};
-#[cfg(feature = "tokio")]
 use tokio::time::{sleep, Sleep};
 
 use crate::client::bridge::gateway::ShardMessenger;

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -13,9 +13,6 @@ use tokio::sync::mpsc::{
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::{delay_for as sleep, Delay as Sleep};
-#[cfg(feature = "tokio")]
 use tokio::time::{sleep, Sleep};
 
 use crate::{

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -16,9 +16,6 @@ use tokio::sync::mpsc::{
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::{delay_for as sleep, Delay as Sleep};
-#[cfg(feature = "tokio")]
 use tokio::time::{sleep, Sleep};
 
 use crate::{client::bridge::gateway::ShardMessenger, collector::LazyArc, model::channel::Message};

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -16,9 +16,6 @@ use tokio::sync::mpsc::{
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::{delay_for as sleep, Delay as Sleep};
-#[cfg(feature = "tokio")]
 use tokio::time::{sleep, Sleep};
 
 use crate::client::bridge::gateway::ShardMessenger;

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -16,9 +16,6 @@ use tokio::sync::mpsc::{
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::{delay_for as sleep, Delay as Sleep};
-#[cfg(feature = "tokio")]
 use tokio::time::{sleep, Sleep};
 
 use crate::{

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -21,9 +21,6 @@ pub use structures::buckets::BucketBuilder;
 use structures::buckets::{Bucket, RateLimitAction};
 pub use structures::*;
 use tokio::sync::Mutex;
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::delay_for as sleep;
-#[cfg(feature = "tokio")]
 use tokio::time::sleep;
 use tracing::instrument;
 use uwl::Stream;

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -52,11 +52,7 @@ use std::{
 use reqwest::{header::HeaderMap, StatusCode};
 use reqwest::{Client, Response};
 use tokio::sync::{Mutex, RwLock};
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::delay_for as sleep;
-#[cfg(feature = "tokio")]
-use tokio::time::sleep;
-use tokio::time::Duration;
+use tokio::time::{sleep, Duration};
 use tracing::{debug, instrument};
 
 pub use super::routing::Route;

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-use tokio::time::delay_for as sleep;
-#[cfg(feature = "tokio")]
 use tokio::time::sleep;
 use tokio::{
     sync::oneshot::{self, error::TryRecvError, Sender},

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -6,5 +6,5 @@ pub mod prelude;
 #[cfg(feature = "gateway")]
 pub mod ws_impl;
 
-#[cfg(any(feature = "tokio", feature = "tokio_compat"))]
+#[cfg(feature = "tokio")]
 pub mod tokio;

--- a/src/internal/tokio.rs
+++ b/src/internal/tokio.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-#[cfg(all(tokio_unstable, not(feature = "tokio_compat")))]
+#[cfg(tokio_unstable)]
 pub fn spawn_named<F, T>(name: &str, future: F) -> tokio::task::JoinHandle<T>
 where
     F: Future<Output = T> + Send + 'static,
@@ -9,7 +9,7 @@ where
     tokio::task::Builder::new().name(&*format!("serenity::{}", name)).spawn(future)
 }
 
-#[cfg(any(not(tokio_unstable), feature = "tokio_compat"))]
+#[cfg(not(tokio_unstable))]
 pub fn spawn_named<F, T>(_name: &str, future: F) -> tokio::task::JoinHandle<T>
 where
     F: Future<Output = T> + Send + 'static,

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -138,18 +138,6 @@ fn websocket_config() -> async_tungstenite::tungstenite::protocol::WebSocketConf
     }
 }
 
-#[cfg(all(
-    any(feature = "rustls_tokio_0_2_backend", feature = "native_tls_tokio_0_2_backend"),
-    not(any(feature = "rustls_backend", feature = "native_tls_backend"))
-))]
-fn websocket_config() -> async_tungstenite::tungstenite::protocol::WebSocketConfig {
-    async_tungstenite::tungstenite::protocol::WebSocketConfig {
-        max_message_size: None,
-        max_frame_size: None,
-        max_send_queue: None,
-    }
-}
-
 #[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
 #[instrument]
 pub(crate) async fn create_rustls_client(url: Url) -> Result<WsStream> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,18 +66,6 @@
 #[macro_use]
 extern crate serde;
 
-#[cfg(all(feature = "tokio_compat", not(feature = "tokio")))]
-extern crate tokio_compat as tokio;
-
-#[cfg(all(feature = "reqwest_compat", not(feature = "reqwest")))]
-extern crate reqwest_compat as reqwest;
-
-#[cfg(all(feature = "async-tungstenite_compat", not(feature = "async-tungstenite")))]
-extern crate async_tungstenite_compat as async_tungstenite;
-
-#[cfg(all(feature = "bytes_compat", not(feature = "bytes")))]
-extern crate bytes_compat as bytes;
-
 #[macro_use]
 mod internal;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,7 @@
 //!
 //! [`serenity::Error`]: crate::Error
 
-#[cfg(any(feature = "tokio", feature = "tokio_compat"))]
+#[cfg(feature = "tokio")]
 pub use tokio::sync::{Mutex, RwLock};
 #[cfg(feature = "client")]
 pub use typemap_rev::{TypeMap, TypeMapKey};


### PR DESCRIPTION
Whether it's 0.11, 0.12 or 1.0, I think it makes sense to drop compatibility for an old version of tokio. At this point pretty much nobody supports tokio 0.2, and there are a few security vulnerabilities when using tokio 0.2: https://rustsec.org/advisories/RUSTSEC-2021-0124, https://rustsec.org/advisories/RUSTSEC-2021-0079, https://rustsec.org/advisories/RUSTSEC-2021-0078.