### PR TITLE
Make chrono a default optional feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
             features: model http rustls_backend
           - name: time
             features: time
+          - name: chrono
+            features: chrono
           - name: unstable Discord API features
             features: default unstable_discord_api
             dont-test: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,14 +54,15 @@ version = "0.13"
 optional = true
 version = "1.0.5"
 
-[dependencies.time]
-optional = true
+[dependencies.dep_time]
+package = "time"
 version = "0.3.6"
 features = ["formatting", "parsing", "serde-well-known"]
 
 [dependencies.chrono]
 default-features = false
 features = ["clock", "serde"]
+optional = true
 version = "0.4.10"
 
 [dependencies.flate2]
@@ -131,6 +132,9 @@ optional = true
 version = "0.12"
 optional = true
 
+[dependencies.cfg-if]
+version = "1.0.0"
+
 [dev-dependencies.http_crate]
 version = "0.2"
 package = "http"
@@ -150,6 +154,7 @@ default_native_tls = ["default_no_backend", "native_tls_backend"]
 default_no_backend = [
     "builder",
     "cache",
+    "chrono",
     "client",
     "framework",
     "gateway",
@@ -174,6 +179,7 @@ standard_framework = ["framework", "uwl", "levenshtein", "command_attr", "static
 unstable_discord_api = []
 utils = ["base64"]
 voice = ["client", "model"]
+time = []
 
 # Enables simd accelerated parsing
 simdjson = ["simd-json"]

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ list all but that:
 default-features = false
 features = [
     "builder",
+    "chrono",
     "client",
     "framework",
     "gateway",

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -30,153 +30,198 @@
 //! ```
 
 use std::fmt;
-use std::ops::Deref;
 use std::str::FromStr;
 
-#[cfg(not(feature = "time"))]
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "time")]
-use time::format_description::well_known::Rfc3339;
-#[cfg(feature = "time")]
-use time::serde::rfc3339;
-#[cfg(feature = "time")]
-use time::{Duration, OffsetDateTime};
 
 /// Discord's epoch starts at "2015-01-01T00:00:00+00:00"
 const DISCORD_EPOCH: u64 = 1_420_070_400_000;
 
-/// Representation of a Unix timestamp.
-///
-/// The struct implements the `std::fmt::Display` trait to format the underlying type as
-/// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
-///
-/// ```
-/// # use serenity::model::id::GuildId;
-/// # use serenity::model::Timestamp;
-/// #
-/// let timestamp: Timestamp = GuildId(175928847299117063).created_at();
-/// assert_eq!(timestamp.unix_timestamp(), 1462015105);
-/// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
-/// ```
-#[cfg(not(feature = "time"))]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(transparent)]
-pub struct Timestamp(DateTime<Utc>);
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "chrono", not(feature = "time")))] {
+        use chrono::{DateTime, NaiveDateTime, ParseError as InnerError, SecondsFormat, TimeZone, Utc};
 
-/// Representation of a Unix timestamp.
-///
-/// The struct implements the `std::fmt::Display` trait to format the underlying type as
-/// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
-///
-/// ```
-/// # use serenity::model::id::GuildId;
-/// # use serenity::model::Timestamp;
-/// #
-/// let timestamp: Timestamp = GuildId(175928847299117063).created_at();
-/// assert_eq!(timestamp.unix_timestamp(), 1462015105);
-/// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
-/// ```
-#[cfg(feature = "time")]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(transparent)]
-pub struct Timestamp(#[serde(with = "rfc3339")] OffsetDateTime);
+        /// Representation of a Unix timestamp.
+        ///
+        /// The struct implements the `std::fmt::Display` trait to format the underlying type as
+        /// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
+        ///
+        /// ```
+        /// # use serenity::model::id::GuildId;
+        /// # use serenity::model::Timestamp;
+        /// #
+        /// let timestamp: Timestamp = GuildId(175928847299117063).created_at();
+        /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
+        /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
+        /// ```
+        #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+        #[serde(transparent)]
+        pub struct Timestamp(DateTime<Utc>);
 
-#[cfg(feature = "time")]
-impl Timestamp {
-    pub(crate) fn from_discord_id(id: u64) -> Timestamp {
-        let ns = Duration::milliseconds(((id >> 22) + DISCORD_EPOCH) as i64).whole_nanoseconds();
-        // This can't fail because of the bit shifting
-        // `(u64::MAX >> 22) + DISCORD_EPOCH` = 5818116911103 = "Wed May 15 2154 07:35:11 GMT+0000"
-        Self(OffsetDateTime::from_unix_timestamp_nanos(ns).expect("can't fail"))
-    }
+        impl Timestamp {
+            pub(crate) fn from_discord_id(id: u64) -> Timestamp {
+                Self(Utc.timestamp_millis(((id >> 22) + DISCORD_EPOCH) as i64))
+            }
 
-    /// Create a new `Timestamp` with the current date and time in UTC.
-    pub fn now() -> Self {
-        Self(OffsetDateTime::now_utc())
-    }
+            /// Create a new `Timestamp` with the current date and time in UTC.
+            pub fn now() -> Self {
+                Self(Utc::now())
+            }
 
-    /// Create a new `Timestamp` from a UNIX timestamp.
-    ///
-    /// Returns `Err` if the value is invalid. The valid range of the value may vary depending on
-    /// the feature flags enabled (`time` with `large-dates`).
-    pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
-        let dt = OffsetDateTime::from_unix_timestamp(secs).map_err(|_| InvalidTimestamp)?;
-        Ok(Self(dt))
-    }
+            /// Create a new `Timestamp` from a UNIX timestamp.
+            ///
+            /// # Errors
+            ///
+            /// Returns `Err` if the value is invalid.
+            pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
+                let dt = NaiveDateTime::from_timestamp_opt(secs, 0).ok_or(InvalidTimestamp)?;
+                Ok(Self(DateTime::from_utc(dt, Utc)))
+            }
 
-    /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
-    pub fn unix_timestamp(&self) -> i64 {
-        self.0.unix_timestamp()
-    }
+            /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
+            pub fn unix_timestamp(&self) -> i64 {
+                self.0.timestamp()
+            }
 
-    /// Parse a timestamp from an RFC 3339 date and time string.
-    ///
-    /// # Examples
-    /// ```
-    /// # use serenity::model::Timestamp;
-    /// #
-    /// let timestamp = Timestamp::parse("2016-04-30T11:18:25Z").unwrap();
-    /// let timestamp = Timestamp::parse("2016-04-30T11:18:25+00:00").unwrap();
-    /// let timestamp = Timestamp::parse("2016-04-30T11:18:25.796Z").unwrap();
-    ///
-    /// assert!(Timestamp::parse("2016-04-30T11:18:25").is_err());
-    /// assert!(Timestamp::parse("2016-04-30T11:18").is_err());
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if the string is not a valid RFC 3339 date and time string.
-    pub fn parse(input: &str) -> Result<Timestamp, ParseError> {
-        OffsetDateTime::parse(input, &Rfc3339).map(Self).map_err(ParseError)
+            /// Parse a timestamp from an RFC 3339 date and time string.
+            ///
+            /// # Examples
+            /// ```
+            /// # use serenity::model::Timestamp;
+            /// #
+            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25Z").unwrap();
+            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25+00:00").unwrap();
+            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25.796Z").unwrap();
+            ///
+            /// assert!(Timestamp::parse("2016-04-30T11:18:25").is_err());
+            /// assert!(Timestamp::parse("2016-04-30T11:18").is_err());
+            /// ```
+            ///
+            /// # Errors
+            ///
+            /// Returns `Err` if the string is not a valid RFC 3339 date and time string.
+            pub fn parse(input: &str) -> Result<Timestamp, ParseError> {
+                DateTime::parse_from_rfc3339(input).map(|d| Self(d.with_timezone(&Utc))).map_err(ParseError)
+            }
+        }
+
+        impl fmt::Display for Timestamp {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let s = self.0.to_rfc3339_opts(SecondsFormat::Millis, true);
+                f.write_str(&s)
+            }
+        }
+    } else {
+        use dep_time::format_description::well_known::Rfc3339;
+        use dep_time::serde::rfc3339;
+        use dep_time::{Duration, OffsetDateTime};
+        use dep_time::error::Parse as InnerError;
+
+        /// Representation of a Unix timestamp.
+        ///
+        /// The struct implements the `std::fmt::Display` trait to format the underlying type as
+        /// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
+        ///
+        /// ```
+        /// # use serenity::model::id::GuildId;
+        /// # use serenity::model::Timestamp;
+        /// #
+        /// let timestamp: Timestamp = GuildId(175928847299117063).created_at();
+        /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
+        /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
+        /// ```
+        #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+        #[serde(transparent)]
+        pub struct Timestamp(#[serde(with = "rfc3339")] OffsetDateTime);
+
+
+        impl Timestamp {
+            pub(crate) fn from_discord_id(id: u64) -> Timestamp {
+                let ns = Duration::milliseconds(((id >> 22) + DISCORD_EPOCH) as i64).whole_nanoseconds();
+                // This can't fail because of the bit shifting
+                // `(u64::MAX >> 22) + DISCORD_EPOCH` = 5818116911103 = "Wed May 15 2154 07:35:11 GMT+0000"
+                Self(OffsetDateTime::from_unix_timestamp_nanos(ns).expect("can't fail"))
+            }
+
+            /// Create a new `Timestamp` with the current date and time in UTC.
+            pub fn now() -> Self {
+                Self(OffsetDateTime::now_utc())
+            }
+
+            /// Create a new `Timestamp` from a UNIX timestamp.
+            ///
+            /// Returns `Err` if the value is invalid. The valid range of the value may vary depending on
+            /// the feature flags enabled (`time` with `large-dates`).
+            pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
+                let dt = OffsetDateTime::from_unix_timestamp(secs).map_err(|_| InvalidTimestamp)?;
+                Ok(Self(dt))
+            }
+
+            /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
+            pub fn unix_timestamp(&self) -> i64 {
+                self.0.unix_timestamp()
+            }
+
+            /// Parse a timestamp from an RFC 3339 date and time string.
+            ///
+            /// # Examples
+            /// ```
+            /// # use serenity::model::Timestamp;
+            /// #
+            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25Z").unwrap();
+            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25+00:00").unwrap();
+            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25.796Z").unwrap();
+            ///
+            /// assert!(Timestamp::parse("2016-04-30T11:18:25").is_err());
+            /// assert!(Timestamp::parse("2016-04-30T11:18").is_err());
+            /// ```
+            ///
+            /// # Errors
+            ///
+            /// Returns `Err` if the string is not a valid RFC 3339 date and time string.
+            pub fn parse(input: &str) -> Result<Timestamp, ParseError> {
+                OffsetDateTime::parse(input, &Rfc3339).map(Self).map_err(ParseError)
+            }
+        }
+
+        impl fmt::Display for Timestamp {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let s = self.0.format(&Rfc3339).map_err(|_| fmt::Error)?;
+                f.write_str(&s)
+            }
+        }
     }
 }
 
