### PR TITLE
[DRAFT] Builder paradigm overhaul

### DIFF
--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -19,10 +19,14 @@ impl EventHandler for Handler {
             // In this case, you can direct message a User directly by simply
             // calling a method on its instance, with the content of the
             // message.
-            let dm = msg.author.dm(&context, |m| m.content("Hello!")).await;
-
-            if let Err(why) = dm {
-                println!("Error when direct messaging user: {:?}", why);
+            match msg.author.dm(&context).await {
+                Ok(create_message) => {
+                    let msg = create_message.content("Hello!").execute(&context).await;
+                    if let Err(why) = msg {
+                        println!("Error when direct messaging user: {:?}", why);
+                    }
+                },
+                Err(why) => println!("Error when direct messaging user: {:?}", why),
             }
         }
     }

--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use serenity::async_trait;
+use serenity::builder::{CreateEmbed, CreateEmbedFooter};
 use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
 use serenity::model::Timestamp;
@@ -16,24 +17,25 @@ impl EventHandler for Handler {
             // using a builder syntax.
             // This example will create a message that says "Hello, World!", with an embed that has
             // a title, description, an image, three fields, and a footer.
+            let footer = CreateEmbedFooter::default().text("This is a footer");
+            let embed = CreateEmbed::default()
+                .title("This is a title")
+                .description("This is a description")
+                .image("attachment://ferris_eyes.png")
+                .fields(vec![
+                    ("This is the first field", "This is a field body", true),
+                    ("This is the second field", "Both fields are inline", true),
+                ])
+                .field("This is the third field", "This is not an inline field", false)
+                .footer(footer)
+                // Add a timestamp for the current time
+                // This also accepts a rfc3339 Timestamp
+                .timestamp(Timestamp::now());
             let msg = msg
                 .channel_id
                 .send_message()
                 .content("Hello, World!")
-                .embed(|e| {
-                    e.title("This is a title")
-                        .description("This is a description")
-                        .image("attachment://ferris_eyes.png")
-                        .fields(vec![
-                            ("This is the first field", "This is a field body", true),
-                            ("This is the second field", "Both fields are inline", true),
-                        ])
-                        .field("This is the third field", "This is not an inline field", false)
-                        .footer(|f| f.text("This is a footer"))
-                        // Add a timestamp for the current time
-                        // This also accepts a rfc3339 Timestamp
-                        .timestamp(Timestamp::now())
-                })
+                .embed(embed)
                 .add_file("./ferris_eyes.png")
                 .execute(&ctx.http)
                 .await;

--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -18,24 +18,24 @@ impl EventHandler for Handler {
             // a title, description, an image, three fields, and a footer.
             let msg = msg
                 .channel_id
-                .send_message(&ctx.http, |m| {
-                    m.content("Hello, World!")
-                        .embed(|e| {
-                            e.title("This is a title")
-                                .description("This is a description")
-                                .image("attachment://ferris_eyes.png")
-                                .fields(vec![
-                                    ("This is the first field", "This is a field body", true),
-                                    ("This is the second field", "Both fields are inline", true),
-                                ])
-                                .field("This is the third field", "This is not an inline field", false)
-                                .footer(|f| f.text("This is a footer"))
-                                // Add a timestamp for the current time
-                                // This also accepts a rfc3339 Timestamp
-                                .timestamp(Timestamp::now())
-                        })
-                        .add_file("./ferris_eyes.png")
+                .send_message()
+                .content("Hello, World!")
+                .embed(|e| {
+                    e.title("This is a title")
+                        .description("This is a description")
+                        .image("attachment://ferris_eyes.png")
+                        .fields(vec![
+                            ("This is the first field", "This is a field body", true),
+                            ("This is the second field", "Both fields are inline", true),
+                        ])
+                        .field("This is the third field", "This is not an inline field", false)
+                        .footer(|f| f.text("This is a footer"))
+                        // Add a timestamp for the current time
+                        // This also accepts a rfc3339 Timestamp
+                        .timestamp(Timestamp::now())
                 })
+                .add_file("./ferris_eyes.png")
+                .execute(&ctx.http)
                 .await;
 
             if let Err(why) = msg {

--- a/examples/e13_parallel_loops/src/main.rs
+++ b/examples/e13_parallel_loops/src/main.rs
@@ -80,21 +80,21 @@ async fn log_system_load(ctx: Arc<Context>) {
     // We can use ChannelId directly to send a message to a specific channel; in this case, the
     // message would be sent to the #testing channel on the discord server.
     let message = ChannelId::new(381926291785383946)
-        .send_message(&ctx, |m| {
-            m.embed(|e| {
-                e.title("System Resource Load")
-                    .field("CPU Load Average", &format!("{:.2}%", cpu_load.one * 10.0), false)
-                    .field(
-                        "Memory Usage",
-                        &format!(
-                            "{:.2} MB Free out of {:.2} MB",
-                            mem_use.free as f32 / 1000.0,
-                            mem_use.total as f32 / 1000.0
-                        ),
-                        false,
-                    )
-            })
+        .send_message()
+        .embed(|e| {
+            e.title("System Resource Load")
+                .field("CPU Load Average", &format!("{:.2}%", cpu_load.one * 10.0), false)
+                .field(
+                    "Memory Usage",
+                    &format!(
+                        "{:.2} MB Free out of {:.2} MB",
+                        mem_use.free as f32 / 1000.0,
+                        mem_use.total as f32 / 1000.0
+                    ),
+                    false,
+                )
         })
+        .execute(ctx)
         .await;
     if let Err(why) = message {
         eprintln!("Error sending message: {:?}", why);

--- a/examples/e13_parallel_loops/src/main.rs
+++ b/examples/e13_parallel_loops/src/main.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use chrono::offset::Utc;
 use serenity::async_trait;
+use serenity::builder::CreateEmbed;
 use serenity::gateway::ActivityData;
 use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
@@ -79,23 +80,19 @@ async fn log_system_load(ctx: Arc<Context>) {
 
     // We can use ChannelId directly to send a message to a specific channel; in this case, the
     // message would be sent to the #testing channel on the discord server.
-    let message = ChannelId::new(381926291785383946)
-        .send_message()
-        .embed(|e| {
-            e.title("System Resource Load")
-                .field("CPU Load Average", &format!("{:.2}%", cpu_load.one * 10.0), false)
-                .field(
-                    "Memory Usage",
-                    &format!(
-                        "{:.2} MB Free out of {:.2} MB",
-                        mem_use.free as f32 / 1000.0,
-                        mem_use.total as f32 / 1000.0
-                    ),
-                    false,
-                )
-        })
-        .execute(ctx)
-        .await;
+    let embed = CreateEmbed::default()
+        .title("System Resource Load")
+        .field("CPU Load Average", format!("{:.2}%", cpu_load.one * 10.0), false)
+        .field(
+            "Memory Usage",
+            format!(
+                "{:.2} MB Free out of {:.2} MB",
+                mem_use.free as f32 / 1000.0,
+                mem_use.total as f32 / 1000.0
+            ),
+            false,
+        );
+    let message = ChannelId::new(381926291785383946).send_message().embed(embed).execute(ctx).await;
     if let Err(why) = message {
         eprintln!("Error sending message: {:?}", why);
     };

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use serenity::async_trait;
-use serenity::builder::*;
+use serenity::builder::CreateInteractionResponseData;
 use serenity::model::application::command::{Command, CommandOptionType};
 use serenity::model::application::interaction::application_command::CommandDataOptionValue;
 use serenity::model::application::interaction::{Interaction, InteractionResponseType};

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use serenity::async_trait;
+use serenity::builder::*;
 use serenity::model::application::command::{Command, CommandOptionType};
 use serenity::model::application::interaction::application_command::CommandDataOptionValue;
 use serenity::model::application::interaction::{Interaction, InteractionResponseType};
@@ -56,12 +57,12 @@ impl EventHandler for Handler {
                 _ => "not implemented :(".to_string(),
             };
 
+            let data = CreateInteractionResponseData::default().content(content);
             if let Err(why) = command
-                .create_interaction_response(&ctx.http, |response| {
-                    response
-                        .kind(InteractionResponseType::ChannelMessageWithSource)
-                        .interaction_response_data(|message| message.content(content))
-                })
+                .create_interaction_response()
+                .kind(InteractionResponseType::ChannelMessageWithSource)
+                .interaction_response_data(data)
+                .execute(&ctx.http)
                 .await
             {
                 println!("Cannot respond to slash command: {}", why);

--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -172,10 +172,10 @@ impl EventHandler for Handler {
         // Ask the user for its favorite animal
         let m = msg
             .channel_id
-            .send_message(&ctx, |m| {
-                m.content("Please select your favorite animal")
-                    .components(|c| c.add_action_row(Animal::action_row()))
-            })
+            .send_message()
+            .content("Please select your favorite animal")
+            .components(|c| c.add_action_row(Animal::action_row()))
+            .execute(&ctx)
             .await
             .unwrap();
 

--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -1,10 +1,23 @@
+#[cfg(feature = "http")]
+use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
 use crate::model::id::RoleId;
+#[cfg(feature = "http")]
+use crate::model::prelude::*;
 
 /// A builder to add parameters when using [`GuildId::add_member`].
 ///
 /// [`GuildId::add_member`]: crate::model::id::GuildId::add_member
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct AddMember {
+    #[cfg(feature = "http")]
+    #[serde(skip)]
+    guild_id: GuildId,
+    #[cfg(feature = "http")]
+    #[serde(skip)]
+    user_id: UserId,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     access_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18,10 +31,27 @@ pub struct AddMember {
 }
 
 impl AddMember {
+    pub fn new(
+        #[cfg(feature = "http")] guild_id: GuildId,
+        #[cfg(feature = "http")] user_id: UserId,
+    ) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            guild_id,
+            #[cfg(feature = "http")]
+            user_id,
+            access_token: None,
+            nick: None,
+            roles: None,
+            mute: None,
+            deaf: None,
+        }
+    }
+
     /// Sets the OAuth2 access token for this request.
     ///
     /// Requires the access token to have the `guilds.join` scope granted.
-    pub fn access_token(&mut self, access_token: impl Into<String>) -> &mut Self {
+    pub fn access_token(mut self, access_token: impl Into<String>) -> Self {
         self.access_token = Some(access_token.into());
         self
     }
@@ -31,7 +61,7 @@ impl AddMember {
     /// Requires the [Manage Nicknames] permission.
     ///
     /// [Manage Nicknames]: crate::model::permissions::Permissions::MANAGE_NICKNAMES
-    pub fn nickname(&mut self, nickname: impl Into<String>) -> &mut Self {
+    pub fn nickname(mut self, nickname: impl Into<String>) -> Self {
         self.nick = Some(nickname.into());
         self
     }
@@ -41,7 +71,7 @@ impl AddMember {
     /// Requires the [Manage Roles] permission.
     ///
     /// [Manage Roles]: crate::model::permissions::Permissions::MANAGE_ROLES
-    pub fn roles(&mut self, roles: impl IntoIterator<Item = impl Into<RoleId>>) -> &mut Self {
+    pub fn roles(mut self, roles: impl IntoIterator<Item = impl Into<RoleId>>) -> Self {
         self.roles = Some(roles.into_iter().map(Into::into).collect());
         self
     }
@@ -51,7 +81,7 @@ impl AddMember {
     /// Requires the [Mute Members] permission.
     ///
     /// [Mute Members]: crate::model::permissions::Permissions::MUTE_MEMBERS
-    pub fn mute(&mut self, mute: bool) -> &mut Self {
+    pub fn mute(mut self, mute: bool) -> Self {
         self.mute = Some(mute);
         self
     }
@@ -61,8 +91,21 @@ impl AddMember {
     /// Requires the [Deafen Members] permission.
     ///
     /// [Deafen Members]: crate::model::permissions::Permissions::DEAFEN_MEMBERS
-    pub fn deafen(&mut self, deafen: bool) -> &mut Self {
+    pub fn deafen(mut self, deafen: bool) -> Self {
         self.deaf = Some(deafen);
         self
+    }
+
+    /// Adds a [`User`] to the corresponding guild with a valid OAuth2 access token.
+    ///
+    /// Returns the created [`Member`] object, or nothing if the user is already a member of the
+    /// guild.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission, or if invalid values are set.
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: impl AsRef<Http>) -> Result<Option<Member>> {
+        http.as_ref().add_guild_member(self.guild_id.into(), self.user_id.into(), &self).await
     }
 }

--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -10,6 +10,7 @@ use crate::model::prelude::*;
 ///
 /// [`GuildId::add_member`]: crate::model::id::GuildId::add_member
 #[derive(Clone, Debug, Serialize)]
+#[must_use]
 pub struct AddMember {
     #[cfg(feature = "http")]
     #[serde(skip)]

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -9,6 +9,7 @@ use crate::model::prelude::*;
 
 /// A builder for constructing an invite link with custom OAuth2 scopes.
 #[derive(Debug, Clone, Default)]
+#[must_use]
 pub struct CreateBotAuthParameters {
     client_id: Option<ApplicationId>,
     scopes: Vec<Scope>,
@@ -54,7 +55,7 @@ impl CreateBotAuthParameters {
     }
 
     /// Specify the client Id of your application.
-    pub fn client_id<U: Into<ApplicationId>>(&mut self, client_id: U) -> &mut Self {
+    pub fn client_id<U: Into<ApplicationId>>(mut self, client_id: U) -> Self {
         self.client_id = Some(client_id.into());
         self
     }
@@ -69,7 +70,7 @@ impl CreateBotAuthParameters {
     ///
     /// [`HttpError::UnsuccessfulRequest`]: crate::http::HttpError::UnsuccessfulRequest
     #[cfg(feature = "http")]
-    pub async fn auto_client_id(&mut self, http: impl AsRef<Http>) -> Result<&mut Self> {
+    pub async fn auto_client_id(mut self, http: impl AsRef<Http>) -> Result<Self> {
         self.client_id = http.as_ref().get_current_application_info().await.map(|v| Some(v.id))?;
         Ok(self)
     }
@@ -79,25 +80,25 @@ impl CreateBotAuthParameters {
     /// **Note**: This needs to include the [`Bot`] scope.
     ///
     /// [`Bot`]: Scope::Bot
-    pub fn scopes(&mut self, scopes: &[Scope]) -> &mut Self {
+    pub fn scopes(mut self, scopes: &[Scope]) -> Self {
         self.scopes = scopes.to_vec();
         self
     }
 
     /// Specify the permissions your application requires.
-    pub fn permissions(&mut self, permissions: Permissions) -> &mut Self {
+    pub fn permissions(mut self, permissions: Permissions) -> Self {
         self.permissions = permissions;
         self
     }
 
     /// Specify the Id of the guild to prefill the dropdown picker for the user.
-    pub fn guild_id<G: Into<GuildId>>(&mut self, guild_id: G) -> &mut Self {
+    pub fn guild_id<G: Into<GuildId>>(mut self, guild_id: G) -> Self {
         self.guild_id = Some(guild_id.into());
         self
     }
 
     /// Specify whether the user cannot change the guild in the dropdown picker.
-    pub fn disable_guild_select(&mut self, disable: bool) -> &mut Self {
+    pub fn disable_guild_select(mut self, disable: bool) -> Self {
         self.disable_guild_select = disable;
         self
     }

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "http")]
+use crate::http::{CacheHttp, Http};
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder for creating a new [`GuildChannel`] in a [`Guild`].
@@ -7,7 +11,11 @@ use crate::model::prelude::*;
 /// [`GuildChannel`]: crate::model::channel::GuildChannel
 /// [`Guild`]: crate::model::guild::Guild
 #[derive(Debug, Clone, Serialize)]
+#[must_use]
 pub struct CreateChannel {
+    #[cfg(feature = "http")]
+    #[serde(skip)]
+    id: GuildId,
     kind: ChannelType,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
@@ -29,55 +37,66 @@ pub struct CreateChannel {
 }
 
 impl CreateChannel {
+    /// Creates a builder with default values, setting [`Self::kind`] to [`ChannelType::Text`].
+    pub fn new(#[cfg(feature = "http")] id: GuildId) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            id,
+            name: None,
+            nsfw: None,
+            topic: None,
+            bitrate: None,
+            position: None,
+            parent_id: None,
+            user_limit: None,
+            rate_limit_per_user: None,
+            kind: ChannelType::Text,
+            permission_overwrites: Vec::new(),
+        }
+    }
+
     /// Specify how to call this new channel.
     ///
     /// **Note**: Must be between 2 and 100 characters long.
-    pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
-
         self
     }
     /// Specify what type the channel is, whether it's a text, voice, category or news channel.
-    pub fn kind(&mut self, kind: ChannelType) -> &mut Self {
+    pub fn kind(mut self, kind: ChannelType) -> Self {
         self.kind = kind;
-
         self
     }
 
     /// Specify the category, the "parent" of this channel.
-    pub fn category<I: Into<ChannelId>>(&mut self, id: I) -> &mut Self {
+    pub fn category<I: Into<ChannelId>>(mut self, id: I) -> Self {
         self.parent_id = Some(id.into());
-
         self
     }
 
     /// Set an interesting topic.
     ///
     /// **Note**: Must be between 0 and 1000 characters long.
-    pub fn topic(&mut self, topic: impl Into<String>) -> &mut Self {
+    pub fn topic(mut self, topic: impl Into<String>) -> Self {
         self.topic = Some(topic.into());
-
         self
     }
 
     /// Specify if this channel will be inappropriate to browse while at work.
-    pub fn nsfw(&mut self, b: bool) -> &mut Self {
+    pub fn nsfw(mut self, b: bool) -> Self {
         self.nsfw = Some(b);
-
         self
     }
 
     /// [Voice-only] Specify the bitrate at which sound plays in the voice channel.
-    pub fn bitrate(&mut self, rate: u32) -> &mut Self {
+    pub fn bitrate(mut self, rate: u32) -> Self {
         self.bitrate = Some(rate);
-
         self
     }
 
     /// [Voice-only] Set how many users may occupy this voice channel.
-    pub fn user_limit(&mut self, limit: u32) -> &mut Self {
+    pub fn user_limit(mut self, limit: u32) -> Self {
         self.user_limit = Some(limit);
-
         self
     }
 
@@ -91,16 +110,14 @@ impl CreateChannel {
     /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
     /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
     #[doc(alias = "slowmode")]
-    pub fn rate_limit_per_user(&mut self, seconds: u64) -> &mut Self {
+    pub fn rate_limit_per_user(mut self, seconds: u64) -> Self {
         self.rate_limit_per_user = Some(seconds);
-
         self
     }
 
     /// Specify where the channel should be located.
-    pub fn position(&mut self, pos: u32) -> &mut Self {
+    pub fn position(mut self, pos: u32) -> Self {
         self.position = Some(pos);
-
         self
     }
 
@@ -129,44 +146,52 @@ impl CreateChannel {
     ///     kind: PermissionOverwriteType::Member(UserId::new(1234)),
     /// }];
     ///
-    /// guild.create_channel(http, |c| c.name("my_new_cool_channel").permissions(permissions)).await?;
+    /// guild.create_channel().name("my_cool_channel").permissions(permissions).execute(&http).await?;
     /// #    Ok(())
     /// # }
     /// ```
-    pub fn permissions<I>(&mut self, perms: I) -> &mut Self
+    pub fn permissions<I>(mut self, perms: I) -> Self
     where
         I: IntoIterator<Item = PermissionOverwrite>,
     {
         self.permission_overwrites = perms.into_iter().map(Into::into).collect();
-
         self
     }
-}
 
-impl Default for CreateChannel {
-    /// Creates a builder with default values, setting [`Self::kind`] to [`ChannelType::Text`].
+    #[cfg(feature = "http")]
+    #[inline]
+    /// Creates a new [`Channel`] in the guild.
     ///
-    /// # Examples
+    /// **Note**: Requires the [Manage Channels] permission.
     ///
-    /// Create a default [`CreateChannel`] builder:
+    /// # Errors
     ///
-    /// ```rust
-    /// use serenity::builder::CreateChannel;
+    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
+    /// does not have permission to manage channels.
     ///
-    /// let channel_builder = CreateChannel::default();
-    /// ```
-    fn default() -> Self {
-        CreateChannel {
-            name: None,
-            nsfw: None,
-            topic: None,
-            bitrate: None,
-            position: None,
-            parent_id: None,
-            user_limit: None,
-            rate_limit_per_user: None,
-            kind: ChannelType::Text,
-            permission_overwrites: Vec::new(),
+    /// Otherwise will return [`Error::Http`] if the current user lacks permission, or if invalid
+    /// data was given.
+    ///
+    /// [Manage Channels]: Permissions::MANAGE_CHANNELS
+    pub async fn execute(self, cache_http: impl CacheHttp) -> Result<GuildChannel> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(cache) = cache_http.cache() {
+                if let Some(guild) = cache.guild(self.id) {
+                    let req = Permissions::MANAGE_CHANNELS;
+
+                    if !guild.has_perms(&cache_http, req).await {
+                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                    }
+                }
+            }
         }
+
+        self._execute(cache_http.http()).await
+    }
+
+    #[cfg(feature = "http")]
+    async fn _execute(self, http: &Http) -> Result<GuildChannel> {
+        http.create_channel(self.id.into(), &self, None).await
     }
 }

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -167,10 +167,8 @@ impl CreateChannel {
     /// # Errors
     ///
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to manage channels.
-    ///
-    /// Otherwise will return [`Error::Http`] if the current user lacks permission, or if invalid
-    /// data was given.
+    /// does not have permission to manage channels. Otherwise returns [`Error::Http`], as well as
+    /// if invalid data was given.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn execute(self, cache_http: impl CacheHttp) -> Result<GuildChannel> {

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -235,9 +235,9 @@ impl CreateEmbed {
     ///         if msg.content == "~embed" {
     ///             let _ = msg
     ///                 .channel_id
-    ///                 .send_message(&context.http, |m| {
-    ///                     m.embed(|e| e.title("hello").timestamp("2004-06-08T16:04:23"))
-    ///                 })
+    ///                 .send_message()
+    ///                 .embed(|e| e.title("hello").timestamp("2004-06-08T16:04:23"))
+    ///                 .execute(&context.http)
     ///                 .await;
     ///         }
     ///     }
@@ -277,15 +277,15 @@ impl CreateEmbed {
     ///                 let user = &member.user;
     ///
     ///                 let _ = channel
-    ///                     .send_message(&context, |m| {
-    ///                         m.embed(|e| {
-    ///                             if let Some(ref joined_at) = member.joined_at {
-    ///                                 e.timestamp(joined_at);
-    ///                             }
-    ///                             e.author(|a| a.icon_url(&user.face()).name(&user.name))
-    ///                                 .title("Member Join")
-    ///                         })
+    ///                     .send_message()
+    ///                     .embed(|e| {
+    ///                         if let Some(ref joined_at) = member.joined_at {
+    ///                             e.timestamp(joined_at);
+    ///                         }
+    ///                         e.author(|a| a.icon_url(&user.face()).name(&user.name))
+    ///                             .title("Member Join")
     ///                     })
+    ///                     .execute(&context)
     ///                     .await;
     ///             }
     ///         }

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -5,18 +5,14 @@
 //! These are used in the [`ChannelId::send_message`] and
 //! [`ExecuteWebhook::embeds`] methods, both as part of builders.
 //!
-//! The only builder that should be exposed is [`CreateEmbed`]. The rest of
-//! these have no real reason for being exposed, but are for completeness' sake.
-//!
 //! Documentation for embeds can be found [here].
 //!
-//! [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
 //! [`ExecuteWebhook::embeds`]: crate::builder::ExecuteWebhook::embeds
 //! [here]: https://discord.com/developers/docs/resources/channel#embed-object
 
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
-use crate::model::channel::{Embed, EmbedField};
+use crate::model::channel::{Embed, EmbedAuthor, EmbedField, EmbedFooter};
 #[cfg(feature = "http")]
 use crate::model::prelude::*;
 use crate::model::Timestamp;
@@ -44,10 +40,9 @@ impl HoldsUrl {
 /// Refer to the documentation for [`ChannelId::send_message`] for a very in-depth
 /// example on how to use this.
 ///
-/// [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
-/// [`Embed`]: crate::model::channel::Embed
 /// [`ExecuteWebhook::embeds`]: crate::builder::ExecuteWebhook::embeds
 #[derive(Clone, Debug, Serialize)]
+#[must_use]
 pub struct CreateEmbed {
     fields: Vec<EmbedField>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -75,21 +70,10 @@ pub struct CreateEmbed {
 }
 
 impl CreateEmbed {
-    /// Build the author of the embed.
-    ///
-    /// Refer to the documentation for [`CreateEmbedAuthor`] for more
-    /// information.
-    pub fn author<F>(&mut self, f: F) -> &mut Self
-    where
-        F: FnOnce(&mut CreateEmbedAuthor) -> &mut CreateEmbedAuthor,
-    {
-        let mut author = CreateEmbedAuthor::default();
-        f(&mut author);
-        self.set_author(author)
-    }
-
     /// Set the author of the embed.
-    pub fn set_author(&mut self, author: CreateEmbedAuthor) -> &mut Self {
+    ///
+    /// Refer to the documentation for [`CreateEmbedAuthor`] for more information.
+    pub fn author(mut self, author: CreateEmbedAuthor) -> Self {
         self.author = Some(author);
         self
     }
@@ -99,22 +83,21 @@ impl CreateEmbed {
     /// This is an alias of [`Self::colour`].
     #[cfg(feature = "utils")]
     #[inline]
-    pub fn color<C: Into<Colour>>(&mut self, colour: C) -> &mut Self {
-        self.colour(colour);
-        self
+    pub fn color<C: Into<Colour>>(self, colour: C) -> Self {
+        self.colour(colour)
     }
 
     /// Set the colour of the left-hand side of the embed.
     #[cfg(feature = "utils")]
     #[inline]
-    pub fn colour<C: Into<Colour>>(&mut self, colour: C) -> &mut Self {
-        self._colour(colour.into());
-        self
+    pub fn colour<C: Into<Colour>>(self, colour: C) -> Self {
+        self._colour(colour.into())
     }
 
     #[cfg(feature = "utils")]
-    fn _colour(&mut self, colour: Colour) {
+    fn _colour(mut self, colour: Colour) -> Self {
         self.colour = Some(colour.0);
+        self
     }
 
     /// Set the colour of the left-hand side of the embed.
@@ -122,14 +105,13 @@ impl CreateEmbed {
     /// This is an alias of [`colour`].
     #[cfg(not(feature = "utils"))]
     #[inline]
-    pub fn color(&mut self, colour: u32) -> &mut Self {
-        self.colour(colour);
-        self
+    pub fn color(self, colour: u32) -> Self {
+        self.colour(colour)
     }
 
     /// Set the colour of the left-hand side of the embed.
     #[cfg(not(feature = "utils"))]
-    pub fn colour(&mut self, colour: u32) -> &mut Self {
+    pub fn colour(mut self, colour: u32) -> Self {
         self.colour = Some(colour);
         self
     }
@@ -138,32 +120,30 @@ impl CreateEmbed {
     ///
     /// **Note**: This can't be longer than 4096 characters.
     #[inline]
-    pub fn description(&mut self, description: impl Into<String>) -> &mut Self {
+    pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }
 
-    /// Set a field. Note that this will not overwrite other fields, and will
-    /// add to them.
+    /// Set a field. Note that this will not overwrite other fields, and will add to them.
     ///
-    /// **Note**: Maximum amount of characters you can put is 256 in a field
-    /// name and 1024 in a field value.
+    /// **Note**: Maximum amount of characters you can put is 256 in a field name an 1024 in a
+    /// field value.
     #[inline]
     pub fn field(
-        &mut self,
+        mut self,
         name: impl Into<String>,
         value: impl Into<String>,
         inline: bool,
-    ) -> &mut Self {
+    ) -> Self {
         self.fields.push(EmbedField::new(name, value, inline));
-
         self
     }
 
     /// Adds multiple fields at once.
     ///
     /// This is sugar to reduce the need of calling [`Self::field`] manually multiple times.
-    pub fn fields<N, V>(&mut self, fields: impl IntoIterator<Item = (N, V, bool)>) -> &mut Self
+    pub fn fields<N, V>(mut self, fields: impl IntoIterator<Item = (N, V, bool)>) -> Self
     where
         N: Into<String>,
         V: Into<String>,
@@ -175,35 +155,24 @@ impl CreateEmbed {
         self
     }
 
-    /// Build the footer of the embed.
-    ///
-    /// Refer to the documentation for [`CreateEmbedFooter`] for more
-    /// information.
-    pub fn footer<F>(&mut self, f: F) -> &mut Self
-    where
-        F: FnOnce(&mut CreateEmbedFooter) -> &mut CreateEmbedFooter,
-    {
-        let mut create_embed_footer = CreateEmbedFooter::default();
-        f(&mut create_embed_footer);
-        self.set_footer(create_embed_footer)
-    }
-
     /// Set the footer of the embed.
-    pub fn set_footer(&mut self, create_embed_footer: CreateEmbedFooter) -> &mut Self {
-        self.footer = Some(create_embed_footer);
+    ///
+    /// Refer to the documentation for [`CreateEmbedFooter`] for more information.
+    pub fn footer(mut self, footer: CreateEmbedFooter) -> Self {
+        self.footer = Some(footer);
         self
     }
 
     /// Set the image associated with the embed. This only supports HTTP(S).
     #[inline]
-    pub fn image(&mut self, url: impl Into<String>) -> &mut Self {
+    pub fn image(mut self, url: impl Into<String>) -> Self {
         self.image = Some(HoldsUrl::new(url.into()));
         self
     }
 
     /// Set the thumbnail of the embed. This only supports HTTP(S).
     #[inline]
-    pub fn thumbnail(&mut self, url: impl Into<String>) -> &mut Self {
+    pub fn thumbnail(mut self, url: impl Into<String>) -> Self {
         self.thumbnail = Some(HoldsUrl::new(url.into()));
         self
     }
@@ -212,14 +181,14 @@ impl CreateEmbed {
     ///
     /// You may pass a direct string:
     ///
-    /// - `2017-01-03T23:00:00`
-    /// - `2004-06-08T16:04:23`
-    /// - `2004-06-08T16:04:23`
+    /// - `2017-01-03T23:00:00Z`
+    /// - `2004-06-08T16:04:23Z`
+    /// - `2004-06-08T16:04:23Z`
     ///
-    /// This timestamp must be in ISO-8601 format. It must also be in UTC format.
+    /// This timestamp must be in RFC 3339 format. It must also be in UTC format.
     ///
-    /// You can also pass an instance of `chrono::DateTime<Utc>`,
-    /// which will construct the timestamp string out of it.
+    /// You can also pass an instance of `chrono::DateTime<Utc>`, which will construct the
+    /// timestamp string out of it.
     ///
     /// # Examples
     ///
@@ -228,6 +197,7 @@ impl CreateEmbed {
     /// ```rust,no_run
     /// # #[cfg(feature = "client")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// use serenity::builder::CreateEmbed;
     /// use serenity::model::channel::Message;
     /// use serenity::prelude::*;
     ///
@@ -237,12 +207,8 @@ impl CreateEmbed {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, mut msg: Message) {
     ///         if msg.content == "~embed" {
-    ///             let _ = msg
-    ///                 .channel_id
-    ///                 .send_message()
-    ///                 .embed(|e| e.title("hello").timestamp("2004-06-08T16:04:23"))
-    ///                 .execute(&context.http)
-    ///                 .await;
+    ///             let embed = CreateEmbed::default().title("hello").timestamp("2004-06-08T16:04:23Z");
+    ///             let _ = msg.channel_id.send_message().embed(embed).execute(&context.http).await;
     ///         }
     ///     }
     /// }
@@ -262,6 +228,7 @@ impl CreateEmbed {
     /// ```rust,no_run
     /// # #[cfg(all(feature = "cache", feature = "client"))]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// use serenity::builder::{CreateEmbed, CreateEmbedAuthor};
     /// use serenity::model::guild::Member;
     /// use serenity::model::id::GuildId;
     /// use serenity::prelude::*;
@@ -278,19 +245,14 @@ impl CreateEmbed {
     ///             let channel_search = channels.values().find(|c| c.name == "join-log");
     ///
     ///             if let Some(channel) = channel_search {
-    ///                 let user = &member.user;
-    ///
-    ///                 let _ = channel
-    ///                     .send_message()
-    ///                     .embed(|e| {
-    ///                         if let Some(ref joined_at) = member.joined_at {
-    ///                             e.timestamp(joined_at);
-    ///                         }
-    ///                         e.author(|a| a.icon_url(&user.face()).name(&user.name))
-    ///                             .title("Member Join")
-    ///                     })
-    ///                     .execute(&context)
-    ///                     .await;
+    ///                 let author = CreateEmbedAuthor::default()
+    ///                     .icon_url(member.user.face())
+    ///                     .name(member.user.name);
+    ///                 let mut embed = CreateEmbed::default().title("Member Join").author(author);
+    ///                 if let Some(ref joined_at) = member.joined_at {
+    ///                     embed = embed.timestamp(joined_at)
+    ///                 }
+    ///                 let _ = channel.send_message().embed(embed).execute(&context).await;
     ///             }
     ///         }
     ///     }
@@ -304,21 +266,21 @@ impl CreateEmbed {
     /// # }
     /// ```
     #[inline]
-    pub fn timestamp<T: Into<Timestamp>>(&mut self, timestamp: T) -> &mut Self {
+    pub fn timestamp<T: Into<Timestamp>>(mut self, timestamp: T) -> Self {
         self.timestamp = Some(timestamp.into().to_string());
         self
     }
 
     /// Set the title of the embed.
     #[inline]
-    pub fn title(&mut self, title: impl Into<String>) -> &mut Self {
+    pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }
 
     /// Set the URL to direct to when clicking on the title.
     #[inline]
-    pub fn url(&mut self, url: impl Into<String>) -> &mut Self {
+    pub fn url(mut self, url: impl Into<String>) -> Self {
         self.url = Some(url.into());
         self
     }
@@ -327,10 +289,8 @@ impl CreateEmbed {
     ///
     /// Note however, you have to be sure you set an attachment (with [`ChannelId::send_files`])
     /// with the provided filename. Or else this won't work.
-    ///
-    /// [`ChannelId::send_files`]: crate::model::id::ChannelId::send_files
     #[inline]
-    pub fn attachment(&mut self, filename: impl Into<String>) -> &mut Self {
+    pub fn attachment(mut self, filename: impl Into<String>) -> Self {
         let mut filename = filename.into();
         filename.insert_str(0, "attachment://");
 
@@ -400,76 +360,50 @@ impl From<Embed> for CreateEmbed {
     ///
     /// Some values - such as Proxy URLs - are not preserved.
     fn from(embed: Embed) -> Self {
-        let mut b = CreateEmbed::default();
+        let mut b = CreateEmbed {
+            description: embed.description,
+            timestamp: embed.timestamp,
+            title: embed.title,
+            url: embed.url,
+            ..Default::default()
+        };
 
         if let Some(colour) = embed.colour {
-            b.colour(colour);
-        }
-
-        if let Some(author) = embed.author {
-            b.author(move |a| {
-                a.name(author.name);
-
-                if let Some(icon_url) = author.icon_url {
-                    a.icon_url(icon_url);
-                }
-
-                if let Some(url) = author.url {
-                    a.url(url);
-                }
-
-                a
-            });
-        }
-
-        if let Some(description) = embed.description {
-            b.description(description);
-        }
-
-        for field in embed.fields {
-            b.field(field.name, field.value, field.inline);
-        }
-
-        if let Some(image) = embed.image {
-            b.image(image.url);
-        }
-
-        if let Some(timestamp) = embed.timestamp {
-            b.timestamp(timestamp);
+            b = b.colour(colour);
         }
 
         if let Some(thumbnail) = embed.thumbnail {
-            b.thumbnail(thumbnail.url);
+            b = b.thumbnail(thumbnail.url);
         }
 
-        if let Some(url) = embed.url {
-            b.url(url);
+        if let Some(image) = embed.image {
+            b = b.image(image.url);
         }
 
-        if let Some(title) = embed.title {
-            b.title(title);
+        if let Some(author) = embed.author {
+            b = b.author(author.into());
         }
 
         if let Some(footer) = embed.footer {
-            b.footer(move |f| {
-                if let Some(icon_url) = footer.icon_url {
-                    f.icon_url(icon_url);
-                }
-                f.text(footer.text)
-            });
+            b = b.footer(footer.into());
+        }
+
+        for field in embed.fields {
+            b = b.field(field.name, field.value, field.inline);
         }
 
         b
     }
 }
 
-/// A builder to create a fake [`Embed`] object's author, for use with the
-/// [`CreateEmbed::author`] method.
+/// A builder to create a fake [`Embed`] object's author, for use with the [`CreateEmbed::author`]
+/// method.
 ///
 /// Requires that you specify a [`Self::name`].
 ///
 /// [`Embed`]: crate::model::channel::Embed
 #[derive(Clone, Debug, Default, Serialize)]
+#[must_use]
 pub struct CreateEmbedAuthor {
     #[serde(skip_serializing_if = "Option::is_none")]
     icon_url: Option<String>,
@@ -481,31 +415,42 @@ pub struct CreateEmbedAuthor {
 
 impl CreateEmbedAuthor {
     /// Set the URL of the author's icon.
-    pub fn icon_url(&mut self, icon_url: impl Into<String>) -> &mut Self {
+    pub fn icon_url(mut self, icon_url: impl Into<String>) -> Self {
         self.icon_url = Some(icon_url.into());
         self
     }
 
     /// Set the author's name.
-    pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
     /// Set the author's URL.
-    pub fn url(&mut self, url: impl Into<String>) -> &mut Self {
+    pub fn url(mut self, url: impl Into<String>) -> Self {
         self.url = Some(url.into());
         self
     }
 }
 
-/// A builder to create a fake [`Embed`] object's footer, for use with the
-/// [`CreateEmbed::footer`] method.
+impl From<EmbedAuthor> for CreateEmbedAuthor {
+    fn from(author: EmbedAuthor) -> Self {
+        Self {
+            icon_url: author.icon_url,
+            name: Some(author.name),
+            url: author.url,
+        }
+    }
+}
+
+/// A builder to create a fake [`Embed`] object's footer, for use with the [`CreateEmbed::footer`]
+/// method.
 ///
-/// This does not require any field be set.
+/// This does not have any required fields.
 ///
 /// [`Embed`]: crate::model::channel::Embed
 #[derive(Clone, Debug, Default, Serialize)]
+#[must_use]
 pub struct CreateEmbedFooter {
     #[serde(skip_serializing_if = "Option::is_none")]
     icon_url: Option<String>,
@@ -515,15 +460,24 @@ pub struct CreateEmbedFooter {
 
 impl CreateEmbedFooter {
     /// Set the icon URL's value. This only supports HTTP(S).
-    pub fn icon_url(&mut self, icon_url: impl Into<String>) -> &mut Self {
+    pub fn icon_url(mut self, icon_url: impl Into<String>) -> Self {
         self.icon_url = Some(icon_url.into());
         self
     }
 
     /// Set the footer's text.
-    pub fn text(&mut self, text: impl Into<String>) -> &mut Self {
+    pub fn text(mut self, text: impl Into<String>) -> Self {
         self.text = Some(text.into());
         self
+    }
+}
+
+impl From<EmbedFooter> for CreateEmbedFooter {
+    fn from(footer: EmbedFooter) -> Self {
+        Self {
+            icon_url: footer.icon_url,
+            text: Some(footer.text),
+        }
     }
 }
 
@@ -577,12 +531,12 @@ mod test {
             }),
         };
 
-        let mut builder = CreateEmbed::from(embed);
-        builder.colour(0xFF0011);
-        builder.description("This is a hakase description");
-        builder.image("https://i.imgur.com/XfWpfCV.gif");
-        builder.title("still a hakase");
-        builder.url("https://i.imgur.com/XfWpfCV.gif");
+        let builder = CreateEmbed::from(embed)
+            .colour(0xFF0011)
+            .description("This is a hakase description")
+            .image("https://i.imgur.com/XfWpfCV.gif")
+            .title("still a hakase")
+            .url("https://i.imgur.com/XfWpfCV.gif");
 
         let built = to_value(builder).unwrap();
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -368,6 +368,6 @@ impl<'a> CreateAutocompleteResponse<'a> {
     /// Returns an [`Error::Http`] if the API returns an error.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().create_interaction_response(self.id.into(), &self.token, &self).await
+        http.as_ref().create_interaction_response(self.id.into(), self.token, &self).await
     }
 }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -13,8 +13,8 @@ use crate::model::prelude::*;
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateInteractionResponse<'a> {
-    #[serde(skip)]
     #[cfg(feature = "http")]
+    #[serde(skip)]
     id: InteractionId,
     #[serde(skip)]
     #[cfg(feature = "http")]
@@ -283,7 +283,9 @@ pub struct AutocompleteChoice {
 #[must_use]
 pub struct CreateAutocompleteResponse<'a> {
     #[cfg(feature = "http")]
+    #[serde(skip)]
     id: InteractionId,
+    #[serde(skip)]
     #[cfg(feature = "http")]
     token: &'a str,
     #[cfg(not(feature = "http"))]

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -8,8 +8,6 @@ use crate::constants;
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::application::interaction::{InteractionResponseType, MessageFlags};
-use crate::model::channel::AttachmentType;
-#[cfg(feature = "http")]
 use crate::model::prelude::*;
 
 #[derive(Clone, Debug, Serialize)]

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -177,12 +177,7 @@ impl<'a> CreateInteractionResponseData<'a> {
     }
 
     /// Create an embed for the message.
-    pub fn embed<F>(self, f: F) -> Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
+    pub fn embed(self, embed: CreateEmbed) -> Self {
         self.add_embed(embed)
     }
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -57,15 +57,7 @@ impl<'a> CreateInteractionResponse<'a> {
     }
 
     /// Sets the `InteractionApplicationCommandCallbackData` for the message.
-    pub fn interaction_response_data<F>(mut self, f: F) -> Self
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseData<'a>,
-        ) -> &'b mut CreateInteractionResponseData<'a>,
-    {
-        let mut data = CreateInteractionResponseData::default();
-        f(&mut data);
-
+    pub fn interaction_response_data(mut self, data: CreateInteractionResponseData<'a>) -> Self {
         self.data = Some(data);
         self
     }
@@ -117,6 +109,7 @@ impl<'a> CreateInteractionResponse<'a> {
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
+#[must_use]
 pub struct CreateInteractionResponseData<'a> {
     embeds: Vec<CreateEmbed>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -144,22 +137,22 @@ impl<'a> CreateInteractionResponseData<'a> {
     /// Think carefully before setting this to `true`.
     ///
     /// Defaults to `false`.
-    pub fn tts(&mut self, tts: bool) -> &mut Self {
+    pub fn tts(mut self, tts: bool) -> Self {
         self.tts = Some(tts);
         self
     }
 
     /// Appends a file to the message.
-    pub fn add_file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
+    pub fn add_file<T: Into<AttachmentType<'a>>>(mut self, file: T) -> Self {
         self.files.push(file.into());
         self
     }
 
     /// Appends a list of files to the message.
     pub fn add_files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
-        &mut self,
+        mut self,
         files: It,
-    ) -> &mut Self {
+    ) -> Self {
         self.files.extend(files.into_iter().map(Into::into));
         self
     }
@@ -169,9 +162,9 @@ impl<'a> CreateInteractionResponseData<'a> {
     /// Calling this multiple times will overwrite the file list.
     /// To append files, call [`Self::add_file`] or [`Self::add_files`] instead.
     pub fn files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
-        &mut self,
+        mut self,
         files: It,
-    ) -> &mut Self {
+    ) -> Self {
         self.files = files.into_iter().map(Into::into).collect();
         self
     }
@@ -180,13 +173,13 @@ impl<'a> CreateInteractionResponseData<'a> {
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
     #[inline]
-    pub fn content(&mut self, content: impl Into<String>) -> &mut Self {
+    pub fn content(mut self, content: impl Into<String>) -> Self {
         self.content = Some(content.into());
         self
     }
 
     /// Create an embed for the message.
-    pub fn embed<F>(&mut self, f: F) -> &mut Self
+    pub fn embed<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {
@@ -196,13 +189,13 @@ impl<'a> CreateInteractionResponseData<'a> {
     }
 
     /// Adds an embed to the message.
-    pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
+    pub fn add_embed(mut self, embed: CreateEmbed) -> Self {
         self.embeds.push(embed);
         self
     }
 
     /// Adds multiple embeds for the message.
-    pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+    pub fn add_embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
         self.embeds.extend(embeds);
         self
     }
@@ -211,22 +204,21 @@ impl<'a> CreateInteractionResponseData<'a> {
     ///
     /// Calling this will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
-    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        self.set_embeds(vec![embed]);
-        self
+    pub fn set_embed(self, embed: CreateEmbed) -> Self {
+        self.set_embeds(vec![embed])
     }
 
     /// Sets a list of embeds to include in the message.
     ///
     /// Calling this multiple times will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
-    pub fn set_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+    pub fn set_embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
         self.embeds = embeds.into_iter().collect();
         self
     }
 
     /// Set the allowed mentions for the message.
-    pub fn allowed_mentions<F>(&mut self, f: F) -> &mut Self
+    pub fn allowed_mentions<F>(mut self, f: F) -> Self
     where
         F: FnOnce(&mut CreateAllowedMentions) -> &mut CreateAllowedMentions,
     {
@@ -238,13 +230,13 @@ impl<'a> CreateInteractionResponseData<'a> {
     }
 
     /// Sets the flags for the message.
-    pub fn flags(&mut self, flags: MessageFlags) -> &mut Self {
+    pub fn flags(mut self, flags: MessageFlags) -> Self {
         self.flags = Some(flags);
         self
     }
 
     /// Adds or removes the ephemeral flag
-    pub fn ephemeral(&mut self, ephemeral: bool) -> &mut Self {
+    pub fn ephemeral(mut self, ephemeral: bool) -> Self {
         let flags = self.flags.unwrap_or_else(MessageFlags::empty);
 
         let flags = if ephemeral {
@@ -258,7 +250,7 @@ impl<'a> CreateInteractionResponseData<'a> {
     }
 
     /// Creates components for this message.
-    pub fn components<F>(&mut self, f: F) -> &mut Self
+    pub fn components<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
     {
@@ -269,19 +261,19 @@ impl<'a> CreateInteractionResponseData<'a> {
     }
 
     /// Sets the components of this message.
-    pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
+    pub fn set_components(mut self, components: CreateComponents) -> Self {
         self.components = Some(components);
         self
     }
 
     /// Sets the custom id for modal interactions
-    pub fn custom_id(&mut self, id: impl Into<String>) -> &mut Self {
+    pub fn custom_id(mut self, id: impl Into<String>) -> Self {
         self.custom_id = Some(id.into());
         self
     }
 
     /// Sets the title for modal interactions
-    pub fn title(&mut self, title: impl Into<String>) -> &mut Self {
+    pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -14,8 +14,8 @@ use crate::model::prelude::*;
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateInteractionResponseFollowup<'a> {
-    #[serde(skip)]
     #[cfg(feature = "http")]
+    #[serde(skip)]
     id: Option<MessageId>,
     #[serde(skip)]
     #[cfg(feature = "http")]

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -234,17 +234,17 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         match self.id {
             Some(id) => {
                 if files.is_empty() {
-                    http.edit_followup_message(&self.token, id.into(), &self).await
+                    http.edit_followup_message(self.token, id.into(), &self).await
                 } else {
-                    http.edit_followup_message_and_attachments(&self.token, id.into(), &self, files)
+                    http.edit_followup_message_and_attachments(self.token, id.into(), &self, files)
                         .await
                 }
             },
             None => {
                 if files.is_empty() {
-                    http.create_followup_message(&self.token, &self).await
+                    http.create_followup_message(self.token, &self).await
                 } else {
-                    http.create_followup_message_with_files(&self.token, &self, files).await
+                    http.create_followup_message_with_files(self.token, &self, files).await
                 }
             },
         }

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -129,12 +129,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Create an embed for the message.
-    pub fn embed<F>(self, f: F) -> Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
+    pub fn embed(self, embed: CreateEmbed) -> Self {
         self.add_embed(embed)
     }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -1,13 +1,28 @@
-#[cfg(not(feature = "model"))]
+#[cfg(not(feature = "http"))]
 use std::marker::PhantomData;
 
 use super::{CreateAllowedMentions, CreateComponents, CreateEmbed};
+#[cfg(feature = "http")]
+use crate::constants;
+#[cfg(feature = "http")]
+use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
 use crate::model::application::interaction::MessageFlags;
-#[cfg(feature = "model")]
-use crate::model::channel::AttachmentType;
+use crate::model::prelude::*;
 
 #[derive(Clone, Debug, Default, Serialize)]
+#[must_use]
 pub struct CreateInteractionResponseFollowup<'a> {
+    #[serde(skip)]
+    #[cfg(feature = "http")]
+    id: Option<MessageId>,
+    #[serde(skip)]
+    #[cfg(feature = "http")]
+    token: &'a str,
+    #[cfg(not(feature = "http"))]
+    token: PhantomData<&'a ()>,
+
     embeds: Vec<CreateEmbed>,
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
@@ -25,32 +40,54 @@ pub struct CreateInteractionResponseFollowup<'a> {
     components: Option<CreateComponents>,
 
     #[serde(skip)]
-    #[cfg(feature = "model")]
-    pub(crate) files: Vec<AttachmentType<'a>>,
-    #[cfg(not(feature = "model"))]
-    pub(crate) files: PhantomData<&'a ()>,
+    files: Vec<AttachmentType<'a>>,
 }
 
 impl<'a> CreateInteractionResponseFollowup<'a> {
+    pub fn new(
+        #[cfg(feature = "http")] id: Option<MessageId>,
+        #[cfg(feature = "http")] token: &'a str,
+    ) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            id,
+            #[cfg(feature = "http")]
+            token,
+            #[cfg(not(feature = "http"))]
+            token: PhantomData::default(),
+
+            embeds: Vec::new(),
+            content: None,
+            username: None,
+            avatar_url: None,
+            tts: None,
+            allowed_mentions: None,
+            flags: None,
+            components: None,
+
+            files: Vec::new(),
+        }
+    }
+
     /// Set the content of the message.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
     #[inline]
-    pub fn content(&mut self, content: impl Into<String>) -> &mut Self {
+    pub fn content(mut self, content: impl Into<String>) -> Self {
         self.content = Some(content.into());
         self
     }
 
     /// Override the default username of the webhook
     #[inline]
-    pub fn username(&mut self, username: impl Into<String>) -> &mut Self {
+    pub fn username(mut self, username: impl Into<String>) -> Self {
         self.username = Some(username.into());
         self
     }
 
     /// Override the default avatar of the webhook
     #[inline]
-    pub fn avatar(&mut self, avatar_url: impl Into<String>) -> &mut Self {
+    pub fn avatar(mut self, avatar_url: impl Into<String>) -> Self {
         self.avatar_url = Some(avatar_url.into());
         self
     }
@@ -60,24 +97,21 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     /// Think carefully before setting this to `true`.
     ///
     /// Defaults to `false`.
-    pub fn tts(&mut self, tts: bool) -> &mut Self {
+    pub fn tts(mut self, tts: bool) -> Self {
         self.tts = Some(tts);
         self
     }
 
     /// Appends a file to the message.
-    #[cfg(feature = "model")]
-    pub fn add_file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
-        self.add_files(vec![file]);
-        self
+    pub fn add_file<T: Into<AttachmentType<'a>>>(self, file: T) -> Self {
+        self.add_files(vec![file])
     }
 
     /// Appends a list of files to the message.
-    #[cfg(feature = "model")]
     pub fn add_files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
-        &mut self,
+        mut self,
         files: It,
-    ) -> &mut Self {
+    ) -> Self {
         self.files.extend(files.into_iter().map(Into::into));
         self
     }
@@ -86,17 +120,16 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ///
     /// Calling this multiple times will overwrite the file list.
     /// To append files, call [`Self::add_file`] or [`Self::add_files`] instead.
-    #[cfg(feature = "model")]
     pub fn files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
-        &mut self,
+        mut self,
         files: It,
-    ) -> &mut Self {
+    ) -> Self {
         self.files = files.into_iter().map(Into::into).collect();
         self
     }
 
     /// Create an embed for the message.
-    pub fn embed<F>(&mut self, f: F) -> &mut Self
+    pub fn embed<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
     {
@@ -106,13 +139,13 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Adds an embed to the message.
-    pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
+    pub fn add_embed(mut self, embed: CreateEmbed) -> Self {
         self.embeds.push(embed);
         self
     }
 
     /// Adds multiple embeds to the message.
-    pub fn add_embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+    pub fn add_embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
         self.embeds.extend(embeds);
         self
     }
@@ -121,22 +154,21 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ///
     /// Calling this will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
-    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
-        self.set_embeds(vec![embed]);
-        self
+    pub fn set_embed(self, embed: CreateEmbed) -> Self {
+        self.set_embeds(vec![embed])
     }
 
     /// Sets a list of embeds to include in the message.
     ///
     /// Calling this multiple times will overwrite the embed list.
     /// To append embeds, call [`Self::add_embed`] instead.
-    pub fn set_embeds(&mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> &mut Self {
+    pub fn set_embeds(mut self, embeds: impl IntoIterator<Item = CreateEmbed>) -> Self {
         self.embeds = embeds.into_iter().collect();
         self
     }
 
     /// Set the allowed mentions for the message.
-    pub fn allowed_mentions<F>(&mut self, f: F) -> &mut Self
+    pub fn allowed_mentions<F>(mut self, f: F) -> Self
     where
         F: FnOnce(&mut CreateAllowedMentions) -> &mut CreateAllowedMentions,
     {
@@ -148,13 +180,13 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Sets the flags for the response.
-    pub fn flags(&mut self, flags: MessageFlags) -> &mut Self {
+    pub fn flags(mut self, flags: MessageFlags) -> Self {
         self.flags = Some(flags);
         self
     }
 
     /// Adds or removes the ephemeral flag
-    pub fn ephemeral(&mut self, ephemeral: bool) -> &mut Self {
+    pub fn ephemeral(mut self, ephemeral: bool) -> Self {
         let flags = self.flags.unwrap_or_else(MessageFlags::empty);
 
         let flags = if ephemeral {
@@ -168,7 +200,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Creates components for this message.
-    pub fn components<F>(&mut self, f: F) -> &mut Self
+    pub fn components<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
     {
@@ -179,8 +211,67 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Sets the components of this message.
-    pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
+    pub fn set_components(mut self, components: CreateComponents) -> Self {
         self.components = Some(components);
         self
+    }
+
+    /// Creates/Edits a followup response to the response sent.
+    ///
+    /// **Note**: Message contents must be under 2000 unicode code points, and embeds must be under
+    /// 6000 unicode code points.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Model`] if the message content is too long. May also return an
+    /// [`Error::Http`] if invalid data is provided, or an [`Error::Json`] if there is an error
+    /// when deserializing the API response.
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: impl AsRef<Http>) -> Result<Message> {
+        self.check_lengths()?;
+        self._execute(http.as_ref()).await
+    }
+
+    #[cfg(feature = "http")]
+    async fn _execute(mut self, http: &Http) -> Result<Message> {
+        let files = std::mem::take(&mut self.files);
+
+        match self.id {
+            Some(id) => {
+                if files.is_empty() {
+                    http.edit_followup_message(&self.token, id.into(), &self).await
+                } else {
+                    http.edit_followup_message_and_attachments(&self.token, id.into(), &self, files)
+                        .await
+                }
+            },
+            None => {
+                if files.is_empty() {
+                    http.create_followup_message(&self.token, &self).await
+                } else {
+                    http.create_followup_message_with_files(&self.token, &self, files).await
+                }
+            },
+        }
+    }
+
+    #[cfg(feature = "http")]
+    fn check_lengths(&self) -> Result<()> {
+        if let Some(ref content) = self.content {
+            let length = content.chars().count();
+            let max_length = constants::MESSAGE_CODE_LIMIT;
+            if length > max_length {
+                let overflow = length - max_length;
+                return Err(Error::Model(ModelError::MessageTooLong(overflow)));
+            }
+        }
+
+        if self.embeds.len() > constants::EMBED_MAX_COUNT {
+            return Err(Error::Model(ModelError::EmbedAmount));
+        }
+        for embed in &self.embeds {
+            embed.check_length()?;
+        }
+        Ok(())
     }
 }

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -72,6 +72,7 @@ use crate::model::prelude::*;
 /// [`GuildChannel::create_invite`]: crate::model::channel::GuildChannel::create_invite
 /// [`RichInvite`]: crate::model::invite::RichInvite
 #[derive(Clone, Debug, Serialize)]
+#[must_use]
 pub struct CreateInvite {
     #[cfg(feature = "http")]
     #[serde(skip)]
@@ -281,10 +282,8 @@ impl CreateInvite {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`]
-    /// if the current user does not have permission to create invites.
-    ///
-    /// Otherwise returns [`Error::Http`] if the current user lacks permission.
+    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`] if the current user
+    /// does not have permission to create invites. Otherwise, returns [`Error::Http`].
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     #[cfg(feature = "http")]

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -7,20 +7,19 @@ use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// A builder to specify the contents of an [`Http::send_message`] request,
-/// primarily meant for use through [`ChannelId::send_message`].
+/// A builder to specify the contents of an [`Http::send_message`] request, primarily meant for use
+/// through [`ChannelId::send_message`].
 ///
 /// There are three situations where different field requirements are present:
 ///
-/// 1. When sending a message without embeds or stickers, [`Self::content`] is
-///    the only required field that is required to be set.
+/// 1. When sending a message without embeds or stickers, [`Self::content`] is the only required
+///    field that is required to be set.
 /// 2. When sending an [`Self::embed`], no other field is required.
-/// 3. When sending stickers with [`Self::sticker_id`] or other sticker methods,
-///    no other field is required.
+/// 3. When sending stickers with [`Self::sticker_id`] or other sticker methods, no other field is
+///    required.
 ///
-/// Note that if you only need to send the content of a message, without
-/// specifying other fields, then [`ChannelId::say`] may be a more preferable
-/// option.
+/// Note that if you only need to send the content of a message, without specifying other fields,
+/// then [`ChannelId::say`] may be a more preferable option.
 ///
 /// # Examples
 ///
@@ -186,8 +185,8 @@ impl<'a> CreateMessage<'a> {
 
     /// Sets a list of files to include in the message.
     ///
-    /// Calling this multiple times will overwrite the file list.
-    /// To append files, call [`Self::add_file`] or [`Self::add_files`] instead.
+    /// Calling this multiple times will overwrite the file list. To append files, call
+    /// [`Self::add_file`] or [`Self::add_files`] instead.
     ///
     /// **Note**: Requres the [Attach Files] permission.
     ///
@@ -242,20 +241,12 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    /// Sets a single sticker ID to include in the message.
-    ///
-    /// **Note**: This will replace all existing stickers. Use
-    /// [`Self::add_sticker_id()`] to add an additional sticker.
-    pub fn sticker_id(self, sticker_id: impl Into<StickerId>) -> Self {
-        self.set_sticker_ids(vec![sticker_id.into()])
-    }
-
     /// Add a sticker ID for the message.
     ///
     /// **Note**: There can be a maximum of 3 stickers in a message.
     ///
-    /// **Note**: This will keep all existing stickers. Use
-    /// [`Self::set_sticker_ids()`] to replace existing stickers.
+    /// **Note**: This will keep all existing stickers. Use [`Self::sticker_ids()`] to replace
+    /// existing stickers.
     pub fn add_sticker_id(mut self, sticker_id: impl Into<StickerId>) -> Self {
         self.sticker_ids.push(sticker_id.into());
         self
@@ -265,8 +256,8 @@ impl<'a> CreateMessage<'a> {
     ///
     /// **Note**: There can be a maximum of 3 stickers in a message.
     ///
-    /// **Note**: This will keep all existing stickers. Use
-    /// [`Self::set_sticker_ids()`] to replace existing stickers.
+    /// **Note**: This will keep all existing stickers. Use [`Self::sticker_ids()`] to replace
+    /// existing stickers.
     pub fn add_sticker_ids<T: Into<StickerId>, It: IntoIterator<Item = T>>(
         mut self,
         sticker_ids: It,
@@ -277,14 +268,21 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
+    /// Sets a single sticker ID to include in the message.
+    ///
+    /// **Note**: This will replace all existing stickers. Use [`Self::add_sticker_id()`] to add an
+    /// additional sticker.
+    pub fn sticker_id(self, sticker_id: impl Into<StickerId>) -> Self {
+        self.sticker_ids(vec![sticker_id.into()])
+    }
+
     /// Sets a list of sticker IDs to include in the message.
     ///
     /// **Note**: There can be a maximum of 3 stickers in a message.
     ///
-    /// **Note**: This will replace all existing stickers. Use
-    /// [`Self::add_sticker_id()`] or [`Self::add_sticker_ids()`] to keep
-    /// existing stickers.
-    pub fn set_sticker_ids<T: Into<StickerId>, It: IntoIterator<Item = T>>(
+    /// **Note**: This will replace all existing stickers. Use [`Self::add_sticker_ids()`] or
+    /// [`Self::add_sticker_ids()`] to keep existing stickers.
+    pub fn sticker_ids<T: Into<StickerId>, It: IntoIterator<Item = T>>(
         mut self,
         sticker_ids: It,
     ) -> Self {

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -27,6 +27,7 @@ use crate::model::prelude::*;
 /// Sending a message with a content of `"test"` and applying text-to-speech:
 ///
 /// ```rust,no_run
+/// use serenity::builder::CreateEmbed;
 /// use serenity::model::id::ChannelId;
 /// # use serenity::http::Http;
 /// # use std::sync::Arc;
@@ -36,19 +37,10 @@ use crate::model::prelude::*;
 ///
 /// let channel_id = ChannelId::new(7);
 ///
-/// let _ = channel_id
-///     .send_message()
-///     .content("test")
-///     .tts(true)
-///     .embed(|e| e.title("This is an embed").description("With a description"))
-///     .execute(&http)
-///     .await;
+/// let embed = CreateEmbed::default().title("This is an embed").description("With a description");
+/// let _ = channel_id.send_message().content("test").tts(true).embed(embed).execute(&http).await;
 /// # }
 /// ```
-///
-/// [`ChannelId::say`]: crate::model::id::ChannelId::say
-/// [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
-/// [`Http::send_message`]: crate::http::client::Http::send_message
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateMessage<'a> {
@@ -116,25 +108,16 @@ impl<'a> CreateMessage<'a> {
 
     /// Add an embed for the message.
     ///
-    /// **Note**: This will keep all existing embeds. Use [`Self::set_embed()`] to replace existing
+    /// **Note**: This will keep all existing embeds. Use [`Self::embed()`] to replace existing
     /// embeds.
-    pub fn add_embed<F>(self, f: F) -> Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
-        self._add_embed(embed)
-    }
-
-    fn _add_embed(mut self, embed: CreateEmbed) -> Self {
+    pub fn add_embed(mut self, embed: CreateEmbed) -> Self {
         self.embeds.push(embed);
         self
     }
 
     /// Add multiple embeds for the message.
     ///
-    /// **Note**: This will keep all existing embeds. Use [`Self::set_embeds()`] to replace existing
+    /// **Note**: This will keep all existing embeds. Use [`Self::embeds()`] to replace existing
     /// embeds.
     pub fn add_embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
         self.embeds.extend(embeds);
@@ -143,35 +126,17 @@ impl<'a> CreateMessage<'a> {
 
     /// Set an embed for the message.
     ///
-    /// Equivalent to [`Self::set_embed()`].
-    ///
-    /// **Note**: This will replace all existing embeds. Use
-    /// [`Self::add_embed()`] to add an additional embed.
-    pub fn embed<F>(self, f: F) -> Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
-
-        self.set_embed(embed)
-    }
-
-    /// Set an embed for the message.
-    ///
-    /// Equivalent to [`Self::embed()`].
-    ///
-    /// **Note**: This will replace all existing embeds.
-    /// Use [`Self::add_embed()`] to add an additional embed.
-    pub fn set_embed(self, embed: CreateEmbed) -> Self {
-        self.set_embeds(vec![embed])
+    /// **Note**: This will replace all existing embeds. Use [`Self::add_embed()`] to keep existing
+    /// embeds.
+    pub fn embed(self, embed: CreateEmbed) -> Self {
+        self.embeds(vec![embed])
     }
 
     /// Set multiple embeds for the message.
     ///
     /// **Note**: This will replace all existing embeds. Use [`Self::add_embeds()`] to keep existing
     /// embeds.
-    pub fn set_embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
+    pub fn embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
         self.embeds = embeds;
         self
     }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -154,8 +154,8 @@ impl CreateScheduledEvent {
     }
 
     #[cfg(feature = "model")]
-    async fn _execute(self, http: impl AsRef<Http>) -> Result<ScheduledEvent> {
-        http.as_ref().create_scheduled_event(self.id.into(), &self.fields, None).await
+    async fn _execute(self, http: &Http) -> Result<ScheduledEvent> {
+        http.create_scheduled_event(self.id.into(), &self.fields, None).await
     }
 }
 

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -120,8 +120,8 @@ impl CreateScheduledEvent {
     ///
     /// # Errors
     ///
-    /// May error if the icon is a URL and the HTTP request fails, or if the image is a file
-    /// on a path that doesn't exist.
+    /// May error if a URL is given and the HTTP request fails, or if a path is given to a file
+    /// that does not exist.
     #[cfg(feature = "http")]
     pub async fn image<'a>(
         mut self,
@@ -131,6 +131,14 @@ impl CreateScheduledEvent {
         let image_data = image.into().data(&http.as_ref().client).await?;
         self.image = Some(encode_image(&image_data));
         Ok(self)
+    }
+
+    /// Sets the cover image for the scheduled event. Requires the input be a base64-encoded image
+    /// that is in either JPG, GIF, or PNG format.
+    #[cfg(not(feature = "http"))]
+    pub fn image(mut self, image: String) -> Self {
+        self.image = Some(image);
+        self
     }
 
     /// Creates a new scheduled event in the guild with the data set, if any.

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -140,9 +140,7 @@ impl CreateScheduledEvent {
     /// # Errors
     ///
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to manage scheduled events.
-    ///
-    /// Otherwise will return [`Error::Http`] if the current user does not have permission.
+    /// does not have permission to manage scheduled events. Otherwise, returns [`Error::Http`].
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     #[cfg(feature = "http")]

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -1,11 +1,17 @@
-use crate::http::CacheHttp;
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::utils::encode_image;
+
+#[derive(Clone, Debug)]
+#[must_use]
+pub struct CreateScheduledEvent {
+    id: GuildId,
+    fields: CreateScheduledEventFields,
+}
 
 #[derive(Clone, Debug, Serialize)]
 pub struct CreateScheduledEventFields {
@@ -29,12 +35,6 @@ pub struct CreateScheduledEventFields {
     privacy_level: u8,
 }
 
-#[derive(Clone, Debug)]
-pub struct CreateScheduledEvent {
-    id: GuildId,
-    fields: CreateScheduledEventFields,
-}
-
 impl CreateScheduledEvent {
     /// Creates a builder with default values, setting the `privacy_level` to `GUILD_ONLY`. As this
     /// is the only possible value of this field, it's only used at event creation, and we don't
@@ -52,21 +52,18 @@ impl CreateScheduledEvent {
     /// [`kind`]: CreateScheduledEvent::kind
     /// [`StageInstance`]: ScheduledEventType::StageInstance
     /// [`Voice`]: ScheduledEventType::Voice
-    #[must_use]
     pub fn channel_id<C: Into<ChannelId>>(mut self, channel_id: C) -> Self {
         self.fields.channel_id = Some(channel_id.into());
         self
     }
 
     /// Sets the name of the scheduled event. Required to be set for event creation.
-    #[must_use]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.fields.name = Some(name.into());
         self
     }
 
     /// Sets the description of the scheduled event.
-    #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.fields.description = Some(description.into());
         self
@@ -74,7 +71,6 @@ impl CreateScheduledEvent {
 
     /// Sets the start time of the scheduled event. Required to be set for event creation.
     #[inline]
-    #[must_use]
     pub fn start_time<T: Into<Timestamp>>(mut self, timestamp: T) -> Self {
         self.fields.scheduled_start_time = Some(timestamp.into().to_string());
         self
@@ -86,14 +82,12 @@ impl CreateScheduledEvent {
     /// [`kind`]: CreateScheduledEvent::kind
     /// [`External`]: ScheduledEventType::External
     #[inline]
-    #[must_use]
     pub fn end_time<T: Into<Timestamp>>(mut self, timestamp: T) -> Self {
         self.fields.scheduled_end_time = Some(timestamp.into().to_string());
         self
     }
 
     /// Sets the entity type of the scheduled event. Required to be set for event creation.
-    #[must_use]
     pub fn kind(mut self, kind: ScheduledEventType) -> Self {
         self.fields.entity_type = Some(kind);
         self
@@ -104,7 +98,6 @@ impl CreateScheduledEvent {
     ///
     /// [`kind`]: CreateScheduledEvent::kind
     /// [`External`]: ScheduledEventType::External
-    #[must_use]
     pub fn location(mut self, location: impl Into<String>) -> Self {
         self.fields.entity_metadata = Some(ScheduledEventMetadata {
             location: location.into(),
@@ -141,6 +134,8 @@ impl CreateScheduledEvent {
     /// Otherwise will return [`Error::Http`] if the current user does not have permission.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
+    #[cfg(feature = "model")]
+    #[inline]
     pub async fn execute(self, cache_http: impl CacheHttp) -> Result<ScheduledEvent> {
         #[cfg(feature = "cache")]
         {
@@ -158,6 +153,7 @@ impl CreateScheduledEvent {
         self._execute(cache_http.http()).await
     }
 
+    #[cfg(feature = "model")]
     async fn _execute(self, http: impl AsRef<Http>) -> Result<ScheduledEvent> {
         http.as_ref().create_scheduled_event(self.id.into(), &self.fields, None).await
     }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -135,26 +135,13 @@ impl CreateScheduledEvent {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    ///
-    /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn execute(self, http: impl AsRef<Http>) -> Result<ScheduledEvent> {
-        http.as_ref().create_scheduled_event(self.id.into(), &self.fields, None).await
-    }
-
-    /// Creates a new scheduled event in the guild with the data set, if any.
-    ///
-    /// **Note**: Requres the [Manage Events] permission.
-    ///
-    /// # Errors
-    ///
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
     /// does not have permission to manage scheduled events.
     ///
     /// Otherwise will return [`Error::Http`] if the current user does not have permission.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn execute_with_cache(self, cache_http: impl CacheHttp) -> Result<ScheduledEvent> {
+    pub async fn execute(self, cache_http: impl CacheHttp) -> Result<ScheduledEvent> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
@@ -168,7 +155,11 @@ impl CreateScheduledEvent {
             }
         }
 
-        self.execute(cache_http.http()).await
+        self._execute(cache_http.http()).await
+    }
+
+    async fn _execute(self, http: impl AsRef<Http>) -> Result<ScheduledEvent> {
+        http.as_ref().create_scheduled_event(self.id.into(), &self.fields, None).await
     }
 }
 

--- a/src/builder/create_stage_instance.rs
+++ b/src/builder/create_stage_instance.rs
@@ -1,26 +1,60 @@
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+#[cfg(all(feature = "http", feature = "cache"))]
+use crate::model::channel::ChannelType;
+#[cfg(feature = "http")]
+use crate::model::channel::StageInstance;
 use crate::model::id::ChannelId;
+#[cfg(all(feature = "http", feature = "cache"))]
+use crate::model::prelude::*;
 
 /// Creates a [`StageInstance`].
 ///
 /// [`StageInstance`]: crate::model::channel::StageInstance
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
 pub struct CreateStageInstance {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    channel_id: Option<ChannelId>,
+    channel_id: ChannelId,
     #[serde(skip_serializing_if = "Option::is_none")]
     topic: Option<String>,
 }
 
 impl CreateStageInstance {
-    // Sets the stage channel id of the stage channel instance.
-    pub fn channel_id(&mut self, id: impl Into<ChannelId>) -> &mut Self {
-        self.channel_id = Some(id.into());
-        self
+    pub fn new(id: impl Into<ChannelId>) -> Self {
+        Self {
+            channel_id: id.into(),
+            topic: None,
+        }
     }
 
     /// Sets the topic of the stage channel instance.
-    pub fn topic(&mut self, topic: impl Into<String>) -> &mut Self {
+    pub fn topic(mut self, topic: impl Into<String>) -> Self {
         self.topic = Some(topic.into());
         self
+    }
+
+    /// Creates the stage instance.
+    ///
+    /// # Errors
+    ///
+    /// If the `cache` is enabled, returns [`ModelError::InvalidChannelType`] if the channel is not
+    /// a stage channel. Otherwise, returns [`Error::Http`], as well as if there is a already a
+    /// stage instance currently.
+    #[cfg(feature = "http")]
+    pub async fn execute(self, cache_http: impl CacheHttp) -> Result<StageInstance> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(cache) = cache_http.cache() {
+                if let Some(channel) = cache.guild_channel(self.channel_id) {
+                    if channel.kind != ChannelType::Stage {
+                        return Err(Error::Model(ModelError::InvalidChannelType));
+                    }
+                }
+            }
+        }
+
+        cache_http.http().create_stage_instance(&self).await
     }
 }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -1,10 +1,11 @@
-use std::borrow::Cow;
-
+use crate::http::CacheHttp;
+#[cfg(feature = "model")]
+use crate::http::Http;
+use crate::internal::prelude::*;
 use crate::model::channel::AttachmentType;
+use crate::model::prelude::*;
 
-type Field = (Cow<'static, str>, Cow<'static, str>);
-
-/// A builder to create or edit a [`Sticker`] for use via a number of model methods.
+/// A builder to create a [`Sticker`] for use via a number of model methods.
 ///
 /// These are:
 ///
@@ -16,65 +17,118 @@ type Field = (Cow<'static, str>, Cow<'static, str>);
 /// [`PartialGuild::create_sticker`]: crate::model::guild::PartialGuild::create_sticker
 /// [`Guild::create_sticker`]: crate::model::guild::Guild::create_sticker
 /// [`GuildId::create_sticker`]: crate::model::id::GuildId::create_sticker
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct CreateSticker<'a> {
-    name: Option<String>,
-    tags: Option<String>,
-    description: Option<String>,
+    id: GuildId,
+    fields: CreateStickerFields,
+    file: Option<AttachmentType<'a>>,
+}
 
-    pub(crate) file: Option<AttachmentType<'a>>,
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CreateStickerFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tags: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
 }
 
 impl<'a> CreateSticker<'a> {
+    pub(crate) fn new(id: GuildId) -> Self {
+        Self {
+            id,
+            fields: CreateStickerFields::default(),
+            file: None,
+        }
+    }
+
     /// The name of the sticker to set.
     ///
     /// **Note**: Must be between 2 and 30 characters long.
-    pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.name = Some(name.into());
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.fields.name = Some(name.into());
         self
     }
 
     /// The description of the sticker.
     ///
     /// **Note**: If not empty, must be between 2 and 100 characters long.
-    pub fn description(&mut self, description: impl Into<String>) -> &mut Self {
-        self.description = Some(description.into());
+    #[must_use]
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.fields.description = Some(description.into());
         self
     }
 
     /// The Discord name of a unicode emoji representing the sticker's expression.
     ///
     /// **Note**: Must be between 2 and 200 characters long.
-    pub fn tags(&mut self, tags: impl Into<String>) -> &mut Self {
-        self.tags = Some(tags.into());
+    #[must_use]
+    pub fn tags(mut self, tags: impl Into<String>) -> Self {
+        self.fields.tags = Some(tags.into());
         self
     }
 
     /// The sticker file.
     ///
     /// **Note**: Must be a PNG, APNG, or Lottie JSON file, max 500 KB.
-    pub fn file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
+    #[must_use]
+    pub fn file<T: Into<AttachmentType<'a>>>(mut self, file: T) -> Self {
         self.file = Some(file.into());
         self
     }
 
-    #[must_use]
-    pub fn build(self) -> Option<(Vec<Field>, AttachmentType<'a>)> {
-        let file = self.file?;
-        let mut buf = Vec::with_capacity(3);
+    /// Executes the request to create a new sticker in the guild with the data set, if any.
+    ///
+    /// **Note**: Requires the [Manage Emojis and Stickers] permission.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
+    ///
+    /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
+    pub async fn execute(self, http: impl AsRef<Http>) -> Result<Sticker> {
+        let file = self.file.ok_or(Error::Model(ModelError::NoStickerFileSet))?;
 
-        if let Some(name) = self.name {
-            buf.push(("name".into(), name.into()));
+        let mut map = Vec::with_capacity(3);
+        if let Some(name) = self.fields.name {
+            map.push(("name", name));
+        }
+        if let Some(tags) = self.fields.tags {
+            map.push(("tags", tags));
+        }
+        if let Some(description) = self.fields.description {
+            map.push(("description", description));
         }
 
-        if let Some(description) = self.description {
-            buf.push(("description".into(), description.into()));
+        http.as_ref().create_sticker(self.id.into(), map, file, None).await
+    }
+
+    /// Executes the request to create a new sticker in the guild with the data set, if any.
+    ///
+    /// **Note**: Requires the [Manage Emojis and Stickers] permission.
+    ///
+    /// # Errors
+    ///
+    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
+    /// lacks permission. Otherwise, returns [`Error::Http`] - see [`Self::execute`].
+    ///
+    /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
+    pub async fn execute_with_cache(self, cache_http: impl CacheHttp) -> Result<Sticker> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(cache) = cache_http.cache() {
+                if let Some(guild) = cache.guild(self.id) {
+                    let req = Permissions::MANAGE_EMOJIS_AND_STICKERS;
+
+                    if !guild.has_perms(&cache_http, req).await {
+                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                    }
+                }
+            }
         }
 
-        if let Some(tags) = self.tags {
-            buf.push(("tags".into(), tags.into()));
-        }
-
-        Some((buf, file))
+        self.execute(cache_http.http()).await
     }
 }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -115,13 +115,13 @@ impl<'a> CreateSticker<'a> {
 
         let mut map = Vec::with_capacity(3);
         if let Some(name) = self.name {
-            map.push(("name", name));
+            map.push(("name".to_string(), name));
         }
         if let Some(tags) = self.tags {
-            map.push(("tags", tags));
+            map.push(("tags".to_string(), tags));
         }
         if let Some(description) = self.description {
-            map.push(("description", description));
+            map.push(("description".to_string(), description));
         }
 
         http.create_sticker(self.id.into(), map, file, None).await

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -87,7 +87,7 @@ impl<'a> CreateSticker<'a> {
     /// # Errors
     ///
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise, returns [`Error::Http`] - see [`Self::execute`].
+    /// lacks permission. Otherwise, returns [`Error::Http`].
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[cfg(feature = "http")]

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -106,7 +106,7 @@ impl<'a> CreateSticker<'a> {
     }
 
     #[cfg(feature = "model")]
-    async fn _execute(self, http: impl AsRef<Http>) -> Result<Sticker> {
+    async fn _execute(self, http: &Http) -> Result<Sticker> {
         let file = self.file.ok_or(Error::Model(ModelError::NoStickerFileSet))?;
 
         let mut map = Vec::with_capacity(3);
@@ -120,6 +120,6 @@ impl<'a> CreateSticker<'a> {
             map.push(("description", description));
         }
 
-        http.as_ref().create_sticker(self.id.into(), map, file, None).await
+        http.create_sticker(self.id.into(), map, file, None).await
     }
 }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -1,6 +1,6 @@
-use crate::http::CacheHttp;
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
+#[cfg(feature = "model")]
 use crate::internal::prelude::*;
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
@@ -18,6 +18,7 @@ use crate::model::prelude::*;
 /// [`Guild::create_sticker`]: crate::model::guild::Guild::create_sticker
 /// [`GuildId::create_sticker`]: crate::model::id::GuildId::create_sticker
 #[derive(Clone, Debug)]
+#[must_use]
 pub struct CreateSticker<'a> {
     id: GuildId,
     fields: CreateStickerFields,
@@ -46,7 +47,6 @@ impl<'a> CreateSticker<'a> {
     /// The name of the sticker to set.
     ///
     /// **Note**: Must be between 2 and 30 characters long.
-    #[must_use]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.fields.name = Some(name.into());
         self
@@ -55,7 +55,6 @@ impl<'a> CreateSticker<'a> {
     /// The description of the sticker.
     ///
     /// **Note**: If not empty, must be between 2 and 100 characters long.
-    #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.fields.description = Some(description.into());
         self
@@ -64,7 +63,6 @@ impl<'a> CreateSticker<'a> {
     /// The Discord name of a unicode emoji representing the sticker's expression.
     ///
     /// **Note**: Must be between 2 and 200 characters long.
-    #[must_use]
     pub fn tags(mut self, tags: impl Into<String>) -> Self {
         self.fields.tags = Some(tags.into());
         self
@@ -73,7 +71,6 @@ impl<'a> CreateSticker<'a> {
     /// The sticker file.
     ///
     /// **Note**: Must be a PNG, APNG, or Lottie JSON file, max 500 KB.
-    #[must_use]
     pub fn file<T: Into<AttachmentType<'a>>>(mut self, file: T) -> Self {
         self.file = Some(file.into());
         self
@@ -89,6 +86,7 @@ impl<'a> CreateSticker<'a> {
     /// lacks permission. Otherwise, returns [`Error::Http`] - see [`Self::execute`].
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
+    #[cfg(feature = "model")]
     #[inline]
     pub async fn execute(self, cache_http: impl CacheHttp) -> Result<Sticker> {
         #[cfg(feature = "cache")]
@@ -107,6 +105,7 @@ impl<'a> CreateSticker<'a> {
         self._execute(cache_http.http()).await
     }
 
+    #[cfg(feature = "model")]
     async fn _execute(self, http: impl AsRef<Http>) -> Result<Sticker> {
         let file = self.file.ok_or(Error::Model(ModelError::NoStickerFileSet))?;
 

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -1,10 +1,12 @@
 #[cfg(feature = "model")]
 use crate::http::Http;
+#[cfg(feature = "model")]
 use crate::internal::prelude::*;
 use crate::model::channel::ChannelType;
 use crate::model::prelude::*;
 
 #[derive(Clone, Debug)]
+#[must_use]
 pub struct CreateThread {
     channel_id: ChannelId,
     message_id: Option<MessageId>,
@@ -37,7 +39,6 @@ impl CreateThread {
     /// The name of the thread.
     ///
     /// **Note**: Must be between 2 and 100 characters long.
-    #[must_use]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.fields.name = Some(name.into());
         self
@@ -46,7 +47,6 @@ impl CreateThread {
     /// Duration in minutes to automatically archive the thread after recent activity.
     ///
     /// **Note**: Can only be set to 60, 1440, 4320, 10080 currently.
-    #[must_use]
     pub fn auto_archive_duration(mut self, duration: u16) -> Self {
         self.fields.auto_archive_duration = Some(duration);
         self
@@ -62,7 +62,6 @@ impl CreateThread {
     /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
     /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
     #[doc(alias = "slowmode")]
-    #[must_use]
     pub fn rate_limit_per_user(mut self, seconds: u16) -> Self {
         self.fields.rate_limit_per_user = Some(seconds);
         self
@@ -74,7 +73,6 @@ impl CreateThread {
     /// when thread documentation was first published. This is a bit of a weird default though,
     /// and thus is highly likely to change in the future, so it is recommended to always
     /// explicitly setting it to avoid any breaking change.
-    #[must_use]
     pub fn kind(mut self, kind: ChannelType) -> Self {
         self.fields.kind = Some(kind);
         self
@@ -86,6 +84,7 @@ impl CreateThread {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
+    #[cfg(feature = "model")]
     pub async fn execute(self, http: impl AsRef<Http>) -> Result<GuildChannel> {
         match self.message_id {
             Some(msg_id) => {

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -1,7 +1,18 @@
+#[cfg(feature = "model")]
+use crate::http::Http;
+use crate::internal::prelude::*;
 use crate::model::channel::ChannelType;
+use crate::model::prelude::*;
+
+#[derive(Clone, Debug)]
+pub struct CreateThread {
+    channel_id: ChannelId,
+    message_id: Option<MessageId>,
+    fields: CreateThreadFields,
+}
 
 #[derive(Clone, Debug, Default, Serialize)]
-pub struct CreateThread {
+pub struct CreateThreadFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -15,21 +26,29 @@ pub struct CreateThread {
 }
 
 impl CreateThread {
+    pub(crate) fn new(channel_id: ChannelId, message_id: Option<MessageId>) -> Self {
+        Self {
+            channel_id,
+            message_id,
+            fields: CreateThreadFields::default(),
+        }
+    }
+
     /// The name of the thread.
     ///
     /// **Note**: Must be between 2 and 100 characters long.
-    pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
-        self.name = Some(name.into());
-
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.fields.name = Some(name.into());
         self
     }
 
     /// Duration in minutes to automatically archive the thread after recent activity.
     ///
     /// **Note**: Can only be set to 60, 1440, 4320, 10080 currently.
-    pub fn auto_archive_duration(&mut self, duration: u16) -> &mut Self {
-        self.auto_archive_duration = Some(duration);
-
+    #[must_use]
+    pub fn auto_archive_duration(mut self, duration: u16) -> Self {
+        self.fields.auto_archive_duration = Some(duration);
         self
     }
 
@@ -43,9 +62,9 @@ impl CreateThread {
     /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
     /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
     #[doc(alias = "slowmode")]
-    pub fn rate_limit_per_user(&mut self, seconds: u16) -> &mut Self {
-        self.rate_limit_per_user = Some(seconds);
-
+    #[must_use]
+    pub fn rate_limit_per_user(mut self, seconds: u16) -> Self {
+        self.fields.rate_limit_per_user = Some(seconds);
         self
     }
 
@@ -55,9 +74,26 @@ impl CreateThread {
     /// when thread documentation was first published. This is a bit of a weird default though,
     /// and thus is highly likely to change in the future, so it is recommended to always
     /// explicitly setting it to avoid any breaking change.
-    pub fn kind(&mut self, kind: ChannelType) -> &mut Self {
-        self.kind = Some(kind);
-
+    #[must_use]
+    pub fn kind(mut self, kind: ChannelType) -> Self {
+        self.fields.kind = Some(kind);
         self
+    }
+
+    /// Executes the request to create a thread, either private or public. Public threads require a
+    /// message to connect the thread to.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn execute(self, http: impl AsRef<Http>) -> Result<GuildChannel> {
+        match self.message_id {
+            Some(msg_id) => {
+                http.as_ref()
+                    .create_public_thread(self.channel_id.into(), msg_id.into(), &self.fields)
+                    .await
+            },
+            None => http.as_ref().create_private_thread(self.channel_id.into(), &self.fields).await,
+        }
     }
 }

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -4,6 +4,8 @@ use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::prelude::*;
+#[cfg(feature = "http")]
+use crate::utils::encode_image;
 
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
@@ -35,8 +37,26 @@ impl CreateWebhook {
         self
     }
 
+    /// Set the webhook's default avatar.
+    ///
+    /// # Errors
+    ///
+    /// May error if a URL is given and the HTTP request fails, or if a path is given to a file
+    /// that does not exist.
+    #[cfg(feature = "http")]
+    pub async fn avatar<'a>(
+        mut self,
+        http: impl AsRef<Http>,
+        avatar: impl Into<AttachmentType<'a>>,
+    ) -> Result<Self> {
+        let avatar_data = avatar.into().data(&http.as_ref().client).await?;
+        self.avatar = Some(encode_image(&avatar_data));
+        Ok(self)
+    }
+
     /// Set the webhook's default avatar. Requires the input be a base64-encoded image that is in
     /// either JPG, GIF, or PNG format.
+    #[cfg(not(feature = "http"))]
     pub fn avatar(mut self, avatar: String) -> Self {
         self.avatar = Some(avatar);
         self

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -1,23 +1,83 @@
-#[derive(Debug, Default, Clone, Serialize)]
+#[cfg(feature = "http")]
+use crate::http::{CacheHttp, Http};
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+#[cfg(feature = "http")]
+use crate::model::prelude::*;
+
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
 pub struct CreateWebhook {
+    #[cfg(feature = "http")]
+    #[serde(skip)]
+    id: ChannelId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) name: Option<String>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Option<String>>,
+    avatar: Option<String>,
 }
 
 impl CreateWebhook {
-    /// Set default name of the Webhook.
+    pub fn new(#[cfg(feature = "http")] id: ChannelId) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            id,
+            name: None,
+            avatar: None,
+        }
+    }
+
+    /// Set the webhook's name.
     ///
     /// This must be between 1-80 characters.
-    pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
-    /// Set default avatar of the webhook.
-    pub fn avatar(&mut self, avatar: Option<String>) -> &mut Self {
+    /// Set the webhook's default avatar. Requires the input be a base64-encoded image that is in
+    /// either JPG, GIF, or PNG format.
+    pub fn avatar(mut self, avatar: String) -> Self {
         self.avatar = Some(avatar);
         self
+    }
+
+    /// Creates the webhook.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Error::Http`] if the current user lacks permission.
+    /// Returns a [`ModelError::NameTooShort`] if the name of the webhook is
+    /// under the limit of 2 characters.
+    /// Returns a [`ModelError::NameTooLong`] if the name of the webhook is
+    /// over the limit of 100 characters.
+    /// Returns a [`ModelError::InvalidChannelType`] if the channel type is not text.
+    #[cfg(feature = "http")]
+    pub async fn execute(self, cache_http: impl CacheHttp) -> Result<Webhook> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(cache) = cache_http.cache() {
+                if let Some(channel) = cache.guild_channel(self.id) {
+                    if !channel.is_text_based() {
+                        return Err(Error::Model(ModelError::InvalidChannelType));
+                    }
+                }
+            }
+        }
+
+        self._execute(cache_http.http()).await
+    }
+
+    #[cfg(feature = "http")]
+    async fn _execute(self, http: &Http) -> Result<Webhook> {
+        if let Some(ref name) = self.name {
+            if name.len() < 2 {
+                return Err(Error::Model(ModelError::NameTooShort));
+            } else if name.len() > 100 {
+                return Err(Error::Model(ModelError::NameTooLong));
+            }
+        }
+
+        http.as_ref().create_webhook(self.id.into(), &self, None).await
     }
 }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -25,12 +25,7 @@ impl EditInteractionResponse {
     }
 
     /// Creates an embed for the message.
-    pub fn embed<F>(&mut self, f: F) -> &mut Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
+    pub fn embed(&mut self, embed: CreateEmbed) -> &mut Self {
         self.add_embed(embed)
     }
 

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -66,14 +66,9 @@ impl<'a> EditMessage<'a> {
 
     /// Add an embed for the message.
     ///
-    /// **Note**: This will keep all existing embeds. Use [`Self::set_embed()`] to replace existing
+    /// **Note**: This will keep all existing embeds. Use [`Self::embed()`] to replace existing
     /// embeds.
-    pub fn add_embed<F>(&mut self, f: F) -> &mut Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
+    pub fn add_embed(&mut self, embed: CreateEmbed) -> &mut Self {
         self._add_embed(embed)
     }
 
@@ -88,26 +83,9 @@ impl<'a> EditMessage<'a> {
 
     /// Set an embed for the message.
     ///
-    /// Equivalent to [`Self::set_embed()`].
-    ///
-    /// **Note**: This will replace all existing embeds. Use
-    /// [`Self::add_embed()`] to add an additional embed.
-    pub fn embed<F>(&mut self, f: F) -> &mut Self
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut embed = CreateEmbed::default();
-        f(&mut embed);
-        self.set_embed(embed)
-    }
-
-    /// Set an embed for the message.
-    ///
-    /// Equivalent to [`Self::embed()`].
-    ///
-    /// **Note**: This will replace all existing embeds.
-    /// Use [`Self::add_embed()`] to add an additional embed.
-    pub fn set_embed(&mut self, embed: CreateEmbed) -> &mut Self {
+    /// **Note**: This will replace all existing embeds. Use [`Self::add_embed()`] to keep existing
+    /// embeds.
+    pub fn embed(&mut self, embed: CreateEmbed) -> &mut Self {
         self.set_embeds(vec![embed])
     }
 

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -1,16 +1,45 @@
+#[cfg(not(feature = "http"))]
+use std::marker::PhantomData;
+
+#[cfg(feature = "http")]
+use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+#[cfg(feature = "http")]
+use crate::model::user::CurrentUser;
+
 /// A builder to edit the current user's settings, to be used in conjunction
 /// with [`CurrentUser::edit`].
 ///
 /// [`CurrentUser::edit`]: crate::model::user::CurrentUser::edit
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct EditProfile {
+#[derive(Debug, Serialize)]
+#[must_use]
+pub struct EditProfile<'a> {
+    #[serde(skip)]
+    #[cfg(feature = "http")]
+    user: &'a mut CurrentUser,
+    #[cfg(not(feature = "http"))]
+    user: PhantomData<&'a ()>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     avatar: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<String>,
 }
 
-impl EditProfile {
+impl<'a> EditProfile<'a> {
+    pub fn new(#[cfg(feature = "http")] user: &'a mut CurrentUser) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            user,
+            #[cfg(not(feature = "http"))]
+            user: PhantomData::default(),
+
+            avatar: None,
+            username: None,
+        }
+    }
+
     /// Sets the avatar of the current user. [`None`] can be passed to remove an
     /// avatar.
     ///
@@ -46,7 +75,7 @@ impl EditProfile {
     /// ```
     ///
     /// [`utils::read_image`]: crate::utils::read_image
-    pub fn avatar(&mut self, avatar: Option<String>) -> &mut Self {
+    pub fn avatar(mut self, avatar: Option<String>) -> Self {
         self.avatar = Some(avatar);
         self
     }
@@ -57,8 +86,20 @@ impl EditProfile {
     /// and current discriminator, a new unique discriminator will be assigned.
     /// If there are no available discriminators with the requested username,
     /// an error will occur.
-    pub fn username(&mut self, username: impl Into<String>) -> &mut Self {
+    pub fn username(mut self, username: impl Into<String>) -> Self {
         self.username = Some(username.into());
         self
+    }
+
+    /// Edits the current user's profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if an invalid value is set. May also return an [`Error::Json`]
+    /// if there is an error in deserializing the API response.
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: impl AsRef<Http>) -> Result<()> {
+        *self.user = http.as_ref().edit_profile(&self).await?;
+        Ok(())
     }
 }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -144,8 +144,8 @@ impl EditRole {
     ///
     /// # Errors
     ///
-    /// May error if the icon is a URL and the HTTP request fails, or if the icon is a file
-    /// on a path that doesn't exist.
+    /// May error if a URL is given and the HTTP request fails, or if a path is given to a file
+    /// that does not exist.
     #[cfg(feature = "model")]
     pub async fn icon<'a>(
         &mut self,
@@ -158,5 +158,14 @@ impl EditRole {
         self.unicode_emoji = None;
 
         Ok(self)
+    }
+
+    /// The image to set as the role icon. Requires the input be a base64-encoded image that is in
+    /// either JPG, GIF, or PNG format.
+    #[cfg(not(feature = "model"))]
+    pub fn icon(&mut self, icon: String) -> &mut Self {
+        self.icon = Some(icon);
+        self.unicode_emoji = None;
+        self
     }
 }

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -141,8 +141,8 @@ impl EditScheduledEvent {
     ///
     /// # Errors
     ///
-    /// May error if the icon is a URL and the HTTP request fails, or if the image is a file
-    /// on a path that doesn't exist.
+    /// May error if a URL is given and the HTTP request fails, or if a path is given to a file
+    /// that does not exist.
     #[cfg(feature = "model")]
     pub async fn image<'a>(
         &mut self,
@@ -152,5 +152,13 @@ impl EditScheduledEvent {
         let image_data = image.into().data(&http.as_ref().client).await?;
         self.image = Some(encode_image(&image_data));
         Ok(self)
+    }
+
+    /// Sets the cover image for the scheduled event. Requires the input be a base64-encoded image
+    /// that is in either JPG, GIF, or PNG format.
+    #[cfg(not(feature = "model"))]
+    pub fn image(&mut self, image: String) -> &mut Self {
+        self.image = Some(image);
+        self
     }
 }

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -1,7 +1,21 @@
-use crate::model::id::ChannelId;
+#[cfg(not(feature = "http"))]
+use std::marker::PhantomData;
 
-#[derive(Debug, Default, Clone, Serialize)]
-pub struct EditWebhook {
+#[cfg(feature = "http")]
+use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+use crate::model::prelude::*;
+
+#[derive(Debug, Serialize)]
+#[must_use]
+pub struct EditWebhook<'a> {
+    #[serde(skip)]
+    #[cfg(feature = "http")]
+    webhook: &'a mut Webhook,
+    #[cfg(not(feature = "http"))]
+    webhook: PhantomData<&'a ()>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -10,24 +24,62 @@ pub struct EditWebhook {
     avatar: Option<Option<String>>,
 }
 
-impl EditWebhook {
-    /// Set default name of the Webhook.
+impl<'a> EditWebhook<'a> {
+    pub fn new(#[cfg(feature = "http")] webhook: &'a mut Webhook) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            webhook,
+            #[cfg(not(feature = "http"))]
+            webhook: PhantomData::default(),
+
+            name: None,
+            channel_id: None,
+            avatar: None,
+        }
+    }
+
+    /// Set the webhook's name.
     ///
     /// This must be between 1-80 characters.
-    pub fn name(&mut self, name: impl Into<String>) -> &mut Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
     /// Set the channel to move the webhook to.
-    pub fn channel_id(&mut self, channel_id: impl Into<ChannelId>) -> &mut Self {
+    pub fn channel_id(mut self, channel_id: impl Into<ChannelId>) -> Self {
         self.channel_id = Some(channel_id.into());
         self
     }
 
-    /// Set default avatar of the webhook.
-    pub fn avatar(&mut self, avatar: Option<String>) -> &mut Self {
-        self.avatar = Some(avatar);
+    /// Set the webhook's default avatar. Requires the input be a base64-encoded image that is in
+    /// either JPG, GIF, or PNG format.
+    pub fn avatar(mut self, avatar: String) -> Self {
+        self.avatar = Some(Some(avatar));
         self
+    }
+
+    /// Deletes the webhook's avatar, resetting it to the default logo.
+    pub fn delete_avatar(mut self) -> Self {
+        self.avatar = Some(None);
+        self
+    }
+
+    /// Sends off the request and edits the webhook. Does not require authentication, as a token is
+    /// required.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Model`] if the token field of the current webhook is `None`.
+    ///
+    /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
+    ///
+    /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: impl AsRef<Http>) -> Result<()> {
+        let token = self.webhook.token.as_ref().ok_or(ModelError::NoTokenSet)?;
+        *self.webhook =
+            http.as_ref().edit_webhook_with_token(self.webhook.id.into(), token, &self).await?;
+        Ok(())
     }
 }

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -52,8 +52,26 @@ impl<'a> EditWebhook<'a> {
         self
     }
 
+    /// Set the webhook's default avatar.
+    ///
+    /// # Errors
+    ///
+    /// May error if a URL is given and the HTTP request fails, or if a path is given to a file
+    /// that does not exist.
+    #[cfg(featuer = "http")]
+    pub async fn avatar(
+        mut self,
+        http: impl AsRef<Http>,
+        avatar: impl Into<AttachmentType<'a>>,
+    ) -> Result<Self> {
+        let avatar_data = avatar.into().data(&http.as_ref().client).await?;
+        self.avatar = Some(Some(encode_image(&avatar_data)));
+        Ok(self)
+    }
+
     /// Set the webhook's default avatar. Requires the input be a base64-encoded image that is in
     /// either JPG, GIF, or PNG format.
+    #[cfg(not(feature = "http"))]
     pub fn avatar(mut self, avatar: String) -> Self {
         self.avatar = Some(Some(avatar));
         self

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -1,10 +1,29 @@
+#[cfg(not(feature = "http"))]
+use std::marker::PhantomData;
+
 use super::{CreateAllowedMentions, CreateComponents, CreateEmbed};
+#[cfg(feature = "http")]
+use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+#[cfg(feature = "http")]
+use crate::model::prelude::*;
 
 /// A builder to specify the fields to edit in an existing [`Webhook`]'s message.
 ///
 /// [`Webhook`]: crate::model::webhook::Webhook
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct EditWebhookMessage {
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
+pub struct EditWebhookMessage<'a> {
+    #[serde(skip)]
+    #[cfg(feature = "http")]
+    webhook: &'a Webhook,
+    #[cfg(not(feature = "http"))]
+    webhook: PhantomData<&'a ()>,
+    #[cfg(feature = "http")]
+    #[serde(skip)]
+    message_id: MessageId,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -15,12 +34,31 @@ pub struct EditWebhookMessage {
     components: Option<CreateComponents>,
 }
 
-impl EditWebhookMessage {
+impl<'a> EditWebhookMessage<'a> {
+    pub fn new(
+        #[cfg(feature = "http")] webhook: &'a Webhook,
+        #[cfg(feature = "http")] message_id: MessageId,
+    ) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            webhook,
+            #[cfg(not(feature = "http"))]
+            webhook: PhantomData::default(),
+            #[cfg(feature = "http")]
+            message_id,
+
+            content: None,
+            embeds: None,
+            allowed_mentions: None,
+            components: None,
+        }
+    }
+
     /// Set the content of the message.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
     #[inline]
-    pub fn content(&mut self, content: impl Into<String>) -> &mut Self {
+    pub fn content(mut self, content: impl Into<String>) -> Self {
         self.content = Some(content.into());
         self
     }
@@ -34,13 +72,13 @@ impl EditWebhookMessage {
     ///
     /// [struct-level documentation of `ExecuteWebhook`]: crate::builder::ExecuteWebhook#examples
     #[inline]
-    pub fn embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+    pub fn embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
         self.embeds = Some(embeds);
         self
     }
 
     /// Set the allowed mentions for the message.
-    pub fn allowed_mentions<F>(&mut self, f: F) -> &mut Self
+    pub fn allowed_mentions<F>(mut self, f: F) -> Self
     where
         F: FnOnce(&mut CreateAllowedMentions) -> &mut CreateAllowedMentions,
     {
@@ -57,7 +95,7 @@ impl EditWebhookMessage {
     ///
     /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
     /// [`WebhookType::Incoming`]: crate::model::webhook::WebhookType
-    pub fn components<F>(&mut self, f: F) -> &mut Self
+    pub fn components<F>(mut self, f: F) -> Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
     {
@@ -66,5 +104,23 @@ impl EditWebhookMessage {
 
         self.components = Some(components);
         self
+    }
+
+    /// Edits the webhook message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Model`] if the token field of the current webhook is `None`.
+    ///
+    /// May also return an [`Error::Http`] if the content is malformed, the webhook's token is
+    /// invalid, or the given message Id does not belong to the current webhook.
+    ///
+    /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: impl AsRef<Http>) -> Result<Message> {
+        let token = self.webhook.token.as_ref().ok_or(ModelError::NoTokenSet)?;
+        http.as_ref()
+            .edit_webhook_message(self.webhook.id.into(), token, self.message_id.into(), &self)
+            .await
     }
 }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -20,8 +20,8 @@ use crate::model::channel::MessageFlags;
 /// payload of [`Webhook::execute`]:
 ///
 /// ```rust,no_run
+/// use serenity::builder::CreateEmbed;
 /// use serenity::http::Http;
-/// use serenity::model::channel::Embed;
 /// use serenity::model::webhook::Webhook;
 /// use serenity::utils::Colour;
 ///
@@ -30,19 +30,17 @@ use crate::model::channel::MessageFlags;
 /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
 /// let webhook = Webhook::from_url(&http, url).await?;
 ///
-/// let website = Embed::fake(|e| {
-///     e.title("The Rust Language Website")
-///         .description("Rust is a systems programming language.")
-///         .colour(Colour::from_rgb(222, 165, 132))
-/// });
+/// let website = CreateEmbed::default()
+///     .title("The Rust Language Website")
+///     .description("Rust is a systems programming language.")
+///     .colour(Colour::from_rgb(222, 165, 132));
 ///
-/// let resources = Embed::fake(|e| {
-///     e.title("Rust Resources")
-///         .description("A few resources to help with learning Rust")
-///         .colour(0xDEA584)
-///         .field("The Rust Book", "A comprehensive resource for Rust.", false)
-///         .field("Rust by Example", "A collection of Rust examples", false)
-/// });
+/// let resources = CreateEmbed::default()
+///     .title("Rust Resources")
+///     .description("A few resources to help with learning Rust")
+///     .colour(0xDEA584)
+///     .field("The Rust Book", "A comprehensive resource for Rust.", false)
+///     .field("Rust by Example", "A collection of Rust examples", false);
 ///
 /// webhook
 ///     .execute(&http, false, |w| {

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,23 +1,20 @@
-#[cfg(not(feature = "model"))]
+#[cfg(not(feature = "http"))]
 use std::marker::PhantomData;
 
 use super::{CreateAllowedMentions, CreateComponents, CreateEmbed};
-#[cfg(feature = "model")]
-use crate::model::channel::AttachmentType;
-use crate::model::channel::MessageFlags;
+#[cfg(feature = "http")]
+use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+use crate::model::prelude::*;
 
-/// A builder to create the inner content of a [`Webhook`]'s execution.
+/// A builder to create the content for a [`Webhook`]'s execution.
 ///
-/// This is a structured way of cleanly creating the inner execution payload,
-/// to reduce potential argument counts.
-///
-/// Refer to the documentation for [`execute_webhook`] on restrictions with
-/// execution payloads and its fields.
+/// Refer to [`Http::execute_webhook`] for restrictions on the execution payload and its fields.
 ///
 /// # Examples
 ///
-/// Creating two embeds, and then sending them as part of the delivery
-/// payload of [`Webhook::execute`]:
+/// Creating two embeds, and then sending them as part of the payload using [`Webhook::execute`]:
 ///
 /// ```rust,no_run
 /// use serenity::builder::CreateEmbed;
@@ -42,20 +39,24 @@ use crate::model::channel::MessageFlags;
 ///     .field("The Rust Book", "A comprehensive resource for Rust.", false)
 ///     .field("Rust by Example", "A collection of Rust examples", false);
 ///
-/// webhook
-///     .execute(&http, false, |w| {
-///         w.content("Here's some information on Rust:").embeds(vec![website, resources])
-///     })
+/// let msg = webhook
+///     .execute()
+///     .content("Here's some information on Rust:")
+///     .embeds(vec![website, resources])
+///     .execute(&http)
 ///     .await?;
 /// #     Ok(())
 /// # }
 /// ```
-///
-/// [`Webhook`]: crate::model::webhook::Webhook
-/// [`Webhook::execute`]: crate::model::webhook::Webhook::execute
-/// [`execute_webhook`]: crate::http::client::Http::execute_webhook
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
 pub struct ExecuteWebhook<'a> {
+    #[serde(skip)]
+    #[cfg(feature = "http")]
+    webhook: &'a Webhook,
+    #[cfg(not(feature = "http"))]
+    webhook: PhantomData<&'a ()>,
+
     tts: bool,
     embeds: Vec<CreateEmbed>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -72,13 +73,36 @@ pub struct ExecuteWebhook<'a> {
     flags: Option<MessageFlags>,
 
     #[serde(skip)]
-    #[cfg(feature = "model")]
-    pub(crate) files: Vec<AttachmentType<'a>>,
-    #[cfg(not(feature = "model"))]
-    files: PhantomData<&'a ()>,
+    wait: bool,
+    #[serde(skip)]
+    thread_id: Option<ChannelId>,
+    #[serde(skip)]
+    files: Vec<AttachmentType<'a>>,
 }
 
 impl<'a> ExecuteWebhook<'a> {
+    pub fn new(#[cfg(feature = "http")] webhook: &'a Webhook) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            webhook,
+            #[cfg(not(feature = "http"))]
+            webhook: PhantomData::default(),
+
+            tts: false,
+            embeds: Vec::new(),
+            avatar_url: None,
+            content: None,
+            allowed_mentions: None,
+            components: None,
+            username: None,
+            flags: None,
+
+            wait: false,
+            thread_id: None,
+            files: Vec::new(),
+        }
+    }
+
     /// Override the default avatar of the webhook with an image URL.
     ///
     /// # Examples
@@ -95,19 +119,18 @@ impl<'a> ExecuteWebhook<'a> {
     /// #
     /// let avatar_url = "https://i.imgur.com/KTs6whd.jpg";
     ///
-    /// webhook.execute(&http, false, |w| w.avatar_url(avatar_url).content("Here's a webhook")).await?;
+    /// webhook.execute().avatar_url(avatar_url).content("Here's a webhook").execute(&http).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    pub fn avatar_url(&mut self, avatar_url: impl Into<String>) -> &mut Self {
+    pub fn avatar_url(mut self, avatar_url: impl Into<String>) -> Self {
         self.avatar_url = Some(avatar_url.into());
         self
     }
 
     /// Set the content of the message.
     ///
-    /// Note that when setting at least one embed via [`Self::embeds`], this may be
-    /// omitted.
+    /// Note that when setting at least one embed via [`Self::embeds`], this may be omitted.
     ///
     /// # Examples
     ///
@@ -121,7 +144,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # let http = Http::new("token");
     /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
-    /// let execution = webhook.execute(&http, false, |w| w.content("foo")).await;
+    /// let execution = webhook.execute().content("foo").execute(&http).await;
     ///
     /// if let Err(why) = execution {
     ///     println!("Err sending webhook: {:?}", why);
@@ -129,43 +152,66 @@ impl<'a> ExecuteWebhook<'a> {
     /// #     Ok(())
     /// # }
     /// ```
-    pub fn content(&mut self, content: impl Into<String>) -> &mut Self {
+    pub fn content(mut self, content: impl Into<String>) -> Self {
         self.content = Some(content.into());
         self
     }
 
+    /// Execute within the context of a thread belonging to the Webhook's channel. If the thread is
+    /// archived, it will automatically be unarchived. If the provided thread Id doesn't belong to
+    /// the current webhook's thread, then the API will return an error at request execution time.
+    ///
+    /// # Examples
+    ///
+    /// Execute a webhook with message content of `test`, in a thread with Id `12345678`:
+    ///
+    /// ```rust,no_run
+    /// # use serenity::http::Http;
+    /// # use serenity::model::webhook::Webhook;
+    /// #
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let http = Http::new("token");
+    /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
+    /// let mut webhook = Webhook::from_url(&http, url).await?;
+    ///
+    /// webhook.execute().in_thread(12345678).content("test").execute(&http).await?;
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn in_thread(mut self, thread_id: impl Into<ChannelId>) -> Self {
+        self.thread_id = Some(thread_id.into());
+        self
+    }
+
     /// Appends a file to the webhook message.
-    #[cfg(feature = "model")]
-    pub fn add_file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
+    pub fn add_file<T: Into<AttachmentType<'a>>>(mut self, file: T) -> Self {
         self.files.push(file.into());
         self
     }
 
     /// Appends a list of files to the webhook message.
-    #[cfg(feature = "model")]
     pub fn add_files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
-        &mut self,
+        mut self,
         files: It,
-    ) -> &mut Self {
+    ) -> Self {
         self.files.extend(files.into_iter().map(Into::into));
         self
     }
 
     /// Sets a list of files to include in the webhook message.
     ///
-    /// Calling this multiple times will overwrite the file list.
-    /// To append files, call [`Self::add_file`] or [`Self::add_files`] instead.
-    #[cfg(feature = "model")]
+    /// Calling this multiple times will overwrite the file list. To append files, call
+    /// [`Self::add_file`] or [`Self::add_files`] instead.
     pub fn files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
-        &mut self,
+        mut self,
         files: It,
-    ) -> &mut Self {
+    ) -> Self {
         self.files = files.into_iter().map(Into::into).collect();
         self
     }
 
     /// Set the allowed mentions for the message.
-    pub fn allowed_mentions<F>(&mut self, f: F) -> &mut Self
+    pub fn allowed_mentions<F>(mut self, f: F) -> Self
     where
         F: FnOnce(&mut CreateAllowedMentions) -> &mut CreateAllowedMentions,
     {
@@ -179,10 +225,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// Creates components for this message. Requires an application-owned webhook, meaning either
     /// the webhook's `kind` field is set to [`WebhookType::Application`], or it was created by an
     /// application (and has kind [`WebhookType::Incoming`]).
-    ///
-    /// [`WebhookType::Application`]: crate::model::webhook::WebhookType
-    /// [`WebhookType::Incoming`]: crate::model::webhook::WebhookType
-    pub fn components<F>(&mut self, f: F) -> &mut Self
+    pub fn components<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
     {
@@ -193,10 +236,8 @@ impl<'a> ExecuteWebhook<'a> {
     }
 
     /// Sets the components of this message. Requires an application-owned webhook. See
-    /// [`components`] for details.
-    ///
-    /// [`components`]: crate::builder::ExecuteWebhook::components
-    pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
+    /// [`Self::components`] for details.
+    pub fn set_components(mut self, components: CreateComponents) -> Self {
         self.components = Some(components);
         self
     }
@@ -205,11 +246,10 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// # Examples
     ///
-    /// Refer to the [struct-level documentation] for an example on how to use
-    /// embeds.
+    /// Refer to the [struct-level documentation] for an example on how to use embeds.
     ///
     /// [struct-level documentation]: #examples
-    pub fn embeds(&mut self, embeds: Vec<CreateEmbed>) -> &mut Self {
+    pub fn embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
         self.embeds = embeds;
         self
     }
@@ -228,7 +268,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # let http = Http::new("token");
     /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
-    /// let execution = webhook.execute(&http, false, |w| w.content("hello").tts(true)).await;
+    /// let execution = webhook.execute().content("hello").tts(true).execute(&http).await;
     ///
     /// if let Err(why) = execution {
     ///     println!("Err sending webhook: {:?}", why);
@@ -236,8 +276,17 @@ impl<'a> ExecuteWebhook<'a> {
     /// #     Ok(())
     /// # }
     /// ```
-    pub fn tts(&mut self, tts: bool) -> &mut Self {
+    pub fn tts(mut self, tts: bool) -> Self {
         self.tts = tts;
+        self
+    }
+
+    /// Set this to `true` to wait for server confirmation of the message having been sent before
+    /// receiving a response. See the [Discord docs] for more details.
+    ///
+    /// [Discord docs]: https://discord.com/developers/docs/resources/webhook#execute-webhook-query-string-params
+    pub fn wait(mut self, wait: bool) -> Self {
+        self.wait = wait;
         self
     }
 
@@ -255,7 +304,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// # let http = Http::new("token");
     /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
-    /// let execution = webhook.execute(&http, false, |w| w.content("hello").username("hakase")).await;
+    /// let execution = webhook.execute().content("hello").username("hakase").execute(&http).await;
     ///
     /// if let Err(why) = execution {
     ///     println!("Err sending webhook: {:?}", why);
@@ -263,7 +312,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// #     Ok(())
     /// # }
     /// ```
-    pub fn username(&mut self, username: impl Into<String>) -> &mut Self {
+    pub fn username(mut self, username: impl Into<String>) -> Self {
         self.username = Some(username.into());
         self
     }
@@ -284,10 +333,10 @@ impl<'a> ExecuteWebhook<'a> {
     /// # let webhook = Webhook::from_id_with_token(&http, 0, "").await?;
     /// #
     /// let execution = webhook
-    ///     .execute(&http, false, |w| {
-    ///         w.content("https://docs.rs/serenity/latest/serenity/")
-    ///             .flags(MessageFlags::SUPPRESS_EMBEDS)
-    ///     })
+    ///     .execute()
+    ///     .content("https://docs.rs/serenity/latest/serenity/")
+    ///     .flags(MessageFlags::SUPPRESS_EMBEDS)
+    ///     .execute(&http)
     ///     .await;
     ///
     /// if let Err(why) = execution {
@@ -296,8 +345,41 @@ impl<'a> ExecuteWebhook<'a> {
     /// #     Ok(())
     /// # }
     /// ```
-    pub fn flags(&mut self, flags: MessageFlags) -> &mut Self {
+    pub fn flags(mut self, flags: MessageFlags) -> Self {
         self.flags = Some(flags);
         self
+    }
+
+    /// Executes the webhook with the given content.
+    ///
+    /// If [`Self::wait`] is set to false, then this function will return `Ok(None)`. Otherwise
+    /// Discord will wait for confirmation that the message was sent, and this function will return
+    /// `Ok(Some(Message))`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Model`] if the token field of the current webhook is `None`.
+    ///
+    /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
+    /// Additionally, this error variant is returned if the webhook attempts to execute in the
+    /// context of a thread whose Id is invalid, or does not belonging to the webhook's
+    /// associated [`Channel`].
+    ///
+    /// Finally, may return an [`Error::Json`] if there is an error in deserialising Discord's
+    /// response.
+    #[cfg(feature = "http")]
+    pub async fn execute(mut self, http: impl AsRef<Http>) -> Result<Option<Message>> {
+        let token = self.webhook.token.as_ref().ok_or(ModelError::NoTokenSet)?;
+        let id = self.webhook.id.into();
+        let thread_id = self.thread_id.map(Into::into);
+        let files = std::mem::take(&mut self.files);
+
+        if files.is_empty() {
+            http.as_ref().execute_webhook(id, thread_id, token, self.wait, &self).await
+        } else {
+            http.as_ref()
+                .execute_webhook_with_files(id, thread_id, token, self.wait, files, &self)
+                .await
+        }
     }
 }

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -1,27 +1,33 @@
-use crate::model::id::MessageId;
+#[cfg(feature = "http")]
+use std::fmt::Write;
+
+#[cfg(feature = "http")]
+use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+use crate::model::prelude::*;
 
 /// Builds a request to the API to retrieve messages.
 ///
-/// This can have 2 different sets of parameters. The first set is around where
-/// to get the messages:
+/// This accepts 2 types of parameters. The first filters messages based on Id, and is set by one
+/// of the following:
 ///
 /// - [`Self::after`]
 /// - [`Self::around`]
 /// - [`Self::before`]
 ///
-/// These can not be mixed, and the first in the list alphabetically will be
-/// used. If one is not specified, `most_recent` will be used.
+/// These are mutually exclusive, and override each other if called sequentially. If one is not
+/// specified, messages are simply sorted by most recent.
 ///
-/// The fourth parameter is to specify the number of messages to retrieve. This
-/// does not _need_ to be called and defaults to a value of 50.
+/// The other parameter specifies number of messages to retrieve. This is _optional_, and defaults
+/// to 50 if not specified.
 ///
-/// This should be used only for retrieving messages; see
-/// [`GuildChannel::messages`] for examples.
+/// See [`GuildChannel::messages`] for more examples.
 ///
 /// # Examples
 ///
-/// Creating a [`GetMessages`] builder to retrieve the first 25 messages after the
-/// message with an Id of `158339864557912064`:
+/// Creating a [`GetMessages`] builder to retrieve the first 25 messages after the message with an
+/// Id of `158339864557912064`:
 ///
 /// ```rust,no_run
 /// # use serenity::http::Http;
@@ -34,24 +40,38 @@ use crate::model::id::MessageId;
 /// let channel_id = ChannelId::new(81384788765712384);
 ///
 /// let _messages = channel_id
-///     .messages(&http, |retriever| retriever.after(MessageId::new(158339864557912064)).limit(25))
+///     .messages()
+///     .after(MessageId::new(158339864557912064))
+///     .limit(25)
+///     .execute(&http)
 ///     .await?;
 /// #     Ok(())
 /// # }
 /// ```
 ///
 /// [`GuildChannel::messages`]: crate::model::channel::GuildChannel::messages
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
+#[must_use]
 pub struct GetMessages {
-    pub search_filter: Option<SearchFilter>,
-    pub limit: Option<u8>,
+    #[cfg(feature = "http")]
+    id: ChannelId,
+    search_filter: Option<SearchFilter>,
+    limit: Option<u8>,
 }
 
 impl GetMessages {
-    /// Indicates to retrieve the messages after a specific message, given by
-    /// its Id.
+    pub fn new(#[cfg(feature = "http")] id: ChannelId) -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            id,
+            search_filter: None,
+            limit: None,
+        }
+    }
+
+    /// Indicates to retrieve the messages after a specific message, given its Id.
     #[inline]
-    pub fn after<M: Into<MessageId>>(&mut self, message_id: M) -> &mut Self {
+    pub fn after<M: Into<MessageId>>(mut self, message_id: M) -> Self {
         self._after(message_id.into());
         self
     }
@@ -60,10 +80,10 @@ impl GetMessages {
         self.search_filter = Some(SearchFilter::After(message_id));
     }
 
-    /// Indicates to retrieve the messages _around_ a specific message in either
-    /// direction (before+after) the given message.
+    /// Indicates to retrieve the messages _around_ a specific message, in other words in either
+    /// direction from the message in time.
     #[inline]
-    pub fn around<M: Into<MessageId>>(&mut self, message_id: M) -> &mut Self {
+    pub fn around<M: Into<MessageId>>(mut self, message_id: M) -> Self {
         self._around(message_id.into());
         self
     }
@@ -72,10 +92,9 @@ impl GetMessages {
         self.search_filter = Some(SearchFilter::Around(message_id));
     }
 
-    /// Indicates to retrieve the messages before a specific message, given by
-    /// its Id.
+    /// Indicates to retrieve the messages before a specific message, given its Id.
     #[inline]
-    pub fn before<M: Into<MessageId>>(&mut self, message_id: M) -> &mut Self {
+    pub fn before<M: Into<MessageId>>(mut self, message_id: M) -> Self {
         self._before(message_id.into());
         self
     }
@@ -88,12 +107,39 @@ impl GetMessages {
     ///
     /// If this is not specified, a default value of 50 is used.
     ///
-    /// **Note**: This field is capped to 100 messages due to a Discord
-    /// limitation. If an amount larger than 100 is supplied, it will be
-    /// reduced.
-    pub fn limit(&mut self, limit: u8) -> &mut Self {
+    /// **Note**: This field is capped to 100 messages due to a Discord limitation. If an amount
+    /// larger than 100 is supplied, it will be truncated.
+    pub fn limit(mut self, limit: u8) -> Self {
         self.limit = Some(limit.min(100));
         self
+    }
+
+    /// Gets messages from the channel.
+    ///
+    /// **Note**: If the user does not have the [Read Message History] permission, returns an empty
+    /// [`Vec`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user does not have permission to view the channel.
+    ///
+    /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: impl AsRef<Http>) -> Result<Vec<Message>> {
+        let mut query = "?".to_string();
+        if let Some(limit) = self.limit {
+            write!(query, "limit={}", limit)?;
+        }
+
+        if let Some(filter) = self.search_filter {
+            match filter {
+                SearchFilter::After(after) => write!(query, "&after={}", after)?,
+                SearchFilter::Around(around) => write!(query, "&around={}", around)?,
+                SearchFilter::Before(before) => write!(query, "&before={}", before)?,
+            }
+        }
+
+        http.as_ref().get_messages(self.id.into(), &query).await
     }
 }
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1034,7 +1034,7 @@ async fn send_grouped_commands_embed(
         embed.field(group.name, &embed_text, true);
     }
 
-    channel_id.send_message(&http, |m| m.set_embed(embed)).await
+    channel_id.send_message().set_embed(embed).execute(http.as_ref()).await
 }
 
 /// Sends embed showcasing information about a single command.
@@ -1046,76 +1046,63 @@ async fn send_single_command_embed(
     command: &Command<'_>,
     colour: Colour,
 ) -> Result<Message, Error> {
-    channel_id
-        .send_message(&http, |m| {
-            m.embed(|embed| {
-                embed.title(command.name);
-                embed.colour(colour);
+    let mut embed = builder::CreateEmbed::default();
+    embed.title(command.name);
+    embed.colour(colour);
 
-                if let Some(desc) = command.description {
-                    embed.description(desc);
-                }
+    if let Some(desc) = command.description {
+        embed.description(desc);
+    }
 
-                if let Some(usage) = command.usage {
-                    let full_usage_text = if let Some(first_prefix) = command.group_prefixes.get(0)
-                    {
-                        format!("`{} {} {}`", first_prefix, command.name, usage)
-                    } else {
-                        format!("`{} {}`", command.name, usage)
-                    };
+    if let Some(usage) = command.usage {
+        let full_usage_text = if let Some(first_prefix) = command.group_prefixes.get(0) {
+            format!("`{} {} {}`", first_prefix, command.name, usage)
+        } else {
+            format!("`{} {}`", command.name, usage)
+        };
 
-                    embed.field(help_options.usage_label, &full_usage_text, true);
-                }
+        embed.field(help_options.usage_label, &full_usage_text, true);
+    }
 
-                if !command.usage_sample.is_empty() {
-                    let full_example_text = if let Some(first_prefix) =
-                        command.group_prefixes.get(0)
-                    {
-                        let format_example =
-                            |example| format!("`{} {} {}`\n", first_prefix, command.name, example);
-                        command.usage_sample.iter().map(format_example).collect::<String>()
-                    } else {
-                        let format_example = |example| format!("`{} {}`\n", command.name, example);
-                        command.usage_sample.iter().map(format_example).collect::<String>()
-                    };
-                    embed.field(help_options.usage_sample_label, &full_example_text, true);
-                }
+    if !command.usage_sample.is_empty() {
+        let full_example_text = if let Some(first_prefix) = command.group_prefixes.get(0) {
+            let format_example =
+                |example| format!("`{} {} {}`\n", first_prefix, command.name, example);
+            command.usage_sample.iter().map(format_example).collect::<String>()
+        } else {
+            let format_example = |example| format!("`{} {}`\n", command.name, example);
+            command.usage_sample.iter().map(format_example).collect::<String>()
+        };
+        embed.field(help_options.usage_sample_label, &full_example_text, true);
+    }
 
-                embed.field(help_options.grouped_label, command.group_name, true);
+    embed.field(help_options.grouped_label, command.group_name, true);
 
-                if !command.aliases.is_empty() {
-                    embed.field(
-                        help_options.aliases_label,
-                        &format!("`{}`", command.aliases.join("`, `")),
-                        true,
-                    );
-                }
+    if !command.aliases.is_empty() {
+        embed.field(
+            help_options.aliases_label,
+            &format!("`{}`", command.aliases.join("`, `")),
+            true,
+        );
+    }
 
-                if !help_options.available_text.is_empty() && !command.availability.is_empty() {
-                    embed.field(help_options.available_text, command.availability, true);
-                }
+    if !help_options.available_text.is_empty() && !command.availability.is_empty() {
+        embed.field(help_options.available_text, command.availability, true);
+    }
 
-                if !command.checks.is_empty() {
-                    embed.field(
-                        help_options.checks_label,
-                        &format!("`{}`", command.checks.join("`, `")),
-                        true,
-                    );
-                }
+    if !command.checks.is_empty() {
+        embed.field(help_options.checks_label, &format!("`{}`", command.checks.join("`, `")), true);
+    }
 
-                if !command.sub_commands.is_empty() {
-                    embed.field(
-                        help_options.sub_commands_label,
-                        &format!("`{}`", command.sub_commands.join("`, `")),
-                        true,
-                    );
-                }
+    if !command.sub_commands.is_empty() {
+        embed.field(
+            help_options.sub_commands_label,
+            &format!("`{}`", command.sub_commands.join("`, `")),
+            true,
+        );
+    }
 
-                embed
-            });
-            m
-        })
-        .await
+    channel_id.send_message().set_embed(embed).execute(http.as_ref()).await
 }
 
 /// Sends embed listing commands that are similar to the sent one.
@@ -1129,7 +1116,11 @@ async fn send_suggestion_embed(
 ) -> Result<Message, Error> {
     let text = help_description.replace("{}", &suggestions.join("`, `"));
 
-    channel_id.send_message(&http, |m| m.embed(|e| e.colour(colour).description(text))).await
+    channel_id
+        .send_message()
+        .embed(|e| e.colour(colour).description(text))
+        .execute(http.as_ref())
+        .await
 }
 
 /// Sends an embed explaining fetching commands failed.
@@ -1140,7 +1131,11 @@ async fn send_error_embed(
     input: &str,
     colour: Colour,
 ) -> Result<Message, Error> {
-    channel_id.send_message(&http, |m| m.embed(|e| e.colour(colour).description(input))).await
+    channel_id
+        .send_message()
+        .embed(|e| e.colour(colour).description(input))
+        .execute(http.as_ref())
+        .await
 }
 
 /// Posts an embed showing each individual command group and its commands.

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1023,18 +1023,16 @@ async fn send_grouped_commands_embed(
     // creating embed outside message builder since flatten_group_to_string
     // may return an error.
 
-    let mut embed = builder::CreateEmbed::default();
-    embed.colour(colour);
-    embed.description(help_description);
+    let mut embed = builder::CreateEmbed::default().colour(colour).description(help_description);
     for group in groups {
         let mut embed_text = String::default();
 
         flatten_group_to_string(&mut embed_text, group, 0, help_options)?;
 
-        embed.field(group.name, &embed_text, true);
+        embed = embed.field(group.name, &embed_text, true);
     }
 
-    channel_id.send_message().set_embed(embed).execute(http.as_ref()).await
+    channel_id.send_message().embed(embed).execute(http.as_ref()).await
 }
 
 /// Sends embed showcasing information about a single command.
@@ -1046,12 +1044,10 @@ async fn send_single_command_embed(
     command: &Command<'_>,
     colour: Colour,
 ) -> Result<Message, Error> {
-    let mut embed = builder::CreateEmbed::default();
-    embed.title(command.name);
-    embed.colour(colour);
+    let mut embed = builder::CreateEmbed::default().title(command.name).colour(colour);
 
     if let Some(desc) = command.description {
-        embed.description(desc);
+        embed = embed.description(desc);
     }
 
     if let Some(usage) = command.usage {
@@ -1061,7 +1057,7 @@ async fn send_single_command_embed(
             format!("`{} {}`", command.name, usage)
         };
 
-        embed.field(help_options.usage_label, &full_usage_text, true);
+        embed = embed.field(help_options.usage_label, &full_usage_text, true);
     }
 
     if !command.usage_sample.is_empty() {
@@ -1073,13 +1069,13 @@ async fn send_single_command_embed(
             let format_example = |example| format!("`{} {}`\n", command.name, example);
             command.usage_sample.iter().map(format_example).collect::<String>()
         };
-        embed.field(help_options.usage_sample_label, &full_example_text, true);
+        embed = embed.field(help_options.usage_sample_label, &full_example_text, true);
     }
 
-    embed.field(help_options.grouped_label, command.group_name, true);
+    embed = embed.field(help_options.grouped_label, command.group_name, true);
 
     if !command.aliases.is_empty() {
-        embed.field(
+        embed = embed.field(
             help_options.aliases_label,
             &format!("`{}`", command.aliases.join("`, `")),
             true,
@@ -1087,22 +1083,26 @@ async fn send_single_command_embed(
     }
 
     if !help_options.available_text.is_empty() && !command.availability.is_empty() {
-        embed.field(help_options.available_text, command.availability, true);
+        embed = embed.field(help_options.available_text, command.availability, true);
     }
 
     if !command.checks.is_empty() {
-        embed.field(help_options.checks_label, &format!("`{}`", command.checks.join("`, `")), true);
+        embed = embed.field(
+            help_options.checks_label,
+            &format!("`{}`", command.checks.join("`, `")),
+            true,
+        );
     }
 
     if !command.sub_commands.is_empty() {
-        embed.field(
+        embed = embed.field(
             help_options.sub_commands_label,
             &format!("`{}`", command.sub_commands.join("`, `")),
             true,
         );
     }
 
-    channel_id.send_message().set_embed(embed).execute(http.as_ref()).await
+    channel_id.send_message().embed(embed).execute(http.as_ref()).await
 }
 
 /// Sends embed listing commands that are similar to the sent one.
@@ -1116,11 +1116,8 @@ async fn send_suggestion_embed(
 ) -> Result<Message, Error> {
     let text = help_description.replace("{}", &suggestions.join("`, `"));
 
-    channel_id
-        .send_message()
-        .embed(|e| e.colour(colour).description(text))
-        .execute(http.as_ref())
-        .await
+    let embed = builder::CreateEmbed::default().colour(colour).description(text);
+    channel_id.send_message().embed(embed).execute(http.as_ref()).await
 }
 
 /// Sends an embed explaining fetching commands failed.
@@ -1131,11 +1128,8 @@ async fn send_error_embed(
     input: &str,
     colour: Colour,
 ) -> Result<Message, Error> {
-    channel_id
-        .send_message()
-        .embed(|e| e.colour(colour).description(input))
-        .execute(http.as_ref())
-        .await
+    let embed = builder::CreateEmbed::default().colour(colour).description(input);
+    channel_id.send_message().embed(embed).execute(http.as_ref()).await
 }
 
 /// Posts an embed showing each individual command group and its commands.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2178,20 +2178,19 @@ impl Http {
         .await
     }
 
-    /// Executes a webhook, posting a [`Message`] in the webhook's associated
-    /// [`Channel`].
+    /// Executes a webhook, posting a [`Message`] in the webhook's associated [`Channel`].
     ///
     /// This method does _not_ require authentication.
     ///
     /// If `thread_id` is not `None`, then the message will be sent to the thread in the webhook's
     /// associated [`Channel`] with the corresponding Id, which will be automatically unarchived.
     ///
-    /// Pass `true` to `wait` to wait for server confirmation of the message sending
-    /// before receiving a response. From the [Discord docs]:
+    /// Pass `true` to `wait` to wait for server confirmation of the message sending before
+    /// receiving a response. From the [Discord docs]:
     ///
-    /// > waits for server confirmation of message send before response, and returns
-    /// > the created message body (defaults to false; when false a message that is
-    /// > not saved does not return an error)
+    /// > waits for server confirmation of message send before response, and returns the created
+    /// > message body (defaults to false; when false a message that is not saved does not return
+    /// > an error
     ///
     /// The map can _optionally_ contain the following data:
     ///
@@ -2204,9 +2203,9 @@ impl Http {
     /// - `content`: The content of the message.
     /// - `embeds`: An array of rich embeds.
     ///
-    /// **Note**: For embed objects, all fields are registered by Discord except for
-    /// `height`, `provider`, `proxy_url`, `type` (it will always be `rich`),
-    /// `video`, and `width`. The rest will be determined by Discord.
+    /// **Note**: For embed objects, all fields are registered by Discord except for `height`,
+    /// `provider`, `proxy_url`, `type` (it will always be `rich`), `video`, and `width`. The rest
+    /// will be determine by Discord.
     ///
     /// # Examples
     ///

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -868,18 +868,18 @@ impl Http {
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
     // Manual async fn to decorate the lifetime manually, avoiding a compiler bug
-    pub fn create_sticker<'a>(
-        &'a self,
+    pub async fn create_sticker<'a>(
+        &self,
         guild_id: u64,
-        map: Vec<(Cow<'static, str>, Cow<'static, str>)>,
+        map: Vec<(&'static str, String)>,
         file: impl Into<AttachmentType<'a>>,
         audit_log_reason: Option<&str>,
-    ) -> impl std::future::Future<Output = Result<Sticker>> + 'a {
+    ) -> Result<Sticker> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
                 files: vec![file.into()],
-                fields: map,
+                fields: map.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
                 payload_json: None,
             }),
             headers: audit_log_reason.map(reason_into_header),
@@ -887,6 +887,7 @@ impl Http {
                 guild_id,
             },
         })
+        .await
     }
 
     /// Creates a webhook for the given [channel][`GuildChannel`]'s Id, passing in

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -867,11 +867,13 @@ impl Http {
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
-    // Manual async fn to decorate the lifetime manually, avoiding a compiler bug
+    // We take a `Vec<(String, String)>` rather than `Vec<(&'static str, String)>` to avoid a compiler
+    // bug around `async fn` and lifetime unification. TODO: change this back once MSRV is on 1.58.
+    // Relevant issue: https://github.com/rust-lang/rust/issues/63033
     pub async fn create_sticker<'a>(
         &self,
         guild_id: u64,
-        map: Vec<(&'static str, String)>,
+        map: Vec<(String, String)>,
         file: impl Into<AttachmentType<'a>>,
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -84,56 +84,12 @@ impl ApplicationCommandInteraction {
         http.as_ref().get_original_interaction_response(&self.token).await
     }
 
-    /// Creates a response to the interaction received.
+    /// Returns a request builder that, when executed, will create a response to the received
+    /// interaction.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Model`] if the message content is too long.
-    /// May also return an [`Error::Http`] if the API returns an error,
-    /// or an [`Error::Json`] if there is an error in deserializing the
-    /// API response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_interaction_response<'a, F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<()>
-    where
-        for<'b> F:
-            FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>,
-    {
-        let mut interaction_response = CreateInteractionResponse::default();
-        f(&mut interaction_response);
-        self._create_interaction_response(http.as_ref(), interaction_response).await
-    }
-
-    async fn _create_interaction_response<'a>(
-        &self,
-        http: &Http,
-        mut interaction_response: CreateInteractionResponse<'a>,
-    ) -> Result<()> {
-        let files = interaction_response
-            .data
-            .as_mut()
-            .map_or_else(Vec::new, |d| std::mem::take(&mut d.files));
-
-        if files.is_empty() {
-            http.create_interaction_response(self.id.get(), &self.token, &interaction_response)
-                .await
-        } else {
-            http.create_interaction_response_with_files(
-                self.id.get(),
-                &self.token,
-                &interaction_response,
-                files,
-            )
-            .await
-        }
+    pub fn create_interaction_response(&self) -> CreateInteractionResponse<'_> {
+        CreateInteractionResponse::new(self.id, &self.token)
     }
 
     /// Edits the initial interaction response.
@@ -286,21 +242,17 @@ impl ApplicationCommandInteraction {
         http.as_ref().get_followup_message(&self.token, message_id.into().into()).await
     }
 
-    /// Helper function to defer an interaction
+    /// Helper function to defer an interaction.
     ///
     /// # Errors
     ///
-    /// May also return an [`Error::Http`] if the API returns an error,
-    /// or an [`Error::Json`] if there is an error in deserializing the
-    /// API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
+    /// Returns an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is
+    /// an error in deserializing the API response.
     pub async fn defer(&self, http: impl AsRef<Http>) -> Result<()> {
-        self.create_interaction_response(http, |f| {
-            f.kind(InteractionResponseType::DeferredChannelMessageWithSource)
-        })
-        .await
+        self.create_interaction_response()
+            .kind(InteractionResponseType::DeferredChannelMessageWithSource)
+            .execute(&http)
+            .await
     }
 }
 

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -133,85 +133,23 @@ impl ApplicationCommandInteraction {
         http.as_ref().delete_original_interaction_response(&self.token).await
     }
 
-    /// Creates a followup response to the response sent.
+    /// Returns a request builder that, when executed, creates a followup response to the response
+    /// previously sent.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Will return [`Error::Model`] if the content is too long.
-    /// May also return [`Error::Http`] if the API returns an error,
-    /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_followup_message<'a, F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<Message>
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseFollowup<'a>,
-        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
-    {
-        let mut interaction_response = CreateInteractionResponseFollowup::default();
-        f(&mut interaction_response);
-        self._create_followup_message(http.as_ref(), interaction_response).await
+    pub async fn create_followup_message(&self) -> CreateInteractionResponseFollowup<'_> {
+        CreateInteractionResponseFollowup::new(None, &self.token)
     }
 
-    async fn _create_followup_message<'a>(
-        &self,
-        http: &Http,
-        mut interaction_response: CreateInteractionResponseFollowup<'a>,
-    ) -> Result<Message> {
-        let files = std::mem::take(&mut interaction_response.files);
-
-        if files.is_empty() {
-            http.create_followup_message(&self.token, &interaction_response).await
-        } else {
-            http.create_followup_message_with_files(&self.token, &interaction_response, files).await
-        }
-    }
-
-    /// Edits a followup response to the response sent.
+    /// Returns a request builder that, when executed, edits a followup response to the response
+    /// previously sent.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Will return [`Error::Model`] if the content is too long.
-    /// May also return [`Error::Http`] if the API returns an error,
-    /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
+    pub async fn edit_followup_message(
         &self,
-        http: impl AsRef<Http>,
-        message_id: M,
-        f: F,
-    ) -> Result<Message>
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseFollowup<'a>,
-        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
-    {
-        let mut builder = CreateInteractionResponseFollowup::default();
-        f(&mut builder);
-
-        let http = http.as_ref();
-        let message_id = message_id.into().into();
-        let files = std::mem::take(&mut builder.files);
-
-        if files.is_empty() {
-            http.edit_followup_message(&self.token, message_id, &builder).await
-        } else {
-            http.edit_followup_message_and_attachments(&self.token, message_id, &builder, files)
-                .await
-        }
+        message_id: impl Into<MessageId>,
+    ) -> CreateInteractionResponseFollowup<'_> {
+        CreateInteractionResponseFollowup::new(Some(message_id.into()), &self.token)
     }
 
     /// Deletes a followup message.

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -6,13 +6,9 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "http")]
 use crate::builder::CreateAutocompleteResponse;
-#[cfg(feature = "http")]
-use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::application::command::{CommandOptionType, CommandType};
 use crate::model::application::interaction::add_guild_id_to_resolved;
-#[cfg(feature = "http")]
-use crate::model::application::interaction::InteractionResponseType;
 use crate::model::guild::Member;
 use crate::model::id::{
     ApplicationId,
@@ -64,33 +60,10 @@ pub struct AutocompleteInteraction {
 
 #[cfg(feature = "http")]
 impl AutocompleteInteraction {
-    /// Creates a response to an autocomplete interaction.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Http`] if the API returns an error.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    pub async fn create_autocomplete_response<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
-    where
-        F: FnOnce(&mut CreateAutocompleteResponse) -> &mut CreateAutocompleteResponse,
-    {
-        #[derive(Serialize)]
-        struct AutocompleteResponse {
-            data: CreateAutocompleteResponse,
-            #[serde(rename = "type")]
-            kind: InteractionResponseType,
-        }
-
-        let mut response = CreateAutocompleteResponse::default();
-        f(&mut response);
-
-        let map = AutocompleteResponse {
-            data: response,
-            kind: InteractionResponseType::Autocomplete,
-        };
-
-        http.as_ref().create_interaction_response(self.id.get(), &self.token, &map).await
+    /// Returns a request builder that creates a response to an autocomplete interaction when
+    /// executed.
+    pub async fn create_autocomplete_response(&self) -> CreateAutocompleteResponse<'_> {
+        CreateAutocompleteResponse::new(self.id, &self.token)
     }
 }
 

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -123,65 +123,23 @@ impl MessageComponentInteraction {
         http.as_ref().delete_original_interaction_response(&self.token).await
     }
 
-    /// Creates a followup response to the response sent.
+    /// Returns a request builder that, when executed, creates a followup response to the response
+    /// previously sent.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Will return [`Error::Model`] if the content is too long.
-    /// May also return [`Error::Http`] if the API returns an error,
-    /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_followup_message<'a, F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<Message>
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseFollowup<'a>,
-        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
-    {
-        let mut interaction_response = CreateInteractionResponseFollowup::default();
-        f(&mut interaction_response);
-
-        http.as_ref().create_followup_message(&self.token, &interaction_response).await
+    pub async fn create_followup_message(&self) -> CreateInteractionResponseFollowup<'_> {
+        CreateInteractionResponseFollowup::new(None, &self.token)
     }
 
-    /// Edits a followup response to the response sent.
+    /// Returns a request builder that, when executed, edits a followup response to the response
+    /// previously sent.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Will return [`Error::Model`] if the content is too long.
-    /// May also return [`Error::Http`] if the API returns an error,
-    /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
+    pub async fn edit_followup_message(
         &self,
-        http: impl AsRef<Http>,
-        message_id: M,
-        f: F,
-    ) -> Result<Message>
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseFollowup<'a>,
-        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
-    {
-        let mut interaction_response = CreateInteractionResponseFollowup::default();
-        f(&mut interaction_response);
-
-        http.as_ref()
-            .edit_followup_message(&self.token, message_id.into().into(), &interaction_response)
-            .await
+        message_id: impl Into<MessageId>,
+    ) -> CreateInteractionResponseFollowup<'_> {
+        CreateInteractionResponseFollowup::new(Some(message_id.into()), &self.token)
     }
 
     /// Deletes a followup message.

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -72,50 +72,12 @@ impl MessageComponentInteraction {
         http.as_ref().get_original_interaction_response(&self.token).await
     }
 
-    /// Creates a response to the interaction received.
+    /// Returns a request builder that, when executed, will create a response to the received
+    /// interaction.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Model`] if the message content is too long.
-    /// May also return an [`Error::Http`] if the API returns an error,
-    /// or an [`Error::Json`] if there is an error in deserializing the
-    /// API response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_interaction_response<'a, F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<()>
-    where
-        for<'b> F:
-            FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>,
-    {
-        let mut interaction_response = CreateInteractionResponse::default();
-        f(&mut interaction_response);
-
-        let http = http.as_ref();
-        let files = interaction_response
-            .data
-            .as_mut()
-            .map_or_else(Vec::new, |d| std::mem::take(&mut d.files));
-
-        if files.is_empty() {
-            http.create_interaction_response(self.id.get(), &self.token, &interaction_response)
-                .await
-        } else {
-            http.create_interaction_response_with_files(
-                self.id.get(),
-                &self.token,
-                &interaction_response,
-                files,
-            )
-            .await
-        }
+    pub fn create_interaction_response(&self) -> CreateInteractionResponse<'_> {
+        CreateInteractionResponse::new(self.id, &self.token)
     }
 
     /// Edits the initial interaction response.
@@ -250,23 +212,17 @@ impl MessageComponentInteraction {
         http.as_ref().get_followup_message(&self.token, message_id.into().into()).await
     }
 
-    /// Helper function to defer an interaction
+    /// Helper function to defer an interaction.
     ///
     /// # Errors
     ///
-    /// May also return an [`Error::Http`] if the API returns an error,
-    /// or an [`Error::Json`] if there is an error in deserializing the
-    /// API response.
-    ///
-    /// # Errors
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
+    /// Returns an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is
+    /// an error in deserializing the API response.
     pub async fn defer(&self, http: impl AsRef<Http>) -> Result<()> {
-        self.create_interaction_response(http, |f| {
-            f.kind(InteractionResponseType::DeferredUpdateMessage)
-        })
-        .await
+        self.create_interaction_response()
+            .kind(InteractionResponseType::DeferredUpdateMessage)
+            .execute(&http)
+            .await
     }
 }
 

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -125,65 +125,23 @@ impl ModalSubmitInteraction {
         http.as_ref().delete_original_interaction_response(&self.token).await
     }
 
-    /// Creates a followup response to the response sent.
+    /// Returns a request builder that, when executed, creates a followup response to the response
+    /// previously sent.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Will return [`Error::Model`] if the content is too long.
-    /// May also return [`Error::Http`] if the API returns an error,
-    /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn create_followup_message<'a, F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<Message>
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseFollowup<'a>,
-        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
-    {
-        let mut interaction_response = CreateInteractionResponseFollowup::default();
-        f(&mut interaction_response);
-
-        http.as_ref().create_followup_message(&self.token, &interaction_response).await
+    pub async fn create_followup_message(&self) -> CreateInteractionResponseFollowup<'_> {
+        CreateInteractionResponseFollowup::new(None, &self.token)
     }
 
-    /// Edits a followup response to the response sent.
+    /// Returns a request builder that, when executed, edits a followup response to the response
+    /// previously sent.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Will return [`Error::Model`] if the content is too long.
-    /// May also return [`Error::Http`] if the API returns an error,
-    /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
+    pub async fn edit_followup_message(
         &self,
-        http: impl AsRef<Http>,
-        message_id: M,
-        f: F,
-    ) -> Result<Message>
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseFollowup<'a>,
-        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
-    {
-        let mut interaction_response = CreateInteractionResponseFollowup::default();
-        f(&mut interaction_response);
-
-        http.as_ref()
-            .edit_followup_message(&self.token, message_id.into().into(), &interaction_response)
-            .await
+        message_id: impl Into<MessageId>,
+    ) -> CreateInteractionResponseFollowup<'_> {
+        CreateInteractionResponseFollowup::new(Some(message_id.into()), &self.token)
     }
 
     /// Deletes a followup message.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -991,44 +991,17 @@ impl ChannelId {
         http.as_ref().delete_stage_instance(self.get()).await
     }
 
-    /// Creates a public thread that is connected to a message.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn create_public_thread<F>(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-        f: F,
-    ) -> Result<GuildChannel>
-    where
-        F: FnOnce(&mut CreateThread) -> &mut CreateThread,
-    {
-        let mut instance = CreateThread::default();
-        f(&mut instance);
-
-        http.as_ref().create_public_thread(self.get(), message_id.into().get(), &instance).await
+    /// Returns a request builder that, when executed, will create a public thread that is
+    /// connected to a message.
+    #[must_use]
+    pub fn create_public_thread(&self, message_id: impl Into<MessageId>) -> CreateThread {
+        CreateThread::new(*self, Some(message_id.into()))
     }
 
-    /// Creates a private thread.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn create_private_thread<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<GuildChannel>
-    where
-        F: FnOnce(&mut CreateThread) -> &mut CreateThread,
-    {
-        let mut instance = CreateThread::default();
-        instance.kind(ChannelType::PrivateThread);
-        f(&mut instance);
-
-        http.as_ref().create_private_thread(self.get(), &instance).await
+    /// Returns a request builder that will create a private thread on execution.
+    #[must_use]
+    pub fn create_private_thread(&self) -> CreateThread {
+        CreateThread::new(*self, None).kind(ChannelType::PrivateThread)
     }
 
     /// Gets the thread members, if this channel is a thread.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -920,24 +920,9 @@ impl ChannelId {
         http.as_ref().get_stage_instance(self.get()).await
     }
 
-    /// Creates a stage instance.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the channel is not a stage channel,
-    /// or if there is already a stage instance currently.
-    pub async fn create_stage_instance<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<StageInstance>
-    where
-        F: FnOnce(&mut CreateStageInstance) -> &mut CreateStageInstance,
-    {
-        let mut instance = CreateStageInstance::default();
-        f(&mut instance);
-
-        http.as_ref().create_stage_instance(&instance).await
+    /// Returns a request builder that creates a [`StageInstance`] when executed.
+    pub fn create_stage_instance(self) -> CreateStageInstance {
+        CreateStageInstance::new(self)
     }
 
     /// Edits a stage instance.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -79,9 +79,9 @@ impl ChannelId {
     /// **Note**: Requires the [Create Instant Invite] permission.
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
-    pub fn create_invite(&self) -> CreateInvite {
+    pub fn create_invite(self) -> CreateInvite {
         CreateInvite::new(
-            *self,
+            self,
             #[cfg(feature = "cache")]
             None,
         )
@@ -987,13 +987,13 @@ impl ChannelId {
 
     /// Returns a request builder that, when executed, will create a public thread that is
     /// connected to a message.
-    pub fn create_public_thread(&self, message_id: impl Into<MessageId>) -> CreateThread {
-        CreateThread::new(*self, Some(message_id.into()))
+    pub fn create_public_thread(self, message_id: impl Into<MessageId>) -> CreateThread {
+        CreateThread::new(self, Some(message_id.into()))
     }
 
     /// Returns a request builder that will create a private thread on execution.
-    pub fn create_private_thread(&self) -> CreateThread {
-        CreateThread::new(*self, None).kind(ChannelType::PrivateThread)
+    pub fn create_private_thread(self) -> CreateThread {
+        CreateThread::new(self, None).kind(ChannelType::PrivateThread)
     }
 
     /// Gets the thread members, if this channel is a thread.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -993,13 +993,11 @@ impl ChannelId {
 
     /// Returns a request builder that, when executed, will create a public thread that is
     /// connected to a message.
-    #[must_use]
     pub fn create_public_thread(&self, message_id: impl Into<MessageId>) -> CreateThread {
         CreateThread::new(*self, Some(message_id.into()))
     }
 
     /// Returns a request builder that will create a private thread on execution.
-    #[must_use]
     pub fn create_private_thread(&self) -> CreateThread {
         CreateThread::new(*self, None).kind(ChannelType::PrivateThread)
     }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -715,7 +715,11 @@ impl ChannelId {
     /// Refer to the documentation for [`CreateMessage`] for more information regarding message
     /// restrictions and requirements.
     pub fn send_message<'a>(self) -> CreateMessage<'a> {
-        CreateMessage::new(self, None)
+        CreateMessage::new(
+            self,
+            #[cfg(feature = "cache")]
+            None,
+        )
     }
 
     /// Starts typing in the channel for an indefinite period of time.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -777,22 +777,8 @@ impl ChannelId {
     /// Returns a [`ModelError::NameTooLong`] if the name of the webhook is
     /// over the limit of 100 characters.
     /// Returns a [`ModelError::InvalidChannelType`] if the channel type is not text.
-    pub async fn create_webhook<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Webhook>
-    where
-        F: FnOnce(&mut CreateWebhook) -> &mut CreateWebhook,
-    {
-        let mut builder = CreateWebhook::default();
-        f(&mut builder);
-
-        if let Some(name) = &builder.name {
-            if name.len() < 2 {
-                return Err(Error::Model(ModelError::NameTooShort));
-            } else if name.len() > 100 {
-                return Err(Error::Model(ModelError::NameTooLong));
-            }
-        }
-
-        http.as_ref().create_webhook(self.get(), &builder, None).await
+    pub fn create_webhook(self) -> CreateWebhook {
+        CreateWebhook::new(self)
     }
 
     /// Returns a future that will await one message sent in this channel.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -78,19 +78,13 @@ impl ChannelId {
     ///
     /// **Note**: Requires the [Create Instant Invite] permission.
     ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
-    ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
-    pub async fn create_invite<F>(&self, http: impl AsRef<Http>, f: F) -> Result<RichInvite>
-    where
-        F: FnOnce(&mut CreateInvite) -> &mut CreateInvite,
-    {
-        let mut invite = CreateInvite::default();
-        f(&mut invite);
-
-        http.as_ref().create_invite(self.get(), &invite, None).await
+    pub fn create_invite(&self) -> CreateInvite {
+        CreateInvite::new(
+            *self,
+            #[cfg(feature = "cache")]
+            None,
+        )
     }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "model")]
-use crate::builder::CreateEmbed;
 #[cfg(feature = "utils")]
 use crate::utils::Colour;
 
@@ -60,40 +58,6 @@ pub struct Embed {
     ///
     /// This is present if the [`Self::kind`] is `"video"`.
     pub video: Option<EmbedVideo>,
-}
-
-#[cfg(feature = "model")]
-impl Embed {
-    /// Creates a fake Embed, giving back a [`serde_json`] map.
-    ///
-    /// This should only be useful in conjunction with [`Webhook::execute`].
-    ///
-    /// [`Webhook::execute`]: crate::model::webhook::Webhook::execute
-    ///
-    /// # Examples
-    ///
-    /// Create an embed:
-    ///
-    /// ```rust,no_run
-    /// use serenity::model::channel::Embed;
-    ///
-    /// let embed = Embed::fake(|e| {
-    ///     e.title("Embed title").description("Making a basic embed").field(
-    ///         "A field",
-    ///         "Has some content.",
-    ///         false,
-    ///     )
-    /// });
-    /// ```
-    #[inline]
-    pub fn fake<F>(f: F) -> CreateEmbed
-    where
-        F: FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
-    {
-        let mut create_embed = CreateEmbed::default();
-        f(&mut create_embed);
-        create_embed
-    }
 }
 
 /// An author object in an embed.

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -1,14 +1,13 @@
 #[cfg(feature = "utils")]
 use crate::utils::Colour;
 
-/// Represents a rich embed which allows using richer markdown, multiple fields
-/// and more. This was heavily inspired by [slack's attachments].
+/// Represents a rich embed which allows using richer markdown, multiple fields and more. This was
+/// heavily inspired by [slack's attachments].
 ///
-/// You can include an attachment in your own message by a user or a bot, or in
-/// a webhook.
+/// You can include an attachment in your own message by a user or a bot, or in a webhook.
 ///
-/// **Note**: Maximum amount of characters you can put is 256 in a field name,
-/// 1024 in a field value, and 2048 in a description.
+/// **Note**: Maximum amount of characters you can put is 256 in a field name, 1024 in a field
+/// value, and 2048 in a description.
 ///
 /// [slack's attachments]: https://api.slack.com/docs/message-attachments
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -43,8 +42,8 @@ pub struct Embed {
     pub kind: Option<String>,
     /// Provider information for the embed.
     ///
-    /// For example, if the embed [`Self::kind`] is `"video"`, the provider might
-    /// contain information about YouTube.
+    /// For example, if the embed [`Self::kind`] is `"video"`, the provider might contain
+    /// information about YouTube.
     pub provider: Option<EmbedProvider>,
     /// Thumbnail information of the embed.
     pub thumbnail: Option<EmbedThumbnail>,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1230,13 +1230,11 @@ impl GuildChannel {
 
     /// Returns a request builder that, when executed, will create a public thread that is
     /// connected to a message.
-    #[must_use]
     pub fn create_public_thread(&self, message_id: impl Into<MessageId>) -> CreateThread {
         self.id.create_public_thread(message_id)
     }
 
     /// Returns a request builder that will create a private thread on execution.
-    #[must_use]
     pub fn create_private_thread(&self) -> CreateThread {
         self.id.create_private_thread()
     }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1157,7 +1157,7 @@ impl GuildChannel {
 
     /// Returns a request builder that creates a [`StageInstance`] when executed.
     pub fn create_stage_instance(&self) -> CreateStageInstance {
-        CreateStageInstance::new(self.id)
+        self.id.create_stage_instance()
     }
 
     /// Edits a stage instance.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -189,7 +189,7 @@ impl GuildChannel {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                utils::user_has_perms_cache(
+                crate::utils::user_has_perms_cache(
                     cache,
                     self.id,
                     Some(self.guild_id),
@@ -310,7 +310,7 @@ impl GuildChannel {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                utils::user_has_perms_cache(
+                crate::utils::user_has_perms_cache(
                     cache,
                     self.id,
                     Some(self.guild_id),
@@ -414,7 +414,7 @@ impl GuildChannel {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                utils::user_has_perms_cache(
+                crate::utils::user_has_perms_cache(
                     cache,
                     self.id,
                     Some(self.guild_id),
@@ -965,7 +965,8 @@ impl GuildChannel {
             if let Some(cache) = cache_http.cache() {
                 let req = Permissions::SEND_MESSAGES;
 
-                if let Ok(false) = utils::user_has_perms(&cache, self.id, Some(self.guild_id), req)
+                if let Ok(false) =
+                    crate::utils::user_has_perms(&cache, self.id, Some(self.guild_id), req)
                 {
                     return Err(Error::Model(ModelError::InvalidPermissions(req)));
                 }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1155,25 +1155,9 @@ impl GuildChannel {
         self.id.get_stage_instance(http).await
     }
 
-    /// Creates a stage instance.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
-    /// Returns [`Error::Http`] if there is already a stage instance currently.
-    pub async fn create_stage_instance<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<StageInstance>
-    where
-        F: FnOnce(&mut CreateStageInstance) -> &mut CreateStageInstance,
-    {
-        if self.kind != ChannelType::Stage {
-            return Err(Error::Model(ModelError::InvalidChannelType));
-        }
-
-        self.id.create_stage_instance(http, f).await
+    /// Returns a request builder that creates a [`StageInstance`] when executed.
+    pub fn create_stage_instance(&self) -> CreateStageInstance {
+        CreateStageInstance::new(self.id)
     }
 
     /// Edits a stage instance.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -911,7 +911,11 @@ impl GuildChannel {
     /// Refer to the documentation for [`CreateMessage`] for more information regarding message
     /// restrictions and requirements.
     pub fn send_message<'a>(&self) -> CreateMessage<'a> {
-        CreateMessage::new(self.id, Some(self.guild_id))
+        CreateMessage::new(
+            self.id,
+            #[cfg(feature = "cache")]
+            Some(self.guild_id),
+        )
     }
 
     /// Starts typing in the channel for an indefinite period of time.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1228,37 +1228,17 @@ impl GuildChannel {
         self.id.delete_stage_instance(http).await
     }
 
-    /// Creates a public thread that is connected to a message.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn create_public_thread<F>(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-        f: F,
-    ) -> Result<GuildChannel>
-    where
-        F: FnOnce(&mut CreateThread) -> &mut CreateThread,
-    {
-        self.id.create_public_thread(http, message_id, f).await
+    /// Returns a request builder that, when executed, will create a public thread that is
+    /// connected to a message.
+    #[must_use]
+    pub fn create_public_thread(&self, message_id: impl Into<MessageId>) -> CreateThread {
+        self.id.create_public_thread(message_id)
     }
 
-    /// Creates a private thread.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn create_private_thread<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<GuildChannel>
-    where
-        F: FnOnce(&mut CreateThread) -> &mut CreateThread,
-    {
-        self.id.create_private_thread(http, f).await
+    /// Returns a request builder that will create a private thread on execution.
+    #[must_use]
+    pub fn create_private_thread(&self) -> CreateThread {
+        self.id.create_private_thread()
     }
 }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -169,36 +169,18 @@ impl GuildChannel {
     /// Create an invite that can only be used 5 times:
     ///
     /// ```rust,ignore
-    /// let invite = channel.create_invite(&context, |i| i.max_uses(5)).await;
+    /// let invite = channel.create_invite().max_uses(5).execute(&context).await;
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`]
-    /// if the current user does not have permission to create invites.
-    ///
-    /// Otherwise returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     #[inline]
     #[cfg(feature = "utils")]
-    pub async fn create_invite<F>(&self, cache_http: impl CacheHttp, f: F) -> Result<RichInvite>
-    where
-        F: FnOnce(&mut CreateInvite) -> &mut CreateInvite,
-    {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    self.id,
-                    Some(self.guild_id),
-                    Permissions::CREATE_INSTANT_INVITE,
-                )?;
-            }
-        }
-
-        self.id.create_invite(cache_http.http(), f).await
+    pub fn create_invite(&self) -> CreateInvite {
+        CreateInvite::new(
+            self.id,
+            #[cfg(feature = "cache")]
+            Some(self.guild_id),
+        )
     }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -649,26 +649,10 @@ impl GuildChannel {
         self.id.message(&cache_http, message_id).await
     }
 
-    /// Gets messages from the channel.
-    ///
-    /// Refer to the [`GetMessages`]-builder for more information on how to
-    /// use `builder`.
-    ///
-    /// **Note**: Returns an empty [`Vec`] if the current user does not have the
-    /// [Read Message History] permission.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission to
-    /// view the channel.
-    ///
-    /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
+    /// Returns a request builder that gets messages from the channel when executed.
     #[inline]
-    pub async fn messages<F>(&self, http: impl AsRef<Http>, builder: F) -> Result<Vec<Message>>
-    where
-        F: FnOnce(&mut GetMessages) -> &mut GetMessages,
-    {
-        self.id.messages(&http, builder).await
+    pub fn messages(&self) -> GetMessages {
+        self.id.messages()
     }
 
     /// Returns the name of the guild channel.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1074,15 +1074,8 @@ impl GuildChannel {
     /// Returns a [`ModelError::NameTooLong`] if the name of the webhook is
     /// over the limit of 100 characters.
     /// Returns a [`ModelError::InvalidChannelType`] if the channel type is not text.
-    pub async fn create_webhook<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Webhook>
-    where
-        F: FnOnce(&mut CreateWebhook) -> &mut CreateWebhook,
-    {
-        if self.is_text_based() {
-            self.id.create_webhook(&http, f).await
-        } else {
-            Err(Error::Model(ModelError::InvalidChannelType))
-        }
+    pub fn create_webhook(&self) -> CreateWebhook {
+        self.id.create_webhook()
     }
 
     /// Gets a stage instance.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -686,22 +686,18 @@ impl Message {
             }
         }
 
-        self.channel_id
-            .send_message(cache_http.http(), |builder| {
-                if let Some(ping_user) = inlined {
-                    builder.reference_message(self).allowed_mentions(|f| {
-                        f.replied_user(ping_user)
-                            // By providing allowed_mentions, Discord disabled _all_ pings by
-                            // default so we need to re-enable them
-                            .parse(crate::builder::ParseValue::Everyone)
-                            .parse(crate::builder::ParseValue::Users)
-                            .parse(crate::builder::ParseValue::Roles)
-                    });
-                }
-
-                builder.content(content)
+        let mut builder = self.channel_id.send_message().content(content);
+        if let Some(ping_user) = inlined {
+            builder = builder.reference_message(self).allowed_mentions(|f| {
+                f.replied_user(ping_user)
+                    // By providing allowed_mentions, Discord disabled _all_ pings by
+                    // default so we need to re-enable them
+                    .parse(crate::builder::ParseValue::Everyone)
+                    .parse(crate::builder::ParseValue::Users)
+                    .parse(crate::builder::ParseValue::Roles)
             })
-            .await
+        }
+        builder.execute(cache_http.http()).await
     }
 
     /// Delete all embeds in this message

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -695,7 +695,7 @@ impl Message {
                     .parse(crate::builder::ParseValue::Everyone)
                     .parse(crate::builder::ParseValue::Users)
                     .parse(crate::builder::ParseValue::Roles)
-            })
+            });
         }
         builder.execute(cache_http.http()).await
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -27,6 +27,8 @@ use crate::json::prelude::*;
 use crate::model::application::component::ActionRow;
 use crate::model::application::interaction::MessageInteraction;
 use crate::model::prelude::*;
+#[cfg(all(feature = "cache", feature = "model"))]
+use crate::utils;
 #[cfg(feature = "model")]
 use crate::{
     constants,

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -294,36 +294,21 @@ impl PrivateChannel {
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES
     #[inline]
-    pub async fn send_files<'a, F, T, It>(
-        &self,
-        http: impl AsRef<Http>,
-        files: It,
-        f: F,
-    ) -> Result<Message>
+    pub fn send_files<'a, T, It>(&self, files: It) -> CreateMessage<'a>
     where
-        for<'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
         T: Into<AttachmentType<'a>>,
         It: IntoIterator<Item = T>,
     {
-        self.id.send_files(&http, files, f).await
+        self.id.send_files(files)
     }
 
     /// Sends a message to the channel with the given content.
     ///
-    /// Refer to the documentation for [`CreateMessage`] for more information
-    /// regarding message restrictions and requirements.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content of the message
-    /// is over the above limit, containing the number of unicode code points
-    /// over the limit.
+    /// Refer to the documentation for [`CreateMessage`] for more information regarding message
+    /// restrictions and requirements.
     #[inline]
-    pub async fn send_message<'a, F>(&self, http: impl AsRef<Http>, f: F) -> Result<Message>
-    where
-        for<'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
-    {
-        self.id.send_message(&http, f).await
+    pub fn send_message<'a>(&self) -> CreateMessage<'a> {
+        self.id.send_message()
     }
 
     /// Starts typing in the channel for an indefinite period of time.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -196,19 +196,10 @@ impl PrivateChannel {
         self.id.message(&cache_http, message_id).await
     }
 
-    /// Gets messages from the channel.
-    ///
-    /// Refer to [`GetMessages`] for more information on how to use `builder`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if an invalid value is set in the builder.
+    /// Returns a request builder that gets messages from the channel when executed.
     #[inline]
-    pub async fn messages<F>(&self, http: impl AsRef<Http>, builder: F) -> Result<Vec<Message>>
-    where
-        F: FnOnce(&mut GetMessages) -> &mut GetMessages,
-    {
-        self.id.messages(&http, builder).await
+    pub fn messages(&self) -> GetMessages {
+        self.id.messages()
     }
 
     /// Returns "DM with $username#discriminator".

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -112,7 +112,7 @@ impl Reaction {
                 }
 
                 if user_id.is_some() {
-                    utils::user_has_perms_cache(
+                    crate::utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
                         self.guild_id,
@@ -151,7 +151,7 @@ impl Reaction {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                utils::user_has_perms_cache(
+                crate::utils::user_has_perms_cache(
                     cache,
                     self.channel_id,
                     self.guild_id,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -48,7 +48,7 @@ use crate::model::prelude::*;
 
 #[cfg(feature = "model")]
 impl GuildId {
-    /// Returns a request builder that adds on execution will add a [`User`] to this guild with a
+    /// Returns a request builder that, when executed, will add a [`User`] to this guild with a
     /// valid OAuth2 access token.
     #[inline]
     pub fn add_member(self, user_id: impl Into<UserId>) -> AddMember {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -345,7 +345,6 @@ impl GuildId {
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    #[must_use]
     pub fn create_sticker<'a>(&self) -> CreateSticker<'a> {
         CreateSticker::new(*self)
     }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -51,8 +51,8 @@ impl GuildId {
     /// Returns a request builder that adds on execution will add a [`User`] to this guild with a
     /// valid OAuth2 access token.
     #[inline]
-    pub fn add_member(&self, user_id: impl Into<UserId>) -> AddMember {
-        AddMember::new(*self, user_id.into())
+    pub fn add_member(self, user_id: impl Into<UserId>) -> AddMember {
+        AddMember::new(self, user_id.into())
     }
 
     /// Ban a [`User`] from the guild, deleting a number of
@@ -211,8 +211,8 @@ impl GuildId {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
-    pub fn create_channel(&self) -> CreateChannel {
-        CreateChannel::new(*self)
+    pub fn create_channel(self) -> CreateChannel {
+        CreateChannel::new(self)
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.
@@ -310,8 +310,8 @@ impl GuildId {
     /// **Note**: Requires the [Manage Events] permission.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub fn create_scheduled_event(&self) -> CreateScheduledEvent {
-        CreateScheduledEvent::new(*self)
+    pub fn create_scheduled_event(self) -> CreateScheduledEvent {
+        CreateScheduledEvent::new(self)
     }
 
     /// Returns a request builder that will create a new [`Sticker`] in the guild when executed.
@@ -320,8 +320,8 @@ impl GuildId {
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    pub fn create_sticker<'a>(&self) -> CreateSticker<'a> {
-        CreateSticker::new(*self)
+    pub fn create_sticker<'a>(self) -> CreateSticker<'a> {
+        CreateSticker::new(self)
     }
 
     /// Deletes the current guild if the current account is the owner of the

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -48,25 +48,11 @@ use crate::model::prelude::*;
 
 #[cfg(feature = "model")]
 impl GuildId {
-    /// Adds a [`User`] to this guild with a valid OAuth2 access token.
-    ///
-    /// Returns the created [`Member`] object, or nothing if the user is already a member of the guild.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission,
-    /// or if invalid values are set.
+    /// Returns a request builder that adds on execution will add a [`User`] to this guild with a
+    /// valid OAuth2 access token.
     #[inline]
-    pub async fn add_member(
-        self,
-        http: impl AsRef<Http>,
-        user_id: impl Into<UserId>,
-        f: impl FnOnce(&mut AddMember) -> &mut AddMember,
-    ) -> Result<Option<Member>> {
-        let mut builder = AddMember::default();
-        f(&mut builder);
-
-        http.as_ref().add_guild_member(self.get(), user_id.into().get(), &builder).await
+    pub fn add_member(&self, user_id: impl Into<UserId>) -> AddMember {
+        AddMember::new(*self, user_id.into())
     }
 
     /// Ban a [`User`] from the guild, deleting a number of

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -352,28 +352,15 @@ impl GuildId {
         http.as_ref().create_scheduled_event(self.get(), &builder, None).await
     }
 
-    /// Creates a new sticker in the guild with the data set, if any.
+    /// Returns a request builder that, when executed, will create a new sticker in the guild.
     ///
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission,
-    /// or if invalid data is given.
-    ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    pub async fn create_sticker<'a, F>(self, http: impl AsRef<Http>, f: F) -> Result<Sticker>
-    where
-        for<'b> F: FnOnce(&'b mut CreateSticker<'a>) -> &'b mut CreateSticker<'a>,
-    {
-        let mut create_sticker = CreateSticker::default();
-        f(&mut create_sticker);
-
-        let (map, file) =
-            create_sticker.build().ok_or(Error::Model(ModelError::NoStickerFileSet))?;
-
-        http.as_ref().create_sticker(self.get(), map, file, None).await
+    #[must_use]
+    pub fn create_sticker<'a>(&self) -> CreateSticker<'a> {
+        CreateSticker::new(*self)
     }
 
     /// Deletes the current guild if the current account is the owner of the

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -329,27 +329,14 @@ impl GuildId {
         Ok(role)
     }
 
-    /// Creates a new scheduled event in the guild with the data set, if any.
+    /// Returns a request builder that, when executed, will create a new scheduled event in the
+    /// guild.
     ///
     /// **Note**: Requires the [Manage Events] permission.
     ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn create_scheduled_event<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<ScheduledEvent>
-    where
-        F: FnOnce(&mut CreateScheduledEvent) -> &mut CreateScheduledEvent,
-    {
-        let mut builder = CreateScheduledEvent::default();
-        f(&mut builder);
-
-        http.as_ref().create_scheduled_event(self.get(), &builder, None).await
+    pub async fn create_scheduled_event(&self) -> CreateScheduledEvent {
+        CreateScheduledEvent::new(*self)
     }
 
     /// Returns a request builder that, when executed, will create a new sticker in the guild.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -329,17 +329,17 @@ impl GuildId {
         Ok(role)
     }
 
-    /// Returns a request builder that, when executed, will create a new scheduled event in the
-    /// guild.
+    /// Returns a request builder that will create a new [`ScheduledEvent`] in the guild when
+    /// executed.
     ///
     /// **Note**: Requires the [Manage Events] permission.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn create_scheduled_event(&self) -> CreateScheduledEvent {
+    pub fn create_scheduled_event(&self) -> CreateScheduledEvent {
         CreateScheduledEvent::new(*self)
     }
 
-    /// Returns a request builder that, when executed, will create a new sticker in the guild.
+    /// Returns a request builder that will create a new [`Sticker`] in the guild when executed.
     ///
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -200,11 +200,12 @@ impl GuildId {
         Ok(channels.into_iter().map(|c| (c.id, c)).collect())
     }
 
-    /// Creates a [`GuildChannel`] in the the guild.
+    /// Returns a request builder that will create a new [`GuildChannel`] in the corresponding
+    /// guild when executed.
     ///
     /// Refer to [`Http::create_channel`] for more information.
     ///
-    /// Requires the [Manage Channels] permission.
+    /// **Note**: Requires the [Manage Channels] permission.
     ///
     /// # Examples
     ///
@@ -218,26 +219,14 @@ impl GuildId {
     /// # use serenity::http::Http;
     /// # let http = Http::new("token");
     /// let _channel =
-    ///     GuildId::new(7).create_channel(&http, |c| c.name("test").kind(ChannelType::Voice)).await;
+    ///     GuildId::new(7).create_channel().name("test").kind(ChannelType::Voice).execute(&http).await;
     /// # }
     /// ```
     ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission,
-    /// or if invalid values are set.
-    ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
-    pub async fn create_channel(
-        self,
-        http: impl AsRef<Http>,
-        f: impl FnOnce(&mut CreateChannel) -> &mut CreateChannel,
-    ) -> Result<GuildChannel> {
-        let mut builder = CreateChannel::default();
-        f(&mut builder);
-
-        http.as_ref().create_channel(self.get(), &builder, None).await
+    pub fn create_channel(&self) -> CreateChannel {
+        CreateChannel::new(*self)
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -889,7 +889,6 @@ impl Guild {
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
-    #[must_use]
     pub fn create_sticker<'a>(&self) -> CreateSticker<'a> {
         CreateSticker::new(self.id)
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -577,7 +577,7 @@ impl Guild {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub fn create_channel(&self) -> CreateChannel {
-        CreateChannel::new(self.id)
+        self.id.create_channel()
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image. The
@@ -860,7 +860,7 @@ impl Guild {
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub fn create_scheduled_event(&self) -> CreateScheduledEvent {
-        CreateScheduledEvent::new(self.id)
+        self.id.create_scheduled_event()
     }
 
     /// Returns a request builder that will create a new [`Sticker`] in the guild when executed.
@@ -869,7 +869,7 @@ impl Guild {
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     pub fn create_sticker<'a>(&self) -> CreateSticker<'a> {
-        CreateSticker::new(self.id)
+        self.id.create_sticker()
     }
 
     /// Deletes the current guild if the current user is the owner of the

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -874,38 +874,14 @@ impl Guild {
         self.id.create_role(cache_http.http(), f).await
     }
 
-    /// Creates a new scheduled event in the guild with the data set, if any.
+    /// Returns a request builder that, when executed, will create a new scheduled event in the
+    /// guild.
     ///
     /// **Note**: Requires the [Manage Events] permission.
     ///
-    /// # Errors
-    ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to manage scheduled events.
-    ///
-    /// Otherwise will return [`Error::Http`] if the current user does not have permission.
-    ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn create_scheduled_event<F>(
-        &self,
-        cache_http: impl CacheHttp,
-        f: F,
-    ) -> Result<ScheduledEvent>
-    where
-        F: FnOnce(&mut CreateScheduledEvent) -> &mut CreateScheduledEvent,
-    {
-        #[cfg(feature = "cache")]
-        {
-            if cache_http.cache().is_some() {
-                let req = Permissions::MANAGE_EVENTS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
-            }
-        }
-
-        self.id.create_scheduled_event(cache_http.http(), f).await
+    pub async fn create_scheduled_event(&self) -> CreateScheduledEvent {
+        CreateScheduledEvent::new(self.id)
     }
 
     /// Returns a request builder that, when executed, will create a new sticker in the guild.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -466,22 +466,11 @@ impl Guild {
         self.id.bans(cache_http.http()).await
     }
 
-    /// Adds a [`User`] to this guild with a valid OAuth2 access token.
-    ///
-    /// Returns the created [`Member`] object, or nothing if the user is already a member of the guild.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission,
-    /// or if invalid values are set.
+    /// Returns a request builder that adds on execution will add a [`User`] to this guild with a
+    /// valid OAuth2 access token.
     #[inline]
-    pub async fn add_member(
-        &self,
-        http: impl AsRef<Http>,
-        user_id: impl Into<UserId>,
-        f: impl FnOnce(&mut AddMember) -> &mut AddMember,
-    ) -> Result<Option<Member>> {
-        self.id.add_member(http, user_id, f).await
+    pub fn add_member(&self, user_id: impl Into<UserId>) -> AddMember {
+        self.id.add_member(user_id)
     }
 
     /// Retrieves a list of [`AuditLogs`] for the guild.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -874,17 +874,17 @@ impl Guild {
         self.id.create_role(cache_http.http(), f).await
     }
 
-    /// Returns a request builder that, when executed, will create a new scheduled event in the
-    /// guild.
+    /// Returns a request builder that will create a new [`ScheduledEvent`] in the guild when
+    /// executed.
     ///
     /// **Note**: Requires the [Manage Events] permission.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn create_scheduled_event(&self) -> CreateScheduledEvent {
+    pub fn create_scheduled_event(&self) -> CreateScheduledEvent {
         CreateScheduledEvent::new(self.id)
     }
 
-    /// Returns a request builder that, when executed, will create a new sticker in the guild.
+    /// Returns a request builder that will create a new [`Sticker`] in the guild when executed.
     ///
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -558,47 +558,37 @@ impl Guild {
         http.as_ref().create_guild(&map).await
     }
 
-    /// Creates a new [`Channel`] in the guild.
+    /// Returns a request builder that will create a new [`GuildChannel`] in the guild when
+    /// executed.
     ///
     /// **Note**: Requires the [Manage Channels] permission.
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
-    /// use serenity::model::ChannelType;
+    /// ```rust,no_run
+    /// # use serenity::http::Http;
+    /// # use serenity::model::guild::Guild;
+    /// # use serenity::model::id::GuildId;
+    /// use serenity::model::channel::ChannelType;
     ///
     /// // assuming a `guild` has already been bound
     ///
-    /// let _ = guild
-    ///     .create_channel(&http, |c| c.name("my-test-channel").kind(ChannelType::Text))
-    ///     .await;
+    /// # async fn run() -> serenity::Result<()> {
+    /// # let http = Http::new("token");
+    /// # let guild = Guild::get(&http, GuildId(7)).await?;
+    /// let channel = guild
+    ///     .create_channel()
+    ///     .name("my-test-channel")
+    ///     .kind(ChannelType::Text)
+    ///     .execute(&http)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
-    /// # Errors
-    ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`]
-    /// if the current user does not have permission to manage channels.
-    ///
-    /// Otherwise will return [`Error::Http`] if the current user lacks permission.
-    ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    pub async fn create_channel(
-        &self,
-        cache_http: impl CacheHttp,
-        f: impl FnOnce(&mut CreateChannel) -> &mut CreateChannel,
-    ) -> Result<GuildChannel> {
-        #[cfg(feature = "cache")]
-        {
-            if cache_http.cache().is_some() {
-                let req = Permissions::MANAGE_CHANNELS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
-            }
-        }
-
-        self.id.create_channel(cache_http.http(), f).await
+    pub fn create_channel(&self) -> CreateChannel {
+        CreateChannel::new(self.id)
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image. The

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -564,7 +564,7 @@ impl Guild {
     ///
     /// # async fn run() -> serenity::Result<()> {
     /// # let http = Http::new("token");
-    /// # let guild = Guild::get(&http, GuildId(7)).await?;
+    /// # let guild = Guild::get(&http, GuildId::new(7)).await?;
     /// let channel = guild
     ///     .create_channel()
     ///     .name("my-test-channel")

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -307,7 +307,7 @@ impl PartialGuild {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
     pub fn create_channel(&self) -> CreateChannel {
-        CreateChannel::new(self.id)
+        self.id.create_channel()
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.
@@ -569,7 +569,7 @@ impl PartialGuild {
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     pub fn create_sticker<'a>(&self) -> CreateSticker<'a> {
-        CreateSticker::new(self.id)
+        self.id.create_sticker()
     }
 
     /// Deletes the current guild if the current user is the owner of the

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -564,7 +564,6 @@ impl PartialGuild {
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
-    #[must_use]
     pub fn create_sticker<'a>(&self) -> CreateSticker<'a> {
         CreateSticker::new(self.id)
     }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -559,7 +559,7 @@ impl PartialGuild {
         self.id.create_role(&http, f).await
     }
 
-    /// Returns a request builder that, when executed, will create a new sticker in the guild.
+    /// Returns a request builder that will create a new [`Sticker`] in the guild when executed.
     ///
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -559,32 +559,14 @@ impl PartialGuild {
         self.id.create_role(&http, f).await
     }
 
-    /// Creates a new sticker in the guild with the data set, if any.
+    /// Returns a request builder that, when executed, will create a new sticker in the guild.
     ///
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
-    /// # Errors
-    ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`]
-    /// if the current user does not have permission to manage roles.
-    ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
-    pub async fn create_sticker<'a, F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Sticker>
-    where
-        for<'b> F: FnOnce(&'b mut CreateSticker<'a>) -> &'b mut CreateSticker<'a>,
-    {
-        #[cfg(feature = "cache")]
-        {
-            if cache_http.cache().is_some() {
-                let req = Permissions::MANAGE_EMOJIS_AND_STICKERS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
-            }
-        }
-
-        self.id.create_sticker(cache_http.http(), f).await
+    #[must_use]
+    pub fn create_sticker<'a>(&self) -> CreateSticker<'a> {
+        CreateSticker::new(self.id)
     }
 
     /// Deletes the current guild if the current user is the owner of the
@@ -1148,7 +1130,11 @@ impl PartialGuild {
     }
 
     #[cfg(feature = "cache")]
-    async fn has_perms(&self, cache_http: impl CacheHttp, mut permissions: Permissions) -> bool {
+    pub(crate) async fn has_perms(
+        &self,
+        cache_http: impl CacheHttp,
+        mut permissions: Permissions,
+    ) -> bool {
         if let Some(cache) = cache_http.cache() {
             let user_id = cache.current_user().id;
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -274,36 +274,40 @@ impl PartialGuild {
         None
     }
 
-    /// Creates a [`GuildChannel`] in the guild.
+    /// Returns a request builder that will create a new [`GuildChannel`] in the guild when
+    /// executed.
     ///
     /// Refer to [`Http::create_channel`] for more information.
     ///
-    /// Requires the [Manage Channels] permission.
+    /// **Note**: Requires the [Manage Channels] permission.
     ///
     /// # Examples
     ///
     /// Create a voice channel in a guild with the name `test`:
     ///
-    /// ```rust,ignore
-    /// use serenity::model::ChannelType;
+    /// ```rust,no_run
+    /// # use serenity::http::Http;
+    /// # use serenity::model::guild::PartialGuild;
+    /// # use serenity::model::id::GuildId;
+    /// use serenity::model::channel::ChannelType;
     ///
-    /// guild.create_channel(|c| c.name("test").kind(ChannelType::Voice));
+    /// # async fn run() -> serenity::Result<()> {
+    /// # let http = Http::new("token");
+    /// # let guild = PartialGuild::get(&http, GuildId(7)).await?;
+    /// let channel = guild
+    ///     .create_channel()
+    ///     .name("my-test-channel")
+    ///     .kind(ChannelType::Voice)
+    ///     .execute(&http)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission,
-    /// or if invalid data was given, such as the channel name being
-    /// too long.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
-    pub async fn create_channel(
-        &self,
-        http: impl AsRef<Http>,
-        f: impl FnOnce(&mut CreateChannel) -> &mut CreateChannel,
-    ) -> Result<GuildChannel> {
-        self.id.create_channel(&http, f).await
+    pub fn create_channel(&self) -> CreateChannel {
+        CreateChannel::new(self.id)
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -293,7 +293,7 @@ impl PartialGuild {
     ///
     /// # async fn run() -> serenity::Result<()> {
     /// # let http = Http::new("token");
-    /// # let guild = PartialGuild::get(&http, GuildId(7)).await?;
+    /// # let guild = PartialGuild::get(&http, GuildId::new(7)).await?;
     /// let channel = guild
     ///     .create_channel()
     ///     .name("my-test-channel")

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -74,11 +74,7 @@ impl Invite {
     /// [permission]: super::permissions
     #[inline]
     pub fn create(channel_id: impl Into<ChannelId>) -> CreateInvite {
-        CreateInvite::new(
-            channel_id.into(),
-            #[cfg(feature = "cache")]
-            None,
-        )
+        channel_id.into().create_invite()
     }
 
     /// Deletes the invite.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -70,39 +70,15 @@ impl Invite {
     ///
     /// Requires the [Create Instant Invite] permission.
     ///
-    /// # Errors
-    ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`]
-    /// if the current user does not have the required [permission].
-    ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     /// [permission]: super::permissions
     #[inline]
-    pub async fn create<F>(
-        cache_http: impl CacheHttp,
-        channel_id: impl Into<ChannelId>,
-        f: F,
-    ) -> Result<RichInvite>
-    where
-        F: FnOnce(CreateInvite) -> CreateInvite,
-    {
-        let channel_id = channel_id.into();
-
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    channel_id,
-                    None,
-                    Permissions::CREATE_INSTANT_INVITE,
-                )?;
-            }
-        }
-
-        let builder = f(CreateInvite::default());
-
-        cache_http.http().create_invite(channel_id.get(), &builder, None).await
+    pub fn create(channel_id: impl Into<ChannelId>) -> CreateInvite {
+        CreateInvite::new(
+            channel_id.into(),
+            #[cfg(feature = "cache")]
+            None,
+        )
     }
 
     /// Deletes the invite.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -2,7 +2,8 @@
 
 use super::prelude::*;
 #[cfg(all(feature = "cache", feature = "model"))]
-use super::{utils as model_utils, Permissions};
+use super::Permissions;
+use super::Timestamp;
 #[cfg(feature = "model")]
 use crate::builder::CreateInvite;
 #[cfg(all(feature = "cache", feature = "model"))]
@@ -11,7 +12,6 @@ use crate::cache::Cache;
 use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
-use crate::model::Timestamp;
 
 /// Information about an invite code.
 ///
@@ -91,7 +91,7 @@ impl Invite {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                model_utils::user_has_perms_cache(
+                crate::utils::user_has_perms_cache(
                     cache,
                     channel_id,
                     None,
@@ -125,7 +125,7 @@ impl Invite {
         {
             if let Some(cache) = cache_http.cache() {
                 let guild_id = self.guild.as_ref().map(|g| g.id);
-                model_utils::user_has_perms_cache(
+                crate::utils::user_has_perms_cache(
                     cache,
                     self.channel.id,
                     guild_id,
@@ -344,7 +344,7 @@ impl RichInvite {
             if let Some(cache) = cache_http.cache() {
                 let guild_id = self.guild.as_ref().map(|g| g.id);
 
-                model_utils::user_has_perms_cache(
+                crate::utils::user_has_perms_cache(
                     cache,
                     self.channel.id,
                     guild_id,

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -37,15 +37,15 @@ pub trait Mentionable {
     /// ) -> Result<(), Error> {
     ///     to_channel
     ///         .id
-    ///         .send_message(ctx, |m| {
-    ///             m.content(format!(
-    ///                 "Hi {member}, welcome to the server! \
-    ///                 Please refer to {rules} for our code of conduct, \
-    ///                 and enjoy your stay.",
-    ///                 member = member.mention(),
-    ///                 rules = rules_channel.mention(),
-    ///             ))
-    ///         })
+    ///         .send_message()
+    ///         .content(format!(
+    ///             "Hi {member}, welcome to the server! \
+    ///             Please refer to {rules} for our code of conduct, \
+    ///             and enjoy your stay.",
+    ///             member = member.mention(),
+    ///             rules = rules_channel.mention(),
+    ///         ))
+    ///         .execute(ctx)
     ///         .await?;
     ///     Ok(())
     /// }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -229,11 +229,8 @@ impl CurrentUser {
         default_avatar_url(self.discriminator)
     }
 
-    /// Edits the current user's profile settings.
-    ///
-    /// This mutates the current user in-place.
-    ///
-    /// Refer to [`EditProfile`]'s documentation for its methods.
+    /// Returns a builder that edits the current user's profile settings when executed, mutating
+    /// the current user in-place.
     ///
     /// # Examples
     ///
@@ -248,30 +245,13 @@ impl CurrentUser {
     /// #     let mut user = CurrentUser::default();
     /// let avatar = serenity::utils::read_image("./avatar.png")?;
     ///
-    /// user.edit(&http, |p| p.avatar(Some(avatar))).await;
+    /// user.edit().avatar(Some(avatar)).execute(&http).await;
     /// #     Ok(())
     /// # }
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Http`] if an invalid value is set.
-    /// May also return an [`Error::Json`] if there is an error in
-    /// deserializing the API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<()>
-    where
-        F: FnOnce(&mut EditProfile) -> &mut EditProfile,
-    {
-        let mut edit_profile = EditProfile::default();
-        edit_profile.username(self.name.clone());
-        f(&mut edit_profile);
-
-        *self = http.as_ref().edit_profile(&edit_profile).await?;
-
-        Ok(())
+    pub fn edit(&mut self) -> EditProfile<'_> {
+        let name = self.name.clone();
+        EditProfile::new(self).username(name)
     }
 
     /// Retrieves the URL to the current user's avatar, falling back to the

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -476,13 +476,13 @@ impl CurrentUser {
         permissions: Permissions,
         scopes: &[Scope],
     ) -> Result<String> {
-        let mut builder = CreateBotAuthParameters::default();
-
-        builder.permissions(permissions);
-        builder.auto_client_id(http).await?;
-        builder.scopes(scopes);
-
-        Ok(builder.build())
+        let url = CreateBotAuthParameters::default()
+            .permissions(permissions)
+            .scopes(scopes)
+            .auto_client_id(&http)
+            .await?
+            .build();
+        Ok(url)
     }
 
     /// Returns a static formatted URL of the user's icon, if one exists.

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -222,9 +222,8 @@ impl Webhook {
         http.as_ref().delete_webhook_with_token(self.id.get(), token).await
     }
 
-    /// Edits the webhook
+    /// Returns a request builder that edits the webhook when executed.
     ///
-    /// Does not require authentication, as this calls [`Http::edit_webhook_with_token`] internally.
     /// # Examples
     ///
     /// ```rust,no_run
@@ -236,33 +235,12 @@ impl Webhook {
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let mut webhook = Webhook::from_url(&http, url).await?;
     ///
-    /// webhook.edit(&http, |b| b.name("new name")).await?;
+    /// webhook.edit().name("new name").execute(&http).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Model`] if the [`Self::token`] is [`None`].
-    ///
-    /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
-    ///
-    /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<()>
-    where
-        F: FnOnce(&mut EditWebhook) -> &mut EditWebhook,
-    {
-        let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
-
-        let mut builder = EditWebhook::default();
-        f(&mut builder);
-
-        *self = http.as_ref().edit_webhook_with_token(self.id.get(), token, &builder).await?;
-        Ok(())
+    pub fn edit(&mut self) -> EditWebhook<'_> {
+        EditWebhook::new(self)
     }
 
     /// Executes a webhook with the fields set via the given builder.

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -297,20 +297,18 @@ impl Webhook {
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
-    /// use serenity::model::channel::Embed;
+    /// use serenity::builder::CreateEmbed;
     ///
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let mut webhook = Webhook::from_url(&http, url).await?;
     ///
-    /// let embed = Embed::fake(|e| {
-    ///     e.title("Rust's website")
-    ///         .description(
-    ///             "Rust is a systems programming language that runs
-    ///                    blazingly fast, prevents segfaults, and guarantees
-    ///                    thread safety.",
-    ///         )
-    ///         .url("https://rust-lang.org")
-    /// });
+    /// let embed = CreateEmbed::default()
+    ///     .title("Rust's website")
+    ///     .description(
+    ///         "Rust is a systems programming language that runs blazingly fast, \
+    ///          prevents segfaults, and guarantees thread safety.",
+    ///     )
+    ///     .url("https://rust-lang.org");
     ///
     /// webhook
     ///     .execute(&http, false, |w| w.content("test").username("serenity").embeds(vec![embed]))

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -419,34 +419,9 @@ impl Webhook {
         http.as_ref().get_webhook_message(self.id.get(), token, message_id.get()).await
     }
 
-    /// Edits a webhook message with the fields set via the given builder.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Model`] if the [`Self::token`] is [`None`].
-    ///
-    /// May also return an [`Error::Http`] if the content is malformed, the webhook's token is invalid, or
-    /// the given message Id does not belong to the current webhook.
-    ///
-    /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn edit_message<F>(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: MessageId,
-        f: F,
-    ) -> Result<Message>
-    where
-        F: FnOnce(&mut EditWebhookMessage) -> &mut EditWebhookMessage,
-    {
-        let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
-        let mut builder = EditWebhookMessage::default();
-        f(&mut builder);
-
-        http.as_ref().edit_webhook_message(self.id.get(), token, message_id.get(), &builder).await
+    /// Returns a request builder that edits a webhook message when executed.
+    pub fn edit_message(&self, message_id: MessageId) -> EditWebhookMessage<'_> {
+        EditWebhookMessage::new(self, message_id)
     }
 
     /// Deletes a webhook message.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -30,9 +30,13 @@ use std::io::Read;
 use std::num::NonZeroU64;
 use std::path::Path;
 
+#[cfg(all(feature = "cache", feature = "model"))]
+use crate::cache::Cache;
 use crate::internal::prelude::*;
-use crate::model::id::{ChannelId, EmojiId, RoleId, UserId};
 use crate::model::misc::EmojiIdentifier;
+#[cfg(all(feature = "cache", feature = "model"))]
+use crate::model::permissions::Permissions;
+use crate::model::prelude::*;
 
 #[cfg(feature = "model")]
 pub(crate) fn encode_image(raw: &[u8]) -> String {
@@ -441,6 +445,76 @@ pub fn parse_webhook(url: &Url) -> Option<(u64, &str)> {
         return None;
     }
     Some((webhook_id.parse().ok()?, token))
+}
+
+/// Tries to find a user's permissions using the cache.
+/// Unlike [`user_has_perms`], this function will return `true` even when
+/// the permissions are not in the cache.
+#[cfg(all(feature = "cache", feature = "model"))]
+#[inline]
+pub(crate) fn user_has_perms_cache(
+    cache: impl AsRef<Cache>,
+    channel_id: ChannelId,
+    guild_id: Option<GuildId>,
+    permissions: Permissions,
+) -> Result<()> {
+    if match user_has_perms(cache, channel_id, guild_id, permissions) {
+        Err(Error::Model(err)) => err.is_cache_err(),
+        result => result?,
+    } {
+        Ok(())
+    } else {
+        Err(Error::Model(ModelError::InvalidPermissions(permissions)))
+    }
+}
+
+#[cfg(all(feature = "cache", feature = "model"))]
+pub(crate) fn user_has_perms(
+    cache: impl AsRef<Cache>,
+    channel_id: ChannelId,
+    guild_id: Option<GuildId>,
+    mut permissions: Permissions,
+) -> Result<bool> {
+    let cache = cache.as_ref();
+
+    let channel = match cache.channel(channel_id) {
+        Some(channel) => channel,
+        None => return Err(Error::Model(ModelError::ChannelNotFound)),
+    };
+
+    // Both users in DMs, all users in groups, and maybe all channels in categories
+    // will have the same permissions.
+    //
+    // The only exception to this is when the current user is blocked by
+    // the recipient in a DM channel, preventing the current user
+    // from sending messages.
+    //
+    // Since serenity can't _reasonably_ check and keep track of these,
+    // just assume that all permissions are granted and return `true`.
+    let (guild_id, guild_channel) = match channel {
+        Channel::Guild(channel) => (channel.guild_id, channel),
+        Channel::Category(_) => return Ok(true),
+        Channel::Private(_) => match guild_id {
+            Some(_) => return Err(Error::Model(ModelError::InvalidChannelType)),
+            None => return Ok(true),
+        },
+    };
+
+    let guild = match cache.guild(guild_id) {
+        Some(guild) => guild,
+        None => return Err(Error::Model(ModelError::GuildNotFound)),
+    };
+
+    let member = match guild.members.get(&cache.current_user().id) {
+        Some(member) => member,
+        None => return Err(Error::Model(ModelError::MemberNotFound)),
+    };
+
+    let perms = guild.user_permissions_in(&guild_channel, member)?;
+
+    permissions.remove(perms);
+
+    Ok(permissions.is_empty())
 }
 
 /// Calculates the Id of the shard responsible for a guild, given its Id and


### PR DESCRIPTION
This is a draft PR as this work will not be ready all at once, and I'm open to comments and bikeshedding as we attempt to get this right. The main goal is to start addressing point number 3 listed in #1905: to rework the builder API to reduce monomorphization bloat (resulting from generic closure parameters), as well to allow for re-using preconstructed builders, and also to enable another later pass of changes to enforce (to a greater extent) API compliance at compile time using the builder API (e.g. always-required, conditionally-required, and mutually exclusive fields).

Some notable changes I've done:
1. Methods on model types that used to take builder construction closures now instead return an empty builder object.
2. Builders have an additional `execute` method that consumes them and actually perform the request. Essentially the functionality from the model types has been moved into the builder itself.
3. Because `execute` takes ownership of `self`, then in order to call `Builder::new().method1().method2().execute()`, the rest of the chain must take ownership as well. Therefore, builders will change to take and return `Self` instead of `&mut Self`.

So far I've tried reworking `CreateSticker` and `CreateThread`, with some success. I do have some concerns though:
~~1. A good deal of builders are called from multiple places. For example, `GuildId`/`Guild`/`PartialGuild`, or `ChannelId`/`GuildChannel`. Since the implementations on guild usually do a cache lookup, to preserve all functionality I had to make the builder store a reference to a generic `GuildIdWrapper`, which I will likely also have to do for `ChannelId`. Is this acceptable? I'm not yet satisfied with it as the implementation is exactly duplicated for `Guild` and `PartialGuild`, but that's something I may solve later, once I'm sure that this fact holds for ***all*** relevant builders.~~
2. Do we want to factor out `execute` ~~and `execute_with_cache`~~ into their own traits, e.g. `Builder<T>` ~~and `BuilderWithCache<T>`~~? We could probably auto-import these so that the user wouldn't have to import them themselves.
3. The reason the `execute` method takes ownership is because `json::hashmap_to_json_map()` consumes the builder's hashmap. Potentially this is addressed by #1962, so I'll wait until that PR is complete before getting too deep into the weeds on this one.

Feedback very much wanted; I'm not great at writing docs so a review of that part is also greatly appreciated.