### PR TITLE
Allow responding to interactions with files

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -713,6 +713,35 @@ impl Http {
         .await
     }
 
+    /// Creates a response to an [`Interaction`] from the gateway with files.
+    ///
+    /// Refer to Discord's [docs] for the object it takes.
+    ///
+    /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#interaction-interaction-response
+    #[cfg(feature = "unstable_discord_api")]
+    pub async fn create_interaction_response_with_files(
+        &self,
+        interaction_id: u64,
+        interaction_token: &str,
+        map: &Value,
+        files: impl IntoIterator<Item = AttachmentType<'_>>,
+    ) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            multipart: Some(Multipart {
+                files: files.into_iter().map(Into::into).collect(),
+                payload_json: Some(to_value(map)?),
+                fields: vec![],
+            }),
+            headers: None,
+            route: RouteInfo::CreateInteractionResponse {
+                interaction_id,
+                interaction_token,
+            },
+        })
+        .await
+    }
+
     /// Creates a [`RichInvite`] for the given [channel][`GuildChannel`].
     ///
     /// Refer to Discord's [docs] for field information.

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -96,9 +96,15 @@ impl ApplicationCommandInteraction {
     /// [`Error::Model`]: crate::error::Error::Model
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_interaction_response<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
+    pub async fn create_interaction_response<F>(
+        &self,
+        http: impl AsRef<Http>,
+        f: F,
+    ) -> Result<()>
     where
-        F: FnOnce(&mut CreateInteractionResponse) -> &mut CreateInteractionResponse,
+        for<'a, 'b> F: FnOnce(
+            &'a mut CreateInteractionResponse<'b>
+        ) -> &'a mut CreateInteractionResponse<'b>,
     {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);
@@ -107,7 +113,20 @@ impl ApplicationCommandInteraction {
 
         Message::check_lengths(&map)?;
 
-        http.as_ref().create_interaction_response(self.id.0, &self.token, &Value::from(map)).await
+        if interaction_response.1.is_empty() {
+            http.as_ref()
+                .create_interaction_response(self.id.0, &self.token, &Value::from(map))
+                .await
+        } else {
+            http.as_ref()
+                .create_interaction_response_with_files(
+                    self.id.0,
+                    &self.token,
+                    &Value::from(map),
+                    interaction_response.1,
+                )
+                .await
+        }
     }
 
     /// Edits the initial interaction response.

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -96,15 +96,10 @@ impl ApplicationCommandInteraction {
     /// [`Error::Model`]: crate::error::Error::Model
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_interaction_response<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<()>
+    pub async fn create_interaction_response<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
     where
-        for<'a, 'b> F: FnOnce(
-            &'a mut CreateInteractionResponse<'b>
-        ) -> &'a mut CreateInteractionResponse<'b>,
+        for<'a, 'b> F:
+            FnOnce(&'a mut CreateInteractionResponse<'b>) -> &'a mut CreateInteractionResponse<'b>,
     {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);

--- a/src/model/interactions/message_component.rs
+++ b/src/model/interactions/message_component.rs
@@ -82,9 +82,14 @@ impl MessageComponentInteraction {
     /// [`Error::Model`]: crate::error::Error::Model
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_interaction_response<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
+    pub async fn create_interaction_response<'a, F>(
+        &self,
+        http: impl AsRef<Http>,
+        f: F,
+    ) -> Result<()>
     where
-        F: FnOnce(&mut CreateInteractionResponse) -> &mut CreateInteractionResponse,
+        for<'b> F:
+            FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>,
     {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);
@@ -94,7 +99,20 @@ impl MessageComponentInteraction {
         Message::check_content_length(&map)?;
         Message::check_embed_length(&map)?;
 
-        http.as_ref().create_interaction_response(self.id.0, &self.token, &Value::from(map)).await
+        if interaction_response.1.is_empty() {
+            http.as_ref()
+                .create_interaction_response(self.id.0, &self.token, &Value::from(map))
+                .await
+        } else {
+            http.as_ref()
+                .create_interaction_response_with_files(
+                    self.id.0,
+                    &self.token,
+                    &Value::from(map),
+                    interaction_response.1,
+                )
+                .await
+        }
     }
 
     /// Edits the initial interaction response.


### PR DESCRIPTION
This closes #1797 by adding a new methods to `CreateInteractionResponseData` and `create_interaction_response_with_files` on the http client