### PR TITLE
Deny broken and private intra doc links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,6 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Build docs
-        env:
-          RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links
         run: |
           cargo doc --no-deps --features collector,voice,unstable_discord_api
           cargo doc --no-deps -p command_attr

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: --cfg docsrs -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links
+          RUSTDOCFLAGS: --cfg docsrs
         run: |
           cargo doc --no-deps --features collector,voice,unstable_discord_api
           cargo doc --no-deps -p command_attr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 #![doc(html_root_url = "https://docs.rs/serenity/*")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rust_2018_idioms)]
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 #![deny(
     clippy::unwrap_used,
     clippy::non_ascii_literal,


### PR DESCRIPTION
`rustdoc::broken_intra_doc_links` is available since Rust 1.52