### PR TITLE
Rework builder module to get rid of all `HashMap<'static str, T>` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,11 +156,11 @@ default_no_backend = [
     "cache",
     "chrono",
     "client",
-#    "framework",
+    "framework",
     "gateway",
     "model",
     "http",
-#    "standard_framework",
+    "standard_framework",
     "utils",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,11 +156,11 @@ default_no_backend = [
     "cache",
     "chrono",
     "client",
-    "framework",
+#    "framework",
     "gateway",
     "model",
     "http",
-    "standard_framework",
+#    "standard_framework",
     "utils",
 ]
 

--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -1,20 +1,28 @@
-use std::collections::HashMap;
-
-use crate::json::{from_number, Value};
 use crate::model::id::RoleId;
 
 /// A builder to add parameters when using [`GuildId::add_member`].
 ///
 /// [`GuildId::add_member`]: crate::model::id::GuildId::add_member
-#[derive(Clone, Debug, Default)]
-pub struct AddMember(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct AddMember {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    access_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nick: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    roles: Option<Vec<RoleId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mute: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deaf: Option<bool>,
+}
 
 impl AddMember {
     /// Sets the OAuth2 access token for this request.
     ///
     /// Requires the access token to have the `guilds.join` scope granted.
     pub fn access_token(&mut self, access_token: impl Into<String>) -> &mut Self {
-        self.0.insert("access_token", Value::String(access_token.into()));
+        self.access_token = Some(access_token.into());
         self
     }
 
@@ -24,7 +32,7 @@ impl AddMember {
     ///
     /// [Manage Nicknames]: crate::model::permissions::Permissions::MANAGE_NICKNAMES
     pub fn nickname(&mut self, nickname: impl Into<String>) -> &mut Self {
-        self.0.insert("nick", Value::String(nickname.into()));
+        self.nick = Some(nickname.into());
         self
     }
 
@@ -33,10 +41,8 @@ impl AddMember {
     /// Requires the [Manage Roles] permission.
     ///
     /// [Manage Roles]: crate::model::permissions::Permissions::MANAGE_ROLES
-    pub fn roles(&mut self, roles: impl IntoIterator<Item = impl AsRef<RoleId>>) -> &mut Self {
-        let roles = roles.into_iter().map(|x| from_number(x.as_ref().0)).collect::<Vec<Value>>();
-
-        self.0.insert("roles", Value::from(roles));
+    pub fn roles(&mut self, roles: impl IntoIterator<Item = impl Into<RoleId>>) -> &mut Self {
+        self.roles = Some(roles.into_iter().map(Into::into).collect());
         self
     }
 
@@ -46,7 +52,7 @@ impl AddMember {
     ///
     /// [Mute Members]: crate::model::permissions::Permissions::MUTE_MEMBERS
     pub fn mute(&mut self, mute: bool) -> &mut Self {
-        self.0.insert("mute", Value::from(mute));
+        self.mute = Some(mute);
         self
     }
 
@@ -56,7 +62,7 @@ impl AddMember {
     ///
     /// [Deafen Members]: crate::model::permissions::Permissions::DEAFEN_MEMBERS
     pub fn deafen(&mut self, deafen: bool) -> &mut Self {
-        self.0.insert("deaf", Value::from(deafen));
+        self.deaf = Some(deafen);
         self
     }
 }

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -45,13 +45,12 @@ impl CreateComponents {
     }
 }
 
-
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 enum ComponentBuilder {
     Button(CreateButton),
     SelectMenu(CreateSelectMenu),
-    InputText(CreateInputText)
+    InputText(CreateInputText),
 }
 
 /// A builder for creating an [`ActionRow`].
@@ -59,7 +58,7 @@ enum ComponentBuilder {
 /// [`ActionRow`]: crate::model::application::component::ActionRow
 #[derive(Clone, Debug, Serialize)]
 pub struct CreateActionRow {
-    components: Vec<ComponentBuilder>, 
+    components: Vec<ComponentBuilder>,
     kind: u8,
 }
 
@@ -246,7 +245,7 @@ pub struct CreateSelectMenu {
     #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<CreateSelectMenuOptions>,
 
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     kind: u8,
 }
 
@@ -259,7 +258,7 @@ impl Default for CreateSelectMenu {
             custom_id: None,
             disabled: None,
             options: None,
-            kind: 3
+            kind: 3,
         }
     }
 }
@@ -445,7 +444,7 @@ pub struct CreateInputText {
     required: Option<bool>,
 
     #[serde(rename = "type")]
-    kind: u8
+    kind: u8,
 }
 
 impl Default for CreateInputText {

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -117,8 +117,7 @@ impl<'a> CreateInteractionResponseData<'a> {
 
     /// Adds an embed to the message.
     pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = json::hashmap_to_json_map(embed.0);
-        let embed = Value::from(map);
+        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
 
         let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
 
@@ -143,8 +142,8 @@ impl<'a> CreateInteractionResponseData<'a> {
     /// Calling this will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = json::hashmap_to_json_map(embed.0);
-        let embed = Value::from(map);
+        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
+
         self.0.insert("embeds", Value::from(vec![embed]));
 
         self
@@ -157,7 +156,7 @@ impl<'a> CreateInteractionResponseData<'a> {
     pub fn set_embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
         let embeds = embeds
             .into_iter()
-            .map(|embed| json::hashmap_to_json_map(embed.0).into())
+            .map(|embed| to_value(embed).expect("CreateEmbed builder should not fail!"))
             .collect::<Vec<Value>>();
 
         self.0.insert("embeds", Value::from(embeds));

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -171,10 +171,9 @@ impl<'a> CreateInteractionResponseData<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = json::hashmap_to_json_map(allowed_mentions.0);
-        let allowed_mentions = Value::from(map);
+        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", allowed_mentions);
+        self.0.insert("allowed_mentions", map);
         self
     }
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -209,13 +209,14 @@ impl<'a> CreateInteractionResponseData<'a> {
         let mut components = CreateComponents::default();
         f(&mut components);
 
-        self.0.insert("components", Value::from(components.0));
-        self
+        self.set_components(components)
     }
 
     /// Sets the components of this message.
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
-        self.0.insert("components", Value::Array(components.0));
+        let map = to_value(components).expect("CreateComponents builder should not fail!");
+        self.0.insert("components", map);
+
         self
     }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -159,10 +159,9 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = json::hashmap_to_json_map(allowed_mentions.0);
-        let allowed_mentions = Value::from(map);
+        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", allowed_mentions);
+        self.0.insert("allowed_mentions", map);
         self
     }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -196,14 +196,17 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     {
         let mut components = CreateComponents::default();
         f(&mut components);
+        let map = to_value(components).expect("CreateComponents builder should not fail!");
 
-        self.0.insert("components", Value::from(components.0));
+        self.0.insert("components", map);
         self
     }
 
     /// Sets the components of this message.
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
-        self.0.insert("components", Value::from(components.0));
+        let map = to_value(components).expect("CreateComponents builder should not fail!");
+        self.0.insert("components", map);
+
         self
     }
 }

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -4,7 +4,6 @@ use std::marker::PhantomData;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
-use crate::json;
 use crate::json::prelude::*;
 use crate::model::application::interaction::MessageFlags;
 #[cfg(feature = "model")]
@@ -104,8 +103,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
 
     /// Adds an embed to the message.
     pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = json::hashmap_to_json_map(embed.0);
-        let embed = Value::from(map);
+        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
 
         self.0
             .entry("embeds")
@@ -131,8 +129,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     /// Calling this will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = json::hashmap_to_json_map(embed.0);
-        let embed = Value::from(map);
+        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
         self.0.insert("embeds", Value::from(vec![embed]));
 
         self
@@ -145,7 +142,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     pub fn set_embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
         let embeds = embeds
             .into_iter()
-            .map(|embed| json::hashmap_to_json_map(embed.0).into())
+            .map(|embed| to_value(embed).expect("CreateEmbed builder should not fail!"))
             .collect::<Vec<Value>>();
 
         self.0.insert("embeds", Value::from(embeds));

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-
-use crate::json::{from_number, Value, NULL};
 use crate::model::id::{ApplicationId, UserId};
 use crate::model::invite::InviteTargetType;
 
@@ -68,8 +65,23 @@ use crate::model::invite::InviteTargetType;
 ///
 /// [`GuildChannel::create_invite`]: crate::model::channel::GuildChannel::create_invite
 /// [`RichInvite`]: crate::model::invite::RichInvite
-#[derive(Clone, Debug)]
-pub struct CreateInvite(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CreateInvite {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_age: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_uses: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temporary: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unique: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_type: Option<InviteTargetType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_user_id: Option<UserId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_application_id: Option<ApplicationId>,
+}
 
 impl CreateInvite {
     /// The duration that the invite will be valid for.
@@ -99,7 +111,7 @@ impl CreateInvite {
     /// # }
     /// ```
     pub fn max_age(&mut self, max_age: u64) -> &mut Self {
-        self.0.insert("max_age", from_number(max_age));
+        self.max_age = Some(max_age);
         self
     }
 
@@ -130,7 +142,7 @@ impl CreateInvite {
     /// # }
     /// ```
     pub fn max_uses(&mut self, max_uses: u64) -> &mut Self {
-        self.0.insert("max_uses", from_number(max_uses));
+        self.max_uses = Some(max_uses);
         self
     }
 
@@ -161,7 +173,7 @@ impl CreateInvite {
     /// # fn main() {}
     /// ```
     pub fn temporary(&mut self, temporary: bool) -> &mut Self {
-        self.0.insert("temporary", Value::from(temporary));
+        self.temporary = Some(temporary);
         self
     }
 
@@ -190,13 +202,13 @@ impl CreateInvite {
     /// # }
     /// ```
     pub fn unique(&mut self, unique: bool) -> &mut Self {
-        self.0.insert("unique", Value::from(unique));
+        self.unique = Some(unique);
         self
     }
 
     /// The type of target for this voice channel invite.
     pub fn target_type(&mut self, target_type: InviteTargetType) -> &mut Self {
-        self.0.insert("target_type", from_number(target_type as u8));
+        self.target_type = Some(target_type);
         self
     }
 
@@ -204,7 +216,7 @@ impl CreateInvite {
     /// `Stream`
     /// The user must be streaming in the channel.
     pub fn target_user_id(&mut self, target_user_id: UserId) -> &mut Self {
-        self.0.insert("target_user_id", from_number(target_user_id.0));
+        self.target_user_id = Some(target_user_id);
         self
     }
 
@@ -223,27 +235,7 @@ impl CreateInvite {
     /// poker: `755827207812677713`
     /// chess: `832012774040141894`
     pub fn target_application_id(&mut self, target_application_id: ApplicationId) -> &mut Self {
-        self.0.insert("target_application_id", from_number(target_application_id.0));
+        self.target_application_id = Some(target_application_id);
         self
-    }
-}
-
-impl Default for CreateInvite {
-    /// Creates a builder with default values, setting `validate` to `null`.
-    ///
-    /// # Examples
-    ///
-    /// Create a default [`CreateInvite`] builder:
-    ///
-    /// ```rust
-    /// use serenity::builder::CreateInvite;
-    ///
-    /// let invite_builder = CreateInvite::default();
-    /// ```
-    fn default() -> CreateInvite {
-        let mut map = HashMap::new();
-        map.insert("validate", NULL);
-
-        CreateInvite(map)
     }
 }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
 use crate::internal::prelude::*;
-use crate::json::{self, from_number, to_value};
+use crate::json::{from_number, to_value};
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::channel::{MessageFlags, MessageReference, ReactionType};
@@ -72,8 +72,7 @@ impl<'a> CreateMessage<'a> {
     }
 
     fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = json::hashmap_to_json_map(embed.0);
-        let embed = Value::from(map);
+        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
 
         let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
         let embeds_array = embeds.as_array_mut().expect("Embeds must be an array");

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -230,13 +230,14 @@ impl<'a> CreateMessage<'a> {
         let mut components = CreateComponents::default();
         f(&mut components);
 
-        self.0.insert("components", Value::from(components.0));
-        self
+        self.set_components(components)
     }
 
     /// Sets the components of this message.
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
-        self.0.insert("components", Value::from(components.0));
+        let map = to_value(components).expect("CreateComponents builder should not fail!");
+        self.0.insert("components", map);
+
         self
     }
 

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -209,10 +209,9 @@ impl<'a> CreateMessage<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = json::hashmap_to_json_map(allowed_mentions.0);
-        let allowed_mentions = Value::from(map);
+        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", allowed_mentions);
+        self.0.insert("allowed_mentions", map);
         self
     }
 

--- a/src/builder/create_stage_instance.rs
+++ b/src/builder/create_stage_instance.rs
@@ -1,24 +1,26 @@
-use std::collections::HashMap;
-
-use crate::json::{from_number, Value};
+use crate::model::id::ChannelId;
 
 /// Creates a [`StageInstance`].
 ///
 /// [`StageInstance`]: crate::model::channel::StageInstance
-#[derive(Clone, Debug, Default)]
-pub struct CreateStageInstance(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CreateStageInstance {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    topic: Option<String>,
+}
 
 impl CreateStageInstance {
     // Sets the stage channel id of the stage channel instance.
-    pub fn channel_id(&mut self, id: u64) -> &mut Self {
-        self.0.insert("channel_id", from_number(id));
+    pub fn channel_id(&mut self, id: impl Into<ChannelId>) -> &mut Self {
+        self.channel_id = Some(id.into());
         self
     }
 
     /// Sets the topic of the stage channel instance.
     pub fn topic(&mut self, topic: impl Into<String>) -> &mut Self {
-        self.0.insert("topic", Value::String(topic.into()));
-
+        self.topic = Some(topic.into());
         self
     }
 }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
+use std::borrow::Cow;
 
-use crate::internal::prelude::*;
 use crate::model::channel::AttachmentType;
 
 /// A builder to create or edit a [`Sticker`] for use via a number of model methods.
@@ -16,14 +15,20 @@ use crate::model::channel::AttachmentType;
 /// [`Guild::create_sticker`]: crate::model::guild::Guild::create_sticker
 /// [`GuildId::create_sticker`]: crate::model::id::GuildId::create_sticker
 #[derive(Clone, Debug, Default)]
-pub struct CreateSticker<'a>(pub HashMap<&'static str, Value>, pub Option<AttachmentType<'a>>);
+pub struct CreateSticker<'a> {
+    name: Option<String>,
+    tags: Option<String>,
+    description: Option<String>,
+
+    pub(crate) file: Option<AttachmentType<'a>>,
+}
 
 impl<'a> CreateSticker<'a> {
     /// The name of the sticker to set.
     ///
     /// **Note**: Must be between 2 and 30 characters long.
     pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.0.insert("name", Value::String(name.into()));
+        self.name = Some(name.into());
         self
     }
 
@@ -31,7 +36,7 @@ impl<'a> CreateSticker<'a> {
     ///
     /// **Note**: If not empty, must be between 2 and 100 characters long.
     pub fn description(&mut self, description: impl Into<String>) -> &mut Self {
-        self.0.insert("description", Value::String(description.into()));
+        self.description = Some(description.into());
         self
     }
 
@@ -39,7 +44,7 @@ impl<'a> CreateSticker<'a> {
     ///
     /// **Note**: Must be between 2 and 200 characters long.
     pub fn tags(&mut self, tags: impl Into<String>) -> &mut Self {
-        self.0.insert("tags", Value::String(tags.into()));
+        self.tags = Some(tags.into());
         self
     }
 
@@ -47,7 +52,28 @@ impl<'a> CreateSticker<'a> {
     ///
     /// **Note**: Must be a PNG, APNG, or Lottie JSON file, max 500 KB.
     pub fn file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
-        self.1 = Some(file.into());
+        self.file = Some(file.into());
         self
+    }
+
+    pub(crate) fn build(
+        self,
+    ) -> Option<(Vec<(Cow<'static, str>, Cow<'static, str>)>, AttachmentType<'a>)> {
+        let file = self.file?;
+        let mut buf = Vec::with_capacity(3);
+
+        if let Some(name) = self.name {
+            buf.push(("name".into(), name.into()));
+        }
+
+        if let Some(description) = self.description {
+            buf.push(("description".into(), description.into()));
+        }
+
+        if let Some(tags) = self.tags {
+            buf.push(("tags".into(), tags.into()));
+        }
+
+        Some((buf, file))
     }
 }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -58,7 +58,8 @@ impl<'a> CreateSticker<'a> {
         self
     }
 
-    pub(crate) fn build(self) -> Option<(Vec<Field>, AttachmentType<'a>)> {
+    #[must_use]
+    pub fn build(self) -> Option<(Vec<Field>, AttachmentType<'a>)> {
         let file = self.file?;
         let mut buf = Vec::with_capacity(3);
 

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 
 use crate::model::channel::AttachmentType;
 
+type Field = (Cow<'static, str>, Cow<'static, str>);
+
 /// A builder to create or edit a [`Sticker`] for use via a number of model methods.
 ///
 /// These are:
@@ -56,9 +58,7 @@ impl<'a> CreateSticker<'a> {
         self
     }
 
-    pub(crate) fn build(
-        self,
-    ) -> Option<(Vec<(Cow<'static, str>, Cow<'static, str>)>, AttachmentType<'a>)> {
+    pub(crate) fn build(self) -> Option<(Vec<Field>, AttachmentType<'a>)> {
         let file = self.file?;
         let mut buf = Vec::with_capacity(3);
 

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -1,17 +1,25 @@
-use std::collections::HashMap;
-
-use crate::json::{from_number, Value};
 use crate::model::channel::ChannelType;
 
-#[derive(Debug, Clone, Default)]
-pub struct CreateThread(pub HashMap<&'static str, Value>);
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CreateThread {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_archive_duration: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rate_limit_per_user: Option<u16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
+    kind: Option<ChannelType>
+}
 
 impl CreateThread {
     /// The name of the thread.
     ///
     /// **Note**: Must be between 2 and 100 characters long.
     pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.0.insert("name", Value::String(name.into()));
+        self.name = Some(name.into());
 
         self
     }
@@ -20,7 +28,7 @@ impl CreateThread {
     ///
     /// **Note**: Can only be set to 60, 1440, 4320, 10080 currently.
     pub fn auto_archive_duration(&mut self, duration: u16) -> &mut Self {
-        self.0.insert("auto_archive_duration", from_number(duration));
+        self.auto_archive_duration = Some(duration);
 
         self
     }
@@ -35,8 +43,8 @@ impl CreateThread {
     /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
     /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
     #[doc(alias = "slowmode")]
-    pub fn rate_limit_per_user(&mut self, seconds: u64) -> &mut Self {
-        self.0.insert("rate_limit_per_user", from_number(seconds));
+    pub fn rate_limit_per_user(&mut self, seconds: u16) -> &mut Self {
+        self.rate_limit_per_user = Some(seconds);
 
         self
     }
@@ -48,7 +56,7 @@ impl CreateThread {
     /// and thus is highly likely to change in the future, so it is recommended to always
     /// explicitly setting it to avoid any breaking change.
     pub fn kind(&mut self, kind: ChannelType) -> &mut Self {
-        self.0.insert("type", from_number(kind as u8));
+        self.kind = Some(kind);
 
         self
     }

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -11,7 +11,7 @@ pub struct CreateThread {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
-    kind: Option<ChannelType>
+    kind: Option<ChannelType>,
 }
 
 impl CreateThread {

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -1,7 +1,3 @@
-use std::collections::HashMap;
-
-use crate::internal::prelude::*;
-use crate::json::{from_number, NULL};
 use crate::model::prelude::*;
 
 /// A builder to optionally edit certain fields of a [`Guild`]. This is meant
@@ -13,8 +9,44 @@ use crate::model::prelude::*;
 /// [`Guild::edit`]: crate::model::guild::Guild::edit
 /// [`Guild`]: crate::model::guild::Guild
 /// [Manage Guild]: crate::model::permissions::Permissions::MANAGE_GUILD
-#[derive(Clone, Debug, Default)]
-pub struct EditGuild(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditGuild {
+    features: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    afk_channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    afk_timeout: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    owner_id: Option<UserId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    splash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    discovery_splash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    banner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rules_channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    public_updates_channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preferred_locale: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explicit_content_filter: Option<ExplicitContentFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_message_notifications: Option<DefaultMessageNotificationLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verification_level: Option<VerificationLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_channel_flags: Option<SystemChannelFlags>,
+}
 
 impl EditGuild {
     /// Set the "AFK voice channel" that users are to move to if they have been
@@ -25,21 +57,14 @@ impl EditGuild {
     /// valid.
     #[inline]
     pub fn afk_channel<C: Into<ChannelId>>(&mut self, channel: Option<C>) -> &mut Self {
-        self._afk_channel(channel.map(Into::into));
+        self.afk_channel_id = channel.map(Into::into);
         self
-    }
-
-    fn _afk_channel(&mut self, channel: Option<ChannelId>) {
-        self.0.insert("afk_channel_id", match channel {
-            Some(channel) => from_number(channel.0),
-            None => NULL,
-        });
     }
 
     /// Set the amount of time a user is to be moved to the AFK channel -
     /// configured via [`Self::afk_channel`] - after being AFK.
     pub fn afk_timeout(&mut self, timeout: u64) -> &mut Self {
-        self.0.insert("afk_timeout", from_number(timeout));
+        self.afk_timeout = Some(timeout);
         self
     }
 
@@ -69,7 +94,7 @@ impl EditGuild {
     ///
     /// [`utils::read_image`]: crate::utils::read_image
     pub fn icon(&mut self, icon: Option<String>) -> &mut Self {
-        self.0.insert("icon", icon.map_or(NULL, Value::String));
+        self.icon = icon;
         self
     }
 
@@ -77,7 +102,7 @@ impl EditGuild {
     ///
     /// **Note**: Must be between (and including) 2-100 characters.
     pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.0.insert("name", Value::String(name.into()));
+        self.name = Some(name.into());
         self
     }
 
@@ -88,7 +113,7 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn description(&mut self, name: impl Into<String>) -> &mut Self {
-        self.0.insert("name", Value::String(name.into()));
+        self.description = Some(name.into());
         self
     }
 
@@ -99,13 +124,7 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn features(&mut self, features: Vec<String>) -> &mut Self {
-        let mut values: Vec<Value> = vec![];
-
-        for value in features {
-            values.push(Value::from(value));
-        }
-
-        self.0.insert("features", Value::from(values));
+        self.features = features;
         self
     }
 
@@ -114,13 +133,8 @@ impl EditGuild {
     /// **Note**: The current user must be the owner of the guild.
     #[inline]
     pub fn owner<U: Into<UserId>>(&mut self, user_id: U) -> &mut Self {
-        self._owner(user_id.into());
+        self.owner_id = Some(user_id.into());
         self
-    }
-
-    fn _owner(&mut self, user_id: UserId) {
-        let id = from_number(user_id.0);
-        self.0.insert("owner_id", id);
     }
 
     /// Set the splash image of the guild on the invitation page.
@@ -132,8 +146,7 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn splash(&mut self, splash: Option<String>) -> &mut Self {
-        let splash = splash.map_or(NULL, Value::String);
-        self.0.insert("splash", splash);
+        self.splash = splash;
         self
     }
 
@@ -146,8 +159,7 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn discovery_splash(&mut self, splash: Option<String>) -> &mut Self {
-        let splash = splash.map_or(NULL, Value::String);
-        self.0.insert("discovery_splash", splash);
+        self.discovery_splash = splash;
         self
     }
 
@@ -160,16 +172,14 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn banner(&mut self, banner: Option<String>) -> &mut Self {
-        let banner = banner.map_or(NULL, Value::String);
-        self.0.insert("banner", banner);
+        self.banner = banner;
         self
     }
 
     /// Set the channel ID where welcome messages and boost events will be
     /// posted.
     pub fn system_channel_id(&mut self, channel_id: Option<ChannelId>) -> &mut Self {
-        let channel_id = channel_id.map_or(NULL, |x| Value::from(x.0));
-        self.0.insert("system_channel_id", channel_id);
+        self.system_channel_id = channel_id;
         self
     }
 
@@ -178,8 +188,7 @@ impl EditGuild {
     /// **Note**:
     /// This feature is for Community guilds only.
     pub fn rules_channel_id(&mut self, channel_id: Option<ChannelId>) -> &mut Self {
-        let channel_id = channel_id.map_or(NULL, |x| Value::from(x.0));
-        self.0.insert("rules_channel_id", channel_id);
+        self.rules_channel_id = channel_id;
         self
     }
 
@@ -189,8 +198,7 @@ impl EditGuild {
     /// **Note**:
     /// This feature is for Community guilds only.
     pub fn public_updates_channel_id(&mut self, channel_id: Option<ChannelId>) -> &mut Self {
-        let channel_id = channel_id.map_or(NULL, |x| Value::from(x.0));
-        self.0.insert("public_updates_channel_id", channel_id);
+        self.public_updates_channel_id = channel_id;
         self
     }
 
@@ -202,15 +210,13 @@ impl EditGuild {
     /// **Note**:
     /// This feature is for Community guilds only.
     pub fn preferred_locale(&mut self, locale: Option<String>) -> &mut Self {
-        let locale = locale.map_or(NULL, Value::String);
-        self.0.insert("preferred_locale", locale);
+        self.preferred_locale = locale;
         self
     }
 
     /// Set the content filter level.
     pub fn explicit_content_filter(&mut self, level: Option<ExplicitContentFilter>) -> &mut Self {
-        let level = level.map_or(NULL, |x| Value::from(x as u8));
-        self.0.insert("explicit_content_filter", level);
+        self.explicit_content_filter = level;
         self
     }
 
@@ -219,8 +225,7 @@ impl EditGuild {
         &mut self,
         level: Option<DefaultMessageNotificationLevel>,
     ) -> &mut Self {
-        let level = level.map_or(NULL, |x| Value::from(x as u8));
-        self.0.insert("default_message_notifications", level);
+        self.default_message_notifications = level;
         self
     }
 
@@ -258,13 +263,8 @@ impl EditGuild {
     where
         V: Into<VerificationLevel>,
     {
-        self._verification_level(verification_level.into());
+        self.verification_level = Some(verification_level.into());
         self
-    }
-
-    fn _verification_level(&mut self, verification_level: VerificationLevel) {
-        let num = from_number(verification_level.num());
-        self.0.insert("verification_level", num);
     }
 
     /// Modifies the notifications that are sent by discord to the configured system channel.
@@ -295,7 +295,7 @@ impl EditGuild {
     /// # }
     /// ```
     pub fn system_channel_flags(&mut self, system_channel_flags: SystemChannelFlags) -> &mut Self {
-        self.0.insert("system_channel_flags", system_channel_flags.bits().into());
+        self.system_channel_flags = Some(system_channel_flags);
         self
     }
 }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -11,37 +11,38 @@ use crate::model::prelude::*;
 /// [Manage Guild]: crate::model::permissions::Permissions::MANAGE_GUILD
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct EditGuild {
-    features: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    afk_channel_id: Option<ChannelId>,
+    afk_channel_id: Option<Option<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_timeout: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<String>,
+    icon: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    features: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<UserId>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    splash: Option<String>,
+    splash: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discovery_splash: Option<String>,
+    discovery_splash: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    banner: Option<String>,
+    banner: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system_channel_id: Option<ChannelId>,
+    system_channel_id: Option<Option<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    rules_channel_id: Option<ChannelId>,
+    rules_channel_id: Option<Option<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    public_updates_channel_id: Option<ChannelId>,
+    public_updates_channel_id: Option<Option<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    preferred_locale: Option<String>,
+    preferred_locale: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    explicit_content_filter: Option<ExplicitContentFilter>,
+    explicit_content_filter: Option<Option<ExplicitContentFilter>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_message_notifications: Option<DefaultMessageNotificationLevel>,
+    default_message_notifications: Option<Option<DefaultMessageNotificationLevel>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     verification_level: Option<VerificationLevel>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,7 +58,7 @@ impl EditGuild {
     /// valid.
     #[inline]
     pub fn afk_channel<C: Into<ChannelId>>(&mut self, channel: Option<C>) -> &mut Self {
-        self.afk_channel_id = channel.map(Into::into);
+        self.afk_channel_id = Some(channel.map(Into::into));
         self
     }
 
@@ -94,7 +95,7 @@ impl EditGuild {
     ///
     /// [`utils::read_image`]: crate::utils::read_image
     pub fn icon(&mut self, icon: Option<String>) -> &mut Self {
-        self.icon = icon;
+        self.icon = Some(icon);
         self
     }
 
@@ -124,7 +125,7 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn features(&mut self, features: Vec<String>) -> &mut Self {
-        self.features = features;
+        self.features = Some(features);
         self
     }
 
@@ -146,7 +147,7 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn splash(&mut self, splash: Option<String>) -> &mut Self {
-        self.splash = splash;
+        self.splash = Some(splash);
         self
     }
 
@@ -159,7 +160,7 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn discovery_splash(&mut self, splash: Option<String>) -> &mut Self {
-        self.discovery_splash = splash;
+        self.discovery_splash = Some(splash);
         self
     }
 
@@ -172,14 +173,14 @@ impl EditGuild {
     ///
     /// [`features`]: crate::model::guild::Guild::features
     pub fn banner(&mut self, banner: Option<String>) -> &mut Self {
-        self.banner = banner;
+        self.banner = Some(banner);
         self
     }
 
     /// Set the channel ID where welcome messages and boost events will be
     /// posted.
     pub fn system_channel_id(&mut self, channel_id: Option<ChannelId>) -> &mut Self {
-        self.system_channel_id = channel_id;
+        self.system_channel_id = Some(channel_id);
         self
     }
 
@@ -188,7 +189,7 @@ impl EditGuild {
     /// **Note**:
     /// This feature is for Community guilds only.
     pub fn rules_channel_id(&mut self, channel_id: Option<ChannelId>) -> &mut Self {
-        self.rules_channel_id = channel_id;
+        self.rules_channel_id = Some(channel_id);
         self
     }
 
@@ -198,7 +199,7 @@ impl EditGuild {
     /// **Note**:
     /// This feature is for Community guilds only.
     pub fn public_updates_channel_id(&mut self, channel_id: Option<ChannelId>) -> &mut Self {
-        self.public_updates_channel_id = channel_id;
+        self.public_updates_channel_id = Some(channel_id);
         self
     }
 
@@ -210,13 +211,13 @@ impl EditGuild {
     /// **Note**:
     /// This feature is for Community guilds only.
     pub fn preferred_locale(&mut self, locale: Option<String>) -> &mut Self {
-        self.preferred_locale = locale;
+        self.preferred_locale = Some(locale);
         self
     }
 
     /// Set the content filter level.
     pub fn explicit_content_filter(&mut self, level: Option<ExplicitContentFilter>) -> &mut Self {
-        self.explicit_content_filter = level;
+        self.explicit_content_filter = Some(level);
         self
     }
 
@@ -225,7 +226,7 @@ impl EditGuild {
         &mut self,
         level: Option<DefaultMessageNotificationLevel>,
     ) -> &mut Self {
-        self.default_message_notifications = level;
+        self.default_message_notifications = Some(level);
         self
     }
 

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -1,26 +1,30 @@
-use std::collections::HashMap;
-
-use crate::internal::prelude::*;
-use crate::json;
 use crate::model::guild::GuildWelcomeChannelEmoji;
+use crate::model::id::{ChannelId, EmojiId};
 
 /// A builder to specify the fields to edit in a [`GuildWelcomeScreen`].
 ///
 /// [`GuildWelcomeScreen`]: crate::model::guild::GuildWelcomeScreen
-#[derive(Clone, Debug, Default)]
-pub struct EditGuildWelcomeScreen(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditGuildWelcomeScreen {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    welcome_channels: Vec<CreateGuildWelcomeChannel>,
+}
 
 impl EditGuildWelcomeScreen {
     /// Whether the welcome screen is enabled or not.
     pub fn enabled(&mut self, enabled: bool) -> &mut Self {
-        self.0.insert("enabled", Value::from(enabled));
+        self.enabled = Some(enabled);
 
         self
     }
 
     /// The server description shown in the welcome screen.
     pub fn description(&mut self, description: impl Into<String>) -> &mut Self {
-        self.0.insert("description", Value::String(description.into()));
+        self.description = Some(description.into());
 
         self
     }
@@ -32,31 +36,16 @@ impl EditGuildWelcomeScreen {
         let mut data = CreateGuildWelcomeChannel::default();
         f(&mut data);
 
-        self.add_welcome_channel(data);
-
-        self
+        self.add_welcome_channel(data)
     }
 
     pub fn add_welcome_channel(&mut self, channel: CreateGuildWelcomeChannel) -> &mut Self {
-        let new_data = json::hashmap_to_json_map(channel.0);
-
-        let channels =
-            self.0.entry("welcome_channels").or_insert_with(|| Value::from(Vec::<Value>::new()));
-        let channels_array = channels.as_array_mut().expect("Must be an array.");
-
-        channels_array.push(Value::from(new_data));
-
+        self.welcome_channels.push(channel);
         self
     }
 
     pub fn set_welcome_channels(&mut self, channels: Vec<CreateGuildWelcomeChannel>) -> &mut Self {
-        let new_channels = channels
-            .into_iter()
-            .map(|f| Value::from(json::hashmap_to_json_map(f.0)))
-            .collect::<Vec<Value>>();
-
-        self.0.insert("welcome_channels", Value::from(new_channels));
-
+        self.welcome_channels = channels;
         self
     }
 }
@@ -64,20 +53,29 @@ impl EditGuildWelcomeScreen {
 /// A builder for creating a [`GuildWelcomeChannel`].
 ///
 /// [`GuildWelcomeChannel`]: crate::model::guild::GuildWelcomeChannel
-#[derive(Clone, Debug, Default)]
-pub struct CreateGuildWelcomeChannel(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CreateGuildWelcomeChannel {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    emoji_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    emoji_id: Option<EmojiId>,
+}
 
 impl CreateGuildWelcomeChannel {
     /// The Id of the channel to show. It is required.
-    pub fn id(&mut self, id: u64) -> &mut Self {
-        self.0.insert("channel_id", Value::from(id.to_string()));
+    pub fn id(&mut self, id: impl Into<ChannelId>) -> &mut Self {
+        self.channel_id = Some(id.into());
 
         self
     }
 
     /// The description shown for the channel. It is required.
     pub fn description(&mut self, description: impl Into<String>) -> &mut Self {
-        self.0.insert("description", Value::from(description.into()));
+        self.description = Some(description.into());
 
         self
     }
@@ -86,14 +84,14 @@ impl CreateGuildWelcomeChannel {
     pub fn emoji(&mut self, emoji: GuildWelcomeChannelEmoji) -> &mut Self {
         match emoji {
             GuildWelcomeChannelEmoji::Unicode(name) => {
-                self.0.insert("emoji_name", Value::from(name));
+                self.emoji_name = Some(name);
             },
             GuildWelcomeChannelEmoji::Custom {
                 id,
                 name,
             } => {
-                self.0.insert("emoji_id", Value::from(id.to_string()));
-                self.0.insert("emoji_name", Value::from(name));
+                self.emoji_id = Some(id);
+                self.emoji_name = Some(name);
             },
         }
 

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -1,24 +1,27 @@
-use std::collections::HashMap;
-
-use crate::internal::prelude::*;
+use crate::model::id::ChannelId;
 
 /// A builder to specify the fields to edit in a [`GuildWidget`].
 ///
 /// [`GuildWidget`]: crate::model::guild::GuildWidget
-#[derive(Clone, Debug, Default)]
-pub struct EditGuildWidget(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditGuildWidget {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_id: Option<ChannelId>,
+}
 
 impl EditGuildWidget {
     /// Whether the widget is enabled or not.
     pub fn enabled(&mut self, enabled: bool) -> &mut Self {
-        self.0.insert("enabled", Value::from(enabled));
+        self.enabled = Some(enabled);
 
         self
     }
 
     /// The server description shown in the welcome screen.
-    pub fn channel_id(&mut self, id: u64) -> &mut Self {
-        self.0.insert("channel_id", Value::from(id.to_string()));
+    pub fn channel_id(&mut self, id: impl Into<ChannelId>) -> &mut Self {
+        self.channel_id = Some(id.into());
 
         self
     }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -91,10 +91,9 @@ impl EditInteractionResponse {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = json::hashmap_to_json_map(allowed_mentions.0);
-        let allowed_mentions = Value::from(map);
+        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", allowed_mentions);
+        self.0.insert("allowed_mentions", map);
         self
     }
 

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
-use crate::json;
 use crate::json::prelude::*;
 
 #[derive(Clone, Debug, Default)]
@@ -36,8 +35,7 @@ impl EditInteractionResponse {
 
     /// Adds an embed for the message.
     pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = json::hashmap_to_json_map(embed.0);
-        let embed = Value::from(map);
+        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
 
         let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
 
@@ -62,8 +60,8 @@ impl EditInteractionResponse {
     /// Calling this will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = json::hashmap_to_json_map(embed.0);
-        let embed = Value::from(map);
+        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
+
         self.0.insert("embeds", Value::from(vec![embed]));
 
         self

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -1,11 +1,16 @@
-use std::collections::HashMap;
+use super::{CreateAllowedMentions, CreateComponents, CreateEmbed};
 
-use super::{CreateAllowedMentions, CreateEmbed};
-use crate::builder::CreateComponents;
-use crate::json::prelude::*;
-
-#[derive(Clone, Debug, Default)]
-pub struct EditInteractionResponse(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditInteractionResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    embeds: Option<Vec<CreateEmbed>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_mentions: Option<CreateAllowedMentions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    components: Option<CreateComponents>,
+}
 
 impl EditInteractionResponse {
     /// Sets the `InteractionApplicationCommandCallbackData` for the message.
@@ -15,11 +20,7 @@ impl EditInteractionResponse {
     /// **Note**: Message contents must be under 2000 unicode code points.
     #[inline]
     pub fn content(&mut self, content: impl Into<String>) -> &mut Self {
-        self._content(content.into())
-    }
-
-    fn _content(&mut self, content: String) -> &mut Self {
-        self.0.insert("content", Value::String(content));
+        self.content = Some(content.into());
         self
     }
 
@@ -33,25 +34,19 @@ impl EditInteractionResponse {
         self.add_embed(embed)
     }
 
+    fn embeds(&mut self) -> &mut Vec<CreateEmbed> {
+        self.embeds.get_or_insert_with(Vec::new)
+    }
+
     /// Adds an embed for the message.
     pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
-
-        let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
-
-        if let Some(embeds) = embeds.as_array_mut() {
-            embeds.push(embed);
-        }
-
+        self.embeds().push(embed);
         self
     }
 
     /// Adds multiple embeds to the message.
     pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
-        for embed in embeds {
-            self.add_embed(embed);
-        }
-
+        self.embeds().extend(embeds);
         self
     }
 
@@ -60,10 +55,7 @@ impl EditInteractionResponse {
     /// Calling this will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
-
-        self.0.insert("embeds", Value::from(vec![embed]));
-
+        self.set_embeds(vec![embed]);
         self
     }
 
@@ -71,14 +63,7 @@ impl EditInteractionResponse {
     ///
     /// **Note**: You can only have up to 10 embeds per message.
     pub fn set_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
-        if self.0.contains_key("embeds") {
-            self.0.remove_entry("embeds");
-        }
-
-        for embed in embeds {
-            self.add_embed(embed);
-        }
-
+        self.embeds = Some(embeds);
         self
     }
 
@@ -89,9 +74,8 @@ impl EditInteractionResponse {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", map);
+        self.allowed_mentions = Some(allowed_mentions);
         self
     }
 
@@ -102,9 +86,8 @@ impl EditInteractionResponse {
     {
         let mut components = CreateComponents::default();
         f(&mut components);
-        let map = to_value(components).expect("CreateComponents builder should not fail!");
 
-        self.0.insert("components", map);
+        self.components = Some(components);
         self
     }
 }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -104,8 +104,9 @@ impl EditInteractionResponse {
     {
         let mut components = CreateComponents::default();
         f(&mut components);
+        let map = to_value(components).expect("CreateComponents builder should not fail!");
 
-        self.0.insert("components", Value::from(components.0));
+        self.0.insert("components", map);
         self
     }
 }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
 use crate::internal::prelude::*;
-use crate::json::{self, from_number};
+use crate::json::{self, from_number, to_value};
 use crate::model::channel::{AttachmentType, MessageFlags};
 use crate::model::id::AttachmentId;
 
@@ -138,10 +138,9 @@ impl<'a> EditMessage<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = json::hashmap_to_json_map(allowed_mentions.0);
-        let allowed_mentions = Value::from(map);
+        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", allowed_mentions);
+        self.0.insert("allowed_mentions", map);
         self
     }
 

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -152,13 +152,14 @@ impl<'a> EditMessage<'a> {
         let mut components = CreateComponents::default();
         f(&mut components);
 
-        self.0.insert("components", Value::from(components.0));
-        self
+        self.set_components(components)
     }
 
     /// Sets the components of this message.
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
-        self.0.insert("components", Value::from(components.0));
+        let map = to_value(components).expect("CreateComponents builder should not fail!");
+        self.0.insert("components", map);
+
         self
     }
 

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -44,8 +44,7 @@ impl<'a> EditMessage<'a> {
     }
 
     fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let map = json::hashmap_to_json_map(embed.0);
-        let embed = Value::from(map);
+        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
 
         let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
         let embeds_array = embeds.as_array_mut().expect("Embeds must be an array");

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -1,9 +1,4 @@
-use std::collections::HashMap;
-
-use super::{CreateAllowedMentions, CreateEmbed};
-use crate::builder::CreateComponents;
-use crate::internal::prelude::*;
-use crate::json::{self, from_number, to_value};
+use super::{CreateAllowedMentions, CreateComponents, CreateEmbed};
 use crate::model::channel::{AttachmentType, MessageFlags};
 use crate::model::id::AttachmentId;
 
@@ -30,8 +25,24 @@ use crate::model::id::AttachmentId;
 /// ```
 ///
 /// [`Message`]: crate::model::channel::Message
-#[derive(Clone, Debug, Default)]
-pub struct EditMessage<'a>(pub HashMap<&'static str, Value>, pub Vec<AttachmentType<'a>>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditMessage<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    embeds: Option<Vec<CreateEmbed>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<MessageFlags>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_mentions: Option<CreateAllowedMentions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    components: Option<CreateComponents>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    attachments: Option<Vec<AttachmentId>>,
+
+    #[serde(skip)]
+    pub(crate) files: Vec<AttachmentType<'a>>,
+}
 
 impl<'a> EditMessage<'a> {
     /// Set the content of the message.
@@ -39,17 +50,16 @@ impl<'a> EditMessage<'a> {
     /// **Note**: Message contents must be under 2000 unicode code points.
     #[inline]
     pub fn content(&mut self, content: impl Into<String>) -> &mut Self {
-        self.0.insert("content", Value::String(content.into()));
+        self.content = Some(content.into());
         self
     }
 
+    fn embeds(&mut self) -> &mut Vec<CreateEmbed> {
+        self.embeds.get_or_insert_with(Vec::new)
+    }
+
     fn _add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        let embed = to_value(embed).expect("CreateEmbed builder should not fail!");
-
-        let embeds = self.0.entry("embeds").or_insert_with(|| Value::from(Vec::<Value>::new()));
-        let embeds_array = embeds.as_array_mut().expect("Embeds must be an array");
-
-        embeds_array.push(embed);
+        self.embeds().push(embed);
 
         self
     }
@@ -72,10 +82,7 @@ impl<'a> EditMessage<'a> {
     /// **Note**: This will keep all existing embeds. Use [`Self::set_embeds()`] to replace existing
     /// embeds.
     pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
-        for embed in embeds {
-            self._add_embed(embed);
-        }
-
+        self.embeds().extend(embeds);
         self
     }
 
@@ -91,8 +98,7 @@ impl<'a> EditMessage<'a> {
     {
         let mut embed = CreateEmbed::default();
         f(&mut embed);
-        self.0.insert("embeds", Value::from(Vec::<Value>::new()));
-        self._add_embed(embed)
+        self.set_embed(embed)
     }
 
     /// Set an embed for the message.
@@ -102,8 +108,7 @@ impl<'a> EditMessage<'a> {
     /// **Note**: This will replace all existing embeds.
     /// Use [`Self::add_embed()`] to add an additional embed.
     pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        self.0.insert("embeds", Value::from(Vec::<Value>::new()));
-        self._add_embed(embed)
+        self.set_embeds(vec![embed])
     }
 
     /// Set multiple embeds for the message.
@@ -111,11 +116,7 @@ impl<'a> EditMessage<'a> {
     /// **Note**: This will replace all existing embeds. Use [`Self::add_embeds()`] to keep existing
     /// embeds.
     pub fn set_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
-        self.0.insert("embeds", Value::from(Vec::<Value>::new()));
-        for embed in embeds {
-            self._add_embed(embed);
-        }
-
+        self.embeds = Some(embeds);
         self
     }
 
@@ -124,9 +125,10 @@ impl<'a> EditMessage<'a> {
     pub fn suppress_embeds(&mut self, suppress: bool) -> &mut Self {
         // `1 << 2` is defined by the API to be the SUPPRESS_EMBEDS flag.
         // At the time of writing, the only accepted value in "flags" is `SUPPRESS_EMBEDS` for editing messages.
-        let flags = if suppress { 1 << 2 } else { 0 };
-        self.0.insert("flags", from_number(flags));
+        let flags =
+            suppress.then(|| MessageFlags::SUPPRESS_EMBEDS).unwrap_or_else(MessageFlags::empty);
 
+        self.flags = Some(flags);
         self
     }
 
@@ -137,9 +139,8 @@ impl<'a> EditMessage<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", map);
+        self.allowed_mentions = Some(allowed_mentions);
         self
     }
 
@@ -156,15 +157,13 @@ impl<'a> EditMessage<'a> {
 
     /// Sets the components of this message.
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
-        let map = to_value(components).expect("CreateComponents builder should not fail!");
-        self.0.insert("components", map);
-
+        self.components = Some(components);
         self
     }
 
     /// Sets the flags for the message.
     pub fn flags(&mut self, flags: MessageFlags) -> &mut Self {
-        self.0.insert("flags", from_number(flags.bits()));
+        self.flags = Some(flags);
         self
     }
 
@@ -172,44 +171,26 @@ impl<'a> EditMessage<'a> {
     ///
     /// This can be called multiple times.
     pub fn attachment(&mut self, attachment: impl Into<AttachmentType<'a>>) -> &mut Self {
-        self.1.push(attachment.into());
+        self.files.push(attachment.into());
         self
+    }
+
+    fn attachments(&mut self) -> &mut Vec<AttachmentId> {
+        self.attachments.get_or_insert_with(Vec::new)
     }
 
     /// Add an existing attachment by id.
     pub fn add_existing_attachment(&mut self, attachment: AttachmentId) -> &mut Self {
-        let attachments =
-            self.0.entry("attachments").or_insert_with(|| Value::from(Vec::<Value>::new()));
-        let attachments_array = attachments.as_array_mut().expect("Attachments must be an array");
-        let mut map = HashMap::new();
-        map.insert("id", Value::from(attachment.to_string()));
-        attachments_array.push(Value::from(json::hashmap_to_json_map(map)));
-
+        self.attachments().push(attachment);
         self
     }
 
     /// Remove an existing attachment by id.
     pub fn remove_existing_attachment(&mut self, attachment: AttachmentId) -> &mut Self {
-        let attachments =
-            self.0.entry("attachments").or_insert_with(|| Value::from(Vec::<Value>::new()));
-        let attachments_array = attachments.as_array_mut().expect("Attachments must be an array");
-        let attachment_string = attachment.to_string();
-        let mut found_at = None;
-        for (index, value) in attachments_array.iter().enumerate() {
-            if attachment_string
-                == value
-                    .as_object()
-                    .expect("Attachments must be an array of objects")
-                    .get("id")
-                    .expect("Attachments must be an array of objects containing ids")
-                    .as_str()
-                    .expect("Attachments must be an array of objects containing string ids")
-            {
-                found_at = Some(index);
-            }
-        }
-        if let Some(index) = found_at {
-            attachments_array.remove(index);
+        if let Some(attachments) = &mut self.attachments {
+            if let Some(attachment_index) = attachments.iter().position(|a| *a == attachment) {
+                attachments.remove(attachment_index);
+            };
         }
 
         self

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -1,14 +1,14 @@
-use std::collections::HashMap;
-
-use crate::internal::prelude::*;
-use crate::json::NULL;
-
 /// A builder to edit the current user's settings, to be used in conjunction
 /// with [`CurrentUser::edit`].
 ///
 /// [`CurrentUser::edit`]: crate::model::user::CurrentUser::edit
-#[derive(Clone, Debug, Default)]
-pub struct EditProfile(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditProfile {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    avatar: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    username: Option<String>,
+}
 
 impl EditProfile {
     /// Sets the avatar of the current user. [`None`] can be passed to remove an
@@ -47,8 +47,7 @@ impl EditProfile {
     ///
     /// [`utils::read_image`]: crate::utils::read_image
     pub fn avatar(&mut self, avatar: Option<String>) -> &mut Self {
-        let avatar = avatar.map_or(NULL, Value::String);
-        self.0.insert("avatar", avatar);
+        self.avatar = Some(avatar);
         self
     }
 
@@ -59,7 +58,7 @@ impl EditProfile {
     /// If there are no available discriminators with the requested username,
     /// an error will occur.
     pub fn username(&mut self, username: impl Into<String>) -> &mut Self {
-        self.0.insert("username", Value::from(username.into()));
+        self.username = Some(username.into());
         self
     }
 }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "model")]
 use crate::http::Http;
+#[cfg(feature = "model")]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
@@ -80,12 +81,12 @@ impl EditRole {
         EditRole {
             hoist: Some(role.hoist),
             mentionable: Some(role.mentionable),
-            name: Some(role.name),
+            name: Some(role.name.clone()),
             permissions: Some(role.permissions.bits()),
             position: Some(role.position),
             colour: Some(colour),
-            unicode_emoji: role.unicode_emoji,
-            icon: role.icon,
+            unicode_emoji: role.unicode_emoji.clone(),
+            icon: role.icon.clone(),
         }
     }
 

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -1,9 +1,6 @@
-use std::collections::HashMap;
-
 #[cfg(feature = "model")]
 use crate::http::Http;
 use crate::internal::prelude::*;
-use crate::json::from_number;
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::guild::Role;
@@ -43,85 +40,99 @@ use crate::model::Permissions;
 /// [`Guild::edit_role`]: crate::model::guild::Guild::edit_role
 /// [`GuildId::create_role`]: crate::model::id::GuildId::create_role
 /// [`GuildId::edit_role`]: crate::model::id::GuildId::edit_role
-#[derive(Clone, Debug, Default)]
-pub struct EditRole(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditRole {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "color")]
+    colour: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hoist: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mentionable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    permissions: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) position: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unicode_emoji: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+}
 
 impl EditRole {
     /// Creates a new builder with the values of the given [`Role`].
     #[must_use]
     pub fn new(role: &Role) -> Self {
-        let mut map = HashMap::with_capacity(9);
+        let colour;
 
         #[cfg(feature = "utils")]
         {
-            map.insert("color", from_number(role.colour.0));
+            colour = role.colour.0;
         }
 
         #[cfg(not(feature = "utils"))]
         {
-            map.insert("color", from_number(role.colour));
+            colour = role.colour;
         }
 
-        map.insert("hoist", Value::from(role.hoist));
-        map.insert("managed", Value::from(role.managed));
-        map.insert("mentionable", Value::from(role.mentionable));
-        map.insert("name", Value::from(role.name.clone()));
-        map.insert("permissions", from_number(role.permissions.bits()));
-        map.insert("position", from_number(role.position));
-
-        if let Some(unicode_emoji) = &role.unicode_emoji {
-            map.insert("unicode_emoji", Value::String(unicode_emoji.clone()));
+        EditRole {
+            hoist: Some(role.hoist),
+            mentionable: Some(role.mentionable),
+            name: Some(role.name),
+            permissions: Some(role.permissions.bits()),
+            position: Some(role.position),
+            colour: Some(colour),
+            unicode_emoji: role.unicode_emoji,
+            icon: role.icon,
         }
-
-        if let Some(icon) = &role.icon {
-            map.insert("icon", Value::String(icon.clone()));
-        }
-
-        EditRole(map)
     }
 
     /// Sets the colour of the role.
-    pub fn colour(&mut self, colour: u64) -> &mut Self {
-        self.0.insert("color", from_number(colour));
+    pub fn colour(&mut self, colour: u32) -> &mut Self {
+        self.colour = Some(colour);
+
         self
     }
 
     /// Whether or not to hoist the role above lower-positioned role in the user
     /// list.
     pub fn hoist(&mut self, hoist: bool) -> &mut Self {
-        self.0.insert("hoist", Value::from(hoist));
+        self.hoist = Some(hoist);
+
         self
     }
 
     /// Whether or not to make the role mentionable, notifying its users.
     pub fn mentionable(&mut self, mentionable: bool) -> &mut Self {
-        self.0.insert("mentionable", Value::from(mentionable));
+        self.mentionable = Some(mentionable);
         self
     }
 
     /// The name of the role to set.
     pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.0.insert("name", Value::String(name.into()));
+        self.name = Some(name.into());
         self
     }
 
     /// The set of permissions to assign the role.
     pub fn permissions(&mut self, permissions: Permissions) -> &mut Self {
-        self.0.insert("permissions", from_number(permissions.bits()));
+        self.permissions = Some(permissions.bits());
         self
     }
 
     /// The position to assign the role in the role list. This correlates to the
     /// role's position in the user list.
-    pub fn position(&mut self, position: u8) -> &mut Self {
-        self.0.insert("position", from_number(position));
+    pub fn position(&mut self, position: i64) -> &mut Self {
+        self.position = Some(position);
         self
     }
 
     /// The unicode emoji to set as the role image.
     pub fn unicode_emoji(&mut self, unicode_emoji: impl Into<String>) -> &mut Self {
-        self.0.remove("icon");
-        self.0.insert("unicode_emoji", Value::String(unicode_emoji.into()));
+        self.unicode_emoji = Some(unicode_emoji.into());
+        self.icon = None;
 
         self
     }
@@ -140,8 +151,9 @@ impl EditRole {
     ) -> Result<&mut Self> {
         let icon_data = icon.into().data(&http.as_ref().client).await?;
         let icon_string = format!("data:image/png;base64,{}", base64::encode(icon_data));
-        self.0.remove("unicode_emoji");
-        self.0.insert("icon", Value::from(icon_string));
+
+        self.icon = Some(icon_string);
+        self.unicode_emoji = None;
 
         Ok(self)
     }

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -4,7 +4,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
-use crate::model::guild::{ScheduledEventStatus, ScheduledEventType, ScheduledEventMetadata};
+use crate::model::guild::{ScheduledEventMetadata, ScheduledEventStatus, ScheduledEventType};
 use crate::model::id::ChannelId;
 use crate::model::Timestamp;
 
@@ -130,7 +130,7 @@ impl EditScheduledEvent {
     /// [`External`]: ScheduledEventType::External
     pub fn location(&mut self, location: impl Into<String>) -> &mut Self {
         self.entity_metadata = Some(Some(ScheduledEventMetadata {
-            location: location.into()
+            location: location.into(),
         }));
         self
     }

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -1,18 +1,34 @@
-use std::collections::HashMap;
-
 #[cfg(feature = "model")]
 use crate::http::Http;
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
-use crate::json::{json, Value, NULL};
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
-use crate::model::guild::{ScheduledEventStatus, ScheduledEventType};
+use crate::model::guild::{ScheduledEventStatus, ScheduledEventType, ScheduledEventMetadata};
 use crate::model::id::ChannelId;
 use crate::model::Timestamp;
 
-#[derive(Clone, Debug, Default)]
-pub struct EditScheduledEvent(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditScheduledEvent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    channel_id: Option<Option<ChannelId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scheduled_start_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scheduled_end_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entity_metadata: Option<Option<ScheduledEventMetadata>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entity_type: Option<ScheduledEventType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<ScheduledEventStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<String>,
+}
 
 impl EditScheduledEvent {
     /// Sets the channel id of the scheduled event. If the [`kind`] of the event is changed from
@@ -23,26 +39,26 @@ impl EditScheduledEvent {
     /// [`Voice`]: ScheduledEventType::Voice
     /// [`External`]: ScheduledEventType::External
     pub fn channel_id<C: Into<ChannelId>>(&mut self, channel_id: C) -> &mut Self {
-        self.0.insert("channel_id", Value::from(channel_id.into().0));
+        self.channel_id = Some(Some(channel_id.into()));
         self
     }
 
     /// Sets the name of the scheduled event.
     pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.0.insert("name", Value::String(name.into()));
+        self.name = Some(name.into());
         self
     }
 
     /// Sets the description of the scheduled event.
     pub fn description(&mut self, description: impl Into<String>) -> &mut Self {
-        self.0.insert("description", Value::from(description.into()));
+        self.description = Some(description.into());
         self
     }
 
     /// Sets the start time of the scheduled event.
     #[inline]
     pub fn start_time<T: Into<Timestamp>>(&mut self, timestamp: T) -> &mut Self {
-        self._timestamp("scheduled_start_time", timestamp.into());
+        self.scheduled_start_time = Some(timestamp.into().to_string());
         self
     }
 
@@ -54,12 +70,8 @@ impl EditScheduledEvent {
     /// [`External`]: ScheduledEventType::External
     #[inline]
     pub fn end_time<T: Into<Timestamp>>(&mut self, timestamp: T) -> &mut Self {
-        self._timestamp("scheduled_end_time", timestamp.into());
+        self.scheduled_end_time = Some(timestamp.into().to_string());
         self
-    }
-
-    fn _timestamp(&mut self, field: &'static str, timestamp: Timestamp) {
-        self.0.insert(field, Value::from(timestamp.to_string()));
     }
 
     // See https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-field-requirements-by-entity-type
@@ -77,11 +89,13 @@ impl EditScheduledEvent {
     /// [`Voice`]: ScheduledEventType::Voice
     /// [`External`]: ScheduledEventType::External
     pub fn kind(&mut self, kind: ScheduledEventType) -> &mut Self {
-        match kind {
-            ScheduledEventType::External => self.0.insert("channel_id", NULL),
-            _ => self.0.insert("entity_metadata", NULL),
-        };
-        self.0.insert("entity_type", Value::from(kind.num()));
+        if let ScheduledEventType::External = kind {
+            self.channel_id = Some(None);
+        } else {
+            self.entity_metadata = Some(None);
+        }
+
+        self.entity_type = Some(kind);
         self
     }
 
@@ -103,7 +117,7 @@ impl EditScheduledEvent {
     /// [`Completed`]: ScheduledEventStatus::Completed
     /// [`Canceled`]: ScheduledEventStatus::Canceled
     pub fn status(&mut self, status: ScheduledEventStatus) -> &mut Self {
-        self.0.insert("status", Value::from(status.num()));
+        self.status = Some(status);
         self
     }
 
@@ -115,10 +129,9 @@ impl EditScheduledEvent {
     /// [`kind`]: EditScheduledEvent::kind
     /// [`External`]: ScheduledEventType::External
     pub fn location(&mut self, location: impl Into<String>) -> &mut Self {
-        let obj = json!({
-            "location": location.into(),
-        });
-        self.0.insert("entity_metadata", obj);
+        self.entity_metadata = Some(Some(ScheduledEventMetadata {
+            location: location.into()
+        }));
         self
     }
 
@@ -136,7 +149,7 @@ impl EditScheduledEvent {
     ) -> Result<&mut Self> {
         let image_data = image.into().data(&http.as_ref().client).await?;
         let image_string = format!("data:image/png;base64,{}", base64::encode(image_data));
-        self.0.insert("image", Value::from(image_string));
+        self.image = Some(image_string);
         Ok(self)
     }
 }

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -1,18 +1,16 @@
-use std::collections::HashMap;
-
-use crate::json::Value;
-
 /// Edits a [`StageInstance`].
 ///
 /// [`StageInstance`]: crate::model::channel::StageInstance
-#[derive(Clone, Debug, Default)]
-pub struct EditStageInstance(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditStageInstance {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    topic: Option<String>,
+}
 
 impl EditStageInstance {
     /// Sets the topic of the stage channel instance.
     pub fn topic(&mut self, topic: impl Into<String>) -> &mut Self {
-        self.0.insert("topic", Value::String(topic.into()));
-
+        self.topic = Some(topic.into());
         self
     }
 }

--- a/src/builder/edit_sticker.rs
+++ b/src/builder/edit_sticker.rs
@@ -1,7 +1,3 @@
-use std::collections::HashMap;
-
-use crate::internal::prelude::*;
-
 /// A builder to create or edit a [`Sticker`] for use via a number of model methods.
 ///
 /// These are:
@@ -16,15 +12,22 @@ use crate::internal::prelude::*;
 /// [`Guild::edit_sticker`]: crate::model::guild::Guild::edit_sticker
 /// [`GuildId::edit_sticker`]: crate::model::id::GuildId::edit_sticker
 /// [`Sticker::edit`]: crate::model::sticker::Sticker::edit
-#[derive(Clone, Debug, Default)]
-pub struct EditSticker(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditSticker {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tags: Option<String>,
+}
 
 impl EditSticker {
     /// The name of the sticker to set.
     ///
     /// **Note**: Must be between 2 and 30 characters long.
     pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.0.insert("name", Value::String(name.into()));
+        self.name = Some(name.into());
         self
     }
 
@@ -32,7 +35,7 @@ impl EditSticker {
     ///
     /// **Note**: If not empty, must be between 2 and 100 characters long.
     pub fn description(&mut self, description: impl Into<String>) -> &mut Self {
-        self.0.insert("description", Value::String(description.into()));
+        self.description = Some(description.into());
         self
     }
 
@@ -40,7 +43,7 @@ impl EditSticker {
     ///
     /// **Note**: Must be between 2 and 200 characters long.
     pub fn tags(&mut self, tags: impl Into<String>) -> &mut Self {
-        self.0.insert("tags", Value::String(tags.into()));
+        self.tags = Some(tags.into());
         self
     }
 }

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -1,16 +1,23 @@
-use std::collections::HashMap;
-
-use crate::json::{from_number, Value};
-
-#[derive(Debug, Clone, Default)]
-pub struct EditThread(pub HashMap<&'static str, Value>);
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct EditThread {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_archive_duration: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    archived: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    locked: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    invitable: Option<bool>,
+}
 
 impl EditThread {
     /// The name of the thread.
     ///
     /// **Note**: Must be between 2 and 100 characters long.
     pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.0.insert("name", Value::String(name.into()));
+        self.name = Some(name.into());
 
         self
     }
@@ -19,7 +26,7 @@ impl EditThread {
     ///
     /// **Note**: Can only be set to 60, 1440, 4320, 10080 currently.
     pub fn auto_archive_duration(&mut self, duration: u16) -> &mut Self {
-        self.0.insert("auto_archive_duration", from_number(duration));
+        self.auto_archive_duration = Some(duration);
 
         self
     }
@@ -28,14 +35,14 @@ impl EditThread {
     ///
     /// **Note**: A thread that is `locked` can only be unarchived if the user has the `MANAGE_THREADS` permission.
     pub fn archived(&mut self, archived: bool) -> &mut Self {
-        self.0.insert("archived", Value::from(archived));
+        self.archived = Some(archived);
 
         self
     }
 
     /// The lock status of the thread.
     pub fn locked(&mut self, lock: bool) -> &mut Self {
-        self.0.insert("locked", Value::from(lock));
+        self.locked = Some(lock);
 
         self
     }
@@ -44,7 +51,7 @@ impl EditThread {
     ///
     /// **Note**: Only available on private threads.
     pub fn invitable(&mut self, invitable: bool) -> &mut Self {
-        self.0.insert("invitable", Value::from(invitable));
+        self.invitable = Some(invitable);
 
         self
     }

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -1,15 +1,17 @@
-use std::collections::HashMap;
-
-use crate::internal::prelude::*;
-use crate::json;
-use crate::model::Timestamp;
+use crate::model::{Timestamp, id::ChannelId};
 
 /// A builder which edits a user's voice state, to be used in conjunction with
 /// [`GuildChannel::edit_voice_state`].
 ///
 /// [`GuildChannel::edit_voice_state`]: crate::model::channel::GuildChannel::edit_voice_state
-#[derive(Clone, Debug, Default)]
-pub struct EditVoiceState(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditVoiceState {
+    pub(crate) channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suppress: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_to_speak_timestamp: Option<Option<Timestamp>>
+}
 
 impl EditVoiceState {
     /// Whether to suppress the user. Setting this to false will invite a user
@@ -20,7 +22,7 @@ impl EditVoiceState {
     ///
     /// [Mute Members]: crate::model::permissions::Permissions::MUTE_MEMBERS
     pub fn suppress(&mut self, deafen: bool) -> &mut Self {
-        self.0.insert("suppress", Value::from(deafen));
+        self.suppress = Some(deafen);
         self
     }
 
@@ -50,12 +52,7 @@ impl EditVoiceState {
         &mut self,
         timestamp: Option<T>,
     ) -> &mut Self {
-        if let Some(timestamp) = timestamp {
-            self.0.insert("request_to_speak_timestamp", Value::from(timestamp.into().to_string()));
-        } else {
-            self.0.insert("request_to_speak_timestamp", json::NULL);
-        }
-
+        self.request_to_speak_timestamp = Some(timestamp.map(Into::into));
         self
     }
 }

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -1,4 +1,5 @@
-use crate::model::{Timestamp, id::ChannelId};
+use crate::model::id::ChannelId;
+use crate::model::Timestamp;
 
 /// A builder which edits a user's voice state, to be used in conjunction with
 /// [`GuildChannel::edit_voice_state`].
@@ -10,7 +11,7 @@ pub struct EditVoiceState {
     #[serde(skip_serializing_if = "Option::is_none")]
     suppress: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    request_to_speak_timestamp: Option<Option<Timestamp>>
+    request_to_speak_timestamp: Option<Option<Timestamp>>,
 }
 
 impl EditVoiceState {

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -64,8 +64,9 @@ impl EditWebhookMessage {
     {
         let mut components = CreateComponents::default();
         f(&mut components);
+        let map = to_value(components).expect("CreateComponents builder should not fail!");
 
-        self.0.insert("components", Value::from(components.0));
+        self.0.insert("components", map);
         self
     }
 }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::CreateAllowedMentions;
 use crate::builder::CreateComponents;
 use crate::internal::prelude::*;
-use crate::json;
+use crate::json::to_value;
 
 /// A builder to specify the fields to edit in an existing [`Webhook`]'s message.
 ///
@@ -46,10 +46,9 @@ impl EditWebhookMessage {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = json::hashmap_to_json_map(allowed_mentions.0);
-        let allowed_mentions = Value::from(map);
+        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", allowed_mentions);
+        self.0.insert("allowed_mentions", map);
         self
     }
 

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -1,15 +1,19 @@
-use std::collections::HashMap;
-
-use super::CreateAllowedMentions;
-use crate::builder::CreateComponents;
-use crate::internal::prelude::*;
-use crate::json::to_value;
+use super::{CreateAllowedMentions, CreateComponents, CreateEmbed};
 
 /// A builder to specify the fields to edit in an existing [`Webhook`]'s message.
 ///
 /// [`Webhook`]: crate::model::webhook::Webhook
-#[derive(Clone, Debug, Default)]
-pub struct EditWebhookMessage(pub HashMap<&'static str, Value>);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct EditWebhookMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    embeds: Option<Vec<CreateEmbed>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_mentions: Option<CreateAllowedMentions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    components: Option<CreateComponents>,
+}
 
 impl EditWebhookMessage {
     /// Set the content of the message.
@@ -17,25 +21,21 @@ impl EditWebhookMessage {
     /// **Note**: Message contents must be under 2000 unicode code points.
     #[inline]
     pub fn content(&mut self, content: impl Into<String>) -> &mut Self {
-        self.0.insert("content", Value::String(content.into()));
+        self.content = Some(content.into());
         self
     }
 
     /// Set the embeds associated with the message.
-    ///
-    /// This should be used in combination with [`Embed::fake`], creating one
-    /// or more fake embeds to send to the API.
     ///
     /// # Examples
     ///
     /// Refer to [struct-level documentation of `ExecuteWebhook`] for an example
     /// on how to use embeds.
     ///
-    /// [`Embed::fake`]: crate::model::channel::Embed::fake
     /// [struct-level documentation of `ExecuteWebhook`]: crate::builder::ExecuteWebhook#examples
     #[inline]
-    pub fn embeds(&mut self, embeds: Vec<Value>) -> &mut Self {
-        self.0.insert("embeds", Value::from(embeds));
+    pub fn embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        self.embeds = Some(embeds);
         self
     }
 
@@ -46,9 +46,8 @@ impl EditWebhookMessage {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", map);
+        self.allowed_mentions = Some(allowed_mentions);
         self
     }
 
@@ -64,9 +63,8 @@ impl EditWebhookMessage {
     {
         let mut components = CreateComponents::default();
         f(&mut components);
-        let map = to_value(components).expect("CreateComponents builder should not fail!");
 
-        self.0.insert("components", map);
+        self.components = Some(components);
         self
     }
 }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -3,7 +3,8 @@ use std::marker::PhantomData;
 
 use super::{CreateAllowedMentions, CreateComponents, CreateEmbed};
 #[cfg(feature = "model")]
-use crate::model::channel::{AttachmentType, MessageFlags};
+use crate::model::channel::AttachmentType;
+use crate::model::channel::MessageFlags;
 
 /// A builder to create the inner content of a [`Webhook`]'s execution.
 ///

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,13 +1,9 @@
-use std::collections::HashMap;
 #[cfg(not(feature = "model"))]
 use std::marker::PhantomData;
 
-use super::CreateAllowedMentions;
-use crate::builder::CreateComponents;
-use crate::json::{from_number, to_value, Value};
+use super::{CreateAllowedMentions, CreateComponents};
 #[cfg(feature = "model")]
-use crate::model::channel::AttachmentType;
-use crate::model::channel::MessageFlags;
+use crate::model::channel::{AttachmentType, MessageFlags};
 
 /// A builder to create the inner content of a [`Webhook`]'s execution.
 ///
@@ -59,12 +55,29 @@ use crate::model::channel::MessageFlags;
 /// [`Webhook`]: crate::model::webhook::Webhook
 /// [`Webhook::execute`]: crate::model::webhook::Webhook::execute
 /// [`execute_webhook`]: crate::http::client::Http::execute_webhook
-#[derive(Clone, Debug)]
-pub struct ExecuteWebhook<'a>(
-    pub HashMap<&'static str, Value>,
-    #[cfg(feature = "model")] pub Vec<AttachmentType<'a>>,
-    #[cfg(not(feature = "model"))] PhantomData<&'a ()>,
-);
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct ExecuteWebhook<'a> {
+    tts: bool,
+    embeds: Vec<CreateEmbed>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    avatar_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_mentions: Option<CreateAllowedMentions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    components: Option<CreateComponents>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<MessageFlags>,
+
+    #[serde(skip)]
+    #[cfg(feature = "model")]
+    pub(crate) files: Vec<AttachmentType<'a>>,
+    #[cfg(not(feature = "model"))]
+    files: PhantomData<&'a ()>,
+}
 
 impl<'a> ExecuteWebhook<'a> {
     /// Override the default avatar of the webhook with an image URL.
@@ -88,7 +101,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # }
     /// ```
     pub fn avatar_url(&mut self, avatar_url: impl Into<String>) -> &mut Self {
-        self.0.insert("avatar_url", Value::String(avatar_url.into()));
+        self.avatar_url = Some(avatar_url.into());
         self
     }
 
@@ -118,14 +131,14 @@ impl<'a> ExecuteWebhook<'a> {
     /// # }
     /// ```
     pub fn content(&mut self, content: impl Into<String>) -> &mut Self {
-        self.0.insert("content", Value::String(content.into()));
+        self.content = Some(content.into());
         self
     }
 
     /// Appends a file to the webhook message.
     #[cfg(feature = "model")]
     pub fn add_file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
-        self.1.push(file.into());
+        self.files.push(file.into());
         self
     }
 
@@ -135,7 +148,7 @@ impl<'a> ExecuteWebhook<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.1.extend(files.into_iter().map(Into::into));
+        self.files.extend(files.into_iter().map(Into::into));
         self
     }
 
@@ -148,7 +161,7 @@ impl<'a> ExecuteWebhook<'a> {
         &mut self,
         files: It,
     ) -> &mut Self {
-        self.1 = files.into_iter().map(Into::into).collect();
+        self.files = files.into_iter().map(Into::into).collect();
         self
     }
 
@@ -159,9 +172,8 @@ impl<'a> ExecuteWebhook<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", map);
+        self.allowed_mentions = Some(allowed_mentions);
         self
     }
 
@@ -186,27 +198,20 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// [`components`]: crate::builder::ExecuteWebhook::components
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
-        let map = to_value(components).expect("CreateComponents builder should not fail!");
-        self.0.insert("components", map);
-
+        self.components = Some(components);
         self
     }
 
     /// Set the embeds associated with the message.
-    ///
-    /// This should be used in combination with [`Embed::fake`], creating one
-    /// or more fake embeds to send to the API.
     ///
     /// # Examples
     ///
     /// Refer to the [struct-level documentation] for an example on how to use
     /// embeds.
     ///
-    /// [`Embed::fake`]: crate::model::channel::Embed::fake
-    /// [`Webhook::execute`]: crate::model::webhook::Webhook::execute
     /// [struct-level documentation]: #examples
-    pub fn embeds(&mut self, embeds: Vec<Value>) -> &mut Self {
-        self.0.insert("embeds", Value::from(embeds));
+    pub fn embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+        self.embeds = embeds;
         self
     }
 
@@ -233,7 +238,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # }
     /// ```
     pub fn tts(&mut self, tts: bool) -> &mut Self {
-        self.0.insert("tts", Value::from(tts));
+        self.tts = Some(tts);
         self
     }
 
@@ -260,7 +265,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # }
     /// ```
     pub fn username(&mut self, username: impl Into<String>) -> &mut Self {
-        self.0.insert("username", Value::String(username.into()));
+        self.username = SOme(username.into());
         self
     }
 
@@ -293,33 +298,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # }
     /// ```
     pub fn flags(&mut self, flags: MessageFlags) -> &mut Self {
-        self.0.insert("flags", from_number(flags.bits()));
+        self.flags = Some(flags);
         self
-    }
-}
-
-impl<'a> Default for ExecuteWebhook<'a> {
-    /// Returns a default set of values for a [`Webhook`] execution.
-    ///
-    /// The only default value is [`Self::tts`] being set to `false`.
-    ///
-    /// # Examples
-    ///
-    /// Creating an [`ExecuteWebhook`] builder:
-    ///
-    /// ```rust
-    /// use serenity::builder::ExecuteWebhook;
-    ///
-    /// let executor = ExecuteWebhook::default();
-    /// ```
-    ///
-    /// [`Webhook`]: crate::model::webhook::Webhook
-    fn default() -> ExecuteWebhook<'a> {
-        let mut map = HashMap::new();
-        map.insert("tts", Value::from(false));
-
-        // Necessary because the type of the second field is different without model feature
-        #[allow(clippy::default_trait_access)]
-        ExecuteWebhook(map, Default::default())
     }
 }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "model"))]
 use std::marker::PhantomData;
 
-use super::{CreateAllowedMentions, CreateComponents};
+use super::{CreateAllowedMentions, CreateComponents, CreateEmbed};
 #[cfg(feature = "model")]
 use crate::model::channel::{AttachmentType, MessageFlags};
 
@@ -238,7 +238,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # }
     /// ```
     pub fn tts(&mut self, tts: bool) -> &mut Self {
-        self.tts = Some(tts);
+        self.tts = tts;
         self
     }
 
@@ -265,7 +265,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # }
     /// ```
     pub fn username(&mut self, username: impl Into<String>) -> &mut Self {
-        self.username = SOme(username.into());
+        self.username = Some(username.into());
         self
     }
 

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use super::CreateAllowedMentions;
 use crate::builder::CreateComponents;
-use crate::json::{self, from_number, Value};
+use crate::json::{from_number, to_value, Value};
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::channel::MessageFlags;
@@ -159,10 +159,9 @@ impl<'a> ExecuteWebhook<'a> {
     {
         let mut allowed_mentions = CreateAllowedMentions::default();
         f(&mut allowed_mentions);
-        let map = json::hashmap_to_json_map(allowed_mentions.0);
-        let allowed_mentions = Value::from(map);
+        let map = to_value(allowed_mentions).expect("AllowedMentions builder should not fail!");
 
-        self.0.insert("allowed_mentions", allowed_mentions);
+        self.0.insert("allowed_mentions", map);
         self
     }
 

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -178,8 +178,7 @@ impl<'a> ExecuteWebhook<'a> {
         let mut components = CreateComponents::default();
         f(&mut components);
 
-        self.0.insert("components", Value::from(components.0));
-        self
+        self.set_components(components)
     }
 
     /// Sets the components of this message. Requires an application-owned webhook. See
@@ -187,7 +186,9 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// [`components`]: crate::builder::ExecuteWebhook::components
     pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
-        self.0.insert("components", Value::Array(components.0));
+        let map = to_value(components).expect("CreateComponents builder should not fail!");
+        self.0.insert("components", map);
+
         self
     }
 

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -5,6 +5,10 @@
 //! optional, and/or sane default values for required parameters can be applied
 //! by a builder.
 
+// Option<Option<T>> is required for fields that are
+// #[serde(skip_serializing_if = "Option::is_none")]
+#![allow(clippy::option_option)]
+
 mod create_channel;
 mod create_embed;
 

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -71,6 +71,7 @@ pub use self::create_components::{
 };
 pub use self::create_embed::{CreateEmbed, CreateEmbedAuthor, CreateEmbedFooter};
 pub use self::create_interaction_response::{
+    AutocompleteChoice,
     CreateAutocompleteResponse,
     CreateInteractionResponse,
     CreateInteractionResponseData,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -376,7 +376,7 @@ impl Http {
     pub async fn create_channel(
         &self,
         guild_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildChannel> {
         let body = to_vec(map)?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -803,10 +803,9 @@ impl Http {
     pub async fn create_role(
         &self,
         guild_id: u64,
-        map: &JsonMap,
+        body: Vec<u8>,
         audit_log_reason: Option<&str>,
     ) -> Result<Role> {
-        let body = to_vec(map)?;
         let mut value = self
             .request(Request {
                 body: Some(body),
@@ -1838,10 +1837,9 @@ impl Http {
         &self,
         guild_id: u64,
         role_id: u64,
-        map: &JsonMap,
+        body: Vec<u8>,
         audit_log_reason: Option<&str>,
     ) -> Result<Role> {
-        let body = to_vec(&map)?;
         let mut value = self
             .request(Request {
                 body: Some(body),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -758,7 +758,7 @@ impl Http {
         &self,
         channel_id: u64,
         target_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<()> {
         let body = to_vec(map)?;
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -393,7 +393,10 @@ impl Http {
     }
 
     /// Creates a stage instance.
-    pub async fn create_stage_instance(&self, map: &Value) -> Result<StageInstance> {
+    pub async fn create_stage_instance(
+        &self,
+        map: &impl serde::Serialize,
+    ) -> Result<StageInstance> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1349,7 +1352,11 @@ impl Http {
     }
 
     /// Edits a stage instance.
-    pub async fn edit_stage_instance(&self, channel_id: u64, map: &Value) -> Result<StageInstance> {
+    pub async fn edit_stage_instance(
+        &self,
+        channel_id: u64,
+        map: &impl serde::Serialize,
+    ) -> Result<StageInstance> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -412,7 +412,7 @@ impl Http {
         &self,
         channel_id: u64,
         message_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
     ) -> Result<GuildChannel> {
         let body = to_vec(map)?;
 
@@ -432,7 +432,7 @@ impl Http {
     pub async fn create_private_thread(
         &self,
         channel_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
     ) -> Result<GuildChannel> {
         let body = to_vec(map)?;
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -862,7 +862,7 @@ impl Http {
     pub async fn create_sticker<'a>(
         &self,
         guild_id: u64,
-        map: JsonMap,
+        map: Vec<(Cow<'static, str>, Cow<'static, str>)>,
         file: impl Into<AttachmentType<'a>>,
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {
@@ -870,19 +870,7 @@ impl Http {
             body: None,
             multipart: Some(Multipart {
                 files: vec![file.into()],
-                fields: map
-                    .into_iter()
-                    .map(|(name, value)| {
-                        (
-                            name.into(),
-                            value
-                                .as_str()
-                                .expect("Create_sticker map must be strings")
-                                .to_string()
-                                .into(),
-                        )
-                    })
-                    .collect(),
+                fields: map,
                 payload_json: None,
             }),
             headers: audit_log_reason.map(reason_into_header),
@@ -1939,7 +1927,7 @@ impl Http {
         &self,
         guild_id: u64,
         sticker_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {
         let body = to_vec(&map)?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1960,9 +1960,7 @@ impl Http {
     }
 
     /// Edits a thread channel in the [`GuildChannel`] given its Id.
-    pub async fn edit_thread(&self, channel_id: u64, map: &JsonMap) -> Result<GuildChannel> {
-        let body = to_vec(map)?;
-
+    pub async fn edit_thread(&self, channel_id: u64, body: Vec<u8>) -> Result<GuildChannel> {
         self.fire(Request {
             body: Some(body),
             multipart: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -681,7 +681,7 @@ impl Http {
         &self,
         interaction_id: u64,
         interaction_token: &str,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<()> {
         self.wind(204, Request {
             body: Some(to_vec(map)?),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -859,12 +859,12 @@ impl Http {
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
-    pub async fn create_sticker<'a>(
-        &self,
+    pub async fn create_sticker<'a, 'b, 'c>(
+        &'a self,
         guild_id: u64,
         map: Vec<(Cow<'static, str>, Cow<'static, str>)>,
-        file: impl Into<AttachmentType<'a>>,
-        audit_log_reason: Option<&str>,
+        file: impl Into<AttachmentType<'b>>,
+        audit_log_reason: Option<&'c str>,
     ) -> Result<Sticker> {
         self.fire(Request {
             body: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1596,7 +1596,11 @@ impl Http {
     }
 
     /// Edits a [`Guild`]'s widget.
-    pub async fn edit_guild_widget(&self, guild_id: u64, map: &Value) -> Result<GuildWidget> {
+    pub async fn edit_guild_widget(
+        &self,
+        guild_id: u64,
+        map: &impl serde::Serialize,
+    ) -> Result<GuildWidget> {
         let body = to_vec(map)?;
 
         self.fire(Request {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use reqwest::header::{HeaderMap as Headers, HeaderValue, CONTENT_TYPE};
+use reqwest::header::{HeaderMap as Headers, HeaderValue};
 use reqwest::{Client, ClientBuilder, Response as ReqwestResponse, StatusCode, Url};
 use serde::de::DeserializeOwned;
 use tracing::{debug, instrument, trace};
@@ -2230,18 +2230,15 @@ impl Http {
         thread_id: Option<u64>,
         token: &str,
         wait: bool,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
     ) -> Result<Option<Message>> {
         let body = to_vec(map)?;
-
-        let mut headers = Headers::new();
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
         let response = self
             .request(Request {
                 body: Some(body),
                 multipart: None,
-                headers: Some(headers),
+                headers: None,
                 route: RouteInfo::ExecuteWebhook {
                     token,
                     wait,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -268,7 +268,7 @@ impl Http {
         &self,
         guild_id: u64,
         user_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
     ) -> Result<Option<Member>> {
         let body = to_vec(map)?;
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -475,7 +475,7 @@ impl Http {
     pub async fn create_followup_message(
         &self,
         interaction_token: &str,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Message> {
         self.fire(Request {
             body: Some(to_vec(map)?),
@@ -495,14 +495,14 @@ impl Http {
     pub async fn create_followup_message_with_files(
         &self,
         interaction_token: &str,
-        map: &Value,
+        map: &impl serde::Serialize,
         files: impl IntoIterator<Item = AttachmentType<'_>>,
     ) -> Result<Message> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
                 files: files.into_iter().map(Into::into).collect(),
-                payload_json: Some(map.clone()),
+                payload_json: Some(to_string(map)?),
                 fields: vec![],
             }),
             headers: None,
@@ -696,14 +696,14 @@ impl Http {
         &self,
         interaction_id: u64,
         interaction_token: &str,
-        map: &Value,
+        map: &impl serde::Serialize,
         files: impl IntoIterator<Item = AttachmentType<'_>>,
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: Some(Multipart {
                 files: files.into_iter().map(Into::into).collect(),
-                payload_json: Some(to_value(map)?),
+                payload_json: Some(to_string(map)?),
                 fields: vec![],
             }),
             headers: None,
@@ -1392,7 +1392,7 @@ impl Http {
         &self,
         interaction_token: &str,
         message_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Message> {
         self.fire(Request {
             body: Some(to_vec(map)?),
@@ -1416,14 +1416,14 @@ impl Http {
         &self,
         interaction_token: &str,
         message_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
         new_attachments: impl IntoIterator<Item = AttachmentType<'_>>,
     ) -> Result<Message> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
                 files: new_attachments.into_iter().map(Into::into).collect(),
-                payload_json: Some(map.clone()),
+                payload_json: Some(to_string(map)?),
                 fields: vec![],
             }),
             headers: None,
@@ -1689,14 +1689,14 @@ impl Http {
         &self,
         channel_id: u64,
         message_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
         new_attachments: impl IntoIterator<Item = AttachmentType<'_>>,
     ) -> Result<Message> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
                 files: new_attachments.into_iter().map(Into::into).collect(),
-                payload_json: Some(map.clone()),
+                payload_json: Some(to_string(map)?),
                 fields: vec![],
             }),
             headers: None,
@@ -2260,23 +2260,20 @@ impl Http {
     /// Returns an
     /// [`HttpError::UnsuccessfulRequest(ErrorResponse)`][`HttpError::UnsuccessfulRequest`]
     /// if the files are too large to send.
-    pub async fn execute_webhook_with_files<'a, T, It: IntoIterator<Item = T>>(
+    pub async fn execute_webhook_with_files<'a>(
         &self,
         webhook_id: u64,
         thread_id: Option<u64>,
         token: &str,
         wait: bool,
-        files: It,
-        map: &JsonMap,
-    ) -> Result<Option<Message>>
-    where
-        T: Into<AttachmentType<'a>>,
-    {
+        files: impl IntoIterator<Item = impl Into<AttachmentType<'a>>>,
+        map: &impl serde::Serialize,
+    ) -> Result<Option<Message>> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
                 files: files.into_iter().map(Into::into).collect(),
-                payload_json: Some(to_value(map)?),
+                payload_json: Some(to_string(map)?),
                 fields: vec![],
             }),
             headers: None,
@@ -3638,20 +3635,17 @@ impl Http {
     /// Returns an
     /// [`HttpError::UnsuccessfulRequest(ErrorResponse)`][`HttpError::UnsuccessfulRequest`]
     /// if the files are too large to send.
-    pub async fn send_files<'a, T, It: IntoIterator<Item = T>>(
+    pub async fn send_files(
         &self,
         channel_id: u64,
-        files: It,
+        files: impl IntoIterator<Item = impl Into<AttachmentType<'_>>>,
         map: &impl serde::Serialize,
-    ) -> Result<Message>
-    where
-        T: Into<AttachmentType<'a>>,
-    {
+    ) -> Result<Message> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
                 files: files.into_iter().map(Into::into).collect(),
-                payload_json: Some(to_value(map)?),
+                payload_json: Some(to_string(map)?),
                 fields: vec![],
             }),
             headers: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2003,7 +2003,7 @@ impl Http {
     /// let map = value.as_object().unwrap();
     ///
     /// // Edit state for another user
-    /// http.edit_voice_state(guild_id, user_id, &map).await?;
+    /// http.edit_voice_state(guild_id, user_id, to_vec(&map)).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -2051,7 +2051,7 @@ impl Http {
     /// let map = value.as_object().unwrap();
     ///
     /// // Edit state for current user
-    /// http.edit_voice_state_me(guild_id, &map).await?;
+    /// http.edit_voice_state_me(guild_id, to_vec(&map)).await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1638,7 +1638,7 @@ impl Http {
         &self,
         guild_id: u64,
         user_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Member> {
         let body = to_vec(map)?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -528,7 +528,10 @@ impl Http {
     /// application will overwrite the old command.
     ///
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
-    pub async fn create_global_application_command(&self, map: &Value) -> Result<Command> {
+    pub async fn create_global_application_command(
+        &self,
+        map: &impl serde::Serialize,
+    ) -> Result<Command> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -541,7 +544,10 @@ impl Http {
     }
 
     /// Creates new global application commands.
-    pub async fn create_global_application_commands(&self, map: &Value) -> Result<Vec<Command>> {
+    pub async fn create_global_application_commands(
+        &self,
+        map: &impl serde::Serialize,
+    ) -> Result<Vec<Command>> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -557,7 +563,7 @@ impl Http {
     pub async fn create_guild_application_commands(
         &self,
         guild_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Vec<Command>> {
         self.fire(Request {
             body: Some(to_vec(map)?),
@@ -624,7 +630,7 @@ impl Http {
     pub async fn create_guild_application_command(
         &self,
         guild_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Command> {
         self.fire(Request {
             body: Some(to_vec(map)?),
@@ -1464,7 +1470,7 @@ impl Http {
     pub async fn edit_global_application_command(
         &self,
         command_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Command> {
         self.fire(Request {
             body: Some(to_vec(map)?),
@@ -1509,7 +1515,7 @@ impl Http {
         &self,
         guild_id: u64,
         command_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Command> {
         self.fire(Request {
             body: Some(to_vec(map)?),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -836,7 +836,7 @@ impl Http {
     pub async fn create_scheduled_event(
         &self,
         guild_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<ScheduledEvent> {
         let body = to_vec(map)?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -803,12 +803,12 @@ impl Http {
     pub async fn create_role(
         &self,
         guild_id: u64,
-        body: Vec<u8>,
+        body: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Role> {
         let mut value = self
             .request(Request {
-                body: Some(body),
+                body: Some(to_vec(body)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 route: RouteInfo::CreateRole {
@@ -1837,12 +1837,12 @@ impl Http {
         &self,
         guild_id: u64,
         role_id: u64,
-        body: Vec<u8>,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Role> {
         let mut value = self
             .request(Request {
-                body: Some(body),
+                body: Some(to_vec(map)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 route: RouteInfo::EditRole {
@@ -1958,9 +1958,13 @@ impl Http {
     }
 
     /// Edits a thread channel in the [`GuildChannel`] given its Id.
-    pub async fn edit_thread(&self, channel_id: u64, body: Vec<u8>) -> Result<GuildChannel> {
+    pub async fn edit_thread(
+        &self,
+        channel_id: u64,
+        map: &impl serde::Serialize,
+    ) -> Result<GuildChannel> {
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditThread {
@@ -1991,21 +1995,24 @@ impl Http {
     /// #     let http = Http::new("token");
     /// let guild_id = 187450744427773963;
     /// let user_id = 150443906511667200;
-    /// let value = json!({
+    /// let map = json!({
     ///     "channel_id": "826929611849334784",
     ///     "suppress": true,
     /// });
     ///
-    /// let map = value.as_object().unwrap();
-    ///
     /// // Edit state for another user
-    /// http.edit_voice_state(guild_id, user_id, to_vec(&map)).await?;
+    /// http.edit_voice_state(guild_id, user_id, &map).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    pub async fn edit_voice_state(&self, guild_id: u64, user_id: u64, body: Vec<u8>) -> Result<()> {
+    pub async fn edit_voice_state(
+        &self,
+        guild_id: u64,
+        user_id: u64,
+        map: &impl serde::Serialize,
+    ) -> Result<()> {
         self.wind(204, Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditVoiceState {
@@ -2038,22 +2045,24 @@ impl Http {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
     /// let guild_id = 187450744427773963;
-    /// let value = json!({
+    /// let map = json!({
     ///     "channel_id": "826929611849334784",
     ///     "suppress": false,
     ///     "request_to_speak_timestamp": "2021-03-31T18:45:31.297561+00:00"
     /// });
     ///
-    /// let map = value.as_object().unwrap();
-    ///
     /// // Edit state for current user
-    /// http.edit_voice_state_me(guild_id, to_vec(&map)).await?;
+    /// http.edit_voice_state_me(guild_id, &map).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    pub async fn edit_voice_state_me(&self, guild_id: u64, body: Vec<u8>) -> Result<()> {
+    pub async fn edit_voice_state_me(
+        &self,
+        guild_id: u64,
+        map: &impl serde::Serialize,
+    ) -> Result<()> {
         self.wind(204, Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditVoiceStateMe {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1488,7 +1488,7 @@ impl Http {
     pub async fn edit_guild(
         &self,
         guild_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<PartialGuild> {
         let body = to_vec(map)?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3642,7 +3642,7 @@ impl Http {
         &self,
         channel_id: u64,
         files: It,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
     ) -> Result<Message>
     where
         T: Into<AttachmentType<'a>>,
@@ -3663,7 +3663,11 @@ impl Http {
     }
 
     /// Sends a message to a channel.
-    pub async fn send_message(&self, channel_id: u64, map: &Value) -> Result<Message> {
+    pub async fn send_message(
+        &self,
+        channel_id: u64,
+        map: &impl serde::Serialize,
+    ) -> Result<Message> {
         let body = to_vec(map)?;
 
         self.fire(Request {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -865,13 +865,14 @@ impl Http {
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
-    pub async fn create_sticker<'a, 'b, 'c>(
+    // Manual async fn to decorate the lifetime manually, avoiding a compiler bug
+    pub fn create_sticker<'a>(
         &'a self,
         guild_id: u64,
         map: Vec<(Cow<'static, str>, Cow<'static, str>)>,
-        file: impl Into<AttachmentType<'b>>,
-        audit_log_reason: Option<&'c str>,
-    ) -> Result<Sticker> {
+        file: impl Into<AttachmentType<'a>>,
+        audit_log_reason: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<Sticker>> + 'a {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
@@ -884,7 +885,6 @@ impl Http {
                 guild_id,
             },
         })
-        .await
     }
 
     /// Creates a webhook for the given [channel][`GuildChannel`]'s Id, passing in

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -728,7 +728,7 @@ impl Http {
     pub async fn create_invite(
         &self,
         channel_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<RichInvite> {
         let body = to_vec(map)?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1614,7 +1614,7 @@ impl Http {
     pub async fn edit_guild_welcome_screen(
         &self,
         guild_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<GuildWelcomeScreen> {
         let body = to_vec(map)?;
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1329,7 +1329,7 @@ impl Http {
     pub async fn edit_channel(
         &self,
         channel_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildChannel> {
         let body = to_vec(map)?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1807,7 +1807,7 @@ impl Http {
     pub async fn edit_original_interaction_response(
         &self,
         interaction_token: &str,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Message> {
         self.fire(Request {
             body: Some(to_vec(map)?),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1912,7 +1912,7 @@ impl Http {
         &self,
         guild_id: u64,
         event_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<ScheduledEvent> {
         let body = to_vec(map)?;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1671,7 +1671,7 @@ impl Http {
         &self,
         channel_id: u64,
         message_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Message> {
         let body = to_vec(map)?;
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1540,7 +1540,7 @@ impl Http {
         &self,
         guild_id: u64,
         command_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<CommandPermission> {
         self.fire(Request {
             body: Some(to_vec(map)?),
@@ -1565,7 +1565,7 @@ impl Http {
     pub async fn edit_guild_application_commands_permissions(
         &self,
         guild_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
     ) -> Result<Vec<CommandPermission>> {
         self.fire(Request {
             body: Some(to_vec(map)?),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2007,9 +2007,7 @@ impl Http {
     /// #     Ok(())
     /// # }
     /// ```
-    pub async fn edit_voice_state(&self, guild_id: u64, user_id: u64, map: &JsonMap) -> Result<()> {
-        let body = to_vec(map)?;
-
+    pub async fn edit_voice_state(&self, guild_id: u64, user_id: u64, body: Vec<u8>) -> Result<()> {
         self.wind(204, Request {
             body: Some(body),
             multipart: None,
@@ -2057,9 +2055,7 @@ impl Http {
     /// #     Ok(())
     /// # }
     /// ```
-    pub async fn edit_voice_state_me(&self, guild_id: u64, map: &JsonMap) -> Result<()> {
-        let body = to_vec(map)?;
-
+    pub async fn edit_voice_state_me(&self, guild_id: u64, body: Vec<u8>) -> Result<()> {
         self.wind(204, Request {
             body: Some(body),
             multipart: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1822,7 +1822,7 @@ impl Http {
     }
 
     /// Edits the current user's profile settings.
-    pub async fn edit_profile(&self, map: &JsonMap) -> Result<CurrentUser> {
+    pub async fn edit_profile(&self, map: &impl serde::Serialize) -> Result<CurrentUser> {
         let body = to_vec(map)?;
 
         let request = self

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2316,7 +2316,7 @@ impl Http {
         webhook_id: u64,
         token: &str,
         message_id: u64,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
     ) -> Result<Message> {
         let body = to_vec(map)?;
 

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -5,7 +5,6 @@ use reqwest::Client;
 
 use super::AttachmentType;
 use crate::internal::prelude::*;
-use crate::json;
 
 /// Holder for multipart body. Contains files, multipart fields, and
 /// payload_json for creating requests with attachments.
@@ -16,9 +15,8 @@ pub struct Multipart<'a> {
     /// fields. If a certain endpoint does not support passing JSON body via
     /// `payload_json`, this must be used instead.
     pub fields: Vec<(Cow<'static, str>, Cow<'static, str>)>,
-    /// JSON body that will be stringified and set as the form value as
-    /// `payload_json`.
-    pub payload_json: Option<Value>,
+    /// JSON body that will set as the form value as `payload_json`.
+    pub payload_json: Option<String>,
 }
 
 impl<'a> Multipart<'a> {
@@ -56,8 +54,8 @@ impl<'a> Multipart<'a> {
             multipart = multipart.text(name.clone(), value.clone());
         }
 
-        if let Some(ref payload_json) = self.payload_json {
-            multipart = multipart.text("payload_json", json::to_string(payload_json)?);
+        if let Some(payload_json) = self.payload_json.clone() {
+            multipart = multipart.text("payload_json", payload_json);
         }
 
         Ok(multipart)

--- a/src/json.rs
+++ b/src/json.rs
@@ -93,7 +93,7 @@ where
     Ok(simd_json::serde::from_owned_value(v)?)
 }
 
-#[cfg(all(any(feature = "builder", feature = "http"), not(feature = "simd-json")))]
+#[cfg(all(any(feature = "builder", feature = "http"), not(feature = "simd-json"), test))]
 pub(crate) fn to_value<T>(value: T) -> Result<Value>
 where
     T: Serialize,
@@ -101,7 +101,7 @@ where
     Ok(serde_json::to_value(value)?)
 }
 
-#[cfg(all(any(feature = "builder", feature = "http"), feature = "simd-json"))]
+#[cfg(all(any(feature = "builder", feature = "http"), feature = "simd-json", test))]
 pub(crate) fn to_value<T>(value: T) -> Result<Value>
 where
     T: Serialize,

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -9,8 +9,6 @@ use crate::error::Result;
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::json::Value;
-#[cfg(feature = "http")]
-use crate::json::{self, JsonMap};
 use crate::model::channel::ChannelType;
 use crate::model::id::{
     ApplicationId,
@@ -157,7 +155,7 @@ impl Command {
         F: FnOnce(&mut CreateApplicationCommand) -> &mut CreateApplicationCommand,
     {
         let map = Command::build_application_command(f);
-        http.as_ref().create_global_application_command(&Value::from(map)).await
+        http.as_ref().create_global_application_command(&map).await
     }
 
     /// Overrides all global application commands.
@@ -181,7 +179,7 @@ impl Command {
 
         f(&mut array);
 
-        http.as_ref().create_global_application_commands(&Value::from(array.0)).await
+        http.as_ref().create_global_application_commands(&array).await
     }
 
     /// Edits a global command by its Id.
@@ -201,7 +199,7 @@ impl Command {
         F: FnOnce(&mut CreateApplicationCommand) -> &mut CreateApplicationCommand,
     {
         let map = Command::build_application_command(f);
-        http.as_ref().edit_global_application_command(command_id.into(), &Value::from(map)).await
+        http.as_ref().edit_global_application_command(command_id.into(), &map).await
     }
 
     /// Gets all global commands.
@@ -250,13 +248,13 @@ impl Command {
 #[cfg(feature = "http")]
 impl Command {
     #[inline]
-    pub(crate) fn build_application_command<F>(f: F) -> JsonMap
+    pub(crate) fn build_application_command<F>(f: F) -> CreateApplicationCommand
     where
         F: FnOnce(&mut CreateApplicationCommand) -> &mut CreateApplicationCommand,
     {
         let mut create_application_command = CreateApplicationCommand::default();
         f(&mut create_application_command);
-        json::hashmap_to_json_map(create_application_command.0)
+        create_application_command
     }
 }
 

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -12,8 +12,6 @@ use crate::builder::{
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::*;
-#[cfg(feature = "http")]
-use crate::json;
 use crate::model::application::command::{CommandOptionType, CommandType};
 use crate::model::application::interaction::add_guild_id_to_resolved;
 #[cfg(feature = "http")]
@@ -163,11 +161,7 @@ impl ApplicationCommandInteraction {
         let mut interaction_response = EditInteractionResponse::default();
         f(&mut interaction_response);
 
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_lengths(&map)?;
-
-        http.as_ref().edit_original_interaction_response(&self.token, &Value::from(map)).await
+        http.as_ref().edit_original_interaction_response(&self.token, &interaction_response).await
     }
 
     /// Deletes the initial interaction response.

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -9,10 +9,6 @@ use crate::builder::CreateAutocompleteResponse;
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::*;
-#[cfg(feature = "http")]
-use crate::json;
-#[cfg(feature = "http")]
-use crate::json::prelude::*;
 use crate::model::application::command::{CommandOptionType, CommandType};
 use crate::model::application::interaction::add_guild_id_to_resolved;
 #[cfg(feature = "http")]
@@ -77,14 +73,20 @@ impl AutocompleteInteraction {
     where
         F: FnOnce(&mut CreateAutocompleteResponse) -> &mut CreateAutocompleteResponse,
     {
+        #[derive(Serialize)]
+        struct AutocompleteResponse {
+            data: CreateAutocompleteResponse,
+            #[serde(rename = "type")]
+            kind: InteractionResponseType,
+        }
+
         let mut response = CreateAutocompleteResponse::default();
         f(&mut response);
-        let data = json::hashmap_to_json_map(response.0);
 
-        let map = json!({
-            "type": InteractionResponseType::Autocomplete as u8,
-            "data": data,
-        });
+        let map = AutocompleteResponse {
+            data: response,
+            kind: InteractionResponseType::Autocomplete,
+        };
 
         http.as_ref().create_interaction_response(self.id.0, &self.token, &map).await
     }

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -193,12 +193,7 @@ impl MessageComponentInteraction {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
 
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
-        http.as_ref().create_followup_message(&self.token, &Value::from(map)).await
+        http.as_ref().create_followup_message(&self.token, &interaction_response).await
     }
 
     /// Edits a followup response to the response sent.
@@ -228,13 +223,8 @@ impl MessageComponentInteraction {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
 
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
         http.as_ref()
-            .edit_followup_message(&self.token, message_id.into().into(), &Value::from(map))
+            .edit_followup_message(&self.token, message_id.into().into(), &interaction_response)
             .await
     }
 

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -10,8 +10,6 @@ use crate::builder::{
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::*;
-#[cfg(feature = "http")]
-use crate::json;
 use crate::model::application::component::ComponentType;
 use crate::model::application::interaction::add_guild_id_to_resolved;
 #[cfg(feature = "http")]
@@ -147,12 +145,7 @@ impl MessageComponentInteraction {
         let mut interaction_response = EditInteractionResponse::default();
         f(&mut interaction_response);
 
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
-        http.as_ref().edit_original_interaction_response(&self.token, &Value::from(map)).await
+        http.as_ref().edit_original_interaction_response(&self.token, &interaction_response).await
     }
 
     /// Deletes the initial interaction response.

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -98,24 +98,22 @@ impl MessageComponentInteraction {
         let mut interaction_response = CreateInteractionResponse::default();
         f(&mut interaction_response);
 
-        let map = json::hashmap_to_json_map(interaction_response.0);
+        let http = http.as_ref();
+        let files = interaction_response
+            .data
+            .as_mut()
+            .map_or_else(Vec::new, |d| std::mem::take(&mut d.files));
 
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
-        if interaction_response.1.is_empty() {
-            http.as_ref()
-                .create_interaction_response(self.id.0, &self.token, &Value::from(map))
-                .await
+        if files.is_empty() {
+            http.create_interaction_response(self.id.0, &self.token, &interaction_response).await
         } else {
-            http.as_ref()
-                .create_interaction_response_with_files(
-                    self.id.0,
-                    &self.token,
-                    &Value::from(map),
-                    interaction_response.1,
-                )
-                .await
+            http.create_interaction_response_with_files(
+                self.id.0,
+                &self.token,
+                &interaction_response,
+                files,
+            )
+            .await
         }
     }
 

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -233,6 +233,15 @@ pub enum InteractionResponseType {
     Modal = 9,
 }
 
+impl serde::Serialize for InteractionResponseType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
 fn add_guild_id_to_resolved(map: &mut JsonMap, guild_id: GuildId) {
     if let Some(member) = map.get_mut("member").and_then(Value::as_object_mut) {
         member.insert("guild_id".to_string(), from_number(guild_id.0));

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -194,12 +194,7 @@ impl ModalSubmitInteraction {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
 
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
-        http.as_ref().create_followup_message(&self.token, &Value::from(map)).await
+        http.as_ref().create_followup_message(&self.token, &interaction_response).await
     }
 
     /// Edits a followup response to the response sent.
@@ -229,13 +224,8 @@ impl ModalSubmitInteraction {
         let mut interaction_response = CreateInteractionResponseFollowup::default();
         f(&mut interaction_response);
 
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
         http.as_ref()
-            .edit_followup_message(&self.token, message_id.into().into(), &Value::from(map))
+            .edit_followup_message(&self.token, message_id.into().into(), &interaction_response)
             .await
     }
 

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -10,8 +10,6 @@ use crate::builder::{
 #[cfg(feature = "model")]
 use crate::http::Http;
 use crate::internal::prelude::*;
-#[cfg(feature = "model")]
-use crate::json;
 use crate::model::application::component::ActionRow;
 #[cfg(feature = "http")]
 use crate::model::application::interaction::InteractionResponseType;
@@ -148,12 +146,7 @@ impl ModalSubmitInteraction {
         let mut interaction_response = EditInteractionResponse::default();
         f(&mut interaction_response);
 
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
-        http.as_ref().edit_original_interaction_response(&self.token, &Value::from(map)).await
+        http.as_ref().edit_original_interaction_response(&self.token, &interaction_response).await
     }
 
     /// Deletes the initial interaction response.

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -2,8 +2,6 @@
 use crate::builder::EditChannel;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-#[cfg(feature = "model")]
-use crate::json;
 use crate::model::prelude::*;
 
 /// A category of [`GuildChannel`]s.
@@ -124,9 +122,8 @@ impl ChannelCategory {
     {
         let mut edit_channel = EditChannel::default();
         f(&mut edit_channel);
-        let map = json::hashmap_to_json_map(edit_channel.0);
 
-        cache_http.http().edit_channel(self.id.0, &map, None).await.map(|channel| {
+        cache_http.http().edit_channel(self.id.0, &edit_channel, None).await.map(|channel| {
             let GuildChannel {
                 id,
                 guild_id,

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -50,7 +50,7 @@ impl ChannelCategory {
     pub async fn create_permission(
         &self,
         http: impl AsRef<Http>,
-        target: &PermissionOverwrite,
+        target: PermissionOverwrite,
     ) -> Result<()> {
         self.id.create_permission(&http, target).await
     }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -109,21 +109,10 @@ impl ChannelId {
     pub async fn create_permission(
         self,
         http: impl AsRef<Http>,
-        target: &PermissionOverwrite,
+        target: PermissionOverwrite,
     ) -> Result<()> {
-        let (id, kind) = match target.kind {
-            PermissionOverwriteType::Member(id) => (id.0, "member"),
-            PermissionOverwriteType::Role(id) => (id.0, "role"),
-        };
-
-        let map = json!({
-            "allow": target.allow.bits(),
-            "deny": target.deny.bits(),
-            "id": id,
-            "type": kind,
-        });
-
-        http.as_ref().create_permission(self.0, id, &map).await
+        let data: PermissionOverwriteData = target.into();
+        http.as_ref().create_permission(self.0, data.id, &data).await
     }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -33,7 +33,7 @@ use crate::collector::{
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(feature = "model")]
-use crate::json::{self, json};
+use crate::json::{self, json, prelude::to_vec};
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
@@ -1012,9 +1012,8 @@ impl ChannelId {
         let mut instance = EditThread::default();
         f(&mut instance);
 
-        let map = json::hashmap_to_json_map(instance.0);
-
-        http.as_ref().edit_thread(self.0, &map).await
+        let body = to_vec(&instance)?;
+        http.as_ref().edit_thread(self.0, body).await
     }
 
     /// Deletes a stage instance.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -33,7 +33,7 @@ use crate::collector::{
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(feature = "model")]
-use crate::json::{self, json, prelude::to_vec};
+use crate::json::{self, json};
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
@@ -1012,8 +1012,7 @@ impl ChannelId {
         let mut instance = EditThread::default();
         f(&mut instance);
 
-        let body = to_vec(&instance)?;
-        http.as_ref().edit_thread(self.0, body).await
+        http.as_ref().edit_thread(self.0, &instance).await
     }
 
     /// Deletes a stage instance.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -334,9 +334,7 @@ impl ChannelId {
         let mut channel = EditChannel::default();
         f(&mut channel);
 
-        let map = json::hashmap_to_json_map(channel.0);
-
-        http.as_ref().edit_channel(self.0, &map, None).await
+        http.as_ref().edit_channel(self.0, &channel, None).await
     }
 
     /// Edits a [`Message`] in the channel given its Id.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -961,9 +961,7 @@ impl ChannelId {
         let mut instance = CreateStageInstance::default();
         f(&mut instance);
 
-        let map = json::hashmap_to_json_map(instance.0);
-
-        http.as_ref().create_stage_instance(&Value::from(map)).await
+        http.as_ref().create_stage_instance(&instance).await
     }
 
     /// Edits a stage instance.
@@ -983,9 +981,7 @@ impl ChannelId {
         let mut instance = EditStageInstance::default();
         f(&mut instance);
 
-        let map = json::hashmap_to_json_map(instance.0);
-
-        http.as_ref().edit_stage_instance(self.0, &Value::from(map)).await
+        http.as_ref().edit_stage_instance(self.0, &instance).await
     }
 
     /// Edits a thread.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1026,9 +1026,7 @@ impl ChannelId {
         let mut instance = CreateThread::default();
         f(&mut instance);
 
-        let map = json::hashmap_to_json_map(instance.0);
-
-        http.as_ref().create_public_thread(self.0, message_id.into().0, &map).await
+        http.as_ref().create_public_thread(self.0, message_id.into().0, &instance).await
     }
 
     /// Creates a private thread.
@@ -1048,9 +1046,7 @@ impl ChannelId {
         instance.kind(ChannelType::PrivateThread);
         f(&mut instance);
 
-        let map = json::hashmap_to_json_map(instance.0);
-
-        http.as_ref().create_private_thread(self.0, &map).await
+        http.as_ref().create_private_thread(self.0, &instance).await
     }
 
     /// Gets the thread members, if this channel is a thread.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -89,9 +89,7 @@ impl ChannelId {
         let mut invite = CreateInvite::default();
         f(&mut invite);
 
-        let map = json::hashmap_to_json_map(invite.0);
-
-        http.as_ref().create_invite(self.0, &map, None).await
+        http.as_ref().create_invite(self.0, &invite, None).await
     }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -96,9 +96,8 @@ impl Embed {
     {
         let mut create_embed = CreateEmbed::default();
         f(&mut create_embed);
-        let map = json::hashmap_to_json_map(create_embed.0);
 
-        Value::from(map)
+        json::to_value(create_embed).expect("CreateEmbed builder should never fail!")
     }
 }
 
@@ -148,7 +147,7 @@ impl EmbedField {
         Self::_new(name.into(), value.into(), inline)
     }
 
-    fn _new(name: String, value: String, inline: bool) -> Self {
+    pub(crate) fn _new(name: String, value: String, inline: bool) -> Self {
         Self {
             name,
             value,

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -1,9 +1,5 @@
 #[cfg(feature = "model")]
 use crate::builder::CreateEmbed;
-#[cfg(feature = "model")]
-use crate::internal::prelude::*;
-#[cfg(feature = "model")]
-use crate::json;
 #[cfg(feature = "utils")]
 use crate::utils::Colour;
 
@@ -90,14 +86,13 @@ impl Embed {
     /// });
     /// ```
     #[inline]
-    pub fn fake<F>(f: F) -> Value
+    pub fn fake<F>(f: F) -> CreateEmbed
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {
         let mut create_embed = CreateEmbed::default();
         f(&mut create_embed);
-
-        json::to_value(create_embed).expect("CreateEmbed builder should never fail!")
+        create_embed
     }
 }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -592,14 +592,14 @@ impl GuildChannel {
         let mut voice_state = EditVoiceState::default();
         f(&mut voice_state);
 
-        voice_state.0.insert("channel_id", Value::from(self.id.0.to_string()));
+        voice_state.channel_id = Some(self.id);
 
-        let map = json::hashmap_to_json_map(voice_state.0);
+        let body = json::prelude::to_vec(&voice_state)?;
 
         if let Some(id) = user_id {
-            http.as_ref().edit_voice_state(self.guild_id.0, id.into().0, &map).await
+            http.as_ref().edit_voice_state(self.guild_id.0, id.into().0, body).await
         } else {
-            http.as_ref().edit_voice_state_me(self.guild_id.0, &map).await
+            http.as_ref().edit_voice_state_me(self.guild_id.0, body).await
         }
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -238,7 +238,7 @@ impl GuildChannel {
     /// // assuming the cache has been unlocked
     /// let channel = cache.guild_channel(channel_id).ok_or(ModelError::ItemMissing)?;
     ///
-    /// channel.create_permission(&http, &overwrite).await?;
+    /// channel.create_permission(&http, overwrite).await?;
     /// #   Ok(())
     /// # }
     /// ```
@@ -271,7 +271,7 @@ impl GuildChannel {
     ///
     /// let channel = cache.guild_channel(channel_id).ok_or(ModelError::ItemMissing)?;
     ///
-    /// channel.create_permission(&http, &overwrite).await?;
+    /// channel.create_permission(&http, overwrite).await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -594,12 +594,10 @@ impl GuildChannel {
 
         voice_state.channel_id = Some(self.id);
 
-        let body = json::prelude::to_vec(&voice_state)?;
-
         if let Some(id) = user_id {
-            http.as_ref().edit_voice_state(self.guild_id.0, id.into().0, body).await
+            http.as_ref().edit_voice_state(self.guild_id.0, id.into().0, &voice_state).await
         } else {
-            http.as_ref().edit_voice_state_me(self.guild_id.0, body).await
+            http.as_ref().edit_voice_state_me(self.guild_id.0, &voice_state).await
         }
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -289,7 +289,7 @@ impl GuildChannel {
     pub async fn create_permission(
         &self,
         http: impl AsRef<Http>,
-        target: &PermissionOverwrite,
+        target: PermissionOverwrite,
     ) -> Result<()> {
         self.id.create_permission(&http, target).await
     }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -32,8 +32,6 @@ use crate::http::{CacheHttp, Http, Typing};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
-use crate::json;
-#[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
 use crate::model::Timestamp;
@@ -427,9 +425,8 @@ impl GuildChannel {
 
         let mut edit_channel = EditChannel::default();
         f(&mut edit_channel);
-        let edited = json::hashmap_to_json_map(edit_channel.0);
 
-        *self = cache_http.http().edit_channel(self.id.0, &edited, None).await?;
+        *self = cache_http.http().edit_channel(self.id.0, &edit_channel, None).await?;
 
         Ok(())
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -22,8 +22,6 @@ use crate::collector::{
 };
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-#[cfg(feature = "model")]
-use crate::json;
 use crate::json::prelude::*;
 use crate::model::application::component::ActionRow;
 use crate::model::application::interaction::MessageInteraction;
@@ -355,16 +353,11 @@ impl Message {
         builder
     }
 
-    async fn _send_edit<'a>(&mut self, http: &Http, builder: EditMessage<'a>) -> Result<()> {
-        let map = json::hashmap_to_json_map(builder.0);
+    async fn _send_edit<'a>(&mut self, http: &Http, mut builder: EditMessage<'a>) -> Result<()> {
+        let files = std::mem::take(&mut builder.files);
 
         *self = http
-            .edit_message_and_attachments(
-                self.channel_id.0,
-                self.id.0,
-                &Value::from(map),
-                builder.1,
-            )
+            .edit_message_and_attachments(self.channel_id.0, self.id.0, &builder, files)
             .await?;
         Ok(())
     }
@@ -730,10 +723,7 @@ impl Message {
         let mut suppress = EditMessage::default();
         suppress.suppress_embeds(true);
 
-        let map = json::hashmap_to_json_map(suppress.0);
-
-        *self =
-            cache_http.http().edit_message(self.channel_id.0, self.id.0, &Value::from(map)).await?;
+        *self = cache_http.http().edit_message(self.channel_id.0, self.id.0, &suppress).await?;
 
         Ok(())
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -881,6 +881,7 @@ impl Message {
         cache.as_ref().channel_category_id(self.channel_id)
     }
 
+    #[allow(dead_code)] // Temporary, will be added back or removed in future
     pub(crate) fn check_lengths(map: &JsonMap) -> Result<()> {
         Self::check_content_length(map)?;
         Self::check_embed_length(map)?;
@@ -889,6 +890,7 @@ impl Message {
         Ok(())
     }
 
+    #[allow(dead_code)] // Temporary, will be added back or removed in future
     pub(crate) fn check_content_length(map: &JsonMap) -> Result<()> {
         if let Some(Value::String(content)) = map.get("content") {
             if let Some(length_over) = Message::overflow_length(content) {
@@ -899,6 +901,7 @@ impl Message {
         Ok(())
     }
 
+    #[allow(dead_code)] // Temporary, will be added back or removed in future
     pub(crate) fn check_embed_length(map: &JsonMap) -> Result<()> {
         let embeds = match map.get("embeds") {
             Some(&Value::Array(ref value)) => value,
@@ -955,6 +958,7 @@ impl Message {
         Ok(())
     }
 
+    #[allow(dead_code)] // Temporary, will be added back or removed in future
     pub(crate) fn check_sticker_ids_length(map: &JsonMap) -> Result<()> {
         if let Some(Value::Array(sticker_ids)) = map.get("sticker_ids") {
             if sticker_ids.len() > constants::STICKER_MAX_COUNT {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -235,9 +235,7 @@ impl GuildId {
         let mut builder = CreateChannel::default();
         f(&mut builder);
 
-        let map = json::hashmap_to_json_map(builder.0);
-
-        http.as_ref().create_channel(self.0, &map, None).await
+        http.as_ref().create_channel(self.0, &builder, None).await
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -568,9 +568,8 @@ impl GuildId {
     {
         let mut edit_member = EditMember::default();
         f(&mut edit_member);
-        let map = json::hashmap_to_json_map(edit_member.0);
 
-        http.as_ref().edit_member(self.0, user_id.into().0, &map, None).await
+        http.as_ref().edit_member(self.0, user_id.into().0, &edit_member, None).await
     }
 
     /// Edits the current user's nickname for the guild.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -506,9 +506,8 @@ impl GuildId {
     {
         let mut edit_guild = EditGuild::default();
         f(&mut edit_guild);
-        let map = json::hashmap_to_json_map(edit_guild.0);
 
-        http.as_ref().edit_guild(self.0, &map, None).await
+        http.as_ref().edit_guild(self.0, &edit_guild, None).await
     }
 
     /// Edits an [`Emoji`]'s name in the guild.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1468,11 +1468,7 @@ impl GuildId {
         f(&mut map);
 
         http.as_ref()
-            .edit_guild_application_command_permissions(
-                self.0,
-                command_id.into(),
-                &Value::from(json::hashmap_to_json_map(map.0)),
-            )
+            .edit_guild_application_command_permissions(self.0, command_id.into(), &map)
             .await
     }
 
@@ -1497,7 +1493,7 @@ impl GuildId {
         let mut map = CreateApplicationCommandsPermissions::default();
         f(&mut map);
 
-        http.as_ref().edit_guild_application_commands_permissions(self.0, &Value::from(map.0)).await
+        http.as_ref().edit_guild_application_commands_permissions(self.0, &map).await
     }
 
     /// Get all guild application commands.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -754,9 +754,7 @@ impl GuildId {
         let mut map = EditGuildWidget::default();
         f(&mut map);
 
-        http.as_ref()
-            .edit_guild_widget(self.0, &Value::from(json::hashmap_to_json_map(map.0)))
-            .await
+        http.as_ref().edit_guild_widget(self.0, &map).await
     }
 
     /// Gets all of the guild's roles over the REST API.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1408,7 +1408,7 @@ impl GuildId {
         F: FnOnce(&mut CreateApplicationCommand) -> &mut CreateApplicationCommand,
     {
         let map = Command::build_application_command(f);
-        http.as_ref().create_guild_application_command(self.0, &Value::from(map)).await
+        http.as_ref().create_guild_application_command(self.0, &map).await
     }
 
     /// Overrides all guild application commands.
@@ -1430,7 +1430,7 @@ impl GuildId {
 
         f(&mut array);
 
-        http.as_ref().create_guild_application_commands(self.0, &Value::from(array.0)).await
+        http.as_ref().create_guild_application_commands(self.0, &array).await
     }
 
     /// Creates a guild specific [`CommandPermission`].
@@ -1532,9 +1532,7 @@ impl GuildId {
         F: FnOnce(&mut CreateApplicationCommand) -> &mut CreateApplicationCommand,
     {
         let map = Command::build_application_command(f);
-        http.as_ref()
-            .edit_guild_application_command(self.0, command_id.into(), &Value::from(map))
-            .await
+        http.as_ref().edit_guild_application_command(self.0, command_id.into(), &map).await
     }
 
     /// Delete guild application command by its Id.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -347,9 +347,7 @@ impl GuildId {
         let mut builder = CreateScheduledEvent::default();
         f(&mut builder);
 
-        let map = json::hashmap_to_json_map(builder.0);
-
-        http.as_ref().create_scheduled_event(self.0, &map, None).await
+        http.as_ref().create_scheduled_event(self.0, &builder, None).await
     }
 
     /// Creates a new sticker in the guild with the data set, if any.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -736,9 +736,7 @@ impl GuildId {
         let mut map = EditGuildWelcomeScreen::default();
         f(&mut map);
 
-        http.as_ref()
-            .edit_guild_welcome_screen(self.0, &Value::from(json::hashmap_to_json_map(map.0)))
-            .await
+        http.as_ref().edit_guild_welcome_screen(self.0, &map).await
     }
 
     /// Edits the [`GuildWidget`].

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -321,12 +321,12 @@ impl GuildId {
     {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
-        let map = json::hashmap_to_json_map(edit_role.0);
 
-        let role = http.as_ref().create_role(self.0, &map, None).await?;
+        let body = to_vec(&edit_role)?;
+        let role = http.as_ref().create_role(self.0, body, None).await?;
 
-        if let Some(position) = map.get("position").and_then(Value::as_u64) {
-            self.edit_role_position(&http, role.id, position).await?;
+        if let Some(position) = edit_role.position {
+            self.edit_role_position(&http, role.id, position as u64).await?;
         }
 
         Ok(role)
@@ -639,9 +639,9 @@ impl GuildId {
     {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
-        let map = json::hashmap_to_json_map(edit_role.0);
 
-        http.as_ref().edit_role(self.0, role_id.into().0, &map, None).await
+        let body = to_vec(&edit_role)?;
+        http.as_ref().edit_role(self.0, role_id.into().0, body, None).await
     }
 
     /// Modifies a scheduled event in the guild with the data set, if any.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -41,8 +41,6 @@ use crate::http::{CacheHttp, Http, UserPagination};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
-use crate::json;
-#[cfg(feature = "model")]
 use crate::json::json;
 #[cfg(feature = "model")]
 use crate::json::prelude::*;
@@ -649,9 +647,8 @@ impl GuildId {
     {
         let mut edit_scheduled_event = EditScheduledEvent::default();
         f(&mut edit_scheduled_event);
-        let map = json::hashmap_to_json_map(edit_scheduled_event.0);
 
-        http.as_ref().edit_scheduled_event(self.0, event_id.into().0, &map, None).await
+        http.as_ref().edit_scheduled_event(self.0, event_id.into().0, &edit_scheduled_event, None).await
     }
 
     /// Edits a [`Sticker`], optionally setting its fields.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -70,9 +70,7 @@ impl GuildId {
         let mut builder = AddMember::default();
         f(&mut builder);
 
-        let map = json::hashmap_to_json_map(builder.0);
-
-        http.as_ref().add_guild_member(self.0, user_id.into().0, &map).await
+        http.as_ref().add_guild_member(self.0, user_id.into().0, &builder).await
     }
 
     /// Ban a [`User`] from the guild, deleting a number of

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -367,16 +367,11 @@ impl GuildId {
     {
         let mut create_sticker = CreateSticker::default();
         f(&mut create_sticker);
-        let map = json::hashmap_to_json_map(create_sticker.0);
 
-        let file = match create_sticker.1 {
-            Some(f) => f,
-            None => return Err(Error::Model(ModelError::NoStickerFileSet)),
-        };
+        let (map, file) =
+            create_sticker.build().ok_or(Error::Model(ModelError::NoStickerFileSet))?;
 
-        let sticker = http.as_ref().create_sticker(self.0, map, file, None).await?;
-
-        Ok(sticker)
+        http.as_ref().create_sticker(self.0, map, file, None).await
     }
 
     /// Deletes the current guild if the current account is the owner of the
@@ -691,9 +686,8 @@ impl GuildId {
     {
         let mut edit_sticker = EditSticker::default();
         f(&mut edit_sticker);
-        let map = json::hashmap_to_json_map(edit_sticker.0);
 
-        http.as_ref().edit_sticker(self.0, sticker_id.into().0, &map, None).await
+        http.as_ref().edit_sticker(self.0, sticker_id.into().0, &edit_sticker, None).await
     }
 
     /// Edits the order of [`Role`]s

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -322,8 +322,7 @@ impl GuildId {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
 
-        let body = to_vec(&edit_role)?;
-        let role = http.as_ref().create_role(self.0, body, None).await?;
+        let role = http.as_ref().create_role(self.0, &edit_role, None).await?;
 
         if let Some(position) = edit_role.position {
             self.edit_role_position(&http, role.id, position as u64).await?;
@@ -640,8 +639,7 @@ impl GuildId {
         let mut edit_role = EditRole::default();
         f(&mut edit_role);
 
-        let body = to_vec(&edit_role)?;
-        http.as_ref().edit_role(self.0, role_id.into().0, body, None).await
+        http.as_ref().edit_role(self.0, role_id.into().0, &edit_role, None).await
     }
 
     /// Modifies a scheduled event in the guild with the data set, if any.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -648,7 +648,9 @@ impl GuildId {
         let mut edit_scheduled_event = EditScheduledEvent::default();
         f(&mut edit_scheduled_event);
 
-        http.as_ref().edit_scheduled_event(self.0, event_id.into().0, &edit_scheduled_event, None).await
+        http.as_ref()
+            .edit_scheduled_event(self.0, event_id.into().0, &edit_scheduled_event, None)
+            .await
     }
 
     /// Edits a [`Sticker`], optionally setting its fields.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -12,8 +12,6 @@ use crate::cache::Cache;
 use crate::http::{CacheHttp, Http};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
-#[cfg(feature = "model")]
-use crate::json;
 use crate::model::permissions::Permissions;
 use crate::model::prelude::*;
 use crate::model::Timestamp;
@@ -157,9 +155,8 @@ impl Member {
 
         let mut builder = EditMember::default();
         builder.roles(&self.roles);
-        let map = json::hashmap_to_json_map(builder.0);
 
-        match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await {
+        match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &builder, None).await {
             Ok(member) => Ok(member.roles),
             Err(why) => {
                 self.roles.retain(|r| !role_ids.contains(r));
@@ -301,11 +298,7 @@ impl Member {
     where
         F: FnOnce(&mut EditMember) -> &mut EditMember,
     {
-        let mut edit_member = EditMember::default();
-        f(&mut edit_member);
-        let map = json::hashmap_to_json_map(edit_member.0);
-
-        http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await
+        self.guild_id.edit_member(http, self.user.id, f).await
     }
 
     /// Allow a user to communicate, removing their timeout, if there is one.
@@ -563,9 +556,8 @@ impl Member {
 
         let mut builder = EditMember::default();
         builder.roles(&self.roles);
-        let map = json::hashmap_to_json_map(builder.0);
 
-        match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &map, None).await {
+        match http.as_ref().edit_member(self.guild_id.0, self.user.id.0, &builder, None).await {
             Ok(member) => Ok(member.roles),
             Err(why) => {
                 self.roles.extend_from_slice(role_ids);

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -11,8 +11,6 @@ use crate::cache::Cache;
 use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
-#[cfg(feature = "model")]
-use crate::json;
 use crate::model::Timestamp;
 
 /// Information about an invite code.
@@ -102,9 +100,9 @@ impl Invite {
             }
         }
 
-        let map = json::hashmap_to_json_map(f(CreateInvite::default()).0);
+        let builder = f(CreateInvite::default());
 
-        cache_http.http().create_invite(channel_id.0, &map, None).await
+        cache_http.http().create_invite(channel_id.0, &builder, None).await
     }
 
     /// Deletes the invite.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -26,8 +26,6 @@ use crate::http::GuildPagination;
 use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
-use crate::json;
-#[cfg(feature = "model")]
 use crate::json::json;
 use crate::json::to_string;
 #[cfg(feature = "model")]
@@ -265,18 +263,11 @@ impl CurrentUser {
     where
         F: FnOnce(&mut EditProfile) -> &mut EditProfile,
     {
-        let mut map = HashMap::new();
-        map.insert("username", Value::from(self.name.clone()));
-
-        if let Some(email) = self.email.as_ref() {
-            map.insert("email", Value::from(email.clone()));
-        }
-
-        let mut edit_profile = EditProfile(map);
+        let mut edit_profile = EditProfile::default();
+        edit_profile.username(self.name.clone());
         f(&mut edit_profile);
-        let map = json::hashmap_to_json_map(edit_profile.0);
 
-        *self = http.as_ref().edit_profile(&map).await?;
+        *self = http.as_ref().edit_profile(&edit_profile).await?;
 
         Ok(())
     }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -559,12 +559,10 @@ impl Webhook {
         F: FnOnce(&mut EditWebhookMessage) -> &mut EditWebhookMessage,
     {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
-        let mut edit_webhook_message = EditWebhookMessage::default();
-        f(&mut edit_webhook_message);
+        let mut builder = EditWebhookMessage::default();
+        f(&mut builder);
 
-        let map = json::hashmap_to_json_map(edit_webhook_message.0);
-
-        http.as_ref().edit_webhook_message(self.id.0, token, message_id.0, &map).await
+        http.as_ref().edit_webhook_message(self.id.0, token, message_id.0, &builder).await
     }
 
     /// Deletes a webhook message.


### PR DESCRIPTION
Swaps all the `HashMap<'static str, T>` for concrete rust structs and make them `derive(serde::Serialize)`, this allows for possible const builders, gets rid of a ton of heap allocations, and cleans up code massively. Nested builders are also serialised while building the top level one, meaning that all serialisation is done in one step. This also actually removes all usage of `json::to_value` outside one usage in a test, so I've `cfg(test)` gated that (and it shows that we no longer need Value, at least for serialisation).

Since I basically did a once over the whole builder module, some arguments have been changed to be more consistent or efficient, the builders internally store the `Type` enums instead of the raw number, and some int sizes have been reduced.

This does make all builder fields private, although a user can still pass custom JSON to the API via the raw HTTP functions. 