### PR TITLE
Reduce int size for days param of prune_count methods

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2960,21 +2960,13 @@ impl Http {
     }
 
     /// Gets the amount of users that can be pruned.
-    pub async fn get_guild_prune_count(&self, guild_id: u64, map: &Value) -> Result<GuildPrune> {
-        // Note for 0.6.x: turn this into a function parameter.
-        #[derive(Deserialize)]
-        struct GetGuildPruneCountRequest {
-            days: u64,
-        }
-
-        let req = from_value::<GetGuildPruneCountRequest>(map.clone())?;
-
+    pub async fn get_guild_prune_count(&self, guild_id: u64, days: u8) -> Result<GuildPrune> {
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
             route: RouteInfo::GetGuildPruneCount {
-                days: req.days,
+                days,
                 guild_id,
             },
         })
@@ -3786,7 +3778,7 @@ impl Http {
     pub async fn start_guild_prune(
         &self,
         guild_id: u64,
-        days: u64,
+        days: u8,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildPrune> {
         self.fire(Request {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -829,7 +829,7 @@ impl Route {
     }
 
     #[must_use]
-    pub fn guild_prune(guild_id: u64, days: u64) -> String {
+    pub fn guild_prune(guild_id: u64, days: u8) -> String {
         api!("/guilds/{}/prune?days={}", guild_id, days)
     }
 
@@ -1603,7 +1603,7 @@ pub enum RouteInfo<'a> {
         guild_id: u64,
     },
     GetGuildPruneCount {
-        days: u64,
+        days: u8,
         guild_id: u64,
     },
     GetGuildRegions {
@@ -1728,7 +1728,7 @@ pub enum RouteInfo<'a> {
         limit: Option<u64>,
     },
     StartGuildPrune {
-        days: u64,
+        days: u8,
         guild_id: u64,
     },
     StartIntegrationSync {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1118,12 +1118,8 @@ impl GuildId {
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
-    pub async fn prune_count(self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
-        let map = json!({
-            "days": days,
-        });
-
-        http.as_ref().get_guild_prune_count(self.0, &map).await
+    pub async fn prune_count(self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
+        http.as_ref().get_guild_prune_count(self.0, days).await
     }
 
     /// Re-orders the channels of the guild.
@@ -1339,8 +1335,8 @@ impl GuildId {
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
-    pub async fn start_prune(self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
-        http.as_ref().start_guild_prune(self.0, days as u64, None).await
+    pub async fn start_prune(self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
+        http.as_ref().start_guild_prune(self.0, days, None).await
     }
 
     /// Unbans a [`User`] from the guild.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2197,7 +2197,7 @@ impl Guild {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn prune_count(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
+    pub async fn prune_count(&self, cache_http: impl CacheHttp, days: u8) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
             if cache_http.cache().is_some() {
@@ -2469,7 +2469,7 @@ impl Guild {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn start_prune(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
+    pub async fn start_prune(&self, cache_http: impl CacheHttp, days: u8) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
             if cache_http.cache().is_some() {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1127,7 +1127,7 @@ impl PartialGuild {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn start_prune(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
+    pub async fn start_prune(&self, cache_http: impl CacheHttp, days: u8) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
             if cache_http.cache().is_some() {
@@ -1358,7 +1358,7 @@ impl PartialGuild {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     /// [`Guild::prune_count`]: crate::model::guild::Guild::prune_count
     #[inline]
-    pub async fn prune_count(&self, http: impl AsRef<Http>, days: u16) -> Result<GuildPrune> {
+    pub async fn prune_count(&self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
         self.id.prune_count(&http, days).await
     }
 


### PR DESCRIPTION
`days` is documented to be max 30 on ddev docs, so a u8 is plenty instead of a u64 or u16. Also fixes the note left for serenity 0.6.... only 3 years late.