### PR TITLE
Remove unneeded futures::iter::stream usage

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -13,8 +13,6 @@ mod scheduled_event;
 mod system_channel;
 mod welcome_screen;
 
-#[cfg(feature = "model")]
-use futures::stream::StreamExt;
 use serde::de::Error as DeError;
 #[cfg(feature = "model")]
 use tracing::error;
@@ -1698,7 +1696,8 @@ impl Guild {
     /// **Note**: This will only search members that are cached. If you want to
     /// search all members in the guild via the Http API, use
     /// [`Self::search_members`].
-    pub async fn members_starting_with(
+    #[must_use]
+    pub fn members_starting_with(
         &self,
         prefix: &str,
         case_sensitive: bool,
@@ -1709,8 +1708,10 @@ impl Guild {
                 || !case_sensitive && starts_with_case_insensitive(name, prefix)
         }
 
-        let mut members = futures::stream::iter(self.members.values())
-            .filter_map(|member| async move {
+        let mut members = self
+            .members
+            .values()
+            .filter_map(|member| {
                 let username = &member.user.name;
 
                 if starts_with(prefix, case_sensitive, username) {
@@ -1728,8 +1729,7 @@ impl Guild {
                     }
                 }
             })
-            .collect::<Vec<(&Member, String)>>()
-            .await;
+            .collect::<Vec<(&Member, String)>>();
 
         if sorted {
             members.sort_by(|a, b| closest_to_origin(prefix, &a.1[..], &b.1[..]));
@@ -1770,7 +1770,8 @@ impl Guild {
     /// **Note**: This will only search members that are cached. If you want to
     /// search all members in the guild via the Http API, use
     /// [`Self::search_members`].
-    pub async fn members_containing(
+    #[must_use]
+    pub fn members_containing(
         &self,
         substring: &str,
         case_sensitive: bool,
@@ -1781,8 +1782,10 @@ impl Guild {
                 || !case_sensitive && contains_case_insensitive(name, substring)
         }
 
-        let mut members = futures::stream::iter(self.members.values())
-            .filter_map(|member| async move {
+        let mut members = self
+            .members
+            .values()
+            .filter_map(|member| {
                 let username = &member.user.name;
 
                 if contains(substring, case_sensitive, username) {
@@ -1800,8 +1803,7 @@ impl Guild {
                     }
                 }
             })
-            .collect::<Vec<(&Member, String)>>()
-            .await;
+            .collect::<Vec<(&Member, String)>>();
 
         if sorted {
             members.sort_by(|a, b| closest_to_origin(substring, &a.1[..], &b.1[..]));
@@ -1837,14 +1839,17 @@ impl Guild {
     /// **Note**: This will only search members that are cached. If you want to
     /// search all members in the guild via the Http API, use
     /// [`Self::search_members`].
-    pub async fn members_username_containing(
+    #[must_use]
+    pub fn members_username_containing(
         &self,
         substring: &str,
         case_sensitive: bool,
         sorted: bool,
     ) -> Vec<(&Member, String)> {
-        let mut members = futures::stream::iter(self.members.values())
-            .filter_map(|member| async move {
+        let mut members = self
+            .members
+            .values()
+            .filter_map(|member| {
                 let name = &member.user.name;
 
                 if (case_sensitive && name.contains(substring))
@@ -1855,8 +1860,7 @@ impl Guild {
                     None
                 }
             })
-            .collect::<Vec<(&Member, String)>>()
-            .await;
+            .collect::<Vec<(&Member, String)>>();
 
         if sorted {
             members.sort_by(|a, b| closest_to_origin(substring, &a.1[..], &b.1[..]));
@@ -1895,14 +1899,17 @@ impl Guild {
     /// **Note**: This will only search members that are cached. If you want to
     /// search all members in the guild via the Http API, use
     /// [`Self::search_members`].
-    pub async fn members_nick_containing(
+    #[must_use]
+    pub fn members_nick_containing(
         &self,
         substring: &str,
         case_sensitive: bool,
         sorted: bool,
     ) -> Vec<(&Member, String)> {
-        let mut members = futures::stream::iter(self.members.values())
-            .filter_map(|member| async move {
+        let mut members = self
+            .members
+            .values()
+            .filter_map(|member| {
                 let nick = match member.nick {
                     Some(ref nick) => nick.to_string(),
                     None => member.user.name.to_string(),
@@ -1916,8 +1923,7 @@ impl Guild {
                     None
                 }
             })
-            .collect::<Vec<(&Member, String)>>()
-            .await;
+            .collect::<Vec<(&Member, String)>>();
 
         if sorted {
             members.sort_by(|a, b| closest_to_origin(substring, &a.1[..], &b.1[..]));


### PR DESCRIPTION
Probably for a historical reason, some guild methods were unnecessarily async so I removed that, targeted at `next` due to breaking of removing async.