### PR TITLE
De-duplicate base64 encoding + data:image/png;base64

### DIFF
--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -10,6 +10,8 @@ use crate::model::channel::AttachmentType;
 use crate::model::guild::ScheduledEventType;
 use crate::model::id::ChannelId;
 use crate::model::Timestamp;
+#[cfg(feature = "model")]
+use crate::utils::encode_image;
 
 #[derive(Clone, Debug)]
 pub struct CreateScheduledEvent(pub HashMap<&'static str, Value>);
@@ -92,8 +94,7 @@ impl CreateScheduledEvent {
         image: impl Into<AttachmentType<'a>>,
     ) -> Result<&mut Self> {
         let image_data = image.into().data(&http.as_ref().client).await?;
-        let image_string = format!("data:image/png;base64,{}", base64::encode(image_data));
-        self.0.insert("image", Value::from(image_string));
+        self.0.insert("image", Value::from(encode_image(&image_data)));
         Ok(self)
     }
 }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -8,6 +8,8 @@ use crate::json::from_number;
 use crate::model::channel::AttachmentType;
 use crate::model::guild::Role;
 use crate::model::Permissions;
+#[cfg(feature = "model")]
+use crate::utils::encode_image;
 
 /// A builder to create or edit a [`Role`] for use via a number of model methods.
 ///
@@ -139,9 +141,9 @@ impl EditRole {
         icon: impl Into<AttachmentType<'a>>,
     ) -> Result<&mut Self> {
         let icon_data = icon.into().data(&http.as_ref().client).await?;
-        let icon_string = format!("data:image/png;base64,{}", base64::encode(icon_data));
+
         self.0.remove("unicode_emoji");
-        self.0.insert("icon", Value::from(icon_string));
+        self.0.insert("icon", Value::from(encode_image(&icon_data)));
 
         Ok(self)
     }

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -10,6 +10,8 @@ use crate::model::channel::AttachmentType;
 use crate::model::guild::{ScheduledEventStatus, ScheduledEventType};
 use crate::model::id::ChannelId;
 use crate::model::Timestamp;
+#[cfg(feature = "model")]
+use crate::utils::encode_image;
 
 #[derive(Clone, Debug, Default)]
 pub struct EditScheduledEvent(pub HashMap<&'static str, Value>);
@@ -135,8 +137,7 @@ impl EditScheduledEvent {
         image: impl Into<AttachmentType<'a>>,
     ) -> Result<&mut Self> {
         let image_data = image.into().data(&http.as_ref().client).await?;
-        let image_string = format!("data:image/png;base64,{}", base64::encode(image_data));
-        self.0.insert("image", Value::from(image_string));
+        self.0.insert("image", Value::from(encode_image(&image_data)));
         Ok(self)
     }
 }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -36,6 +36,8 @@ use crate::json::{self, json};
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
+#[cfg(feature = "model")]
+use crate::utils::encode_image;
 
 #[cfg(feature = "model")]
 impl ChannelId {
@@ -914,7 +916,7 @@ impl ChannelId {
         let data = avatar.into().data(&http.client).await?;
         let map = json!({
             "name": name.to_string(),
-            "avatar": format!("data:image/png;base64,{}", base64::encode(data)),
+            "avatar": encode_image(&data),
         });
 
         http.create_webhook(self.0, &map, None).await

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -18,6 +18,8 @@ use crate::json::{self, NULL};
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::ModelError;
+#[cfg(feature = "model")]
+use crate::utils::encode_image;
 
 /// A representation of a type of webhook.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -309,10 +311,7 @@ impl Webhook {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
         let data = avatar.into().data(&http.client).await?;
         let mut map = JsonMap::new();
-        map.insert(
-            "avatar".to_string(),
-            Value::from(format!("data:image/png;base64,{}", base64::encode(data))),
-        );
+        map.insert("avatar".to_string(), Value::from(encode_image(&data)));
         *self = http.edit_webhook_with_token(self.id.0, token, &map).await?;
         Ok(())
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -36,7 +36,7 @@ use crate::model::misc::EmojiIdentifier;
 #[cfg(feature = "model")]
 pub(crate) fn encode_image(raw: &[u8]) -> String {
     let mut encoded = base64::encode(raw);
-    encoded.insert_str(0, "data:image/png;base64");
+    encoded.insert_str(0, "data:image/png;base64,");
     encoded
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -33,6 +33,7 @@ use crate::internal::prelude::*;
 use crate::model::id::EmojiId;
 use crate::model::misc::EmojiIdentifier;
 
+#[cfg(feature = "model")]
 pub(crate) fn encode_image(raw: &[u8]) -> String {
     let mut encoded = base64::encode(raw);
     encoded.insert_str(0, "data:image/png;base64");

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -33,6 +33,12 @@ use crate::internal::prelude::*;
 use crate::model::id::EmojiId;
 use crate::model::misc::EmojiIdentifier;
 
+pub(crate) fn encode_image(raw: &[u8]) -> String {
+    let mut encoded = base64::encode(raw);
+    encoded.insert_str(0, "data:image/png;base64");
+    encoded
+}
+
 /// Retrieves the "code" part of an invite out of a URL.
 ///
 /// # Examples


### PR DESCRIPTION
This also avoids going through format!, leading to slightly faster compile time, and speeds up runtime by using the String allocation returned from `base64::encode` instead of creating an entirely new one.