### PR TITLE
Clean up macro usage in `model::misc`

### DIFF
--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -11,6 +11,8 @@ mod partial_channel;
 mod private_channel;
 mod reaction;
 
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+use std::error::Error as StdError;
 use std::fmt;
 
 use serde::de::{Error as DeError, Unexpected};
@@ -32,8 +34,6 @@ use crate::cache::Cache;
 use crate::cache::FromStrAndCache;
 #[cfg(feature = "model")]
 use crate::http::CacheHttp;
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use crate::model::misc::ChannelParseError;
 use crate::model::utils::is_false;
 use crate::model::Timestamp;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
@@ -582,6 +582,26 @@ mod test {
         }
     }
 }
+
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+#[derive(Debug)]
+pub enum ChannelParseError {
+    NotPresentInCache,
+    InvalidChannel,
+}
+
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+impl fmt::Display for ChannelParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChannelParseError::NotPresentInCache => f.write_str("not present in cache"),
+            ChannelParseError::InvalidChannel => f.write_str("invalid channel"),
+        }
+    }
+}
+
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+impl StdError for ChannelParseError {}
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 impl FromStrAndCache for Channel {

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -1,4 +1,6 @@
 use std::cmp::Ordering;
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+use std::error::Error as StdError;
 use std::fmt;
 
 #[cfg(feature = "model")]
@@ -11,8 +13,6 @@ use crate::cache::FromStrAndCache;
 use crate::http::Http;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use crate::model::misc::RoleParseError;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
@@ -260,6 +260,26 @@ impl<'a> From<&'a Role> for RoleId {
         role.id
     }
 }
+
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+#[derive(Debug)]
+pub enum RoleParseError {
+    NotPresentInCache,
+    InvalidRole,
+}
+
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+impl fmt::Display for RoleParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RoleParseError::NotPresentInCache => f.write_str("not present in cache"),
+            RoleParseError::InvalidRole => f.write_str("invalid role"),
+        }
+    }
+}
+
+#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
+impl StdError for RoleParseError {}
 
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 impl FromStrAndCache for Role {

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -168,29 +168,8 @@ mentionable!(value:
     Emoji, (value.id, value.animated);
 );
 
-#[cfg(all(feature = "model", feature = "utils"))]
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum UserParseError {
-    InvalidUsername,
-    Rest(Box<Error>),
-}
-
-#[cfg(all(feature = "model", feature = "utils"))]
-impl fmt::Display for UserParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            UserParseError::InvalidUsername => f.write_str("invalid username"),
-            UserParseError::Rest(_) => f.write_str("could not fetch"),
-        }
-    }
-}
-
-#[cfg(all(feature = "model", feature = "utils"))]
-impl StdError for UserParseError {}
-
 macro_rules! impl_from_str {
-    (id: $($id:ident, $err:ident, $parse_function:ident;)*) => {
+    ($($id:ident, $err:ident, $parse_function:ident;)+) => {
         $(
             #[cfg(all(feature = "model", feature = "utils"))]
             #[derive(Debug)]
@@ -201,9 +180,7 @@ macro_rules! impl_from_str {
             #[cfg(all(feature = "model", feature = "utils"))]
             impl fmt::Display for $err {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    match self {
-                        $err::InvalidFormat => f.write_str("invalid id format"),
-                    }
+                    f.write_str("invalid id format")
                 }
             }
 
@@ -225,41 +202,12 @@ macro_rules! impl_from_str {
             }
         )*
     };
-
-    (struct: $($struct:ty, $id:tt, $err:ident, $invalid_variant:tt, $parse_fn:ident, $desc:expr;)*) => {
-        $(
-            #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-            #[derive(Debug)]
-            pub enum $err {
-                NotPresentInCache,
-                $invalid_variant,
-            }
-
-            #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-            impl fmt::Display for $err {
-                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    match self {
-                        $err::NotPresentInCache => f.write_str("not present in cache"),
-                        $err::$invalid_variant => f.write_str($desc),
-                    }
-                }
-            }
-
-            #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-            impl StdError for $err {}
-        )*
-    };
 }
 
-impl_from_str! { id:
+impl_from_str! {
     UserId, UserIdParseError, parse_username;
     RoleId, RoleIdParseError, parse_role;
     ChannelId, ChannelIdParseError, parse_channel;
-}
-
-impl_from_str! { struct:
-    Channel, ChannelId, ChannelParseError, InvalidChannel, parse_channel, "invalid channel";
-    Role, RoleId, RoleParseError, InvalidRole, parse_role, "invalid role";
 }
 
 /// A version of an emoji used only when solely the animated state, Id, and name are known.


### PR DESCRIPTION
Refactor `impl_from_str!` to cut down on complexity, and move the error handling logic for `Channel` and `Role` into their respective modules. Furthermore, remove the unused `misc::UserParseError` enum, as it's gone unused since #448 and was replaced in functionality by `argument_convert::UserParseError` in #1380.