### PR TITLE
Implement suggested `todo` fixes

### DIFF
--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc::{
 use tokio::time::{sleep, Sleep};
 
 use crate::client::bridge::gateway::ShardMessenger;
-use crate::collector::LazyArc;
+use crate::collector::{FilterFn, LazyArc};
 use crate::model::application::interaction::message_component::MessageComponentInteraction;
 
 macro_rules! impl_component_interaction_collector {
@@ -47,8 +47,8 @@ macro_rules! impl_component_interaction_collector {
                 /// This is the last instance to pass for an interaction to count as *collected*.
                 ///
                 /// This function is intended to be an interaction filter.
-                pub fn filter<F: Fn(&Arc<MessageComponentInteraction>) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
-                    self.filter.as_mut().unwrap().filter = Some(Arc::new(function));
+                pub fn filter<F: Fn(&MessageComponentInteraction) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
+                    self.filter.as_mut().unwrap().filter = Some(FilterFn(Arc::new(function)));
 
                     self
                 }
@@ -143,16 +143,12 @@ impl ComponentInteractionFilter {
     /// Checks if the `interaction` passes set constraints.
     /// Constraints are optional, as it is possible to limit interactions to
     /// be sent by a specific author or in a specific guild.
-    fn is_passing_constraints(
-        &self,
-        interaction: &mut LazyArc<'_, MessageComponentInteraction>,
-    ) -> bool {
-        // TODO: On next branch, switch filter arg to &T so this as_arc() call can be removed.
+    fn is_passing_constraints(&self, interaction: &MessageComponentInteraction) -> bool {
         self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id.map(|g| g.0))
             && self.options.message_id.map_or(true, |id| interaction.message.id.0 == id)
             && self.options.channel_id.map_or(true, |id| id == interaction.channel_id.as_ref().0)
             && self.options.author_id.map_or(true, |id| id == interaction.user.id.0)
-            && self.options.filter.as_ref().map_or(true, |f| f(&interaction.as_arc()))
+            && self.options.filter.as_ref().map_or(true, |f| f.0(interaction))
     }
 
     /// Checks if the filter is within set receive and collect limits.
@@ -168,7 +164,7 @@ impl ComponentInteractionFilter {
 struct FilterOptions {
     filter_limit: Option<u32>,
     collect_limit: Option<u32>,
-    filter: Option<Arc<dyn Fn(&Arc<MessageComponentInteraction>) -> bool + 'static + Send + Sync>>,
+    filter: Option<FilterFn<MessageComponentInteraction>>,
     channel_id: Option<u64>,
     guild_id: Option<u64>,
     author_id: Option<u64>,

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -14,7 +13,7 @@ use tokio::sync::mpsc::{
 use tokio::time::{sleep, Sleep};
 
 use crate::client::bridge::gateway::ShardMessenger;
-use crate::collector::{CollectorError, LazyArc};
+use crate::collector::{CollectorError, FilterFn, LazyArc};
 use crate::model::event::{Event, EventType, RelatedIdsForEventType};
 use crate::model::id::{ChannelId, GuildId, MessageId, UserId};
 use crate::{Error, Result};
@@ -99,8 +98,7 @@ impl EventFilter {
     /// Checks if the `event` passes set constraints.
     /// Constraints are optional, as it is possible to limit events to
     /// be sent by a specific user or in a specifc guild.
-    #[allow(clippy::wrong_self_convention)]
-    fn is_passing_constraints(&mut self, event: &mut LazyArc<'_, Event>) -> bool {
+    fn is_passing_constraints(&self, event: &Event) -> bool {
         fn empty_or_any<T, F>(slice: &[T], f: F) -> bool
         where
             F: Fn(&T) -> bool,
@@ -108,12 +106,11 @@ impl EventFilter {
             slice.is_empty() || slice.iter().any(f)
         }
 
-        // TODO: On next branch, switch filter arg to &T so this as_arc() call can be removed.
         empty_or_any(&self.options.guild_id, |id| event.guild_id().contains(id))
             && empty_or_any(&self.options.user_id, |id| event.user_id().contains(id))
             && empty_or_any(&self.options.channel_id, |id| event.channel_id().contains(id))
             && empty_or_any(&self.options.message_id, |id| event.message_id().contains(id))
-            && self.options.filter.as_mut().map_or(true, |f| f.0(&event.as_arc()))
+            && self.options.filter.as_ref().map_or(true, |f| f.0(event))
     }
 
     /// Checks if the filter is within set receive and collect limits.
@@ -125,21 +122,12 @@ impl EventFilter {
     }
 }
 
-#[derive(Clone)]
-struct FilterFn(Arc<dyn Fn(&Arc<Event>) -> bool + 'static + Send + Sync>);
-
-impl fmt::Debug for FilterFn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("Arc<dyn Fn(&Arc<Event>) -> bool + 'static + Send + Sync>")
-    }
-}
-
 #[derive(Clone, Debug, Default)]
 struct FilterOptions {
     event_types: Vec<EventType>,
     filter_limit: Option<u32>,
     collect_limit: Option<u32>,
-    filter: Option<FilterFn>,
+    filter: Option<FilterFn<Event>>,
     channel_id: Vec<ChannelId>,
     guild_id: Vec<GuildId>,
     user_id: Vec<UserId>,
@@ -191,10 +179,7 @@ impl EventCollectorBuilder {
     /// process.
     /// This is the last step to pass for a event to count as *collected*.
     #[allow(clippy::unwrap_used)]
-    pub fn filter<F: Fn(&Arc<Event>) -> bool + 'static + Send + Sync>(
-        mut self,
-        function: F,
-    ) -> Self {
+    pub fn filter<F: Fn(&Event) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
         self.filter.as_mut().unwrap().filter = Some(FilterFn(Arc::new(function)));
 
         self

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -112,7 +112,9 @@ impl MessageFilter {
     /// Sends a `message` to the consuming collector if the `message` conforms
     /// to the constraints and the limits are not reached yet.
     pub(crate) fn send_message(&mut self, message: &mut LazyArc<'_, Message>) -> bool {
-        if self.is_passing_constraints(message) && self.options.filter.as_ref().map_or(true, |f| f.0(message)) {
+        if self.is_passing_constraints(message)
+            && self.options.filter.as_ref().map_or(true, |f| f.0(message))
+        {
             self.collected += 1;
 
             if self.sender.send(message.as_arc()).is_err() {

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -15,7 +14,7 @@ use tokio::sync::mpsc::{
 use tokio::time::{sleep, Sleep};
 
 use crate::client::bridge::gateway::ShardMessenger;
-use crate::collector::LazyArc;
+use crate::collector::{FilterFn, LazyArc};
 use crate::model::channel::Message;
 
 macro_rules! impl_message_collector {
@@ -40,8 +39,8 @@ macro_rules! impl_message_collector {
                 ///
                 /// This function is intended to be a message content filter.
                 #[must_use]
-                pub fn filter<F: Fn(&Arc<Message>) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
-                    self.filter.as_mut().unwrap().filter = Some(Arc::new(function));
+                pub fn filter<F: Fn(&Message) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
+                    self.filter.as_mut().unwrap().filter = Some(FilterFn(Arc::new(function)));
 
                     self
                 }
@@ -113,14 +112,11 @@ impl MessageFilter {
     /// Sends a `message` to the consuming collector if the `message` conforms
     /// to the constraints and the limits are not reached yet.
     pub(crate) fn send_message(&mut self, message: &mut LazyArc<'_, Message>) -> bool {
-        if self.is_passing_constraints(message) {
-            // TODO: On next branch, switch filter arg to &T so this as_arc() call can be removed.
-            if self.options.filter.as_ref().map_or(true, |f| f(&message.as_arc())) {
-                self.collected += 1;
+        if self.is_passing_constraints(message) && self.options.filter.as_ref().map_or(true, |f| f.0(message)) {
+            self.collected += 1;
 
-                if self.sender.send(message.as_arc()).is_err() {
-                    return false;
-                }
+            if self.sender.send(message.as_arc()).is_err() {
+                return false;
             }
         }
 
@@ -147,11 +143,11 @@ impl MessageFilter {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 struct FilterOptions {
     filter_limit: Option<u32>,
     collect_limit: Option<u32>,
-    filter: Option<Arc<dyn Fn(&Arc<Message>) -> bool + 'static + Send + Sync>>,
+    filter: Option<FilterFn<Message>>,
     channel_id: Option<u64>,
     guild_id: Option<u64>,
     author_id: Option<u64>,
@@ -249,18 +245,6 @@ impl Future for CollectReply {
         }
 
         self.fut.as_mut().unwrap().as_mut().poll(ctx)
-    }
-}
-
-impl fmt::Debug for FilterOptions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MessageFilter")
-            .field("collect_limit", &self.collect_limit)
-            .field("filter", &"Option<Arc<dyn Fn(&Arc<Message>) -> bool + 'static + Send + Sync>>")
-            .field("channel_id", &self.channel_id)
-            .field("guild_id", &self.guild_id)
-            .field("author_id", &self.author_id)
-            .finish()
     }
 }
 

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -2,6 +2,7 @@
 //! filter lets them pass, and collects if the receive, collect, or time limits
 //! are not reached yet.
 
+use std::fmt;
 use std::sync::Arc;
 
 mod error;
@@ -18,6 +19,16 @@ pub use event_collector::*;
 pub use message_collector::*;
 pub use modal_interaction_collector::*;
 pub use reaction_collector::*;
+
+#[derive(Clone)]
+struct FilterFn<Arg>(Arc<dyn Fn(&Arg) -> bool + 'static + Send + Sync>);
+impl<Arg> fmt::Debug for FilterFn<Arg> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("FilterFn")
+            .field(&format_args!("Arc<dyn Fn({}) -> bool", stringify!(Arg)))
+            .finish()
+    }
+}
 
 /// Wraps a &T and clones the value into an Arc<T> lazily. Used with collectors to allow inspecting
 /// the value in filters while only cloning values that actually match.

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -143,7 +143,7 @@ impl ModalInteractionFilter {
     /// Checks if the `interaction` passes set constraints.
     /// Constraints are optional, as it is possible to limit interactions to
     /// be sent by a specific author or in a specific guild.
-    fn is_passing_constraints(&self, interaction: &ModalSubmitInteraction,) -> bool {
+    fn is_passing_constraints(&self, interaction: &ModalSubmitInteraction) -> bool {
         self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id.map(|g| g.0))
             && self
                 .options

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -55,11 +55,9 @@ impl Action {
         }
     }
 
-    // TODO: Change function to `from_value(u8) -> Action` in the next version and return
-    // `Action::Unknown(u8)` for unknown values.
     #[must_use]
-    pub fn from_value(value: u8) -> Option<Action> {
-        let action = match value {
+    pub fn from_value(value: u8) -> Action {
+        match value {
             1 => Action::GuildUpdate,
             10..=12 => Action::Channel(unsafe { transmute(value) }),
             13..=15 => Action::ChannelOverwrite(unsafe { transmute(value) }),
@@ -73,17 +71,15 @@ impl Action {
             83..=85 => Action::StageInstance(unsafe { transmute(value) }),
             90..=92 => Action::Sticker(unsafe { transmute(value) }),
             110..=112 => Action::Thread(unsafe { transmute(value) }),
-            _ => return None,
-        };
-
-        Some(action)
+            _ => Action::Unknown(value),
+        }
     }
 }
 
 impl<'de> Deserialize<'de> for Action {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let value = u8::deserialize(deserializer)?;
-        Ok(Action::from_value(value).unwrap_or(Action::Unknown(value)))
+        Ok(Action::from_value(value))
     }
 }
 
@@ -277,7 +273,7 @@ mod tests {
     fn action_value() {
         macro_rules! assert_action {
             ($action:pat, $num:literal) => {{
-                let a = Action::from_value($num).expect("invalid action value");
+                let a = Action::from_value($num);
                 assert!(matches!(a, $action), "{:?} didn't match the variant", a);
                 assert_eq!(a.num(), $num);
             }};
@@ -327,9 +323,7 @@ mod tests {
         assert_action!(Action::Thread(ThreadAction::Create), 110);
         assert_action!(Action::Thread(ThreadAction::Update), 111);
         assert_action!(Action::Thread(ThreadAction::Delete), 112);
-
-        // TODO: use `assert_action!` when `Action::from_value` returns `Action::Unknown`
-        assert_eq!(Action::Unknown(234).num(), 234);
+        assert_action!(Action::Unknown(234), 234);
     }
 
     #[test]


### PR DESCRIPTION
I noticed a couple of `// TODO` comments, so implemented the fixes for them. Also de-duplicates a little bit of `src/collector`, although fully DRYing it out would definitely need a separate PR