### PR TITLE
Avoid cloning member out of cache in Guild::member

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -13,6 +13,7 @@ mod scheduled_event;
 mod system_channel;
 mod welcome_screen;
 
+#[cfg(feature = "model")]
 use std::borrow::Cow;
 
 use serde::de::Error as DeError;

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -13,6 +13,8 @@ mod scheduled_event;
 mod system_channel;
 mod welcome_screen;
 
+use std::borrow::Cow;
+
 use serde::de::Error as DeError;
 #[cfg(feature = "model")]
 use tracing::error;
@@ -1583,6 +1585,9 @@ impl Guild {
 
     /// Gets a user's [`Member`] for the guild by Id.
     ///
+    /// If the cache feature is enabled [`Self::members`] will be checked
+    /// first, if so, a reference to the member will be returned.
+    ///
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the user is not in
@@ -1594,8 +1599,14 @@ impl Guild {
         &self,
         cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
-    ) -> Result<Member> {
-        self.id.member(cache_http, user_id).await
+    ) -> Result<Cow<'_, Member>> {
+        let user_id = user_id.into();
+
+        if let Some(member) = self.members.get(&user_id) {
+            Ok(Cow::Borrowed(member))
+        } else {
+            cache_http.http().get_member(self.id.0, user_id.0).await.map(Cow::Owned)
+        }
     }
 
     /// Gets a list of the guild's members.


### PR DESCRIPTION
Uses `std::borrow::Cow` to avoid cloning the member out of the members hashmap. This is not possible for `GuildId::member` or `Cache::member` because it would be returning a reference into the `GuildRef` which would be dropped at the end of the function.