### PR TITLE
Add `Attachment` option type in Application Commands

### DIFF
--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -570,7 +570,7 @@ pub struct ApplicationCommandInteractionDataResolved {
     pub channels: HashMap<ChannelId, PartialChannel>,
     /// The resolved messages.
     pub messages: HashMap<MessageId, Message>,
-    /// The resolved partial attachments
+    /// The resolved attachments
     pub attachments: HashMap<AttachmentId, Attachment>,
 }
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -130,6 +130,15 @@ pub fn deserialize_messages_map<'de, D: Deserializer<'de>>(
 }
 
 #[cfg(feature = "unstable_discord_api")]
+pub fn deserialize_attachments_map<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> StdResult<HashMap<AttachmentId, Attachment>, D::Error> {
+    let map: HashMap<AttachmentId, Attachment> = Deserialize::deserialize(deserializer)?;
+
+    Ok(map)
+}
+
+#[cfg(feature = "unstable_discord_api")]
 pub fn deserialize_options<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<Vec<ApplicationCommandInteractionDataOption>, D::Error> {
@@ -210,6 +219,13 @@ fn try_resolve(
         },
         ApplicationCommandOptionType::Number => {
             Some(ApplicationCommandInteractionDataOptionValue::Number(value.as_f64()?))
+        },
+        ApplicationCommandOptionType::Attachment => {
+            let id = &AttachmentId(string?.parse().ok()?);
+
+            let attachment = resolved.attachments.get(id)?.to_owned();
+
+            Some(ApplicationCommandInteractionDataOptionValue::Attachment(attachment))
         },
         _ => None,
     }


### PR DESCRIPTION
Attachments are passed much like the other resolvable types, an id snowflake that matches to an object in the `resolved` table.

Tested as working against my current bot, could use another set of eyes.

Would resolve #1851