### PR TITLE
Remove the `unstable_discord_api` feature guard from the application commands

### DIFF
--- a/examples/e14_slash_commands/Cargo.toml
+++ b/examples/e14_slash_commands/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "unstable_discord_api"] }
+serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e17_message_components/Cargo.toml
+++ b/examples/e17_message_components/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "unstable_discord_api", "collector"] }
+serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "collector"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 dotenv = { version = "0.15.0" }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use super::CreateAllowedMentions;
 use super::CreateEmbed;
-#[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
 use crate::internal::prelude::*;
 use crate::json::{self, from_number, to_value};
@@ -218,7 +217,6 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Creates components for this message.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
@@ -231,7 +229,6 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Sets the components of this message.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
         self.0.insert("components", Value::from(components.0));
         self

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -101,7 +101,6 @@ impl EditInteractionResponse {
     }
 
     /// Sets the components of this message.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use super::{CreateAllowedMentions, CreateEmbed};
-#[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
 use crate::internal::prelude::*;
 use crate::json::{self, from_number};
@@ -147,7 +146,6 @@ impl<'a> EditMessage<'a> {
     }
 
     /// Creates components for this message.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
@@ -160,7 +158,6 @@ impl<'a> EditMessage<'a> {
     }
 
     /// Sets the components of this message.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
         self.0.insert("components", Value::from(components.0));
         self

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use super::CreateAllowedMentions;
-#[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
 use crate::internal::prelude::*;
 use crate::json;
