### PR TITLE
Fix missing serde(rename = "type")

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -59,6 +59,7 @@ enum ComponentBuilder {
 #[derive(Clone, Debug, Serialize)]
 pub struct CreateActionRow {
     components: Vec<ComponentBuilder>,
+    #[serde(rename = "type")]
     kind: u8,
 }
 
@@ -145,8 +146,9 @@ pub struct CreateButton {
     emoji: Option<JsonMap>,
     #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
-
     style: ButtonStyle,
+
+    #[serde(rename = "type")]
     kind: u8,
 }
 


### PR DESCRIPTION
Missed the `#[serde(rename = "type")]` on the `CreateActionRow` and `CreateButton` builders in #1962. This caused `Invalid Form Body (components.0: The specified component type is invalid in this context)`.