### PR TITLE
Move around boxes to fix `clippy::large_enum_variant`

### DIFF
--- a/src/client/bridge/gateway/mod.rs
+++ b/src/client/bridge/gateway/mod.rs
@@ -63,14 +63,12 @@ pub use self::shard_runner_message::{ChunkGuildFilter, ShardRunnerMessage};
 use crate::gateway::ConnectionStage;
 
 /// A message either for a [`ShardManager`] or a [`ShardRunner`].
-// Once we can use `Box` as part of a pattern, we will reconsider boxing.
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum ShardClientMessage {
     /// A message intended to be worked with by a [`ShardManager`].
     Manager(ShardManagerMessage),
     /// A message intended to be worked with by a [`ShardRunner`].
-    Runner(ShardRunnerMessage),
+    Runner(Box<ShardRunnerMessage>),
 }
 
 /// A message for a [`ShardManager`] relating to an operation with a shard.

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -249,7 +249,7 @@ impl ShardMessenger {
     /// Returns a [`TrySendError`] if the shard's receiver was closed.
     #[inline]
     pub fn send_to_shard(&self, msg: ShardRunnerMessage) -> Result<(), TrySendError<InterMessage>> {
-        self.tx.unbounded_send(InterMessage::Client(Box::new(ShardClientMessage::Runner(msg))))
+        self.tx.unbounded_send(InterMessage::Client(ShardClientMessage::Runner(Box::new(msg))))
     }
 
     /// Sets a new filter for an event collector.

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -244,7 +244,7 @@ impl ShardQueuer {
         if let Some(runner) = self.runners.lock().await.get(&shard_id) {
             let shutdown = ShardManagerMessage::Shutdown(shard_id, code);
             let client_msg = ShardClientMessage::Manager(shutdown);
-            let msg = InterMessage::Client(Box::new(client_msg));
+            let msg = InterMessage::Client(client_msg);
 
             if let Err(why) = runner.runner_tx.tx.unbounded_send(msg) {
                 warn!(

--- a/src/client/bridge/gateway/shard_runner_message.rs
+++ b/src/client/bridge/gateway/shard_runner_message.rs
@@ -23,8 +23,6 @@ pub enum ChunkGuildFilter {
 }
 
 /// A message to send from a shard over a WebSocket.
-// Once we can use `Box` as part of a pattern, we will reconsider boxing.
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum ShardRunnerMessage {
     /// Indicates that the client is to send a member chunk message.

--- a/src/error.rs
+++ b/src/error.rs
@@ -95,7 +95,7 @@ pub enum Error {
     ///
     /// [`http`]: crate::http
     #[cfg(feature = "http")]
-    Http(Box<HttpError>),
+    Http(HttpError),
     /// An error from the `tungstenite` crate.
     #[cfg(feature = "gateway")]
     Tungstenite(TungsteniteError),
@@ -149,7 +149,7 @@ impl From<TungsteniteError> for Error {
 #[cfg(feature = "http")]
 impl From<HttpError> for Error {
     fn from(e: HttpError) -> Error {
-        Error::Http(Box::new(e))
+        Error::Http(e)
     }
 }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -150,7 +150,7 @@ impl fmt::Display for ConnectionStage {
 #[non_exhaustive]
 pub enum InterMessage {
     #[cfg(feature = "client")]
-    Client(Box<ShardClientMessage>),
+    Client(ShardClientMessage),
     Json(Value),
 }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3955,7 +3955,7 @@ impl Http {
         if response.status().is_success() {
             Ok(response)
         } else {
-            Err(Error::Http(Box::new(HttpError::from_response(response).await)))
+            Err(Error::Http(HttpError::from_response(response).await))
         }
     }
 
@@ -3974,7 +3974,7 @@ impl Http {
         debug!("Expected {}, got {}", expected, response.status());
         trace!("Unsuccessful response: {:?}", response);
 
-        Err(Error::Http(Box::new(HttpError::from_response(response).await)))
+        Err(Error::Http(HttpError::from_response(response).await))
     }
 }
 

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -452,18 +452,13 @@ mod tests {
     fn test_parse_header_errors() {
         let headers = headers();
 
-        // This macro wouldn't be needed if `Error::Http` didn't
-        // box its error, or if box patterns were stable.
-        macro_rules! is_err {
-            ($header:expr, $err:pat) => {
-                match parse_header::<i64>(&headers, $header).unwrap_err() {
-                    Error::Http(x) => matches!(*x, $err),
-                    _ => false,
-                }
-            };
-        }
-
-        assert!(is_err!("x-bad-num", HttpError::RateLimitI64F64));
-        assert!(is_err!("x-bad-unicode", HttpError::RateLimitUtf8));
+        assert!(matches!(
+            parse_header::<i64>(&headers, "x-bad-num").unwrap_err(),
+            Error::Http(HttpError::RateLimitI64F64)
+        ));
+        assert!(matches!(
+            parse_header::<i64>(&headers, "x-bad-unicode").unwrap_err(),
+            Error::Http(HttpError::RateLimitUtf8)
+        ));
     }
 }


### PR DESCRIPTION
> // Once we can use `Box` as part of a pattern, we will reconsider boxing.

Just use multiple match expressions? First get to the variant, then deref the box, then continue matching.

Also HttpError was boxed however removing the box causes no extra warnings, so free performance there.