### PR TITLE
Use custom enum for Nonce instead of Value

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -996,7 +996,6 @@ mod test {
     use std::collections::HashMap;
 
     use crate::cache::{Cache, CacheUpdate, Settings};
-    use crate::json::from_number;
     use crate::model::prelude::*;
 
     #[test]
@@ -1032,7 +1031,7 @@ mod test {
                 mention_roles: vec![],
                 mention_channels: vec![],
                 mentions: vec![],
-                nonce: from_number(1),
+                nonce: Some(Nonce::Number(1)),
                 pinned: false,
                 reactions: vec![],
                 timestamp: datetime,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -22,6 +22,7 @@ use crate::collector::{
 };
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
+#[cfg(feature = "model")]
 use crate::json::prelude::*;
 use crate::model::application::component::ActionRow;
 use crate::model::application::interaction::MessageInteraction;

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -91,7 +91,7 @@ pub struct Message {
     pub mentions: Vec<User>,
     /// Non-repeating number used for ensuring message order.
     #[serde(default)]
-    pub nonce: Value,
+    pub nonce: Option<Nonce>,
     /// Indicator of whether the message is pinned.
     pub pinned: bool,
     /// Array of reactions performed on the message.
@@ -1231,4 +1231,11 @@ impl MessageId {
 
         self.link(channel_id, guild_id)
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Nonce {
+    String(String),
+    Number(u64),
 }

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -1,4 +1,3 @@
-use crate::json::NULL;
 use crate::model::prelude::*;
 use crate::model::Timestamp;
 
@@ -263,7 +262,7 @@ fn dummy_message() -> Message {
         mention_roles: Vec::new(),
         mention_channels: Vec::new(),
         mentions: Vec::new(),
-        nonce: NULL,
+        nonce: None,
         pinned: false,
         reactions: Vec::new(),
         tts: false,


### PR DESCRIPTION
This narrows the type it can be, speeds up deserialization, and reduces the size of Message slightly