### PR TITLE
Use `dashmap` 5.2.0 for the MSRV build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,10 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
+      # dashmap 5.3+ MSRV is 1.59
+      - name: Pin dashmap to 5.2.0
+        run: cargo update -p dashmap --precise 5.2.0
+
       - name: Check
         run: cargo check --features collector,unstable_discord_api
 


### PR DESCRIPTION
`dashmap` 5.3+ MSRV is 1.59 and depends on `hashbrown` 0.12 (MSRV 1.56 + edition2021)

see failed build job: https://github.com/nickelc/serenity/runs/6240254476