### PR TITLE
feat: lift unnecessary `CacheHttp` requirements

### DIFF
--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -499,8 +499,8 @@ impl Member {
     /// And/or returns [`ModelError::ItemMissing`] if the "default channel" of the guild is not
     /// found.
     #[cfg(feature = "cache")]
-    pub fn permissions(&self, cache_http: impl CacheHttp + AsRef<Cache>) -> Result<Permissions> {
-        let perms_opt = cache_http
+    pub fn permissions(&self, cache: impl AsRef<Cache>) -> Result<Permissions> {
+        let perms_opt = cache
             .as_ref()
             .guild_field(self.guild_id, |guild| guild._member_permission_from_member(self));
 


### PR DESCRIPTION
This lifts the `CacheHttp` requirement for parameters where only the cache is used.