### PR TITLE
Add missing fields serenity::model::application types

### DIFF
--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -302,13 +302,11 @@ pub struct CommandOption {
     /// The option name.
     pub name: String,
     /// Localizations of the option name with locale as the key
-    #[serde(default)]
-    pub name_localizations: std::collections::HashMap<String, String>,
+    pub name_localizations: Option<std::collections::HashMap<String, String>>,
     /// The option description.
     pub description: String,
     /// Localizations of the option description with locale as the key
-    #[serde(default)]
-    pub description_localizations: std::collections::HashMap<String, String>,
+    pub description_localizations: Option<std::collections::HashMap<String, String>>,
     /// Whether the parameter is optional or required.
     #[serde(default)]
     pub required: bool,
@@ -387,8 +385,7 @@ pub struct CommandOptionChoice {
     /// The choice name.
     pub name: String,
     /// Localizations of the choice name, with locale as key
-    #[serde(default)]
-    pub name_localizations: std::collections::HashMap<String, String>,
+    pub name_localizations: Option<std::collections::HashMap<String, String>>,
     /// The choice value.
     pub value: Value,
 }

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -306,6 +306,7 @@ pub struct CommandOption {
     /// The option description.
     pub description: String,
     /// Localizations of the option description with locale as the key
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description_localizations: Option<std::collections::HashMap<String, String>>,
     /// Whether the parameter is optional or required.
     #[serde(default)]

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -302,6 +302,7 @@ pub struct CommandOption {
     /// The option name.
     pub name: String,
     /// Localizations of the option name with locale as the key
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name_localizations: Option<std::collections::HashMap<String, String>>,
     /// The option description.
     pub description: String,

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -295,8 +295,14 @@ pub struct CommandOption {
     pub kind: CommandOptionType,
     /// The option name.
     pub name: String,
+    /// Localizations of the option name with locale as the key
+    #[serde(default)]
+    pub name_localizations: std::collections::HashMap<String, String>,
     /// The option description.
     pub description: String,
+    /// Localizations of the option description with locale as the key
+    #[serde(default)]
+    pub description_localizations: std::collections::HashMap<String, String>,
     /// Whether the parameter is optional or required.
     #[serde(default)]
     pub required: bool,
@@ -368,6 +374,9 @@ enum_number!(CommandOptionType {
 pub struct CommandOptionChoice {
     /// The choice name.
     pub name: String,
+    /// Localizations of the choice name, with locale as key
+    #[serde(default)]
+    pub name_localizations: std::collections::HashMap<String, String>,
     /// The choice value.
     pub value: Value,
 }

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -24,6 +24,8 @@ use crate::model::id::{
 use crate::model::Permissions;
 
 /// The base command model that belongs to an application.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Command {
@@ -270,6 +272,8 @@ impl Command {
 }
 
 /// The type of an application command.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -287,6 +291,8 @@ enum_number!(CommandType {
 });
 
 /// The parameters for an [`Command`].
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandOption {
@@ -333,9 +339,13 @@ pub struct CommandOption {
     /// Maximum permitted value for Integer or Number options
     #[serde(default)]
     pub max_value: Option<serde_json::Number>,
+    #[serde(default)]
+    pub autocomplete: bool,
 }
 
 /// The type of an [`CommandOption`].
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -369,6 +379,8 @@ enum_number!(CommandOptionType {
 });
 
 /// The only valid values a user can pick in an [`CommandOption`].
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-choice-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandOptionChoice {
@@ -382,6 +394,8 @@ pub struct CommandOptionChoice {
 }
 
 /// An [`Command`] permission.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandPermission {
@@ -396,6 +410,8 @@ pub struct CommandPermission {
 }
 
 /// The [`CommandPermission`] data.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandPermissionData {
@@ -409,6 +425,8 @@ pub struct CommandPermissionData {
 }
 
 /// The type of an [`CommandPermissionData`].
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -387,6 +387,7 @@ pub struct CommandOptionChoice {
     /// The choice name.
     pub name: String,
     /// Localizations of the choice name, with locale as key
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name_localizations: Option<std::collections::HashMap<String, String>>,
     /// The choice value.
     pub value: Value,

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -608,7 +608,6 @@ pub struct CommandDataOption {
     /// The name of the parameter.
     pub name: String,
     /// The given value.
-    // TODO: Why does this field exist? Why a raw json Value when CommandDataOptionValue exists
     pub value: Option<Value>,
     /// The value type.
     #[serde(rename = "type")]

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -37,6 +37,8 @@ use crate::model::user::User;
 use crate::model::utils::deserialize_options_with_resolved;
 
 /// An interaction when a user invokes a slash command.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct ApplicationCommandInteraction {
@@ -65,10 +67,10 @@ pub struct ApplicationCommandInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
-    /// The guild's preferred locale.
-    pub guild_locale: Option<String>,
     /// The selected language of the invoking user.
     pub locale: String,
+    /// The guild's preferred locale.
+    pub guild_locale: Option<String>,
 }
 
 #[cfg(feature = "http")]
@@ -440,6 +442,8 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteraction {
 }
 
 /// The command data payload.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct CommandData {
@@ -451,11 +455,11 @@ pub struct CommandData {
     #[serde(rename = "type")]
     pub kind: CommandType,
     /// The parameters and the given values.
-    #[serde(default)]
-    pub options: Vec<CommandDataOption>,
     /// The converted objects from the given options.
     #[serde(default)]
     pub resolved: CommandDataResolved,
+    #[serde(default)]
+    pub options: Vec<CommandDataOption>,
     /// The Id of the guild the command is registered to.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
@@ -565,6 +569,8 @@ pub enum ResolvedTarget {
 
 /// The resolved data of a command data interaction payload.
 /// It contains the objects of [`CommandDataOption`]s.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandDataResolved {
@@ -594,12 +600,15 @@ pub struct CommandDataResolved {
 /// top-level key and another vector of `options`.
 ///
 /// Their resolved objects can be found on [`CommandData::resolved`].
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct CommandDataOption {
     /// The name of the parameter.
     pub name: String,
     /// The given value.
+    // TODO: Why does this field exist? Why a raw json Value when CommandDataOptionValue exists
     pub value: Option<Value>,
     /// The value type.
     #[serde(rename = "type")]

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -435,8 +435,8 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteraction {
             user,
             token,
             version,
-            guild_locale,
             locale,
+            guild_locale,
         })
     }
 }
@@ -550,8 +550,8 @@ impl<'de> Deserialize<'de> for CommandData {
             id,
             name,
             kind,
-            options,
             resolved,
+            options,
             guild_id,
             target_id,
         })

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -18,6 +18,8 @@ use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
 
 /// An interaction received when the user fills in an autocomplete option
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct AutocompleteInteraction {
@@ -46,10 +48,10 @@ pub struct AutocompleteInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
-    /// The guild's preferred locale.
-    pub guild_locale: Option<String>,
     /// The selected language of the invoking user.
     pub locale: String,
+    /// The guild's preferred locale.
+    pub guild_locale: Option<String>,
 }
 
 #[cfg(feature = "http")]

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -188,8 +188,8 @@ impl<'de> Deserialize<'de> for AutocompleteInteraction {
             user,
             token,
             version,
-            guild_locale,
             locale,
+            guild_locale,
         })
     }
 }

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -402,15 +402,15 @@ impl<'de> Deserialize<'de> for MessageComponentInteraction {
             application_id,
             kind,
             data,
-            message,
             guild_id,
             channel_id,
             member,
             user,
             token,
             version,
-            guild_locale,
+            message,
             locale,
+            guild_locale,
         })
     }
 }

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -25,6 +25,8 @@ use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
 
 /// An interaction triggered by a message component.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct MessageComponentInteraction {
@@ -37,9 +39,6 @@ pub struct MessageComponentInteraction {
     pub kind: InteractionType,
     /// The data of the interaction which was triggered.
     pub data: MessageComponentInteractionData,
-    /// The message this interaction was triggered by, if
-    /// it is a component.
-    pub message: Message,
     /// The guild Id this interaction was sent from, if there is one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
@@ -56,10 +55,13 @@ pub struct MessageComponentInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
-    /// The guild's preferred locale.
-    pub guild_locale: Option<String>,
+    /// The message this interaction was triggered by, if
+    /// it is a component.
+    pub message: Message,
     /// The selected language of the invoking user.
     pub locale: String,
+    /// The guild's preferred locale.
+    pub guild_locale: Option<String>,
 }
 
 #[cfg(feature = "http")]
@@ -414,6 +416,8 @@ impl<'de> Deserialize<'de> for MessageComponentInteraction {
 }
 
 /// A message component interaction data, provided by [`MessageComponentInteraction::data`]
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageComponentInteractionData {

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -13,7 +13,6 @@ use self::message_component::MessageComponentInteraction;
 use self::modal::ModalSubmitInteraction;
 use self::ping::PingInteraction;
 use crate::json::{from_value, JsonMap, Value};
-use crate::model::guild::PartialMember;
 use crate::model::id::{ApplicationId, InteractionId};
 use crate::model::user::User;
 
@@ -243,8 +242,6 @@ pub struct MessageInteraction {
     pub name: String,
     /// The user who invoked the interaction.
     pub user: User,
-    /// If in a guild, the member who invoked the interaction.
-    pub member: Option<PartialMember>,
 }
 
 /// The available responses types for an interaction response.

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -13,9 +13,11 @@ use self::message_component::MessageComponentInteraction;
 use self::modal::ModalSubmitInteraction;
 use self::ping::PingInteraction;
 use crate::json::{from_value, JsonMap, Value};
+use crate::model::guild::PartialMember;
 use crate::model::id::{ApplicationId, InteractionId};
 use crate::model::user::User;
 
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object)
 #[derive(Clone, Debug)]
 pub enum Interaction {
     Ping(PingInteraction),
@@ -186,6 +188,8 @@ impl Serialize for Interaction {
 }
 
 /// The type of an Interaction.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -208,6 +212,9 @@ enum_number!(InteractionType {
 
 bitflags! {
     /// The flags for an interaction response message.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-flags)
+    /// ([only some are valid in this context](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-messages))
     #[derive(Default)]
     pub struct MessageFlags: u64 {
         /// Do not include any embeds when serializing this message.
@@ -221,6 +228,8 @@ bitflags! {
 /// Sent when a [`Message`] is a response to an [`Interaction`].
 ///
 /// [`Message`]: crate::model::channel::Message
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#message-interaction-object).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MessageInteraction {
     /// The id of the interaction.
@@ -234,9 +243,13 @@ pub struct MessageInteraction {
     pub name: String,
     /// The user who invoked the interaction.
     pub user: User,
+    /// If in a guild, the member who invoked the interaction.
+    pub member: Option<PartialMember>,
 }
 
 /// The available responses types for an interaction response.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -387,15 +387,15 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
             application_id,
             kind,
             data,
-            message,
             guild_id,
             channel_id,
             member,
             user,
             token,
             version,
-            guild_locale,
+            message,
             locale,
+            guild_locale,
         })
     }
 }

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -25,6 +25,8 @@ use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
 
 /// An interaction triggered by a modal submit.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct ModalSubmitInteraction {
@@ -37,11 +39,6 @@ pub struct ModalSubmitInteraction {
     pub kind: InteractionType,
     /// The data of the interaction which was triggered.
     pub data: ModalSubmitInteractionData,
-    /// The message this interaction was triggered by
-    /// **Note**: Does not exist if the modal interaction originates from
-    /// an application command interaction
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message: Option<Message>,
     /// The guild Id this interaction was sent from, if there is one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
@@ -58,10 +55,16 @@ pub struct ModalSubmitInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
-    /// The guild's preferred locale.
-    pub guild_locale: Option<String>,
+    /// The message this interaction was triggered by
+    ///
+    /// **Note**: Does not exist if the modal interaction originates from
+    /// an application command interaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<Message>,
     /// The selected language of the invoking user.
     pub locale: String,
+    /// The guild's preferred locale.
+    pub guild_locale: Option<String>,
 }
 
 #[cfg(feature = "model")]
@@ -398,6 +401,8 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
 }
 
 /// A modal submit interaction data, provided by [`ModalSubmitInteraction::data`]
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ModalSubmitInteractionData {

--- a/src/model/application/interaction/ping.rs
+++ b/src/model/application/interaction/ping.rs
@@ -4,6 +4,8 @@ use crate::model::application::interaction::InteractionType;
 use crate::model::id::{ApplicationId, InteractionId};
 
 /// A ping interaction, which can only be received through an endpoint url.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct PingInteraction {


### PR DESCRIPTION
Fixes #1957, plus I took the liberty of adding Discord docs links to all types in that module, as well as reordering all fields to match Discord docs (makes it easier to check serenity struct fields for completeness). And I added `CommandOption::autocomplete` and `MessageInteraction::member` because those fields were present in Discord docs and not in serenity. I briefly tested those two new fields with a one-off bot and `println!()`

