### PR TITLE
Remove unused maps

### DIFF
--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -3,7 +3,7 @@ use crate::builder::EditChannel;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
-use crate::json::{self, from_number};
+use crate::json;
 use crate::model::prelude::*;
 
 /// A category of [`GuildChannel`]s.
@@ -122,10 +122,6 @@ impl ChannelCategory {
     where
         F: FnOnce(&mut EditChannel) -> &mut EditChannel,
     {
-        let mut map = HashMap::new();
-        map.insert("name", Value::from(self.name.clone()));
-        map.insert("position", from_number(self.position));
-
         let mut edit_channel = EditChannel::default();
         f(&mut edit_channel);
         let map = json::hashmap_to_json_map(edit_channel.0);

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -35,7 +35,7 @@ use crate::http::{CacheHttp, Http, Typing};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
-use crate::json::{self, from_number};
+use crate::json;
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
@@ -427,10 +427,6 @@ impl GuildChannel {
                 )?;
             }
         }
-
-        let mut map = HashMap::new();
-        map.insert("name", Value::from(self.name.clone()));
-        map.insert("position", from_number(self.position));
 
         let mut edit_channel = EditChannel::default();
         f(&mut edit_channel);


### PR DESCRIPTION
Looks like these were a historical mistake, used to be passed to the builders however this was broken, since this has worked for so long without complaint without these maps, just stop the maps being constructed.