### PR TITLE
Fix clippy warnings suggested by `clippy::pedantic`

### DIFF
--- a/command_attr/src/attributes.rs
+++ b/command_attr/src/attributes.rs
@@ -95,7 +95,7 @@ pub fn parse_values(attr: &Attribute) -> Result<Values> {
                     NestedMeta::Meta(m) => match m {
                         Meta::Path(path) => {
                             let i = to_ident(path)?;
-                            lits.push(Lit::Str(LitStr::new(&i.to_string(), i.span())))
+                            lits.push(Lit::Str(LitStr::new(&i.to_string(), i.span())));
                         }
                         Meta::List(_) | Meta::NameValue(_) => {
                             return Err(Error::new(attr.span(), "cannot nest a list; only accept literals and identifiers at this level"))

--- a/command_attr/src/attributes.rs
+++ b/command_attr/src/attributes.rs
@@ -34,7 +34,7 @@ impl fmt::Display for ValueKind {
     }
 }
 
-fn to_ident(p: Path) -> Result<Ident> {
+fn to_ident(p: &Path) -> Result<Ident> {
     if p.segments.is_empty() {
         return Err(Error::new(p.span(), "cannot convert an empty path to an identifier"));
     }
@@ -75,12 +75,12 @@ pub fn parse_values(attr: &Attribute) -> Result<Values> {
 
     match meta {
         Meta::Path(path) => {
-            let name = to_ident(path)?;
+            let name = to_ident(&path)?;
 
             Ok(Values::new(name, ValueKind::Name, Vec::new(), attr.span()))
         },
         Meta::List(meta) => {
-            let name = to_ident(meta.path)?;
+            let name = to_ident(&meta.path)?;
             let nested = meta.nested;
 
             if nested.is_empty() {
@@ -94,7 +94,7 @@ pub fn parse_values(attr: &Attribute) -> Result<Values> {
                     NestedMeta::Lit(l) => lits.push(l),
                     NestedMeta::Meta(m) => match m {
                         Meta::Path(path) => {
-                            let i = to_ident(path)?;
+                            let i = to_ident(&path)?;
                             lits.push(Lit::Str(LitStr::new(&i.to_string(), i.span())));
                         }
                         Meta::List(_) | Meta::NameValue(_) => {
@@ -109,7 +109,7 @@ pub fn parse_values(attr: &Attribute) -> Result<Values> {
             Ok(Values::new(name, kind, lits, attr.span()))
         },
         Meta::NameValue(meta) => {
-            let name = to_ident(meta.path)?;
+            let name = to_ident(&meta.path)?;
             let lit = meta.lit;
 
             Ok(Values::new(name, ValueKind::Equals, vec![lit], attr.span()))

--- a/command_attr/src/attributes.rs
+++ b/command_attr/src/attributes.rs
@@ -193,7 +193,7 @@ impl AttributeOption for bool {
     fn parse(values: Values) -> Result<Self> {
         validate(&values, &[ValueKind::Name, ValueKind::SingleList])?;
 
-        Ok(values.literals.get(0).map_or(true, |l| l.to_bool()))
+        Ok(values.literals.get(0).map_or(true, LitExt::to_bool))
     }
 }
 
@@ -211,7 +211,7 @@ impl AttributeOption for Vec<Ident> {
     fn parse(values: Values) -> Result<Self> {
         validate(&values, &[ValueKind::List])?;
 
-        Ok(values.literals.into_iter().map(|l| l.to_ident()).collect())
+        Ok(values.literals.iter().map(LitExt::to_ident).collect())
     }
 }
 
@@ -219,7 +219,7 @@ impl AttributeOption for Option<String> {
     fn parse(values: Values) -> Result<Self> {
         validate(&values, &[ValueKind::Name, ValueKind::Equals, ValueKind::SingleList])?;
 
-        Ok(values.literals.get(0).map(|l| l.to_str()))
+        Ok(values.literals.get(0).map(LitExt::to_str))
     }
 }
 

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -100,10 +100,10 @@ macro_rules! match_options {
 pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut fun = parse_macro_input!(input as CommandFun);
 
-    let _name = if !attr.is_empty() {
-        parse_macro_input!(attr as Lit).to_str()
-    } else {
+    let _name = if attr.is_empty() {
         fun.name.to_string_non_raw()
+    } else {
+        parse_macro_input!(attr as Lit).to_str()
     };
 
     let mut options = Options::new();
@@ -279,7 +279,9 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
 pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut fun = parse_macro_input!(input as CommandFun);
 
-    let names = if !attr.is_empty() {
+    let names = if attr.is_empty() {
+        vec!["help".to_string()]
+    } else {
         struct Names(Vec<String>);
 
         impl Parse for Names {
@@ -291,8 +293,6 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
         let Names(names) = parse_macro_input!(attr as Names);
 
         names
-    } else {
-        vec!["help".to_string()]
     };
 
     // Revert the change for the names of documentation attributes done when
@@ -618,10 +618,10 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
     let group = parse_macro_input!(input as GroupStruct);
 
-    let name = if !attr.is_empty() {
-        parse_macro_input!(attr as Lit).to_str()
-    } else {
+    let name = if attr.is_empty() {
         group.name.to_string_non_raw()
+    } else {
+        parse_macro_input!(attr as Lit).to_str()
     };
 
     let mut options = GroupOptions::new();

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -172,7 +172,7 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
     propagate_err!(create_declaration_validations(&mut fun, DeclarFor::Command));
 
     let res = parse_quote!(serenity::framework::standard::CommandResult);
-    create_return_type_validation(&mut fun, res);
+    create_return_type_validation(&mut fun, &res);
 
     let visibility = fun.visibility;
     let name = fun.name.clone();
@@ -457,7 +457,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     propagate_err!(create_declaration_validations(&mut fun, DeclarFor::Help));
 
     let res = parse_quote!(serenity::framework::standard::CommandResult);
-    create_return_type_validation(&mut fun, res);
+    create_return_type_validation(&mut fun, &res);
 
     let options = fun.name.with_suffix(HELP_OPTIONS);
 
@@ -772,7 +772,7 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
     propagate_err!(create_declaration_validations(&mut fun, DeclarFor::Check));
 
     let res = parse_quote!(std::result::Result<(), serenity::framework::standard::Reason>);
-    create_return_type_validation(&mut fun, res);
+    create_return_type_validation(&mut fun, &res);
 
     let n = fun.name.clone();
     let n2 = name.clone();

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -279,14 +279,11 @@ pub fn append_line(desc: &mut AsOption<String>, mut line: String) {
 
     let desc = desc.0.get_or_insert_with(String::default);
 
-    match line.rfind("\\$") {
-        Some(i) => {
-            desc.push_str(line[..i].trim_end());
-            desc.push(' ');
-        },
-        None => {
-            desc.push_str(&line);
-            desc.push('\n');
-        },
+    if let Some(i) = line.rfind("\\$") {
+        desc.push_str(line[..i].trim_end());
+        desc.push(' ');
+    } else {
+        desc.push_str(&line);
+        desc.push('\n');
     }
 }

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -79,7 +79,7 @@ impl IdentExt2 for Ident {
 }
 
 #[inline]
-pub fn into_stream(e: Error) -> TokenStream {
+pub fn into_stream(e: &Error) -> TokenStream {
     e.to_compile_error().into()
 }
 
@@ -87,7 +87,7 @@ macro_rules! propagate_err {
     ($res:expr) => {{
         match $res {
             Ok(v) => v,
-            Err(e) => return $crate::util::into_stream(e),
+            Err(e) => return $crate::util::into_stream(&e),
         }
     }};
 }
@@ -176,7 +176,7 @@ impl ToTokens for Argument {
 }
 
 #[inline]
-pub fn generate_type_validation(have: Type, expect: Type) -> syn::Stmt {
+pub fn generate_type_validation(have: &Type, expect: &Type) -> syn::Stmt {
     parse_quote! {
         serenity::static_assertions::assert_type_eq_all!(#have, #expect);
     }
@@ -216,7 +216,7 @@ pub fn create_declaration_validations(fun: &mut CommandFun, dec_for: DeclarFor) 
 
     let mut spoof_or_check = |kind: Type, name: &str| {
         match fun.args.get(index) {
-            Some(x) => fun.body.insert(0, generate_type_validation(x.kind.clone(), kind)),
+            Some(x) => fun.body.insert(0, generate_type_validation(&x.kind, &kind)),
             None => fun.args.push(Argument {
                 mutable: None,
                 name: Ident::new(name, Span::call_site()),
@@ -249,8 +249,8 @@ pub fn create_declaration_validations(fun: &mut CommandFun, dec_for: DeclarFor) 
 }
 
 #[inline]
-pub fn create_return_type_validation(r#fn: &mut CommandFun, expect: Type) {
-    let stmt = generate_type_validation(r#fn.ret.clone(), expect);
+pub fn create_return_type_validation(r#fn: &mut CommandFun, expect: &Type) {
+    let stmt = generate_type_validation(&r#fn.ret, expect);
     r#fn.body.insert(0, stmt);
 }
 

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -29,7 +29,7 @@ impl CreateBotAuthParameters {
         if !self.scopes.is_empty() {
             valid_data.push((
                 "scope",
-                self.scopes.iter().map(|i| i.to_string()).collect::<Vec<_>>().join(" "),
+                self.scopes.iter().map(ToString::to_string).collect::<Vec<_>>().join(" "),
             ));
         }
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -194,8 +194,7 @@ impl<'a> CreateInteractionResponseData<'a> {
         let flags = self
             .0
             .get("flags")
-            .map(|f| f.as_u64().expect("Interaction response flag was not a number"))
-            .unwrap_or(0);
+            .map_or(0, |f| f.as_u64().expect("Interaction response flag was not a number"));
 
         let flags = if ephemeral {
             flags | InteractionApplicationCommandCallbackDataFlags::EPHEMERAL.bits()

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -81,7 +81,7 @@ impl<'a> CreateInteractionResponseData<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.1.extend(files.into_iter().map(|f| f.into()));
+        self.1.extend(files.into_iter().map(Into::into));
         self
     }
 
@@ -93,7 +93,7 @@ impl<'a> CreateInteractionResponseData<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.1 = files.into_iter().map(|f| f.into()).collect();
+        self.1 = files.into_iter().map(Into::into).collect();
         self
     }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -77,7 +77,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.1.extend(files.into_iter().map(|f| f.into()));
+        self.1.extend(files.into_iter().map(Into::into));
         self
     }
 
@@ -90,7 +90,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.1 = files.into_iter().map(|f| f.into()).collect();
+        self.1 = files.into_iter().map(Into::into).collect();
         self
     }
 

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -283,7 +283,7 @@ impl<'a> CreateMessage<'a> {
         &mut self,
         sticker_ids: It,
     ) -> &mut Self {
-        for sticker_id in sticker_ids.into_iter() {
+        for sticker_id in sticker_ids {
             self.add_sticker_id(sticker_id);
         }
 

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -186,7 +186,7 @@ impl<'a> CreateMessage<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.2.extend(files.into_iter().map(|f| f.into()));
+        self.2.extend(files.into_iter().map(Into::into));
         self
     }
 
@@ -199,7 +199,7 @@ impl<'a> CreateMessage<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.2 = files.into_iter().map(|f| f.into()).collect();
+        self.2 = files.into_iter().map(Into::into).collect();
         self
     }
 

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -315,6 +315,6 @@ impl<'a> Default for CreateMessage<'a> {
         let mut map = HashMap::new();
         map.insert("tts", Value::from(false));
 
-        CreateMessage(map, None, Default::default())
+        CreateMessage(map, None, Vec::default())
     }
 }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -132,7 +132,7 @@ impl<'a> ExecuteWebhook<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.1.extend(files.into_iter().map(|f| f.into()));
+        self.1.extend(files.into_iter().map(Into::into));
         self
     }
 
@@ -145,7 +145,7 @@ impl<'a> ExecuteWebhook<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.1 = files.into_iter().map(|f| f.into()).collect();
+        self.1 = files.into_iter().map(Into::into).collect();
         self
     }
 

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -307,6 +307,6 @@ impl<'a> Default for ExecuteWebhook<'a> {
         let mut map = HashMap::new();
         map.insert("tts", Value::from(false));
 
-        ExecuteWebhook(map, Default::default())
+        ExecuteWebhook(map, Vec::default())
     }
 }

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -192,13 +192,13 @@ impl CacheUpdate for GuildCreateEvent {
             }
         }
 
-        for pair in guild.channels.clone().into_iter() {
+        for pair in guild.channels.clone() {
             if let Channel::Guild(channel) = pair.1 {
                 cache.channels.insert(pair.0, channel);
             }
         }
 
-        for pair in guild.channels.clone().into_iter() {
+        for pair in guild.channels.clone() {
             if let Channel::Category(category) = pair.1 {
                 cache.categories.insert(pair.0, category);
             }

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -256,7 +256,7 @@ impl ShardManager {
     /// [`ShardRunner`]: super::ShardRunner
     #[instrument(skip(self))]
     pub async fn shards_instantiated(&self) -> Vec<ShardId> {
-        self.runners.lock().await.keys().cloned().collect()
+        self.runners.lock().await.keys().copied().collect()
     }
 
     /// Attempts to shut down the shard runner by Id.
@@ -310,7 +310,7 @@ impl ShardManager {
                 return;
             }
 
-            runners.keys().cloned().collect::<Vec<_>>()
+            runners.keys().copied().collect::<Vec<_>>()
         };
 
         info!("Shutting down all shards");

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -288,7 +288,7 @@ impl ShardManager {
             },
             Ok(None) => (),
             Err(why) => {
-                warn!("Failed to cleanly shutdown shard {}, reached timeout: {:?}", shard_id, why,)
+                warn!("Failed to cleanly shutdown shard {}, reached timeout: {:?}", shard_id, why);
             },
         }
 

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -272,11 +272,12 @@ impl ShardManager {
     #[instrument(skip(self))]
     #[allow(clippy::let_underscore_must_use)]
     pub async fn shutdown(&mut self, shard_id: ShardId, code: u16) {
+        const TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(5);
+
         info!("Shutting down shard {}", shard_id);
 
         let _ = self.shard_queuer.unbounded_send(ShardQueuerMessage::ShutdownShard(shard_id, code));
 
-        const TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(5);
         match timeout(TIMEOUT, self.shard_shutdown.next()).await {
             Ok(Some(shutdown_shard_id)) => {
                 if shutdown_shard_id != shard_id {

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -225,7 +225,7 @@ impl ShardQueuer {
                 return;
             }
 
-            runners.keys().cloned().collect::<Vec<_>>()
+            runners.keys().copied().collect::<Vec<_>>()
         };
 
         info!("Shutting down all shards");

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -387,17 +387,9 @@ impl ShardRunner {
                 },
                 ShardClientMessage::Manager(ShardManagerMessage::ShardUpdate {
                     ..
-                }) => {
-                    // nb: not sent here
-
-                    true
-                },
-                ShardClientMessage::Manager(ShardManagerMessage::ShutdownInitiated) => {
-                    // nb: not sent here
-
-                    true
-                },
-                ShardClientMessage::Manager(ShardManagerMessage::ShutdownFinished(_)) => {
+                })
+                | ShardClientMessage::Manager(ShardManagerMessage::ShutdownInitiated)
+                | ShardClientMessage::Manager(ShardManagerMessage::ShutdownFinished(_)) => {
                     // nb: not sent here
 
                     true

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -308,7 +308,7 @@ pub(crate) fn dispatch<'rec>(
                     },
                     other => {
                         handle_event(other, data, handler, runner_tx, shard_id, cache_and_http)
-                            .await
+                            .await;
                     },
                 }
             },

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -444,7 +444,7 @@ impl Future for ClientBuilder {
                     voice_manager,
                     cache_and_http,
                 })
-            }))
+            }));
         }
 
         self.fut.as_mut().unwrap().as_mut().poll(ctx)

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -779,12 +779,11 @@ impl Args {
         let before = self.offset;
         self.restore();
 
-        let pos = match self.iter::<T>().quoted().position(|res| res.is_ok()) {
-            Some(p) => p,
-            None => {
-                self.offset = before;
-                return Err(Error::Eos);
-            },
+        let pos = if let Some(p) = self.iter::<T>().quoted().position(|res| res.is_ok()) {
+            p
+        } else {
+            self.offset = before;
+            return Err(Error::Eos);
         };
 
         self.offset = pos;
@@ -827,12 +826,11 @@ impl Args {
         let before = self.offset;
         self.restore();
 
-        let pos = match self.iter::<T>().quoted().position(|res| res.is_ok()) {
-            Some(p) => p,
-            None => {
-                self.offset = before;
-                return Err(Error::Eos);
-            },
+        let pos = if let Some(p) = self.iter::<T>().quoted().position(|res| res.is_ok()) {
+            p
+        } else {
+            self.offset = before;
+            return Err(Error::Eos);
         };
 
         self.offset = pos;

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -349,7 +349,7 @@ impl Args {
                 Delimiter::Single(c) => message.contains(*c),
                 Delimiter::Multiple(s) => message.contains(s),
             })
-            .map(|delim| delim.to_str())
+            .map(Delimiter::to_str)
             .collect::<Vec<_>>();
 
         let args = if delims.is_empty() && !message.is_empty() {

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -542,7 +542,7 @@ impl Configuration {
         It: IntoIterator<Item = T>,
     {
         self.delimiters.clear();
-        self.delimiters.extend(delimiters.into_iter().map(|s| s.into()));
+        self.delimiters.extend(delimiters.into_iter().map(Into::into));
 
         self
     }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -431,9 +431,8 @@ fn nested_commands_search<'rec, 'a: 'rec>(
                     .await
                 {
                     return Some(command);
-                } else {
-                    break;
                 }
+                break;
             }
         }
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -817,7 +817,7 @@ pub fn searched_lowercase<'rec, 'a: 'rec>(
                         .options
                         .description
                         .as_ref()
-                        .map(|s| s.to_string())
+                        .map(ToString::to_string)
                         .unwrap_or_default(),
                     groups: vec![single_group],
                 });

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -895,13 +895,13 @@ pub async fn create_customised_help_data<'a>(
     }
 
     let strikethrough_command_tip = if msg.is_private() {
-        &help_options.strikethrough_commands_tip_in_dm
+        help_options.strikethrough_commands_tip_in_dm
     } else {
-        &help_options.strikethrough_commands_tip_in_guild
+        help_options.strikethrough_commands_tip_in_guild
     };
 
-    let description = if let Some(ref strikethrough_command_text) = strikethrough_command_tip {
-        format!("{}\n{}", &help_options.individual_command_tip, &strikethrough_command_text)
+    let description = if let Some(strikethrough_command_text) = strikethrough_command_tip {
+        format!("{}\n{}", help_options.individual_command_tip, strikethrough_command_text)
     } else {
         help_options.individual_command_tip.to_string()
     };
@@ -1064,11 +1064,11 @@ async fn send_single_command_embed(
                 embed.title(&command.name);
                 embed.colour(colour);
 
-                if let Some(ref desc) = command.description {
+                if let Some(desc) = command.description {
                     embed.description(desc);
                 }
 
-                if let Some(ref usage) = command.usage {
+                if let Some(usage) = command.usage {
                     let full_usage_text = if let Some(first_prefix) = command.group_prefixes.get(0)
                     {
                         format!("`{} {} {}`", first_prefix, command.name, usage)
@@ -1306,11 +1306,11 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
         );
     }
 
-    if let Some(ref description) = command.description {
+    if let Some(description) = command.description {
         let _ = writeln!(result, "**{}**: {}", help_options.description_label, description);
     };
 
-    if let Some(ref usage) = command.usage {
+    if let Some(usage) = command.usage {
         if let Some(first_prefix) = command.group_prefixes.get(0) {
             let _ = writeln!(
                 result,

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -373,7 +373,7 @@ fn nested_commands_search<'rec, 'a: 'rec>(
                         .sub_commands
                         .iter()
                         .find(|n| n.options.names.contains(&name_str))
-                        .cloned();
+                        .copied();
 
                     // If we found a sub-command, we replace the parent with
                     // it. This allows the help-system to extract information

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -358,7 +358,7 @@ fn nested_commands_search<'rec, 'a: 'rec>(
                                     .await
                             {
                                 similar_commands.push(SuggestedCommandName {
-                                    name: command_name.to_string(),
+                                    name: (*command_name).to_string(),
                                     levenshtein_distance,
                                 });
                             }
@@ -1423,7 +1423,7 @@ pub async fn plain(
             ref suggestions,
         } => help_description.replace("{}", &suggestions.join("`, `")),
         CustomisedHelpData::NoCommandFound {
-            ref help_error_message,
+            help_error_message,
         } => help_error_message.to_string(),
         CustomisedHelpData::GroupedCommands {
             ref help_description,

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -635,14 +635,11 @@ async fn fill_eligible_commands<'a>(
         let options = &command.options;
         let name = &options.names[0];
 
-        match &group_behaviour {
-            HelpBehaviour::Nothing => (),
-            _ => {
-                let name = format_command_name!(&group_behaviour, &name);
-                to_fill.command_names.push(name);
+        if group_behaviour != HelpBehaviour::Nothing {
+            let name = format_command_name!(&group_behaviour, &name);
+            to_fill.command_names.push(name);
 
-                continue;
-            },
+            continue;
         }
 
         let command_behaviour = check_command_behaviour(

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -551,7 +551,7 @@ fn nested_group_command_search<'rec, 'a: 'rec>(
                 });
             }
 
-            match nested_group_command_search(
+            if let Ok(found) = nested_group_command_search(
                 ctx,
                 msg,
                 group.options.sub_groups,
@@ -562,8 +562,7 @@ fn nested_group_command_search<'rec, 'a: 'rec>(
             )
             .await
             {
-                Ok(found) => return Ok(found),
-                Err(()) => (),
+                return Ok(found);
             }
         }
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -391,7 +391,7 @@ impl StandardFramework {
     /// it's not intended to be chained as the other commands are.
     pub fn group_remove(&mut self, group: &'static CommandGroup) {
         // Iterates through the vector and if a given group _doesn't_ match, we retain it
-        self.groups.retain(|&(g, _)| g != group)
+        self.groups.retain(|&(g, _)| g != group);
     }
 
     /// Specify the function that's called in case a command wasn't executed for one reason or

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -887,7 +887,7 @@ pub(crate) fn has_correct_roles(
         options
             .allowed_roles()
             .iter()
-            .flat_map(|r| roles.values().find(|role| *r == role.name))
+            .filter_map(|r| roles.values().find(|role| *r == role.name))
             .any(|g| member.roles.contains(&g.id))
     }
 }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -716,7 +716,7 @@ impl Framework for StandardFramework {
                                 v.push(Delimiter::Single(delim.chars().next().unwrap()));
                             } else {
                                 // This too.
-                                v.push(Delimiter::Multiple(delim.to_string()));
+                                v.push(Delimiter::Multiple((*delim).to_string()));
                             }
                         }
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -611,7 +611,7 @@ impl Framework for StandardFramework {
 
         let mut stream = Stream::new(&msg.content);
 
-        stream.take_while_char(|c| c.is_whitespace());
+        stream.take_while_char(char::is_whitespace);
 
         let prefix = parse::prefix(&ctx, &msg, &mut stream, &self.config).await;
 

--- a/src/framework/standard/parse/map.rs
+++ b/src/framework/standard/parse/map.rs
@@ -38,7 +38,7 @@ impl CommandMap {
                 map.max_length = std::cmp::max(len, map.max_length);
 
                 let name =
-                    if conf.case_insensitive { name.to_lowercase() } else { name.to_string() };
+                    if conf.case_insensitive { name.to_lowercase() } else { (*name).to_string() };
 
                 map.cmds.insert(name, (*cmd, sub_map.clone()));
             }

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -514,6 +514,7 @@ pub async fn command(
                     last = res;
                 }
             },
+            #[allow(clippy::items_after_statements)]
             Map::Prefixless(subgroups, commands) => {
                 is_prefixless = true;
 

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -37,13 +37,12 @@ fn permissions_in(
         return Permissions::all();
     }
 
-    let everyone = match roles.get(&RoleId(guild_id.0)) {
-        Some(everyone) => everyone,
-        None => {
-            tracing::error!("@everyone role is missing in guild {}", guild_id);
+    let everyone = if let Some(everyone) = roles.get(&RoleId(guild_id.0)) {
+        everyone
+    } else {
+        tracing::error!("@everyone role is missing in guild {}", guild_id);
 
-            return Permissions::empty();
-        },
+        return Permissions::empty();
     };
 
     let mut permissions = everyone.permissions;

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -220,7 +220,7 @@ pub async fn prefix<'a>(
     config: &Configuration,
 ) -> Option<Cow<'a, str>> {
     if let Some(id) = mention(stream, config) {
-        stream.take_while_char(|c| c.is_whitespace());
+        stream.take_while_char(char::is_whitespace);
 
         return Some(Cow::Borrowed(id));
     }
@@ -232,7 +232,7 @@ pub async fn prefix<'a>(
     }
 
     if config.with_whitespace.prefixes {
-        stream.take_while_char(|c| c.is_whitespace());
+        stream.take_while_char(char::is_whitespace);
     }
 
     prefix
@@ -299,7 +299,7 @@ fn try_parse<M: ParseMap>(
     f: impl Fn(&str) -> String,
 ) -> (String, Option<M::Storage>) {
     if by_space {
-        let n = f(stream.peek_until_char(|c| c.is_whitespace()));
+        let n = f(stream.peek_until_char(char::is_whitespace));
 
         let o = map.get(&n);
 
@@ -344,7 +344,7 @@ fn parse_cmd<'a>(
             stream.increment(n.len());
 
             if config.with_whitespace.commands {
-                stream.take_while_char(|c| c.is_whitespace());
+                stream.take_while_char(char::is_whitespace);
             }
 
             check_discrepancy(ctx, msg, config, &cmd.options).await.map_err(|e| {
@@ -383,7 +383,7 @@ fn parse_group<'a>(
             stream.increment(n.len());
 
             if config.with_whitespace.groups {
-                stream.take_while_char(|c| c.is_whitespace());
+                stream.take_while_char(char::is_whitespace);
             }
 
             check_discrepancy(ctx, msg, config, &group.options).await.map_err(|e| {
@@ -490,7 +490,7 @@ pub async fn command(
             if name == &n {
                 stream.increment(n.len());
 
-                stream.take_while_char(|c| c.is_whitespace());
+                stream.take_while_char(char::is_whitespace);
 
                 return Ok(Invoke::Help(name));
             }

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -231,10 +231,9 @@ impl TicketCounter {
                         action,
                         is_first_try: was_first_try,
                     });
-                } else {
-                    ticket_owner.tickets = 0;
-                    ticket_owner.set_time = now;
                 }
+                ticket_owner.tickets = 0;
+                ticket_owner.set_time = now;
             }
         }
 
@@ -277,12 +276,11 @@ impl TicketCounter {
                 action,
                 is_first_try: was_first_try,
             });
-        } else {
-            ticket_owner.awaiting = ticket_owner.awaiting.saturating_sub(1);
-            ticket_owner.tickets += 1;
-            ticket_owner.is_first_try = true;
-            ticket_owner.last_time = Some(now);
         }
+        ticket_owner.awaiting = ticket_owner.awaiting.saturating_sub(1);
+        ticket_owner.tickets += 1;
+        ticket_owner.is_first_try = true;
+        ticket_owner.last_time = Some(now);
 
         None
     }

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -88,7 +88,7 @@ impl Bucket {
             Self::User(counter) => counter.give(ctx, msg, msg.author.id.0).await,
             Self::Guild(counter) => {
                 if let Some(guild_id) = msg.guild_id {
-                    counter.give(ctx, msg, guild_id.0).await
+                    counter.give(ctx, msg, guild_id.0).await;
                 }
             },
             Self::Channel(counter) => counter.give(ctx, msg, msg.channel_id.0).await,
@@ -97,7 +97,7 @@ impl Bucket {
             #[cfg(feature = "cache")]
             Self::Category(counter) => {
                 if let Some(category_id) = msg.category_id(ctx) {
-                    counter.give(ctx, msg, category_id.0).await
+                    counter.give(ctx, msg, category_id.0).await;
                 }
             },
         }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -452,8 +452,7 @@ impl Shard {
         }
 
         let resume = num
-            .map(|x| x != close_codes::AUTHENTICATION_FAILED && self.session_id.is_some())
-            .unwrap_or(true);
+            .map_or(true, |x| x != close_codes::AUTHENTICATION_FAILED && self.session_id.is_some());
 
         Ok(Some(if resume {
             ShardAction::Reconnect(ReconnectType::Resume)

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -808,14 +808,14 @@ impl Shard {
 async fn connect(base_url: &str) -> Result<WsStream> {
     let url = build_gateway_url(base_url)?;
 
-    Ok(create_rustls_client(url).await?)
+    create_rustls_client(url).await
 }
 
 #[cfg(feature = "native_tls_backend_marker")]
 async fn connect(base_url: &str) -> Result<WsStream> {
     let url = build_gateway_url(base_url)?;
 
-    Ok(create_native_tls_client(url).await?)
+    create_native_tls_client(url).await
 }
 
 fn build_gateway_url(base: &str) -> Result<Url> {

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -361,14 +361,13 @@ impl Shard {
                 self.stage = ConnectionStage::Identifying;
 
                 return ShardAction::Identify;
-            } else {
-                warn!(
-                    "[Shard {:?}] Heartbeat during non-Handshake; auto-reconnecting",
-                    self.shard_info
-                );
-
-                return ShardAction::Reconnect(self.reconnection_type());
             }
+            warn!(
+                "[Shard {:?}] Heartbeat during non-Handshake; auto-reconnecting",
+                self.shard_info
+            );
+
+            return ShardAction::Reconnect(self.reconnection_type());
         }
 
         ShardAction::Heartbeat

--- a/src/gateway/ws_client_ext.rs
+++ b/src/gateway/ws_client_ext.rs
@@ -76,7 +76,7 @@ impl WebSocketGatewayClientExt for WsStream {
             ChunkGuildFilter::Query(query) => payload["d"]["query"] = json!(query),
             ChunkGuildFilter::UserIds(user_ids) => {
                 let ids = user_ids.iter().map(|x| x.0).collect::<Vec<u64>>();
-                payload["d"]["user_ids"] = json!(ids)
+                payload["d"]["user_ids"] = json!(ids);
             },
         };
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1175,7 +1175,7 @@ impl Http {
         user_id: Option<u64>,
         reaction_type: &ReactionType,
     ) -> Result<()> {
-        let user = user_id.map(|uid| uid.to_string()).unwrap_or_else(|| "@me".to_string());
+        let user = user_id.map_or_else(|| "@me".to_string(), |uid| uid.to_string());
 
         self.wind(204, Request {
             body: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2275,6 +2275,12 @@ impl Http {
     ///
     /// Does not require authentication.
     pub async fn get_active_maintenances(&self) -> Result<Vec<Maintenance>> {
+        #[derive(Deserialize)]
+        struct StatusResponse {
+            #[serde(default)]
+            scheduled_maintenances: Vec<Maintenance>,
+        }
+
         let response = self
             .request(Request {
                 body: None,
@@ -2283,12 +2289,6 @@ impl Http {
                 route: RouteInfo::GetActiveMaintenance,
             })
             .await?;
-
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            scheduled_maintenances: Vec<Maintenance>,
-        }
 
         let status: StatusResponse = response.json().await?;
         Ok(status.scheduled_maintenances)
@@ -3242,6 +3242,12 @@ impl Http {
     ///
     /// Does not require authentication.
     pub async fn get_unresolved_incidents(&self) -> Result<Vec<Incident>> {
+        #[derive(Deserialize)]
+        struct StatusResponse {
+            #[serde(default)]
+            incidents: Vec<Incident>,
+        }
+
         let response = self
             .request(Request {
                 body: None,
@@ -3251,12 +3257,6 @@ impl Http {
             })
             .await?;
 
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            incidents: Vec<Incident>,
-        }
-
         let status: StatusResponse = response.json().await?;
         Ok(status.incidents)
     }
@@ -3265,6 +3265,12 @@ impl Http {
     ///
     /// Does not require authentication.
     pub async fn get_upcoming_maintenances(&self) -> Result<Vec<Maintenance>> {
+        #[derive(Deserialize)]
+        struct StatusResponse {
+            #[serde(default)]
+            scheduled_maintenances: Vec<Maintenance>,
+        }
+
         let response = self
             .request(Request {
                 body: None,
@@ -3273,12 +3279,6 @@ impl Http {
                 route: RouteInfo::GetUpcomingMaintenances,
             })
             .await?;
-
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            scheduled_maintenances: Vec<Maintenance>,
-        }
 
         let status: StatusResponse = response.json().await?;
         Ok(status.scheduled_maintenances)

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -110,8 +110,8 @@ impl Ratelimiter {
     fn _new(client: Client, token: String) -> Self {
         Self {
             client,
-            global: Default::default(),
-            routes: Default::default(),
+            global: Arc::default(),
+            routes: Arc::default(),
             token,
         }
     }

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -261,26 +261,23 @@ impl Ratelimit {
             return;
         }
 
-        let reset = match self.reset {
-            Some(reset) => reset,
-            None => {
-                // We're probably in the past.
-                self.remaining = self.limit;
+        let reset = if let Some(reset) = self.reset {
+            reset
+        } else {
+            // We're probably in the past.
+            self.remaining = self.limit;
 
-                return;
-            },
+            return;
         };
 
-        let delay = match reset.duration_since(SystemTime::now()) {
-            Ok(delay) => delay,
-
+        let delay = if let Ok(delay) = reset.duration_since(SystemTime::now()) {
+            delay
+        } else {
             // if duration is negative (i.e. adequate time has passed since last call to this api)
-            Err(_) => {
-                if self.remaining() != 0 {
-                    self.remaining -= 1;
-                }
-                return;
-            },
+            if self.remaining() != 0 {
+                self.remaining -= 1;
+            }
+            return;
         };
 
         if self.remaining() == 0 {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1914,6 +1914,9 @@ impl<'a> RouteInfo<'a> {
             ),
             RouteInfo::EditChannel {
                 channel_id,
+            }
+            | RouteInfo::EditThread {
+                channel_id,
             } => (
                 LightMethod::Patch,
                 Route::ChannelsId(channel_id),
@@ -2087,13 +2090,6 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdStickersId(guild_id),
                 Cow::from(Route::guild_sticker(guild_id, sticker_id)),
             ),
-            RouteInfo::EditThread {
-                channel_id,
-            } => (
-                LightMethod::Patch,
-                Route::ChannelsId(channel_id),
-                Cow::from(Route::channel(channel_id)),
-            ),
             RouteInfo::EditVoiceState {
                 guild_id,
                 user_id,
@@ -2151,9 +2147,6 @@ impl<'a> RouteInfo<'a> {
                 Route::WebhooksId(webhook_id),
                 Cow::from(Route::webhook_with_token_optioned(webhook_id, token, wait)),
             ),
-            RouteInfo::GetActiveMaintenance => {
-                (LightMethod::Get, Route::None, Cow::from(Route::status_maintenances_active()))
-            },
             RouteInfo::GetAuditLogs {
                 action_type,
                 before,
@@ -2545,12 +2538,6 @@ impl<'a> RouteInfo<'a> {
             RouteInfo::GetStickerPacks => {
                 (LightMethod::Get, Route::StickerPacks, Cow::from(Route::sticker_packs()))
             },
-            RouteInfo::GetUnresolvedIncidents => {
-                (LightMethod::Get, Route::None, Cow::from(Route::status_incidents_unresolved()))
-            },
-            RouteInfo::GetUpcomingMaintenances => {
-                (LightMethod::Get, Route::None, Cow::from(Route::status_maintenances_upcoming()))
-            },
             RouteInfo::GetUser {
                 user_id,
             } => (LightMethod::Get, Route::UsersId, Cow::from(Route::user(user_id))),
@@ -2654,13 +2641,13 @@ impl<'a> RouteInfo<'a> {
                 Route::GuildsIdIntegrationsId(guild_id),
                 Cow::from(Route::guild_integration_sync(guild_id, integration_id)),
             ),
-            RouteInfo::StatusIncidentsUnresolved => {
+            RouteInfo::GetUnresolvedIncidents | RouteInfo::StatusIncidentsUnresolved => {
                 (LightMethod::Get, Route::None, Cow::from(Route::status_incidents_unresolved()))
             },
-            RouteInfo::StatusMaintenancesActive => {
+            RouteInfo::GetActiveMaintenance | RouteInfo::StatusMaintenancesActive => {
                 (LightMethod::Get, Route::None, Cow::from(Route::status_maintenances_active()))
             },
-            RouteInfo::StatusMaintenancesUpcoming => {
+            RouteInfo::GetUpcomingMaintenances | RouteInfo::StatusMaintenancesUpcoming => {
                 (LightMethod::Get, Route::None, Cow::from(Route::status_maintenances_upcoming()))
             },
             RouteInfo::UnpinMessage {

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -17,12 +17,12 @@ pub fn deserialize_errors<'de, D: Deserializer<'de>>(
 
     let mut errors = Vec::new();
 
-    loop_errors(map, &mut errors, Vec::new());
+    loop_errors(&map, &mut errors, &[]);
 
     Ok(errors)
 }
 
-fn loop_errors(value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: Vec<String>) {
+fn loop_errors(value: &Value, errors: &mut Vec<DiscordJsonSingleError>, path: &[String]) {
     for (key, looped) in value.as_object().expect("expected object").iter() {
         let object = looped.as_object().expect("expected object");
         if object.contains_key("_errors") {
@@ -34,7 +34,7 @@ fn loop_errors(value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: Vec
                 .to_owned();
             for error in found_errors {
                 let error_object = error.as_object().expect("expected object");
-                let mut object_path = path.clone();
+                let mut object_path = path.to_owned();
 
                 object_path.push(key.to_string());
 
@@ -57,9 +57,9 @@ fn loop_errors(value: Value, errors: &mut Vec<DiscordJsonSingleError>, path: Vec
             continue;
         }
 
-        let mut new_path = path.clone();
+        let mut new_path = path.to_owned();
         new_path.push(key.to_string());
 
-        loop_errors(looped.clone(), errors, new_path);
+        loop_errors(looped, errors, &new_path);
     }
 }

--- a/src/model/channel/attachment_type.rs
+++ b/src/model/channel/attachment_type.rs
@@ -67,11 +67,9 @@ impl<'a> AttachmentType<'a> {
             AttachmentType::Path(path) => {
                 Ok(path.file_name().map(|filename| filename.to_string_lossy().to_string()))
             },
-            AttachmentType::Image(url) => {
-                match url.path_segments().and_then(|segments| segments.last()) {
-                    Some(filename) => Ok(Some(filename.to_string())),
-                    None => Err(Error::Url(url.to_string())),
-                }
+            AttachmentType::Image(url) => match url.path_segments().and_then(Iterator::last) {
+                Some(filename) => Ok(Some(filename.to_string())),
+                None => Err(Error::Url(url.to_string())),
             },
         }
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1256,11 +1256,10 @@ impl MessageId {
     /// Returns a link referencing this message. When clicked, users will jump to the message.
     /// The link will be valid for messages in either private channels or guilds.
     pub fn link(&self, channel_id: ChannelId, guild_id: Option<GuildId>) -> String {
-        match guild_id {
-            Some(guild_id) => {
-                format!("https://discord.com/channels/{}/{}/{}", guild_id.0, channel_id.0, self.0)
-            },
-            None => format!("https://discord.com/channels/@me/{}/{}", channel_id.0, self.0),
+        if let Some(guild_id) = guild_id {
+            format!("https://discord.com/channels/{}/{}/{}", guild_id, channel_id, self)
+        } else {
+            format!("https://discord.com/channels/@me/{}/{}", channel_id, self)
         }
     }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -219,14 +219,13 @@ impl Message {
                 if self.author.id != cache.current_user_id() {
                     if self.is_private() {
                         return Err(Error::Model(ModelError::NotAuthor));
-                    } else {
-                        utils::user_has_perms_cache(
-                            cache,
-                            self.channel_id,
-                            self.guild_id,
-                            Permissions::MANAGE_MESSAGES,
-                        )?;
                     }
+                    utils::user_has_perms_cache(
+                        cache,
+                        self.channel_id,
+                        self.guild_id,
+                        Permissions::MANAGE_MESSAGES,
+                    )?;
                 }
             }
         }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -89,7 +89,7 @@ impl PrivateChannel {
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
-    pub async fn delete_messages<T: AsRef<MessageId>, It: IntoIterator<Item = T>>(
+    pub async fn delete_messages<T, It>(
         &self,
         http: impl AsRef<Http>,
         message_ids: It,

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -434,7 +434,7 @@ impl ReactionType {
                 ref name,
                 ..
             } => {
-                format!("{}:{}", name.as_ref().map_or("", |s| s.as_str()), id)
+                format!("{}:{}", name.as_ref().map_or("", String::as_str), id)
             },
             ReactionType::Unicode(ref unicode) => unicode.clone(),
         }
@@ -659,7 +659,7 @@ impl fmt::Display for ReactionType {
                 } else {
                     f.write_str("<:")?;
                 }
-                f.write_str(name.as_ref().map_or("", |s| s.as_str()))?;
+                f.write_str(name.as_ref().map_or("", String::as_str))?;
                 f.write_char(':')?;
                 fmt::Display::fmt(&id, f)?;
                 f.write_char('>')

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -221,20 +221,19 @@ impl Reaction {
     /// Returns [`Error::Http`] if the user that made the reaction is unable to be
     /// retrieved from the API.
     pub async fn user(&self, cache_http: impl CacheHttp) -> Result<User> {
-        match self.user_id {
-            Some(id) => id.to_user(cache_http).await,
-            None => {
-                // This can happen if only Http was passed to Message::react, even though
-                // "cache" was enabled.
-                #[cfg(feature = "cache")]
-                {
-                    if let Some(cache) = cache_http.cache() {
-                        return Ok(User::from(&cache.current_user()));
-                    }
+        if let Some(id) = self.user_id {
+            id.to_user(cache_http).await
+        } else {
+            // This can happen if only Http was passed to Message::react, even though
+            // "cache" was enabled.
+            #[cfg(feature = "cache")]
+            {
+                if let Some(cache) = cache_http.cache() {
+                    return Ok(User::from(&cache.current_user()));
                 }
+            }
 
-                Ok(cache_http.http().get_current_user().await?.into())
-            },
+            Ok(cache_http.http().get_current_user().await?.into())
         }
     }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -358,7 +358,7 @@ impl<'de> Deserialize<'de> for ReactionType {
                             }
 
                             if let Ok(emoji_id) = map.next_value::<EmojiId>() {
-                                id = Some(emoji_id)
+                                id = Some(emoji_id);
                             }
                         },
                         Field::Name => {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -318,10 +318,7 @@ impl Member {
     /// [Moderate Members]: Permissions::MODERATE_MEMBERS
     #[doc(alias = "timeout")]
     pub async fn enable_communication(&mut self, http: impl AsRef<Http>) -> Result<()> {
-        match self
-            .guild_id
-            .edit_member(&http, self.user.id, |member| member.enable_communication())
-            .await
+        match self.guild_id.edit_member(&http, self.user.id, EditMember::enable_communication).await
         {
             Ok(_) => {
                 self.communication_disabled_until = None;

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1897,13 +1897,12 @@ impl Guild {
             return Permissions::all();
         }
 
-        let everyone = match self.roles.get(&RoleId(self.id.0)) {
-            Some(everyone) => everyone,
-            None => {
-                error!("@everyone role ({}) missing in '{}'", self.id, self.name);
+        let everyone = if let Some(everyone) = self.roles.get(&RoleId(self.id.0)) {
+            everyone
+        } else {
+            error!("@everyone role ({}) missing in '{}'", self.id, self.name);
 
-                return Permissions::empty();
-            },
+            return Permissions::empty();
         };
 
         let mut permissions = everyone.permissions;
@@ -1976,12 +1975,11 @@ impl Guild {
         }
 
         // Start by retrieving the @everyone role's permissions.
-        let everyone = match roles.get(&RoleId(guild_id.0)) {
-            Some(everyone) => everyone,
-            None => {
-                error!("@everyone role missing in {}", guild_id,);
-                return Err(Error::Model(ModelError::RoleNotFound));
-            },
+        let everyone = if let Some(everyone) = roles.get(&RoleId(guild_id.0)) {
+            everyone
+        } else {
+            error!("@everyone role missing in {}", guild_id,);
+            return Err(Error::Model(ModelError::RoleNotFound));
         };
 
         // Create a base set of permissions, starting with `@everyone`s.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1050,13 +1050,12 @@ impl PartialGuild {
             return Ok(Permissions::all());
         }
 
-        let everyone = match self.roles.get(&RoleId(self.id.0)) {
-            Some(everyone) => everyone,
-            None => {
-                error!("@everyone role ({}) missing in '{}'", self.id, self.name,);
+        let everyone = if let Some(everyone) = self.roles.get(&RoleId(self.id.0)) {
+            everyone
+        } else {
+            error!("@everyone role ({}) missing in '{}'", self.id, self.name,);
 
-                return Ok(Permissions::empty());
-            },
+            return Ok(Permissions::empty());
         };
 
         let member = self.member(cache_http, &user_id).await?;

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -67,6 +67,7 @@ pub(crate) mod discriminator {
         deserializer.deserialize_any(DiscriminatorVisitor)
     }
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn serialize<S: Serializer>(value: &u16, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.collect_str(&format_args!("{:04}", value))
     }
@@ -126,6 +127,7 @@ pub(crate) mod discriminator {
             deserializer.deserialize_option(OptionalDiscriminatorVisitor)
         }
 
+        #[allow(clippy::trivially_copy_pass_by_ref)]
         pub fn serialize<S: Serializer>(
             value: &Option<u16>,
             serializer: S,

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -78,7 +78,7 @@ pub fn deserialize_options_with_resolved<'de, D: Deserializer<'de>>(
 ) -> StdResult<Vec<ApplicationCommandInteractionDataOption>, D::Error> {
     let mut options = Vec::deserialize(deserializer)?;
 
-    for option in options.iter_mut() {
+    for option in &mut options {
         loop_resolved(option, resolved);
     }
 
@@ -160,7 +160,7 @@ fn loop_resolved(
         options.resolved = try_resolve(value, options.kind, resolved);
     }
 
-    for option in options.options.iter_mut() {
+    for option in &mut options.options {
         loop_resolved(option, resolved);
     }
 }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -120,7 +120,7 @@ fn try_resolve(
 
             if let Some(user) = resolved.users.get(&UserId(id)) {
                 let user = user.to_owned();
-                let member = resolved.members.get(&UserId(id)).map(|m| m.to_owned());
+                let member = resolved.members.get(&UserId(id)).map(ToOwned::to_owned);
 
                 Some(ApplicationCommandInteractionDataOptionValue::User(user, member))
             } else {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -331,12 +331,12 @@ impl Webhook {
 
         let map = json::hashmap_to_json_map(execute_webhook.0);
 
-        if !execute_webhook.1.is_empty() {
+        if execute_webhook.1.is_empty() {
+            http.as_ref().execute_webhook(self.id.0, token, wait, &map).await
+        } else {
             http.as_ref()
                 .execute_webhook_with_files(self.id.0, token, wait, execute_webhook.1.clone(), &map)
                 .await
-        } else {
-            http.as_ref().execute_webhook(self.id.0, token, wait, &map).await
         }
     }
 

--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -123,8 +123,7 @@ impl std::error::Error for GuildChannelParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Http(e) => Some(e),
-            Self::NotFoundOrMalformed => None,
-            Self::NotAGuildChannel => None,
+            Self::NotFoundOrMalformed | Self::NotAGuildChannel => None,
         }
     }
 }
@@ -182,8 +181,7 @@ impl std::error::Error for ChannelCategoryParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Http(e) => Some(e),
-            Self::NotFoundOrMalformed => None,
-            Self::NotAChannelCategory => None,
+            Self::NotFoundOrMalformed | Self::NotAChannelCategory => None,
         }
     }
 }

--- a/src/utils/argument_convert/message.rs
+++ b/src/utils/argument_convert/message.rs
@@ -18,9 +18,8 @@ pub enum MessageParseError {
 impl std::error::Error for MessageParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Malformed => None,
             Self::Http(e) => Some(e),
-            Self::HttpNotAvailable => None,
+            Self::HttpNotAvailable | Self::Malformed => None,
         }
     }
 }

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -22,10 +22,10 @@ pub enum RoleParseError {
 impl std::error::Error for RoleParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            RoleParseError::NotInGuild => None,
-            RoleParseError::NotInCache => None,
             RoleParseError::Http(e) => Some(e),
-            RoleParseError::NotFoundOrMalformed => None,
+            RoleParseError::NotFoundOrMalformed
+            | RoleParseError::NotInGuild
+            | RoleParseError::NotInCache => None,
         }
     }
 }

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -306,7 +306,7 @@ fn clean_users(
                 let code_start = if has_exclamation { "<@!" } else { "<@" };
                 let to_replace = format!("{}{}>", code_start, &s[mention_start..mention_end]);
 
-                *s = s.replace(&to_replace, &replacement)
+                *s = s.replace(&to_replace, &replacement);
             } else {
                 let id = &s[mention_start..mention_end].to_string();
 

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1047,7 +1047,7 @@ impl<T: ToString> Add<T> for Content {
     type Output = Content;
 
     fn add(mut self, rhs: T) -> Content {
-        self.inner = self.inner + &rhs.to_string();
+        self.inner += &rhs.to_string();
 
         self
     }
@@ -1058,7 +1058,7 @@ impl<T: ToString> Add<T> for ContentModifier {
 
     fn add(self, rhs: T) -> Content {
         let mut nc = self.to_content();
-        nc.inner = nc.inner + &rhs.to_string();
+        nc.inner += &rhs.to_string();
 
         nc
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -297,15 +297,13 @@ pub fn parse_emoji(mention: impl AsRef<str>) -> Option<EmojiIdentifier> {
                 for y in mention[from..].chars() {
                     if y == '>' {
                         break;
-                    } else {
-                        id.push(y);
                     }
+                    id.push(y);
                 }
 
                 break;
-            } else {
-                name.push(x);
             }
+            name.push(x);
         }
 
         match id.parse::<u64>() {


### PR DESCRIPTION
It also fixes the current clippy warnings `single_match` and `needless_question_mark` on `next` branch.

There are much more lints like `must_use_candidate`, `similar_names` and `module_name_repetitions` which I ignored for this PR.