### PR TITLE
Add event handler methods for scheduled events

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -871,5 +871,40 @@ async fn handle_event(
                 event_handler.thread_members_update(context, event).await;
             });
         },
+        DispatchEvent::Model(Event::GuildScheduledEventCreate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            spawn_named("dispatch::event_handler::guild_scheduled_event_create", async move {
+                event_handler.guild_scheduled_event_create(context, event.event).await;
+            });
+        },
+        DispatchEvent::Model(Event::GuildScheduledEventUpdate(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            spawn_named("dispatch::event_handler::guild_scheduled_event_update", async move {
+                event_handler.guild_scheduled_event_update(context, event.event).await;
+            });
+        },
+        DispatchEvent::Model(Event::GuildScheduledEventDelete(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            spawn_named("dispatch::event_handler::guild_scheduled_event_delete", async move {
+                event_handler.guild_scheduled_event_delete(context, event.event).await;
+            });
+        },
+        DispatchEvent::Model(Event::GuildScheduledEventUserAdd(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            spawn_named("dispatch::event_handler::guild_scheduled_event_user_add", async move {
+                event_handler.guild_scheduled_event_user_add(context, event).await;
+            });
+        },
+        DispatchEvent::Model(Event::GuildScheduledEventUserRemove(event)) => {
+            let event_handler = Arc::clone(event_handler);
+
+            spawn_named("dispatch::event_handler::guild_scheduled_event_user_remove", async move {
+                event_handler.guild_scheduled_event_user_remove(context, event).await;
+            });
+        },
     }
 }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -519,6 +519,41 @@ pub trait EventHandler: Send + Sync {
         _thread_members_update: ThreadMembersUpdateEvent,
     ) {
     }
+
+    /// Dispatched when a scheduled event is created.
+    ///
+    /// Provides data about the scheduled event.
+    async fn guild_scheduled_event_create(&self, _ctx: Context, _event: ScheduledEvent) {}
+
+    /// Dispatched when a scheduled event is updated.
+    ///
+    /// Provides data about the scheduled event.
+    async fn guild_scheduled_event_update(&self, _ctx: Context, _event: ScheduledEvent) {}
+
+    /// Dispatched when a scheduled event is deleted.
+    ///
+    /// Provides data about the scheduled event.
+    async fn guild_scheduled_event_delete(&self, _ctx: Context, _event: ScheduledEvent) {}
+
+    /// Dispatched when a guild member has subscribed to a scheduled event.
+    ///
+    /// Provides data about the subscription.
+    async fn guild_scheduled_event_user_add(
+        &self,
+        _ctx: Context,
+        _subscribed: GuildScheduledEventUserAddEvent,
+    ) {
+    }
+
+    /// Dispatched when a guild member has unsubscribed from a scheduled event.
+    ///
+    /// Provides data about the cancelled subscription.
+    async fn guild_scheduled_event_user_remove(
+        &self,
+        _ctx: Context,
+        _unsubscribed: GuildScheduledEventUserRemoveEvent,
+    ) {
+    }
 }
 
 /// This core trait for handling raw events


### PR DESCRIPTION
Gateway events:
- `GUILD_SCHEDULED_EVENT_CREATE`
- `GUILD_SCHEDULED_EVENT_UPDATE`
- `GUILD_SCHEDULED_EVENT_DELETE`
- `GUILD_SCHEDULED_EVENT_USER_ADD`
- `GUILD_SCHEDULED_EVENT_USER_REMOVE`

closes: #1915 
likes: #1916 :)