### PR TITLE
Add missing `webhook.get_message`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1960,6 +1960,25 @@ impl Http {
         response.json::<Message>().await.map(Some).map_err(From::from)
     }
 
+    // Gets a webhook's message by Id
+    pub async fn get_webhook_message(
+        &self,
+        webhook_id: u64,
+        token: &str,
+        message_id: u64,
+    ) -> Result<Message> {
+        self.fire(Request {
+            body: None,
+            headers: None,
+            route: RouteInfo::GetWebhookMessage {
+                token,
+                webhook_id,
+                message_id,
+            },
+        })
+        .await
+    }
+
     /// Edits a webhook's message by Id.
     pub async fn edit_webhook_message(
         &self,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1275,6 +1275,11 @@ pub enum RouteInfo<'a> {
         token: &'a str,
         webhook_id: u64,
     },
+    GetWebhookMessage {
+        token: &'a str,
+        webhook_id: u64,
+        message_id: u64,
+    },
     EditWebhookMessage {
         token: &'a str,
         webhook_id: u64,
@@ -2102,6 +2107,15 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Patch,
                 Route::WebhooksId(webhook_id),
                 Cow::from(Route::webhook_with_token(webhook_id, token)),
+            ),
+            RouteInfo::GetWebhookMessage {
+                token,
+                webhook_id,
+                message_id,
+            } => (
+                LightMethod::Get,
+                Route::WebhooksIdMessagesId(webhook_id),
+                Cow::from(Route::webhook_message(webhook_id, token, message_id)),
             ),
             RouteInfo::EditWebhookMessage {
                 token,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1275,11 +1275,6 @@ pub enum RouteInfo<'a> {
         token: &'a str,
         webhook_id: u64,
     },
-    GetWebhookMessage {
-        token: &'a str,
-        webhook_id: u64,
-        message_id: u64,
-    },
     EditWebhookMessage {
         token: &'a str,
         webhook_id: u64,
@@ -1489,6 +1484,11 @@ pub enum RouteInfo<'a> {
     GetWebhookWithToken {
         token: &'a str,
         webhook_id: u64,
+    },
+    GetWebhookMessage {
+        token: &'a str,
+        webhook_id: u64,
+        message_id: u64,
     },
     KickMember {
         guild_id: u64,

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -316,6 +316,30 @@ impl Webhook {
         }
     }
 
+    /// Gets a previously sent message from the webhook.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Model`] if the [`Self::token`] is [`None`].
+    ///
+    /// May also return [`Error::Http`] if the webhook's token is invalid, or
+    /// the given message Id does not belong to the current webhook.
+    ///
+    /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
+    ///
+    /// [`Error::Model`]: crate::error::Error::Model
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
+    pub async fn get_message(
+        &self,
+        http: impl AsRef<Http>,
+        message_id: MessageId,
+    ) -> Result<Message> {
+        let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
+
+        http.as_ref().get_webhook_message(self.id.0, token, message_id.0).await
+    }
+
     /// Edits a webhook message with the fields set via the given builder.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary
Adds `webhook.get_message(http, message_id)` for fetching existing messages sent by the webhook.

## Discord Docs
https://discord.com/developers/docs/resources/webhook#get-webhook-message