-#[cfg(not(feature = "time"))]
-impl Timestamp {
-    pub(crate) fn from_discord_id(id: u64) -> Timestamp {
-        Self(Utc.timestamp_millis(((id >> 22) + DISCORD_EPOCH) as i64))
-    }
+cfg_if::cfg_if! {
+    if #[cfg(feature = "time")] {
+        impl std::ops::Deref for Timestamp {
+            type Target = OffsetDateTime;
 
-    /// Create a new `Timestamp` with the current date and time in UTC.
-    pub fn now() -> Self {
-        Self(Utc::now())
-    }
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
 
-    /// Create a new `Timestamp` from a UNIX timestamp.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if the value is invalid.
-    pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
-        let dt = NaiveDateTime::from_timestamp_opt(secs, 0).ok_or(InvalidTimestamp)?;
-        Ok(Self(DateTime::from_utc(dt, Utc)))
-    }
+        impl From<OffsetDateTime> for Timestamp {
+            fn from(dt: OffsetDateTime) -> Self {
+                Self(dt)
+            }
+        }
+    } else if #[cfg(feature = "chrono")] {
+        impl std::ops::Deref for Timestamp {
+            type Target = DateTime<Utc>;
 
-    /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
-    pub fn unix_timestamp(&self) -> i64 {
-        self.0.timestamp()
-    }
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
 
-    /// Parse a timestamp from an RFC 3339 date and time string.
-    ///
-    /// # Examples
-    /// ```
-    /// # use serenity::model::Timestamp;
-    /// #
-    /// let timestamp = Timestamp::parse("2016-04-30T11:18:25Z").unwrap();
-    /// let timestamp = Timestamp::parse("2016-04-30T11:18:25+00:00").unwrap();
-    /// let timestamp = Timestamp::parse("2016-04-30T11:18:25.796Z").unwrap();
-    ///
-    /// assert!(Timestamp::parse("2016-04-30T11:18:25").is_err());
-    /// assert!(Timestamp::parse("2016-04-30T11:18").is_err());
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if the string is not a valid RFC 3339 date and time string.
-    pub fn parse(input: &str) -> Result<Timestamp, ParseError> {
-        DateTime::parse_from_rfc3339(input).map(|d| Self(d.with_timezone(&Utc))).map_err(ParseError)
+        impl<Tz: TimeZone> From<DateTime<Tz>> for Timestamp {
+            fn from(dt: DateTime<Tz>) -> Self {
+                Self(dt.with_timezone(&Utc))
+            }
+        }
     }
 }
 
@@ -191,11 +236,6 @@ impl fmt::Display for InvalidTimestamp {
     }
 }
 
