### PR TITLE
Remove duplicate WS client creation for native/rustls backends

### DIFF
--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -78,31 +78,16 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Valu
     })
 }
 
-#[cfg(any(feature = "rustls_backend", feature = "native_tls_backend"))]
-fn websocket_config() -> async_tungstenite::tungstenite::protocol::WebSocketConfig {
-    async_tungstenite::tungstenite::protocol::WebSocketConfig {
+#[instrument]
+pub(crate) async fn create_client(url: Url) -> Result<WsStream> {
+    let config = async_tungstenite::tungstenite::protocol::WebSocketConfig {
         max_message_size: None,
         max_frame_size: None,
         max_send_queue: None,
         accept_unmasked_frames: false,
-    }
-}
-
-#[cfg(all(feature = "rustls_backend", not(feature = "native_tls_backend")))]
-#[instrument]
-pub(crate) async fn create_rustls_client(url: Url) -> Result<WsStream> {
+    };
     let (stream, _) =
-        async_tungstenite::tokio::connect_async_with_config::<Url>(url, Some(websocket_config()))
-            .await?;
-
-    Ok(stream)
-}
-
-#[cfg(feature = "native_tls_backend")]
-#[instrument]
-pub(crate) async fn create_native_tls_client(url: Url) -> Result<WsStream> {
-    let (stream, _) =
-        async_tungstenite::tokio::connect_async_with_config(url, Some(websocket_config())).await?;
+        async_tungstenite::tokio::connect_async_with_config(url, Some(config)).await?;
 
     Ok(stream)
 }


### PR DESCRIPTION
The creation of the websocket client for both tls backends is identical
and can be merged into a single code path.