### PR TITLE
Split up a few functions to minimize monomorphization-bloat

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -334,12 +334,12 @@ impl Message {
                 }
             }
         }
-        let mut builder = self._prepare_edit_builder()?;
+        let mut builder = self._prepare_edit_builder();
         f(&mut builder);
         self._send_edit(cache_http.http(), builder).await
     }
 
-    fn _prepare_edit_builder<'a>(&self) -> Result<EditMessage<'a>> {
+    fn _prepare_edit_builder<'a>(&self) -> EditMessage<'a> {
         let mut builder = EditMessage::default();
 
         if !self.content.is_empty() {
@@ -352,7 +352,7 @@ impl Message {
         for attachment in &self.attachments {
             builder.add_existing_attachment(attachment.id);
         }
-        Ok(builder)
+        builder
     }
 
     async fn _send_edit<'a>(&mut self, http: &Http, builder: EditMessage<'a>) -> Result<()> {

--- a/src/model/interactions/application_command.rs
+++ b/src/model/interactions/application_command.rs
@@ -107,7 +107,14 @@ impl ApplicationCommandInteraction {
     {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);
+        self._create_interaction_response(http.as_ref(), interaction_response).await
+    }
 
+    async fn _create_interaction_response<'a>(
+        &self,
+        http: &Http,
+        interaction_response: CreateInteractionResponse<'a>,
+    ) -> Result<()> {
         let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_lengths(&map)?;
@@ -198,7 +205,14 @@ impl ApplicationCommandInteraction {
     {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
+        self._create_followup_message(http.as_ref(), interaction_response).await
+    }
 
+    async fn _create_followup_message<'a>(
+        &self,
+        http: &Http,
+        interaction_response: CreateInteractionResponseFollowup<'a>,
+    ) -> Result<Message> {
         let map = json::hashmap_to_json_map(interaction_response.0);
 
         Message::check_lengths(&map)?;


### PR DESCRIPTION
This PR splits up the large and commonly used functions create_message, edit, create_interaction_response and create_followup_message, to minimize the length of the function that is generic over the closure argument.

In most cases, closures count as unique types, and thus every use of these functions _can_ cause a new copy of that function to be generated during monomorphization.
By moving most of the function body into separate, non-generic functions, we can minimize the impact of this monomorphization-bloat.

In my mid-sized discord bot, this change alone managed to reduce the size of the LLVM-codegen output (via `cargo-llvm-lines`) by about 8%, which _is_ noticable in build times, especially incremental builds.