-#[cfg(not(feature = "time"))]
-use chrono::ParseError as InnerError;
-#[cfg(feature = "time")]
-use time::error::Parse as InnerError;
-
 /// Signifies the failure to parse the `Timestamp` from an RFC 3339 string.
 #[derive(Debug)]
 pub struct ParseError(InnerError);
@@ -205,41 +245,6 @@ impl std::error::Error for ParseError {}
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
-    }
-}
-
-#[cfg(feature = "time")]
-impl fmt::Display for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = self.0.format(&Rfc3339).map_err(|_| fmt::Error)?;
-        f.write_str(&s)
-    }
-}
-
-#[cfg(not(feature = "time"))]
-impl fmt::Display for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use chrono::SecondsFormat;
-        let s = self.0.to_rfc3339_opts(SecondsFormat::Millis, true);
-        f.write_str(&s)
-    }
-}
-
-#[cfg(not(feature = "time"))]
-impl Deref for Timestamp {
-    type Target = DateTime<Utc>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-#[cfg(feature = "time")]
-impl Deref for Timestamp {
-    type Target = OffsetDateTime;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 
@@ -277,20 +282,6 @@ impl From<&Timestamp> for Timestamp {
     }
 }
 
-#[cfg(not(feature = "time"))]
-impl<Tz: TimeZone> From<DateTime<Tz>> for Timestamp {
-    fn from(dt: DateTime<Tz>) -> Self {
-        Self(dt.with_timezone(&Utc))
-    }
-}
-
-#[cfg(feature = "time")]
-impl From<OffsetDateTime> for Timestamp {
-    fn from(dt: OffsetDateTime) -> Self {
-        Self(dt)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::Timestamp;
@@ -299,9 +290,10 @@ mod tests {
     fn from_unix_timestamp() {
         let timestamp = Timestamp::from_unix_timestamp(1462015105).unwrap();
         assert_eq!(timestamp.unix_timestamp(), 1462015105);
-        #[cfg(not(feature = "time"))]
-        assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.000Z");
-        #[cfg(feature = "time")]
-        assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25Z");
+        if cfg!(all(feature = "chrono", not(feature = "time"))) {
+            assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.000Z");
+        } else {
+            assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25Z");
+        }
     }
 }


### PR DESCRIPTION
chrono is insecure. In #1683, time was introduced as a feature to avoid increasing MSRV. Now that MSRV was increased this is no longer a concern.

This avoids `cargo audit` complaining about `chrono` dependency. Even when `time` feature was enabled `chrono` was still in the dependency tree as it wasn't an optional feature.