### PR TITLE
Initial application command permissions v2

### DIFF
--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -9,6 +9,7 @@ use crate::model::interactions::application_command::{
     ApplicationCommandOptionType,
     ApplicationCommandType,
 };
+use crate::model::Permissions;
 
 /// A builder for creating a new [`ApplicationCommandOption`].
 ///
@@ -206,10 +207,25 @@ impl CreateApplicationCommand {
         self
     }
 
+    /// Specifies the default permissions required to execute the command.
+    pub fn default_member_permissions(&mut self, permissions: Permissions) -> &mut Self {
+        self.0.insert("default_member_permissions", Value::from(permissions.bits().to_string()));
+
+        self
+    }
+
+    /// Specifies if the command is available in DMs.
+    pub fn dm_permission(&mut self, enabled: bool) -> &mut Self {
+        self.0.insert("dm_permission", Value::from(enabled));
+
+        self
+    }
+
     /// Specifies if the command should not be usable by default
     ///
     /// **Note**: Setting it to false will disable it for anyone,
     /// including administrators and guild owners.
+    #[deprecated(note = "replaced by `default_member_permissions`")]
     pub fn default_permission(&mut self, default_permission: bool) -> &mut Self {
         self.0.insert("default_permission", Value::from(default_permission));
 

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -352,6 +352,18 @@ async fn handle_event(
                 event_handler.shard_stage_update(context, event).await;
             });
         },
