### PR TITLE
Fix lifetimes on interaction response methods

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -30,9 +30,9 @@ impl<'a> CreateInteractionResponse<'a> {
     /// Sets the `InteractionApplicationCommandCallbackData` for the message.
     pub fn interaction_response_data<F>(&mut self, f: F) -> &mut Self
     where
-        for<'b, 'c> F: FnOnce(
-            &'b mut CreateInteractionResponseData<'c>,
-        ) -> &'b mut CreateInteractionResponseData<'c>,
+        for<'b> F: FnOnce(
+            &'b mut CreateInteractionResponseData<'a>,
+        ) -> &'b mut CreateInteractionResponseData<'a>,
     {
         let mut data = CreateInteractionResponseData::default();
         f(&mut data);

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -98,10 +98,14 @@ impl ApplicationCommandInteraction {
     /// [`Error::Model`]: crate::error::Error::Model
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_interaction_response<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
+    pub async fn create_interaction_response<'a, F>(
+        &self,
+        http: impl AsRef<Http>,
+        f: F,
+    ) -> Result<()>
     where
-        for<'a, 'b> F:
-            FnOnce(&'a mut CreateInteractionResponse<'b>) -> &'a mut CreateInteractionResponse<'b>,
+        for<'b> F:
+            FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>,
     {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);


### PR DESCRIPTION
#1808 added support for attachments on initial interaction responses. Unfortunately, the lifetimes were subtly wrong, locking users out of using any lifetime other than `'static` in `AttachmentType<'a>`.

Specifically, the response builder callback bound said:
```rust
for<'b, 'c> F: FnOnce(
    &'b mut CreateInteractionResponseData<'c>,
) -> &'b mut CreateInteractionResponseData<'c>,
```

Which means "this callback must be compatible with _any_ 'b and 'c", where 'c is the lifetime of `AttachmentType<'c>` stored inside `CreateInteractionResponseData`. In other words, attachments added by the user must conform to any possible lifetime, which means they must be 'static.

This PR fixes the oversight by changing the lifetimes:
```rust
for<'b> F: FnOnce(
    &'b mut CreateInteractionResponseData<'a>,
) -> &'b mut CreateInteractionResponseData<'a>,
```

Where 'a is an outer lifetime chosen by the user