### PR TITLE
Clean up `Guild::member_named` to use `utils::parse_user_tag`

### DIFF
--- a/src/utils/argument_convert/mod.rs
+++ b/src/utils/argument_convert/mod.rs
@@ -115,24 +115,3 @@ pub fn parse_message_url(s: &str) -> Option<(GuildId, ChannelId, MessageId)> {
     let message_id = MessageId(parts.next()?.parse().ok()?);
     Some((guild_id, channel_id, message_id))
 }
-
-/// Retrieves the username and discriminator out of a user tag (`name#discrim`).
-///
-/// If the user tag is invalid, None is returned.
-///
-/// # Examples
-/// ```rust
-/// use serenity::utils::parse_user_tag;
-///
-/// assert_eq!(parse_user_tag("kangalioo#9108"), Some(("kangalioo", 9108)));
-/// assert_eq!(parse_user_tag("kangalioo#10108"), None);
-/// ```
-pub fn parse_user_tag(s: &str) -> Option<(&str, u16)> {
-    let pound_sign = s.find('#')?;
-    let name = &s[..pound_sign];
-    let discrim = s[(pound_sign + 1)..].parse::<u16>().ok()?;
-    if discrim > 9999 {
-        return None;
-    }
-    Some((name, discrim))
-}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -71,6 +71,27 @@ pub fn parse_invite(code: &str) -> &str {
     }
 }
 
+/// Retrieves the username and discriminator out of a user tag (`name#discrim`).
+///
+/// If the user tag is invalid, None is returned.
+///
+/// # Examples
+/// ```rust
+/// use serenity::utils::parse_user_tag;
+///
+/// assert_eq!(parse_user_tag("kangalioo#9108"), Some(("kangalioo", 9108)));
+/// assert_eq!(parse_user_tag("kangalioo#10108"), None);
+/// ```
+pub fn parse_user_tag(s: &str) -> Option<(&str, u16)> {
+    let pound_sign = s.find('#')?;
+    let name = &s[..pound_sign];
+    let discrim = s[(pound_sign + 1)..].parse::<u16>().ok()?;
+    if discrim > 9999 {
+        return None;
+    }
+    Some((name, discrim))
+}
+
 /// Retrieves an Id from a user mention.
 ///
 /// If the mention is invalid, then [`None`] is returned.


### PR DESCRIPTION
Replace custom parsing logic with call to existing functionality. Also, move `parse_user_tag` from `utils/argument_convert` to `utils`, since it doesn't need to be gated by the model feature.