### PR TITLE
Fix deserialization errors

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use futures::channel::mpsc::UnboundedSender as Sender;
 use futures::future::{BoxFuture, FutureExt};
 use tokio::sync::RwLock;
-use tracing::{instrument, warn};
+use tracing::{debug, instrument};
 use typemap_rev::TypeMap;
 
 #[cfg(feature = "gateway")]
@@ -721,7 +721,7 @@ async fn handle_event(
                 event_handler.typing_start(context, event).await;
             });
         },
-        DispatchEvent::Model(Event::Unknown) => warn!("An unknown event was received"),
+        DispatchEvent::Model(Event::Unknown) => debug!("An unknown event was received"),
         DispatchEvent::Model(Event::UserUpdate(mut event)) => {
             let _before = update(&cache_and_http, &mut event);
             let event_handler = Arc::clone(event_handler);

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -15,6 +15,7 @@ use super::utils::{
     remove_from_map_opt,
     roles,
     stickers,
+    ignore_input,
 };
 use crate::constants::OpCode;
 use crate::internal::prelude::*;
@@ -266,11 +267,19 @@ impl<'de> Deserialize<'de> for GuildMembersChunkEvent {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleCreateEvent {
-    #[serde(deserialize_with = "roles::deserialize_event")]
     pub role: Role,
+}
+
+impl<'de> Deserialize<'de> for GuildRoleCreateEvent {
+    /// Custom deserializer to pass entire payload to roles::deserialize_event, does not work using `deserialize_with`
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        Ok(Self {
+            role: roles::deserialize_event(deserializer)?,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -280,11 +289,19 @@ pub struct GuildRoleDeleteEvent {
     pub role_id: RoleId,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleUpdateEvent {
-    #[serde(deserialize_with = "roles::deserialize_event")]
     pub role: Role,
+}
+
+impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
+    /// Custom deserializer to pass entire payload to roles::deserialize_event, does not work using `deserialize_with`
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        Ok(Self {
+            role: roles::deserialize_event(deserializer)?,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -822,7 +839,7 @@ pub enum Event {
     /// A guild member has unsubscribed from a scheduled event.
     GuildScheduledEventUserRemove(GuildScheduledEventUserRemoveEvent),
     /// An event type not covered by the above
-    #[serde(other)]
+    #[serde(other, deserialize_with = "ignore_input")]
     Unknown,
 }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -11,11 +11,11 @@ use super::utils::{
     add_guild_id_to_map,
     deserialize_val,
     emojis,
+    ignore_input,
     remove_from_map,
     remove_from_map_opt,
     roles,
     stickers,
-    ignore_input,
 };
 use crate::constants::OpCode;
 use crate::internal::prelude::*;

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1632,8 +1632,11 @@ impl<'de> Deserialize<'de> for PartialGuild {
             banner: remove_from_map_opt(&mut map, "banner")?.flatten(),
             vanity_url_code: remove_from_map_opt(&mut map, "vanity_url_code")?.flatten(),
             welcome_screen: remove_from_map_opt(&mut map, "welcome_screen")?,
-            approximate_member_count: remove_from_map(&mut map, "approximate_member_count")?,
-            approximate_presence_count: remove_from_map(&mut map, "approximate_presence_count")?,
+            approximate_member_count: remove_from_map_opt(&mut map, "approximate_member_count")?,
+            approximate_presence_count: remove_from_map_opt(
+                &mut map,
+                "approximate_presence_count",
+            )?,
             nsfw_level: remove_from_map(&mut map, "nsfw_level")?,
             max_video_channel_users: remove_from_map(&mut map, "max_video_channel_users")?,
             max_presences: remove_from_map_opt(&mut map, "max_presences")?.flatten(),

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -30,6 +30,11 @@ pub fn is_false(v: &bool) -> bool {
     !v
 }
 
+#[allow(clippy::unnecessary_wraps)]
+pub fn ignore_input<'de, D: Deserializer<'de>>(_: D) -> StdResult<(), D::Error> {
+    Ok(())
+}
+
 pub fn deserialize_val<T, E>(val: Value) -> StdResult<T, E>
 where
     T: serde::de::DeserializeOwned,


### PR DESCRIPTION
Fixes errors caused by #1938, found, fixed, and tested by running this branch on my bot. Also drops down unknown event log to debug level, as my bot got a lot of unknown events with no way to silence them.