### PR TITLE
feat: keep framework optional even if the feature is enabled

### DIFF
--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -77,7 +77,7 @@ use crate::CacheAndHttp;
 ///     data: &data,
 ///     event_handler: &Some(event_handler),
 ///     raw_event_handler: &None,
-///     framework: &framework,
+///     framework: &Some(framework),
 ///     // the shard index to start initiating from
 ///     shard_index: 0,
 ///     // the number of shards to initiate (this initiates 0, 1, and 2)

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -129,7 +129,7 @@ impl ShardManager {
             event_handler: opt.event_handler.as_ref().map(Arc::clone),
             raw_event_handler: opt.raw_event_handler.as_ref().map(Arc::clone),
             #[cfg(feature = "framework")]
-            framework: Arc::clone(opt.framework),
+            framework: opt.framework.as_ref().map(Arc::clone),
             last_start: None,
             manager_tx: thread_tx.clone(),
             queue: VecDeque::new(),
@@ -349,7 +349,7 @@ pub struct ShardManagerOptions<'a> {
     pub event_handler: &'a Option<Arc<dyn EventHandler>>,
     pub raw_event_handler: &'a Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    pub framework: &'a Arc<dyn Framework + Send + Sync>,
+    pub framework: &'a Option<Arc<dyn Framework + Send + Sync>>,
     pub shard_index: u64,
     pub shard_init: u64,
     pub shard_total: u64,

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -55,7 +55,7 @@ pub struct ShardQueuer {
     pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
-    pub framework: Arc<dyn Framework + Send + Sync>,
+    pub framework: Option<Arc<dyn Framework + Send + Sync>>,
     /// The instant that a shard was last started.
     ///
     /// This is used to determine how long to wait between shard IDENTIFYs.
@@ -188,7 +188,7 @@ impl ShardQueuer {
             event_handler: self.event_handler.as_ref().map(Arc::clone),
             raw_event_handler: self.raw_event_handler.as_ref().map(Arc::clone),
             #[cfg(feature = "framework")]
-            framework: Arc::clone(&self.framework),
+            framework: self.framework.as_ref().map(Arc::clone),
             manager_tx: self.manager_tx.clone(),
             #[cfg(feature = "voice")]
             voice_manager: self.voice_manager.clone(),

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -41,7 +41,7 @@ pub struct ShardRunner {
     event_handler: Option<Arc<dyn EventHandler>>,
     raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    framework: Arc<dyn Framework + Send + Sync>,
+    framework: Option<Arc<dyn Framework + Send + Sync>>,
     manager_tx: Sender<ShardManagerMessage>,
     // channel to receive messages from the shard manager and dispatches
     runner_rx: Receiver<InterMessage>,
@@ -689,7 +689,7 @@ pub struct ShardRunnerOptions {
     pub event_handler: Option<Arc<dyn EventHandler>>,
     pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    pub framework: Arc<dyn Framework + Send + Sync>,
+    pub framework: Option<Arc<dyn Framework + Send + Sync>>,
     pub manager_tx: Sender<ShardManagerMessage>,
     pub shard: Shard,
     #[cfg(feature = "voice")]

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -158,7 +158,7 @@ impl DispatchEvent {
 pub(crate) fn dispatch<'rec>(
     // #[allow(unused_variables)]
     mut event: DispatchEvent,
-    #[cfg(feature = "framework")] framework: &'rec Arc<dyn Framework + Send + Sync>,
+    #[cfg(feature = "framework")] framework: &'rec Option<Arc<dyn Framework + Send + Sync>>,
     data: &'rec Arc<RwLock<TypeMap>>,
     event_handler: &'rec Option<Arc<dyn EventHandler>>,
     raw_event_handler: &'rec Option<Arc<dyn RawEventHandler>>,
@@ -184,11 +184,13 @@ pub(crate) fn dispatch<'rec>(
                         &cache_and_http.cache,
                     );
 
-                    let framework = Arc::clone(framework);
+                    if let Some(framework) = framework {
+                        let framework = Arc::clone(framework);
 
-                    spawn_named("dispatch::framework::message", async move {
-                        framework.dispatch(context, event.message).await;
-                    });
+                        spawn_named("dispatch::framework::message", async move {
+                            framework.dispatch(context, event.message).await;
+                        });
+                    }
                 }
             },
             (Some(ref h), None) => match event {
@@ -216,11 +218,13 @@ pub(crate) fn dispatch<'rec>(
                     {
                         dispatch_message(context.clone(), event.message.clone(), h).await;
 
-                        let framework = Arc::clone(framework);
+                        if let Some(framework) = framework {
+                            let framework = Arc::clone(framework);
 
-                        spawn_named("dispatch::framework::message", async move {
-                            framework.dispatch(context, event.message).await;
-                        });
+                            spawn_named("dispatch::framework::message", async move {
+                                framework.dispatch(context, event.message).await;
+                            });
+                        }
                     }
                 },
                 other => {
@@ -257,11 +261,13 @@ pub(crate) fn dispatch<'rec>(
                             let message = msg_event.message.clone();
                             event_handler.raw_event(context.clone(), event).await;
 
-                            let framework = Arc::clone(framework);
+                            if let Some(framework) = framework {
+                                let framework = Arc::clone(framework);
 
-                            spawn_named("dispatch::framework::message", async move {
-                                framework.dispatch(context, message).await;
-                            });
+                                spawn_named("dispatch::framework::message", async move {
+                                    framework.dispatch(context, message).await;
+                                });
+                            }
                         } else {
                             // Avoid cloning if there will be no framework dispatch.
                             event_handler.raw_event(context, event).await;
@@ -294,11 +300,13 @@ pub(crate) fn dispatch<'rec>(
                         {
                             dispatch_message(context.clone(), event.message.clone(), handler).await;
 
-                            let framework = Arc::clone(framework);
-                            let message = event.message;
-                            spawn_named("dispatch::framework::message", async move {
-                                framework.dispatch(context, message).await;
-                            });
+                            if let Some(framework) = framework {
+                                let framework = Arc::clone(framework);
+
+                                spawn_named("dispatch::framework::message", async move {
+                                    framework.dispatch(context, event.message).await;
+                                });
+                            }
                         }
                     },
                     other => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -357,9 +357,7 @@ impl Future for ClientBuilder {
         if self.fut.is_none() {
             let data = Arc::new(RwLock::new(self.data.take().unwrap()));
             #[cfg(feature = "framework")]
-            let framework = self.framework.take()
-                .expect("The `framework`-feature is enabled (it's on by default), but no framework was provided.\n\
-                If you don't want to use the command framework, disable default features and specify all features you want to use.");
+            let framework = self.framework.take();
             let event_handler = self.event_handler.take();
             let raw_event_handler = self.raw_event_handler.take();
             let intents = self.intents;


### PR DESCRIPTION
This wraps the framework in an `Option` so that there doesn't need to be a panic if the feature is enabled but no framework was provided. This contributes to resolving #1856.