### PR TITLE
Expose wrapped dashmap Ref to reduce cloning

### DIFF
--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -26,7 +26,8 @@ use crate::model::invite::InviteTargetType;
 /// impl EventHandler for Handler {
 ///     async fn message(&self, context: Context, msg: Message) {
 ///         if msg.content == "!createinvite" {
-///             let channel = match context.cache.guild_channel(msg.channel_id) {
+///             let channel_opt = context.cache.guild_channel(msg.channel_id).map(|c| c.clone());
+///             let channel = match channel_opt {
 ///                 Some(channel) => channel,
 ///                 None => {
 ///                     let _ = msg.channel_id.say(&context, "Error creating invite").await;
@@ -91,7 +92,7 @@ impl CreateInvite {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap();
+    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap().clone();
     /// #
     /// let invite = channel.create_invite(context, |i| i.max_age(3600)).await?;
     /// #     Ok(())
@@ -122,7 +123,7 @@ impl CreateInvite {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap();
+    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap().clone();
     /// #
     /// let invite = channel.create_invite(context, |i| i.max_uses(5)).await?;
     /// #     Ok(())
@@ -151,7 +152,7 @@ impl CreateInvite {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap();
+    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap().clone();
     /// #
     /// let invite = channel.create_invite(context, |i| i.temporary(true)).await?;
     /// #     Ok(())
@@ -182,7 +183,7 @@ impl CreateInvite {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap();
+    /// #     let channel = context.cache.guild_channel(81384788765712384).unwrap().clone();
     /// #
     /// let invite = channel.create_invite(context, |i| i.unique(true)).await?;
     /// #     Ok(())

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -81,9 +81,9 @@ impl<K: Eq + Hash, V> std::ops::Deref for CacheRef<'_, K, V> {
     }
 }
 
-pub(crate) type GuildRef<'a> = CacheRef<'a, GuildId, Guild>;
-pub(crate) type GuildChannelRef<'a> = CacheRef<'a, ChannelId, GuildChannel>;
-pub(crate) type PrivateChannelRef<'a> = CacheRef<'a, ChannelId, PrivateChannel>;
+pub type GuildRef<'a> = CacheRef<'a, GuildId, Guild>;
+pub type GuildChannelRef<'a> = CacheRef<'a, ChannelId, GuildChannel>;
+pub type PrivateChannelRef<'a> = CacheRef<'a, ChannelId, PrivateChannel>;
 
 pub trait FromStrAndCache: Sized {
     type Err;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -32,7 +32,7 @@
 
 use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, VecDeque};
-use std::hash::BuildHasher;
+use std::hash::{BuildHasher, Hash};
 use std::str::FromStr;
 #[cfg(feature = "temp_cache")]
 use std::time::Duration;
@@ -40,6 +40,7 @@ use std::time::Duration;
 use dashmap::iter::Iter;
 use dashmap::mapref::entry::Entry;
 use dashmap::mapref::multiple::RefMulti;
+use dashmap::mapref::one::Ref;
 use dashmap::{DashMap, DashSet};
 #[cfg(feature = "temp_cache")]
 use moka::dash::Cache as DashCache;
@@ -55,6 +56,34 @@ pub use self::cache_update::CacheUpdate;
 pub use self::settings::Settings;
 
 type MessageCache = DashMap<ChannelId, DashMap<MessageId, Message>>;
+
+struct NotSend();
+
+pub struct CacheRef<'a, K, V> {
+    inner: Ref<'a, K, V>,
+    phantom: std::marker::PhantomData<*const NotSend>,
+}
+
+impl<'a, K, V> From<Ref<'a, K, V>> for CacheRef<'a, K, V> {
+    fn from(inner: Ref<'a, K, V>) -> Self {
+        Self {
+            inner,
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<K: Eq + Hash, V> std::ops::Deref for CacheRef<'_, K, V> {
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.value()
+    }
+}
+
+pub(crate) type GuildRef<'a> = CacheRef<'a, GuildId, Guild>;
+pub(crate) type GuildChannelRef<'a> = CacheRef<'a, ChannelId, GuildChannel>;
+pub(crate) type PrivateChannelRef<'a> = CacheRef<'a, ChannelId, PrivateChannel>;
 
 pub trait FromStrAndCache: Sized {
     type Err;
@@ -401,10 +430,7 @@ impl Cache {
         Some(selector(message_iter))
     }
 
-    /// Clones an entire guild from the cache based on the given `id`.
-    ///
-    /// In order to clone only a field of the guild, use [`Self::guild_field`].
-    ///
+    /// Gets a reference to a guild from the cache based on the given `id`.
     ///
     /// # Examples
     ///
@@ -417,48 +443,15 @@ impl Cache {
     /// // assuming the cache is in scope, e.g. via `Context`
     /// if let Some(guild) = cache.guild(7) {
     ///     println!("Guild name: {}", guild.name);
-    /// }
+    /// };
     /// ```
     #[inline]
-    pub fn guild<G: Into<GuildId>>(&self, id: G) -> Option<Guild> {
+    pub fn guild<G: Into<GuildId>>(&self, id: G) -> Option<GuildRef<'_>> {
         self._guild(id.into())
     }
 
-    fn _guild(&self, id: GuildId) -> Option<Guild> {
-        self.guilds.get(&id).map(|i| i.clone())
-    }
-
-    /// This method allows to select a field of the guild instead of
-    /// the entire guild by providing a `field_selector`-closure picking what
-    /// you want to clone.
-    ///
-    /// ```rust,no_run
-    /// # use serenity::cache::Cache;
-    /// #
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let cache = Cache::default();
-    /// // We clone only the `len()` returned `usize` instead of the entire guild or the channels.
-    /// if let Some(channel_len) = cache.guild_field(7, |guild| guild.channels.len()) {
-    ///     println!("Guild channels count: {}", channel_len);
-    /// }
-    /// #   Ok(())
-    /// # }
-    /// ```
-    #[inline]
-    pub fn guild_field<Ret, Fun>(&self, id: impl Into<GuildId>, field_selector: Fun) -> Option<Ret>
-    where
-        Fun: FnOnce(&Guild) -> Ret,
-    {
-        self._guild_field(id.into(), field_selector)
-    }
-
-    fn _guild_field<Ret, Fun>(&self, id: GuildId, field_accessor: Fun) -> Option<Ret>
-    where
-        Fun: FnOnce(&Guild) -> Ret,
-    {
-        let guild = self.guilds.get(&id)?;
-
-        Some(field_accessor(&*guild))
+    fn _guild(&self, id: GuildId) -> Option<GuildRef<'_>> {
+        self.guilds.get(&id).map(Into::into)
     }
 
     /// Returns the number of cached guilds.
@@ -486,7 +479,8 @@ impl Cache {
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, message: Message) {
-    ///         let channel = match context.cache.guild_channel(message.channel_id) {
+    ///         let channel_opt = context.cache.guild_channel(message.channel_id).map(|c| c.clone());
+    ///         let channel = match channel_opt {
     ///             Some(channel) => channel,
     ///             None => {
     ///                 let result = message
@@ -515,49 +509,12 @@ impl Cache {
     ///
     /// [`EventHandler::message`]: crate::client::EventHandler::message
     #[inline]
-    pub fn guild_channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannel> {
+    pub fn guild_channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannelRef<'_>> {
         self._guild_channel(id.into())
     }
 
-    fn _guild_channel(&self, id: ChannelId) -> Option<GuildChannel> {
-        self.channels.get(&id).map(|i| i.clone())
-    }
-
-    /// This method allows to only clone a field of the guild channel instead of
-    /// the entire guild by providing a `field_selector`-closure picking what
-    /// you want to clone.
-    ///
-    /// ```rust,no_run
-    /// # use serenity::cache::Cache;
-    /// #
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let cache = Cache::default();
-    /// // We clone only the `name` instead of the entire channel.
-    /// if let Some(channel_name) = cache.guild_channel_field(7, |channel| channel.name.clone()) {
-    ///     println!("Guild channel name: {}", channel_name);
-    /// }
-    /// #   Ok(())
-    /// # }
-    /// ```
-    #[inline]
-    pub fn guild_channel_field<Ret, Fun>(
-        &self,
-        id: impl Into<ChannelId>,
-        field_selector: Fun,
-    ) -> Option<Ret>
-    where
-        Fun: FnOnce(&GuildChannel) -> Ret,
-    {
-        self._guild_channel_field(id.into(), field_selector)
-    }
-
-    fn _guild_channel_field<Ret, Fun>(&self, id: ChannelId, field_selector: Fun) -> Option<Ret>
-    where
-        Fun: FnOnce(&GuildChannel) -> Ret,
-    {
-        let channel = self.channels.get(&id)?;
-
-        Some(field_selector(&*channel))
+    fn _guild_channel(&self, id: ChannelId) -> Option<GuildChannelRef<'_>> {
+        self.channels.get(&id).map(Into::into)
     }
 
     /// Retrieves a [`Guild`]'s member from the cache based on the guild's and
@@ -796,15 +753,18 @@ impl Cache {
     ///
     /// if let Some(channel) = cache.private_channel(7) {
     ///     println!("The recipient is {}", channel.recipient);
-    /// }
+    /// };
     /// ```
     #[inline]
-    pub fn private_channel(&self, channel_id: impl Into<ChannelId>) -> Option<PrivateChannel> {
+    pub fn private_channel(
+        &self,
+        channel_id: impl Into<ChannelId>,
+    ) -> Option<PrivateChannelRef<'_>> {
         self._private_channel(channel_id.into())
     }
 
-    fn _private_channel(&self, channel_id: ChannelId) -> Option<PrivateChannel> {
-        self.private_channels.get(&channel_id).map(|i| i.clone())
+    fn _private_channel(&self, channel_id: ChannelId) -> Option<PrivateChannelRef<'_>> {
+        self.private_channels.get(&channel_id).map(Into::into)
     }
 
     /// Retrieves a [`Guild`]'s role by their Ids.

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -611,8 +611,7 @@ async fn handle_event(
 
             spawn_named("dispatch::event_handler::guild_update", async move {
                 feature_cache! {{
-                    let before = cache_and_http.cache
-                        .guild(&event.guild.id);
+                    let before = cache_and_http.cache.guild(&event.guild.id).map(|g| g.clone());
 
                     update(&cache_and_http, &mut event);
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -254,16 +254,17 @@ fn check_common_behaviour(
         return help_options.lacking_permissions;
     }
 
-    msg.guild_field(&cache, |guild| {
-        if let Some(member) = guild.members.get(&msg.author.id) {
-            if !has_correct_roles(options, &guild.roles, member) {
-                return help_options.lacking_role;
+    msg.guild(cache.as_ref())
+        .and_then(|guild| {
+            if let Some(member) = guild.members.get(&msg.author.id) {
+                if !has_correct_roles(options, &guild.roles, member) {
+                    return Some(help_options.lacking_role);
+                }
             }
-        }
 
-        HelpBehaviour::Nothing
-    })
-    .unwrap_or(HelpBehaviour::Nothing)
+            None
+        })
+        .unwrap_or(HelpBehaviour::Nothing)
 }
 
 #[cfg(all(feature = "cache", feature = "http"))]

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -259,10 +259,8 @@ impl StandardFramework {
                     return Some(DispatchError::BlockedGuild);
                 }
 
-                let owner_id_option = ctx.cache.guild_field(guild_id, |guild| guild.owner_id);
-
-                if let Some(owner_id) = owner_id_option {
-                    if self.config.blocked_users.contains(&owner_id) {
+                if let Some(guild) = ctx.cache.guild(guild_id) {
+                    if self.config.blocked_users.contains(&guild.owner_id) {
                         return Some(DispatchError::BlockedGuild);
                     }
                 }
@@ -861,7 +859,8 @@ pub(crate) fn has_correct_permissions(
         true
     } else {
         message
-            .guild_field(cache, |guild| {
+            .guild(cache.as_ref())
+            .map(|guild| {
                 let channel = match guild.channels.get(&message.channel_id) {
                     Some(Channel::Guild(channel)) => channel,
                     _ => return false,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 #[cfg(all(feature = "model", feature = "utils"))]
 use crate::builder::{CreateEmbed, EditMessage};
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
@@ -442,28 +442,8 @@ impl Message {
     ///
     /// Requires the `cache` feature be enabled.
     #[cfg(feature = "cache")]
-    pub fn guild(&self, cache: impl AsRef<Cache>) -> Option<Guild> {
-        cache.as_ref().guild(self.guild_id?)
-    }
-
-    /// Returns a field to the [`Guild`] for the message if one is in the cache.
-    /// The field can be selected via the `field_accessor`.
-    ///
-    /// Returns [`None`] if the guild's ID could not be found via [`Self::guild_id`] or
-    /// if the Guild itself is not cached.
-    ///
-    /// Requires the `cache` feature be enabled.
-    #[cfg(feature = "cache")]
-    pub fn guild_field<Ret, Fun>(
-        &self,
-        cache: impl AsRef<Cache>,
-        field_accessor: Fun,
-    ) -> Option<Ret>
-    where
-        Ret: Clone,
-        Fun: FnOnce(&Guild) -> Ret,
-    {
-        cache.as_ref().guild_field(self.guild_id?, field_accessor)
+    pub fn guild<'a>(&self, cache: &'a Cache) -> Option<GuildRef<'a>> {
+        cache.guild(self.guild_id?)
     }
 
     /// True if message was sent using direct messages.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -353,7 +353,8 @@ impl PrivateChannel {
     /// # let http = Arc::new(Http::new("token"));
     /// # let cache = Cache::default();
     /// # let channel = cache.private_channel(ChannelId(7))
-    /// #    .ok_or(ModelError::ItemMissing)?;
+    /// #    .ok_or(ModelError::ItemMissing)?
+    /// #    .clone();
     /// // Initiate typing (assuming http is `Arc<Http>` and `channel` is bound)
     /// let typing = channel.start_typing(&http)?;
     ///

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -26,7 +26,7 @@ use crate::builder::{
     EditScheduledEvent,
 };
 #[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
+use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
@@ -804,7 +804,7 @@ impl GuildId {
     /// Tries to find the [`Guild`] by its Id in the cache.
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn to_guild_cached(self, cache: impl AsRef<Cache>) -> Option<Guild> {
+    pub fn to_guild_cached(self, cache: &impl AsRef<Cache>) -> Option<GuildRef<'_>> {
         cache.as_ref().guild(self)
     }
 
@@ -1083,8 +1083,7 @@ impl GuildId {
     #[cfg(feature = "cache")]
     #[must_use]
     pub fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
-        let guild = self.to_guild_cached(&cache)?;
-        Some(guild.name)
+        self.to_guild_cached(cache.as_ref()).map(|g| g.name.clone())
     }
 
     /// Disconnects a member from a voice channel in the guild.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -205,12 +205,12 @@ impl Member {
     /// Determines the member's colour.
     #[cfg(feature = "cache")]
     pub fn colour(&self, cache: impl AsRef<Cache>) -> Option<Colour> {
-        let guild_roles = cache.as_ref().guild_field(self.guild_id, |g| g.roles.clone())?;
+        let guild = cache.as_ref().guild(self.guild_id)?;
 
         let mut roles = self
             .roles
             .iter()
-            .filter_map(|role_id| guild_roles.get(role_id))
+            .filter_map(|role_id| guild.roles.get(role_id))
             .collect::<Vec<&Role>>();
 
         roles.sort_by_key(|&b| Reverse(b));
@@ -225,7 +225,7 @@ impl Member {
     /// one returns [`None`])
     #[cfg(feature = "cache")]
     pub fn default_channel(&self, cache: impl AsRef<Cache>) -> Option<GuildChannel> {
-        let guild = self.guild_id.to_guild_cached(cache)?;
+        let guild = self.guild_id.to_guild_cached(&cache)?;
 
         let member = guild.members.get(&self.user.id)?;
 
@@ -343,12 +343,12 @@ impl Member {
     /// role with the lowest ID is the highest.
     #[cfg(feature = "cache")]
     pub fn highest_role_info(&self, cache: impl AsRef<Cache>) -> Option<(RoleId, i64)> {
-        let guild_roles = cache.as_ref().guild_field(self.guild_id, |g| g.roles.clone())?;
+        let guild = cache.as_ref().guild(self.guild_id)?;
 
         let mut highest = None;
 
         for role_id in &self.roles {
-            if let Some(role) = guild_roles.get(role_id) {
+            if let Some(role) = guild.roles.get(role_id) {
                 // Skip this role if this role in iteration has:
                 //
                 // - a position less than the recorded highest
@@ -501,12 +501,8 @@ impl Member {
     /// found.
     #[cfg(feature = "cache")]
     pub fn permissions(&self, cache: impl AsRef<Cache>) -> Result<Permissions> {
-        let perms_opt = cache
-            .as_ref()
-            .guild_field(self.guild_id, |guild| guild._member_permission_from_member(self));
-
-        match perms_opt {
-            Some(perms) => Ok(perms),
+        match cache.as_ref().guild(self.guild_id) {
+            Some(guild) => Ok(guild._member_permission_from_member(self)),
             None => Err(From::from(ModelError::GuildNotFound)),
         }
     }
@@ -589,10 +585,11 @@ impl Member {
         Some(
             cache
                 .as_ref()
-                .guild_field(self.guild_id, |g| g.roles.clone())?
-                .into_iter()
-                .map(|(_, v)| v)
-                .filter(|role| self.roles.contains(&role.id))
+                .guild(self.guild_id)?
+                .roles
+                .iter()
+                .filter(|(id, _)| self.roles.contains(id))
+                .map(|(_, v)| v.clone())
                 .collect(),
         )
     }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1061,7 +1061,11 @@ impl User {
             }
         }
 
-        guild_id.member(cache_http, &self.id).await.ok().and_then(|member| member.nick)
+        guild_id
+            .member(&cache_http, &self.id)
+            .await
+            .ok()
+            .and_then(|member| member.nick.as_ref().map(String::clone))
     }
 
     /// Returns a future that will await one message by this user.

--- a/src/utils/argument_convert/message.rs
+++ b/src/utils/argument_convert/message.rs
@@ -69,7 +69,7 @@ impl ArgumentConvert for Message {
 
         #[cfg(feature = "cache")]
         if let Some(msg) = ctx.cache.message(channel_id, message_id) {
-            return Ok(msg.clone());
+            return Ok(msg);
         }
 
         if cfg!(feature = "http") {

--- a/src/utils/argument_convert/message.rs
+++ b/src/utils/argument_convert/message.rs
@@ -69,7 +69,7 @@ impl ArgumentConvert for Message {
 
         #[cfg(feature = "cache")]
         if let Some(msg) = ctx.cache.message(channel_id, message_id) {
-            return Ok(msg);
+            return Ok(msg.clone());
         }
 
         if cfg!(feature = "http") {


### PR DESCRIPTION
1. Exposes the cache dashmap refs through a newtype and adds public type aliases for it
2. Removes the a couple of `{model}_field` methods to encourage use of direct reference usage
3. Fixes the unnecessary async in `GuildChannel::members` to fix a Send issue