### PR TITLE
refactor: prefer "URL" over "URI"

### DIFF
--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -81,7 +81,7 @@ pub struct ShardQueuer {
     /// A copy of the client's voice manager.
     #[cfg(feature = "voice")]
     pub voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
-    /// A copy of the URI to use to connect to the gateway.
+    /// A copy of the URL to use to connect to the gateway.
     pub ws_url: Arc<Mutex<String>>,
     pub cache_and_http: Arc<CacheAndHttp>,
     pub intents: GatewayIntents,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -414,7 +414,7 @@ impl Future for ClientBuilder {
             });
 
             self.fut = Some(Box::pin(async move {
-                let url = Arc::new(Mutex::new(http.get_gateway().await?.url));
+                let ws_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 
                 let (shard_manager, shard_manager_worker) = {
                     ShardManager::new(ShardManagerOptions {
@@ -428,7 +428,7 @@ impl Future for ClientBuilder {
                         shard_total: 0,
                         #[cfg(feature = "voice")]
                         voice_manager: &voice_manager,
-                        ws_url: &url,
+                        ws_url: &ws_url,
                         cache_and_http: &cache_and_http,
                         intents,
                     })
@@ -436,7 +436,7 @@ impl Future for ClientBuilder {
                 };
 
                 Ok(Client {
-                    ws_uri: url,
+                    ws_url,
                     data,
                     shard_manager,
                     shard_manager_worker,
@@ -669,14 +669,14 @@ pub struct Client {
     /// connections.
     #[cfg(feature = "voice")]
     pub voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
-    /// URI that the client's shards will use to connect to the gateway.
+    /// URL that the client's shards will use to connect to the gateway.
     ///
     /// This is likely not important for production usage and is, at best, used
     /// for debugging.
     ///
     /// This is wrapped in an `Arc<Mutex<T>>` so all shards will have an updated
     /// value available.
-    pub ws_uri: Arc<Mutex<String>>,
+    pub ws_url: Arc<Mutex<String>>,
     /// A container for an optional cache and HTTP client.
     /// It also contains the cache update timeout.
     pub cache_and_http: Arc<CacheAndHttp>,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -9,7 +9,7 @@ pub const EMBED_MAX_COUNT: usize = 10;
 /// The maximum number of stickers in a message.
 pub const STICKER_MAX_COUNT: usize = 3;
 
-/// The gateway version used by the library. The gateway URI is retrieved via
+/// The gateway version used by the library. The gateway URL is retrieved via
 /// the REST API.
 pub const GATEWAY_VERSION: u8 = 10;
 

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -10,26 +10,26 @@
 //! > account when generating rate limits since it's the major parameter. The
 //! only current major parameters are `channel_id`, `guild_id` and `webhook_id`.
 //!
-//! This results in the two URIs of `GET /channels/4/messages/7` and
+//! This results in the two URLs of `GET /channels/4/messages/7` and
 //! `GET /channels/5/messages/8` being rate limited _separately_. However, the
-//! two URIs of `GET /channels/10/messages/11` and
+//! two URLs of `GET /channels/10/messages/11` and
 //! `GET /channels/10/messages/12` will count towards the "same ratelimit", as
-//! the major parameter - `10` is equivalent in both URIs' format.
+//! the major parameter - `10` is equivalent in both URLs' format.
 //!
 //! # Examples
 //!
-//! First: taking the first two URIs - `GET /channels/4/messages/7` and
+//! First: taking the first two URLs - `GET /channels/4/messages/7` and
 //! `GET /channels/5/messages/8` - and assuming both buckets have a `limit` of
-//! `10`, requesting the first URI will result in the response containing a
+//! `10`, requesting the first URL will result in the response containing a
 //! `remaining` of `9`. Immediately after - prior to buckets resetting -
-//! performing a request to the _second_ URI will also contain a `remaining` of
+//! performing a request to the _second_ URL will also contain a `remaining` of
 //! `9` in the response, as the major parameter - `channel_id` - is different
 //! in the two requests (`4` and `5`).
 //!
-//! Second: take for example the last two URIs. Assuming the bucket's `limit` is
-//! `10`, requesting the first URI will return a `remaining` of `9` in the
+//! Second: take for example the last two URLs. Assuming the bucket's `limit` is
+//! `10`, requesting the first URL will return a `remaining` of `9` in the
 //! response. Immediately after - prior to buckets resetting - performing a
-//! request to the _second_ URI will return a `remaining` of `8` in the
+//! request to the _second_ URL will return a `remaining` of `8` in the
 //! response, as the major parameter - `channel_id` - is equivalent for the two
 //! requests (`10`).
 //!

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -505,7 +505,7 @@ impl Route {
         limit: u8,
         after: Option<u64>,
     ) -> String {
-        let mut uri = api!(
+        let mut url = api!(
             "/channels/{}/messages/{}/reactions/{}?limit={}",
             channel_id,
             message_id,
@@ -514,10 +514,10 @@ impl Route {
         );
 
         if let Some(after) = after {
-            let _ = write!(uri, "&after={}", after);
+            let _ = write!(url, "&after={}", after);
         }
 
-        uri
+        url
     }
 
     pub fn channel_messages(channel_id: u64, query: Option<&str>) -> String {


### PR DESCRIPTION
Both variants are used in the code base currently. Because URL is more specific than URI and the one preferred by Discord too, that's what I went with.