### PR TITLE
Remove the `Error::Rustls` enum variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,12 +21,6 @@ use crate::gateway::GatewayError;
 #[cfg(feature = "http")]
 use crate::http::HttpError;
 use crate::internal::prelude::*;
-#[cfg(all(
-    feature = "gateway",
-    feature = "rustls_backend",
-    not(feature = "native_tls_backend")
-))]
-use crate::internal::ws_impl::RustlsError;
 use crate::model::ModelError;
 
 /// The common result type between most library functions.
@@ -108,13 +102,6 @@ pub enum Error {
     /// [`http`]: crate::http
     #[cfg(feature = "http")]
     Http(Box<HttpError>),
-    /// An error occurring in rustls
-    #[cfg(all(
-        feature = "gateway",
-        feature = "rustls_backend",
-        not(feature = "native_tls_backend")
-    ))]
-    Rustls(RustlsError),
     /// An error from the `tungstenite` crate.
     #[cfg(feature = "gateway")]
     Tungstenite(TungsteniteError),
@@ -161,13 +148,6 @@ impl From<ParseIntError> for Error {
 impl From<ModelError> for Error {
     fn from(e: ModelError) -> Error {
         Error::Model(e)
-    }
-}
-
-#[cfg(all(feature = "gateway", feature = "rustls_backend", not(feature = "native_tls_backend")))]
-impl From<RustlsError> for Error {
-    fn from(e: RustlsError) -> Error {
-        Error::Rustls(e)
     }
 }
 
@@ -221,8 +201,6 @@ impl fmt::Display for Error {
             Error::Gateway(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "http")]
             Error::Http(inner) => fmt::Display::fmt(&inner, f),
-            #[cfg(all(feature = "gateway", not(feature = "native_tls_backend")))]
-            Error::Rustls(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "gateway")]
             Error::Tungstenite(inner) => fmt::Display::fmt(&inner, f),
         }
@@ -246,12 +224,6 @@ impl StdError for Error {
             Error::Gateway(inner) => Some(inner),
             #[cfg(feature = "http")]
             Error::Http(inner) => Some(inner),
-            #[cfg(all(
-                feature = "gateway",
-                feature = "rustls_backend",
-                not(feature = "native_tls_backend")
-            ))]
-            Error::Rustls(inner) => Some(inner),
             #[cfg(feature = "gateway")]
             Error::Tungstenite(inner) => Some(inner),
             _ => None,


### PR DESCRIPTION
This error variant is no longer needed since the asynchronous
refactoring and is now covered by the `Error::Tungstenite` variant.