### PR TITLE
Strip leading "Bot " in parse_token

### DIFF
--- a/src/utils/token.rs
+++ b/src/utils/token.rs
@@ -51,7 +51,8 @@ impl fmt::Display for InvalidToken {
 /// the token generation unix timestamp.
 pub fn parse(token: impl AsRef<str>) -> Option<(UserId, i64)> {
     // The token consists of three base64-encoded parts
-    let mut parts = token.as_ref().split('.');
+    // Tokens can be preceded by "Bot " (that's how the Discord API expects them)
+    let mut parts = token.as_ref().trim_start_matches("Bot ").split('.');
 
     // First part must be a base64-encoded stringified user ID
     let user_id = base64::decode_config(parts.next()?, base64::URL_SAFE).ok()?;


### PR DESCRIPTION
Serenity supports tokens with or without leading "Bot ", so parse_token should, too

I bumped into this issue in poise via `parse_token(client_builder.get_token())` (retrieving bot user ID from the ClientBuilder passed in by a user).