### PR TITLE
Use getch logic in ChannelId::message

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -654,10 +654,10 @@ impl GuildChannel {
     #[inline]
     pub async fn message(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
     ) -> Result<Message> {
-        self.id.message(&http, message_id).await
+        self.id.message(&cache_http, message_id).await
     }
 
     /// Gets messages from the channel.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditMessage, GetMessages};
-#[cfg(feature = "cache")]
+#[cfg(all(feature = "model", feature = "http"))]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::http::{Http, Typing};

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditMessage, GetMessages};
+#[cfg(feature = "cache")]
+use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::http::{Http, Typing};
 #[cfg(feature = "model")]
@@ -187,10 +189,10 @@ impl PrivateChannel {
     #[inline]
     pub async fn message(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
     ) -> Result<Message> {
-        self.id.message(&http, message_id).await
+        self.id.message(&cache_http, message_id).await
     }
 
     /// Gets messages from the channel.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -195,10 +195,6 @@ impl Reaction {
     ///
     /// Requires the [Read Message History] permission.
     ///
-    /// **Note**: This will send a request to the REST API. Prefer maintaining
-    /// your own message cache or otherwise having the message available if
-    /// possible.
-    ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission to
@@ -206,8 +202,8 @@ impl Reaction {
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     #[inline]
-    pub async fn message(&self, http: impl AsRef<Http>) -> Result<Message> {
-        self.channel_id.message(&http, self.message_id).await
+    pub async fn message(&self, cache_http: impl CacheHttp) -> Result<Message> {
+        self.channel_id.message(&cache_http, self.message_id).await
     }
 
     /// Retrieves the user that made the reaction.


### PR DESCRIPTION
Fixes #1597 

If anyone is wondering what `getch` means, it's `get` then `fetch`, aka `get` from cache, then if not found, `fetch` from api