### PR TITLE
Use `Cow` in `utils/content_safe.rs` to save on allocations

### DIFF
--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -225,7 +225,7 @@ fn clean_mention(
         },
         Mention::Role(id) => id
             .to_role_cached(&cache)
-            .map_or_else(|| "@deleted-role".into(), |role| format!("@{}", role.name).into()),
+            .map_or(Cow::Borrowed("@deleted-role"), |role| format!("@{}", role.name).into()),
         Mention::User(id) => {
             if let Some(guild_id) = options.guild_reference {
                 if let Some(guild) = cache.guild(&guild_id) {
@@ -253,7 +253,7 @@ fn clean_mention(
                 .as_ref()
                 .map(get_username)
                 .or_else(|| users.iter().find(|u| u.id == id).map(get_username))
-                .unwrap_or_else(|| "@invalid-user".into())
+                .unwrap_or(Cow::Borrowed("@invalid-user"))
         },
         Mention::Emoji(_, _) => unreachable!(),
     }


### PR DESCRIPTION
Some unnecesary allocations were being done converting `&'static str` to `String` in `clean_mention`. Changing the return type to `Cow` lets us avoid these. Since content_safe might potentially be a hot code path in some cases, saving on allocations is a good thing.