### PR TITLE
Add methods to `Webhook` to enable direct creation

### DIFF
--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -25,6 +25,7 @@ use crate::model::channel::MessageFlags;
 /// ```rust,no_run
 /// use serenity::http::Http;
 /// use serenity::model::channel::Embed;
+/// use serenity::model::webhook::Webhook;
 /// use serenity::utils::Colour;
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -74,6 +75,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
@@ -101,6 +103,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
@@ -215,6 +218,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
@@ -241,6 +245,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
@@ -268,6 +273,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// ```rust,no_run
     /// # use serenity::http::Http;
     /// # use serenity::model::channel::MessageFlags;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -30,7 +30,7 @@ use crate::model::channel::MessageFlags;
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// # let http = Http::new("token");
 /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-/// let webhook = http.get_webhook_from_url(url).await?;
+/// let webhook = Webhook::from_url(&http, url).await?;
 ///
 /// let website = Embed::fake(|e| {
 ///     e.title("The Rust Language Website")
@@ -77,7 +77,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
-    /// # let webhook = http.get_webhook_with_token(0, "").await?;
+    /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
     /// let avatar_url = "https://i.imgur.com/KTs6whd.jpg";
     ///
@@ -104,7 +104,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
-    /// # let webhook = http.get_webhook_with_token(0, "").await?;
+    /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
     /// let execution = webhook.execute(&http, false, |w| w.content("foo")).await;
     ///
@@ -218,7 +218,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
-    /// # let webhook = http.get_webhook_with_token(0, "").await?;
+    /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
     /// let execution = webhook.execute(&http, false, |w| w.content("hello").tts(true)).await;
     ///
@@ -244,7 +244,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
-    /// # let webhook = http.get_webhook_with_token(0, "").await?;
+    /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
     /// let execution = webhook.execute(&http, false, |w| w.content("hello").username("hakase")).await;
     ///
@@ -271,7 +271,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
-    /// # let webhook = http.get_webhook_with_token(0, "").await?;
+    /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
     /// let execution = webhook
     ///     .execute(&http, false, |w| {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3479,8 +3479,8 @@ impl Http {
 
     /// Retrieves a webhook given its Id.
     ///
