### PR TITLE
Fix parsing interaction with DM channel argument

### DIFF
--- a/src/model/channel/partial_channel.rs
+++ b/src/model/channel/partial_channel.rs
@@ -9,7 +9,7 @@ pub struct PartialChannel {
     /// The channel Id.
     pub id: ChannelId,
     /// The channel name.
-    pub name: String,
+    pub name: Option<String>,
     /// The channel type.
     #[serde(rename = "type")]
     pub kind: ChannelType,


### PR DESCRIPTION
In the interaction create gateway event, the "name" field for DM channels in slash command arguments is set to null, but serenity expects a non-null value

See `"name": Null` in gateway event JSON:
```rust
[/home/kangalioo/dev/rust/_downloaded/serenity/src/client/bridge/gateway/shard_runner.rs:569] self.shard.client.recv_json().await = Ok(
    Some(
        Object({
            "d": Object({
                "application_id": String(
                    "846453852164587620",
                ),
                "channel_id": String(
                    "850849185678622721",
                ),
                "data": Object({
                    "id": String(
                        "960606515578941503",
                    ),
                    "name": String(
                        "booboo",
                    ),
                    "options": Array([
                        Object({
                            "name": String(
                                "channel",
                            ),
                            "type": Number(
                                7,
                            ),
                            "value": String(
                                "850849185678622721",
                            ),
                        }),
                    ]),
                    "resolved": Object({
                        "channels": Object({
                            "850849185678622721": Object({
                                "id": String(
                                    "850849185678622721",
                                ),
                                "name": Null,
                                "permissions": String(
                                    "0",
                                ),
                                "type": Number(
                                    1,
                                ),
                            }),
                        }),
                    }),
                    "type": Number(
                        1,
                    ),
                }),
                "id": String(
                    "960624610779488276",
                ),
                "locale": String(
                    "en-US",
                ),
                "token": String(
                    "REDACTED",
                ),
                "type": Number(
                    2,
                ),
                "user": Object({
                    "avatar": String(
                        "15f8dc44cca4ee0d9a45022514291e64",
                    ),
                    "discriminator": String(
                        "9108",
                    ),
                    "id": String(
                        "472029906943868929",
                    ),
                    "public_flags": Number(
                        128,
                    ),
                    "username": String(
                        "kangalioo",
                    ),
                }),
                "version": Number(
                    1,
                ),
            }),
            "op": Number(
                0,
            ),
            "s": Number(
                3,
            ),
            "t": String(
                "INTERACTION_CREATE",
            ),
        }),
    ),
)
```

And the resulting deserialization error:
```rust
[/home/kangalioo/dev/rust/_downloaded/serenity/src/client/bridge/gateway/shard_runner.rs:570] GatewayEvent::deserialize(value) = Err(
    Error("event InteractionCreate: invalid type: null, expected a string", line: 0, column: 0),
)
```