### PR TITLE
Take Into<String> in more places

### DIFF
--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -68,8 +68,8 @@ impl EditGuild {
     /// ```
     ///
     /// [`utils::read_image`]: crate::utils::read_image
-    pub fn icon(&mut self, icon: Option<impl Into<String>>) -> &mut Self {
-        self.0.insert("icon", icon.map(Into::into).map_or(NULL, Value::String));
+    pub fn icon(&mut self, icon: Option<String>) -> &mut Self {
+        self.0.insert("icon", icon.map_or(NULL, Value::String));
         self
     }
 
@@ -131,8 +131,8 @@ impl EditGuild {
     /// You can check this through a guild's [`features`] list.
     ///
     /// [`features`]: crate::model::guild::Guild::features
-    pub fn splash(&mut self, splash: Option<impl Into<String>>) -> &mut Self {
-        let splash = splash.map(Into::into).map_or(NULL, Value::String);
+    pub fn splash(&mut self, splash: Option<String>) -> &mut Self {
+        let splash = splash.map_or(NULL, Value::String);
         self.0.insert("splash", splash);
         self
     }
@@ -145,8 +145,8 @@ impl EditGuild {
     /// You can check this through a guild's [`features`] list.
     ///
     /// [`features`]: crate::model::guild::Guild::features
-    pub fn discovery_splash(&mut self, splash: Option<impl Into<String>>) -> &mut Self {
-        let splash = splash.map(Into::into).map_or(NULL, Value::String);
+    pub fn discovery_splash(&mut self, splash: Option<String>) -> &mut Self {
+        let splash = splash.map_or(NULL, Value::String);
         self.0.insert("discovery_splash", splash);
         self
     }
@@ -159,8 +159,8 @@ impl EditGuild {
     /// You can check this through a guild's [`features`] list.
     ///
     /// [`features`]: crate::model::guild::Guild::features
-    pub fn banner(&mut self, banner: Option<impl Into<String>>) -> &mut Self {
-        let banner = banner.map(Into::into).map_or(NULL, Value::String);
+    pub fn banner(&mut self, banner: Option<String>) -> &mut Self {
+        let banner = banner.map_or(NULL, Value::String);
         self.0.insert("banner", banner);
         self
     }
@@ -201,8 +201,8 @@ impl EditGuild {
     ///
     /// **Note**:
     /// This feature is for Community guilds only.
-    pub fn preferred_locale(&mut self, locale: Option<impl Into<String>>) -> &mut Self {
-        let locale = locale.map(Into::into).map_or(NULL, Value::String);
+    pub fn preferred_locale(&mut self, locale: Option<String>) -> &mut Self {
+        let locale = locale.map_or(NULL, Value::String);
         self.0.insert("preferred_locale", locale);
         self
     }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -62,7 +62,7 @@ impl EditGuild {
     ///
     /// let base64_icon = utils::read_image("./guild_icon.png")?;
     ///
-    /// guild.edit(&http, |g| g.icon(Some(&base64_icon))).await?;
+    /// guild.edit(&http, |g| g.icon(Some(base64_icon))).await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -68,8 +68,8 @@ impl EditGuild {
     /// ```
     ///
     /// [`utils::read_image`]: crate::utils::read_image
-    pub fn icon(&mut self, icon: Option<&str>) -> &mut Self {
-        self.0.insert("icon", icon.map_or_else(|| NULL, |x| Value::from(x.to_string())));
+    pub fn icon(&mut self, icon: Option<impl Into<String>>) -> &mut Self {
+        self.0.insert("icon", icon.map(Into::into).map_or(NULL, Value::String));
         self
     }
 
@@ -131,8 +131,8 @@ impl EditGuild {
     /// You can check this through a guild's [`features`] list.
     ///
     /// [`features`]: crate::model::guild::Guild::features
-    pub fn splash(&mut self, splash: Option<&str>) -> &mut Self {
-        let splash = splash.map_or(NULL, |x| Value::from(x.to_string()));
+    pub fn splash(&mut self, splash: Option<impl Into<String>>) -> &mut Self {
+        let splash = splash.map(Into::into).map_or(NULL, Value::String);
         self.0.insert("splash", splash);
         self
     }
@@ -145,8 +145,8 @@ impl EditGuild {
     /// You can check this through a guild's [`features`] list.
     ///
     /// [`features`]: crate::model::guild::Guild::features
-    pub fn discovery_splash(&mut self, splash: Option<&str>) -> &mut Self {
-        let splash = splash.map_or(NULL, |x| Value::from(x.to_string()));
+    pub fn discovery_splash(&mut self, splash: Option<impl Into<String>>) -> &mut Self {
+        let splash = splash.map(Into::into).map_or(NULL, Value::String);
         self.0.insert("discovery_splash", splash);
         self
     }
@@ -159,8 +159,8 @@ impl EditGuild {
     /// You can check this through a guild's [`features`] list.
     ///
     /// [`features`]: crate::model::guild::Guild::features
-    pub fn banner(&mut self, banner: Option<&str>) -> &mut Self {
-        let banner = banner.map_or(NULL, |x| Value::from(x.to_string()));
+    pub fn banner(&mut self, banner: Option<impl Into<String>>) -> &mut Self {
+        let banner = banner.map(Into::into).map_or(NULL, Value::String);
         self.0.insert("banner", banner);
         self
     }
@@ -201,8 +201,8 @@ impl EditGuild {
     ///
     /// **Note**:
     /// This feature is for Community guilds only.
-    pub fn preferred_locale(&mut self, locale: Option<&str>) -> &mut Self {
-        let locale = locale.map_or(NULL, |x| Value::from(x.to_string()));
+    pub fn preferred_locale(&mut self, locale: Option<impl Into<String>>) -> &mut Self {
+        let locale = locale.map(Into::into).map_or(NULL, Value::String);
         self.0.insert("preferred_locale", locale);
         self
     }

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -46,8 +46,8 @@ impl EditProfile {
     /// ```
     ///
     /// [`utils::read_image`]: crate::utils::read_image
-    pub fn avatar(&mut self, avatar: Option<impl Into<String>>) -> &mut Self {
-        let avatar = avatar.map(Into::into).map_or(NULL, Value::String);
+    pub fn avatar(&mut self, avatar: Option<String>) -> &mut Self {
+        let avatar = avatar.map_or(NULL, Value::String);
         self.0.insert("avatar", avatar);
         self
     }

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -46,9 +46,8 @@ impl EditProfile {
     /// ```
     ///
     /// [`utils::read_image`]: crate::utils::read_image
-    pub fn avatar(&mut self, avatar: Option<&str>) -> &mut Self {
-        let avatar = avatar.map_or(NULL, |x| Value::from(x.to_string()));
-
+    pub fn avatar(&mut self, avatar: Option<impl Into<String>>) -> &mut Self {
+        let avatar = avatar.map(Into::into).map_or(NULL, Value::String);
         self.0.insert("avatar", avatar);
         self
     }

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -39,7 +39,7 @@ impl EditProfile {
     /// let base64 = utils::read_image("./my_image.jpg").expect("Failed to read image");
     ///
     /// let mut user = context.cache.current_user();
-    /// let _ = user.edit(&context, |p| p.avatar(Some(&base64))).await;
+    /// let _ = user.edit(&context, |p| p.avatar(Some(base64))).await;
     /// #     }
     /// # }
     /// # }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -248,7 +248,7 @@ impl CurrentUser {
     /// #     let mut user = CurrentUser::default();
     /// let avatar = serenity::utils::read_image("./avatar.png")?;
     ///
-    /// user.edit(&http, |p| p.avatar(Some(&avatar))).await;
+    /// user.edit(&http, |p| p.avatar(Some(avatar))).await;
     /// #     Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
Fixes a couple more `ToString` usages I missed in #1903 by constructing the Value in `Embed::field` without the `json!` macro, and swaps out `Option<&str>` for `Option<impl Into<String>>`