### PR TITLE
Reduce the usage of value in CreateComponents

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -1,5 +1,3 @@
-use crate::internal::prelude::*;
-use crate::json::Value;
 use crate::model::application::component::{ButtonStyle, InputTextStyle};
 use crate::model::channel::ReactionType;
 
@@ -143,7 +141,7 @@ pub struct CreateButton {
     #[serde(skip_serializing_if = "Option::is_none")]
     url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    emoji: Option<JsonMap>,
+    emoji: Option<ReactionType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
     style: ButtonStyle,
@@ -194,31 +192,7 @@ impl CreateButton {
 
     /// Sets emoji of the button.
     pub fn emoji<R: Into<ReactionType>>(&mut self, emoji: R) -> &mut Self {
-        self._emoji(emoji.into())
-    }
-
-    fn _emoji(&mut self, emoji: ReactionType) -> &mut Self {
-        let mut map = JsonMap::new();
-
-        match emoji {
-            ReactionType::Unicode(u) => {
-                map.insert("name".into(), Value::from(u));
-            },
-            ReactionType::Custom {
-                animated,
-                id,
-                name,
-            } => {
-                map.insert("animated".into(), Value::from(animated));
-                map.insert("id".into(), Value::String(id.to_string()));
-
-                if let Some(name) = name {
-                    map.insert("name".into(), Value::String(name));
-                }
-            },
-        };
-
-        self.emoji = Some(map);
+        self.emoji = Some(emoji.into());
         self
     }
 
@@ -355,7 +329,7 @@ pub struct CreateSelectMenuOption {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    emoji: Option<JsonMap>,
+    emoji: Option<ReactionType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default: Option<bool>,
 }
@@ -388,31 +362,7 @@ impl CreateSelectMenuOption {
 
     /// Sets emoji of the option.
     pub fn emoji<R: Into<ReactionType>>(&mut self, emoji: R) -> &mut Self {
-        self._emoji(emoji.into())
-    }
-
-    fn _emoji(&mut self, emoji: ReactionType) -> &mut Self {
-        let mut map = JsonMap::new();
-
-        match emoji {
-            ReactionType::Unicode(u) => {
-                map.insert("name".into(), Value::String(u));
-            },
-            ReactionType::Custom {
-                animated,
-                id,
-                name,
-            } => {
-                map.insert("animated".into(), Value::from(animated));
-                map.insert("id".into(), Value::String(id.to_string()));
-
-                if let Some(name) = name {
-                    map.insert("name".into(), Value::from(name));
-                }
-            },
-        };
-
-        self.emoji = Some(map);
+        self.emoji = Some(emoji.into());
         self
     }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -358,24 +358,24 @@ impl Serialize for ReactionType {
     where
         S: Serializer,
     {
-        match *self {
+        match self {
             ReactionType::Custom {
                 animated,
                 id,
-                ref name,
+                name,
             } => {
                 let mut map = serializer.serialize_map(Some(3))?;
 
-                map.serialize_entry("animated", &animated)?;
-                map.serialize_entry("id", &id)?;
-                map.serialize_entry("name", &name)?;
+                map.serialize_entry("animated", animated)?;
+                map.serialize_entry("id", id)?;
+                map.serialize_entry("name", name)?;
 
                 map.end()
             },
-            ReactionType::Unicode(ref name) => {
+            ReactionType::Unicode(name) => {
                 let mut map = serializer.serialize_map(Some(1))?;
 
-                map.serialize_entry("name", &name)?;
+                map.serialize_entry("name", name)?;
 
                 map.end()
             },


### PR DESCRIPTION
Turns out `ReactionType` already had a serialize implementation that did the same thing. That serialize implementation was improvable a tiny bit though.