### PR TITLE
Place temporary caching functionality under a separate feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ default_no_backend = [
 ]
 
 builder = ["utils"]
-cache = ["moka", "dashmap", "parking_lot"]
+cache = ["dashmap", "parking_lot"]
 collector = ["gateway", "model"]
 client = ["http", "typemap_rev"]
 extras = []
@@ -177,6 +177,9 @@ voice = ["client", "model"]
 
 # Enables simd accelerated parsing
 simdjson = ["simd-json"]
+
+# Enables temporary caching in functions that retrieve data via the HTTP API.
+tempcaching = ["cache", "moka"]
 
 # Backends to pick from:
 # - Rustls Backends

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ voice = ["client", "model"]
 simdjson = ["simd-json"]
 
 # Enables temporary caching in functions that retrieve data via the HTTP API.
-tempcaching = ["cache", "moka"]
+temp_cache = ["cache", "moka"]
 
 # Backends to pick from:
 # - Rustls Backends

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ due to latency in the network. If you turn this feature on, it is recommended to
 synchronise your clock with an NTP server (such as Google's).
 - **unstable_discord_api**: Enables features of the Discord API that do not have a stable interface. The features might not have official documentation or are subject to change.
 - **simdjson**: Enables SIMD accelerated JSON parsing and rendering for API calls, use with `RUSTFLAGS="-C target-cpu=native"`
+- **tempcaching**: Enables temporary caching in functions that retrieve data via the HTTP API.
 
 Serenity offers two TLS-backends, `rustls_backend` by default, you need to pick
 one if you do not use the default features:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ due to latency in the network. If you turn this feature on, it is recommended to
 synchronise your clock with an NTP server (such as Google's).
 - **unstable_discord_api**: Enables features of the Discord API that do not have a stable interface. The features might not have official documentation or are subject to change.
 - **simdjson**: Enables SIMD accelerated JSON parsing and rendering for API calls, use with `RUSTFLAGS="-C target-cpu=native"`
-- **tempcaching**: Enables temporary caching in functions that retrieve data via the HTTP API.
+- **temp_cache**: Enables temporary caching in functions that retrieve data via the HTTP API.
 
 Serenity offers two TLS-backends, `rustls_backend` by default, you need to pick
 one if you do not use the default features:

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -34,7 +34,7 @@ use std::collections::{hash_map::RandomState, HashMap, VecDeque};
 use std::default::Default;
 use std::hash::BuildHasher;
 use std::str::FromStr;
-#[cfg(feature = "tempcaching")]
+#[cfg(feature = "temp_cache")]
 use std::time::Duration;
 
 use dashmap::{
@@ -43,7 +43,7 @@ use dashmap::{
     DashMap,
     DashSet,
 };
-#[cfg(feature = "tempcaching")]
+#[cfg(feature = "temp_cache")]
 use moka::dash::Cache as DashCache;
 use parking_lot::RwLock;
 use tracing::instrument;
@@ -138,7 +138,7 @@ pub struct Cache {
     /// Cache of channels that have been fetched via to_channel.
     ///
     /// Each value has a maximum TTL of 1 hour.
-    #[cfg(feature = "tempcaching")]
+    #[cfg(feature = "temp_cache")]
     pub(crate) temp_channels: DashCache<ChannelId, GuildChannel>,
     /// A map of channel categories.
     pub(crate) categories: DashMap<ChannelId, ChannelCategory>,
@@ -194,7 +194,7 @@ pub struct Cache {
     /// Cache of users who have been fetched from `to_user`.
     ///
     /// Each value has a max TTL of 1 hour.
-    #[cfg(feature = "tempcaching")]
+    #[cfg(feature = "temp_cache")]
     pub(crate) temp_users: DashCache<UserId, User>,
     /// The settings for the cache.
     settings: RwLock<Settings>,
@@ -364,7 +364,7 @@ impl Cache {
             return Some(Channel::Guild(channel));
         }
 
-        #[cfg(feature = "tempcaching")]
+        #[cfg(feature = "temp_cache")]
         {
             if let Some(channel) = self.temp_channels.get(&id) {
                 return Some(Channel::Guild(channel));
@@ -891,7 +891,7 @@ impl Cache {
         self._user(user_id.into())
     }
 
-    #[cfg(feature = "tempcaching")]
+    #[cfg(feature = "temp_cache")]
     fn _user(&self, user_id: UserId) -> Option<User> {
         if let Some(user) = self.users.get(&user_id) {
             Some(user.clone())
@@ -900,7 +900,7 @@ impl Cache {
         }
     }
 
-    #[cfg(not(feature = "tempcaching"))]
+    #[cfg(not(feature = "temp_cache"))]
     fn _user(&self, user_id: UserId) -> Option<User> {
         self.users.get(&user_id).map(|u| u.clone())
     }
@@ -1013,7 +1013,7 @@ impl Default for Cache {
     fn default() -> Cache {
         Cache {
             channels: DashMap::default(),
-            #[cfg(feature = "tempcaching")]
+            #[cfg(feature = "temp_cache")]
             temp_channels: DashCache::builder().time_to_live(Duration::from_secs(60 * 60)).build(),
             categories: DashMap::default(),
             guilds: DashMap::default(),
@@ -1025,7 +1025,7 @@ impl Default for Cache {
             unavailable_guilds: DashSet::default(),
             user: RwLock::new(CurrentUser::default()),
             users: DashMap::default(),
-            #[cfg(feature = "tempcaching")]
+            #[cfg(feature = "temp_cache")]
             temp_users: DashCache::builder().time_to_live(Duration::from_secs(60 * 60)).build(),
             message_queue: DashMap::default(),
         }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -34,6 +34,7 @@ use std::collections::{hash_map::RandomState, HashMap, VecDeque};
 use std::default::Default;
 use std::hash::BuildHasher;
 use std::str::FromStr;
+#[cfg(feature = "tempcaching")]
 use std::time::Duration;
 
 use dashmap::{
@@ -42,6 +43,7 @@ use dashmap::{
     DashMap,
     DashSet,
 };
+#[cfg(feature = "tempcaching")]
 use moka::dash::Cache as DashCache;
 use parking_lot::RwLock;
 use tracing::instrument;
@@ -136,6 +138,7 @@ pub struct Cache {
     /// Cache of channels that have been fetched via to_channel.
     ///
     /// Each value has a maximum TTL of 1 hour.
+    #[cfg(feature = "tempcaching")]
     pub(crate) temp_channels: DashCache<ChannelId, GuildChannel>,
     /// A map of channel categories.
     pub(crate) categories: DashMap<ChannelId, ChannelCategory>,
@@ -191,6 +194,7 @@ pub struct Cache {
     /// Cache of users who have been fetched from `to_user`.
     ///
     /// Each value has a max TTL of 1 hour.
+    #[cfg(feature = "tempcaching")]
     pub(crate) temp_users: DashCache<UserId, User>,
     /// The settings for the cache.
     settings: RwLock<Settings>,
@@ -358,8 +362,13 @@ impl Cache {
         if let Some(channel) = self.channels.get(&id) {
             let channel = channel.clone();
             return Some(Channel::Guild(channel));
-        } else if let Some(channel) = self.temp_channels.get(&id) {
-            return Some(Channel::Guild(channel));
+        }
+
+        #[cfg(feature = "tempcaching")]
+        {
+            if let Some(channel) = self.temp_channels.get(&id) {
+                return Some(Channel::Guild(channel));
+            }
         }
 
         if let Some(private_channel) = self.private_channels.get(&id) {
@@ -882,12 +891,18 @@ impl Cache {
         self._user(user_id.into())
     }
 
+    #[cfg(feature = "tempcaching")]
     fn _user(&self, user_id: UserId) -> Option<User> {
         if let Some(user) = self.users.get(&user_id) {
             Some(user.clone())
         } else {
             self.temp_users.get(&user_id)
         }
+    }
+
+    #[cfg(not(feature = "tempcaching"))]
+    fn _user(&self, user_id: UserId) -> Option<User> {
+        self.users.get(&user_id).map(|u| u.clone())
     }
 
     /// Clones all users and returns them.
@@ -998,6 +1013,7 @@ impl Default for Cache {
     fn default() -> Cache {
         Cache {
             channels: DashMap::default(),
+            #[cfg(feature = "tempcaching")]
             temp_channels: DashCache::builder().time_to_live(Duration::from_secs(60 * 60)).build(),
             categories: DashMap::default(),
             guilds: DashMap::default(),
@@ -1009,6 +1025,7 @@ impl Default for Cache {
             unavailable_guilds: DashSet::default(),
             user: RwLock::new(CurrentUser::default()),
             users: DashMap::default(),
+            #[cfg(feature = "tempcaching")]
             temp_users: DashCache::builder().time_to_live(Duration::from_secs(60 * 60)).build(),
             message_queue: DashMap::default(),
         }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -407,7 +407,7 @@ impl ChannelId {
         }
 
         let channel = cache_http.http().get_channel(self.0).await?;
-        #[cfg(feature = "cache")]
+        #[cfg(all(feature = "cache", feature = "tempcaching"))]
         {
             if let Some(cache) = cache_http.cache() {
                 if let Channel::Guild(guild_channel) = &channel {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -392,8 +392,10 @@ impl ChannelId {
     /// First attempts to find a [`Channel`] by its Id in the cache,
     /// upon failure requests it via the REST API.
     ///
-    /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon
-    /// owning the required permissions the HTTP-request will be issued.
+    /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon owning the
+    /// required permissions the HTTP-request will be issued. Additionally, you might want to
+    /// enable the `tempcaching` feature to cache channel data retrieved by this function for a
+    /// short duration.
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn to_channel(self, cache_http: impl CacheHttp) -> Result<Channel> {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -394,7 +394,7 @@ impl ChannelId {
     ///
     /// **Note**: If the `cache`-feature is enabled permissions will be checked and upon owning the
     /// required permissions the HTTP-request will be issued. Additionally, you might want to
-    /// enable the `tempcaching` feature to cache channel data retrieved by this function for a
+    /// enable the `temp_cache` feature to cache channel data retrieved by this function for a
     /// short duration.
     #[allow(clippy::missing_errors_doc)]
     #[inline]
@@ -409,7 +409,8 @@ impl ChannelId {
         }
 
         let channel = cache_http.http().get_channel(self.0).await?;
-        #[cfg(all(feature = "cache", feature = "tempcaching"))]
+
+        #[cfg(all(feature = "cache", feature = "temp_cache"))]
         {
             if let Some(cache) = cache_http.cache() {
                 if let Channel::Guild(guild_channel) = &channel {
@@ -417,6 +418,7 @@ impl ChannelId {
                 }
             }
         }
+
         Ok(channel)
     }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1134,7 +1134,7 @@ impl UserId {
     ///
     /// **Note**: If the cache is not enabled, REST API will be used only.
     ///
-    /// **Note**: If the cache is enabled, you might want to enable the `tempcaching` feature to
+    /// **Note**: If the cache is enabled, you might want to enable the `temp_cache` feature to
     /// cache user data retrieved by this function for a short duration.
     ///
     /// # Errors
@@ -1159,12 +1159,14 @@ impl UserId {
         }
 
         let user = cache_http.http().get_user(self.0).await?;
-        #[cfg(all(feature = "cache", feature = "tempcaching"))]
+
+        #[cfg(all(feature = "cache", feature = "temp_cache"))]
         {
             if let Some(cache) = cache_http.cache() {
                 cache.temp_users.insert(user.id, user.clone());
             }
         }
+
         Ok(user)
     }
 }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1132,8 +1132,10 @@ impl UserId {
     /// First attempts to find a [`User`] by its Id in the cache,
     /// upon failure requests it via the REST API.
     ///
-    /// **Note**: If the cache is not enabled,
-    /// REST API will be used only.
+    /// **Note**: If the cache is not enabled, REST API will be used only.
+    ///
+    /// **Note**: If the cache is enabled, you might want to enable the `tempcaching` feature to
+    /// cache user data retrieved by this function for a short duration.
     ///
     /// # Errors
     ///

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1157,7 +1157,7 @@ impl UserId {
         }
 
         let user = cache_http.http().get_user(self.0).await?;
-        #[cfg(feature = "cache")]
+        #[cfg(all(feature = "cache", feature = "tempcaching"))]
         {
             if let Some(cache) = cache_http.cache() {
                 cache.temp_users.insert(user.id, user.clone());


### PR DESCRIPTION
`moka` pulls in a lot of transitive dependencies, which may extend build times by a big margin. Furthermore, not everyone might utilise temporary caching. As such, to kill two birds with one stone, temporary caching is put behind the `tempcaching` feature (this name is subject to bikeshedding).

**BREAKING CHANGE**: Users who desire temporary caching must now enable `tempcaching` for Serenity, otherwise their code might not work.   