### PR TITLE
Allow select menus response for modals

### DIFF
--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -152,6 +152,8 @@ pub struct SelectMenu {
     /// The options of this select menu.
     #[serde(default)]
     pub options: Vec<SelectMenuOption>,
+    /// The result location for modals
+    pub values: Vec<String>,
 }
 
 /// A select menu component options.


### PR DESCRIPTION
When using modals, the "values" are returned within the SelectMenu object instead of the top component.

Here under is an example of the reply from a discord modal, with "Pastafari" selected (out of 3 options)

```
    "data": Object({
        "components": Array([
            Object({
                "components": Array([
                    Object({
                        "custom_id": String(
                            "load_config",
                        ),
                        "type": Number(
                            3,
                        ),
                        "values": Array([
                            String(
                                "Pastafari",
                            ),
                        ]),
                    }),
                ]),
                "type": Number(
                    1,
                ),
            }),
        ]),
        "custom_id": String(
            "modal_data",
        ),
    }),
```