### PR TITLE
Use concrete fields instead of HashMap in GetMessages

### DIFF
--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::model::id::MessageId;
 
 /// Builds a request to the API to retrieve messages.
@@ -43,8 +41,11 @@ use crate::model::id::MessageId;
 /// ```
 ///
 /// [`GuildChannel::messages`]: crate::model::channel::GuildChannel::messages
-#[derive(Clone, Debug, Default)]
-pub struct GetMessages(pub HashMap<&'static str, u64>);
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GetMessages {
+    pub search_filter: Option<SearchFilter>,
+    pub limit: Option<u8>,
+}
 
 impl GetMessages {
     /// Indicates to retrieve the messages after a specific message, given by
@@ -56,7 +57,7 @@ impl GetMessages {
     }
 
     fn _after(&mut self, message_id: MessageId) {
-        self.0.insert("after", message_id.0);
+        self.search_filter = Some(SearchFilter::After(message_id));
     }
 
     /// Indicates to retrieve the messages _around_ a specific message in either
@@ -68,7 +69,7 @@ impl GetMessages {
     }
 
     fn _around(&mut self, message_id: MessageId) {
-        self.0.insert("around", message_id.0);
+        self.search_filter = Some(SearchFilter::Around(message_id));
     }
 
     /// Indicates to retrieve the messages before a specific message, given by
@@ -80,7 +81,7 @@ impl GetMessages {
     }
 
     fn _before(&mut self, message_id: MessageId) {
-        self.0.insert("before", message_id.0);
+        self.search_filter = Some(SearchFilter::Before(message_id));
     }
 
     /// The maximum number of messages to retrieve for the query.
@@ -90,8 +91,15 @@ impl GetMessages {
     /// **Note**: This field is capped to 100 messages due to a Discord
     /// limitation. If an amount larger than 100 is supplied, it will be
     /// reduced.
-    pub fn limit(&mut self, limit: u64) -> &mut Self {
-        self.0.insert("limit", if limit > 100 { 100 } else { limit });
+    pub fn limit(&mut self, limit: u8) -> &mut Self {
+        self.limit = Some(limit.min(100));
         self
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum SearchFilter {
+    After(MessageId),
+    Around(MessageId),
+    Before(MessageId),
 }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -94,4 +94,4 @@ pub use self::edit_thread::EditThread;
 pub use self::edit_voice_state::EditVoiceState;
 pub use self::edit_webhook_message::EditWebhookMessage;
 pub use self::execute_webhook::ExecuteWebhook;
-pub use self::get_messages::GetMessages;
+pub use self::get_messages::{GetMessages, SearchFilter};

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -17,6 +17,7 @@ use crate::builder::{
     EditStageInstance,
     EditThread,
     GetMessages,
+    SearchFilter,
 };
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::Cache;
@@ -503,15 +504,14 @@ impl ChannelId {
     {
         let mut get_messages = GetMessages::default();
         builder(&mut get_messages);
-        let mut map = get_messages.0;
-        let mut query = format!("?limit={}", map.remove(&"limit").unwrap_or(50));
+        let mut query = format!("?limit={}", get_messages.limit.unwrap_or(50));
 
-        if let Some(after) = map.remove(&"after") {
-            write!(query, "&after={}", after)?;
-        } else if let Some(around) = map.remove(&"around") {
-            write!(query, "&around={}", around)?;
-        } else if let Some(before) = map.remove(&"before") {
-            write!(query, "&before={}", before)?;
+        if let Some(filter) = get_messages.search_filter {
+            match filter {
+                SearchFilter::After(after) => write!(query, "&after={}", after)?,
+                SearchFilter::Around(around) => write!(query, "&around={}", around)?,
+                SearchFilter::Before(before) => write!(query, "&before={}", before)?,
+            }
         }
 
         http.as_ref().get_messages(self.0, &query).await


### PR DESCRIPTION
Gets rid of the `HashMap` which was used with `&'static str` keys, and swaps it for proper fields. Totally open on bikeshedding of `SearchFilter` name