### PR TITLE
Add `SUPPRESS_EMBEDS` flag for interaction response messages

### DIFF
--- a/src/model/interactions/mod.rs
+++ b/src/model/interactions/mod.rs
@@ -203,6 +203,8 @@ bitflags! {
     /// The flags for an interaction response.
     #[derive(Default)]
     pub struct InteractionApplicationCommandCallbackDataFlags: u64 {
+        /// Do not include any embeds when serializing this message.
+        const SUPPRESS_EMBEDS = 1 << 2;
         /// Interaction message will only be visible to sender and will
         /// be quickly deleted.
         const EPHEMERAL = 1 << 6;


### PR DESCRIPTION
> message flags combined as a bitfield (only SUPPRESS_EMBEDS and EPHEMERAL can be set)

See: [receiving-and-responding#interaction-response-object-messages]

[receiving-and-responding#interaction-response-object-messages]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-messages