### PR TITLE
Make it required to set gateway intents explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A basic ping-pong bot looks like:
 use std::env;
 
 use serenity::async_trait;
-use serenity::client::{Client, Context, EventHandler};
+use serenity::prelude::*;
 use serenity::model::channel::Message;
 use serenity::framework::standard::macros::{command, group};
 use serenity::framework::standard::{StandardFramework, CommandResult};

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ async fn main() {
     let mut client = Client::builder(token)
         .event_handler(Handler)
         .framework(framework)
+        .intents(GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT)
         .await
         .expect("Error creating client");
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ async fn main() {
 
     // Login with a bot token from the environment
     let token = env::var("DISCORD_TOKEN").expect("token");
-    let mut client = Client::builder(token)
+    let intents = GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT;
+    let mut client = Client::builder(token, intents)
         .event_handler(Handler)
         .framework(framework)
-        .intents(GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT)
         .await
         .expect("Error creating client");
 

--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -2,7 +2,10 @@ use std::env;
 
 use serenity::{
     async_trait,
-    model::{channel::Message, gateway::Ready},
+    model::{
+        channel::Message,
+        gateway::{GatewayIntents, Ready},
+    },
     prelude::*,
 };
 
@@ -46,8 +49,15 @@ async fn main() {
     // Create a new instance of the Client, logging in as a bot. This will
     // automatically prepend your bot token with "Bot ", which is a requirement
     // by Discord for bot users.
-    let mut client =
-        Client::builder(&token).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token)
+        .event_handler(Handler)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
+        .await
+        .expect("Err creating client");
 
     // Finally, start a single shard, and start listening to events.
     //

--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -45,19 +45,16 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
+    // Set gateway intents, which decides what events the bot will be notified about
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
 
     // Create a new instance of the Client, logging in as a bot. This will
     // automatically prepend your bot token with "Bot ", which is a requirement
     // by Discord for bot users.
-    let mut client = Client::builder(&token)
-        .event_handler(Handler)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
-        .await
-        .expect("Err creating client");
+    let mut client =
+        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
 
     // Finally, start a single shard, and start listening to events.
     //

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -2,7 +2,10 @@ use std::env;
 
 use serenity::{
     async_trait,
-    model::{channel::Message, gateway::Ready},
+    model::{
+        channel::Message,
+        gateway::{GatewayIntents, Ready},
+    },
     prelude::*,
 };
 
@@ -47,8 +50,15 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
-    let mut client =
-        Client::builder(&token).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token)
+        .event_handler(Handler)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
+        .await
+        .expect("Err creating client");
 
     // The total number of shards to use. The "current shard number" of a
     // shard - that is, the shard it is assigned to - is indexed at 0,

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -50,15 +50,11 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
-    let mut client = Client::builder(&token)
-        .event_handler(Handler)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
-        .await
-        .expect("Err creating client");
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client =
+        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
 
     // The total number of shards to use. The "current shard number" of a
     // shard - that is, the shard it is assigned to - is indexed at 0,

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -40,15 +40,11 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
-    let mut client = Client::builder(&token)
-        .event_handler(Handler)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
-        .await
-        .expect("Err creating client");
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client =
+        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {:?}", why);

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -2,7 +2,10 @@ use std::env;
 
 use serenity::{
     async_trait,
-    model::{channel::Message, gateway::Ready},
+    model::{
+        channel::Message,
+        gateway::{GatewayIntents, Ready},
+    },
     prelude::*,
 };
 
@@ -37,8 +40,15 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
-    let mut client =
-        Client::builder(&token).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token)
+        .event_handler(Handler)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
+        .await
+        .expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {:?}", why);

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -52,15 +52,11 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
-    let mut client = Client::builder(&token)
-        .event_handler(Handler)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
-        .await
-        .expect("Err creating client");
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client =
+        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {:?}", why);

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -2,7 +2,10 @@ use std::env;
 
 use serenity::{
     async_trait,
-    model::{channel::Message, gateway::Ready},
+    model::{
+        channel::Message,
+        gateway::{GatewayIntents, Ready},
+    },
     prelude::*,
     utils::MessageBuilder,
 };
