### PR TITLE
Remove sunsetted store channel type

### DIFF
--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -311,10 +311,6 @@ pub enum ChannelType {
     ///
     /// Note: `NewsChannel` is serialized into a [`GuildChannel`]
     News = 5,
-    /// An indicator that the channel is a `StoreChannel`
-    ///
-    /// Note: `StoreChannel` is serialized into a [`GuildChannel`]
-    Store = 6,
     /// An indicator that the channel is a news thread [`GuildChannel`].
     NewsThread = 10,
     /// An indicator that the channel is a public thread [`GuildChannel`].
@@ -336,7 +332,6 @@ enum_number!(ChannelType {
     Voice,
     Category,
     News,
-    Store,
     NewsThread,
     PublicThread,
     PrivateThread,
@@ -354,7 +349,6 @@ impl ChannelType {
             ChannelType::Voice => "voice",
             ChannelType::Category => "category",
             ChannelType::News => "news",
-            ChannelType::Store => "store",
             ChannelType::NewsThread => "news_thread",
             ChannelType::PublicThread => "public_thread",
             ChannelType::PrivateThread => "private_thread",


### PR DESCRIPTION
see: https://github.com/discord/discord-api-docs/commit/cec84b8ed433719ea4153fc6090d6da9e238572d 
> https://support-dev.discord.com/hc/en-us/articles/4414590563479
> **Self-serve Game Selling Deprecation**
> After December 1, 2021, Discord will no longer offer the ability to purchase a license to sell PC games on Discord. After March 10, 2022, Discord will be sunsetting store channel functionality.
