### PR TITLE
Add `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,17 @@
+# List of noisy revisions that can be ignored with git-blame(1).
+#
+# See `blame.ignoreRevsFile` in git-config(1) to enable it by default, or
+# use it with `--ignore-revs-file` manually with git-blame.
+#
+# To "install" it:
+#
+# git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+
+# rustfmt
+550030264952f0e0043b63f4582bb817ef8bbf37
+
+# Apply rustfmt
+dae2cb77b407044f44a7a2790d93efba3891854e
+
+# Format the repository and add a workflow for formatting and linting (#1174)
+9bbb25aac4d651804286f333eb503a72d41e473b

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,15 @@ Improper commit summaries are:
 The first letter of the summary must be capitalised. The summary should also
 preferably fit into 50 characters, but this is not actively enforced.
 
+# Noisy commits
+
+Set `blame.ignoreRevsFile` to ignore [noise commits][noise-commits] in `git blame`:
+```
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 [test_ci]: .github/workflows/ci.yml
+[noise-commits]: https://github.com/serenity-rs/serenity/commit/9bbb25aac4d651804286f333eb503a72d41e473b
 [make]: https://github.com/sagiegurari/cargo-make
 [`rustup`]: https://rustup.rs
 [in-links]: https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md


### PR DESCRIPTION
The file contains commit hashes of noisy commits that can be ignored and
is meant for use with `git blame --ignore-revs-file` or via `git config`.

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

It's also supported by Github.
https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/