### PR TITLE
Make typing.stop() to return bool instead of option, allow ignoring result.

### DIFF
--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -92,6 +92,7 @@ impl Typing {
     /// Returns false in case if typing has already been stopped.
     ///
     /// [`Channel`]: crate::model::channel::Channel
+    #[allow(clippy::must_use_candidate)]
     pub fn stop(self) -> bool {
         self.0.send(()).is_ok()
     }

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -89,10 +89,10 @@ impl Typing {
     ///
     /// This should be used to stop typing after it is started using [`Typing::start`].
     /// Typing may persist for a few seconds on some clients after this is called.
+    /// Returns false in case if typing has already been stopped.
     ///
     /// [`Channel`]: crate::model::channel::Channel
-    #[must_use]
-    pub fn stop(self) -> Option<()> {
-        self.0.send(()).ok()
+    pub fn stop(self) -> bool {
+        self.0.send(()).is_ok()
     }
 }

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -89,7 +89,7 @@ impl Typing {
     ///
     /// This should be used to stop typing after it is started using [`Typing::start`].
     /// Typing may persist for a few seconds on some clients after this is called.
-    /// Returns false in case if typing has already been stopped.
+    /// Returns false if typing has already stopped.
     ///
     /// [`Channel`]: crate::model::channel::Channel
     #[allow(clippy::must_use_candidate)]


### PR DESCRIPTION
Mostly we don't want (I think) to check return valur of `stop()`

It doesn't tell if there was error or not but instead if there was typing to stop or not, and there is nothing to do usually if typing wasn't active unless very specific cases.