### PR TITLE
Fixing e12 count

### DIFF
--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -80,19 +80,19 @@ struct Handler;
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
         // We are verifying if the bot id is the same as the message author id
-        if msg.author.id != ctx.cache.current_user_id()  {
-            if msg.content.to_lowercase().contains("owo") {
-                // Since data is located in Context, this means you are also able to use it within events!
-                let count = {
-                    let data_read = ctx.data.read().await;
-                    data_read.get::<MessageCount>().expect("Expected MessageCount in TypeMap.").clone()
-                };
+        if msg.author.id != ctx.cache.current_user_id()
+            && msg.content.to_lowercase().contains("owo")
+        {
+            // Since data is located in Context, this means you are also able to use it within events!
+            let count = {
+                let data_read = ctx.data.read().await;
+                data_read.get::<MessageCount>().expect("Expected MessageCount in TypeMap.").clone()
+            };
 
-                // Atomic operations with ordering do not require mut to be modified.
-                // In this case, we want to increase the message count by 1.
-                // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
-                count.fetch_add(1, Ordering::SeqCst);
-            }
+            // Atomic operations with ordering do not require mut to be modified.
+            // In this case, we want to increase the message count by 1.
+            // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
+            count.fetch_add(1, Ordering::SeqCst);
         }
     }
 

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -79,17 +79,20 @@ struct Handler;
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        if msg.content.to_lowercase().contains("owo") {
-            // Since data is located in Context, this means you are also able to use it within events!
-            let count = {
-                let data_read = ctx.data.read().await;
-                data_read.get::<MessageCount>().expect("Expected MessageCount in TypeMap.").clone()
-            };
+        // We are verifying if the bot id is the same as the message author id
+        if msg.author.id != ctx.cache.current_user().id  {
+            if msg.content.to_lowercase().contains("owo") {
+                // Since data is located in Context, this means you are also able to use it within events!
+                let count = {
+                    let data_read = ctx.data.read().await;
+                    data_read.get::<MessageCount>().expect("Expected MessageCount in TypeMap.").clone()
+                };
 
-            // Atomic operations with ordering do not require mut to be modified.
-            // In this case, we want to increase the message count by 1.
-            // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
-            count.fetch_add(1, Ordering::SeqCst);
+                // Atomic operations with ordering do not require mut to be modified.
+                // In this case, we want to increase the message count by 1.
+                // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
+                count.fetch_add(1, Ordering::SeqCst);
+            }
         }
     }
 

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -80,7 +80,7 @@ struct Handler;
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
         // We are verifying if the bot id is the same as the message author id
-        if msg.author.id != ctx.cache.current_user().id  {
+        if msg.author.id != ctx.cache.current_user_id()  {
             if msg.content.to_lowercase().contains("owo") {
                 // Since data is located in Context, this means you are also able to use it within events!
                 let count = {


### PR DESCRIPTION
The "owo" count was counting the bot messages, and it was going like this:
![2022-06-19_21-12](https://user-images.githubusercontent.com/107818001/174505967-d7547578-51f9-4ab5-9ce3-26ffcfbc11f4.png)


After the changes, it stopped counting the bot messages: 
![2022-06-19_21-14](https://user-images.githubusercontent.com/107818001/174506022-b3531d68-f0d0-4fca-86ca-29459ef31c84.png)

