### PR TITLE
Remove `guild_id` insertion for the `PartialChannel` deserialization

### DIFF
--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -348,20 +348,6 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteraction {
                             }
                         }
                     }
-
-                    if let Some(channels) = resolved.get_mut("channels") {
-                        if let Some(values) = channels.as_object_mut() {
-                            for value in values.values_mut() {
-                                value
-                                    .as_object_mut()
-                                    .expect("couldn't deserialize application command")
-                                    .insert(
-                                        "guild_id".to_string(),
-                                        Value::from(guild_id.to_string()),
-                                    );
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -101,20 +101,6 @@ impl<'de> Deserialize<'de> for AutocompleteInteraction {
                             }
                         }
                     }
-
-                    if let Some(channels) = resolved.get_mut("channels") {
-                        if let Some(values) = channels.as_object_mut() {
-                            for value in values.values_mut() {
-                                value
-                                    .as_object_mut()
-                                    .expect("couldn't deserialize application command")
-                                    .insert(
-                                        "guild_id".to_string(),
-                                        Value::from(guild_id.to_string()),
-                                    );
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -315,22 +315,6 @@ impl<'de> Deserialize<'de> for MessageComponentInteraction {
                             }
                         }
                     }
-
-                    if let Some(channels) = resolved.get_mut("channels") {
-                        if let Some(values) = channels.as_object_mut() {
-                            for value in values.values_mut() {
-                                value
-                                    .as_object_mut()
-                                    .expect(
-                                        "couldn't deserialize the message component interaction",
-                                    )
-                                    .insert(
-                                        "guild_id".to_string(),
-                                        Value::from(guild_id.to_string()),
-                                    );
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -302,22 +302,6 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
                             }
                         }
                     }
-
-                    if let Some(channels) = resolved.get_mut("channels") {
-                        if let Some(values) = channels.as_object_mut() {
-                            for value in values.values_mut() {
-                                value
-                                    .as_object_mut()
-                                    .expect(
-                                        "couldn't deserialize the message component interaction",
-                                    )
-                                    .insert(
-                                        "guild_id".to_string(),
-                                        Value::String(guild_id.to_string()),
-                                    );
-                            }
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
The `resolved` data map is using the `PartialChannel` struct which has
no `guild_id` field.