### PR TITLE
refactor(Http): simplify constructor functions

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -221,7 +221,7 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
-    let http = Http::new_with_token(&token);
+    let http = Http::new(&token);
 
     // We will fetch your bot's owners and id
     let (owners, bot_id) = match http.get_current_application_info().await {

--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
 
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
-    let http = Http::new_with_token(&token);
+    let http = Http::new(&token);
 
     // We will fetch your bot's owners and id
     let (owners, _bot_id) = match http.get_current_application_info().await {

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -53,7 +53,7 @@ async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
-    let http = Http::new_with_token(&token);
+    let http = Http::new(&token);
 
     // We will fetch your bot's id.
     let bot_id = match http.get_current_user().await {

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -100,7 +100,7 @@ impl CreateChannel {
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Arc::new(Http::default());
+    /// #     let http = Arc::new(Http::new("token"));
     /// #     let mut guild = GuildId(0).to_partial_guild(&http).await?;
     /// use serenity::model::channel::{PermissionOverwrite, PermissionOverwriteType};
     /// use serenity::model::id::UserId;

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -35,7 +35,7 @@ use crate::model::id::StickerId;
 /// # use serenity::http::Http;
 /// # use std::sync::Arc;
 /// #
-/// # let http = Arc::new(Http::default());
+/// # let http = Arc::new(Http::new("token"));
 ///
 /// let channel_id = ChannelId(7);
 ///

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -16,7 +16,7 @@ use crate::model::id::ChannelId;
 /// # use serenity::{http::Http, model::id::ChannelId};
 /// #
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// #     let http = Http::default();
+/// #     let http = Http::new("token");
 /// #     let mut channel = ChannelId(0);
 /// // assuming a channel has already been bound
 /// if let Err(why) = channel.edit(&http, |c| c.name("new name").topic("a test topic")).await {
@@ -160,7 +160,7 @@ impl EditChannel {
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Arc::new(Http::default());
+    /// #     let http = Arc::new(Http::new("token"));
     /// #     let mut channel = ChannelId(0);
     /// use serenity::model::channel::{PermissionOverwrite, PermissionOverwriteType};
     /// use serenity::model::id::UserId;

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -54,7 +54,7 @@ impl EditGuild {
     /// # use serenity::{http::Http, model::id::GuildId};
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// #     let mut guild = GuildId(0).to_partial_guild(&http).await?;
     /// use serenity::utils;
     ///
@@ -239,7 +239,7 @@ impl EditGuild {
     /// # use serenity::{http::Http, model::id::GuildId};
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// #     let mut guild = GuildId(0).to_partial_guild(&http).await?;
     /// use serenity::model::guild::VerificationLevel;
     ///
@@ -273,7 +273,7 @@ impl EditGuild {
     /// # use serenity::{http::Http, model::id::GuildId};
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// #     let mut guild = GuildId(0).to_partial_guild(&http).await?;
     /// use serenity::model::guild::SystemChannelFlags;
     ///

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -35,7 +35,7 @@ use crate::model::Permissions;
 /// # use serenity::{model::id::{ChannelId, GuildId}, http::Http};
 /// # use std::sync::Arc;
 /// #
-/// # let http = Arc::new(Http::default());
+/// # let http = Arc::new(Http::new("token"));
 /// # let (channel_id, guild_id) = (ChannelId(1), GuildId(2));
 /// #
 /// // assuming a `channel_id` and `guild_id` has been bound

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -28,7 +28,7 @@ use crate::model::channel::MessageFlags;
 /// use serenity::utils::Colour;
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// # let http = Http::default();
+/// # let http = Http::new("token");
 /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
 /// let webhook = http.get_webhook_from_url(url).await?;
 ///
@@ -76,7 +76,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// # let webhook = http.get_webhook_with_token(0, "").await?;
     /// #
     /// let avatar_url = "https://i.imgur.com/KTs6whd.jpg";
@@ -103,7 +103,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// # let webhook = http.get_webhook_with_token(0, "").await?;
     /// #
     /// let execution = webhook.execute(&http, false, |w| w.content("foo")).await;
@@ -212,7 +212,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// # let webhook = http.get_webhook_with_token(0, "").await?;
     /// #
     /// let execution = webhook.execute(&http, false, |w| w.content("hello").tts(true)).await;
@@ -238,7 +238,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// # let webhook = http.get_webhook_with_token(0, "").await?;
     /// #
     /// let execution = webhook.execute(&http, false, |w| w.content("hello").username("hakase")).await;
@@ -265,7 +265,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # use serenity::model::channel::MessageFlags;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// # let webhook = http.get_webhook_with_token(0, "").await?;
     /// #
     /// let execution = webhook

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -29,7 +29,7 @@ use crate::model::id::MessageId;
 /// # use serenity::http::Http;
 /// #
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// # let http = Http::default();
+/// # let http = Http::new("token");
 /// use serenity::model::id::{ChannelId, MessageId};
 ///
 /// // you can then pass it into a function which retrieves messages:

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -65,7 +65,9 @@ use crate::CacheAndHttp;
 /// impl EventHandler for Handler {}
 /// impl RawEventHandler for Handler {}
 ///
-/// # let cache_and_http = Arc::new(CacheAndHttp::default());
+/// # let http = Arc::new(Http::new("token"));
+/// # let cache = Arc::new(Cache::default());
+/// # let cache_and_http = Arc::new(CacheAndHttp { http, cache });
 /// # let http = &cache_and_http.http;
 /// let gateway_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 /// let data = Arc::new(RwLock::new(TypeMap::new()));

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -65,10 +65,7 @@ use crate::CacheAndHttp;
 /// impl EventHandler for Handler {}
 /// impl RawEventHandler for Handler {}
 ///
-/// # let http = Arc::new(Http::new("token"));
-/// # #[cfg(feature = "cache")]
-/// # let cache = Arc::new(Cache::default());
-/// # let cache_and_http = Arc::new(CacheAndHttp { http, #[cfg(feature = "cache")] cache });
+/// # let cache_and_http: Arc<CacheAndHttp> = unimplemented!();
 /// # let http = &cache_and_http.http;
 /// let gateway_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 /// let data = Arc::new(RwLock::new(TypeMap::new()));

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -66,8 +66,9 @@ use crate::CacheAndHttp;
 /// impl RawEventHandler for Handler {}
 ///
 /// # let http = Arc::new(Http::new("token"));
+/// # #[cfg(feature = "cache")]
 /// # let cache = Arc::new(Cache::default());
-/// # let cache_and_http = Arc::new(CacheAndHttp { http, cache });
+/// # let cache_and_http = Arc::new(CacheAndHttp { http, #[cfg(feature = "cache")] cache });
 /// # let http = &cache_and_http.http;
 /// let gateway_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 /// let data = Arc::new(RwLock::new(TypeMap::new()));

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -111,7 +111,7 @@ impl ClientBuilder {
     /// a framework via the [`Self::framework`] or [`Self::framework_arc`] method,
     /// otherwise awaiting the builder will cause a panic.
     pub fn new(token: impl AsRef<str>) -> Self {
-        Self::_new(Http::new_with_token(token.as_ref()))
+        Self::_new(Http::new(token.as_ref()))
     }
 
     /// Construct a new builder with a [`Http`] instance to calls methods on
@@ -128,7 +128,7 @@ impl ClientBuilder {
     /// Sets a token for the bot. If the token is not prefixed "Bot ",
     /// this method will automatically do so.
     pub fn token(mut self, token: impl AsRef<str>) -> Self {
-        self.http = Some(Http::new_with_token(token.as_ref()));
+        self.http = Some(Http::new(token.as_ref()));
 
         self
     }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -113,7 +113,7 @@ impl Shard {
     /// # use serenity::model::gateway::GatewayIntents;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Arc::new(Http::default());
+    /// #     let http = Arc::new(Http::new("token"));
     /// let token = std::env::var("DISCORD_BOT_TOKEN")?;
     /// // retrieve the gateway response, which contains the URL to connect to
     /// let gateway = Arc::new(Mutex::new(http.get_gateway().await?.url));

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -32,7 +32,7 @@ use crate::{constants, utils};
 /// A builder for the underlying [`Http`] client that performs requests
 /// to Discord's HTTP API. If you do not need to use a proxy or do not
 /// need to disable the rate limiter, you can use [`Http::new`] or
-/// [`Http::new_with_token`] instead.
+/// [`Http::new_with_application_id`] instead.
 ///
 /// ## Example
 ///

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -587,7 +587,7 @@ impl Http {
     /// use serenity::json::json;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #    let http = Http::default();
+    /// #    let http = Http::new("token");
     /// let map = json!({
     ///     "name": "test",
     /// });
@@ -886,7 +886,7 @@ impl Http {
     /// use serenity::json::json;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #    let http = Http::default();
+    /// #    let http = Http::new("token");
     /// let channel_id = 81384788765712384;
     /// let map = json!({"name": "test"});
     ///
@@ -1083,7 +1083,7 @@ impl Http {
     /// use serenity::model::id::{ChannelId, MessageId};
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// let channel_id = ChannelId(7);
     /// let message_id = MessageId(8);
     ///
@@ -1233,7 +1233,7 @@ impl Http {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// // Due to the `delete_webhook` function requiring you to authenticate, you
     /// // must have set the token first.
-    /// let http = Http::default();
+    /// let http = Http::new("token");
     ///
     /// http.delete_webhook(245037420704169985).await?;
     /// Ok(())
@@ -1263,7 +1263,7 @@ impl Http {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
@@ -1902,7 +1902,7 @@ impl Http {
     /// use serenity::json::{json, prelude::*};
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let guild_id = 187450744427773963;
     /// let user_id = 150443906511667200;
     /// let value = json!({
@@ -1952,7 +1952,7 @@ impl Http {
     /// use serenity::json::{json, prelude::*};
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let guild_id = 187450744427773963;
     /// let value = json!({
     ///     "channel_id": "826929611849334784",
@@ -2004,7 +2004,7 @@ impl Http {
     /// use serenity::json::json;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let id = 245037420704169985;
     /// let image = serenity::utils::read_image("./webhook_img.png")?;
     /// let map = json!({
@@ -2047,7 +2047,7 @@ impl Http {
     /// use serenity::json::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let value = json!({"name": "new name"});
@@ -2113,7 +2113,7 @@ impl Http {
     /// use serenity::json::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let value = json!({"content": "test"});
@@ -2491,7 +2491,7 @@ impl Http {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// let channel_id = 81384788765712384;
     ///
     /// let webhooks = http.get_channel_webhooks(channel_id).await?;
@@ -2991,7 +2991,7 @@ impl Http {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let guild_id = 81384788765712384;
     ///
     /// let webhooks = http.get_guild_webhooks(guild_id).await?;
@@ -3024,7 +3024,7 @@ impl Http {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// use serenity::http::GuildPagination;
     /// use serenity::model::id::GuildId;
     ///
@@ -3333,7 +3333,7 @@ impl Http {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let id = 245037420704169985;
     /// let webhook = http.get_webhook(id).await?;
     /// #     Ok(())
@@ -3363,7 +3363,7 @@ impl Http {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
@@ -3396,7 +3396,7 @@ impl Http {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
 
     /// let webhook = http.get_webhook_from_url(url).await?;
@@ -3654,7 +3654,7 @@ impl Http {
     /// #
     /// # fn long_process() {}
     /// # fn main() -> Result<()> {
-    /// # let http = Arc::new(Http::default());
+    /// # let http = Arc::new(Http::new("token"));
     /// // Initiate typing (assuming http is `Arc<Http>`)
     /// let typing = http.start_typing(7)?;
     ///
@@ -3705,7 +3705,7 @@ impl Http {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # use serenity::http::Http;
     /// #
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// use serenity::{
     ///     http::{
     ///         routing::RouteInfo,
@@ -3756,7 +3756,7 @@ impl Http {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// use serenity::http::{
     ///     request::RequestBuilder,
     ///     routing::RouteInfo,

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -127,7 +127,7 @@ impl Ratelimiter {
     /// # use serenity::http::Http;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// let routes = http.ratelimiter.routes();
     /// let reader = routes.read().await;
     ///

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -31,7 +31,7 @@ use crate::internal::tokio::spawn_named;
 /// #
 /// # fn long_process() {}
 /// # fn main() -> Result<()> {
-/// # let http = Http::default();
+/// # let http = Http::new("token");
 /// // Initiate typing (assuming `http` is bound)
 /// let typing = Typing::start(Arc::new(http), 7)?;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub use crate::error::{Error, Result};
 use crate::http::Http;
 
 #[cfg(feature = "client")]
+#[non_exhaustive]
 pub struct CacheAndHttp {
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,6 @@ pub use crate::error::{Error, Result};
 use crate::http::Http;
 
 #[cfg(feature = "client")]
-#[non_exhaustive]
 pub struct CacheAndHttp {
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,6 @@ pub use crate::error::{Error, Result};
 use crate::http::Http;
 
 #[cfg(feature = "client")]
-#[derive(Clone, Default)]
 #[non_exhaustive]
 pub struct CacheAndHttp {
     #[cfg(feature = "cache")]

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -105,7 +105,7 @@ impl ChannelCategory {
     /// # async fn run() {
     /// #     use serenity::http::Http;
     /// #     use serenity::model::id::ChannelId;
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// #     let category = ChannelId(1234);
     /// category.edit(&http, |c| c.name("test").bitrate(86400)).await;
     /// # }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -56,7 +56,7 @@ impl ChannelId {
     /// use serenity::model::id::ChannelId;
     ///
     /// # async fn run() {
-    /// # let http = serenity::http::Http::default();
+    /// # let http = serenity::http::Http::new("token");
     /// let _successful = ChannelId(7).broadcast_typing(&http).await;
     /// # }
     /// ```
@@ -315,7 +315,7 @@ impl ChannelId {
     /// # async fn run() {
     /// #     use serenity::http::Http;
     /// #     use serenity::model::id::ChannelId;
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// #     let channel_id = ChannelId(1234);
     /// channel_id.edit(&http, |c| c.name("test").bitrate(64000)).await;
     /// # }
@@ -515,7 +515,7 @@ impl ChannelId {
     /// #
     /// # async fn run() {
     /// # let channel_id = ChannelId::default();
-    /// # let ctx = Http::default();
+    /// # let ctx = Http::new("token");
     /// use serenity::futures::StreamExt;
     /// use serenity::model::channel::MessagesIter;
     ///
@@ -670,7 +670,7 @@ impl ChannelId {
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() {
-    /// # let http = Arc::new(Http::default());
+    /// # let http = Arc::new(Http::new("token"));
     /// use serenity::model::id::ChannelId;
     ///
     /// let channel_id = ChannelId(7);
@@ -688,7 +688,7 @@ impl ChannelId {
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Arc::new(Http::default());
+    /// # let http = Arc::new(Http::new("token"));
     /// use serenity::model::id::ChannelId;
     /// use tokio::fs::File;
     ///
@@ -806,7 +806,7 @@ impl ChannelId {
     /// #
     /// # fn long_process() {}
     /// # fn main() -> Result<()> {
-    /// # let http = Arc::new(Http::default());
+    /// # let http = Arc::new(Http::new("token"));
     /// // Initiate typing (assuming http is `Arc<Http>`)
     /// let typing = ChannelId(7).start_typing(&http)?;
     ///
@@ -1274,7 +1274,7 @@ impl<H: AsRef<Http>> MessagesIter<H> {
     /// #
     /// # async fn run() {
     /// # let channel_id = ChannelId::default();
-    /// # let ctx = Http::default();
+    /// # let ctx = Http::new("token");
     /// use serenity::futures::StreamExt;
     /// use serenity::model::channel::MessagesIter;
     ///

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -226,7 +226,7 @@ impl GuildChannel {
     /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
     /// # use std::sync::Arc;
     /// #
-    /// #     let http = Arc::new(Http::default());
+    /// #     let http = Arc::new(Http::new("token"));
     /// #     let cache = Cache::default();
     /// #     let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
@@ -258,7 +258,7 @@ impl GuildChannel {
     /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
     /// # use std::sync::Arc;
     /// #
-    /// #   let http = Arc::new(Http::default());
+    /// #   let http = Arc::new(Http::new("token"));
     /// #   let cache = Cache::default();
     /// #   let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
@@ -500,7 +500,7 @@ impl GuildChannel {
     /// # use std::sync::Arc;
     /// # use serenity::{cache::Cache, http::Http, model::id::{ChannelId, UserId}};
     /// #
-    /// #     let http = Arc::new(Http::default());
+    /// #     let http = Arc::new(Http::new("token"));
     /// #     let cache = Cache::default();
     /// #     let (channel_id, user_id) = (ChannelId(0), UserId(0));
     /// #
@@ -550,7 +550,7 @@ impl GuildChannel {
     /// # use std::sync::Arc;
     /// # use serenity::{cache::Cache, http::Http, model::id::ChannelId};
     /// #
-    /// #     let http = Arc::new(Http::default());
+    /// #     let http = Arc::new(Http::new("token"));
     /// #     let cache = Cache::default();
     /// #     let channel_id = ChannelId(0);
     /// #
@@ -994,7 +994,7 @@ impl GuildChannel {
     /// # use std::sync::Arc;
     /// #
     /// # fn long_process() {}
-    /// # let http = Arc::new(Http::default());
+    /// # let http = Arc::new(Http::new("token"));
     /// # let cache = Cache::default();
     /// # let channel = cache
     /// #    .guild_channel(ChannelId(7))

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -348,7 +348,7 @@ impl PrivateChannel {
     /// # use std::sync::Arc;
     /// #
     /// # fn long_process() {}
-    /// # let http = Arc::new(Http::default());
+    /// # let http = Arc::new(Http::new("token"));
     /// # let cache = Cache::default();
     /// # let channel = cache.private_channel(ChannelId(7))
     /// #    .ok_or(ModelError::ItemMissing)?;

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -90,7 +90,7 @@ impl GuildId {
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # use serenity::http::Http;
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// # let user = UserId(1);
     /// // assuming a `user` has already been bound
     /// let _ = GuildId(81384788765712384).ban(&http, user, 4).await;
@@ -224,7 +224,7 @@ impl GuildId {
     ///
     /// # async fn run() {
     /// # use serenity::http::Http;
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// let _channel =
     ///     GuildId(7).create_channel(&http, |c| c.name("test").kind(ChannelType::Voice)).await;
     /// # }
@@ -968,7 +968,7 @@ impl GuildId {
     /// #
     /// # async fn run() {
     /// # let guild_id = GuildId::default();
-    /// # let ctx = Http::default();
+    /// # let ctx = Http::new("token");
     /// use serenity::futures::StreamExt;
     /// use serenity::model::guild::MembersIter;
     ///
@@ -1637,7 +1637,7 @@ impl<H: AsRef<Http>> MembersIter<H> {
     /// #
     /// # async fn run() {
     /// # let guild_id = GuildId::default();
-    /// # let ctx = Http::default();
+    /// # let ctx = Http::new("token");
     /// use serenity::futures::StreamExt;
     /// use serenity::model::guild::MembersIter;
     ///

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -728,7 +728,7 @@ impl ApplicationCommand {
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() {
-    /// # let http = Arc::new(Http::default());
+    /// # let http = Arc::new(Http::new("token"));
     /// use serenity::model::id::ApplicationId;
     /// use serenity::model::interactions::application_command::ApplicationCommand;
     ///
@@ -746,7 +746,7 @@ impl ApplicationCommand {
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() {
-    /// # let http = Arc::new(Http::default());
+    /// # let http = Arc::new(Http::new("token"));
     /// use serenity::model::id::ApplicationId;
     /// use serenity::model::interactions::application_command::{
     ///     ApplicationCommand,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -242,7 +242,7 @@ impl CurrentUser {
     /// # use serenity::model::user::CurrentUser;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// #     let mut user = CurrentUser::default();
     /// let avatar = serenity::utils::read_image("./avatar.png")?;
     ///
@@ -301,7 +301,7 @@ impl CurrentUser {
     /// #
     /// # async fn run() {
     /// #     let user = CurrentUser::default();
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// // assuming the user has been bound
     ///
     /// if let Ok(guilds) = user.guilds(&http).await {
@@ -360,7 +360,7 @@ impl CurrentUser {
     /// #
     /// # async fn run() {
     /// #     let user = CurrentUser::default();
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// use serenity::model::Permissions;
     ///
     /// // assuming the user has been bound
@@ -389,7 +389,7 @@ impl CurrentUser {
     /// #
     /// # async fn run() {
     /// #     let user = CurrentUser::default();
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// use serenity::model::Permissions;
     ///
     /// // assuming the user has been bound
@@ -441,7 +441,7 @@ impl CurrentUser {
     /// #
     /// # async fn run() {
     /// #     let user = CurrentUser::default();
-    /// #     let http = Http::default();
+    /// #     let http = Http::new("token");
     /// use serenity::model::oauth2::OAuth2Scope;
     /// use serenity::model::Permissions;
     ///

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -136,7 +136,7 @@ impl Webhook {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let mut webhook = http.get_webhook_from_url(url).await?;
     ///
@@ -175,7 +175,7 @@ impl Webhook {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let mut webhook = http.get_webhook_from_url(url).await?;
     ///
@@ -222,7 +222,7 @@ impl Webhook {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let mut webhook = http.get_webhook_from_url(url).await?;
     ///
@@ -263,7 +263,7 @@ impl Webhook {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let mut webhook = http.get_webhook_from_url(url).await?;
     ///
@@ -279,7 +279,7 @@ impl Webhook {
     /// # use serenity::http::Http;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let http = Http::default();
+    /// # let http = Http::new("token");
     /// use serenity::model::channel::Embed;
     ///
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";


### PR DESCRIPTION
This PR aims to clean up the different methods for creating a new `Http` instance.

Removals:
- `Http::new()`: Providing your own reqwest client seems like a niche use case where you can use `HttpBuilder` instead
- `Http::new_with_application_id()`: Creates an HTTP client without a token, so you won't be able to use it anyway
- `Http::default()`: Same as above

Renames:
- `Http::new_with_token()` -> `Http::new()`
- `Http::new_with_token_application_id()` -> `Http::new_with_application_id()`