### PR TITLE
Rework manual deserialization implementations 

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -181,8 +181,7 @@ pub struct Cache {
     pub(crate) private_channels: DashMap<ChannelId, PrivateChannel>,
     /// The total number of shards being used by the bot.
     pub(crate) shard_count: RwLock<u64>,
-    /// A list of guilds which are "unavailable". Refer to the documentation for
-    /// [`Event::GuildUnavailable`] for more information on when this can occur.
+    /// A list of guilds which are "unavailable".
     ///
     /// Additionally, guilds are always unavailable for bot users when a Ready
     /// is received. Guilds are "sent in" over time through the receiving of

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -158,9 +158,8 @@ pub struct Cache {
     /// A map of channels in [`Guild`]s that the current user has received data
     /// for.
     ///
-    /// When a [`Event::GuildDelete`] or [`Event::GuildUnavailable`] is
-    /// received and processed by the cache, the relevant channels are also
-    /// removed from this map.
+    /// When a [`Event::GuildDelete`] is received and processed by the cache,
+    /// the relevant channels are also removed from this map.
     pub(crate) channels: DashMap<ChannelId, GuildChannel>,
     /// Cache of channels that have been fetched via to_channel.
     ///

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -5,7 +5,6 @@ use async_tungstenite::tungstenite;
 use async_tungstenite::tungstenite::error::Error as TungsteniteError;
 use async_tungstenite::tungstenite::protocol::frame::CloseFrame;
 use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
-use serde::Deserialize;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, instrument, trace, warn};
 use typemap_rev::TypeMap;
@@ -551,8 +550,7 @@ impl ShardRunner {
     #[instrument(skip(self))]
     async fn recv_event(&mut self) -> Result<(Option<Event>, Option<ShardAction>, bool)> {
         let gw_event = match self.shard.client.recv_json().await {
-            Ok(Some(value)) => GatewayEvent::deserialize(value).map(Some).map_err(From::from),
-            Ok(None) => Ok(None),
+            Ok(inner) => Ok(inner),
             Err(Error::Tungstenite(TungsteniteError::Io(_))) => {
                 debug!("Attempting to auto-reconnect");
 

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -721,7 +721,7 @@ async fn handle_event(
                 event_handler.typing_start(context, event).await;
             });
         },
-        DispatchEvent::Model(Event::Unknown) => warn!("An unknown event was recieved"),
+        DispatchEvent::Model(Event::Unknown) => warn!("An unknown event was received"),
         DispatchEvent::Model(Event::UserUpdate(mut event)) => {
             let _before = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -117,9 +117,6 @@ impl DispatchEvent {
             Self::Model(Event::GuildStickersUpdate(ref mut event)) => {
                 update(cache_and_http, event);
             },
-            Self::Model(Event::GuildUnavailable(ref mut event)) => {
-                update(cache_and_http, event);
-            },
             // Already handled by the framework check macro
             Self::Model(Event::MessageCreate(_)) => {},
             Self::Model(Event::MessageUpdate(ref mut event)) => {
@@ -598,14 +595,6 @@ async fn handle_event(
                 event_handler.guild_stickers_update(context, event.guild_id, event.stickers).await;
             });
         },
-        DispatchEvent::Model(Event::GuildUnavailable(mut event)) => {
-            update(&cache_and_http, &mut event);
-            let event_handler = Arc::clone(event_handler);
-
-            spawn_named("dispatch::event_handler::guild_unavailable", async move {
-                event_handler.guild_unavailable(context, event.guild_id).await;
-            });
-        },
         DispatchEvent::Model(Event::GuildUpdate(mut event)) => {
             let event_handler = Arc::clone(event_handler);
 
@@ -732,11 +721,11 @@ async fn handle_event(
                 event_handler.typing_start(context, event).await;
             });
         },
-        DispatchEvent::Model(Event::Unknown(event)) => {
+        DispatchEvent::Model(Event::Unknown) => {
             let event_handler = Arc::clone(event_handler);
 
             spawn_named("dispatch::event_handler::unknown", async move {
-                event_handler.unknown(context, event.kind, event.value).await;
+                event_handler.unknown(context).await;
             });
         },
         DispatchEvent::Model(Event::UserUpdate(mut event)) => {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -722,11 +722,7 @@ async fn handle_event(
             });
         },
         DispatchEvent::Model(Event::Unknown) => {
-            let event_handler = Arc::clone(event_handler);
-
-            spawn_named("dispatch::event_handler::unknown", async move {
-                event_handler.unknown(context).await;
-            });
+            // No point in handling this event, gives no info.
         },
         DispatchEvent::Model(Event::UserUpdate(mut event)) => {
             let _before = update(&cache_and_http, &mut event);

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use futures::channel::mpsc::UnboundedSender as Sender;
 use futures::future::{BoxFuture, FutureExt};
 use tokio::sync::RwLock;
-use tracing::instrument;
+use tracing::{instrument, warn};
 use typemap_rev::TypeMap;
 
 #[cfg(feature = "gateway")]
@@ -721,9 +721,7 @@ async fn handle_event(
                 event_handler.typing_start(context, event).await;
             });
         },
-        DispatchEvent::Model(Event::Unknown) => {
-            // No point in handling this event, gives no info.
-        },
+        DispatchEvent::Model(Event::Unknown) => warn!("An unknown event was recieved"),
         DispatchEvent::Model(Event::UserUpdate(mut event)) => {
             let _before = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 
 use super::context::Context;
 use crate::client::bridge::gateway::event::*;
-use crate::json::Value;
 use crate::model::application::command::CommandPermission;
 use crate::model::application::interaction::Interaction;
 use crate::model::prelude::*;
@@ -393,7 +392,7 @@ pub trait EventHandler: Send + Sync {
     /// Dispatched when an unknown event was sent from discord.
     ///
     /// Provides the event's name and its unparsed data.
-    async fn unknown(&self, _ctx: Context, _name: String, _raw: Value) {}
+    async fn unknown(&self, _ctx: Context) {}
 
     /// Dispatched when the bot's data is updated.
     ///

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -389,11 +389,6 @@ pub trait EventHandler: Send + Sync {
     /// Dispatched when a user starts typing.
     async fn typing_start(&self, _ctx: Context, _: TypingStartEvent) {}
 
-    /// Dispatched when an unknown event was sent from discord.
-    ///
-    /// Provides the event's name and its unparsed data.
-    async fn unknown(&self, _ctx: Context) {}
-
     /// Dispatched when the bot's data is updated.
     ///
     /// Provides the old and new data.

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -16,6 +16,7 @@ use crate::client::bridge::gateway::ChunkGuildFilter;
 use crate::constants::{self, OpCode};
 use crate::gateway::{CurrentPresence, GatewayError};
 use crate::json::{from_str, json, to_string, Value};
+use crate::model::event::GatewayEvent;
 use crate::model::gateway::GatewayIntents;
 use crate::model::id::GuildId;
 use crate::{Error, Result};
@@ -38,7 +39,7 @@ impl WsClient {
         Ok(Self(stream))
     }
 
-    pub(crate) async fn recv_json(&mut self) -> Result<Option<Value>> {
+    pub(crate) async fn recv_json(&mut self) -> Result<Option<GatewayEvent>> {
         let message = match timeout(TIMEOUT, self.0.next()).await {
             Ok(Some(Ok(msg))) => msg,
             Ok(Some(Err(e))) => return Err(e.into()),

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -14,7 +14,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::json;
-use crate::json::prelude::*;
+use crate::json::from_number;
 use crate::model::application::command::{CommandOptionType, CommandType};
 #[cfg(feature = "http")]
 use crate::model::application::interaction::InteractionResponseType;
@@ -34,7 +34,11 @@ use crate::model::id::{
     UserId,
 };
 use crate::model::user::User;
-use crate::model::utils::deserialize_options_with_resolved;
+use crate::model::utils::{
+    deserialize_options_with_resolved,
+    remove_from_map,
+    remove_from_map_opt,
+};
 
 /// An interaction when a user invokes a slash command.
 #[derive(Clone, Debug, Serialize)]
@@ -329,11 +333,11 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteraction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
 
-        let id = map.get("guild_id").and_then(Value::as_str).and_then(|x| x.parse::<u64>().ok());
+        let guild_id = remove_from_map_opt::<GuildId, _>(&mut map, "guild_id")?;
 
-        if let Some(guild_id) = id {
+        if let Some(guild_id) = guild_id {
             if let Some(member) = map.get_mut("member").and_then(Value::as_object_mut) {
-                member.insert("guild_id".to_string(), from_number(guild_id));
+                member.insert("guild_id".to_string(), from_number(guild_id.0));
             }
 
             if let Some(data) = map.get_mut("data") {
@@ -341,10 +345,9 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteraction {
                     if let Some(roles) = resolved.get_mut("roles") {
                         if let Some(values) = roles.as_object_mut() {
                             for value in values.values_mut() {
-                                value.as_object_mut().expect("couldn't deserialize").insert(
-                                    "guild_id".to_string(),
-                                    Value::from(guild_id.to_string()),
-                                );
+                                if let Some(role) = value.as_object_mut() {
+                                    role.insert("guild_id".to_string(), from_number(guild_id.0));
+                                };
                             }
                         }
                     }
@@ -352,89 +355,24 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteraction {
             }
         }
 
-        let id = map
-            .remove("id")
-            .ok_or_else(|| DeError::custom("expected id"))
-            .and_then(InteractionId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let application_id = map
-            .remove("application_id")
-            .ok_or_else(|| DeError::custom("expected application id"))
-            .and_then(ApplicationId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let kind = map
-            .remove("type")
-            .ok_or_else(|| DeError::custom("expected type"))
-            .and_then(InteractionType::deserialize)
-            .map_err(DeError::custom)?;
-
-        let data = map
-            .remove("data")
-            .ok_or_else(|| DeError::custom("expected data"))
-            .and_then(CommandData::deserialize)
-            .map_err(DeError::custom)?;
-
-        let guild_id = map
-            .remove("guild_id")
-            .map(GuildId::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let channel_id = map
-            .remove("channel_id")
-            .ok_or_else(|| DeError::custom("expected channel_id"))
-            .and_then(ChannelId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let member =
-            map.remove("member").map(Member::deserialize).transpose().map_err(DeError::custom)?;
-
-        let user =
-            map.remove("user").map(User::deserialize).transpose().map_err(DeError::custom)?;
-
-        let user = user
+        let member = remove_from_map_opt::<Member, _>(&mut map, "member")?;
+        let user = remove_from_map_opt(&mut map, "user")?
             .or_else(|| member.as_ref().map(|m| m.user.clone()))
             .ok_or_else(|| DeError::custom("expected user or member"))?;
 
-        let token = map
-            .remove("token")
-            .ok_or_else(|| DeError::custom("expected token"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-
-        let version = map
-            .remove("version")
-            .ok_or_else(|| DeError::custom("expected version"))
-            .and_then(u8::deserialize)
-            .map_err(DeError::custom)?;
-
-        let guild_locale = map
-            .remove("guild_locale")
-            .map(String::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let locale = map
-            .remove("locale")
-            .ok_or_else(|| DeError::custom("expected locale"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-
         Ok(Self {
-            id,
-            application_id,
-            kind,
-            data,
             guild_id,
-            channel_id,
             member,
             user,
-            token,
-            version,
-            guild_locale,
-            locale,
+            id: remove_from_map(&mut map, "id")?,
+            application_id: remove_from_map(&mut map, "application_id")?,
+            kind: remove_from_map(&mut map, "type")?,
+            data: remove_from_map(&mut map, "data")?,
+            channel_id: remove_from_map(&mut map, "channel_id")?,
+            token: remove_from_map(&mut map, "token")?,
+            version: remove_from_map(&mut map, "version")?,
+            guild_locale: remove_from_map_opt(&mut map, "guild_locale")?,
+            locale: remove_from_map(&mut map, "locale")?,
         })
     }
 }
@@ -500,24 +438,7 @@ impl<'de> Deserialize<'de> for CommandData {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
 
-        let name = map
-            .remove("name")
-            .ok_or_else(|| DeError::custom("expected value"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-
-        let id = map
-            .remove("id")
-            .ok_or_else(|| DeError::custom("expected value"))
-            .and_then(CommandId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let resolved = map
-            .remove("resolved")
-            .map(CommandDataResolved::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?
-            .unwrap_or_default();
+        let resolved = remove_from_map_opt(&mut map, "resolved")?.unwrap_or_default();
 
         let options = map
             .remove("options")
@@ -526,30 +447,14 @@ impl<'de> Deserialize<'de> for CommandData {
             .map_err(DeError::custom)?
             .unwrap_or_default();
 
-        let kind = map
-            .remove("type")
-            .ok_or_else(|| DeError::custom("expected type"))
-            .and_then(CommandType::deserialize)
-            .map_err(DeError::custom)?;
-
-        let guild_id = match map.remove("guild_id") {
-            Some(id) => Option::<GuildId>::deserialize(id).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let target_id = match map.remove("target_id") {
-            Some(id) => Option::<TargetId>::deserialize(id).map_err(DeError::custom)?,
-            None => None,
-        };
-
         Ok(Self {
-            id,
-            name,
-            kind,
             options,
             resolved,
-            guild_id,
-            target_id,
+            id: remove_from_map(&mut map, "id")?,
+            name: remove_from_map(&mut map, "name")?,
+            kind: remove_from_map(&mut map, "kind")?,
+            guild_id: remove_from_map_opt(&mut map, "guild_id")?.flatten(),
+            target_id: remove_from_map_opt(&mut map, "target_id")?.flatten(),
         })
     }
 }
@@ -594,7 +499,7 @@ pub struct CommandDataResolved {
 /// top-level key and another vector of `options`.
 ///
 /// Their resolved objects can be found on [`CommandData::resolved`].
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandDataOption {
     /// The name of the parameter.
@@ -617,47 +522,6 @@ pub struct CommandDataOption {
     /// this option is currently focused by the user.
     #[serde(default)]
     pub focused: bool,
-}
-
-impl<'de> Deserialize<'de> for CommandDataOption {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
-
-        let name = map
-            .remove("name")
-            .ok_or_else(|| DeError::custom("expected value"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-
-        let value = map.remove("value");
-
-        let kind = map
-            .remove("type")
-            .ok_or_else(|| DeError::custom("expected type"))
-            .and_then(CommandOptionType::deserialize)
-            .map_err(DeError::custom)?;
-
-        let options = map
-            .remove("options")
-            .map(Vec::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?
-            .unwrap_or_default();
-
-        let focused = match map.get("focused") {
-            Some(value) => value.as_bool().ok_or_else(|| DeError::custom("expected bool"))?,
-            None => false,
-        };
-
-        Ok(Self {
-            name,
-            value,
-            kind,
-            options,
-            resolved: None,
-            focused,
-        })
-    }
 }
 
 /// The resolved value of an [`CommandDataOption`].

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -435,7 +435,7 @@ impl<'de> Deserialize<'de> for CommandData {
             resolved,
             id: remove_from_map(&mut map, "id")?,
             name: remove_from_map(&mut map, "name")?,
-            kind: remove_from_map(&mut map, "kind")?,
+            kind: remove_from_map(&mut map, "type")?,
             guild_id: remove_from_map_opt(&mut map, "guild_id")?.flatten(),
             target_id: remove_from_map_opt(&mut map, "target_id")?.flatten(),
         })

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -8,6 +8,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::json;
+#[cfg(feature = "http")]
 use crate::json::prelude::*;
 use crate::model::application::interaction::application_command::CommandData;
 #[cfg(feature = "http")]

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -12,10 +12,11 @@ use crate::json::prelude::*;
 use crate::model::application::interaction::application_command::CommandData;
 #[cfg(feature = "http")]
 use crate::model::application::interaction::InteractionResponseType;
-use crate::model::application::interaction::InteractionType;
+use crate::model::application::interaction::{add_guild_id_to_resolved, InteractionType};
 use crate::model::guild::Member;
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
+use crate::model::utils::{remove_from_map, remove_from_map_opt};
 
 /// An interaction received when the user fills in an autocomplete option
 #[derive(Clone, Debug, Serialize)]
@@ -82,112 +83,30 @@ impl<'de> Deserialize<'de> for AutocompleteInteraction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
 
-        let id = map.get("guild_id").and_then(Value::as_str).and_then(|x| x.parse::<u64>().ok());
+        let guild_id = remove_from_map_opt(&mut map, "guild_id")?;
 
-        if let Some(guild_id) = id {
-            if let Some(member) = map.get_mut("member").and_then(Value::as_object_mut) {
-                member.insert("guild_id".to_string(), from_number(guild_id));
-            }
-
-            if let Some(data) = map.get_mut("data") {
-                if let Some(resolved) = data.get_mut("resolved") {
-                    if let Some(roles) = resolved.get_mut("roles") {
-                        if let Some(values) = roles.as_object_mut() {
-                            for value in values.values_mut() {
-                                value.as_object_mut().expect("couldn't deserialize").insert(
-                                    "guild_id".to_string(),
-                                    Value::from(guild_id.to_string()),
-                                );
-                            }
-                        }
-                    }
-                }
-            }
+        if let Some(guild_id) = guild_id {
+            add_guild_id_to_resolved(&mut map, guild_id);
         }
 
-        let id = map
-            .remove("id")
-            .ok_or_else(|| DeError::custom("expected id"))
-            .and_then(InteractionId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let application_id = map
-            .remove("application_id")
-            .ok_or_else(|| DeError::custom("expected application id"))
-            .and_then(ApplicationId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let kind = map
-            .remove("type")
-            .ok_or_else(|| DeError::custom("expected type"))
-            .and_then(InteractionType::deserialize)
-            .map_err(DeError::custom)?;
-
-        let data = map
-            .remove("data")
-            .ok_or_else(|| DeError::custom("expected data"))
-            .and_then(CommandData::deserialize)
-            .map_err(DeError::custom)?;
-
-        let guild_id = map
-            .remove("guild_id")
-            .map(GuildId::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let channel_id = map
-            .remove("channel_id")
-            .ok_or_else(|| DeError::custom("expected channel_id"))
-            .and_then(ChannelId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let member =
-            map.remove("member").map(Member::deserialize).transpose().map_err(DeError::custom)?;
-
-        let user =
-            map.remove("user").map(User::deserialize).transpose().map_err(DeError::custom)?;
-
-        let user = user
+        let member = remove_from_map_opt::<Member, _>(&mut map, "member")?;
+        let user = remove_from_map_opt(&mut map, "user")?
             .or_else(|| member.as_ref().map(|m| m.user.clone()))
             .ok_or_else(|| DeError::custom("expected user or member"))?;
 
-        let token = map
-            .remove("token")
-            .ok_or_else(|| DeError::custom("expected token"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-
-        let version = map
-            .remove("version")
-            .ok_or_else(|| DeError::custom("expected version"))
-            .and_then(u8::deserialize)
-            .map_err(DeError::custom)?;
-
-        let guild_locale = map
-            .remove("guild_locale")
-            .map(String::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let locale = map
-            .remove("locale")
-            .ok_or_else(|| DeError::custom("expected locale"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-
         Ok(Self {
-            id,
-            application_id,
-            kind,
-            data,
             guild_id,
-            channel_id,
             member,
             user,
-            token,
-            version,
-            guild_locale,
-            locale,
+            id: remove_from_map(&mut map, "id")?,
+            application_id: remove_from_map(&mut map, "application_id")?,
+            kind: remove_from_map(&mut map, "type")?,
+            data: remove_from_map(&mut map, "data")?,
+            channel_id: remove_from_map(&mut map, "channel_id")?,
+            token: remove_from_map(&mut map, "token")?,
+            version: remove_from_map(&mut map, "version")?,
+            guild_locale: remove_from_map_opt(&mut map, "guild_locale")?,
+            locale: remove_from_map(&mut map, "locale")?,
         })
     }
 }

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -12,7 +12,8 @@ use self::autocomplete::AutocompleteInteraction;
 use self::message_component::MessageComponentInteraction;
 use self::modal::ModalSubmitInteraction;
 use self::ping::PingInteraction;
-use crate::json::{from_value, Value};
+use crate::internal::prelude::*;
+use crate::json::from_value;
 use crate::model::id::{ApplicationId, InteractionId};
 use crate::model::user::User;
 use crate::model::utils::deserialize_val;
@@ -134,7 +135,7 @@ impl Interaction {
 }
 
 impl<'de> Deserialize<'de> for Interaction {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
         let value = Value::deserialize(deserializer)?;
         let map = value.as_object().ok_or_else(|| DeError::custom("expected JsonMap"))?;
 
@@ -158,17 +159,13 @@ impl<'de> Deserialize<'de> for Interaction {
 }
 
 impl Serialize for Interaction {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
         match self {
-            Interaction::Ping(i) => PingInteraction::serialize(i, serializer),
-            Interaction::ApplicationCommand(i) => {
-                ApplicationCommandInteraction::serialize(i, serializer)
-            },
-            Interaction::MessageComponent(i) => {
-                MessageComponentInteraction::serialize(i, serializer)
-            },
-            Interaction::Autocomplete(i) => AutocompleteInteraction::serialize(i, serializer),
-            Interaction::ModalSubmit(i) => ModalSubmitInteraction::serialize(i, serializer),
+            Interaction::Ping(i) => i.serialize(serializer),
+            Interaction::ApplicationCommand(i) => i.serialize(serializer),
+            Interaction::MessageComponent(i) => i.serialize(serializer),
+            Interaction::Autocomplete(i) => i.serialize(serializer),
+            Interaction::ModalSubmit(i) => i.serialize(serializer),
         }
     }
 }

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -140,9 +140,7 @@ impl<'de> Deserialize<'de> for Interaction {
         let map = value.as_object().ok_or_else(|| DeError::custom("expected JsonMap"))?;
 
         let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?;
-        let kind = deserialize_val(raw_kind.clone())?;
-
-        match kind {
+        match deserialize_val(raw_kind.clone())? {
             InteractionType::ApplicationCommand => {
                 from_value(value).map(Interaction::ApplicationCommand)
             },

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -12,7 +12,6 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::json;
-use crate::json::prelude::*;
 use crate::model::application::component::ActionRow;
 #[cfg(feature = "http")]
 use crate::model::application::interaction::InteractionResponseType;
@@ -23,6 +22,7 @@ use crate::model::guild::Member;
 use crate::model::id::MessageId;
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
+use crate::model::utils::{remove_from_map, remove_from_map_opt};
 
 /// An interaction triggered by a modal submit.
 #[derive(Clone, Debug, Serialize)]
@@ -280,119 +280,25 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
 
-        let id = map.get("guild_id").and_then(Value::as_str).and_then(|x| x.parse::<u64>().ok());
-
-        if let Some(guild_id) = id {
-            if let Some(member) = map.get_mut("member").and_then(Value::as_object_mut) {
-                member.insert("guild_id".to_string(), from_number(guild_id));
-            }
-
-            if let Some(data) = map.get_mut("data") {
-                if let Some(resolved) = data.get_mut("resolved") {
-                    if let Some(roles) = resolved.get_mut("roles") {
-                        if let Some(values) = roles.as_object_mut() {
-                            for value in values.values_mut() {
-                                value
-                                    .as_object_mut()
-                                    .expect("couldn't deserialize message component")
-                                    .insert(
-                                        "guild_id".to_string(),
-                                        Value::String(guild_id.to_string()),
-                                    );
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let id = map
-            .remove("id")
-            .ok_or_else(|| DeError::custom("expected id"))
-            .and_then(InteractionId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let application_id = map
-            .remove("application_id")
-            .ok_or_else(|| DeError::custom("expected application id"))
-            .and_then(ApplicationId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let kind = map
-            .remove("type")
-            .ok_or_else(|| DeError::custom("expected type"))
-            .and_then(InteractionType::deserialize)
-            .map_err(DeError::custom)?;
-
-        let data = map
-            .remove("data")
-            .ok_or_else(|| DeError::custom("expected data"))
-            .and_then(ModalSubmitInteractionData::deserialize)
-            .map_err(DeError::custom)?;
-
-        let guild_id = map
-            .remove("guild_id")
-            .map(GuildId::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let channel_id = map
-            .remove("channel_id")
-            .ok_or_else(|| DeError::custom("expected channel_id"))
-            .and_then(ChannelId::deserialize)
-            .map_err(DeError::custom)?;
-
-        let member =
-            map.remove("member").map(Member::deserialize).transpose().map_err(DeError::custom)?;
-
-        let user =
-            map.remove("user").map(User::deserialize).transpose().map_err(DeError::custom)?;
-
-        let user = user
+        let member = remove_from_map_opt::<Member, _>(&mut map, "member")?;
+        let user = remove_from_map_opt(&mut map, "user")?
             .or_else(|| member.as_ref().map(|m| m.user.clone()))
             .ok_or_else(|| DeError::custom("expected user or member"))?;
 
-        let message =
-            map.remove("message").map(Message::deserialize).transpose().map_err(DeError::custom)?;
-
-        let token = map
-            .remove("token")
-            .ok_or_else(|| DeError::custom("expected token"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-
-        let version = map
-            .remove("version")
-            .ok_or_else(|| DeError::custom("expected version"))
-            .and_then(u8::deserialize)
-            .map_err(DeError::custom)?;
-
-        let guild_locale = map
-            .remove("guild_locale")
-            .map(String::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let locale = map
-            .remove("locale")
-            .ok_or_else(|| DeError::custom("expected locale"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-
         Ok(Self {
-            id,
-            application_id,
-            kind,
-            data,
-            message,
-            guild_id,
-            channel_id,
             member,
             user,
-            token,
-            version,
-            guild_locale,
-            locale,
+            id: remove_from_map(&mut map, "id")?,
+            guild_id: remove_from_map_opt(&mut map, "guild_id")?,
+            application_id: remove_from_map(&mut map, "application_id")?,
+            kind: remove_from_map(&mut map, "type")?,
+            data: remove_from_map(&mut map, "data")?,
+            message: remove_from_map(&mut map, "message")?,
+            channel_id: remove_from_map(&mut map, "channel_id")?,
+            token: remove_from_map(&mut map, "token")?,
+            version: remove_from_map(&mut map, "version")?,
+            guild_locale: remove_from_map_opt(&mut map, "guild_locale")?,
+            locale: remove_from_map(&mut map, "locale")?,
         })
     }
 }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -228,16 +228,12 @@ impl<'de> Deserialize<'de> for Channel {
 
         let kind = {
             let kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?;
-
-            match kind.as_u64() {
-                Some(kind) => kind,
-                None => {
-                    return Err(DeError::invalid_type(
-                        Unexpected::Other("non-positive integer"),
-                        &"a positive integer",
-                    ));
-                },
-            }
+            kind.as_u64().ok_or_else(|| {
+                DeError::invalid_type(
+                    Unexpected::Other("non-positive integer"),
+                    &"a positive integer",
+                )
+            })?
         };
 
         match kind {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1434,7 +1434,9 @@ pub fn deserialize_event_with_type(kind: EventType, mut v: Value) -> Result<Even
             if v.get("unavailable").and_then(Value::as_bool).unwrap_or(false) {
                 Event::GuildUnavailable(from_value(v)?)
             } else {
-                let map = v.as_object_mut().ok_or_else(|| Error::Json(DeError::custom("expected JsonMap")))?;
+                let map = v
+                    .as_object_mut()
+                    .ok_or_else(|| Error::Json(DeError::custom("expected JsonMap")))?;
 
                 let id_val =
                     map.get("id").ok_or_else(|| Error::Json(DeError::missing_field("id")))?;

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -316,13 +316,6 @@ pub struct InviteDeleteEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
-pub struct GuildUnavailableEvent {
-    #[serde(rename = "id")]
-    pub guild_id: GuildId,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct GuildUpdateEvent {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1630,9 +1630,6 @@ pub enum EventType {
     /// This maps to [`GuildScheduledEventUserRemoveEvent`].
     GuildScheduledEventUserRemove,
     /// An unknown event was received over the gateway.
-    ///
-    /// This should be logged so that support for it can be added in the
-    /// library.
     Other,
 }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -72,7 +72,14 @@ use crate::json::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::application::command::{Command, CommandPermission};
 use crate::model::prelude::*;
-use crate::model::utils::{emojis, presences, roles, stickers};
+use crate::model::utils::{
+    emojis,
+    presences,
+    remove_from_map,
+    remove_from_map_opt,
+    roles,
+    stickers,
+};
 use crate::model::Timestamp;
 
 /// A representation of a banning of a user.
@@ -2632,24 +2639,10 @@ impl<'de> Deserialize<'de> for Guild {
             if let Some(array) = map.get_mut(key).and_then(Value::as_array_mut) {
                 for value in array {
                     if let Some(item) = value.as_object_mut() {
-                        item.insert("guild_id".to_string(), from_number(id.get()));
+                        item.insert("guild_id".to_string(), from_number(id.0));
                     }
                 }
             }
-        }
-
-        fn remove_from_map_opt<T: serde::de::DeserializeOwned, E: DeError>(
-            map: &mut JsonMap,
-            key: &str,
-        ) -> StdResult<Option<T>, E> {
-            map.remove(key).map(T::deserialize).transpose().map_err(DeError::custom)
-        }
-
-        fn remove_from_map<T: serde::de::DeserializeOwned, E: DeError>(
-            map: &mut JsonMap,
-            key: &'static str,
-        ) -> StdResult<T, E> {
-            remove_from_map_opt(map, key)?.ok_or_else(|| DeError::missing_field(key))
         }
 
         let mut map = JsonMap::deserialize(deserializer)?;
@@ -2718,34 +2711,35 @@ impl<'de> Deserialize<'de> for Guild {
             roles,
             voice_states,
             stickers,
-            afk_channel_id: remove_from_map_opt(&mut map, "afk_channel_id")?,
+            afk_channel_id: remove_from_map_opt(&mut map, "afk_channel_id")?.flatten(),
             afk_timeout: remove_from_map(&mut map, "afk_timeout")?,
-            application_id: remove_from_map_opt(&mut map, "application_id")?,
+            application_id: remove_from_map_opt(&mut map, "application_id")?.flatten(),
             default_message_notifications: remove_from_map(
                 &mut map,
                 "default_message_notifications",
             )?,
             explicit_content_filter: remove_from_map(&mut map, "explicit_content_filter")?,
             features: remove_from_map(&mut map, "features")?,
-            icon: remove_from_map_opt(&mut map, "icon")?,
+            icon: remove_from_map_opt(&mut map, "icon")?.flatten(),
             joined_at: remove_from_map(&mut map, "joined_at")?,
             large: remove_from_map(&mut map, "large")?,
             member_count: remove_from_map(&mut map, "member_count")?,
             mfa_level: remove_from_map(&mut map, "mfa_level")?,
             name: remove_from_map(&mut map, "name")?,
             owner_id: remove_from_map(&mut map, "owner_id")?,
-            splash: remove_from_map_opt(&mut map, "splash")?,
-            discovery_splash: remove_from_map_opt(&mut map, "discovery_splash")?,
-            system_channel_id: remove_from_map_opt(&mut map, "system_channel_id")?,
+            splash: remove_from_map_opt(&mut map, "splash")?.flatten(),
+            discovery_splash: remove_from_map_opt(&mut map, "discovery_splash")?.flatten(),
+            system_channel_id: remove_from_map_opt(&mut map, "system_channel_id")?.flatten(),
             system_channel_flags: remove_from_map(&mut map, "system_channel_flags")?,
-            rules_channel_id: remove_from_map_opt(&mut map, "rules_channel_id")?,
-            public_updates_channel_id: remove_from_map_opt(&mut map, "public_updates_channel_id")?,
+            rules_channel_id: remove_from_map_opt(&mut map, "rules_channel_id")?.flatten(),
+            public_updates_channel_id: remove_from_map_opt(&mut map, "public_updates_channel_id")?
+                .flatten(),
             verification_level: remove_from_map(&mut map, "verification_level")?,
-            description: remove_from_map_opt(&mut map, "description")?,
+            description: remove_from_map_opt(&mut map, "description")?.flatten(),
             premium_tier: remove_from_map_opt(&mut map, "premium_tier")?.unwrap_or_default(),
             premium_subscription_count,
-            banner: remove_from_map_opt(&mut map, "banner")?,
-            vanity_url_code: remove_from_map_opt(&mut map, "vanity_url_code")?,
+            banner: remove_from_map_opt(&mut map, "banner")?.flatten(),
+            vanity_url_code: remove_from_map_opt(&mut map, "vanity_url_code")?.flatten(),
             preferred_locale: remove_from_map(&mut map, "preferred_locale")?,
             welcome_screen: remove_from_map_opt(&mut map, "welcome_screen")?,
             approximate_member_count: remove_from_map_opt(&mut map, "approximate_member_count")?,
@@ -2755,10 +2749,10 @@ impl<'de> Deserialize<'de> for Guild {
             )?,
             nsfw_level: remove_from_map(&mut map, "nsfw_level")?,
             max_video_channel_users: remove_from_map_opt(&mut map, "max_video_channel_users")?,
-            max_presences: remove_from_map_opt(&mut map, "max_presences")?,
+            max_presences: remove_from_map_opt(&mut map, "max_presences")?.flatten(),
             max_members: remove_from_map_opt(&mut map, "max_members")?,
-            widget_enabled: remove_from_map_opt(&mut map, "widget_enabled")?,
-            widget_channel_id: remove_from_map_opt(&mut map, "widget_channel_id")?,
+            widget_enabled: remove_from_map_opt(&mut map, "widget_enabled")?.flatten(),
+            widget_channel_id: remove_from_map_opt(&mut map, "widget_channel_id")?.flatten(),
             stage_instances: remove_from_map_opt(&mut map, "stage_instances")?.unwrap_or_default(),
             threads: remove_from_map_opt(&mut map, "threads")?.unwrap_or_default(),
         })

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2672,19 +2672,19 @@ impl<'de> Deserialize<'de> for Guild {
 
         let presences = map
             .remove("presences")
-            .ok_or_else(|| DeError::custom("expected guild presences"))
+            .ok_or_else(|| DeError::missing_field("presences"))
             .and_then(presences::deserialize)
             .map_err(DeError::custom)?;
 
         let voice_states = map
             .remove("voice_states")
-            .ok_or_else(|| DeError::custom("expected guild voice_states"))
+            .ok_or_else(|| DeError::missing_field("voice_states"))
             .and_then(deserialize_voice_states)
             .map_err(DeError::custom)?;
 
         let roles = map
             .remove("roles")
-            .ok_or_else(|| DeError::custom("expected guild roles"))
+            .ok_or_else(|| DeError::missing_field("roles"))
             .and_then(roles::deserialize)
             .map_err(DeError::custom)?;
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2653,8 +2653,8 @@ impl<'de> Deserialize<'de> for Guild {
         add_guild_id_to_map(&mut map, "roles", id);
 
         let channels = map
-            .remove("emojis")
-            .ok_or_else(|| DeError::missing_field("emojis"))
+            .remove("channels")
+            .ok_or_else(|| DeError::missing_field("channels"))
             .and_then(deserialize_guild_channels)
             .map_err(DeError::custom)?;
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -66,7 +66,8 @@ use crate::collector::{
 use crate::constants::LARGE_THRESHOLD;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, UserPagination};
-use crate::json::prelude::*;
+#[cfg(feature = "model")]
+use crate::json::prelude::json;
 #[cfg(feature = "model")]
 use crate::model::application::command::{Command, CommandPermission};
 use crate::model::prelude::*;

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -30,12 +30,18 @@ use crate::collector::{
 };
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-use crate::json::from_value;
 use crate::json::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::application::command::{Command, CommandPermission};
 use crate::model::prelude::*;
-use crate::model::utils::{add_guild_id_to_map, emojis, remove_from_map, roles, stickers};
+use crate::model::utils::{
+    add_guild_id_to_map,
+    emojis,
+    remove_from_map,
+    remove_from_map_opt,
+    roles,
+    stickers,
+};
 
 /// Partial information about a [`Guild`]. This does not include information
 /// like member data.
@@ -1567,71 +1573,18 @@ impl<'de> Deserialize<'de> for PartialGuild {
 
         add_guild_id_to_map(&mut map, "roles", id);
 
-        let afk_channel_id = match map.remove("afk_channel_id") {
-            Some(v) => from_value::<Option<ChannelId>>(v).map_err(DeError::custom)?,
-            None => None,
-        };
-        let afk_timeout = map
-            .remove("afk_timeout")
-            .ok_or_else(|| DeError::custom("expected guild afk_timeout"))
-            .and_then(u64::deserialize)
-            .map_err(DeError::custom)?;
-        let default_message_notifications = map
-            .remove("default_message_notifications")
-            .ok_or_else(|| DeError::custom("expected guild default_message_notifications"))
-            .and_then(DefaultMessageNotificationLevel::deserialize)
-            .map_err(DeError::custom)?;
         let emojis = map
             .remove("emojis")
             .ok_or_else(|| DeError::custom("expected guild emojis"))
             .and_then(emojis::deserialize)
             .map_err(DeError::custom)?;
-        let features = map
-            .remove("features")
-            .ok_or(Error::Other("expected guild features"))
-            .and_then(from_value::<Vec<String>>)
-            .map_err(DeError::custom)?;
-        let icon = match map.remove("icon") {
-            Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-        let mfa_level = map
-            .remove("mfa_level")
-            .ok_or_else(|| DeError::custom("expected guild mfa_level"))
-            .and_then(MfaLevel::deserialize)
-            .map_err(DeError::custom)?;
-        let name = map
-            .remove("name")
-            .ok_or_else(|| DeError::custom("expected guild name"))
-            .and_then(String::deserialize)
-            .map_err(DeError::custom)?;
-        let owner_id = map
-            .remove("owner_id")
-            .ok_or_else(|| DeError::custom("expected guild owner_id"))
-            .and_then(UserId::deserialize)
-            .map_err(DeError::custom)?;
+
         let roles = map
             .remove("roles")
             .ok_or_else(|| DeError::custom("expected guild roles"))
             .and_then(roles::deserialize)
             .map_err(DeError::custom)?;
-        let splash = match map.remove("splash") {
-            Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-        let verification_level = map
-            .remove("verification_level")
-            .ok_or_else(|| DeError::custom("expected guild verification_level"))
-            .and_then(VerificationLevel::deserialize)
-            .map_err(DeError::custom)?;
-        let description = match map.remove("description") {
-            Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-        let premium_tier = match map.remove("premium_tier") {
-            Some(v) => PremiumTier::deserialize(v).map_err(DeError::custom)?,
-            None => PremiumTier::default(),
-        };
+
         let premium_subscription_count = match map.remove("premium_subscription_count") {
             #[cfg(not(feature = "simd-json"))]
             Some(Value::Null) | None => 0,
@@ -1639,104 +1592,6 @@ impl<'de> Deserialize<'de> for PartialGuild {
             Some(Value::Static(StaticNode::Null)) | None => 0,
             Some(v) => u64::deserialize(v).map_err(DeError::custom)?,
         };
-        let banner = match map.remove("banner") {
-            Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-        let vanity_url_code = match map.remove("vanity_url_code") {
-            Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-        let system_channel_id = match map.remove("system_channel_id") {
-            Some(v) => Option::<ChannelId>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let approximate_member_count = map
-            .remove("approximate_member_count")
-            .map(u64::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let approximate_presence_count = map
-            .remove("approximate_presence_count")
-            .map(u64::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let owner = map
-            .remove("owner")
-            .map(bool::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?
-            .unwrap_or_default();
-
-        let nsfw_level = map
-            .remove("nsfw_level")
-            .ok_or_else(|| DeError::custom("expected nsfw_level"))
-            .and_then(NsfwLevel::deserialize)
-            .map_err(DeError::custom)?;
-
-        let max_video_channel_users = map
-            .remove("max_video_channel_users")
-            .map(u64::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
-
-        let max_presences = match map.remove("max_presences") {
-            Some(v) => Option::<u64>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let max_members =
-            map.remove("max_members").map(u64::deserialize).transpose().map_err(DeError::custom)?;
-
-        let discovery_splash = match map.remove("discovery_splash") {
-            Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let application_id = match map.remove("application_id") {
-            Some(v) => Option::<ApplicationId>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let public_updates_channel_id = match map.remove("public_updates_channel_id") {
-            Some(v) => Option::<ChannelId>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let system_channel_flags = map
-            .remove("system_channel_flags")
-            .ok_or_else(|| DeError::custom("expected system_channel_flags"))
-            .and_then(SystemChannelFlags::deserialize)
-            .map_err(DeError::custom)?;
-
-        let rules_channel_id = match map.remove("rules_channel_id") {
-            Some(v) => Option::<ChannelId>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let widget_enabled = match map.remove("widget_enabled") {
-            Some(v) => Option::<bool>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let widget_channel_id = match map.remove("widget_channel_id") {
-            Some(v) => Option::<ChannelId>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let permissions = match map.remove("permissions") {
-            Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
-            None => None,
-        };
-
-        let welcome_screen = map
-            .remove("welcome_screen")
-            .map(GuildWelcomeScreen::deserialize)
-            .transpose()
-            .map_err(DeError::custom)?;
 
         let stickers = map
             .remove("stickers")
@@ -1745,42 +1600,46 @@ impl<'de> Deserialize<'de> for PartialGuild {
             .map_err(DeError::custom)?;
 
         Ok(Self {
-            application_id,
             id,
-            afk_channel_id,
-            afk_timeout,
-            default_message_notifications,
-            widget_enabled,
-            widget_channel_id,
             emojis,
-            features,
-            icon,
-            mfa_level,
-            name,
-            owner_id,
-            owner,
             roles,
-            splash,
-            discovery_splash,
-            system_channel_id,
-            system_channel_flags,
-            rules_channel_id,
-            public_updates_channel_id,
-            verification_level,
-            description,
-            premium_tier,
             premium_subscription_count,
-            banner,
-            vanity_url_code,
-            welcome_screen,
-            approximate_member_count,
-            approximate_presence_count,
-            nsfw_level,
-            max_video_channel_users,
-            max_presences,
-            max_members,
-            permissions,
             stickers,
+            afk_channel_id: remove_from_map_opt(&mut map, "afk_channel_id")?.flatten(),
+            afk_timeout: remove_from_map(&mut map, "afk_timeout")?,
+            application_id: remove_from_map_opt(&mut map, "application_id")?.flatten(),
+            default_message_notifications: remove_from_map(
+                &mut map,
+                "default_message_notifications",
+            )?,
+            features: remove_from_map(&mut map, "features")?,
+            widget_enabled: remove_from_map_opt(&mut map, "widget_enabled")?.flatten(),
+            widget_channel_id: remove_from_map_opt(&mut map, "widget_channel_id")?.flatten(),
+            icon: remove_from_map_opt(&mut map, "icon")?.flatten(),
+            mfa_level: remove_from_map(&mut map, "mfa_level")?,
+            name: remove_from_map(&mut map, "name")?,
+            owner_id: remove_from_map(&mut map, "owner_id")?,
+            owner: remove_from_map_opt(&mut map, "owner")?.unwrap_or_default(),
+            splash: remove_from_map_opt(&mut map, "splash")?.flatten(),
+            discovery_splash: remove_from_map_opt(&mut map, "discovery_splash")?.flatten(),
+            system_channel_id: remove_from_map_opt(&mut map, "system_channel_id")?.flatten(),
+            system_channel_flags: remove_from_map(&mut map, "system_channel_flags")?,
+            rules_channel_id: remove_from_map_opt(&mut map, "rules_channel_id")?.flatten(),
+            public_updates_channel_id: remove_from_map_opt(&mut map, "public_updates_channel_id")?
+                .flatten(),
+            verification_level: remove_from_map(&mut map, "verification_level")?,
+            description: remove_from_map_opt(&mut map, "description")?.flatten(),
+            premium_tier: remove_from_map_opt(&mut map, "premium_tier")?.unwrap_or_default(),
+            banner: remove_from_map_opt(&mut map, "banner")?.flatten(),
+            vanity_url_code: remove_from_map_opt(&mut map, "vanity_url_code")?.flatten(),
+            welcome_screen: remove_from_map_opt(&mut map, "welcome_screen")?,
+            approximate_member_count: remove_from_map(&mut map, "approximate_member_count")?,
+            approximate_presence_count: remove_from_map(&mut map, "approximate_presence_count")?,
+            nsfw_level: remove_from_map(&mut map, "nsfw_level")?,
+            max_video_channel_users: remove_from_map(&mut map, "max_video_channel_users")?,
+            max_presences: remove_from_map_opt(&mut map, "max_presences")?.flatten(),
+            max_members: remove_from_map_opt(&mut map, "max_members")?.flatten(),
+            permissions: remove_from_map_opt(&mut map, "permissions")?.unwrap_or_default(),
         })
     }
 }

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -41,6 +41,7 @@
 //! [Manage Roles]: Permissions::MANAGE_ROLES
 //! [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
 
+#[cfg(feature = "model")]
 use std::fmt;
 
 use serde::de::{Deserialize, Deserializer, Error as DeError};

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -43,7 +43,7 @@
 
 use std::fmt;
 
-use serde::de::{Deserialize, Deserializer};
+use serde::de::{Deserialize, Deserializer, Error as DeError};
 use serde::ser::{Serialize, Serializer};
 
 /// This macro generates the [`Permissions::get_permission_names`] method.
@@ -775,32 +775,15 @@ impl Permissions {
 
 impl<'de> Deserialize<'de> for Permissions {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct StringVisitor;
+        let permissions_str = String::deserialize(deserializer)?;
+        let permissions_num = permissions_str.parse().map_err(DeError::custom)?;
 
-        impl<'de> serde::de::Visitor<'de> for StringVisitor {
-            type Value = Permissions;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("permissions string")
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                let value = v.parse().map_err(E::custom)?;
-                Ok(Permissions::from_bits_truncate(value))
-            }
-        }
-        deserializer.deserialize_str(StringVisitor)
+        Ok(Permissions::from_bits_truncate(permissions_num))
     }
 }
 
 impl Serialize for Permissions {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.collect_str(&self.bits())
     }
 }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -37,6 +37,7 @@ where
     T::deserialize(val).map_err(serde::de::Error::custom)
 }
 
+#[allow(unused)]
 pub fn remove_from_map_opt<T, E>(map: &mut JsonMap, key: &str) -> StdResult<Option<T>, E>
 where
     T: serde::de::DeserializeOwned,
@@ -45,6 +46,7 @@ where
     map.remove(key).map(deserialize_val).transpose()
 }
 
+#[allow(unused)]
 pub fn remove_from_map<T, E>(map: &mut JsonMap, key: &'static str) -> StdResult<T, E>
 where
     T: serde::de::DeserializeOwned,

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -12,6 +12,7 @@ use super::prelude::*;
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
 use crate::internal::prelude::*;
+use crate::json::from_number;
 use crate::model::application::command::CommandOptionType;
 use crate::model::application::interaction::application_command::{
     CommandDataOption,
@@ -37,7 +38,6 @@ where
     T::deserialize(val).map_err(serde::de::Error::custom)
 }
 
-#[allow(unused)]
 pub fn remove_from_map_opt<T, E>(map: &mut JsonMap, key: &str) -> StdResult<Option<T>, E>
 where
     T: serde::de::DeserializeOwned,
@@ -46,13 +46,22 @@ where
     map.remove(key).map(deserialize_val).transpose()
 }
 
-#[allow(unused)]
 pub fn remove_from_map<T, E>(map: &mut JsonMap, key: &'static str) -> StdResult<T, E>
 where
     T: serde::de::DeserializeOwned,
     E: serde::de::Error,
 {
     remove_from_map_opt(map, key)?.ok_or_else(|| serde::de::Error::missing_field(key))
+}
+
+pub fn add_guild_id_to_map(map: &mut JsonMap, key: &str, id: GuildId) {
+    if let Some(array) = map.get_mut(key).and_then(Value::as_array_mut) {
+        for value in array {
+            if let Some(item) = value.as_object_mut() {
+                item.insert("guild_id".to_string(), from_number(id.0));
+            }
+        }
+    }
 }
 
 /// Used with `#[serde(with = "emojis")]`

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -29,6 +29,22 @@ pub fn is_false(v: &bool) -> bool {
     !v
 }
 
+pub fn remove_from_map_opt<T, E>(map: &mut JsonMap, key: &str) -> StdResult<Option<T>, E>
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::Error,
+{
+    map.remove(key).map(T::deserialize).transpose().map_err(serde::de::Error::custom)
+}
+
+pub fn remove_from_map<T, E>(map: &mut JsonMap, key: &'static str) -> StdResult<T, E>
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::Error,
+{
+    remove_from_map_opt(map, key)?.ok_or_else(|| serde::de::Error::missing_field(key))
+}
+
 /// Used with `#[serde(with = "emojis")]`
 pub mod emojis {
     use std::collections::HashMap;

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -29,12 +29,20 @@ pub fn is_false(v: &bool) -> bool {
     !v
 }
 
+pub fn deserialize_val<T, E>(val: Value) -> StdResult<T, E>
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::Error,
+{
+    T::deserialize(val).map_err(serde::de::Error::custom)
+}
+
 pub fn remove_from_map_opt<T, E>(map: &mut JsonMap, key: &str) -> StdResult<Option<T>, E>
 where
     T: serde::de::DeserializeOwned,
     E: serde::de::Error,
 {
-    map.remove(key).map(T::deserialize).transpose().map_err(serde::de::Error::custom)
+    map.remove(key).map(deserialize_val).transpose()
 }
 
 pub fn remove_from_map<T, E>(map: &mut JsonMap, key: &'static str) -> StdResult<T, E>


### PR DESCRIPTION
This performs multiple optimizations throughout the library:
- Moves chunks of logic used for deserializing to functions, to remove duplication
- Moves adding extra `guild_id` fields to a function, to remove duplication
- Deserializes straight into `GatewayEvent` instead of to Value
- Uses serde derive for deserialization of:
- -  `Event`, removes `GuildUnavailable` in the process
- -  `Guild`, moves preprocessing to `GuildCreateEvent
- -  `CommandDataOption`
- Deduplicates a load of logic in deserializing:
- - `Reaction`
- - `PartialGuild`
- - `CommandData`
- - `ModalSubmitInteraction`
- - `MessageComponentInteraction`
- - `ApplicationCommandInteraction`