@@ -58,7 +57,6 @@ impl EditWebhookMessage {
     /// the webhook's `kind` field is set to [`WebhookType::Application`].
     ///
     /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
-    #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use super::CreateAllowedMentions;
-#[cfg(feature = "unstable_discord_api")]
 use crate::builder::CreateComponents;
 use crate::json::{self, from_number, Value};
 use crate::model::channel::{AttachmentType, MessageFlags};
@@ -157,7 +156,6 @@ impl<'a> ExecuteWebhook<'a> {
     /// the webhook's `kind` field is set to [`WebhookType::Application`].
     ///
     /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
-    #[cfg(feature = "unstable_discord_api")]
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
@@ -170,7 +168,6 @@ impl<'a> ExecuteWebhook<'a> {
     }
 
     /// Sets the components of this message. Requires an application-owned webhook. See [`ExecuteWebhook::components`] for details.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
         self.0.insert("components", Value::Array(components.0));
         self

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -8,19 +8,14 @@
 mod create_channel;
 mod create_embed;
 
-#[cfg(feature = "unstable_discord_api")]
 mod create_application_command;
-#[cfg(feature = "unstable_discord_api")]
 mod create_application_command_permission;
 
 mod add_member;
 mod bot_auth_parameters;
 mod create_allowed_mentions;
-#[cfg(feature = "unstable_discord_api")]
 mod create_components;
-#[cfg(feature = "unstable_discord_api")]
 mod create_interaction_response;
-#[cfg(feature = "unstable_discord_api")]
 mod create_interaction_response_followup;
 mod create_invite;
 mod create_message;
@@ -31,7 +26,6 @@ mod edit_channel;
 mod edit_guild;
 mod edit_guild_welcome_screen;
 mod edit_guild_widget;
-#[cfg(feature = "unstable_discord_api")]
 mod edit_interaction_response;
 mod edit_member;
 mod edit_message;
@@ -73,7 +67,6 @@ pub use self::{
     execute_webhook::ExecuteWebhook,
     get_messages::GetMessages,
 };
-#[cfg(feature = "unstable_discord_api")]
 pub use self::{
     create_application_command::{
         CreateApplicationCommand,

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -321,7 +321,6 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     user: self.user.clone(),
                     pending: self.pending,
                     premium_since: self.premium_since,
-                    #[cfg(feature = "unstable_discord_api")]
                     permissions: None,
                     avatar: self.avatar.clone(),
                     communication_disabled_until: self.communication_disabled_until,
@@ -560,7 +559,6 @@ impl CacheUpdate for PresenceUpdateEvent {
                         roles: vec![],
                         pending: false,
                         premium_since: None,
-                        #[cfg(feature = "unstable_discord_api")]
                         permissions: None,
                         avatar: None,
                         communication_disabled_until: None,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1083,9 +1083,7 @@ mod test {
                 flags: None,
                 sticker_items: vec![],
                 referenced_message: None,
-                #[cfg(feature = "unstable_discord_api")]
                 interaction: None,
-                #[cfg(feature = "unstable_discord_api")]
                 components: vec![],
             },
         };

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -2,10 +2,14 @@ use async_tungstenite::tungstenite::Message;
 use futures::channel::mpsc::{TrySendError, UnboundedSender as Sender};
 
 use super::{ChunkGuildFilter, ShardClientMessage, ShardRunnerMessage};
-#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-use crate::collector::{ComponentInteractionFilter, ModalInteractionFilter};
 #[cfg(feature = "collector")]
-use crate::collector::{EventFilter, MessageFilter, ReactionFilter};
+use crate::collector::{
+    ComponentInteractionFilter,
+    EventFilter,
+    MessageFilter,
+    ModalInteractionFilter,
+    ReactionFilter,
+};
 use crate::gateway::InterMessage;
 use crate::model::prelude::*;
 
@@ -276,14 +280,14 @@ impl ShardMessenger {
     }
 
     /// Sets a new filter for a component interaction collector.
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     pub fn set_component_interaction_filter(&self, collector: ComponentInteractionFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetComponentInteractionFilter(collector));
     }
 
     /// Sets a new filter for a modal interaction collector.
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     pub fn set_modal_interaction_filter(&self, collector: ModalInteractionFilter) {
         #[allow(clippy::let_underscore_must_use)]
         let _ = self.send_to_shard(ShardRunnerMessage::SetModalInteractionFilter(collector));

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -18,17 +18,23 @@ use super::{ShardClientMessage, ShardId, ShardManagerMessage, ShardRunnerMessage
 use crate::client::bridge::voice::VoiceGatewayManager;
 use crate::client::dispatch::{dispatch, DispatchEvent};
 use crate::client::{EventHandler, RawEventHandler};
-#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-use crate::collector::{ComponentInteractionFilter, ModalInteractionFilter};
 #[cfg(feature = "collector")]
-use crate::collector::{EventFilter, LazyArc, LazyReactionAction, MessageFilter, ReactionFilter};
+use crate::collector::{
+    ComponentInteractionFilter,
+    EventFilter,
+    LazyArc,
+    LazyReactionAction,
+    MessageFilter,
+    ModalInteractionFilter,
+    ReactionFilter,
+};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
 use crate::gateway::{GatewayError, InterMessage, ReconnectType, Shard, ShardAction};
 use crate::internal::prelude::*;
 use crate::internal::ws_impl::{ReceiverExt, SenderExt};
 use crate::model::event::{Event, GatewayEvent};
-#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+#[cfg(feature = "collector")]
 use crate::model::interactions::Interaction;
 use crate::CacheAndHttp;
 
@@ -54,9 +60,9 @@ pub struct ShardRunner {
     message_filters: Vec<MessageFilter>,
     #[cfg(feature = "collector")]
     reaction_filters: Vec<ReactionFilter>,
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     component_interaction_filters: Vec<ComponentInteractionFilter>,
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     modal_interaction_filters: Vec<ModalInteractionFilter>,
 }
 
@@ -84,9 +90,9 @@ impl ShardRunner {
             message_filters: Vec::new(),
             #[cfg(feature = "collector")]
             reaction_filters: Vec::new(),
-            #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+            #[cfg(feature = "collector")]
             component_interaction_filters: vec![],
-            #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+            #[cfg(feature = "collector")]
             modal_interaction_filters: vec![],
         }
     }
@@ -235,7 +241,7 @@ impl ShardRunner {
                 let mut reaction = LazyReactionAction::new(&reaction_event.reaction, false);
                 retain(&mut self.reaction_filters, |f| f.send_reaction(&mut reaction));
             },
-            #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+            #[cfg(feature = "collector")]
             Event::InteractionCreate(ref interaction_event) => {
                 match &interaction_event.interaction {
                     Interaction::MessageComponent(interaction) => {
@@ -469,7 +475,7 @@ impl ShardRunner {
 
                     true
                 },
-                #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+                #[cfg(feature = "collector")]
                 ShardClientMessage::Runner(ShardRunnerMessage::SetComponentInteractionFilter(
                     collector,
                 )) => {
@@ -477,7 +483,7 @@ impl ShardRunner {
 
                     true
                 },
-                #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+                #[cfg(feature = "collector")]
                 ShardClientMessage::Runner(ShardRunnerMessage::SetModalInteractionFilter(
                     collector,
                 )) => {

--- a/src/client/bridge/gateway/shard_runner_message.rs
+++ b/src/client/bridge/gateway/shard_runner_message.rs
@@ -1,9 +1,13 @@
 use async_tungstenite::tungstenite::Message;
 
-#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-use crate::collector::{ComponentInteractionFilter, ModalInteractionFilter};
 #[cfg(feature = "collector")]
-use crate::collector::{EventFilter, MessageFilter, ReactionFilter};
+use crate::collector::{
+    ComponentInteractionFilter,
+    EventFilter,
+    MessageFilter,
+    ModalInteractionFilter,
+    ReactionFilter,
+};
 use crate::model::{
     gateway::Activity,
     id::{GuildId, UserId},
@@ -71,9 +75,9 @@ pub enum ShardRunnerMessage {
     #[cfg(feature = "collector")]
     SetReactionFilter(ReactionFilter),
     /// Sends a new filter for component interactions to the shard.
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     SetComponentInteractionFilter(ComponentInteractionFilter),
     /// Sends a new filter for modal interactions to the shard.
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     SetModalInteractionFilter(ModalInteractionFilter),
 }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -8,10 +8,8 @@ use typemap_rev::TypeMap;
 pub use crate::cache::Cache;
 #[cfg(feature = "gateway")]
 use crate::client::bridge::gateway::ShardMessenger;
-#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
-use crate::collector::ComponentInteractionFilter;
 #[cfg(feature = "collector")]
-use crate::collector::{MessageFilter, ReactionFilter};
+use crate::collector::{ComponentInteractionFilter, MessageFilter, ReactionFilter};
 #[cfg(feature = "gateway")]
 use crate::gateway::InterMessage;
 use crate::http::Http;
@@ -404,7 +402,7 @@ impl Context {
     /// Sets a new `filter` for the shard to check if an interaction event shall be
     /// sent back to `filter`'s paired receiver.
     #[inline]
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     pub async fn set_component_interaction_filter(&self, filter: ComponentInteractionFilter) {
         self.shard.set_component_interaction_filter(filter);
     }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -767,7 +767,6 @@ async fn handle_event(
                 event_handler.webhook_update(context, event.guild_id, event.channel_id).await;
             });
         },
-        #[cfg(feature = "unstable_discord_api")]
         DispatchEvent::Model(Event::InteractionCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
@@ -775,7 +774,6 @@ async fn handle_event(
                 event_handler.interaction_create(context, event.interaction).await;
             });
         },
-        #[cfg(feature = "unstable_discord_api")]
         DispatchEvent::Model(Event::IntegrationCreate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
@@ -783,7 +781,6 @@ async fn handle_event(
                 event_handler.integration_create(context, event.integration).await;
             });
         },
-        #[cfg(feature = "unstable_discord_api")]
         DispatchEvent::Model(Event::IntegrationUpdate(event)) => {
             let event_handler = Arc::clone(event_handler);
 
@@ -791,7 +788,6 @@ async fn handle_event(
                 event_handler.integration_update(context, event.integration).await;
             });
         },
-        #[cfg(feature = "unstable_discord_api")]
         DispatchEvent::Model(Event::IntegrationDelete(event)) => {
             let event_handler = Arc::clone(event_handler);
 

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use super::context::Context;
 use crate::client::bridge::gateway::event::*;
 use crate::json::Value;
-#[cfg(feature = "unstable_discord_api")]
 use crate::model::interactions::Interaction;
 use crate::model::prelude::*;
 
@@ -430,25 +429,21 @@ pub trait EventHandler: Send + Sync {
     /// Dispatched when an interaction is created (e.g a slash command was used or a button was clicked).
     ///
     /// Provides the created interaction.
-    #[cfg(feature = "unstable_discord_api")]
     async fn interaction_create(&self, _ctx: Context, _interaction: Interaction) {}
 
     /// Dispatched when a guild integration is created.
     ///
     /// Provides the created integration.
-    #[cfg(feature = "unstable_discord_api")]
     async fn integration_create(&self, _ctx: Context, _integration: Integration) {}
 
     /// Dispatched when a guild integration is updated.
     ///
     /// Provides the updated integration.
-    #[cfg(feature = "unstable_discord_api")]
     async fn integration_update(&self, _ctx: Context, _integration: Integration) {}
 
     /// Dispatched when a guild integration is deleted.
     ///
     /// Provides the integration's id, the id of the guild it belongs to, and its associated application id
-    #[cfg(feature = "unstable_discord_api")]
     async fn integration_delete(
         &self,
         _ctx: Context,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -69,7 +69,6 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 #[cfg(feature = "gateway")]
 use crate::model::gateway::GatewayIntents;
-#[cfg(feature = "unstable_discord_api")]
 use crate::model::id::ApplicationId;
 pub use crate::CacheAndHttp;
 
@@ -80,7 +79,6 @@ pub struct ClientBuilder {
     http: Http,
     fut: Option<BoxFuture<'static, Result<Client>>>,
     intents: GatewayIntents,
-    #[cfg(feature = "unstable_discord_api")]
     application_id: Option<ApplicationId>,
     #[cfg(feature = "cache")]
     timeout: Option<Duration>,
@@ -103,7 +101,6 @@ impl ClientBuilder {
             http,
             fut: None,
             intents: GatewayIntents::non_privileged(),
-            #[cfg(feature = "unstable_discord_api")]
             application_id: None,
             #[cfg(feature = "cache")]
             timeout: None,
@@ -154,7 +151,6 @@ impl ClientBuilder {
     }
 
     /// Sets the application id.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn application_id(mut self, application_id: u64) -> Self {
         self.application_id = Some(ApplicationId(application_id));
 
@@ -164,7 +160,6 @@ impl ClientBuilder {
     }
 
     /// Gets the application ID, if already initialized. See [`Self::application_id`] for more info.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn get_application_id(&self) -> Option<ApplicationId> {
         self.application_id
     }
@@ -404,7 +399,7 @@ impl Future for ClientBuilder {
             let intents = self.intents;
             let http = Arc::new(std::mem::take(&mut self.http));
 
-            #[cfg(feature = "unstable_discord_api")]
+            // TODO: It should not be required for all users of serenity to set the application_id or get a panic.
             if http.application_id == 0 {
                 panic!("Please provide an Application Id in order to use interactions features.");
             }

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -7,19 +7,15 @@ use std::sync::Arc;
 mod error;
 pub use error::Error as CollectorError;
 
-#[cfg(feature = "unstable_discord_api")]
 pub mod component_interaction_collector;
 pub mod event_collector;
 pub mod message_collector;
-#[cfg(feature = "unstable_discord_api")]
 pub mod modal_interaction_collector;
 pub mod reaction_collector;
 
-#[cfg(feature = "unstable_discord_api")]
 pub use component_interaction_collector::*;
 pub use event_collector::*;
 pub use message_collector::*;
-#[cfg(feature = "unstable_discord_api")]
 pub use modal_interaction_collector::*;
 pub use reaction_collector::*;
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -26,7 +26,6 @@ use super::{
 use crate::constants;
 use crate::internal::prelude::*;
 use crate::json::{from_number, from_value, json, to_value, to_vec};
-#[cfg(feature = "unstable_discord_api")]
 use crate::model::interactions::application_command::{
     ApplicationCommand,
     ApplicationCommandPermission,
@@ -59,7 +58,6 @@ pub struct HttpBuilder {
     ratelimiter_disabled: bool,
     token: String,
     proxy: Option<Url>,
-    #[cfg(feature = "unstable_discord_api")]
     application_id: Option<u64>,
 }
 
@@ -73,13 +71,11 @@ impl HttpBuilder {
             ratelimiter_disabled: false,
             token: parse_token(token),
             proxy: None,
-            #[cfg(feature = "unstable_discord_api")]
             application_id: None,
         }
     }
 
     /// Sets the application_id to use interactions.
-    #[cfg(feature = "unstable_discord_api")]
     pub fn application_id(mut self, application_id: u64) -> Self {
         self.application_id = Some(application_id);
 
@@ -151,7 +147,7 @@ impl HttpBuilder {
     pub fn build(self) -> Http {
         let token = self.token;
 
-        #[cfg(feature = "unstable_discord_api")]
+        // TODO: It should not be required for all users of serenity to set the application_id or get a panic.
         let application_id = self
             .application_id
             .expect("Expected application Id in order to use interacions features");
@@ -174,7 +170,6 @@ impl HttpBuilder {
             ratelimiter_disabled,
             proxy: self.proxy,
             token,
-            #[cfg(feature = "unstable_discord_api")]
             application_id,
         }
     }
@@ -211,7 +206,6 @@ pub struct Http {
     pub ratelimiter_disabled: bool,
     pub proxy: Option<Url>,
     pub token: String,
-    #[cfg(feature = "unstable_discord_api")]
     pub application_id: u64,
 }
 
@@ -236,12 +230,10 @@ impl Http {
             ratelimiter_disabled: false,
             proxy: None,
             token: token.to_string(),
-            #[cfg(feature = "unstable_discord_api")]
             application_id: 0,
         }
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn new_with_application_id(application_id: u64) -> Self {
         let builder = configure_client_backend(Client::builder());
         let built = builder.build().expect("Cannot build reqwest::Client");
@@ -267,7 +259,6 @@ impl Http {
         Self::new(built, &token)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn new_with_token_application_id(token: &str, application_id: u64) -> Self {
         let mut base = Self::new_with_token(token);
 
@@ -487,7 +478,6 @@ impl Http {
     /// Create a follow-up message for an Interaction.
     ///
     /// Functions the same as [`Self::execute_webhook`]
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_followup_message(
         &self,
         interaction_token: &str,
@@ -508,7 +498,6 @@ impl Http {
     /// Create a follow-up message with attachments for an Interaction.
     ///
     /// Functions the same as [`Self::execute_webhook`]
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_followup_message_with_files(
         &self,
         interaction_token: &str,
@@ -542,7 +531,6 @@ impl Http {
     /// application will overwrite the old command.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_global_application_command(
         &self,
         map: &Value,
@@ -559,7 +547,6 @@ impl Http {
     }
 
     /// Creates new global application commands.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_global_application_commands(
         &self,
         map: &Value,
@@ -576,7 +563,6 @@ impl Http {
     }
 
     /// Creates new guild application commands.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_guild_application_commands(
         &self,
         guild_id: u64,
@@ -644,7 +630,6 @@ impl Http {
     /// Refer to Discord's [docs] for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_guild_application_command(
         &self,
         guild_id: u64,
@@ -694,7 +679,6 @@ impl Http {
     /// Refer to Discord's [docs] for the object it takes.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#interaction-interaction-response
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_interaction_response(
         &self,
         interaction_id: u64,
@@ -953,7 +937,6 @@ impl Http {
     }
 
     /// Deletes a follow-up message for an interaction.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn delete_followup_message(
         &self,
         interaction_token: &str,
@@ -973,7 +956,6 @@ impl Http {
     }
 
     /// Deletes a global command.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn delete_global_application_command(&self, command_id: u64) -> Result<()> {
         self.wind(204, Request {
             body: None,
@@ -1001,7 +983,6 @@ impl Http {
     }
 
     /// Deletes a guild command.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn delete_guild_application_command(
         &self,
         guild_id: u64,
@@ -1127,7 +1108,6 @@ impl Http {
     }
 
     /// Deletes the initial interaction response.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn delete_original_interaction_response(
         &self,
         interaction_token: &str,
@@ -1347,7 +1327,6 @@ impl Http {
     /// Refer to Discord's [docs] for Edit Webhook Message for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_followup_message(
         &self,
         interaction_token: &str,
@@ -1372,7 +1351,6 @@ impl Http {
     /// Refer to Discord's [docs] for Edit Webhook Message for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_followup_message_and_attachments(
         &self,
         interaction_token: &str,
@@ -1402,7 +1380,6 @@ impl Http {
     /// Refer to Discord's [docs] for Get Webhook Message for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/resources/webhook#get-webhook-message
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_followup_message(
         &self,
         interaction_token: &str,
@@ -1428,7 +1405,6 @@ impl Http {
     /// Refer to Discord's [docs] for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_global_application_command(
         &self,
         command_id: u64,
@@ -1473,7 +1449,6 @@ impl Http {
     /// Refer to Discord's [docs] for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_guild_application_command(
         &self,
         guild_id: u64,
@@ -1500,7 +1475,6 @@ impl Http {
     /// Refer to Discord's [documentation] for field information.
     ///
     /// [documentation]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_guild_application_command_permissions(
         &self,
         guild_id: u64,
@@ -1527,7 +1501,6 @@ impl Http {
     /// Refer to Discord's [documentation] for field information.
     ///
     /// [documentation]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_guild_application_commands_permissions(
         &self,
         guild_id: u64,
@@ -1724,7 +1697,6 @@ impl Http {
     }
 
     /// Gets the initial interaction response.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_original_interaction_response(
         &self,
         interaction_token: &str,
@@ -1746,7 +1718,6 @@ impl Http {
     /// Refer to Discord's [docs] for Edit Webhook Message for field information.
     ///
     /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_original_interaction_response(
         &self,
         interaction_token: &str,
@@ -2609,7 +2580,6 @@ impl Http {
     }
 
     /// Fetches all of the global commands for your application.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_global_application_commands(&self) -> Result<Vec<ApplicationCommand>> {
         self.fire(Request {
             body: None,
@@ -2623,7 +2593,6 @@ impl Http {
     }
 
     /// Fetches a global commands for your application by its Id.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_global_application_command(
         &self,
         command_id: u64,
@@ -2667,7 +2636,6 @@ impl Http {
     }
 
     /// Fetches all of the guild commands for your application for a specific guild.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_guild_application_commands(
         &self,
         guild_id: u64,
@@ -2685,7 +2653,6 @@ impl Http {
     }
 
     /// Fetches a guild command by its Id.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_guild_application_command(
         &self,
         guild_id: u64,
@@ -2705,7 +2672,6 @@ impl Http {
     }
 
     /// Fetches all of the guild commands permissions for your application for a specific guild.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_guild_application_commands_permissions(
         &self,
         guild_id: u64,
@@ -2723,7 +2689,6 @@ impl Http {
     }
 
     /// Gives the guild command permission for your application for a specific guild.
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_guild_application_command_permissions(
         &self,
         guild_id: u64,
@@ -3843,7 +3808,6 @@ impl Default for Http {
             ratelimiter_disabled: false,
             proxy: None,
             token: "".to_string(),
-            #[cfg(feature = "unstable_discord_api")]
             application_id: 0,
         }
     }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -383,56 +383,48 @@ pub enum Route {
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
-    #[cfg(feature = "unstable_discord_api")]
     WebhooksApplicationId(u64),
     /// Route for the `/interactions/:interaction_id` path.
     ///
     /// The data is the relevant [`InteractionId`].
     ///
     /// [`InteractionId`]: crate::model::id::InteractionId
-    #[cfg(feature = "unstable_discord_api")]
     InteractionsId(u64),
     /// Route for the `/applications/:application_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
-    #[cfg(feature = "unstable_discord_api")]
     ApplicationsIdCommands(u64),
     /// Route for the `/applications/:application_id/commands/:command_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
-    #[cfg(feature = "unstable_discord_api")]
     ApplicationsIdCommandsId(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
-    #[cfg(feature = "unstable_discord_api")]
     ApplicationsIdGuildsIdCommands(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id/commands/permissions` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
-    #[cfg(feature = "unstable_discord_api")]
     ApplicationsIdGuildsIdCommandsPermissions(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id/commands/:command_id/permissions` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
-    #[cfg(feature = "unstable_discord_api")]
     ApplicationsIdGuildsIdCommandIdPermissions(u64),
     /// Route for the `/applications/:application_id/guilds/:guild_id` path.
     ///
     /// The data is the relevant [`ApplicationId`].
     ///
     /// [`ApplicationId`]: crate::model::id::ApplicationId
-    #[cfg(feature = "unstable_discord_api")]
     ApplicationsIdGuildsIdCommandsId(u64),
     /// Route for the `/stage-instances` path.
     ///
@@ -954,7 +946,6 @@ impl Route {
         api!("/webhooks/{}/{}/messages/{}", webhook_id, token, message_id)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn webhook_original_interaction_response<D: Display>(
         application_id: u64,
         token: D,
@@ -962,7 +953,6 @@ impl Route {
         api!("/webhooks/{}/{}/messages/@original", application_id, token)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn webhook_followup_message<D: Display>(
         application_id: u64,
         token: D,
@@ -971,27 +961,22 @@ impl Route {
         api!("/webhooks/{}/{}/messages/{}", application_id, token, message_id)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn webhook_followup_messages<D: Display>(application_id: u64, token: D) -> String {
         api!("/webhooks/{}/{}", application_id, token)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn interaction_response<D: Display>(application_id: u64, token: D) -> String {
         api!("/interactions/{}/{}/callback", application_id, token)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn application_command(application_id: u64, command_id: u64) -> String {
         api!("/applications/{}/commands/{}", application_id, command_id)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn application_commands(application_id: u64) -> String {
         api!("/applications/{}/commands", application_id)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn application_guild_command(
         application_id: u64,
         guild_id: u64,
@@ -1000,7 +985,6 @@ impl Route {
         api!("/applications/{}/guilds/{}/commands/{}", application_id, guild_id, command_id)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn application_guild_command_permissions(
         application_id: u64,
         guild_id: u64,
@@ -1014,12 +998,10 @@ impl Route {
         )
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn application_guild_commands(application_id: u64, guild_id: u64) -> String {
         api!("/applications/{}/guilds/{}/commands", application_id, guild_id)
     }
 
-    #[cfg(feature = "unstable_discord_api")]
     pub fn application_guild_commands_permissions(application_id: u64, guild_id: u64) -> String {
         api!("/applications/{}/guilds/{}/commands/permissions", application_id, guild_id)
     }
@@ -1067,26 +1049,21 @@ pub enum RouteInfo<'a> {
     CreateEmoji {
         guild_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     CreateFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
     },
-    #[cfg(feature = "unstable_discord_api")]
     CreateGlobalApplicationCommand {
         application_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     CreateGlobalApplicationCommands {
         application_id: u64,
     },
     CreateGuild,
-    #[cfg(feature = "unstable_discord_api")]
     CreateGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     CreateGuildApplicationCommands {
         application_id: u64,
         guild_id: u64,
@@ -1095,7 +1072,6 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         integration_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     CreateInteractionResponse {
         interaction_id: u64,
         interaction_token: &'a str,
@@ -1135,13 +1111,11 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         emoji_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     DeleteFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
         message_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     DeleteGlobalApplicationCommand {
         application_id: u64,
         command_id: u64,
@@ -1149,7 +1123,6 @@ pub enum RouteInfo<'a> {
     DeleteGuild {
         guild_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     DeleteGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
@@ -1178,7 +1151,6 @@ pub enum RouteInfo<'a> {
         message_id: u64,
         reaction: &'a str,
     },
-    #[cfg(feature = "unstable_discord_api")]
     DeleteOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
@@ -1223,13 +1195,11 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         emoji_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     EditFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
         message_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     EditGlobalApplicationCommand {
         application_id: u64,
         command_id: u64,
@@ -1237,19 +1207,16 @@ pub enum RouteInfo<'a> {
     EditGuild {
         guild_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     EditGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
         command_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     EditGuildApplicationCommandPermission {
         application_id: u64,
         guild_id: u64,
         command_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     EditGuildApplicationCommandsPermissions {
         application_id: u64,
         guild_id: u64,
@@ -1281,12 +1248,10 @@ pub enum RouteInfo<'a> {
     EditNickname {
         guild_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     GetOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
     },
-    #[cfg(feature = "unstable_discord_api")]
     EditOriginalInteractionResponse {
         application_id: u64,
         interaction_token: &'a str,
@@ -1398,18 +1363,15 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
         emoji_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     GetFollowupMessage {
         application_id: u64,
         interaction_token: &'a str,
         message_id: u64,
     },
     GetGateway,
-    #[cfg(feature = "unstable_discord_api")]
     GetGlobalApplicationCommands {
         application_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     GetGlobalApplicationCommand {
         application_id: u64,
         command_id: u64,
@@ -1420,23 +1382,19 @@ pub enum RouteInfo<'a> {
     GetGuildWithCounts {
         guild_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     GetGuildApplicationCommands {
         application_id: u64,
         guild_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     GetGuildApplicationCommand {
         application_id: u64,
         guild_id: u64,
         command_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     GetGuildApplicationCommandsPermissions {
         application_id: u64,
         guild_id: u64,
     },
-    #[cfg(feature = "unstable_discord_api")]
     GetGuildApplicationCommandPermissions {
         application_id: u64,
         guild_id: u64,
@@ -1658,7 +1616,6 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojis(guild_id),
                 Cow::from(Route::guild_emojis(guild_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::CreateFollowupMessage {
                 application_id,
                 interaction_token,
@@ -1667,7 +1624,6 @@ impl<'a> RouteInfo<'a> {
                 Route::WebhooksId(application_id),
                 Cow::from(Route::webhook_followup_messages(application_id, interaction_token)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::CreateGlobalApplicationCommand {
                 application_id,
             } => (
@@ -1675,7 +1631,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ApplicationsIdCommands(application_id),
                 Cow::from(Route::application_commands(application_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::CreateGlobalApplicationCommands {
                 application_id,
             } => (
@@ -1686,7 +1641,6 @@ impl<'a> RouteInfo<'a> {
             RouteInfo::CreateGuild => {
                 (LightMethod::Post, Route::Guilds, Cow::from(Route::guilds()))
             },
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::CreateGuildApplicationCommand {
                 application_id,
                 guild_id,
@@ -1695,7 +1649,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ApplicationsIdGuildsIdCommands(application_id),
                 Cow::from(Route::application_guild_commands(application_id, guild_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::CreateGuildApplicationCommands {
                 application_id,
                 guild_id,
@@ -1712,7 +1665,6 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdIntegrationsId(guild_id),
                 Cow::from(Route::guild_integration(guild_id, integration_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::CreateInteractionResponse {
                 interaction_id,
                 interaction_token,
@@ -1808,7 +1760,6 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojisId(guild_id),
                 Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::DeleteFollowupMessage {
                 application_id,
                 interaction_token,
@@ -1822,7 +1773,6 @@ impl<'a> RouteInfo<'a> {
                     message_id,
                 )),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::DeleteGlobalApplicationCommand {
                 application_id,
                 command_id,
@@ -1836,7 +1786,6 @@ impl<'a> RouteInfo<'a> {
             } => {
                 (LightMethod::Delete, Route::GuildsId(guild_id), Cow::from(Route::guild(guild_id)))
             },
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::DeleteGuildApplicationCommand {
                 application_id,
                 guild_id,
@@ -1889,7 +1838,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ChannelsIdMessagesBulkDelete(channel_id),
                 Cow::from(Route::channel_messages_bulk_delete(channel_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::DeleteOriginalInteractionResponse {
                 application_id,
                 interaction_token,
@@ -1981,7 +1929,6 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdEmojisId(guild_id),
                 Cow::from(Route::guild_emoji(guild_id, emoji_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::EditFollowupMessage {
                 application_id,
                 interaction_token,
@@ -1995,7 +1942,6 @@ impl<'a> RouteInfo<'a> {
                     message_id,
                 )),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::EditGlobalApplicationCommand {
                 application_id,
                 command_id,
@@ -2007,7 +1953,6 @@ impl<'a> RouteInfo<'a> {
             RouteInfo::EditGuild {
                 guild_id,
             } => (LightMethod::Patch, Route::GuildsId(guild_id), Cow::from(Route::guild(guild_id))),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::EditGuildApplicationCommand {
                 application_id,
                 guild_id,
@@ -2017,7 +1962,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ApplicationsIdGuildsIdCommandsId(application_id),
                 Cow::from(Route::application_guild_command(application_id, guild_id, command_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::EditGuildApplicationCommandPermission {
                 application_id,
                 guild_id,
@@ -2031,7 +1975,6 @@ impl<'a> RouteInfo<'a> {
                     command_id,
                 )),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::EditGuildApplicationCommandsPermissions {
                 application_id,
                 guild_id,
@@ -2091,7 +2034,6 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdMembersMeNick(guild_id),
                 Cow::from(Route::guild_nickname(guild_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::GetOriginalInteractionResponse {
                 application_id,
                 interaction_token,
@@ -2103,7 +2045,6 @@ impl<'a> RouteInfo<'a> {
                     interaction_token,
                 )),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::EditOriginalInteractionResponse {
                 application_id,
                 interaction_token,
@@ -2289,7 +2230,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ChannelsIdMeJoindedArchivedPrivateThreads(channel_id),
                 Cow::from(Route::channel_joined_private_threads(channel_id, before, limit)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::GetFollowupMessage {
                 application_id,
                 interaction_token,
@@ -2364,7 +2304,6 @@ impl<'a> RouteInfo<'a> {
             RouteInfo::GetGateway => {
                 (LightMethod::Get, Route::Gateway, Cow::from(Route::gateway()))
             },
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::GetGlobalApplicationCommands {
                 application_id,
             } => (
@@ -2372,7 +2311,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ApplicationsIdCommands(application_id),
                 Cow::from(Route::application_commands(application_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::GetGlobalApplicationCommand {
                 application_id,
                 command_id,
@@ -2391,7 +2329,6 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsId(guild_id),
                 Cow::from(Route::guild_with_counts(guild_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::GetGuildApplicationCommands {
                 application_id,
                 guild_id,
@@ -2400,7 +2337,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ApplicationsIdGuildsIdCommands(application_id),
                 Cow::from(Route::application_guild_commands(application_id, guild_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::GetGuildApplicationCommand {
                 application_id,
                 guild_id,
@@ -2410,7 +2346,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ApplicationsIdGuildsIdCommandsId(application_id),
                 Cow::from(Route::application_guild_command(application_id, guild_id, command_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::GetGuildApplicationCommandsPermissions {
                 application_id,
                 guild_id,
@@ -2419,7 +2354,6 @@ impl<'a> RouteInfo<'a> {
                 Route::ApplicationsIdGuildsIdCommandsPermissions(application_id),
                 Cow::from(Route::application_guild_commands_permissions(application_id, guild_id)),
             ),
-            #[cfg(feature = "unstable_discord_api")]
             RouteInfo::GetGuildApplicationCommandPermissions {
                 application_id,
                 guild_id,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -14,21 +14,20 @@ use crate::builder::{CreateEmbed, EditMessage};
 use crate::cache::Cache;
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
-#[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+#[cfg(feature = "collector")]
 use crate::collector::{
     CollectComponentInteraction,
     CollectModalInteraction,
+    CollectReaction,
     ComponentInteractionCollectorBuilder,
     ModalInteractionCollectorBuilder,
+    ReactionCollectorBuilder,
 };
-#[cfg(feature = "collector")]
-use crate::collector::{CollectReaction, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
 use crate::json;
 use crate::json::Value;
-#[cfg(feature = "unstable_discord_api")]
 use crate::model::interactions::{message_component::ActionRow, MessageInteraction};
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
@@ -127,10 +126,8 @@ pub struct Message {
     /// Sent if the message is a response to an [`Interaction`].
     ///
     /// [`Interaction`]: crate::model::interactions::Interaction
-    #[cfg(feature = "unstable_discord_api")]
     pub interaction: Option<MessageInteraction>,
     /// The components of this message
-    #[cfg(feature = "unstable_discord_api")]
     #[serde(default)]
     pub components: Vec<ActionRow>,
 }
@@ -891,7 +888,7 @@ impl Message {
     }
 
     /// Await a single component interaction on this message.
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     pub fn await_component_interaction(
         &self,
         shard_messenger: impl AsRef<ShardMessenger>,
@@ -900,7 +897,7 @@ impl Message {
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of component interactions on this message.
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     pub fn await_component_interactions(
         &self,
         shard_messenger: impl AsRef<ShardMessenger>,
@@ -909,7 +906,7 @@ impl Message {
     }
 
     /// Await a single modal submit interaction on this message.
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     pub fn await_modal_interaction(
         &self,
         shard_messenger: impl AsRef<ShardMessenger>,
@@ -918,7 +915,7 @@ impl Message {
     }
 
     /// Returns a stream builder which can be awaited to obtain a stream of modal submit interactions on this message.
-    #[cfg(all(feature = "unstable_discord_api", feature = "collector"))]
+    #[cfg(feature = "collector")]
     pub fn await_modal_interactions(
         &self,
         shard_messenger: impl AsRef<ShardMessenger>,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -8,7 +8,6 @@ use serde::de::{Error as DeError, IgnoredAny, MapAccess};
 use super::prelude::*;
 use super::utils::{emojis, roles, stickers};
 use crate::internal::prelude::*;
-#[cfg(feature = "unstable_discord_api")]
 use crate::model::interactions::Interaction;
 use crate::{constants::OpCode, json::prelude::*};
 
@@ -462,7 +461,6 @@ pub struct WebhookUpdateEvent {
     pub guild_id: GuildId,
 }
 
-#[cfg(feature = "unstable_discord_api")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -470,7 +468,6 @@ pub struct InteractionCreateEvent {
     pub interaction: Interaction,
 }
 
-#[cfg(feature = "unstable_discord_api")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -478,7 +475,6 @@ pub struct IntegrationCreateEvent {
     pub integration: Integration,
 }
 
-#[cfg(feature = "unstable_discord_api")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -486,7 +482,6 @@ pub struct IntegrationUpdateEvent {
     pub integration: Integration,
 }
 
-#[cfg(feature = "unstable_discord_api")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct IntegrationDeleteEvent {
@@ -771,16 +766,12 @@ pub enum Event {
     /// A webhook for a [channel][`GuildChannel`] was updated in a [`Guild`].
     WebhookUpdate(WebhookUpdateEvent),
     /// An interaction was created.
-    #[cfg(feature = "unstable_discord_api")]
     InteractionCreate(InteractionCreateEvent),
     /// A guild integration was created
-    #[cfg(feature = "unstable_discord_api")]
     IntegrationCreate(IntegrationCreateEvent),
     /// A guild integration was updated
-    #[cfg(feature = "unstable_discord_api")]
     IntegrationUpdate(IntegrationUpdateEvent),
     /// A guild integration was deleted
-    #[cfg(feature = "unstable_discord_api")]
     IntegrationDelete(IntegrationDeleteEvent),
     /// A stage instance was created.
     StageInstanceCreate(StageInstanceCreateEvent),
@@ -1108,7 +1099,6 @@ macro_rules! with_related_ids_for_event_types {
                 channel_id: Some(e.channel_id),
                 message_id: Never,
             },
-            #[cfg(feature = "unstable_discord_api")]
             Self::InteractionCreate, Self::InteractionCreate(e) => {
                 user_id: match &e.interaction {
                     Interaction::Ping(_) => None,
@@ -1139,21 +1129,18 @@ macro_rules! with_related_ids_for_event_types {
                     Interaction::ModalSubmit(i) => i.message.as_ref().map(|m| m.id).into(),
                 },
             },
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationCreate, Self::IntegrationCreate(e) => {
                 user_id: e.integration.user.as_ref().map(|u| u.id).into(),
                 guild_id: Some(e.integration.guild_id),
                 channel_id: Never,
                 message_id: Never,
             },
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationUpdate, Self::IntegrationUpdate(e) => {
                 user_id: e.integration.user.as_ref().map(|u| u.id).into(),
                 guild_id: Some(e.integration.guild_id),
                 channel_id: Never,
                 message_id: Never,
             },
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationDelete, Self::IntegrationDelete(e) => {
                 user_id: Never,
                 guild_id: Some(e.guild_id),
@@ -1271,13 +1258,9 @@ impl Event {
             Self::VoiceStateUpdate(_) => EventType::VoiceStateUpdate,
             Self::VoiceServerUpdate(_) => EventType::VoiceServerUpdate,
             Self::WebhookUpdate(_) => EventType::WebhookUpdate,
-            #[cfg(feature = "unstable_discord_api")]
             Self::InteractionCreate(_) => EventType::InteractionCreate,
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationCreate(_) => EventType::IntegrationCreate,
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationUpdate(_) => EventType::IntegrationUpdate,
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationDelete(_) => EventType::IntegrationDelete,
             Self::StageInstanceCreate(_) => EventType::StageInstanceCreate,
             Self::StageInstanceUpdate(_) => EventType::StageInstanceUpdate,
@@ -1420,13 +1403,9 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
         EventType::VoiceServerUpdate => Event::VoiceServerUpdate(from_value(v)?),
         EventType::VoiceStateUpdate => Event::VoiceStateUpdate(from_value(v)?),
         EventType::WebhookUpdate => Event::WebhookUpdate(from_value(v)?),
-        #[cfg(feature = "unstable_discord_api")]
         EventType::InteractionCreate => Event::InteractionCreate(from_value(v)?),
-        #[cfg(feature = "unstable_discord_api")]
         EventType::IntegrationCreate => Event::IntegrationCreate(from_value(v)?),
-        #[cfg(feature = "unstable_discord_api")]
         EventType::IntegrationUpdate => Event::IntegrationUpdate(from_value(v)?),
-        #[cfg(feature = "unstable_discord_api")]
         EventType::IntegrationDelete => Event::IntegrationDelete(from_value(v)?),
         EventType::StageInstanceCreate => Event::StageInstanceCreate(from_value(v)?),
         EventType::StageInstanceUpdate => Event::StageInstanceUpdate(from_value(v)?),
@@ -1609,22 +1588,18 @@ pub enum EventType {
     /// Indicator that an interaction was created.
     ///
     /// This maps to [`InteractionCreateEvent`].
-    #[cfg(feature = "unstable_discord_api")]
     InteractionCreate,
     /// Indicator that an integration was created.
     ///
     /// This maps to [`IntegrationCreateEvent`].
-    #[cfg(feature = "unstable_discord_api")]
     IntegrationCreate,
     /// Indicator that an integration was created.
     ///
     /// This maps to [`IntegrationUpdateEvent`].
-    #[cfg(feature = "unstable_discord_api")]
     IntegrationUpdate,
     /// Indicator that an integration was created.
     ///
     /// This maps to [`IntegrationDeleteEvent`].
-    #[cfg(feature = "unstable_discord_api")]
     IntegrationDelete,
     /// Indicator that a stage instance was created.
     ///
@@ -1771,13 +1746,9 @@ impl EventType {
     const VOICE_SERVER_UPDATE: &'static str = "VOICE_SERVER_UPDATE";
     const VOICE_STATE_UPDATE: &'static str = "VOICE_STATE_UPDATE";
     const WEBHOOKS_UPDATE: &'static str = "WEBHOOKS_UPDATE";
-    #[cfg(feature = "unstable_discord_api")]
     const INTERACTION_CREATE: &'static str = "INTERACTION_CREATE";
-    #[cfg(feature = "unstable_discord_api")]
     const INTEGRATION_CREATE: &'static str = "INTEGRATION_CREATE";
-    #[cfg(feature = "unstable_discord_api")]
     const INTEGRATION_UPDATE: &'static str = "INTEGRATION_UPDATE";
-    #[cfg(feature = "unstable_discord_api")]
     const INTEGRATION_DELETE: &'static str = "INTEGRATION_DELETE";
     const STAGE_INSTANCE_CREATE: &'static str = "STAGE_INSTANCE_CREATE";
     const STAGE_INSTANCE_UPDATE: &'static str = "STAGE_INSTANCE_UPDATE";
@@ -1831,13 +1802,9 @@ impl EventType {
             Self::VoiceServerUpdate => Some(Self::VOICE_SERVER_UPDATE),
             Self::VoiceStateUpdate => Some(Self::VOICE_STATE_UPDATE),
             Self::WebhookUpdate => Some(Self::WEBHOOKS_UPDATE),
-            #[cfg(feature = "unstable_discord_api")]
             Self::InteractionCreate => Some(Self::INTERACTION_CREATE),
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationCreate => Some(Self::INTEGRATION_CREATE),
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationUpdate => Some(Self::INTEGRATION_UPDATE),
-            #[cfg(feature = "unstable_discord_api")]
             Self::IntegrationDelete => Some(Self::INTEGRATION_DELETE),
             Self::StageInstanceCreate => Some(Self::STAGE_INSTANCE_CREATE),
             Self::StageInstanceUpdate => Some(Self::STAGE_INSTANCE_UPDATE),
@@ -1915,13 +1882,9 @@ impl<'de> Deserialize<'de> for EventType {
                     EventType::VOICE_SERVER_UPDATE => EventType::VoiceServerUpdate,
                     EventType::VOICE_STATE_UPDATE => EventType::VoiceStateUpdate,
                     EventType::WEBHOOKS_UPDATE => EventType::WebhookUpdate,
-                    #[cfg(feature = "unstable_discord_api")]
                     EventType::INTERACTION_CREATE => EventType::InteractionCreate,
-                    #[cfg(feature = "unstable_discord_api")]
                     EventType::INTEGRATION_CREATE => EventType::IntegrationCreate,
-                    #[cfg(feature = "unstable_discord_api")]
                     EventType::INTEGRATION_UPDATE => EventType::IntegrationUpdate,
-                    #[cfg(feature = "unstable_discord_api")]
                     EventType::INTEGRATION_DELETE => EventType::IntegrationDelete,
                     EventType::STAGE_INSTANCE_CREATE => EventType::StageInstanceCreate,
                     EventType::STAGE_INSTANCE_UPDATE => EventType::StageInstanceUpdate,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -38,7 +38,7 @@ use crate::json::json;
 #[cfg(feature = "model")]
 use crate::json::prelude::*;
 use crate::model::prelude::*;
-#[cfg(all(feature = "model", feature = "unstable_discord_api"))]
+#[cfg(feature = "model")]
 use crate::{
     builder::{
         CreateApplicationCommand,
@@ -1282,7 +1282,6 @@ impl GuildId {
     ///
     /// [`ApplicationCommand`]: crate::model::interactions::application_command::ApplicationCommand
     /// [`create_global_application_command`]: crate::model::interactions::application_command::ApplicationCommand::create_global_application_command
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1302,7 +1301,6 @@ impl GuildId {
     /// Returns the same possible errors as [`set_global_application_commands`].
     ///
     /// [`set_global_application_commands`]: crate::model::interactions::application_command::ApplicationCommand::set_global_application_commands
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1330,7 +1328,6 @@ impl GuildId {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1362,7 +1359,6 @@ impl GuildId {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1387,7 +1383,6 @@ impl GuildId {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_commands(
         &self,
         http: impl AsRef<Http>,
@@ -1403,7 +1398,6 @@ impl GuildId {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -1420,7 +1414,6 @@ impl GuildId {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1444,7 +1437,6 @@ impl GuildId {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -1461,7 +1453,6 @@ impl GuildId {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -1477,7 +1468,6 @@ impl GuildId {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -14,7 +14,6 @@ use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::json;
-#[cfg(feature = "unstable_discord_api")]
 use crate::model::permissions::Permissions;
 use crate::model::prelude::*;
 use crate::model::Timestamp;
@@ -51,7 +50,6 @@ pub struct Member {
     /// This is only [`Some`] when returned in an [`Interaction`] object.
     ///
     /// [`Interaction`]: crate::model::interactions::Interaction
-    #[cfg(feature = "unstable_discord_api")]
     pub permissions: Option<Permissions>,
     /// The guild avatar hash
     pub avatar: Option<String>,
@@ -77,7 +75,6 @@ pub(crate) struct InterimMember {
     #[serde(default)]
     pub pending: bool,
     pub premium_since: Option<Timestamp>,
-    #[cfg(feature = "unstable_discord_api")]
     pub permissions: Option<Permissions>,
     pub avatar: Option<String>,
     pub communication_disabled_until: Option<Timestamp>,
@@ -95,7 +92,6 @@ impl From<InterimMember> for Member {
             user: m.user,
             pending: m.pending,
             premium_since: m.premium_since,
-            #[cfg(feature = "unstable_discord_api")]
             permissions: m.permissions,
             avatar: m.avatar,
             communication_disabled_until: m.communication_disabled_until,
@@ -687,7 +683,6 @@ pub struct PartialMember {
     /// This is only [`Some`] when returned in an [`Interaction`] object.
     ///
     /// [`Interaction`]: crate::model::interactions::Interaction
-    #[cfg(feature = "unstable_discord_api")]
     pub permissions: Option<Permissions>,
 }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -65,7 +65,7 @@ use crate::constants::LARGE_THRESHOLD;
 use crate::http::{CacheHttp, Http};
 #[cfg(all(feature = "http", feature = "model"))]
 use crate::json::json;
-#[cfg(all(feature = "model", feature = "unstable_discord_api"))]
+#[cfg(feature = "model")]
 use crate::{
     builder::{
         CreateApplicationCommand,
@@ -658,7 +658,6 @@ impl Guild {
     /// Returns the same possible errors as `create_global_application_command`.
     ///
     /// [`ApplicationCommand`]: crate::model::interactions::application_command::ApplicationCommand
-    #[cfg(feature = "unstable_discord_api")]
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn create_application_command<F>(
@@ -682,7 +681,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
@@ -706,7 +704,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -729,7 +726,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -751,7 +747,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_commands(
         &self,
         http: impl AsRef<Http>,
@@ -767,7 +762,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -784,7 +778,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -805,7 +798,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -822,7 +814,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -838,7 +829,6 @@ impl Guild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -3062,7 +3052,6 @@ mod test {
                 user: u,
                 pending: false,
                 premium_since: None,
-                #[cfg(feature = "unstable_discord_api")]
                 permissions: None,
                 avatar: None,
                 communication_disabled_until: None,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -29,7 +29,7 @@ use crate::collector::{
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
 use crate::json::{from_number, prelude::*};
-#[cfg(all(feature = "model", feature = "unstable_discord_api"))]
+#[cfg(feature = "model")]
 use crate::{
     builder::{
         CreateApplicationCommand,
@@ -367,7 +367,6 @@ impl PartialGuild {
     /// Returns the same possible errors as `create_global_application_command`.
     ///
     /// [`ApplicationCommand`]: crate::model::interactions::application_command::ApplicationCommand
-    #[cfg(feature = "unstable_discord_api")]
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn create_application_command<F>(
@@ -391,7 +390,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
@@ -415,7 +413,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -441,7 +438,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -463,7 +459,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_commands(
         &self,
         http: impl AsRef<Http>,
@@ -479,7 +474,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -496,7 +490,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -517,7 +510,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -534,7 +526,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -550,7 +541,6 @@ impl PartialGuild {
     ///
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    #[cfg(feature = "unstable_discord_api")]
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Deserializer};
 use simd_json::ValueAccess;
 
 use super::prelude::*;
+#[cfg(feature = "http")]
 use crate::builder::CreateApplicationCommand;
 #[cfg(feature = "http")]
 use crate::builder::{
@@ -17,7 +18,9 @@ use crate::builder::{
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::StdResult;
-use crate::json::{self, from_number, JsonMap, Value};
+#[cfg(feature = "http")]
+use crate::json;
+use crate::json::{from_number, JsonMap, Value};
 use crate::model::channel::{Attachment, ChannelType, PartialChannel};
 use crate::model::guild::{Member, PartialMember, Role};
 use crate::model::id::{
@@ -31,7 +34,6 @@ use crate::model::id::{
 };
 use crate::model::interactions::InteractionType;
 use crate::model::prelude::User;
-#[cfg(feature = "unstable_discord_api")]
 use crate::model::utils::deserialize_options_with_resolved;
 
 /// An interaction when a user invokes a slash command.
@@ -651,7 +653,6 @@ pub struct ApplicationCommandInteractionDataOption {
     pub focused: bool,
 }
 
-#[cfg(feature = "unstable_discord_api")]
 impl<'de> Deserialize<'de> for ApplicationCommandInteractionDataOption {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
@@ -917,6 +918,7 @@ impl ApplicationCommand {
     }
 }
 
+#[cfg(feature = "http")]
 impl ApplicationCommand {
     #[inline]
     pub(crate) fn build_application_command<F>(f: F) -> JsonMap

--- a/src/model/interactions/modal.rs
+++ b/src/model/interactions/modal.rs
@@ -5,13 +5,17 @@ use simd_json::ValueAccess;
 
 use super::message_component::ActionRow;
 use super::prelude::*;
+#[cfg(feature = "model")]
 use crate::builder::{
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     EditInteractionResponse,
 };
+#[cfg(feature = "model")]
 use crate::http::Http;
-use crate::json::{self, from_number};
+#[cfg(feature = "model")]
+use crate::json;
+use crate::json::from_number;
 use crate::model::interactions::InteractionType;
 
 /// An interaction triggered by a modal submit.
@@ -54,6 +58,7 @@ pub struct ModalSubmitInteraction {
     pub locale: String,
 }
 
+#[cfg(feature = "model")]
 impl ModalSubmitInteraction {
     /// Gets the interaction response.
     ///

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -479,7 +479,6 @@ mod test {
                 user: user.clone(),
                 pending: false,
                 premium_since: None,
-                #[cfg(feature = "unstable_discord_api")]
                 permissions: None,
                 avatar: None,
                 communication_disabled_until: None,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -30,7 +30,6 @@ pub mod event;
 pub mod gateway;
 pub mod guild;
 pub mod id;
-#[cfg(feature = "unstable_discord_api")]
 pub mod interactions;
 pub mod invite;
 pub mod misc;

--- a/src/model/prelude.rs
+++ b/src/model/prelude.rs
@@ -18,7 +18,6 @@ pub use super::gateway::*;
 pub use super::guild::audit_log::*;
 pub use super::guild::*;
 pub use super::id::*;
-#[cfg(feature = "unstable_discord_api")]
 pub use super::interactions::*;
 pub use super::invite::*;
 pub use super::misc::*;

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -11,7 +11,6 @@ use super::prelude::*;
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
 use crate::internal::prelude::*;
-#[cfg(feature = "unstable_discord_api")]
 use crate::model::interactions::application_command::*;
 
 pub fn default_true() -> bool {
@@ -73,7 +72,6 @@ pub fn deserialize_members<'de, D: Deserializer<'de>>(
     deserializer.deserialize_seq(SequenceToMapVisitor::new(|member: &Member| member.user.id))
 }
 
-#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_options_with_resolved<'de, D: Deserializer<'de>>(
     deserializer: D,
     resolved: &ApplicationCommandInteractionDataResolved,
@@ -87,7 +85,6 @@ pub fn deserialize_options_with_resolved<'de, D: Deserializer<'de>>(
     Ok(options)
 }
 
-#[cfg(feature = "unstable_discord_api")]
 fn try_resolve(
     value: &Value,
     kind: ApplicationCommandOptionType,
@@ -158,7 +155,6 @@ fn try_resolve(
     }
 }
 
-#[cfg(feature = "unstable_discord_api")]
 fn loop_resolved(
     options: &mut ApplicationCommandInteractionDataOption,
     resolved: &ApplicationCommandInteractionDataResolved,

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -383,7 +383,6 @@ mod tests {
             user: user.clone(),
             pending: false,
             premium_since: None,
-            #[cfg(feature = "unstable_discord_api")]
             permissions: None,
             avatar: None,
             communication_disabled_until: None,

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -272,9 +272,7 @@ fn dummy_message() -> Message {
         flags: None,
         sticker_items: Vec::new(),
         referenced_message: None,
-        #[cfg(feature = "unstable_discord_api")]
         interaction: None,
-        #[cfg(feature = "unstable_discord_api")]
         components: vec![],
     }
 }


### PR DESCRIPTION
The current code assumes that the `unstable_discord_api` feature is the application command feature. With the removal of the unstable feature guard, it's now required to set the `application_id` or it will panic on `Client` or `Http` creation.