### PR TITLE
Update `simd-json` to 0.4.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde-value = "0.7"
 async-trait = "0.1.9"
 
 [dependencies.simd-json]
-version = "0.4"
+version = "0.4.14"
 optional = true
 
 [dependencies.tracing]


### PR DESCRIPTION
This version includes a fix for a deserialization issue with newtype
structs and `simd_json::value::owned::Value`.

The ID types and `utils::Colour` deserialization fails on gateway
events because the payload is deserialized as `json::Value` before it is
deserialized into the actual type.

See: #1869 