### PR TITLE
Rename announcement channel -> news channel

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1711,7 +1711,7 @@ impl Http {
 
     /// Crossposts a message by Id.
     ///
-    /// **Note**: Only available on announcements channels.
+    /// **Note**: Only available on news channels.
     pub async fn crosspost_message(&self, channel_id: u64, message_id: u64) -> Result<Message> {
         self.fire(Request {
             body: None,
@@ -1758,7 +1758,7 @@ impl Http {
         .await
     }
 
-    /// Follow an Announcement Channel to send messages to a target channel.
+    /// Follow a News Channel to send messages to a target channel.
     pub async fn follow_news_channel(
         &self,
         news_channel_id: u64,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -382,11 +382,11 @@ impl ChannelId {
             .await
     }
 
-    /// Follows the announcement channel
+    /// Follows the News Channel
     ///
     /// Requires [Manage Webhook] permissions on the target channel.
     ///
-    /// **Note**: Only available on announcement channels.
+    /// **Note**: Only available on news channels.
     ///
     /// # Errors
     ///
@@ -581,7 +581,7 @@ impl ChannelId {
     ///
     /// Requires either to be the message author or to have manage [Manage Messages] permissions on this channel.
     ///
-    /// **Note**: Only available on announcements channels.
+    /// **Note**: Only available on news channels.
     ///
     /// # Errors
     ///

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -610,11 +610,11 @@ impl GuildChannel {
         }
     }
 
-    /// Follows the announcement channel
+    /// Follows the News Channel
     ///
     /// Requires [Manage Webhook] permissions on the target channel.
     ///
-    /// **Note**: Only available on announcement channels.
+    /// **Note**: Only available on news channels.
     ///
     /// # Errors
     ///

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -136,7 +136,7 @@ impl Message {
     ///
     /// Requires either to be the message author or to have manage [Manage Messages] permissions on this channel.
     ///
-    /// **Note**: Only available on announcements channels.
+    /// **Note**: Only available on news channels.
     ///
     /// # Errors
     ///
@@ -1084,7 +1084,7 @@ pub enum MessageType {
     NitroTier2 = 10,
     /// An indicator that the guild has reached nitro tier 3
     NitroTier3 = 11,
-    /// An indicator that the channel is now following an announcement channel
+    /// An indicator that the channel is now following a news channel
     ChannelFollowAdd = 12,
     /// An indicator that the guild is disqualified for Discovery Feature
     GuildDiscoveryDisqualified = 14,

--- a/src/model/channel/partial_channel.rs
+++ b/src/model/channel/partial_channel.rs
@@ -21,7 +21,7 @@ pub struct PartialChannel {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct FollowedChannel {
-    /// The source announcement channel
+    /// The source news channel
     channel_id: ChannelId,
     /// The created webhook ID in the target channel
     webhook_id: WebhookId,


### PR DESCRIPTION
Improves consistency throughout the library when referring to text channels with the type 5, `GUILD_NEWS`

Follow up to #1900, turns out a next targetting PR wasn't needed, `announcement` was only used in docs.