### PR TITLE
Revert #1759

### DIFF
--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -53,10 +53,7 @@ impl EditWebhookMessage {
         self
     }
 
-    /// Sets the components of this message. Requires an application-owned webhook, meaning
-    /// the webhook's `kind` field is set to [`WebhookType::Application`].
-    ///
-    /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
+    /// Sets the components of this message.
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -163,10 +163,7 @@ impl<'a> ExecuteWebhook<'a> {
         self
     }
 
-    /// Creates components for this message. Requires an application-owned webhook, meaning
-    /// the webhook's `kind` field is set to [`WebhookType::Application`].
-    ///
-    /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
+    /// Creates components for this message.
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
@@ -178,7 +175,7 @@ impl<'a> ExecuteWebhook<'a> {
         self
     }
 
-    /// Sets the components of this message. Requires an application-owned webhook. See [`ExecuteWebhook::components`] for details.
+    /// Sets the components of this message.
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
         self.0.insert("components", Value::Array(components.0));
         self


### PR DESCRIPTION
Now that #1811 has been merged, serenity allows message components to be used with regular webhooks, so the documentation should be reverted back to its previous state.