### PR TITLE
Update methods and properties in `Permissions`

### DIFF
--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -108,7 +108,7 @@ impl CreateChannel {
     ///
     /// // Assuming a guild has already been bound.
     /// let permissions = vec![PermissionOverwrite {
-    ///     allow: Permissions::READ_MESSAGES,
+    ///     allow: Permissions::VIEW_CHANNEL,
     ///     deny: Permissions::SEND_TTS_MESSAGES,
     ///     kind: PermissionOverwriteType::Member(UserId(1234)),
     /// }];

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -168,7 +168,7 @@ impl EditChannel {
     ///
     /// // Assuming a channel has already been bound.
     /// let permissions = vec![PermissionOverwrite {
-    ///     allow: Permissions::READ_MESSAGES,
+    ///     allow: Permissions::VIEW_CHANNEL,
     ///     deny: Permissions::SEND_TTS_MESSAGES,
     ///     kind: PermissionOverwriteType::Member(UserId(1234)),
     /// }];

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -182,7 +182,7 @@ pub struct Cache {
     /// Note, however, that users are _not_ removed from the map on removal
     /// events such as [`GuildMemberRemove`][`GuildMemberRemoveEvent`], as other
     /// structs such as members or recipients may still exist.
-    pub users: DashMap<UserId, User>,
+    pub(crate) users: DashMap<UserId, User>,
     /// Queue of message IDs for each channel.
     ///
     /// This is simply a vecdeque so we can keep track of the order of messages

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -184,7 +184,7 @@ pub struct Cache {
     /// Note, however, that users are _not_ removed from the map on removal
     /// events such as [`GuildMemberRemove`][`GuildMemberRemoveEvent`], as other
     /// structs such as members or recipients may still exist.
-    pub(crate) users: DashMap<UserId, User>,
+    pub users: DashMap<UserId, User>,
     /// Queue of message IDs for each channel.
     ///
     /// This is simply a vecdeque so we can keep track of the order of messages

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -104,7 +104,7 @@ fn permissions_in(
     }
 
     if channel_id.0 == guild_id.0 {
-        permissions |= Permissions::READ_MESSAGES;
+        permissions |= Permissions::VIEW_CHANNEL;
     }
 
     // No SEND_MESSAGES => no message-sending-related actions
@@ -117,9 +117,9 @@ fn permissions_in(
             | Permissions::ATTACH_FILES);
     }
 
-    // If the permission does not have the `READ_MESSAGES` permission, then
+    // If the permission does not have the `VIEW_CHANNEL` permission, then
     // throw out actionable permissions.
-    if !permissions.contains(Permissions::READ_MESSAGES) {
+    if !permissions.contains(Permissions::VIEW_CHANNEL) {
         permissions &= !(Permissions::KICK_MEMBERS
             | Permissions::BAN_MEMBERS
             | Permissions::ADMINISTRATOR

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -724,7 +724,7 @@ impl Http {
     ///
     /// **Note**: Requires the [Create Invite] permission.
     ///
-    /// [Create Invite]: Permissions::CREATE_INVITE
+    /// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
     /// [docs]: https://discord.com/developers/docs/resources/channel#create-channel-invite
     pub async fn create_invite(
         &self,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -722,9 +722,9 @@ impl Http {
     ///
     /// All fields are optional.
     ///
-    /// **Note**: Requires the [Create Invite] permission.
+    /// **Note**: Requires the [Create Instant Invite] permission.
     ///
-    /// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
+    /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     /// [docs]: https://discord.com/developers/docs/resources/channel#create-channel-invite
     pub async fn create_invite(
         &self,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -74,13 +74,13 @@ impl ChannelId {
 
     /// Creates an invite leading to the given channel.
     ///
-    /// **Note**: Requires the [Create Invite] permission.
+    /// **Note**: Requires the [Create Instant Invite] permission.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
-    /// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
+    /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     pub async fn create_invite<F>(&self, http: impl AsRef<Http>, f: F) -> Result<RichInvite>
     where
         F: FnOnce(&mut CreateInvite) -> &mut CreateInvite,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -80,7 +80,7 @@ impl ChannelId {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
-    /// [Create Invite]: Permissions::CREATE_INVITE
+    /// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
     pub async fn create_invite<F>(&self, http: impl AsRef<Http>, f: F) -> Result<RichInvite>
     where
         F: FnOnce(&mut CreateInvite) -> &mut CreateInvite,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -166,7 +166,7 @@ impl GuildChannel {
 
     /// Creates an invite leading to the given channel.
     ///
-    /// **Note**: Requires the [Create Invite] permission.
+    /// **Note**: Requires the [Create Instant Invite] permission.
     ///
     /// # Examples
     ///

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -183,7 +183,7 @@ impl GuildChannel {
     ///
     /// Otherwise returns [`Error::Http`] if the current user lacks permission.
     ///
-    /// [Create Instant Invite]: Permissions::CREATE_INVITE
+    /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     #[inline]
     #[cfg(feature = "utils")]
     pub async fn create_invite<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<RichInvite>
@@ -197,7 +197,7 @@ impl GuildChannel {
                     cache,
                     self.id,
                     Some(self.guild_id),
-                    Permissions::CREATE_INVITE,
+                    Permissions::CREATE_INSTANT_INVITE,
                 )?;
             }
         }
@@ -1085,7 +1085,7 @@ impl GuildChannel {
                     .filter_map(|e| async move {
                         if self
                             .permissions_for_user(cache, e.0)
-                            .map(|p| p.contains(Permissions::READ_MESSAGES))
+                            .map(|p| p.contains(Permissions::VIEW_CHANNEL))
                             .unwrap_or(false)
                         {
                             Some(e.1.clone())

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -231,7 +231,7 @@ impl Member {
 
         for channel in guild.channels.values() {
             if let Channel::Guild(channel) = channel {
-                if guild.user_permissions_in(channel, member).ok()?.read_messages() {
+                if guild.user_permissions_in(channel, member).ok()?.view_channel() {
                     return Some(channel.clone());
                 }
             }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -286,7 +286,7 @@ impl Guild {
         let member = self.members.get(&uid)?;
         for channel in self.channels.values() {
             if let Channel::Guild(channel) = channel {
-                if self.user_permissions_in(channel, member).ok()?.read_messages() {
+                if self.user_permissions_in(channel, member).ok()?.view_channel() {
                     return Some(channel);
                 }
             }
@@ -305,7 +305,7 @@ impl Guild {
         for channel in self.channels.values() {
             if let Channel::Guild(channel) = channel {
                 for member in self.members.values() {
-                    if self.user_permissions_in(channel, member).ok()?.read_messages() {
+                    if self.user_permissions_in(channel, member).ok()?.view_channel() {
                         return Some(channel);
                     }
                 }
@@ -2037,7 +2037,7 @@ impl Guild {
 
         // The default channel is always readable.
         if channel.id.0 == guild_id.0 {
-            permissions |= Permissions::READ_MESSAGES;
+            permissions |= Permissions::VIEW_CHANNEL;
         }
 
         Self::remove_unusable_permissions(&mut permissions);
@@ -2133,9 +2133,9 @@ impl Guild {
                 | Permissions::ATTACH_FILES);
         }
 
-        // If the permission does not have the `READ_MESSAGES` permission, then
+        // If the permission does not have the `VIEW_CHANNEL` permission, then
         // throw out actionable permissions.
-        if !permissions.contains(Permissions::READ_MESSAGES) {
+        if !permissions.contains(Permissions::VIEW_CHANNEL) {
             *permissions &= !(Permissions::KICK_MEMBERS
                 | Permissions::BAN_MEMBERS
                 | Permissions::ADMINISTRATOR

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -77,7 +77,7 @@ impl Invite {
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`]
     /// if the current user does not have the required [permission].
     ///
-    /// [Create Invite]: Permissions::CREATE_INVITE
+    /// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
     /// [permission]: super::permissions
     #[inline]
     pub async fn create<F>(
@@ -97,7 +97,7 @@ impl Invite {
                     cache,
                     channel_id,
                     None,
-                    Permissions::CREATE_INVITE,
+                    Permissions::CREATE_INSTANT_INVITE,
                 )?;
             }
         }

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -70,14 +70,14 @@ impl Invite {
     /// See the documentation for the [`CreateInvite`] builder for information
     /// on how to use this and the default values that it provides.
     ///
-    /// Requires the [Create Invite] permission.
+    /// Requires the [Create Instant Invite] permission.
     ///
     /// # Errors
     ///
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`]
     /// if the current user does not have the required [permission].
     ///
-    /// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
+    /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     /// [permission]: super::permissions
     #[inline]
     pub async fn create<F>(

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -192,11 +192,11 @@ pub const PRESET_TEXT: Permissions = Permissions {
     bits: Permissions::ADD_REACTIONS.bits
         | Permissions::ATTACH_FILES.bits
         | Permissions::CHANGE_NICKNAME.bits
-        | Permissions::CREATE_INVITE.bits
+        | Permissions::CREATE_INSTANT_INVITE.bits
         | Permissions::EMBED_LINKS.bits
         | Permissions::MENTION_EVERYONE.bits
         | Permissions::READ_MESSAGE_HISTORY.bits
-        | Permissions::READ_MESSAGES.bits
+        | Permissions::VIEW_CHANNEL.bits
         | Permissions::SEND_MESSAGES.bits
         | Permissions::SEND_TTS_MESSAGES.bits
         | Permissions::USE_EXTERNAL_EMOJIS.bits,
@@ -233,7 +233,7 @@ bitflags::bitflags! {
         /// Allows for the creation of [`RichInvite`]s.
         ///
         /// [`RichInvite`]: super::invite::RichInvite
-        const CREATE_INVITE = 1 << 0;
+        const CREATE_INSTANT_INVITE = 1 << 0;
         /// Allows for the kicking of guild [member]s.
         ///
         /// [member]: super::guild::Member
@@ -266,11 +266,11 @@ bitflags::bitflags! {
         const VIEW_AUDIT_LOG = 1 << 7;
         /// Allows the use of priority speaking in voice channels.
         const PRIORITY_SPEAKER = 1 << 8;
-        // Allows the user to go live
+        // Allows the user to go live.
         const STREAM = 1 << 9;
-        /// Allows reading messages in a guild channel. If a user does not have
-        /// this permission, then they will not be able to see the channel.
-        const READ_MESSAGES = 1 << 10;
+        /// Allows guild members to view a channel, which includes reading
+        /// messages in text channels and joining voice channels.
+        const VIEW_CHANNEL = 1 << 10;
         /// Allows sending messages in a guild channel.
         const SEND_MESSAGES = 1 << 11;
         /// Allows the sending of text-to-speech messages in a channel.
@@ -346,7 +346,7 @@ bitflags::bitflags! {
         /// Allows for sending messages in threads
         const SEND_MESSAGES_IN_THREADS = 1 << 38;
         /// Allows for launching activities in a voice channel
-        const START_EMBEDDED_ACTIVITIES = 1 << 39;
+        const USE_EMBEDDED_ACTIVITIES = 1 << 39;
         /// Allows for timing out users to prevent them from sending or reacting to messages in
         /// chat and threads, and from speaking in voice and stage channels.
         const MODERATE_MEMBERS = 1 << 40;
@@ -361,7 +361,9 @@ generate_get_permission_names! {
     ban_members: "Ban Members",
     change_nickname: "Change Nickname",
     connect: "Connect",
-    create_invite: "Create Invite",
+    create_instant_invite: "Create Instant Invite",
+    create_private_threads: "Create Private Threads",
+    create_public_threads: "Create Public Threads",
     deafen_members: "Deafen Members",
     embed_links: "Embed Links",
     external_emojis: "Use External Emojis",
@@ -372,23 +374,28 @@ generate_get_permission_names! {
     manage_messages: "Manage Messages",
     manage_nicknames: "Manage Nicknames",
     manage_roles: "Manage Roles",
+    manage_threads: "Manage Threads",
     manage_webhooks: "Manage Webhooks",
     mention_everyone: "Mention Everyone",
+    moderate_members: "Moderate Members",
     move_members: "Move Members",
     mute_members: "Mute Members",
     priority_speaker: "Priority Speaker",
     read_message_history: "Read Message History",
     request_to_speak: "Request To Speak",
-    read_messages: "Read Messages",
     send_messages: "Send Messages",
+    send_messages_in_threads: "Send Messages in Threads",
     send_tts_messages: "Send TTS Messages",
     speak: "Speak",
     stream: "Stream",
+    use_embedded_activities: "Use Embedded Activities",
     use_external_emojis: "Use External Emojis",
     use_external_stickers: "Use External Stickers",
     use_slash_commands: "Use Slash Commands",
     use_vad: "Use Voice Activity",
-    view_audit_log: "View Audit Log"
+    view_audit_log: "View Audit Log",
+    view_channel: "View Channel",
+    view_guild_insights: "View Guild Insights"
 }
 
 #[cfg(feature = "model")]
@@ -449,6 +456,22 @@ impl Permissions {
         self.contains(Self::VIEW_AUDIT_LOG)
     }
 
+    /// Shorthand for checking that the set of permissions contains the
+    /// [View Channel] permission.
+    ///
+    /// [View Channel]: Self::VIEW_CHANNEL
+    pub fn view_channel(self) -> bool {
+        self.contains(Self::VIEW_CHANNEL)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
+    /// [View Guild Insights] permission.
+    ///
+    /// [View Guild Insights]: Self::VIEW_GUILD_INSIGHTS
+    pub fn view_guild_insights(self) -> bool {
+        self.contains(Self::VIEW_GUILD_INSIGHTS)
+    }
+
     /// Shorthand for checking that the set of permission contains the
     /// [Priority Speaker] permission.
     ///
@@ -466,11 +489,27 @@ impl Permissions {
     }
 
     /// Shorthand for checking that the set of permissions contains the
-    /// [Create Invite] permission.
+    /// [Create Instant Invite] permission.
     ///
-    /// [Create Invite]: Self::CREATE_INVITE
-    pub fn create_invite(self) -> bool {
-        self.contains(Self::CREATE_INVITE)
+    /// [Create Instant Invite]: Self::CREATE_INSTANT_INVITE
+    pub fn create_instant_invite(self) -> bool {
+        self.contains(Self::CREATE_INSTANT_INVITE)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
+    /// [Create Private Threads] permission.
+    ///
+    /// [Create Private Threads]: Self::CREATE_PRIVATE_THREADS
+    pub fn create_private_threads(self) -> bool {
+        self.contains(Self::CREATE_PRIVATE_THREADS)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
+    /// [Create Public Threads] permission.
+    ///
+    /// [Create Public Threads]: Self::CREATE_PUBLIC_THREADS
+    pub fn create_public_threads(self) -> bool {
+        self.contains(Self::CREATE_PUBLIC_THREADS)
     }
 
     /// Shorthand for checking that the set of permissions contains the
@@ -554,6 +593,14 @@ impl Permissions {
     }
 
     /// Shorthand for checking that the set of permissions contains the
+    /// [Manage Threads] permission.
+    ///
+    /// [Manage Threads]: Self::MANAGE_THREADS
+    pub fn manage_threads(self) -> bool {
+        self.contains(Self::MANAGE_THREADS)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
     /// [Manage Webhooks] permission.
     ///
     /// [Manage Webhooks]: Self::MANAGE_WEBHOOKS
@@ -567,6 +614,14 @@ impl Permissions {
     /// [Mention Everyone]: Self::MENTION_EVERYONE
     pub fn mention_everyone(self) -> bool {
         self.contains(Self::MENTION_EVERYONE)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
+    /// [Moderate Members] permission.
+    ///
+    /// [Moderate Members]: Self::MODERATE_MEMBERS
+    pub fn moderate_members(self) -> bool {
+        self.contains(Self::MODERATE_MEMBERS)
     }
 
     /// Shorthand for checking that the set of permissions contains the
@@ -594,19 +649,19 @@ impl Permissions {
     }
 
     /// Shorthand for checking that the set of permissions contains the
-    /// [Read Messages] permission.
-    ///
-    /// [Read Messages]: Self::READ_MESSAGES
-    pub fn read_messages(self) -> bool {
-        self.contains(Self::READ_MESSAGES)
-    }
-
-    /// Shorthand for checking that the set of permissions contains the
     /// [Send Messages] permission.
     ///
     /// [Send Messages]: Self::SEND_MESSAGES
     pub fn send_messages(self) -> bool {
         self.contains(Self::SEND_MESSAGES)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
+    /// [Send Messages in Threads] permission.
+    ///
+    /// [Send Messages in Threads]: Self::SEND_MESSAGES_IN_THREADS
+    pub fn send_messages_in_threads(self) -> bool {
+        self.contains(Self::SEND_MESSAGES_IN_THREADS)
     }
 
     /// Shorthand for checking that the set of permissions contains the
@@ -631,6 +686,14 @@ impl Permissions {
     /// [Request To Speak]: Self::REQUEST_TO_SPEAK
     pub fn request_to_speak(self) -> bool {
         self.contains(Self::REQUEST_TO_SPEAK)
+    }
+
+    /// Shorthand for checking that the set of permissions contains the
+    /// [Use Embedded Activities] permission.
+    ///
+    /// [Use Embedded Activities]: Self::USE_EMBEDDED_ACTIVITIES
+    pub fn use_embedded_activities(self) -> bool {
+        self.contains(Self::USE_EMBEDDED_ACTIVITIES)
     }
 
     /// Shorthand for checking that the set of permissions contains the

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -109,11 +109,11 @@ macro_rules! generate_get_permission_names {
 /// - [Attach Files]
 /// - [Change Nickname]
 /// - [Connect]
-/// - [Create Invite]
+/// - [Create Instant Invite]
 /// - [Embed Links]
 /// - [Mention Everyone]
 /// - [Read Message History]
-/// - [Read Messages]
+/// - [View Channel]
 /// - [Send Messages]
 /// - [Send TTS Messages]
 /// - [Speak]
@@ -133,11 +133,11 @@ macro_rules! generate_get_permission_names {
 /// [Attach Files]: Permissions::ATTACH_FILES
 /// [Change Nickname]: Permissions::CHANGE_NICKNAME
 /// [Connect]: Permissions::CONNECT
-/// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
+/// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
 /// [Embed Links]: Permissions::EMBED_LINKS
 /// [Mention Everyone]: Permissions::MENTION_EVERYONE
 /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-/// [Read Messages]: Permissions::VIEW_CHANNEL
+/// [View Channel]: Permissions::VIEW_CHANNEL
 /// [Send Messages]: Permissions::SEND_MESSAGES
 /// [Send TTS Messages]: Permissions::SEND_TTS_MESSAGES
 /// [Speak]: Permissions::SPEAK
@@ -168,11 +168,11 @@ pub const PRESET_GENERAL: Permissions = Permissions {
 /// - [Add Reactions]
 /// - [Attach Files]
 /// - [Change Nickname]
-/// - [Create Invite]
+/// - [Create Instant Invite]
 /// - [Embed Links]
 /// - [Mention Everyone]
 /// - [Read Message History]
-/// - [Read Messages]
+/// - [View Channel]
 /// - [Send Messages]
 /// - [Send TTS Messages]
 /// - [Use External Emojis]
@@ -180,11 +180,11 @@ pub const PRESET_GENERAL: Permissions = Permissions {
 /// [Add Reactions]: Permissions::ADD_REACTIONS
 /// [Attach Files]: Permissions::ATTACH_FILES
 /// [Change Nickname]: Permissions::CHANGE_NICKNAME
-/// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
+/// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
 /// [Embed Links]: Permissions::EMBED_LINKS
 /// [Mention Everyone]: Permissions::MENTION_EVERYONE
 /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-/// [Read Messages]: Permissions::VIEW_CHANNEL
+/// [View Channel]: Permissions::VIEW_CHANNEL
 /// [Send Messages]: Permissions::SEND_MESSAGES
 /// [Send TTS Messages]: Permissions::SEND_TTS_MESSAGES
 /// [Use External Emojis]: Permissions::USE_EXTERNAL_EMOJIS

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -133,11 +133,11 @@ macro_rules! generate_get_permission_names {
 /// [Attach Files]: Permissions::ATTACH_FILES
 /// [Change Nickname]: Permissions::CHANGE_NICKNAME
 /// [Connect]: Permissions::CONNECT
-/// [Create Invite]: Permissions::CREATE_INVITE
+/// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
 /// [Embed Links]: Permissions::EMBED_LINKS
 /// [Mention Everyone]: Permissions::MENTION_EVERYONE
 /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-/// [Read Messages]: Permissions::READ_MESSAGES
+/// [Read Messages]: Permissions::VIEW_CHANNEL
 /// [Send Messages]: Permissions::SEND_MESSAGES
 /// [Send TTS Messages]: Permissions::SEND_TTS_MESSAGES
 /// [Speak]: Permissions::SPEAK
@@ -148,11 +148,11 @@ pub const PRESET_GENERAL: Permissions = Permissions {
         | Permissions::ATTACH_FILES.bits
         | Permissions::CHANGE_NICKNAME.bits
         | Permissions::CONNECT.bits
-        | Permissions::CREATE_INVITE.bits
+        | Permissions::CREATE_INSTANT_INVITE.bits
         | Permissions::EMBED_LINKS.bits
         | Permissions::MENTION_EVERYONE.bits
         | Permissions::READ_MESSAGE_HISTORY.bits
-        | Permissions::READ_MESSAGES.bits
+        | Permissions::VIEW_CHANNEL.bits
         | Permissions::SEND_MESSAGES.bits
         | Permissions::SEND_TTS_MESSAGES.bits
         | Permissions::SPEAK.bits
@@ -180,11 +180,11 @@ pub const PRESET_GENERAL: Permissions = Permissions {
 /// [Add Reactions]: Permissions::ADD_REACTIONS
 /// [Attach Files]: Permissions::ATTACH_FILES
 /// [Change Nickname]: Permissions::CHANGE_NICKNAME
-/// [Create Invite]: Permissions::CREATE_INVITE
+/// [Create Invite]: Permissions::CREATE_INSTANT_INVITE
 /// [Embed Links]: Permissions::EMBED_LINKS
 /// [Mention Everyone]: Permissions::MENTION_EVERYONE
 /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-/// [Read Messages]: Permissions::READ_MESSAGES
+/// [Read Messages]: Permissions::VIEW_CHANNEL
 /// [Send Messages]: Permissions::SEND_MESSAGES
 /// [Send TTS Messages]: Permissions::SEND_TTS_MESSAGES
 /// [Use External Emojis]: Permissions::USE_EXTERNAL_EMOJIS

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -394,7 +394,7 @@ impl CurrentUser {
     ///
     /// // assuming the user has been bound
     /// let permissions =
-    ///     Permissions::READ_MESSAGES | Permissions::SEND_MESSAGES | Permissions::EMBED_LINKS;
+    ///     Permissions::VIEW_CHANNEL | Permissions::SEND_MESSAGES | Permissions::EMBED_LINKS;
     /// let url = match user.invite_url(&http, permissions).await {
     ///     Ok(v) => v,
     ///     Err(why) => {


### PR DESCRIPTION
What this pull request changes per the [Discord API Documentation](https://discord.com/developers/docs/topics/permissions):
- rename `CREATE_INVITE` to `CREATE_INSTANT_INVITE`
- rename `READ_MESSAGES` to `VIEW_CHANNEL`
- adds the `create_instant_invite`, `create_private_threads`, `create_public_threads`, `manage_threads`, `moderate_members`, `send_messages_in_threads`, `use_embedded_activities`, `view_channel`, and the `view_guild_insights` function to the `Permissions` impl