+        DispatchEvent::Model(Event::ApplicationCommandPermissionsUpdate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            spawn_named(
+                "dispatch::event_handler::application_command_permissions_update",
+                async move {
+                    event_handler
+                        .application_command_permissions_update(context, event.permission)
+                        .await;
+                },
+            );
+        },
         DispatchEvent::Model(Event::ChannelCreate(mut event)) => {
             update(&cache_and_http, &mut event);
             match event.channel {

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -5,12 +5,23 @@ use async_trait::async_trait;
 use super::context::Context;
 use crate::client::bridge::gateway::event::*;
 use crate::json::Value;
+use crate::model::interactions::application_command::ApplicationCommandPermission;
 use crate::model::interactions::Interaction;
 use crate::model::prelude::*;
 
 /// The core trait for handling events by serenity.
 #[async_trait]
 pub trait EventHandler: Send + Sync {
+    /// Dispatched when the permissions of an application command was updated.
+    ///
+    /// Provides said permission's data.
+    async fn application_command_permissions_update(
+        &self,
+        _ctx: Context,
+        _permission: ApplicationCommandPermission,
+    ) {
+    }
+
     /// Dispatched when the cache has received and inserted all data from
     /// guilds.
     ///

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -11,7 +11,15 @@ use super::utils::{emojis, roles, stickers};
 use crate::constants::OpCode;
 use crate::internal::prelude::*;
 use crate::json::prelude::*;
+use crate::model::interactions::application_command::ApplicationCommandPermission;
 use crate::model::interactions::Interaction;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+#[non_exhaustive]
+pub struct ApplicationCommandPermissionsUpdateEvent {
+    pub permission: ApplicationCommandPermission,
+}
 
 /// Event data for the channel creation event.
 ///
@@ -669,6 +677,13 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 #[non_exhaustive]
 #[serde(untagged)]
 pub enum Event {
+    /// The permissions of an [`ApplicationCommand`] was changed.
+    ///
+    /// Fires the [`EventHandler::application_command_permissions_update`] event.
+    ///
+    /// [`ApplicationCommand`]: crate::model::interactions::application_command::ApplicationCommand
+    /// [`EventHandler::application_command_permissions_update`]: crate::client::EventHandler::application_command_permissions_update
+    ApplicationCommandPermissionsUpdate(ApplicationCommandPermissionsUpdateEvent),
     /// A [`Channel`] was created.
     ///
     /// Fires the [`EventHandler::channel_create`] event.
@@ -813,6 +828,12 @@ fn gid_from_channel(c: &Channel) -> RelatedId<GuildId> {
 macro_rules! with_related_ids_for_event_types {
     ($macro:ident) => {
         $macro! {
+            Self::ApplicationCommandPermissionsUpdate, Self::ApplicationCommandPermissionsUpdate(e) => {
+                user_id: Never,
+                guild_id: Some(e.permission.guild_id),
+                channel_id: Never,
+                message_id: Never,
+            },
             Self::ChannelCreate, Self::ChannelCreate(e) => {
                 user_id: Never,
                 guild_id: gid_from_channel(&e.channel),
@@ -1222,6 +1243,9 @@ impl Event {
     /// Return the type of this event.
     pub fn event_type(&self) -> EventType {
         match self {
+            Self::ApplicationCommandPermissionsUpdate(_) => {
+                EventType::ApplicationCommandPermissionsUpdate
+            },
             Self::ChannelCreate(_) => EventType::ChannelCreate,
             Self::ChannelDelete(_) => EventType::ChannelDelete,
             Self::ChannelPinsUpdate(_) => EventType::ChannelPinsUpdate,
@@ -1345,6 +1369,9 @@ impl<T> TryFrom<RelatedId<T>> for Option<T> {
 /// Returns [`Error::Json`] if there is an error in deserializing the event data.
 pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
     Ok(match kind {
+        EventType::ApplicationCommandPermissionsUpdate => {
+            Event::ApplicationCommandPermissionsUpdate(from_value(v)?)
+        },
         EventType::ChannelCreate => Event::ChannelCreate(from_value(v)?),
         EventType::ChannelDelete => Event::ChannelDelete(from_value(v)?),
         EventType::ChannelPinsUpdate => Event::ChannelPinsUpdate(from_value(v)?),
@@ -1427,6 +1454,10 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum EventType {
+    /// Indicator that an application command permission update payload was received.
+    ///
+    /// This maps to [`ApplicationCommandPermissionsUpdateEvent`].
+    ApplicationCommandPermissionsUpdate,
     /// Indicator that a channel create payload was received.
     ///
     /// This maps to [`ChannelCreateEvent`].
@@ -1703,6 +1734,8 @@ macro_rules! define_related_ids_for_event_type {
 }
 
 impl EventType {
+    const APPLICATION_COMMAND_PERMISSIONS_UPDATE: &'static str =
+        "APPLICATION_COMMAND_PERMISSIONS_UPDATE";
     const CHANNEL_CREATE: &'static str = "CHANNEL_CREATE";
     const CHANNEL_DELETE: &'static str = "CHANNEL_DELETE";
     const CHANNEL_PINS_UPDATE: &'static str = "CHANNEL_PINS_UPDATE";
@@ -1759,6 +1792,9 @@ impl EventType {
     /// case this method returns [`None`].
     pub fn name(&self) -> Option<&str> {
         match self {
+            Self::ApplicationCommandPermissionsUpdate => {
+                Some(Self::APPLICATION_COMMAND_PERMISSIONS_UPDATE)
+            },
             Self::ChannelCreate => Some(Self::CHANNEL_CREATE),
             Self::ChannelDelete => Some(Self::CHANNEL_DELETE),
             Self::ChannelPinsUpdate => Some(Self::CHANNEL_PINS_UPDATE),
@@ -1839,6 +1875,9 @@ impl<'de> Deserialize<'de> for EventType {
                 E: DeError,
             {
                 Ok(match v {
+                    EventType::APPLICATION_COMMAND_PERMISSIONS_UPDATE => {
+                        EventType::ApplicationCommandPermissionsUpdate
+                    },
                     EventType::CHANNEL_CREATE => EventType::ChannelCreate,
                     EventType::CHANNEL_DELETE => EventType::ChannelDelete,
                     EventType::CHANNEL_PINS_UPDATE => EventType::ChannelPinsUpdate,

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -700,9 +700,16 @@ pub struct ApplicationCommand {
     /// The parameters for the command.
     #[serde(default)]
     pub options: Vec<ApplicationCommandOption>,
+    /// The default permissions required to execute the command.
+    pub default_member_permissions: Option<Permissions>,
+    /// Indicates whether the command is available in DMs with the app, only for globally-scoped commands.
+    /// By default, commands are visible.
+    #[serde(default)]
+    pub dm_permission: Option<bool>,
     /// Whether the command is enabled by default when
     /// the application is added to a guild.
     #[serde(default = "self::default_permission_value")]
+    #[deprecated(note = "replaced by `default_member_permissions`")]
     pub default_permission: bool,
     /// An autoincremented version identifier updated during substantial record changes.
     pub version: CommandVersionId,
@@ -1118,12 +1125,14 @@ enum_number!(ApplicationCommandOptionType {
 pub enum ApplicationCommandPermissionType {
     Role = 1,
     User = 2,
+    Channel = 3,
     Unknown = !0,
 }
 
 enum_number!(ApplicationCommandPermissionType {
     Role,
-    User
+    User,
+    Channel,
 });
 
 /// The only valid values a user can pick in an [`ApplicationCommandOption`].


### PR DESCRIPTION
The PR adds support for the new `APPLICATION_COMMAND_PERMISSIONS_UPDATE` gateway event
and adds fields & methods to `ApplicationCommand` and its builder. 