### PR TITLE
Swap out storing &[u8] to Vec<u8> in Request

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3896,7 +3896,7 @@ impl Http {
     /// let route_info = RouteInfo::CreateMessage { channel_id };
     ///
     /// let mut request = RequestBuilder::new(route_info);
-    /// request.body(Some(&bytes));
+    /// request.body(Some(bytes));
     ///
     /// let message = http.fire::<Message>(request.build()).await?;
     ///
@@ -3944,7 +3944,7 @@ impl Http {
     /// let route_info = RouteInfo::CreateMessage { channel_id };
     ///
     /// let mut request = RequestBuilder::new(route_info);
-    /// request.body(Some(&bytes));
+    /// request.body(Some(bytes));
     ///
     /// let response = http.request(request.build()).await?;
     ///

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -274,7 +274,7 @@ impl Http {
 
         let response = self
             .request(Request {
-                body: Some(&body),
+                body: Some(body),
                 multipart: None,
                 headers: None,
                 route: RouteInfo::AddGuildMember {
@@ -382,7 +382,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateChannel {
@@ -395,7 +395,7 @@ impl Http {
     /// Creates a stage instance.
     pub async fn create_stage_instance(&self, map: &Value) -> Result<StageInstance> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateStageInstance,
@@ -414,7 +414,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::CreatePublicThread {
@@ -434,7 +434,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::CreatePrivateThread {
@@ -459,7 +459,7 @@ impl Http {
         audit_log_reason: Option<&str>,
     ) -> Result<Emoji> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateEmoji {
@@ -478,7 +478,7 @@ impl Http {
         map: &Value,
     ) -> Result<Message> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateFollowupMessage {
@@ -527,7 +527,7 @@ impl Http {
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
     pub async fn create_global_application_command(&self, map: &Value) -> Result<Command> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGlobalApplicationCommand {
@@ -540,7 +540,7 @@ impl Http {
     /// Creates new global application commands.
     pub async fn create_global_application_commands(&self, map: &Value) -> Result<Vec<Command>> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGlobalApplicationCommands {
@@ -557,7 +557,7 @@ impl Http {
         map: &Value,
     ) -> Result<Vec<Command>> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGuildApplicationCommands {
@@ -603,7 +603,7 @@ impl Http {
     /// [whitelist]: https://discord.com/developers/docs/resources/guild#create-guild
     pub async fn create_guild(&self, map: &Value) -> Result<PartialGuild> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGuild,
@@ -624,7 +624,7 @@ impl Http {
         map: &Value,
     ) -> Result<Command> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGuildApplicationCommand {
@@ -651,7 +651,7 @@ impl Http {
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(204, Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateGuildIntegration {
@@ -675,7 +675,7 @@ impl Http {
         map: &Value,
     ) -> Result<()> {
         self.wind(204, Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateInteractionResponse {
@@ -734,7 +734,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateInvite {
@@ -754,7 +754,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.wind(204, Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::CreatePermission {
@@ -770,7 +770,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::CreatePrivateChannel,
@@ -809,7 +809,7 @@ impl Http {
         let body = to_vec(map)?;
         let mut value = self
             .request(Request {
-                body: Some(&body),
+                body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 route: RouteInfo::CreateRole {
@@ -842,7 +842,7 @@ impl Http {
     ) -> Result<ScheduledEvent> {
         let body = to_vec(map)?;
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateScheduledEvent {
@@ -929,7 +929,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateWebhook {
@@ -1089,7 +1089,7 @@ impl Http {
     /// Deletes a bunch of messages, only works for bots.
     pub async fn delete_messages(&self, channel_id: u64, map: &Value) -> Result<()> {
         self.wind(204, Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::DeleteMessages {
@@ -1339,7 +1339,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditChannel {
@@ -1352,7 +1352,7 @@ impl Http {
     /// Edits a stage instance.
     pub async fn edit_stage_instance(&self, channel_id: u64, map: &Value) -> Result<StageInstance> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditStageInstance {
@@ -1373,7 +1373,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditEmoji {
@@ -1396,7 +1396,7 @@ impl Http {
         map: &Value,
     ) -> Result<Message> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditFollowupMessage {
@@ -1473,7 +1473,7 @@ impl Http {
         map: &Value,
     ) -> Result<Command> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGlobalApplicationCommand {
@@ -1494,7 +1494,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditGuild {
@@ -1518,7 +1518,7 @@ impl Http {
         map: &Value,
     ) -> Result<Command> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommand {
@@ -1544,7 +1544,7 @@ impl Http {
         map: &Value,
     ) -> Result<CommandPermission> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommandPermission {
@@ -1569,7 +1569,7 @@ impl Http {
         map: &Value,
     ) -> Result<Vec<CommandPermission>> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommandsPermissions {
@@ -1585,7 +1585,7 @@ impl Http {
         let body = to_vec(value)?;
 
         self.wind(204, Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildChannels {
@@ -1600,7 +1600,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildWidget {
@@ -1619,7 +1619,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildWelcomeScreen {
@@ -1641,7 +1641,7 @@ impl Http {
 
         let mut value = self
             .request(Request {
-                body: Some(&body),
+                body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 route: RouteInfo::EditMember {
@@ -1672,7 +1672,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditMessage {
@@ -1730,7 +1730,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditMemberMe {
@@ -1748,7 +1748,7 @@ impl Http {
         let body = to_vec(&map)?;
 
         self.wind(200, Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditMemberMe {
@@ -1768,7 +1768,7 @@ impl Http {
         let body = to_vec(&map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::FollowNewsChannel {
@@ -1806,7 +1806,7 @@ impl Http {
         map: &Value,
     ) -> Result<Message> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             route: RouteInfo::EditOriginalInteractionResponse {
@@ -1823,7 +1823,7 @@ impl Http {
 
         let request = self
             .request(Request {
-                body: Some(&body),
+                body: Some(body),
                 multipart: None,
                 headers: None,
                 route: RouteInfo::EditProfile,
@@ -1844,7 +1844,7 @@ impl Http {
         let body = to_vec(&map)?;
         let mut value = self
             .request(Request {
-                body: Some(&body),
+                body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 route: RouteInfo::EditRole {
@@ -1878,7 +1878,7 @@ impl Http {
 
         let mut value = self
             .request(Request {
-                body: Some(&body),
+                body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 route: RouteInfo::EditRolePosition {
@@ -1914,7 +1914,7 @@ impl Http {
     ) -> Result<ScheduledEvent> {
         let body = to_vec(map)?;
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditScheduledEvent {
@@ -1940,7 +1940,7 @@ impl Http {
         let body = to_vec(&map)?;
         let mut value = self
             .request(Request {
-                body: Some(&body),
+                body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 route: RouteInfo::EditSticker {
@@ -1964,7 +1964,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditThread {
@@ -2011,7 +2011,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.wind(204, Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditVoiceState {
@@ -2061,7 +2061,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.wind(204, Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditVoiceStateMe {
@@ -2112,7 +2112,7 @@ impl Http {
         audit_log_reason: Option<&str>,
     ) -> Result<Webhook> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditWebhook {
@@ -2156,7 +2156,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditWebhookWithToken {
@@ -2233,7 +2233,7 @@ impl Http {
 
         let response = self
             .request(Request {
-                body: Some(&body),
+                body: Some(body),
                 multipart: None,
                 headers: Some(headers),
                 route: RouteInfo::ExecuteWebhook {
@@ -2320,7 +2320,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::EditWebhookMessage {
@@ -3666,7 +3666,7 @@ impl Http {
         let body = to_vec(map)?;
 
         self.fire(Request {
-            body: Some(&body),
+            body: Some(body),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateMessage {
@@ -3954,7 +3954,7 @@ impl Http {
     /// # }
     /// ```
     #[instrument]
-    pub async fn request(&self, mut req: Request<'_>) -> Result<ReqwestResponse> {
+    pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
         let response = if self.ratelimiter_disabled {
             let request =
                 req.build(&self.client, &self.token, self.proxy.as_ref()).await?.build()?;

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -152,7 +152,7 @@ impl Ratelimiter {
     #[instrument]
     pub async fn perform(&self, req: RatelimitedRequest<'_>) -> Result<Response> {
         let RatelimitedRequest {
-            mut req,
+            req,
         } = req;
 
         loop {
@@ -182,7 +182,7 @@ impl Ratelimiter {
 
             bucket.lock().await.pre_hook(&route).await;
 
-            let request = req.build(&self.client, &self.token, None).await?.build()?;
+            let request = req.clone().build(&self.client, &self.token, None).await?.build()?;
 
             let response = self.client.execute(request).await?;
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::convert::TryFrom;
 
 use reqwest::header::{
     HeaderMap as Headers,
@@ -18,7 +19,7 @@ use crate::constants;
 use crate::internal::prelude::*;
 
 pub struct RequestBuilder<'a> {
-    body: Option<&'a [u8]>,
+    body: Option<Vec<u8>>,
     multipart: Option<Multipart<'a>>,
     headers: Option<Headers>,
     route: RouteInfo<'a>,
@@ -40,7 +41,7 @@ impl<'a> RequestBuilder<'a> {
         Request::new(self)
     }
 
-    pub fn body(&mut self, body: Option<&'a [u8]>) -> &mut Self {
+    pub fn body(&mut self, body: Option<Vec<u8>>) -> &mut Self {
         self.body = body;
 
         self
@@ -67,7 +68,7 @@ impl<'a> RequestBuilder<'a> {
 
 #[derive(Clone, Debug)]
 pub struct Request<'a> {
-    pub(super) body: Option<&'a [u8]>,
+    pub(super) body: Option<Vec<u8>>,
     pub(super) multipart: Option<Multipart<'a>>,
     pub(super) headers: Option<Headers>,
     pub(super) route: RouteInfo<'a>,
@@ -93,7 +94,7 @@ impl<'a> Request<'a> {
 
     #[instrument(skip(token))]
     pub async fn build(
-        &mut self,
+        mut self,
         client: &Client,
         token: &str,
         proxy: Option<&Url>,
@@ -103,7 +104,7 @@ impl<'a> Request<'a> {
             ref mut multipart,
             headers: ref request_headers,
             route: ref route_info,
-        } = *self;
+        } = self;
 
         let (method, _, mut path) = route_info.deconstruct();
 
@@ -114,10 +115,6 @@ impl<'a> Request<'a> {
         let mut builder =
             client.request(method.reqwest_method(), Url::parse(&path).map_err(HttpError::Url)?);
 
-        if let Some(bytes) = body {
-            builder = builder.body(Vec::from(bytes));
-        }
-
         let mut headers = Headers::with_capacity(4);
         headers.insert(USER_AGENT, HeaderValue::from_static(constants::USER_AGENT));
         headers
@@ -125,7 +122,7 @@ impl<'a> Request<'a> {
 
         // Discord will return a 400: Bad Request response if we set the content type header,
         // but don't give a body.
-        if self.body.is_some() {
+        if body.is_some() {
             headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
         }
 
@@ -133,28 +130,34 @@ impl<'a> Request<'a> {
             // Setting multipart adds the content-length header
             builder = builder.multipart(multipart.build_form(client).await?);
         } else {
-            headers.insert(
-                CONTENT_LENGTH,
-                HeaderValue::from_str(&body.unwrap_or(&Vec::new()).len().to_string())
-                    .map_err(HttpError::InvalidHeader)?,
-            );
+            let length = body
+                .as_ref()
+                .map(|b| HeaderValue::try_from(b.len().to_string()))
+                .transpose()
+                .map_err(HttpError::InvalidHeader)?;
+
+            headers.insert(CONTENT_LENGTH, length.unwrap_or_else(|| HeaderValue::from_static("0")));
         }
 
         if let Some(ref request_headers) = request_headers {
             headers.extend(request_headers.clone());
         }
 
+        if let Some(bytes) = body {
+            builder = builder.body(bytes);
+        }
+
         Ok(builder.headers(headers))
     }
 
     #[must_use]
-    pub fn body_ref(&self) -> Option<&'a [u8]> {
-        self.body
+    pub fn body_ref(&self) -> Option<&[u8]> {
+        self.body.as_deref()
     }
 
     #[must_use]
-    pub fn body_mut(&mut self) -> &mut Option<&'a [u8]> {
-        &mut self.body
+    pub fn body_mut(&mut self) -> Option<&mut [u8]> {
+        self.body.as_deref_mut()
     }
 
     #[must_use]


### PR DESCRIPTION
Makes the Vec allocation occur earlier, and opens up the possibility of passing `Vec<u8>` directly into http methods.