### PR TITLE
Make the non cache version of the `shard_id` methods synchronous

### DIFF
--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1146,15 +1146,13 @@ impl GuildId {
     /// use serenity::model::id::GuildId;
     /// use serenity::utils;
     ///
-    /// # async fn run() {
     /// let guild_id = GuildId(81384788765712384);
     ///
-    /// assert_eq!(guild_id.shard_id(17).await, 7);
-    /// # }
+    /// assert_eq!(guild_id.shard_id(17), 7);
     /// ```
     #[cfg(all(feature = "utils", not(feature = "cache")))]
     #[inline]
-    pub async fn shard_id(self, shard_count: u64) -> u64 {
+    pub fn shard_id(self, shard_count: u64) -> u64 {
         crate::utils::shard_id(self.0, shard_count)
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2272,8 +2272,8 @@ impl Guild {
     /// ```
     #[cfg(all(feature = "utils", not(feature = "cache")))]
     #[inline]
-    pub async fn shard_id(&self, shard_count: u64) -> u64 {
-        self.id.shard_id(shard_count).await
+    pub fn shard_id(&self, shard_count: u64) -> u64 {
+        self.id.shard_id(shard_count)
     }
 
     /// Returns the formatted URL of the guild's splash image, if one exists.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1424,8 +1424,8 @@ impl PartialGuild {
     /// ```
     #[cfg(all(feature = "utils", not(feature = "cache")))]
     #[inline]
-    pub async fn shard_id(&self, shard_count: u64) -> u64 {
-        self.id.shard_id(shard_count).await
+    pub fn shard_id(&self, shard_count: u64) -> u64 {
+        self.id.shard_id(shard_count)
     }
 
     /// Returns the formatted URL of the guild's splash image, if one exists.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -280,8 +280,8 @@ impl InviteGuild {
     /// ```
     #[cfg(all(feature = "utils", not(feature = "cache")))]
     #[inline]
-    pub async fn shard_id(&self, shard_count: u64) -> u64 {
-        self.id.shard_id(shard_count).await
+    pub fn shard_id(&self, shard_count: u64) -> u64 {
+        self.id.shard_id(shard_count)
     }
 }
 


### PR DESCRIPTION
This was overlooked when the cache was made synchronous.

See: #1444 