### PR TITLE
Add support for executing Webhooks in threads

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2152,6 +2152,9 @@ impl Http {
     ///
     /// This method does _not_ require authentication.
     ///
+    /// If `thread_id` is not `None`, then the message will be sent to the thread in the webhook's
+    /// associated [`Channel`] with the corresponding Id, which will be automatically unarchived.
+    ///
     /// Pass `true` to `wait` to wait for server confirmation of the message sending
     /// before receiving a response. From the [Discord docs]:
     ///
@@ -2189,15 +2192,16 @@ impl Http {
     /// let value = json!({"content": "test"});
     /// let map = value.as_object().unwrap();
     ///
-    /// let message = http.execute_webhook(id, token, true, map).await?;
+    /// let message = http.execute_webhook(id, None, token, true, map).await?;
     /// #     Ok(())
     /// # }
     /// ```
     ///
-    /// [Discord docs]: https://discord.com/developers/docs/resources/webhook#querystring-params
+    /// [Discord docs]: https://discord.com/developers/docs/resources/webhook#execute-webhook-query-string-params
     pub async fn execute_webhook(
         &self,
         webhook_id: u64,
+        thread_id: Option<u64>,
         token: &str,
         wait: bool,
         map: &JsonMap,
@@ -2216,6 +2220,7 @@ impl Http {
                     token,
                     wait,
                     webhook_id,
+                    thread_id,
                 },
             })
             .await?;
@@ -2237,6 +2242,7 @@ impl Http {
     pub async fn execute_webhook_with_files<'a, T, It: IntoIterator<Item = T>>(
         &self,
         webhook_id: u64,
+        thread_id: Option<u64>,
         token: &str,
         wait: bool,
         files: It,
@@ -2257,6 +2263,7 @@ impl Http {
                 token,
                 wait,
                 webhook_id,
+                thread_id,
             },
         })
         .await

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1064,11 +1064,22 @@ impl Route {
     }
 
     #[must_use]
-    pub fn webhook_with_token_optioned<D>(webhook_id: u64, token: D, wait: bool) -> String
+    pub fn webhook_with_token_optioned<D>(
+        webhook_id: u64,
+        thread_id: Option<u64>,
+        token: D,
+        wait: bool,
+    ) -> String
     where
         D: Display,
     {
-        api!("/webhooks/{}/{}?wait={}", webhook_id, token, wait)
+        let mut s = api!("/webhooks/{}/{}?wait={}", webhook_id, token, wait);
+
+        if let Some(thread_id) = thread_id {
+            s.push_str(&format!("&thread_id={}", thread_id));
+        }
+
+        s
     }
 
     #[must_use]
@@ -1450,6 +1461,7 @@ pub enum RouteInfo<'a> {
         token: &'a str,
         wait: bool,
         webhook_id: u64,
+        thread_id: Option<u64>,
     },
     JoinThread {
         channel_id: u64,
@@ -2339,10 +2351,11 @@ impl<'a> RouteInfo<'a> {
                 token,
                 wait,
                 webhook_id,
+                thread_id,
             } => (
                 LightMethod::Post,
                 Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook_with_token_optioned(webhook_id, token, wait)),
+                Cow::from(Route::webhook_with_token_optioned(webhook_id, thread_id, token, wait)),
             ),
             RouteInfo::GetAuditLogs {
                 action_type,


### PR DESCRIPTION
Adds a method `Webhook::execute_in_thread` which takes an additional thread id (which is just a `ChannelId`) parameter. Then, the webhook will execute in that thread, provided it belongs to the webhook's assigned guild channel.

Adds a new `thread_id` parameter to `Http::execute_webhook`, which is a breaking change, so this PR is targeting `next`. However, note that users aren't expected to call this method directly.

Closes #1919.