### PR TITLE
Unasync `ShardManager::new`

### DIFF
--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -117,7 +117,8 @@ pub struct ShardManager {
 impl ShardManager {
     /// Creates a new shard manager, returning both the manager and a monitor
     /// for usage in a separate thread.
-    pub async fn new(opt: ShardManagerOptions) -> (Arc<Mutex<Self>>, ShardManagerMonitor) {
+    #[must_use]
+    pub fn new(opt: ShardManagerOptions) -> (Arc<Mutex<Self>>, ShardManagerMonitor) {
         let (thread_tx, thread_rx) = mpsc::unbounded();
         let (shard_queue_tx, shard_queue_rx) = mpsc::unbounded();
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -375,7 +375,7 @@ impl Future for ClientBuilder {
             self.fut = Some(Box::pin(async move {
                 let ws_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 
-                let (shard_manager, shard_manager_worker) = {
+                let (shard_manager, shard_manager_worker) =
                     ShardManager::new(ShardManagerOptions {
                         data: Arc::clone(&data),
                         event_handler,
@@ -390,9 +390,7 @@ impl Future for ClientBuilder {
                         ws_url: Arc::clone(&ws_url),
                         cache_and_http: Arc::clone(&cache_and_http),
                         intents,
-                    })
-                    .await
-                };
+                    });
 
                 Ok(Client {
                     data,


### PR DESCRIPTION
The method is declared `async` but has no `.await`s inside of it.