@@ -49,8 +52,15 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
-    let mut client =
-        Client::builder(&token).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token)
+        .event_handler(Handler)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
+        .await
+        .expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {:?}", why);

--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -305,16 +305,16 @@ async fn main() {
         .group(&MATH_GROUP)
         .group(&OWNER_GROUP);
 
-    let mut client = Client::builder(&token)
+    // For this example to run properly, the "Presence Intent" and "Server Members Intent"
+    // options need to be enabled.
+    // These are needed so the `required_permissions` macro works on the commands that need to
+    // use it.
+    // You will need to enable these 2 options on the bot application, and possibly wait up to 5
+    // minutes.
+    let intents = GatewayIntents::all();
+    let mut client = Client::builder(&token, intents)
         .event_handler(Handler)
         .framework(framework)
-        // For this example to run properly, the "Presence Intent" and "Server Members Intent"
-        // options need to be enabled.
-        // These are needed so the `required_permissions` macro works on the commands that need to
-        // use it.
-        // You will need to enable these 2 options on the bot application, and possibly wait up to 5
-        // minutes.
-        .intents(GatewayIntents::all())
         .type_map_insert::<CommandCounter>(HashMap::default())
         .await
         .expect("Err creating client");

--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -80,14 +80,12 @@ async fn main() {
     let framework =
         StandardFramework::new().configure(|c| c.owners(owners).prefix("~")).group(&GENERAL_GROUP);
 
-    let mut client = Client::builder(&token)
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client = Client::builder(&token, intents)
         .framework(framework)
         .event_handler(Handler)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
         .await
         .expect("Err creating client");
 

--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -18,7 +18,10 @@ use serenity::{
     client::bridge::gateway::ShardManager,
     framework::{standard::macros::group, StandardFramework},
     http::Http,
-    model::{event::ResumedEvent, gateway::Ready},
+    model::{
+        event::ResumedEvent,
+        gateway::{GatewayIntents, Ready},
+    },
     prelude::*,
 };
 use tracing::{error, info};
@@ -80,6 +83,11 @@ async fn main() {
     let mut client = Client::builder(&token)
         .framework(framework)
         .event_handler(Handler)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
         .await
         .expect("Err creating client");
 

--- a/examples/e07_env_logging/src/main.rs
+++ b/examples/e07_env_logging/src/main.rs
@@ -76,14 +76,12 @@ async fn main() {
     let framework =
         StandardFramework::new().configure(|c| c.prefix("~")).before(before).group(&GENERAL_GROUP);
 
-    let mut client = Client::builder(&token)
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client = Client::builder(&token, intents)
         .event_handler(Handler)
         .framework(framework)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
         .await
         .expect("Err creating client");
 

--- a/examples/e07_env_logging/src/main.rs
+++ b/examples/e07_env_logging/src/main.rs
@@ -7,7 +7,11 @@ use serenity::{
         CommandResult,
         StandardFramework,
     },
-    model::{channel::Message, event::ResumedEvent, gateway::Ready},
+    model::{
+        channel::Message,
+        event::ResumedEvent,
+        gateway::{GatewayIntents, Ready},
+    },
     prelude::*,
 };
 use tracing::{debug, error, info, instrument};
@@ -75,6 +79,11 @@ async fn main() {
     let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
         .await
         .expect("Err creating client");
 

--- a/examples/e08_shard_manager/src/main.rs
+++ b/examples/e08_shard_manager/src/main.rs
@@ -24,7 +24,11 @@
 //! update, depending on how often Discord tells the client to send a heartbeat.
 use std::{env, time::Duration};
 
-use serenity::{async_trait, model::gateway::Ready, prelude::*};
+use serenity::{
+    async_trait,
+    model::gateway::{GatewayIntents, Ready},
+    prelude::*,
+};
 use tokio::time::sleep;
 
 struct Handler;
@@ -46,8 +50,15 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
-    let mut client =
-        Client::builder(&token).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token)
+        .event_handler(Handler)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
+        .await
+        .expect("Err creating client");
 
     // Here we clone a lock to the Shard Manager, and then move it into a new
     // thread. The thread will unlock the manager and print shards' status on a

--- a/examples/e08_shard_manager/src/main.rs
+++ b/examples/e08_shard_manager/src/main.rs
@@ -50,15 +50,11 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
-    let mut client = Client::builder(&token)
-        .event_handler(Handler)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
-        .await
-        .expect("Err creating client");
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client =
+        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
 
     // Here we clone a lock to the Shard Manager, and then move it into a new
     // thread. The thread will unlock the manager and print shards' status on a

--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -3,7 +3,10 @@ use std::env;
 use serenity::{
     async_trait,
     model::Timestamp,
-    model::{channel::Message, gateway::Ready},
+    model::{
+        channel::Message,
+        gateway::{GatewayIntents, Ready},
+    },
     prelude::*,
 };
 
@@ -54,8 +57,15 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
-    let mut client =
-        Client::builder(&token).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token)
+        .event_handler(Handler)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
+        .await
+        .expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {:?}", why);

--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -57,15 +57,11 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
-    let mut client = Client::builder(&token)
-        .event_handler(Handler)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
-        .await
-        .expect("Err creating client");
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client =
+        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {:?}", why);

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -72,6 +72,11 @@ async fn main() {
     let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
         .await
         .expect("Err creating client");
 

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -69,14 +69,12 @@ async fn main() {
         .help(&MY_HELP)
         .group(&COLLECTOR_GROUP);
 
-    let mut client = Client::builder(&token)
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client = Client::builder(&token, intents)
         .event_handler(Handler)
         .framework(framework)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
         .await
         .expect("Err creating client");
 

--- a/examples/e11_gateway_intents/src/main.rs
+++ b/examples/e11_gateway_intents/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
         .event_handler(Handler)
         // Intents are a bitflag, bitwise operations can be used to dictate which intents to use
         // By default, GatewayIntents::non_privileged() is used.
-        .intents(GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES)
+        .intents(GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT)
         .await
         .expect("Error creating client");
 

--- a/examples/e11_gateway_intents/src/main.rs
+++ b/examples/e11_gateway_intents/src/main.rs
@@ -34,12 +34,12 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
+    // Intents are a bitflag, bitwise operations can be used to dictate which intents to use
+    let intents =
+        GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT;
     // Build our client.
-    let mut client = Client::builder(token)
+    let mut client = Client::builder(token, intents)
         .event_handler(Handler)
-        // Intents are a bitflag, bitwise operations can be used to dictate which intents to use
-        // By default, GatewayIntents::non_privileged() is used.
-        .intents(GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT)
         .await
         .expect("Error creating client");
 

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -119,14 +119,12 @@ async fn main() {
         .before(before)
         .group(&GENERAL_GROUP);
 
-    let mut client = Client::builder(&token)
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client = Client::builder(&token, intents)
         .event_handler(Handler)
         .framework(framework)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
         .await
         .expect("Err creating client");
 

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -18,7 +18,10 @@ use serenity::{
         CommandResult,
         StandardFramework,
     },
-    model::{channel::Message, gateway::Ready},
+    model::{
+        channel::Message,
+        gateway::{GatewayIntents, Ready},
+    },
     prelude::*,
 };
 use tokio::sync::RwLock;
@@ -119,6 +122,11 @@ async fn main() {
     let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
         .await
         .expect("Err creating client");
 

--- a/examples/e13_parallel_loops/src/main.rs
+++ b/examples/e13_parallel_loops/src/main.rs
@@ -119,15 +119,13 @@ async fn set_status_to_current_time(ctx: Arc<Context>) {
 async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
-    let mut client = Client::builder(&token)
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client = Client::builder(&token, intents)
         .event_handler(Handler {
             is_loop_running: AtomicBool::new(false),
         })
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
         .await
         .expect("Error creating client");
 

--- a/examples/e13_parallel_loops/src/main.rs
+++ b/examples/e13_parallel_loops/src/main.rs
@@ -12,7 +12,7 @@ use serenity::{
     async_trait,
     model::{
         channel::Message,
-        gateway::{Activity, Ready},
+        gateway::{Activity, GatewayIntents, Ready},
         id::{ChannelId, GuildId},
     },
     prelude::*,
@@ -123,6 +123,11 @@ async fn main() {
         .event_handler(Handler {
             is_loop_running: AtomicBool::new(false),
         })
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
         .await
         .expect("Error creating client");
 

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -193,9 +193,8 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
     // Build our client.
-    let mut client = Client::builder(token)
+    let mut client = Client::builder(token, GatewayIntents::empty())
         .event_handler(Handler)
-        .intents(GatewayIntents::empty())
         .await
         .expect("Error creating client");
 

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use serenity::{
     async_trait,
     model::{
-        gateway::Ready,
+        gateway::{GatewayIntents, Ready},
         id::GuildId,
         interactions::{
             application_command::{
@@ -192,16 +192,10 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
-    // The Application Id is usually the Bot User Id.
-    let application_id: u64 = env::var("APPLICATION_ID")
-        .expect("Expected an application id in the environment")
-        .parse()
-        .expect("application id is not a valid id");
-
     // Build our client.
     let mut client = Client::builder(token)
         .event_handler(Handler)
-        .application_id(application_id)
+        .intents(GatewayIntents::empty())
         .await
         .expect("Error creating client");
 

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -426,6 +426,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let mut client = Client::builder(token)
         .event_handler(Handler)
         .framework(framework)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
         .type_map_insert::<RillRateComponents>(components)
         .await?;
 

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -423,14 +423,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         command_usage_values: Mutex::new(command_usage_values),
     });
 
-    let mut client = Client::builder(token)
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client = Client::builder(token, intents)
         .event_handler(Handler)
         .framework(framework)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
         .type_map_insert::<RillRateComponents>(components)
         .await?;
 

--- a/examples/e16_sqlite_database/src/main.rs
+++ b/examples/e16_sqlite_database/src/main.rs
@@ -81,14 +81,10 @@ async fn main() {
         database,
     };
 
-    let mut client = Client::builder(&token)
-        .event_handler(bot)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
-        .await
-        .expect("Err creating client");
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client =
+        Client::builder(&token, intents).event_handler(bot).await.expect("Err creating client");
     client.start().await.unwrap();
 }

--- a/examples/e16_sqlite_database/src/main.rs
+++ b/examples/e16_sqlite_database/src/main.rs
@@ -81,6 +81,14 @@ async fn main() {
         database,
     };
 
-    let mut client = Client::builder(&token).event_handler(bot).await.expect("Err creating client");
+    let mut client = Client::builder(&token)
+        .event_handler(bot)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
+        .await
+        .expect("Err creating client");
     client.start().await.unwrap();
 }

--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -4,13 +4,14 @@ use std::time::Duration;
 use std::{env, fmt};
 
 use dotenv::dotenv;
+use serenity::async_trait;
 use serenity::builder::{CreateActionRow, CreateButton, CreateSelectMenu, CreateSelectMenuOption};
 use serenity::client::{Context, EventHandler};
 use serenity::futures::StreamExt;
 use serenity::model::channel::Message;
 use serenity::model::interactions::message_component::ButtonStyle;
 use serenity::model::interactions::InteractionResponseType;
-use serenity::{async_trait, Client};
+use serenity::prelude::*;
 
 #[derive(Debug)]
 enum Animal {

--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -8,6 +8,7 @@ use serenity::{
     futures::StreamExt,
     model::{
         channel::Message,
+        gateway::GatewayIntents,
         interactions::{message_component::ButtonStyle, InteractionResponseType},
     },
     Client,
@@ -236,16 +237,14 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
-    // The Application Id is usually the Bot User Id. It is needed for components
-    let application_id: u64 = env::var("APPLICATION_ID")
-        .expect("Expected an application id in the environment")
-        .parse()
-        .expect("application id is not a valid id");
-
     // Build our client.
     let mut client = Client::builder(token)
         .event_handler(Handler)
-        .application_id(application_id)
+        .intents(
+            GatewayIntents::GUILD_MESSAGES
+                | GatewayIntents::DIRECT_MESSAGES
+                | GatewayIntents::MESSAGE_CONTENT,
+        )
         .await
         .expect("Error creating client");
 

--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -238,13 +238,11 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
     // Build our client.
-    let mut client = Client::builder(token)
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+    let mut client = Client::builder(token, intents)
         .event_handler(Handler)
-        .intents(
-            GatewayIntents::GUILD_MESSAGES
-                | GatewayIntents::DIRECT_MESSAGES
-                | GatewayIntents::MESSAGE_CONTENT,
-        )
         .await
         .expect("Error creating client");
 

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -237,7 +237,7 @@ impl CreateEmbed {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -285,7 +285,7 @@ impl CreateEmbed {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -237,7 +237,8 @@ impl CreateEmbed {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -285,7 +286,8 @@ impl CreateEmbed {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -57,7 +57,8 @@ use crate::model::invite::InviteTargetType;
 ///     }
 /// }
 ///
-/// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+/// let mut client =
+///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #     Ok(())

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -57,7 +57,7 @@ use crate::model::invite::InviteTargetType;
 ///     }
 /// }
 ///
-/// let mut client = Client::builder("token").event_handler(Handler).await?;
+/// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #     Ok(())

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -263,7 +263,8 @@ impl Cache {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -503,7 +504,8 @@ impl Cache {
     ///
     /// # #[cfg(feature = "client")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -263,7 +263,7 @@ impl Cache {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -503,7 +503,7 @@ impl Cache {
     ///
     /// # #[cfg(feature = "client")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -221,7 +221,7 @@ impl ShardManager {
     /// use std::env;
     ///
     /// use serenity::client::bridge::gateway::ShardId;
-    /// use serenity::client::{Client, EventHandler};
+    /// use serenity::prelude::*;
     ///
     /// struct Handler;
     ///
@@ -229,7 +229,8 @@ impl ShardManager {
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// // restart shard ID 7
     /// client.shard_manager.lock().await.restart(ShardId(7)).await;

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -229,7 +229,7 @@ impl ShardManager {
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// // restart shard ID 7
     /// client.shard_manager.lock().await.restart(ShardId(7)).await;

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -112,7 +112,8 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -149,7 +150,8 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -186,7 +188,8 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -222,7 +225,8 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -260,7 +264,8 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -302,7 +307,8 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -338,7 +344,8 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -368,7 +375,8 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -112,7 +112,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -149,7 +149,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -186,7 +186,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -222,7 +222,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -260,7 +260,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -302,7 +302,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -338,7 +338,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -368,7 +368,7 @@ impl Context {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -448,7 +448,7 @@ impl Future for ClientBuilder {
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut client =
-///     Client::builder("my token here", Default::default()).event_handler(Handler).await?;
+///     Client::builder("my token here", GatewayIntents::default()).event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #   Ok(())
@@ -534,7 +534,7 @@ pub struct Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     /// {
     ///     let mut data = client.data.write().await;
     ///     data.insert::<MessageEventCounter>(HashMap::default());
@@ -571,7 +571,7 @@ pub struct Client {
     /// 5 seconds:
     ///
     /// ```rust,no_run
-    /// # use serenity::client::{Client, EventHandler};
+    /// # use serenity::prelude::*;
     /// # use std::time::Duration;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -580,7 +580,8 @@ pub struct Client {
     /// impl EventHandler for Handler {}
     ///
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// let shard_manager = client.shard_manager.clone();
     ///
@@ -603,14 +604,15 @@ pub struct Client {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::time::Duration;
     ///
-    /// use serenity::client::{Client, EventHandler};
+    /// use serenity::prelude::*;
     ///
     /// struct Handler;
     ///
     /// impl EventHandler for Handler {}
     ///
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// // Create a clone of the `Arc` containing the shard manager.
     /// let shard_manager = client.shard_manager.clone();
@@ -672,7 +674,7 @@ impl Client {
     ///
     /// ```rust,no_run
     /// # use std::error::Error;
-    /// # use serenity::prelude::EventHandler;
+    /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
     /// struct Handler;
@@ -681,7 +683,8 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start().await {
     ///     println!("Err with client: {:?}", why);
@@ -714,7 +717,7 @@ impl Client {
     ///
     /// ```rust,no_run
     /// # use std::error::Error;
-    /// # use serenity::prelude::EventHandler;
+    /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
     /// struct Handler;
@@ -723,7 +726,8 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_autosharded().await {
     ///     println!("Err with client: {:?}", why);
@@ -767,7 +771,7 @@ impl Client {
     ///
     /// ```rust,no_run
     /// # use std::error::Error;
-    /// # use serenity::prelude::EventHandler;
+    /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
     /// struct Handler;
@@ -776,7 +780,8 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard(3, 5).await {
     ///     println!("Err with client: {:?}", why);
@@ -790,7 +795,7 @@ impl Client {
     ///
     /// ```rust,no_run
     /// # use std::error::Error;
-    /// # use serenity::prelude::EventHandler;
+    /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
     /// struct Handler;
@@ -799,7 +804,8 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard(0, 1).await {
     ///     println!("Err with client: {:?}", why);
@@ -837,7 +843,7 @@ impl Client {
     ///
     /// ```rust,no_run
     /// # use std::error::Error;
-    /// # use serenity::prelude::EventHandler;
+    /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
     /// struct Handler;
@@ -846,7 +852,8 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shards(8).await {
     ///     println!("Err with client: {:?}", why);
@@ -885,7 +892,7 @@ impl Client {
     ///
     /// ```rust,no_run
     /// # use std::error::Error;
-    /// # use serenity::prelude::EventHandler;
+    /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
     /// struct Handler;
@@ -894,7 +901,8 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard_range([4, 7], 10).await {
     ///     println!("Err with client: {:?}", why);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -73,7 +73,7 @@ pub struct ClientBuilder {
     data: Option<TypeMap>,
     http: Http,
     fut: Option<BoxFuture<'static, Result<Client>>>,
-    intents: GatewayIntents,
+    intents: Option<GatewayIntents>,
     application_id: Option<ApplicationId>,
     #[cfg(feature = "cache")]
     timeout: Option<Duration>,
@@ -95,7 +95,7 @@ impl ClientBuilder {
             data: Some(TypeMap::new()),
             http,
             fut: None,
-            intents: GatewayIntents::non_privileged(),
+            intents: None,
             application_id: None,
             #[cfg(feature = "cache")]
             timeout: None,
@@ -329,13 +329,13 @@ impl ClientBuilder {
     /// [Privileged intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
     /// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
     pub fn intents(mut self, intents: GatewayIntents) -> Self {
-        self.intents = intents;
+        self.intents = Some(intents);
 
         self
     }
 
     /// Gets the intents. See [`Self::intents`] for more info.
-    pub fn get_intents(&self) -> GatewayIntents {
+    pub fn get_intents(&self) -> Option<GatewayIntents> {
         self.intents
     }
 
@@ -391,7 +391,10 @@ impl Future for ClientBuilder {
                 If you don't want to use the command framework, disable default features and specify all features you want to use.");
             let event_handler = self.event_handler.take();
             let raw_event_handler = self.raw_event_handler.take();
-            let intents = self.intents;
+            let intents = self.intents.expect(
+                "No gateway intents were provided. \
+                Please set gateway intents using `.intents()` on `ClientBuilder`",
+            );
             let http = Arc::new(std::mem::take(&mut self.http));
 
             // TODO: It should not be required for all users of serenity to set the application_id or get a panic.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -447,7 +447,8 @@ impl Future for ClientBuilder {
 /// }
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut client = Client::builder("my token here").event_handler(Handler).await?;
+/// let mut client =
+///     Client::builder("my token here", Default::default()).event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #   Ok(())
@@ -533,7 +534,7 @@ pub struct Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     /// {
     ///     let mut data = client.data.write().await;
     ///     data.insert::<MessageEventCounter>(HashMap::default());
@@ -579,7 +580,7 @@ pub struct Client {
     /// impl EventHandler for Handler {}
     ///
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// let shard_manager = client.shard_manager.clone();
     ///
@@ -609,7 +610,7 @@ pub struct Client {
     /// impl EventHandler for Handler {}
     ///
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// // Create a clone of the `Arc` containing the shard manager.
     /// let shard_manager = client.shard_manager.clone();
@@ -680,7 +681,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start().await {
     ///     println!("Err with client: {:?}", why);
@@ -722,7 +723,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_autosharded().await {
     ///     println!("Err with client: {:?}", why);
@@ -775,7 +776,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard(3, 5).await {
     ///     println!("Err with client: {:?}", why);
@@ -798,7 +799,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard(0, 1).await {
     ///     println!("Err with client: {:?}", why);
@@ -845,7 +846,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shards(8).await {
     ///     println!("Err with client: {:?}", why);
@@ -893,7 +894,7 @@ impl Client {
     ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// if let Err(why) = client.start_shard_range([4, 7], 10).await {
     ///     println!("Err with client: {:?}", why);

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -32,10 +32,10 @@
 //! ping and about command:
 //!
 //! ```rust,no_run
-//! use serenity::client::{Client, Context, EventHandler};
 //! use serenity::framework::standard::macros::{command, group};
 //! use serenity::framework::standard::{CommandResult, StandardFramework};
 //! use serenity::model::channel::Message;
+//! use serenity::prelude::*;
 //!
 //! #[command]
 //! async fn about(ctx: &Context, msg: &Message) -> CommandResult {
@@ -70,7 +70,7 @@
 //!     // all-uppercased version of the `name` with a `_GROUP` suffix appended at the end.
 //!     .group(&GENERAL_GROUP);
 //!
-//! let mut client = Client::builder(&token, Default::default())
+//! let mut client = Client::builder(&token, GatewayIntents::default())
 //!     .event_handler(Handler)
 //!     .framework(framework)
 //!     .await?;

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -70,7 +70,10 @@
 //!     // all-uppercased version of the `name` with a `_GROUP` suffix appended at the end.
 //!     .group(&GENERAL_GROUP);
 //!
-//! let mut client = Client::builder(&token).event_handler(Handler).framework(framework).await?;
+//! let mut client = Client::builder(&token, Default::default())
+//!     .event_handler(Handler)
+//!     .framework(framework)
+//!     .await?;
 //! #     Ok(())
 //! # }
 //! ```

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -76,7 +76,7 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 /// Responding to mentions and setting a command prefix of `"~"`:
 ///
 /// ```rust,no_run
-/// # use serenity::prelude::EventHandler;
+/// # use serenity::prelude::*;
 /// struct Handler;
 ///
 /// impl EventHandler for Handler {}
@@ -90,7 +90,7 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 /// let framework =
 ///     StandardFramework::new().configure(|c| c.on_mention(Some(UserId(5))).prefix("~"));
 ///
-/// let mut client = Client::builder(&token, Default::default())
+/// let mut client = Client::builder(&token, GatewayIntents::default())
 ///     .event_handler(Handler)
 ///     .framework(framework)
 ///     .await?;

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -90,7 +90,10 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 /// let framework =
 ///     StandardFramework::new().configure(|c| c.on_mention(Some(UserId(5))).prefix("~"));
 ///
-/// let mut client = Client::builder(&token).event_handler(Handler).framework(framework).await?;
+/// let mut client = Client::builder(&token, Default::default())
+///     .event_handler(Handler)
+///     .framework(framework)
+///     .await?;
 /// #     Ok(())
 /// # }
 /// ```

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -148,7 +148,10 @@ impl StandardFramework {
     /// let token = std::env::var("DISCORD_TOKEN")?;
     /// let framework = StandardFramework::new().configure(|c| c.with_whitespace(true).prefix("~"));
     ///
-    /// let mut client = Client::builder(&token).event_handler(Handler).framework(framework).await?;
+    /// let mut client = Client::builder(&token, Default::default())
+    ///     .event_handler(Handler)
+    ///     .framework(framework)
+    ///     .await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -138,7 +138,7 @@ impl StandardFramework {
     /// Configuring the framework for a [`Client`], [allowing whitespace between prefixes], and setting the [`prefix`] to `"~"`:
     ///
     /// ```rust,no_run
-    /// # use serenity::prelude::EventHandler;
+    /// # use serenity::prelude::*;
     /// # struct Handler;
     /// # impl EventHandler for Handler {}
     /// use serenity::framework::StandardFramework;
@@ -148,7 +148,7 @@ impl StandardFramework {
     /// let token = std::env::var("DISCORD_TOKEN")?;
     /// let framework = StandardFramework::new().configure(|c| c.with_whitespace(true).prefix("~"));
     ///
-    /// let mut client = Client::builder(&token, Default::default())
+    /// let mut client = Client::builder(&token, GatewayIntents::default())
     ///     .event_handler(Handler)
     ///     .framework(framework)
     ///     .await?;

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -111,7 +111,7 @@ impl Attachment {
     ///     }
     /// }
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -111,7 +111,8 @@ impl Attachment {
     ///     }
     /// }
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -715,7 +715,7 @@ impl GuildChannel {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -768,7 +768,7 @@ impl GuildChannel {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -715,7 +715,8 @@ impl GuildChannel {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())
@@ -768,7 +769,8 @@ impl GuildChannel {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -47,7 +47,8 @@ use super::Permissions;
 ///     }
 /// }
 /// let token = std::env::var("DISCORD_BOT_TOKEN")?;
-/// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
+/// let mut client =
+///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #     Ok(())

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -47,7 +47,7 @@ use super::Permissions;
 ///     }
 /// }
 /// let token = std::env::var("DISCORD_BOT_TOKEN")?;
-/// let mut client = Client::builder(&token).event_handler(Handler).await?;
+/// let mut client = Client::builder(&token, Default::default()).event_handler(Handler).await?;
 ///
 /// client.start().await?;
 /// #     Ok(())

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2411,7 +2411,7 @@ impl Guild {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #    Ok(())

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2411,7 +2411,8 @@ impl Guild {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #    Ok(())

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1515,7 +1515,8 @@ impl PartialGuild {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #    Ok(())

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1515,7 +1515,7 @@ impl PartialGuild {
     ///     }
     /// }
     ///
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #    Ok(())

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -835,7 +835,8 @@ impl User {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     /// #     Ok(())
     /// # }
     /// # }
@@ -1013,7 +1014,8 @@ impl User {
     ///         }
     ///     }
     /// }
-    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
+    /// let mut client =
+    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -835,7 +835,7 @@ impl User {
     /// }
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     /// #     Ok(())
     /// # }
     /// # }
@@ -1013,7 +1013,7 @@ impl User {
     ///         }
     ///     }
     /// }
-    /// let mut client = Client::builder("token").event_handler(Handler).await?;
+    /// let mut client = Client::builder("token", Default::default()).event_handler(Handler).await?;
     ///
     /// client.start().await?;
     /// #     Ok(())

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -30,4 +30,4 @@ pub use crate::gateway::GatewayError;
 pub use crate::http::HttpError;
 pub use crate::model::misc::Mentionable;
 #[cfg(feature = "model")]
-pub use crate::model::ModelError;
+pub use crate::model::{gateway::GatewayIntents, ModelError};


### PR DESCRIPTION
As decided democratically in the serenity server...
![Screenshot_20220403_120102](https://user-images.githubusercontent.com/21220820/161422212-eee83d75-fe72-482d-a120-8bf74ffcbc0a.png)
https://discord.com/channels/381880193251409931/673965002805477386/957727492880343101

...this PR changes ClientBuilder to ~~panic when gateway intents are not provided~~ take not just token but also gateway intents as required parameters. Examples were updated accordingly, I hope I didn't miss any

I also removed the explicit application ID settings from some examples in favor of #1772. We need #1772 anyways because otherwise almost all examples wouldn't run anymore (due to stabilization of application commands).
