### PR TITLE
Use `#[serde(default)]` for the `ScheduledEventMetadata::location` field

### DIFF
--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -78,6 +78,8 @@ enum_number!(ScheduledEventType {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ScheduledEventMetadata {
+    // TODO: Change to `Option<String>` in next version.
+    #[serde(default)]
     pub location: String,
 }
 


### PR DESCRIPTION
This field is optional and isn't sent for stage & voice events when the
metadata is sent for gateway events in some circumstances.

Adding `#[serde(default)]` is a workaround instead of changing it to
`Option<String>`.

discord docs: [guild-scheduled-event-entity-metadata]

[guild-scheduled-event-entity-metadata]: https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata