### PR TITLE
Simplify the hidden preparation code in doc examples

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -297,15 +297,11 @@ impl Cache {
     ///
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
     /// #
-    /// # fn run() {
     /// # let cache = Cache::default();
     /// let amount = cache.private_channels().len();
     ///
     /// println!("There are {} private channels", amount);
-    /// # }
     /// ```
     pub fn private_channels(&self) -> DashMap<ChannelId, PrivateChannel> {
         self.private_channels.clone()
@@ -407,17 +403,12 @@ impl Cache {
     ///
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
     /// #
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let cache = Cache::default();
     /// // assuming the cache is in scope, e.g. via `Context`
     /// if let Some(guild) = cache.guild(7) {
     ///     println!("Guild name: {}", guild.name);
     /// }
-    /// #   Ok(())
-    /// # }
     /// ```
     #[inline]
     pub fn guild<G: Into<GuildId>>(&self, id: G) -> Option<Guild> {
@@ -573,13 +564,9 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
     /// # use serenity::http::Http;
-    /// # use serenity::model::id::{ChannelId, MessageId};
-    /// # use std::sync::Arc;
+    /// # use serenity::model::channel::Message;
     /// #
-    /// # async fn run() {
-    /// # let http = Arc::new(Http::new_with_token("DISCORD_TOKEN"));
-    /// # let message = ChannelId(0).message(&http, MessageId(1)).await.unwrap();
-    /// # let cache = Cache::default();
+    /// # async fn run(http: Http, cache: Cache, message: Message) {
     /// #
     /// let member = {
     ///     let channel = match cache.guild_channel(message.channel_id) {
@@ -753,21 +740,14 @@ impl Cache {
     ///
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
-    /// # use serenity::http::Http;
-    /// # use serenity::model::id::{ChannelId, MessageId};
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
+    /// # use serenity::model::channel::Message;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Arc::new(Http::new_with_token("DISCORD_TOKEN"));
-    /// # let message = ChannelId(0).message(&http, MessageId(1)).await?;
-    /// # let cache = Cache::default();
+    /// # fn run(cache: Cache, message: Message) {
     /// #
     /// match cache.message(message.channel_id, message.id) {
     ///     Some(m) => assert_eq!(message.content, m.content),
     ///     None => println!("No message found in cache."),
     /// };
-    /// #     Ok(())
     /// # }
     /// ```
     ///
@@ -800,18 +780,13 @@ impl Cache {
     ///
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
     /// #
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #   let cache = Cache::default();
+    /// # let cache = Cache::default();
     /// // assuming the cache has been unlocked
     ///
     /// if let Some(channel) = cache.private_channel(7) {
     ///     println!("The recipient is {}", channel.recipient);
     /// }
-    /// #     Ok(())
-    /// # }
     /// ```
     #[inline]
     pub fn private_channel(&self, channel_id: impl Into<ChannelId>) -> Option<PrivateChannel> {
@@ -836,17 +811,12 @@ impl Cache {
     ///
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
     /// #
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let cache = Cache::default();
     /// // assuming the cache is in scope, e.g. via `Context`
     /// if let Some(role) = cache.role(7, 77) {
     ///     println!("Role with Id 77 is called {}", role.name);
     /// }
-    /// #     Ok(())
-    /// # }
     /// ```
     #[inline]
     pub fn role<G, R>(&self, guild_id: G, role_id: R) -> Option<Role>

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -224,7 +224,6 @@ impl GuildChannel {
     /// # #[cfg(feature = "cache")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
-    /// # use tokio::sync::RwLock;
     /// # use std::sync::Arc;
     /// #
     /// #     let http = Arc::new(Http::default());
@@ -257,7 +256,6 @@ impl GuildChannel {
     /// # #[cfg(feature = "cache")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
-    /// # use tokio::sync::RwLock;
     /// # use std::sync::Arc;
     /// #
     /// #   let http = Arc::new(Http::default());

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -69,14 +69,8 @@ impl Channel {
     /// Basic usage:
     ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "model", feature = "cache"))]
-    /// # async fn run() {
-    /// # use serenity::{cache::Cache, model::id::ChannelId};
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
-    /// #
-    /// #   let cache = Cache::default();
-    /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
+    /// # use serenity::model::channel::Channel;
+    /// # fn run(channel: Channel) {
     /// #
     /// match channel.guild() {
     ///     Some(guild_channel) => {
@@ -106,14 +100,8 @@ impl Channel {
     /// Basic usage:
     ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "model", feature = "cache"))]
-    /// # async fn run() {
-    /// # use serenity::{cache::Cache, model::id::ChannelId};
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
-    /// #
-    /// #   let cache = Cache::default();
-    /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
+    /// # use serenity::model::channel::Channel;
+    /// # fn run(channel: Channel) {
     /// #
     /// match channel.private() {
     ///     Some(private) => {
@@ -143,14 +131,8 @@ impl Channel {
     /// Basic usage:
     ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "model", feature = "cache"))]
-    /// # async fn run() {
-    /// # use serenity::{cache::Cache, model::id::ChannelId};
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
-    /// #
-    /// #   let cache = Cache::default();
-    /// #   let channel = ChannelId(0).to_channel_cached(&cache).unwrap();
+    /// # use serenity::model::channel::Channel;
+    /// # fn run(channel: Channel) {
     /// #
     /// match channel.category() {
     ///     Some(category) => {
@@ -160,7 +142,6 @@ impl Channel {
     ///         println!("It's not a category!");
     ///     },
     /// }
-    /// #
     /// # }
     /// ```
     pub fn category(self) -> Option<ChannelCategory> {

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -69,17 +69,13 @@ impl Emoji {
     /// # use serde_json::{json, from_value};
     /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// # use serenity::client::Context;
-    /// # use serenity::model::prelude::{EmojiId, Emoji, Role};
+    /// # use serenity::model::prelude::{EmojiId, Emoji};
     /// #
     /// # #[command]
     /// # async fn example(ctx: &Context) -> CommandResult {
     /// #     let mut emoji = from_value::<Emoji>(json!({
-    /// #         "animated": false,
     /// #         "id": EmojiId(7),
     /// #         "name": "blobface",
-    /// #         "managed": false,
-    /// #         "require_colons": false,
-    /// #         "roles": Vec::<Role>::new(),
     /// #     }))?;
     /// #
     /// // assuming emoji has been set already
@@ -151,22 +147,10 @@ impl Emoji {
     /// Print the guild id that owns this emoji:
     ///
     /// ```rust,no_run
-    /// # use serde_json::{json, from_value};
-    /// # use serenity::{cache::Cache, model::{guild::{Emoji, Role}, id::EmojiId}};
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
+    /// # use serenity::cache::Cache;
+    /// # use serenity::model::guild::Emoji;
     /// #
-    /// # async fn run() {
-    /// # let cache = Cache::default();
-    /// #
-    /// # let mut emoji = from_value::<Emoji>(json!({
-    /// #     "animated": false,
-    /// #     "id": EmojiId(7),
-    /// #     "name": "blobface",
-    /// #     "managed": false,
-    /// #     "require_colons": false,
-    /// #     "roles": Vec::<Role>::new(),
-    /// # })).unwrap();
+    /// # fn run(cache: Cache, emoji: Emoji) {
     /// #
     /// // assuming emoji has been set already
     /// if let Some(guild_id) = emoji.find_guild_id(&cache) {
@@ -194,18 +178,9 @@ impl Emoji {
     /// Print the direct link to the given emoji:
     ///
     /// ```rust,no_run
-    /// # use serde_json::{json, from_value};
-    /// # use serenity::model::{guild::{Emoji, Role}, id::EmojiId};
+    /// # use serenity::model::guild::Emoji;
     /// #
-    /// # fn main() {
-    /// # let mut emoji = from_value::<Emoji>(json!({
-    /// #     "animated": false,
-    /// #     "id": EmojiId(7),
-    /// #     "name": "blobface",
-    /// #     "managed": false,
-    /// #     "require_colons": false,
-    /// #     "roles": Vec::<Role>::new(),
-    /// # })).unwrap();
+    /// # fn run(emoji: Emoji) {
     /// #
     /// // assuming emoji has been set already
     /// println!("Direct link to emoji image: {}", emoji.url());

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -198,10 +198,8 @@ impl CurrentUser {
     ///
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
-    /// # async fn run() {
+    /// # fn run() {
     /// # use serenity::cache::Cache;
-    /// # use tokio::sync::RwLock;
-    /// # use std::sync::Arc;
     /// #
     /// # let cache = Cache::default();
     /// // assuming the cache has been unlocked

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -109,11 +109,8 @@ impl Default for ContentSafeOptions {
 /// Sanitise an `@everyone` mention.
 ///
 /// ```rust
-/// # use std::sync::Arc;
 /// # use serenity::client::Cache;
-/// # use tokio::sync::RwLock;
 /// #
-/// # fn run() {
 /// # let cache = Cache::default();
 /// use serenity::utils::{content_safe, ContentSafeOptions};
 ///
@@ -121,7 +118,6 @@ impl Default for ContentSafeOptions {
 /// let without_mention = content_safe(&cache, &with_mention, &ContentSafeOptions::default());
 ///
 /// assert_eq!("@\u{200B}everyone".to_string(), without_mention);
-/// # }
 /// ```
 pub fn content_safe(
     cache: impl AsRef<Cache>,

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -21,19 +21,9 @@ use crate::model::{
 /// value:
 ///
 /// ```rust,no_run
-/// # use serde_json::{json, from_value};
 /// # use serenity::model::prelude::*;
 /// #
-/// # async fn run() {
-/// # let user = UserId(1);
-/// # let emoji = from_value::<Emoji>(json!({
-/// #     "animated": false,
-/// #     "id": EmojiId(2),
-/// #     "name": "test",
-/// #     "managed": false,
-/// #     "require_colons": true,
-/// #     "roles": Vec::<Role>::new(),
-/// # })).unwrap();
+/// # fn run(user: UserId, emoji: Emoji) {
 /// #
 /// use serenity::utils::MessageBuilder;
 ///
@@ -150,28 +140,19 @@ impl MessageBuilder {
     /// Mention an emoji in a message's content:
     ///
     /// ```rust
-    /// # use serenity::model::guild::Role;
-    /// #
-    /// # {
-    /// #
     /// # use serde_json::{json, from_value};
     /// # use serenity::model::guild::Emoji;
     /// # use serenity::model::id::EmojiId;
     /// # use serenity::utils::MessageBuilder;
     ///
     /// # let emoji = from_value::<Emoji>(json!({
-    /// #     "animated": false,
     /// #     "id": EmojiId(302516740095606785),
-    /// #     "managed": true,
-    /// #     "name": "smugAnimeFace".to_string(),
-    /// #     "require_colons": true,
-    /// #     "roles": Vec::<Role>::new(),
+    /// #     "name": "smugAnimeFace",
     /// # })).unwrap();
     ///
     /// let message = MessageBuilder::new().push("foo ").emoji(&emoji).push(".").build();
     ///
     /// assert_eq!(message, "foo <:smugAnimeFace:302516740095606785>.");
-    /// # }
     /// ```
     ///
     /// [Display implementation]: crate::model::guild::Emoji#impl-Display


### PR DESCRIPTION
- Instead of creating the required types, the code is wrapped in a
  function with the required types as parameters.

- Remove unused imports, unneeded `fn run()` and `async fn`.

- Use minimal json data to initial `Emoji` structs.