### PR TITLE
Fix typo in environment variable in `Publish docs` build job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
       - next
 
 env:
-  rust-nightly: nightly-2022-03-22
+  rust_nightly: nightly-2022-03-22
 
 jobs:
   docs:


### PR DESCRIPTION
The documentation is currently not published because of this typo.