### PR TITLE
Use reference instead of clone in ResolvedTarget

### DIFF
--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -470,21 +470,21 @@ impl ApplicationCommandInteractionData {
     /// The target resolved data of [`target_id`]
     ///
     /// [`target_id`]: Self::target_id
-    pub fn target(&self) -> Option<ResolvedTarget> {
+    pub fn target(&self) -> Option<ResolvedTarget<'_>> {
         match (self.kind, self.target_id) {
             (ApplicationCommandType::User, Some(id)) => {
                 let user_id = id.to_user_id();
 
-                let user = self.resolved.users.get(&user_id).cloned()?;
-                let member = self.resolved.members.get(&user_id).cloned();
+                let user = self.resolved.users.get(&user_id)?;
+                let member = self.resolved.members.get(&user_id);
 
-                Some(ResolvedTarget::User(user, member.map(Box::new)))
+                Some(ResolvedTarget::User(user, member))
             },
             (ApplicationCommandType::Message, Some(id)) => {
                 let message_id = id.to_message_id();
-                let message = self.resolved.messages.get(&message_id).cloned()?;
+                let message = self.resolved.messages.get(&message_id)?;
 
-                Some(ResolvedTarget::Message(Box::new(message)))
+                Some(ResolvedTarget::Message(message))
             },
             _ => None,
         }
@@ -550,12 +550,12 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteractionData {
 }
 
 /// The resolved value of a [`ApplicationCommandInteractionData::target_id`].
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
-pub enum ResolvedTarget {
-    User(User, Option<Box<PartialMember>>),
-    Message(Box<Message>),
+pub enum ResolvedTarget<'a> {
+    User(&'a User, Option<&'a PartialMember>),
+    Message(&'a Message),
 }
 
 /// The resolved data of a command data interaction payload.


### PR DESCRIPTION
Avoids cloning the message/user off the heap, then putting the message back on the heap.