### PR TITLE
chore: remove `_marker` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,11 +193,8 @@ rustls_backend = [
     "reqwest/rustls-tls",
     "async-tungstenite/tokio-rustls-webpki-roots",
     "tokio",
-    "rustls_backend_marker",
     "bytes",
 ]
-# Marks that a Rustls backend is active
-rustls_backend_marker = []
 
 # - Native TLS Backends
 native_tls_backend = [
@@ -205,10 +202,7 @@ native_tls_backend = [
     "async-tungstenite/tokio-native-tls",
     "tokio",
     "bytes",
-    "native_tls_backend_marker",
 ]
-# Marks that a Native TLS backend is active
-native_tls_backend_marker = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 #[cfg(all(
     any(feature = "http", feature = "gateway"),
-    not(any(feature = "rustls_backend_marker", feature = "native_tls_backend_marker"))
+    not(any(feature = "rustls_backend", feature = "native_tls_backend"))
 ))]
 compile_error!(
     "You have the `http` or `gateway` feature enabled, \

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,8 +23,8 @@ use crate::http::HttpError;
 use crate::internal::prelude::*;
 #[cfg(all(
     feature = "gateway",
-    feature = "rustls_backend_marker",
-    not(feature = "native_tls_backend_marker")
+    feature = "rustls_backend",
+    not(feature = "native_tls_backend")
 ))]
 use crate::internal::ws_impl::RustlsError;
 use crate::model::ModelError;
@@ -111,8 +111,8 @@ pub enum Error {
     /// An error occurring in rustls
     #[cfg(all(
         feature = "gateway",
-        feature = "rustls_backend_marker",
-        not(feature = "native_tls_backend_marker")
+        feature = "rustls_backend",
+        not(feature = "native_tls_backend")
     ))]
     Rustls(RustlsError),
     /// An error from the `tungstenite` crate.
@@ -164,11 +164,7 @@ impl From<ModelError> for Error {
     }
 }
 
-#[cfg(all(
-    feature = "gateway",
-    feature = "rustls_backend_marker",
-    not(feature = "native_tls_backend_marker")
-))]
+#[cfg(all(feature = "gateway", feature = "rustls_backend", not(feature = "native_tls_backend")))]
 impl From<RustlsError> for Error {
     fn from(e: RustlsError) -> Error {
         Error::Rustls(e)
@@ -225,7 +221,7 @@ impl fmt::Display for Error {
             Error::Gateway(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "http")]
             Error::Http(inner) => fmt::Display::fmt(&inner, f),
-            #[cfg(all(feature = "gateway", not(feature = "native_tls_backend_marker")))]
+            #[cfg(all(feature = "gateway", not(feature = "native_tls_backend")))]
             Error::Rustls(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "gateway")]
             Error::Tungstenite(inner) => fmt::Display::fmt(&inner, f),
@@ -252,8 +248,8 @@ impl StdError for Error {
             Error::Http(inner) => Some(inner),
             #[cfg(all(
                 feature = "gateway",
-                feature = "rustls_backend_marker",
-                not(feature = "native_tls_backend_marker")
+                feature = "rustls_backend",
+                not(feature = "native_tls_backend")
             ))]
             Error::Rustls(inner) => Some(inner),
             #[cfg(feature = "gateway")]

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -23,9 +23,9 @@ use super::{
 use crate::client::bridge::gateway::ChunkGuildFilter;
 use crate::constants::{self, close_codes};
 use crate::internal::prelude::*;
-#[cfg(feature = "native_tls_backend_marker")]
+#[cfg(feature = "native_tls_backend")]
 use crate::internal::ws_impl::create_native_tls_client;
-#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
+#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 use crate::internal::ws_impl::create_rustls_client;
 use crate::model::{
     event::{Event, GatewayEvent},
@@ -806,14 +806,14 @@ impl Shard {
     }
 }
 
-#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
+#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 async fn connect(base_url: &str) -> Result<WsStream> {
     let url = build_gateway_url(base_url)?;
 
     Ok(create_rustls_client(url).await?)
 }
 
-#[cfg(feature = "native_tls_backend_marker")]
+#[cfg(feature = "native_tls_backend")]
 async fn connect(base_url: &str) -> Result<WsStream> {
     let url = build_gateway_url(base_url)?;
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3829,12 +3829,12 @@ impl Http {
     }
 }
 
-#[cfg(not(feature = "native_tls_backend_marker"))]
+#[cfg(not(feature = "native_tls_backend"))]
 fn configure_client_backend(builder: ClientBuilder) -> ClientBuilder {
     builder.use_rustls_tls()
 }
 
-#[cfg(feature = "native_tls_backend_marker")]
+#[cfg(feature = "native_tls_backend")]
 fn configure_client_backend(builder: ClientBuilder) -> ClientBuilder {
     builder.use_native_tls()
 }

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
+#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 use std::{error::Error as StdError, fmt, io::Error as IoError};
 
 use async_trait::async_trait;
@@ -84,7 +84,7 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Valu
 /// An error that occurred while connecting over rustls
 #[derive(Debug)]
 #[non_exhaustive]
-#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
+#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 pub enum RustlsError {
     /// WebPKI X.509 Certificate Validation Error.
     WebPKI,
@@ -94,14 +94,14 @@ pub enum RustlsError {
     Io(IoError),
 }
 
-#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
+#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 impl From<IoError> for RustlsError {
     fn from(e: IoError) -> Self {
         RustlsError::Io(e)
     }
 }
 
-#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
+#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 impl fmt::Display for RustlsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -114,7 +114,7 @@ impl fmt::Display for RustlsError {
     }
 }
 
-#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
+#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 impl StdError for RustlsError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
@@ -134,7 +134,7 @@ fn websocket_config() -> async_tungstenite::tungstenite::protocol::WebSocketConf
     }
 }
 
-#[cfg(all(feature = "rustls_backend_marker", not(feature = "native_tls_backend_marker")))]
+#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
 #[instrument]
 pub(crate) async fn create_rustls_client(url: Url) -> Result<WsStream> {
     let (stream, _) =
@@ -145,7 +145,7 @@ pub(crate) async fn create_rustls_client(url: Url) -> Result<WsStream> {
     Ok(stream)
 }
 
-#[cfg(feature = "native_tls_backend_marker")]
+#[cfg(feature = "native_tls_backend")]
 #[instrument]
 pub(crate) async fn create_native_tls_client(url: Url) -> Result<WsStream> {
     let (stream, _) =


### PR DESCRIPTION
Remnants of tokio 0.2 compatibility, which has been removed in #1780.