### PR TITLE
Remove useless reference on `Option<&T>`

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -148,8 +148,8 @@ impl<'a> Request<'a> {
     }
 
     #[must_use]
-    pub fn body_ref(&self) -> &Option<&'a [u8]> {
-        &self.body
+    pub fn body_ref(&self) -> Option<&'a [u8]> {
+        self.body
     }
 
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,8 @@
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,
     clippy::struct_excessive_bools,
-    clippy::ref_option_ref,
     clippy::unused_self,
-    // Allowed as they are too pedantic 
+    // Allowed as they are too pedantic
     clippy::cast_possible_truncation,
     clippy::unreadable_literal,
     clippy::cast_possible_wrap,


### PR DESCRIPTION
Since `&` is Copy, it’s useless to have a reference on `Option<&'a [u8]>`.