### PR TITLE
Fix compile errors in builder when model disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
             dont-test: true
           - name: builder without model
             features: builder
+          - name: unstable Discord API (no default features)
+            features: unstable_discord_api
+            dont-test: true
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
             dont-test: true
           - name: builder without model
             features: builder
+            dont-test: true
           - name: unstable Discord API (no default features)
             features: unstable_discord_api
             dont-test: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
           - name: unstable Discord API features
             features: default unstable_discord_api
             dont-test: true
+          - name: builder without model
+            features: builder
 
     steps:
       - name: Checkout sources

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -314,6 +314,8 @@ impl<'a> Default for CreateMessage<'a> {
         let mut map = HashMap::new();
         map.insert("tts", Value::from(false));
 
-        CreateMessage(map, None, Vec::default())
+        // Necessary because the type of the third field is different without model feature
+        #[allow(clippy::default_trait_access)]
+        CreateMessage(map, None, Default::default())
     }
 }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 #[cfg(feature = "model")]
 use crate::http::Http;
+#[cfg(feature = "model")]
 use crate::internal::prelude::*;
 use crate::json::{json, Value};
 #[cfg(feature = "model")]

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 #[cfg(feature = "model")]
 use crate::http::Http;
+#[cfg(feature = "model")]
 use crate::internal::prelude::*;
 use crate::json::{json, Value, NULL};
 #[cfg(feature = "model")]

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -318,6 +318,8 @@ impl<'a> Default for ExecuteWebhook<'a> {
         let mut map = HashMap::new();
         map.insert("tts", Value::from(false));
 
-        ExecuteWebhook(map, Vec::default())
+        // Necessary because the type of the third field is different without model feature
+        #[allow(clippy::default_trait_access)]
+        ExecuteWebhook(map, Default::default())
     }
 }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -318,7 +318,7 @@ impl<'a> Default for ExecuteWebhook<'a> {
         let mut map = HashMap::new();
         map.insert("tts", Value::from(false));
 
-        // Necessary because the type of the third field is different without model feature
+        // Necessary because the type of the second field is different without model feature
         #[allow(clippy::default_trait_access)]
         ExecuteWebhook(map, Default::default())
     }


### PR DESCRIPTION
PR #1830 fixed a bunch of clippy pedantic level lints, which also unfortunately caused some regressions for the no-model use case, as I intentionally used bare Default in #1770 to automatically select the correct type without manually inspecting the feature flags again.

I admit my use case is somewhat outlandish, but would you mind if I added one or two regression tests to CI to avoid situations like this in the future?