### PR TITLE
Clean up previous changes to cache

### DIFF
--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -26,7 +26,7 @@ use crate::model::invite::InviteTargetType;
 /// impl EventHandler for Handler {
 ///     async fn message(&self, context: Context, msg: Message) {
 ///         if msg.content == "!createinvite" {
-///             let channel_opt = context.cache.guild_channel(msg.channel_id).map(|c| c.clone());
+///             let channel_opt = context.cache.guild_channel(msg.channel_id).as_deref().cloned();
 ///             let channel = match channel_opt {
 ///                 Some(channel) => channel,
 ///                 None => {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -57,16 +57,16 @@ pub use self::settings::Settings;
 
 type MessageCache = DashMap<ChannelId, DashMap<MessageId, Message>>;
 
-struct NotSend();
+struct NotSend;
 
 pub struct CacheRef<'a, K, V> {
     inner: Ref<'a, K, V>,
     phantom: std::marker::PhantomData<*const NotSend>,
 }
 
-impl<'a, K, V> From<Ref<'a, K, V>> for CacheRef<'a, K, V> {
-    fn from(inner: Ref<'a, K, V>) -> Self {
-        Self {
+impl<'a, K, V> CacheRef<'a, K, V> {
+    fn from_ref(inner: Ref<'a, K, V>) -> Self {
+        CacheRef {
             inner,
             phantom: std::marker::PhantomData,
         }
@@ -451,7 +451,7 @@ impl Cache {
     }
 
     fn _guild(&self, id: GuildId) -> Option<GuildRef<'_>> {
-        self.guilds.get(&id).map(Into::into)
+        self.guilds.get(&id).map(CacheRef::from_ref)
     }
 
     /// Returns the number of cached guilds.
@@ -479,7 +479,7 @@ impl Cache {
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, message: Message) {
-    ///         let channel_opt = context.cache.guild_channel(message.channel_id).map(|c| c.clone());
+    ///         let channel_opt = context.cache.guild_channel(message.channel_id).as_deref().cloned();
     ///         let channel = match channel_opt {
     ///             Some(channel) => channel,
     ///             None => {
@@ -514,7 +514,7 @@ impl Cache {
     }
 
     fn _guild_channel(&self, id: ChannelId) -> Option<GuildChannelRef<'_>> {
-        self.channels.get(&id).map(Into::into)
+        self.channels.get(&id).map(CacheRef::from_ref)
     }
 
     /// Retrieves a [`Guild`]'s member from the cache based on the guild's and
@@ -764,7 +764,7 @@ impl Cache {
     }
 
     fn _private_channel(&self, channel_id: ChannelId) -> Option<PrivateChannelRef<'_>> {
-        self.private_channels.get(&channel_id).map(Into::into)
+        self.private_channels.get(&channel_id).map(CacheRef::from_ref)
     }
 
     /// Retrieves a [`Guild`]'s role by their Ids.

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -611,7 +611,7 @@ async fn handle_event(
 
             spawn_named("dispatch::event_handler::guild_update", async move {
                 feature_cache! {{
-                    let before = cache_and_http.cache.guild(&event.guild.id).map(|g| g.clone());
+                    let before = cache_and_http.cache.guild(&event.guild.id).as_deref().cloned();
 
                     update(&cache_and_http, &mut event);
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1005,24 +1005,7 @@ impl User {
         cache_http: impl CacheHttp,
         guild_id: impl Into<GuildId>,
     ) -> Option<String> {
-        let guild_id = guild_id.into();
-
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = guild_id.to_guild_cached(cache) {
-                    if let Some(member) = guild.members.get(&self.id) {
-                        return member.nick.clone();
-                    }
-                }
-            }
-        }
-
-        guild_id
-            .member(&cache_http, &self.id)
-            .await
-            .ok()
-            .and_then(|member| member.nick.as_ref().map(String::clone))
+        guild_id.into().member(cache_http, &self.id).await.ok().and_then(|member| member.nick)
     }
 
     /// Returns a future that will await one message by this user.


### PR DESCRIPTION
This replaces the implementation of `From<Ref>` for `CacheRef` with a private method in order to not expose the dashmap type as part of the public API. Also, replaces `.map(|c| c.clone())` with `.as_deref().cloned()` on types returned from the cache in code and docs. Finally, removes an extra clone in `User::nick_in`, and refactors example 5 slightly.