### PR TITLE
Remove unused allowed clippy warnings or fix them

### DIFF
--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -510,10 +510,7 @@ pub async fn command(
                     last = res;
                 }
             },
-            #[allow(clippy::items_after_statements)]
             Map::Prefixless(subgroups, commands) => {
-                is_prefixless = true;
-
                 fn command_name_if_recognised(res: &Result<Invoke, ParseError>) -> Option<&str> {
                     match res {
                         Ok(Invoke::Command {
@@ -526,6 +523,8 @@ pub async fn command(
                         }) => Some(command_name),
                     }
                 }
+
+                is_prefixless = true;
 
                 let res = handle_group(stream, ctx, msg, config, subgroups).await;
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -544,7 +544,7 @@ impl Message {
         cache_http: impl CacheHttp,
         reaction_type: &ReactionType,
     ) -> Result<Reaction> {
-        #[allow(unused_mut)]
+        #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut user_id = None;
 
         #[cfg(feature = "cache")]

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -314,7 +314,6 @@ pub enum ReactionType {
 }
 
 impl<'de> Deserialize<'de> for ReactionType {
-    #[allow(clippy::unwrap_used)] // allow unwrap here because name being none is unreachable
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         #[derive(Deserialize)]
         #[serde(field_identifier, rename_all = "snake_case")]

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -130,14 +130,13 @@ impl Reaction {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     /// [permissions]: super::permissions
     pub async fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
-        // Silences a warning when compiling without the `cache` feature.
-        #[allow(unused_mut)]
+        #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut user_id = self.user_id.map(|id| id.0);
 
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.user_id.is_some() && self.user_id == Some(cache.current_user().id) {
+                if self.user_id == Some(cache.current_user().id) {
                     user_id = None;
                 }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -197,11 +197,6 @@ impl GuildId {
     ) -> Result<HashMap<ChannelId, GuildChannel>> {
         let mut channels = HashMap::new();
 
-        // Clippy is suggesting:
-        // consider removing
-        // `http.as_ref().get_channels(self.0)?()`:
-        // `http.as_ref().get_channels(self.0)?`.
-        #[allow(clippy::useless_conversion)]
         for channel in http.as_ref().get_channels(self.0).await? {
             channels.insert(channel.id, channel);
         }
@@ -793,7 +788,6 @@ impl GuildId {
     pub async fn roles(self, http: impl AsRef<Http>) -> Result<HashMap<RoleId, Role>> {
         let mut roles = HashMap::new();
 
-        #[allow(clippy::useless_conversion)]
         for role in http.as_ref().get_guild_roles(self.0).await? {
             roles.insert(role.id, role);
         }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -195,13 +195,9 @@ impl GuildId {
         self,
         http: impl AsRef<Http>,
     ) -> Result<HashMap<ChannelId, GuildChannel>> {
-        let mut channels = HashMap::new();
+        let channels = http.as_ref().get_channels(self.0).await?;
 
-        for channel in http.as_ref().get_channels(self.0).await? {
-            channels.insert(channel.id, channel);
-        }
-
-        Ok(channels)
+        Ok(channels.into_iter().map(|c| (c.id, c)).collect())
     }
 
     /// Creates a [`GuildChannel`] in the the guild.
@@ -786,13 +782,9 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user is not in
     /// the guild.
     pub async fn roles(self, http: impl AsRef<Http>) -> Result<HashMap<RoleId, Role>> {
-        let mut roles = HashMap::new();
+        let roles = http.as_ref().get_guild_roles(self.0).await?;
 
-        for role in http.as_ref().get_guild_roles(self.0).await? {
-            roles.insert(role.id, role);
-        }
-
-        Ok(roles)
+        Ok(roles.into_iter().map(|r| (r.id, r)).collect())
     }
 
     /// Tries to find the [`Guild`] by its Id in the cache.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -654,7 +654,6 @@ impl Guild {
     /// # Errors
     ///
     /// Returns the same possible errors as `create_global_application_command`.
-    #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn create_application_command<F>(
         &self,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -357,7 +357,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// Returns the same possible errors as `create_global_application_command`.
-    #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn create_application_command<F>(
         &self,

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -7,7 +7,6 @@ use crate::prelude::*;
 /// Error that can be returned from [`Role::convert`].
 #[non_exhaustive]
 #[derive(Debug)]
-#[allow(clippy::enum_variant_names)]
 pub enum RoleParseError {
     /// When the operation was invoked outside a guild.
     NotInGuild,

--- a/src/utils/argument_convert/user.rs
+++ b/src/utils/argument_convert/user.rs
@@ -7,7 +7,6 @@ use crate::prelude::*;
 /// Error that can be returned from [`User::convert`].
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-#[allow(clippy::enum_variant_names)]
 pub enum UserParseError {
     /// The provided user string failed to parse, or the parsed result cannot be found in the
     /// guild cache data.


### PR DESCRIPTION
Also removes a couple comments and replaces them with self-explaining code. 