### PR TITLE
refactor(Message): don't set message content not sent by the api

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -314,14 +314,9 @@ pub(crate) fn dispatch<'rec>(
 
 async fn dispatch_message(
     context: Context,
-    mut message: Message,
+    message: Message,
     event_handler: &Arc<dyn EventHandler>,
 ) {
-    #[cfg(feature = "model")]
-    {
-        message.transform_content();
-    }
-
     let event_handler = Arc::clone(event_handler);
 
     spawn_named("dispatch::event_handler::message", async move {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -31,23 +31,6 @@ pub const USER_AGENT: &str = concat!(
     ")"
 );
 
-/// List of messages Discord shows on member join.
-pub static JOIN_MESSAGES: &[&str] = &[
-    "$user joined the party.",
-    "$user is here.",
-    "Welcome, $user. We hope you brought pizza.",
-    "A wild $user appeared.",
-    "$user just landed.",
-    "$user just slid into the server.",
-    "$user just showed up!",
-    "Welcome $user. Say hi!",
-    "$user hopped into the server.",
-    "Everyone welcome $user!",
-    "Glad you're here, $user.",
-    "Good to see you, $user.",
-    "Yay you made it, $user!",
-];
-
 /// Enum to map gateway opcodes.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -451,11 +451,7 @@ impl ChannelId {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<Message> {
-        http.as_ref().get_message(self.0, message_id.into().0).await.map(|mut msg| {
-            msg.transform_content();
-
-            msg
-        })
+        http.as_ref().get_message(self.0, message_id.into().0).await
     }
 
     /// Gets messages from the channel.
@@ -488,15 +484,7 @@ impl ChannelId {
             write!(query, "&before={}", before)?;
         }
 
-        http.as_ref().get_messages(self.0, &query).await.map(|msgs| {
-            msgs.into_iter()
-                .map(|mut msg| {
-                    msg.transform_content();
-
-                    msg
-                })
-                .collect::<Vec<Message>>()
-        })
+        http.as_ref().get_messages(self.0, &query).await
     }
 
     /// Streams over all the messages in a channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -367,26 +367,6 @@ impl Message {
         Ok(())
     }
 
-    pub(crate) fn transform_content(&mut self) {
-        match self.kind {
-            MessageType::PinsAdd => {
-                self.content =
-                    format!("{} pinned a message to this channel. See all the pins.", self.author);
-            },
-            MessageType::MemberJoin => {
-                let sec = self.timestamp.unix_timestamp() as usize;
-                let chosen = constants::JOIN_MESSAGES[sec % constants::JOIN_MESSAGES.len()];
-
-                self.content = if chosen.contains("$user") {
-                    chosen.replace("$user", &self.author.mention().to_string())
-                } else {
-                    chosen.to_string()
-                };
-            },
-            _ => {},
-        }
-    }
-
     /// Returns message content, but with user and role mentions replaced with
     /// names and everyone/here mentions cancelled.
     #[cfg(feature = "cache")]


### PR DESCRIPTION
Problems with the current setup:

- The content of messages with these types is not documented, meaning that it can change anytime
- Not every message type is handled, e.g. boost or thread creation messages do not get their content added
- Overall more possibly unexpected behaviour and less consistency with the API