### PR TITLE
Update documentation around webhook components

### DIFF
--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -53,10 +53,12 @@ impl EditWebhookMessage {
         self
     }
 
-    /// Sets the components of this message. Requires an application-owned webhook, meaning
-    /// the webhook's `kind` field is set to [`WebhookType::Application`].
+    /// Creates components for this message. Requires an application-owned webhook, meaning either
+    /// the webhook's `kind` field is set to [`WebhookType::Application`], or it was created by an
+    /// application (and has kind [`WebhookType::Incoming`]).
     ///
     /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
+    /// [`WebhookType::Incoming`]: crate::model::webhook::WebhookType
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -163,10 +163,12 @@ impl<'a> ExecuteWebhook<'a> {
         self
     }
 
-    /// Creates components for this message. Requires an application-owned webhook, meaning
-    /// the webhook's `kind` field is set to [`WebhookType::Application`].
+    /// Creates components for this message. Requires an application-owned webhook, meaning either
+    /// the webhook's `kind` field is set to [`WebhookType::Application`], or it was created by an
+    /// application (and has kind [`WebhookType::Incoming`]).
     ///
     /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
+    /// [`WebhookType::Incoming`]: crate::model::webhook::WebhookType
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
@@ -178,7 +180,10 @@ impl<'a> ExecuteWebhook<'a> {
         self
     }
 
-    /// Sets the components of this message. Requires an application-owned webhook. See [`ExecuteWebhook::components`] for details.
+    /// Sets the components of this message. Requires an application-owned webhook. See
+    /// [`components`] for details.
+    ///
+    /// [`components`]: crate::builder::ExecuteWebhook::components
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
         self.0.insert("components", Value::Array(components.0));
         self


### PR DESCRIPTION
Since #1811 was merged, users can use webhook message components with webhooks of any kind, but only application-owned webhooks and those created by bots are able to correctly use them. This clarifies the docs around this to make them more precise.