### PR TITLE
Unify `std::fmt` imports and `Display` & `Debug` trait implementations

### DIFF
--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -1,10 +1,4 @@
-use std::{
-    env,
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-    str::FromStr,
-    time::Duration,
-};
+use std::{env, error::Error as StdError, fmt, str::FromStr, time::Duration};
 
 use dotenv::dotenv;
 use serenity::{
@@ -34,16 +28,16 @@ enum Animal {
 #[derive(Debug)]
 struct ParseComponentError(String);
 
-impl Display for ParseComponentError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for ParseComponentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Failed to parse {} as component", self.0)
     }
 }
 
 impl StdError for ParseComponentError {}
 
-impl Display for Animal {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for Animal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Cat => write!(f, "Cat"),
             Self::Dog => write!(f, "Dog"),
@@ -115,8 +109,8 @@ enum Sound {
     Honk,
 }
 
-impl Display for Sound {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for Sound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Meow => write!(f, "meow"),
             Self::Woof => write!(f, "woof"),

--- a/src/client/bridge/gateway/mod.rs
+++ b/src/client/bridge/gateway/mod.rs
@@ -51,10 +51,7 @@ mod shard_queuer;
 mod shard_runner;
 mod shard_runner_message;
 
-use std::{
-    fmt::{Display, Formatter, Result as FmtResult},
-    time::Duration as StdDuration,
-};
+use std::{fmt, time::Duration as StdDuration};
 
 pub use self::shard_manager::{ShardManager, ShardManagerOptions};
 pub use self::shard_manager_monitor::{ShardManagerError, ShardManagerMonitor};
@@ -132,8 +129,8 @@ pub enum ShardQueuerMessage {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct ShardId(pub u64);
 
-impl Display for ShardId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for ShardId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,7 +1,4 @@
-use std::{
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
+use std::{error::Error as StdError, fmt};
 
 /// An error returned from the [`Client`].
 ///
@@ -22,8 +19,8 @@ pub enum Error {
     Shutdown,
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::ShardBootFailure => f.write_str("Failed to (re-)boot a shard"),
             Error::Shutdown => f.write_str("The clients shards shutdown"),

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -1,5 +1,6 @@
 use std::{
     boxed::Box,
+    fmt,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -179,8 +180,8 @@ struct FilterOptions {
     message_id: Option<u64>,
 }
 
-impl std::fmt::Debug for FilterOptions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for FilterOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ComponentInteractionFilter")
             .field("collect_limit", &self.collect_limit)
             .field("filter", &"Option<Arc<dyn Fn(&Arc<Reaction>) -> bool + 'static + Send + Sync>>")

--- a/src/collector/error.rs
+++ b/src/collector/error.rs
@@ -1,7 +1,4 @@
-use std::{
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
+use std::{error::Error as StdError, fmt};
 
 /// An error that occurred while working with a collector.
 #[derive(Clone, Debug)]
@@ -31,8 +28,8 @@ pub enum Error {
     InvalidEventIdFilters,
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::NoEventTypes => f.write_str("No event types provided"),
             Error::InvalidEventIdFilters => {

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -1,5 +1,6 @@
 use std::{
     boxed::Box,
+    fmt,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -135,8 +136,8 @@ impl EventFilter {
 #[derive(Clone)]
 struct FilterFn(Arc<dyn Fn(&Arc<Event>) -> bool + 'static + Send + Sync>);
 
-impl std::fmt::Debug for FilterFn {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for FilterFn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Arc<dyn Fn(&Arc<Event>) -> bool + 'static + Send + Sync>")
     }
 }

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -1,5 +1,6 @@
 use std::{
     boxed::Box,
+    fmt,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -246,8 +247,8 @@ impl Future for CollectReply {
     }
 }
 
-impl std::fmt::Debug for FilterOptions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for FilterOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MessageFilter")
             .field("collect_limit", &self.collect_limit)
             .field("filter", &"Option<Arc<dyn Fn(&Arc<Message>) -> bool + 'static + Send + Sync>>")

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -1,5 +1,6 @@
 use std::{
     boxed::Box,
+    fmt,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -182,8 +183,8 @@ struct FilterOptions {
     message_id: Option<u64>,
 }
 
-impl std::fmt::Debug for FilterOptions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for FilterOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ModalInteractionFilter")
             .field("collect_limit", &self.collect_limit)
             .field("filter", &"Option<Arc<dyn Fn(&Arc<Reaction>) -> bool + 'static + Send + Sync>>")

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -1,5 +1,6 @@
 use std::{
     boxed::Box,
+    fmt,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -369,8 +370,8 @@ impl Future for CollectReaction {
     }
 }
 
-impl std::fmt::Debug for FilterOptions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for FilterOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReactionFilter")
             .field("collect_limit", &self.collect_limit)
             .field("filter", &"Option<Arc<dyn Fn(&Arc<Reaction>) -> bool + 'static + Send + Sync>>")

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::{
     error::Error as StdError,
-    fmt::{self, Display, Error as FormatError},
+    fmt::{self, Error as FormatError},
     io::Error as IoError,
     num::ParseIntError,
 };
@@ -203,7 +203,7 @@ impl From<ReqwestError> for Error {
     }
 }
 
-impl Display for Error {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Decode(msg, _) | Error::Other(msg) => f.write_str(msg),

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::time::{Duration, Instant};
 
 use futures::future::BoxFuture;
@@ -322,8 +323,8 @@ impl TicketCounter {
 #[derive(Debug)]
 pub struct RevertBucket;
 
-impl std::fmt::Display for RevertBucket {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for RevertBucket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("RevertBucket")
     }
 }

--- a/src/framework/standard/structures/check.rs
+++ b/src/framework/standard/structures/check.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use std::fmt::{self, Debug, Display};
+use std::fmt;
 
 use futures::future::BoxFuture;
 
@@ -54,7 +54,7 @@ pub struct Check {
     pub display_in_help: bool,
 }
 
-impl Debug for Check {
+impl fmt::Debug for Check {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Check")
             .field("name", &self.name)
@@ -65,7 +65,7 @@ impl Debug for Check {
     }
 }
 
-impl Display for Reason {
+impl fmt::Display for Reason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unknown => f.write_str("Unknown"),

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -1,7 +1,4 @@
-use std::{
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
+use std::{error::Error as StdError, fmt};
 
 use async_tungstenite::tungstenite::protocol::CloseFrame;
 
@@ -57,8 +54,8 @@ pub enum Error {
     DisallowedGatewayIntents,
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::BuildingUrl => f.write_str("Error building url"),
             Error::Closed(_) => f.write_str("Connection closed"),

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -50,7 +50,7 @@ mod error;
 mod shard;
 mod ws_client_ext;
 
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::fmt;
 
 pub use self::{
     error::Error as GatewayError,
@@ -132,8 +132,8 @@ impl ConnectionStage {
     }
 }
 
-impl Display for ConnectionStage {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for ConnectionStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::ConnectionStage::*;
 
         f.write_str(match *self {

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -1,7 +1,4 @@
-use std::{
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
+use std::{error::Error as StdError, fmt};
 
 use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, Response, StatusCode, Url};
 use url::ParseError as UrlError;
@@ -136,8 +133,8 @@ impl From<InvalidHeaderValue> for Error {
     }
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::UnsuccessfulRequest(e) => {
                 f.write_str(&e.error.message)?;

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -1,9 +1,5 @@
 #[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
-use std::{
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-    io::Error as IoError,
-};
+use std::{error::Error as StdError, fmt, io::Error as IoError};
 
 use async_trait::async_trait;
 use async_tungstenite::tungstenite::Message;
@@ -106,14 +102,14 @@ impl From<IoError> for RustlsError {
 }
 
 #[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
-impl Display for RustlsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for RustlsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RustlsError::WebPKI => f.write_str("Failed to validate X.509 certificate"),
             RustlsError::HandshakeError => {
                 f.write_str("TLS handshake failed when making the websocket connection")
             },
-            RustlsError::Io(inner) => Display::fmt(&inner, f),
+            RustlsError::Io(inner) => fmt::Display::fmt(&inner, f),
         }
     }
 }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1,5 +1,4 @@
-#[cfg(feature = "model")]
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::fmt;
 #[cfg(feature = "model")]
 use std::sync::Arc;
 
@@ -1289,10 +1288,10 @@ impl GuildChannel {
     }
 }
 
-impl Display for GuildChannel {
+impl fmt::Display for GuildChannel {
     /// Formats the channel, creating a mention of it.
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        Display::fmt(&self.id.mention(), f)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.id.mention(), f)
     }
 }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -11,8 +11,7 @@ mod partial_channel;
 mod private_channel;
 mod reaction;
 
-#[cfg(feature = "model")]
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::fmt;
 
 use serde::de::{Error as DeError, Unexpected};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
@@ -278,7 +277,7 @@ impl Serialize for Channel {
     }
 }
 
-impl Display for Channel {
+impl fmt::Display for Channel {
     /// Formats the channel into a "mentioned" string.
     ///
     /// This will return a different format for each type of channel:
@@ -286,11 +285,11 @@ impl Display for Channel {
     /// - [`PrivateChannel`]s: the recipient's name;
     /// - [`GuildChannel`]s: a string mentioning the channel that users who can
     /// see the channel can click on.
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Channel::Guild(ch) => Display::fmt(&ch.id.mention(), f),
-            Channel::Private(ch) => Display::fmt(&ch.recipient.name, f),
-            Channel::Category(ch) => Display::fmt(&ch.name, f),
+            Channel::Guild(ch) => fmt::Display::fmt(&ch.id.mention(), f),
+            Channel::Private(ch) => fmt::Display::fmt(&ch.recipient.name, f),
+            Channel::Category(ch) => fmt::Display::fmt(&ch.name, f),
         }
     }
 }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::fmt;
 #[cfg(feature = "model")]
 use std::sync::Arc;
 
@@ -269,11 +269,7 @@ impl PrivateChannel {
     /// is over the above limit, containing the number of unicode code points
     /// over the limit.
     #[inline]
-    pub async fn say(
-        &self,
-        http: impl AsRef<Http>,
-        content: impl std::fmt::Display,
-    ) -> Result<Message> {
+    pub async fn say(&self, http: impl AsRef<Http>, content: impl fmt::Display) -> Result<Message> {
         self.id.say(&http, content).await
     }
 
@@ -394,9 +390,9 @@ impl PrivateChannel {
     }
 }
 
-impl Display for PrivateChannel {
+impl fmt::Display for PrivateChannel {
     /// Formats the private channel, displaying the recipient's username.
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.recipient.name)
     }
 }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "model")]
 use std::cmp::Ordering;
 use std::convert::TryFrom;
-use std::fmt::{self, Display, Formatter, Result as FmtResult, Write as FmtWrite};
+#[cfg(doc)]
+use std::fmt::Display as _;
+use std::fmt::{self, Write as _};
 use std::str::FromStr;
 
 use serde::de::{Deserialize, Error as DeError, MapAccess, Visitor};
@@ -318,6 +320,7 @@ pub enum ReactionType {
 }
 
 impl<'de> Deserialize<'de> for ReactionType {
+    #[allow(clippy::unwrap_used)] // allow unwrap here because name being none is unreachable
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         #[derive(Deserialize)]
         #[serde(field_identifier, rename_all = "snake_case")]
@@ -332,7 +335,7 @@ impl<'de> Deserialize<'de> for ReactionType {
         impl<'de> Visitor<'de> for ReactionTypeVisitor {
             type Value = ReactionType;
 
-            fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("enum ReactionType")
             }
 
@@ -526,8 +529,8 @@ impl From<EmojiIdentifier> for ReactionType {
 #[derive(Debug)]
 pub struct ReactionConversionError;
 
-impl Display for ReactionConversionError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for ReactionConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("failed to convert from a string to ReactionType")
     }
 }
@@ -637,7 +640,7 @@ impl FromStr for ReactionType {
     }
 }
 
-impl Display for ReactionType {
+impl fmt::Display for ReactionType {
     /// Formats the reaction type, displaying the associated emoji in a
     /// way that clients can understand.
     ///
@@ -645,7 +648,7 @@ impl Display for ReactionType {
     /// the documentation for [emoji's formatter][`Emoji::fmt`] on how this is
     /// displayed. Otherwise, if the type is a
     /// [unicode][`ReactionType::Unicode`], then the inner unicode is displayed.
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ReactionType::Custom {
                 animated,
@@ -659,7 +662,7 @@ impl Display for ReactionType {
                 }
                 f.write_str(name.as_ref().map_or("", |s| s.as_str()))?;
                 f.write_char(':')?;
-                Display::fmt(&id, f)?;
+                fmt::Display::fmt(&id, f)?;
                 f.write_char('>')
             },
             ReactionType::Unicode(ref unicode) => f.write_str(unicode),

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -1,9 +1,6 @@
 //! Error enum definition wrapping potential model implementation errors.
 
-use std::{
-    error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
+use std::{error::Error as StdError, fmt};
 
 use super::Permissions;
 
@@ -188,8 +185,8 @@ impl Error {
     }
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::BulkDeleteAmount => f.write_str("Too few/many messages to bulk delete."),
             Error::DeleteMessageDaysAmount(_) => f.write_str("Invalid delete message days."),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1869,7 +1869,7 @@ impl<'de> Deserialize<'de> for EventType {
         impl<'de> Visitor<'de> for EventTypeVisitor {
             type Value = EventType;
 
-            fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("event type str")
             }
 

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Display, Formatter, Result as FmtResult, Write as FmtWrite};
+use std::fmt;
 
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::Cache;
@@ -218,22 +218,22 @@ impl Emoji {
     }
 }
 
-impl Display for Emoji {
+impl fmt::Display for Emoji {
     /// Formats the emoji into a string that will cause Discord clients to
     /// render the emoji.
     ///
     /// This is in the format of either `<:NAME:EMOJI_ID>` for normal emojis,
     /// or `<a:NAME:EMOJI_ID>` for animated emojis.
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.animated {
             f.write_str("<a:")?;
         } else {
             f.write_str("<:")?;
         }
         f.write_str(&self.name)?;
-        FmtWrite::write_char(f, ':')?;
-        Display::fmt(&self.id, f)?;
-        FmtWrite::write_char(f, '>')
+        fmt::Write::write_char(f, ':')?;
+        fmt::Display::fmt(&self.id, f)?;
+        fmt::Write::write_char(f, '>')
     }
 }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[cfg(feature = "model")]
 use futures::stream::Stream;
 
@@ -1686,8 +1688,8 @@ pub enum GuildWidgetStyle {
     Banner4,
 }
 
-impl Display for GuildWidgetStyle {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+impl fmt::Display for GuildWidgetStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             GuildWidgetStyle::Shield => f.write_str("shield"),
             GuildWidgetStyle::Banner1 => f.write_str("banner1"),

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -2,7 +2,7 @@
 use std::borrow::Cow;
 #[cfg(feature = "cache")]
 use std::cmp::Reverse;
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::fmt;
 
 #[cfg(feature = "model")]
 use crate::builder::EditMember;
@@ -637,7 +637,7 @@ impl Member {
     }
 }
 
-impl Display for Member {
+impl fmt::Display for Member {
     /// Mentions the user so that they receive a notification.
     ///
     /// # Examples
@@ -648,8 +648,8 @@ impl Display for Member {
     /// ```
     ///
     /// This is in the format of `<@USER_ID>`.
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        Display::fmt(&self.user.mention(), f)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.user.mention(), f)
     }
 }
 

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::fmt;
 
 #[cfg(feature = "model")]
 use crate::builder::EditRole;
@@ -193,11 +194,11 @@ impl Role {
     }
 }
 
-impl Display for Role {
+impl fmt::Display for Role {
     /// Format a mention for the role, pinging its members.
     // This is in the format of: `<@&ROLE_ID>`.
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        Display::fmt(&self.mention(), f)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.mention(), f)
     }
 }
 

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -1,6 +1,6 @@
 //! A collection of newtypes defining type-strong IDs.
 
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::fmt;
 
 use super::Timestamp;
 
@@ -53,9 +53,9 @@ macro_rules! id_u64 {
                 }
             }
 
-            impl Display for $name {
-                fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-                    Display::fmt(&self.0, f)
+            impl fmt::Display for $name {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    fmt::Display::fmt(&self.0, f)
                 }
             }
 

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -21,6 +21,8 @@ pub trait Mentionable {
     /// be called on it, or inserted directly into a [`format_args!`] type of
     /// macro.
     ///
+    /// [`Display`]: fmt::Display
+    ///
     /// # Examples
     ///
     /// ```
@@ -74,6 +76,8 @@ pub trait Mentionable {
 /// [`format_args!`] type of macro or with [`ToString::to_string()`]. A
 /// [`Mention`] is created using [`Mentionable::mention()`], or with
 /// [`From`]/[`Into`].
+///
+/// [`Display`]: fmt::Display
 ///
 /// # Examples
 ///
@@ -130,8 +134,8 @@ mention!(value:
     &'_ Emoji, MentionableImpl::Emoji(value.id, value.animated);
 );
 
-impl Display for Mention {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for Mention {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             MentionableImpl::Channel(id) => f.write_fmt(format_args!("<#{}>", id.0)),
             MentionableImpl::User(id) => f.write_fmt(format_args!("<@{}>", id.0)),
@@ -299,8 +303,8 @@ pub struct EmojiIdentifierParseError {
 }
 
 #[cfg(all(feature = "model", feature = "utils"))]
-impl Display for EmojiIdentifierParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for EmojiIdentifierParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "`{}` is not a valid emoji identifier", self.parsed_string)
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -43,11 +43,7 @@ pub mod user;
 pub mod voice;
 pub mod webhook;
 
-use std::{
-    collections::HashMap,
-    fmt::{Display, Formatter, Result as FmtResult},
-    result::Result as StdResult,
-};
+use std::{collections::HashMap, result::Result as StdResult};
 
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer};

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -41,8 +41,7 @@
 //! [Manage Roles]: Permissions::MANAGE_ROLES
 //! [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
 
-#[cfg(feature = "model")]
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::fmt;
 
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
@@ -669,8 +668,6 @@ impl Permissions {
 
 impl<'de> Deserialize<'de> for Permissions {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use std::fmt;
-
         struct StringVisitor;
 
         impl<'de> serde::de::Visitor<'de> for StringVisitor {
@@ -702,8 +699,8 @@ impl Serialize for Permissions {
 }
 
 #[cfg(feature = "model")]
-impl Display for Permissions {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+impl fmt::Display for Permissions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let names = self.get_permission_names();
 
         let total = names.len();

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::marker::PhantomData;
 use std::{collections::HashMap, hash::Hash};
 
@@ -441,7 +442,7 @@ where
 {
     type Value = HashMap<K, V>;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("sequence")
     }
 

--- a/src/utils/argument_convert/_template.rs
+++ b/src/utils/argument_convert/_template.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
@@ -9,8 +10,8 @@ pub enum PLACEHOLDERParseError {
 
 impl std::error::Error for PLACEHOLDERParseError {}
 
-impl std::fmt::Display for PLACEHOLDERParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for PLACEHOLDERParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
         }
     }

--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
@@ -21,8 +23,8 @@ impl std::error::Error for ChannelParseError {
     }
 }
 
-impl std::fmt::Display for ChannelParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ChannelParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Http(_) => f.write_str("Failed to request channel via HTTP"),
             Self::NotFoundOrMalformed => f.write_str("Channel not found or unknown format"),
@@ -116,8 +118,8 @@ impl std::error::Error for GuildChannelParseError {
     }
 }
 
-impl std::fmt::Display for GuildChannelParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for GuildChannelParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Http(_) => f.write_str("Failed to request channel via HTTP"),
             Self::NotFoundOrMalformed => f.write_str("Channel not found or unknown format"),
@@ -176,8 +178,8 @@ impl std::error::Error for ChannelCategoryParseError {
     }
 }
 
-impl std::fmt::Display for ChannelCategoryParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ChannelCategoryParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Http(_) => f.write_str("Failed to request channel via HTTP"),
             Self::NotFoundOrMalformed => f.write_str("Channel not found or unknown format"),

--- a/src/utils/argument_convert/emoji.rs
+++ b/src/utils/argument_convert/emoji.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
@@ -12,8 +14,8 @@ pub enum EmojiParseError {
 
 impl std::error::Error for EmojiParseError {}
 
-impl std::fmt::Display for EmojiParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for EmojiParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotFoundOrMalformed => f.write_str("Emoji not found or unknown format"),
         }

--- a/src/utils/argument_convert/guild.rs
+++ b/src/utils/argument_convert/guild.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
@@ -12,8 +14,8 @@ pub enum GuildParseError {
 
 impl std::error::Error for GuildParseError {}
 
-impl std::fmt::Display for GuildParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for GuildParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotFoundOrMalformed => f.write_str("Guild not found or unknown format"),
         }

--- a/src/utils/argument_convert/member.rs
+++ b/src/utils/argument_convert/member.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
@@ -16,8 +18,8 @@ pub enum MemberParseError {
 
 impl std::error::Error for MemberParseError {}
 
-impl std::fmt::Display for MemberParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for MemberParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::OutsideGuild => f.write_str("Tried to find member outside a guild"),
             Self::GuildNotInCache => f.write_str("Guild is not in cache"),

--- a/src/utils/argument_convert/message.rs
+++ b/src/utils/argument_convert/message.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
@@ -23,8 +25,8 @@ impl std::error::Error for MessageParseError {
     }
 }
 
-impl std::fmt::Display for MessageParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for MessageParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Malformed => {
                 f.write_str("Provided string did not adhere to any known guild message format")

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
@@ -17,8 +19,8 @@ pub enum RoleParseError {
 
 impl std::error::Error for RoleParseError {}
 
-impl std::fmt::Display for RoleParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for RoleParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotInGuild => f.write_str("Must invoke this operation in a guild"),
             Self::NotInCache => f.write_str("Guild's roles were not found in cache"),

--- a/src/utils/argument_convert/user.rs
+++ b/src/utils/argument_convert/user.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
@@ -13,8 +15,8 @@ pub enum UserParseError {
 
 impl std::error::Error for UserParseError {}
 
-impl std::fmt::Display for UserParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for UserParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotFoundOrMalformed => f.write_str("User not found or unknown format"),
         }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1,6 +1,6 @@
 use std::{
     default::Default,
-    fmt::{self, Display, Write},
+    fmt::{self, Write},
     ops::Add,
 };
 
@@ -882,7 +882,7 @@ impl MessageBuilder {
     }
 }
 
-impl Display for MessageBuilder {
+impl fmt::Display for MessageBuilder {
     /// Formats the message builder into a string.
     ///
     /// This is done by simply taking the internal value of the tuple-struct and

--- a/voice-model/src/id.rs
+++ b/voice-model/src/id.rs
@@ -1,16 +1,16 @@
 //! A collection of newtypes defining type-strong IDs.
 use crate::util::json_safe_u64;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::fmt;
 
 #[derive(
     Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct GuildId(#[serde(with = "json_safe_u64")] pub u64);
 
-impl Display for GuildId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        Display::fmt(&self.0, f)
+impl fmt::Display for GuildId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
@@ -19,8 +19,8 @@ impl Display for GuildId {
 )]
 pub struct UserId(#[serde(with = "json_safe_u64")] pub u64);
 
-impl Display for UserId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        Display::fmt(&self.0, f)
+impl fmt::Display for UserId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
     }
 }


### PR DESCRIPTION
```
use std::fmt;

impl fmt::Display for T {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        // ...
    }
}

impl fmt::Debug for T {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        // ...
    }
}
```