-    /// This method requires authentication, whereas [`Self::get_webhook_with_token`] and
-    /// [`Self::get_webhook_from_url`] do not.
+    /// This method requires authentication, whereas [`Http::get_webhook_with_token`] and
+    /// [`Http::get_webhook_from_url`] do not.
     ///
     /// # Examples
     ///

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -103,6 +103,79 @@ impl fmt::Debug for Webhook {
 
 #[cfg(feature = "model")]
 impl Webhook {
+    /// Retrieves a webhook given its Id.
+    ///
+    /// This method requires authentication, whereas [`Webhook::from_id_with_token`] and
+    /// [`Webhook::from_url`] do not.
+    ///
+    /// # Examples
+    ///
+    /// Retrieve a webhook by Id:
+    ///
+    /// ```rust,no_run
+    /// # use serenity::http::Http;
+    /// #
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// #     let http = Http::new("token");
+    /// let id = 245037420704169985;
+    /// let webhook = Webhook::from_id(&http, id).await?;
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub async fn from_id(http: impl AsRef<Http>, webhook_id: impl Into<WebhookId>) -> Result<Self> {
+        http.as_ref().get_webhook(webhook_id.into().0).await
+    }
+
+    /// Retrieves a webhook given its Id and unique token.
+    ///
+    /// This method does _not_ require authentication.
+    ///
+    /// # Examples
+    ///
+    /// Retrieve a webhook by Id and its unique token:
+    ///
+    /// ```rust,no_run
+    /// # use serenity::http::Http;
+    /// #
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// #     let http = Http::new("token");
+    /// let id = 245037420704169985;
+    /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+    ///
+    /// let webhook = Webhook::from_id_with_token(&http, id, token).await?;
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub async fn from_id_with_token(
+        http: impl AsRef<Http>,
+        webhook_id: impl Into<WebhookId>,
+        token: &str,
+    ) -> Result<Self> {
+        http.as_ref().get_webhook_with_token(webhook_id.into().0, token).await
+    }
+
+    /// Retrieves a webhook given its url.
+    ///
+    /// This method does _not_ require authentication
+    ///
+    /// # Examples
+    ///
+    /// Retrieve a webhook by url:
+    ///
+    /// ```rust,no_run
+    /// # use serenity::http::Http;
+    /// #
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// #     let http = Http::new("token");
+    /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+    /// let webhook = Webhook::from_url(&http, url).await?;
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub async fn from_url(http: impl AsRef<Http>, url: &str) -> Result<Self> {
+        http.as_ref().get_webhook_from_url(url).await
+    }
+
     /// Deletes the webhook.
     ///
     /// As this calls the [`Http::delete_webhook_with_token`] function,
@@ -137,7 +210,7 @@ impl Webhook {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-    /// let mut webhook = http.get_webhook_from_url(url).await?;
+    /// let mut webhook = Webhook::from_url(&http, url).await?;
     ///
     /// webhook.edit_name(&http, "new name").await?;
     /// #     Ok(())
@@ -176,7 +249,7 @@ impl Webhook {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-    /// let mut webhook = http.get_webhook_from_url(url).await?;
+    /// let mut webhook = Webhook::from_url(&http, url).await?;
     ///
     /// webhook.edit_avatar(&http, "./webhook_img.png").await?;
     /// #     Ok(())
@@ -223,7 +296,7 @@ impl Webhook {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-    /// let mut webhook = http.get_webhook_from_url(url).await?;
+    /// let mut webhook = Webhook::from_url(&http, url).await?;
     ///
     /// webhook.delete_avatar(&http).await?;
     /// #     Ok(())
@@ -264,7 +337,7 @@ impl Webhook {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-    /// let mut webhook = http.get_webhook_from_url(url).await?;
+    /// let mut webhook = Webhook::from_url(&http, url).await?;
     ///
     /// webhook.execute(&http, false, |w| w.content("test")).await?;
     /// #     Ok(())
@@ -282,7 +355,7 @@ impl Webhook {
     /// use serenity::model::channel::Embed;
     ///
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-    /// let mut webhook = http.get_webhook_from_url(url).await?;
+    /// let mut webhook = Webhook::from_url(&http, url).await?;
     ///
     /// let embed = Embed::fake(|e| {
     ///     e.title("Rust's website")

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -114,6 +114,7 @@ impl Webhook {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
@@ -146,6 +147,7 @@ impl Webhook {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
@@ -183,6 +185,7 @@ impl Webhook {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
@@ -234,6 +237,7 @@ impl Webhook {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
@@ -273,6 +277,7 @@ impl Webhook {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
@@ -320,6 +325,7 @@ impl Webhook {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
@@ -361,6 +367,7 @@ impl Webhook {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
@@ -377,6 +384,7 @@ impl Webhook {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -122,6 +122,16 @@ impl Webhook {
     /// #     Ok(())
     /// # }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the current user is not authenticated, or if the webhook does
+    /// not exist.
+    ///
+    /// May also return an [`Error::Json`] if there is an error in deserialising Discord's response.
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn from_id(http: impl AsRef<Http>, webhook_id: impl Into<WebhookId>) -> Result<Self> {
         http.as_ref().get_webhook(webhook_id.into().0).await
     }
@@ -146,6 +156,15 @@ impl Webhook {
     /// #     Ok(())
     /// # }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the webhook does not exist, or if the token is invalid.
+    ///
+    /// May also return an [`Error::Json`] if there is an error in deserialising Discord's response.
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn from_id_with_token(
         http: impl AsRef<Http>,
         webhook_id: impl Into<WebhookId>,
@@ -172,6 +191,15 @@ impl Webhook {
     /// #     Ok(())
     /// # }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the url is malformed, or otherwise if the webhook does not exist, or if the token is invalid.
+    ///
+    /// May also return an [`Error::Json`] if there is an error in deserialising Discord's response.
+    ///
+    /// [`Error::Http`]: crate::error::Error::Http
+    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn from_url(http: impl AsRef<Http>, url: &str) -> Result<Self> {
         http.as_ref().get_webhook_from_url(url).await
     }


### PR DESCRIPTION
Adds `Webhook::{from_id, from_id_with_token, from_url}` that wrap the equivalent methods on `Http`. These take the same parameters as the methods they wrap, plus an additional `http` parameter. Also changes documentation to use these methods instead instead of the now-wrapped ones.