### PR TITLE
Move allow for clippy::unused_self to only trigger of it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@
     clippy::needless_pass_by_value,
     clippy::struct_excessive_bools,
     clippy::ref_option_ref,
-    clippy::unused_self,
     // Allowed as they are too pedantic 
     clippy::cast_possible_truncation,
     clippy::unreadable_literal,

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -174,6 +174,7 @@ impl PrivateChannel {
     /// `false`, due to DMs not being considered NSFW.
     #[inline]
     #[must_use]
+    #[allow(clippy::unused_self)]
     pub fn is_nsfw(&self) -> bool {
         false
     }


### PR DESCRIPTION
This lint was set to allow globally by a previous PR of mine, however it is only triggered in one (unavoidable) place. Allows the lint to trigger for future code changes if they are problematic.