### PR TITLE
Improve binary message deserialization time by optimizing convert_ws_message

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -93,24 +93,6 @@ where
     Ok(simd_json::from_str(s)?)
 }
 
-#[cfg(all(feature = "gateway", not(feature = "simd-json")))]
-pub(crate) fn from_reader<R, T>(r: R) -> Result<T>
-where
-    T: DeserializeOwned,
-    R: std::io::Read,
-{
-    Ok(serde_json::from_reader(r)?)
-}
-
-#[cfg(all(feature = "gateway", feature = "simd-json"))]
-pub(crate) fn from_reader<R, T>(r: R) -> Result<T>
-where
-    T: DeserializeOwned,
-    R: std::io::Read,
-{
-    Ok(simd_json::from_reader(r)?)
-}
-
 #[cfg(not(feature = "simd-json"))]
 pub(crate) fn from_value<T>(v: Value) -> Result<T>
 where


### PR DESCRIPTION
I did some profiling earlier using callgrind then qcachegrind to analyze the output on a small program I wrote that mimics the startup of a bot. To test this, I used my own bot which has all privileged intents and the cache enabled and is in several servers with a few 100 people along with one server that has over 69,000 people.  Using this, I realized that a massive chunk of startup cost (a little over half by instruction count) was from the decompression of several rather large zlib-compressed binary payloads sent over the gateway for the Guild Create event. This occurred because the current implementation of ``convert_ws_message`` (assuming the simdjson feature is not enabled) uses serde's ``from_reader`` function. The reader passed into the function is a reader returned by flate2 to decompress the payload. However, ``from_reader`` appears to call the underlying reader's read function way more times than is necessary (10s of millions of times in my bot's case), which makes binary message deserialization within this function incredibly slow. ~~Unfortunately, there doesn't appear to be a way to reduce the amount of calls being made to the read function while still using ``from_reader``~~ (See other comments below), so this PR makes it so that ``convert_ws_message`` allocates a String and reads the reader into it. Then, instead of using ``from_reader``, ``from_str`` is used. Because this was the only usage of ``from_reader ``, this PR also removes that function, which is pub(crate). The callgrind outputs showed a reduction in instruction count by a factor of roughly 3 for the entirety of the aforementioned program as a result of this optimization.

If anyone is curious about the program I used to mimic startup, here it is:
``` rust
use std::sync::Arc;

use once_cell::sync::OnceCell;
use serenity::client::bridge::gateway::ShardManager;
use serenity::client::{Context, EventHandler};
use serenity::framework::StandardFramework;
use serenity::model::id::GuildId;
use serenity::prelude::{GatewayIntents, Mutex};
use serenity::{async_trait, Client};
use simplelog::{ConfigBuilder, LevelFilter, SimpleLogger};

struct TestEventHandler;

static SHARD_MANAGER: OnceCell<Arc<Mutex<ShardManager>>> = OnceCell::new();

#[async_trait]
impl EventHandler for TestEventHandler {
    async fn cache_ready(&self, _ctx: Context, _guilds: Vec<GuildId>) {
        let mut lock = SHARD_MANAGER.get().unwrap().lock().await;

        lock.shutdown_all().await;
    }
}

#[tokio::main]
async fn main() -> serenity::Result<()> {
    let token = include_str!(".env");
    let framework = StandardFramework::new();
    let mut client = Client::builder(token, GatewayIntents::all())
        .framework(framework)
        .event_handler(TestEventHandler)
        .await
        .expect("Couldn't build client.");

    SHARD_MANAGER
        .try_insert(client.shard_manager.clone())
        .unwrap();

    SimpleLogger::init(LevelFilter::Warn, ConfigBuilder::new().build()).unwrap();

    client.start().await
}
```


I've also attached the callgrind outputs when I ran it using my bot. Both callgrind outputs take into account the changes made in #1870 even though it hasn't been merged yet.  

Before this change: [callgrind.out-before.txt](https://github.com/serenity-rs/serenity/files/8551436/callgrind.out-before.txt)

After this change: [callgrind.out-after.txt](https://github.com/serenity-rs/serenity/files/8551438/callgrind.out-after.txt)

Final notes: This will likely increase the peak memory usage of ``serenity`` on startup because decompressed websocket binary messages are allocated into a temporary String. For a Create Guild event when all privileged intents are enabled, which should be the worst case scenario in terms of payload size, this could be up to roughly 30 MBs for a guild that is near the capacity before guild data must be chunked.