### PR TITLE
Ignore doctests on non-exported `macro_rules!`

### DIFF
--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -55,7 +55,7 @@ use serde::ser::{Serialize, Serializer};
 ///
 /// Using this macro
 ///
-/// ```rust,no_run
+/// ```ignore
 /// generate_get_permission_names! {
 ///     add_reactions: "Add Reactions",
 ///     administrator: "Administrator"
@@ -64,7 +64,7 @@ use serde::ser::{Serialize, Serializer};
 ///
 /// Generates this implementation:
 ///
-/// ```
+/// ```ignore
 /// impl Permissions {
 ///     fn get_permission_names(self) -> Vec<&'static str> {
 ///         let mut names = Vec::new();


### PR DESCRIPTION
Non-exported `macro_rules!` are now included in the `doctest` target but
cannot test the macro.

```
error: cannot find macro `generate_get_permission_names` in this scope
 --> src/model/permissions.rs:59:1
```