### PR TITLE
Replace custom `I` trait with `Into<Content>`

### DIFF
--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -215,7 +215,7 @@ impl MessageBuilder {
     /// );
     /// ```
     #[inline]
-    pub fn push<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push(&mut self, content: impl Into<Content>) -> &mut Self {
         self._push(&content.into().to_string())
     }
 
@@ -263,7 +263,11 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "```\nhello\n```");
     /// ```
-    pub fn push_codeblock<D: I>(&mut self, content: D, language: Option<&str>) -> &mut Self {
+    pub fn push_codeblock(
+        &mut self,
+        content: impl Into<Content>,
+        language: Option<&str>,
+    ) -> &mut Self {
         self.0.push_str("```");
 
         if let Some(language) = language {
@@ -301,7 +305,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, expected);
     /// ```
-    pub fn push_mono<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_mono(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push('`');
         self.0.push_str(&content.into().to_string());
         self.0.push('`');
@@ -330,7 +334,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, expected);
     /// ```
-    pub fn push_italic<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_italic(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push('_');
         self.0.push_str(&content.into().to_string());
         self.0.push('_');
@@ -339,7 +343,7 @@ impl MessageBuilder {
     }
 
     /// Pushes an inline bold text to the content.
-    pub fn push_bold<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_bold(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("**");
         self.0.push_str(&content.into().to_string());
         self.0.push_str("**");
@@ -348,7 +352,7 @@ impl MessageBuilder {
     }
 
     /// Pushes an underlined inline text to the content.
-    pub fn push_underline<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_underline(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("__");
         self.0.push_str(&content.into().to_string());
         self.0.push_str("__");
@@ -357,7 +361,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a strikethrough inline text to the content.
-    pub fn push_strike<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_strike(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("~~");
         self.0.push_str(&content.into().to_string());
         self.0.push_str("~~");
@@ -366,7 +370,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a spoiler'd inline text to the content.
-    pub fn push_spoiler<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_spoiler(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("||");
         self.0.push_str(&content.into().to_string());
         self.0.push_str("||");
@@ -375,7 +379,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a quoted inline text to the content
-    pub fn push_quote<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_quote(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("> ");
         self.0.push_str(&content.into().to_string());
 
@@ -395,7 +399,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "hello\nworld");
     /// ```
-    pub fn push_line<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_line(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push(content);
         self.0.push('\n');
 
@@ -415,7 +419,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "`hello`\nworld");
     /// ```
-    pub fn push_mono_line<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_mono_line(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_mono(content);
         self.0.push('\n');
 
@@ -435,7 +439,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "_hello_\nworld");
     /// ```
-    pub fn push_italic_line<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_italic_line(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_italic(content);
         self.0.push('\n');
 
@@ -455,7 +459,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "**hello**\nworld");
     /// ```
-    pub fn push_bold_line<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_bold_line(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_bold(content);
         self.0.push('\n');
 
@@ -475,7 +479,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "__hello__\nworld");
     /// ```
-    pub fn push_underline_line<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_underline_line(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_underline(content);
         self.0.push('\n');
 
@@ -495,7 +499,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "~~hello~~\nworld");
     /// ```
-    pub fn push_strike_line<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_strike_line(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_strike(content);
         self.0.push('\n');
 
@@ -515,7 +519,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "||hello||\nworld");
     /// ```
-    pub fn push_spoiler_line<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_spoiler_line(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_spoiler(content);
         self.0.push('\n');
 
@@ -535,7 +539,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "> hello\nworld");
     /// ```
-    pub fn push_quote_line<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_quote_line(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_quote(content);
         self.0.push('\n');
 
@@ -544,7 +548,7 @@ impl MessageBuilder {
 
     /// Pushes text to your message, but normalizing content - that means
     /// ensuring that there's no unwanted formatting, mention spam etc.
-    pub fn push_safe<C: I>(&mut self, content: C) -> &mut Self {
+    pub fn push_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         {
             let mut c = content.into();
             c.inner =
@@ -557,7 +561,11 @@ impl MessageBuilder {
     }
 
     /// Pushes a code-block to your message normalizing content.
-    pub fn push_codeblock_safe<D: I>(&mut self, content: D, language: Option<&str>) -> &mut Self {
+    pub fn push_codeblock_safe(
+        &mut self,
+        content: impl Into<Content>,
+        language: Option<&str>,
+    ) -> &mut Self {
         self.0.push_str("```");
 
         if let Some(language) = language {
@@ -576,7 +584,7 @@ impl MessageBuilder {
     }
 
     /// Pushes an inline monospaced text to the content normalizing content.
-    pub fn push_mono_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_mono_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push('`');
         {
             let mut c = content.into();
@@ -589,7 +597,7 @@ impl MessageBuilder {
     }
 
     /// Pushes an inline italicized text to the content normalizing content.
-    pub fn push_italic_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_italic_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push('_');
         {
             let mut c = content.into();
@@ -602,7 +610,7 @@ impl MessageBuilder {
     }
 
     /// Pushes an inline bold text to the content normalizing content.
-    pub fn push_bold_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_bold_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("**");
         {
             let mut c = content.into();
@@ -615,7 +623,7 @@ impl MessageBuilder {
     }
 
     /// Pushes an underlined inline text to the content normalizing content.
-    pub fn push_underline_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_underline_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("__");
         {
             let mut c = content.into();
@@ -628,7 +636,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a strikethrough inline text to the content normalizing content.
-    pub fn push_strike_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_strike_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("~~");
         {
             let mut c = content.into();
@@ -641,7 +649,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a spoiler'd inline text to the content normalizing content.
-    pub fn push_spoiler_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_spoiler_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("||");
         {
             let mut c = content.into();
@@ -654,7 +662,7 @@ impl MessageBuilder {
     }
 
     /// Pushes a quoted inline text to the content normalizing content.
-    pub fn push_quote_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_quote_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.0.push_str("> ");
         {
             let mut c = content.into();
@@ -679,7 +687,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "Hello @\u{200B}everyone\nHow are you?");
     /// ```
-    pub fn push_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_line_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_safe(content);
         self.0.push('\n');
 
@@ -700,7 +708,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "`'hello @\u{200B}everyone'`\nworld");
     /// ```
-    pub fn push_mono_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_mono_line_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_mono_safe(content);
         self.0.push('\n');
 
@@ -721,7 +729,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "_@\u{200B}everyone_\nIsn't a mention.");
     /// ```
-    pub fn push_italic_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_italic_line_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_italic_safe(content);
         self.0.push('\n');
 
@@ -742,7 +750,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "**@\u{200B}everyone**\nIsn't a mention.");
     /// ```
-    pub fn push_bold_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_bold_line_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_bold_safe(content);
         self.0.push('\n');
 
@@ -765,7 +773,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "__@\u{200B}everyone__\nIsn't a mention.");
     /// ```
-    pub fn push_underline_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_underline_line_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_underline_safe(content);
         self.0.push('\n');
 
@@ -787,7 +795,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "~~@\u{200B}everyone~~\nIsn't a mention.");
     /// ```
-    pub fn push_strike_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_strike_line_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_strike_safe(content);
         self.0.push('\n');
 
@@ -809,7 +817,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "||@\u{200B}everyone||\nIsn't a mention.");
     /// ```
-    pub fn push_spoiler_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_spoiler_line_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_spoiler_safe(content);
         self.0.push('\n');
 
@@ -831,7 +839,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "> @\u{200B}everyone\nIsn't a mention.");
     /// ```
-    pub fn push_quote_line_safe<D: I>(&mut self, content: D) -> &mut Self {
+    pub fn push_quote_line_safe(&mut self, content: impl Into<Content>) -> &mut Self {
         self.push_quote_safe(content);
         self.0.push('\n');
 
@@ -948,7 +956,7 @@ pub trait EmbedMessageBuilding {
     /// #[cfg(not(feature = "utils"))]
     /// {}
     /// ```
-    fn push_named_link<T: I, U: I>(&mut self, name: T, url: U) -> &mut Self;
+    fn push_named_link(&mut self, name: impl Into<Content>, url: impl Into<Content>) -> &mut Self;
 
     /// Pushes a named link intended for use in an embed, but with a normalized
     /// name to avoid escaping issues.
@@ -976,11 +984,15 @@ pub trait EmbedMessageBuilding {
     /// #[cfg(not(feature = "utils"))]
     /// {}
     /// ```
-    fn push_named_link_safe<T: I, U: I>(&mut self, name: T, url: U) -> &mut Self;
+    fn push_named_link_safe(
+        &mut self,
+        name: impl Into<Content>,
+        url: impl Into<Content>,
+    ) -> &mut Self;
 }
 
 impl EmbedMessageBuilding for MessageBuilder {
-    fn push_named_link<T: I, U: I>(&mut self, name: T, url: U) -> &mut Self {
+    fn push_named_link(&mut self, name: impl Into<Content>, url: impl Into<Content>) -> &mut Self {
         let name = name.into().to_string();
         let url = url.into().to_string();
 
@@ -991,7 +1003,11 @@ impl EmbedMessageBuilding for MessageBuilder {
         self
     }
 
-    fn push_named_link_safe<T: I, U: I>(&mut self, name: T, url: U) -> &mut Self {
+    fn push_named_link_safe(
+        &mut self,
+        name: impl Into<Content>,
+        url: impl Into<Content>,
+    ) -> &mut Self {
         self.0.push('[');
         {
             let mut c = name.into();
@@ -1201,52 +1217,17 @@ impl Content {
     }
 }
 
-impl From<ContentModifier> for Content {
-    fn from(cm: ContentModifier) -> Content {
-        cm.to_content()
-    }
-}
-
-mod private {
-    use std::fmt;
-
-    use super::{Content, ContentModifier};
-
-    pub trait A {}
-
-    impl A for ContentModifier {}
-    impl A for Content {}
-    impl<T: fmt::Display> A for T {}
-}
-
-/// This trait exists for the purpose of bypassing the "conflicting implementations" error from the compiler.
-pub trait I: self::private::A {
-    fn into(self) -> Content;
-}
-
-impl<T: fmt::Display> I for T {
-    fn into(self) -> Content {
+impl<T: fmt::Display> From<T> for Content {
+    fn from(t: T) -> Content {
         Content {
             italic: false,
             bold: false,
             strikethrough: false,
-            inner: self.to_string(),
+            inner: t.to_string(),
             code: false,
             underline: false,
             spoiler: false,
         }
-    }
-}
-
-impl I for ContentModifier {
-    fn into(self) -> Content {
-        self.to_content()
-    }
-}
-
-impl I for Content {
-    fn into(self) -> Content {
-        self
     }
 }
 


### PR DESCRIPTION
Using a custom trait to create `Content` is unnecessary; From/Into serve just as well. Also, we don't implement `Into<Content> for ContentModifier` as it's essentially useless to include a `ContentModifier` by itself in a message. The various implementations of `Add` take care of coercion for us, and the various `push_{modifier}` methods can take empty strings either way.