### PR TITLE
Refactor User::has_role

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2967,20 +2967,6 @@ fn closest_to_origin(origin: &str, word_a: &str, word_b: &str) -> std::cmp::Orde
     value_a.cmp(&value_b)
 }
 
-/// A container for guilds.
-///
-/// This is used to differentiate whether a guild itself can be used or whether
-/// a guild needs to be retrieved from the cache.
-#[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum GuildContainer {
-    /// A guild which can have its contents directly searched.
-    Guild(PartialGuild),
-    /// A guild's id, which can be used to search the cache for a guild.
-    Id(GuildId),
-}
-
 /// A [`Guild`] widget.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -3030,24 +3016,6 @@ impl GuildInfo {
 
             cdn!("/icons/{}/{}.{}", self.id, icon, ext)
         })
-    }
-}
-
-impl From<PartialGuild> for GuildContainer {
-    fn from(guild: PartialGuild) -> GuildContainer {
-        GuildContainer::Guild(guild)
-    }
-}
-
-impl From<GuildId> for GuildContainer {
-    fn from(guild_id: GuildId) -> GuildContainer {
-        GuildContainer::Id(guild_id)
-    }
-}
-
-impl From<u64> for GuildContainer {
-    fn from(id: u64) -> GuildContainer {
-        GuildContainer::Id(GuildId(id))
     }
 }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -2,8 +2,6 @@
 
 use std::fmt;
 
-#[cfg(feature = "model")]
-use futures::future::{BoxFuture, FutureExt};
 use serde::{Deserialize, Serialize};
 
 use super::prelude::*;
@@ -896,9 +894,6 @@ impl User {
     /// the [`Cache`] if it is available, and then check if that guild has the
     /// given [`Role`].
     ///
-    /// Three forms of data may be passed in to the guild parameter: either a
-    /// [`PartialGuild`], a [`GuildId`], or a `u64`.
-    ///
     /// # Examples
     ///
     /// Check if a guild has a [`Role`] by Id:
@@ -925,50 +920,10 @@ impl User {
     pub async fn has_role(
         &self,
         cache_http: impl CacheHttp,
-        guild: impl Into<GuildContainer>,
+        guild_id: impl Into<GuildId>,
         role: impl Into<RoleId>,
     ) -> Result<bool> {
-        self._has_role(&cache_http, guild.into(), role.into()).await
-    }
-
-    fn _has_role<'a>(
-        &'a self,
-        cache_http: &'a impl CacheHttp,
-        guild: GuildContainer,
-        role: RoleId,
-    ) -> BoxFuture<'a, Result<bool>> {
-        async move {
-            match guild {
-                GuildContainer::Guild(partial_guild) => {
-                    self._has_role(cache_http, GuildContainer::Id(partial_guild.id), role).await
-                },
-                GuildContainer::Id(guild_id) => {
-                    // Silences a warning when compiling without the `cache` feature.
-                    #[allow(unused_mut)]
-                    let mut has_role = None;
-
-                    #[cfg(feature = "cache")]
-                    {
-                        if let Some(cache) = cache_http.cache() {
-                            if let Some(member) = cache.member(guild_id, self.id) {
-                                has_role = Some(member.roles.contains(&role));
-                            }
-                        }
-                    }
-
-                    if let Some(has_role) = has_role {
-                        Ok(has_role)
-                    } else {
-                        cache_http
-                            .http()
-                            .get_member(guild_id.0, self.id.0)
-                            .await
-                            .map(|m| m.roles.contains(&role))
-                    }
-                },
-            }
-        }
-        .boxed()
+        guild_id.into().member(cache_http, self).await.map(|m| m.roles.contains(&role.into()))
     }
 
     /// Refreshes the information about the user.


### PR DESCRIPTION
This also removes `GuildContainer`, as this was (and historically has been) the only use of it. Targetted at next due to signature change and struct removal.