### PR TITLE
Remove kind check for sending webhook components

### DIFF
--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -329,7 +329,7 @@ impl Webhook {
         let mut execute_webhook = ExecuteWebhook::default();
         f(&mut execute_webhook);
 
-        let map = self.verify_map(execute_webhook.0)?;
+        let map = json::hashmap_to_json_map(execute_webhook.0);
 
         if !execute_webhook.1.is_empty() {
             http.as_ref()
@@ -391,7 +391,7 @@ impl Webhook {
         let mut edit_webhook_message = EditWebhookMessage::default();
         f(&mut edit_webhook_message);
 
-        let map = self.verify_map(edit_webhook_message.0)?;
+        let map = json::hashmap_to_json_map(edit_webhook_message.0);
 
         http.as_ref().edit_webhook_message(self.id.0, token, message_id.0, &map).await
     }
@@ -461,21 +461,6 @@ impl Webhook {
     pub fn url(&self) -> Result<String> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
         Ok(format!("https://discord.com/api/webhooks/{}/{}", self.id, token))
-    }
-
-    fn verify_map(&self, map: HashMap<&'static str, Value>) -> Result<JsonMap> {
-        // Having components is only valid for application-owned webhooks
-        if map.contains_key("components") {
-            match self.kind {
-                WebhookType::Application => (),
-                _ => {
-                    return Err(Error::Other(
-                        "Only application-owned webhooks can use message components",
-                    ))
-                },
-            }
-        }
-        Ok(json::hashmap_to_json_map(map))
     }
 }
 


### PR DESCRIPTION
This check prevents discord API errors by preemptively erroring as discord documented, however the discord documentation isn't entirely correct. It is possible to send components with a webhook if the webhook is owned by the application, even if the kind is not of an "application" webhook. Removing this check allows me to send components in this situation.