### PR TITLE
fix: pass parsed token to `Ratelimiter::new()`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -220,12 +220,14 @@ impl Http {
         let client = builder.build().expect("Cannot build reqwest::Client");
         let client2 = client.clone();
 
+        let token = parse_token(token);
+
         Http {
             client,
             ratelimiter: Ratelimiter::new(client2, token.to_string()),
             ratelimiter_disabled: false,
             proxy: None,
-            token: parse_token(token),
+            token,
             application_id: AtomicU64::new(0),
         }
     }


### PR DESCRIPTION
Fixes a regression caused by #1840 where `Ratelimiter::new()` receives the original token instead of the one prefixed with `Bot `.