### PR TITLE
Use CacheRef for CurrentUser

### DIFF
--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -38,7 +38,7 @@ impl EditProfile {
     ///
     /// let base64 = utils::read_image("./my_image.jpg").expect("Failed to read image");
     ///
-    /// let mut user = context.cache.current_user();
+    /// let mut user = context.cache.current_user().clone();
     /// let _ = user.edit(&context, |p| p.avatar(Some(base64))).await;
     /// #     }
     /// # }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -61,7 +61,7 @@ struct NotSend;
 
 enum CacheRefInner<'a, K, V> {
     DashRef(Ref<'a, K, V>),
-    ReadGuard(parking_lot::RwLockReadGuard<'a, V>)
+    ReadGuard(parking_lot::RwLockReadGuard<'a, V>),
 }
 
 pub struct CacheRef<'a, K, V> {
@@ -73,7 +73,7 @@ impl<'a, K, V> CacheRef<'a, K, V> {
     fn new(inner: CacheRefInner<'a, K, V>) -> Self {
         Self {
             inner,
-            phantom: std::marker::PhantomData
+            phantom: std::marker::PhantomData,
         }
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -59,17 +59,30 @@ type MessageCache = DashMap<ChannelId, DashMap<MessageId, Message>>;
 
 struct NotSend;
 
+enum CacheRefInner<'a, K, V> {
+    DashRef(Ref<'a, K, V>),
+    ReadGuard(parking_lot::RwLockReadGuard<'a, V>)
+}
+
 pub struct CacheRef<'a, K, V> {
-    inner: Ref<'a, K, V>,
+    inner: CacheRefInner<'a, K, V>,
     phantom: std::marker::PhantomData<*const NotSend>,
 }
 
 impl<'a, K, V> CacheRef<'a, K, V> {
-    fn from_ref(inner: Ref<'a, K, V>) -> Self {
-        CacheRef {
+    fn new(inner: CacheRefInner<'a, K, V>) -> Self {
+        Self {
             inner,
-            phantom: std::marker::PhantomData,
+            phantom: std::marker::PhantomData
         }
+    }
+
+    fn from_ref(inner: Ref<'a, K, V>) -> Self {
+        Self::new(CacheRefInner::DashRef(inner))
+    }
+
+    fn from_guard(inner: parking_lot::RwLockReadGuard<'a, V>) -> Self {
+        Self::new(CacheRefInner::ReadGuard(inner))
     }
 }
 
@@ -77,11 +90,15 @@ impl<K: Eq + Hash, V> std::ops::Deref for CacheRef<'_, K, V> {
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
-        self.inner.value()
+        match &self.inner {
+            CacheRefInner::DashRef(inner) => inner.value(),
+            CacheRefInner::ReadGuard(inner) => &*inner,
+        }
     }
 }
 
 pub type GuildRef<'a> = CacheRef<'a, GuildId, Guild>;
+pub type CurrentUserRef<'a> = CacheRef<'a, (), CurrentUser>;
 pub type GuildChannelRef<'a> = CacheRef<'a, ChannelId, GuildChannel>;
 pub type PrivateChannelRef<'a> = CacheRef<'a, ChannelId, PrivateChannel>;
 
@@ -904,41 +921,10 @@ impl Cache {
         self.categories.get(&channel_id).map(|category| category.id)
     }
 
-    /// This method clones and returns the user used by the bot.
+    /// This method provides a reference to the user used by the bot.
     #[inline]
-    pub fn current_user(&self) -> CurrentUser {
-        self.user.read().clone()
-    }
-
-    /// This method returns the bot's ID.
-    #[inline]
-    pub fn current_user_id(&self) -> UserId {
-        self.user.read().id
-    }
-
-    /// This method allows to only clone a field of the current user instead of
-    /// the entire user by providing a `field_selector`-closure picking what
-    /// you want to clone.
-    ///
-    /// ```rust,no_run
-    /// # use serenity::cache::Cache;
-    /// #
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let cache = Cache::default();
-    /// // We clone only the `name` instead of the entire channel.
-    /// let id = cache.current_user_field(|user| user.id);
-    /// println!("Current user's ID: {}", id);
-    /// #   Ok(())
-    /// # }
-    /// ```
-    #[inline]
-    pub fn current_user_field<Ret: Clone, Fun>(&self, field_selector: Fun) -> Ret
-    where
-        Fun: FnOnce(&CurrentUser) -> Ret,
-    {
-        let user = self.user.read();
-
-        field_selector(&user)
+    pub fn current_user(&self) -> CurrentUserRef<'_> {
+        CacheRef::from_guard(self.user.read())
     }
 
     /// Updates the cache with the update implementation for an event or other

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -748,7 +748,7 @@ impl GuildChannel {
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, mut msg: Message) {
-    ///         let current_user_id = context.cache.current_user_id();
+    ///         let current_user_id = context.cache.current_user().id;
     ///         let permissions = match context.cache.guild_channel(msg.channel_id) {
     ///             Some(channel) => channel.permissions_for_user(&context.cache, current_user_id),
     ///             None => return,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -152,7 +152,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.author.id != cache.current_user_id() && self.guild_id.is_some() {
+                if self.author.id != cache.current_user().id && self.guild_id.is_some() {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
@@ -213,7 +213,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.author.id != cache.current_user_id() {
+                if self.author.id != cache.current_user().id {
                     if self.is_private() {
                         return Err(Error::Model(ModelError::NotAuthor));
                     }
@@ -328,7 +328,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if self.author.id != cache.current_user_id() {
+                if self.author.id != cache.current_user().id {
                     return Err(Error::Model(ModelError::InvalidUser));
                 }
             }
@@ -553,7 +553,7 @@ impl Message {
                     )?;
                 }
 
-                user_id = Some(cache.current_user_id());
+                user_id = Some(cache.current_user().id);
             }
         }
 
@@ -715,7 +715,7 @@ impl Message {
                     Permissions::MANAGE_MESSAGES,
                 )?;
 
-                if self.author.id != cache.current_user_id() {
+                if self.author.id != cache.current_user().id {
                     return Err(Error::Model(ModelError::NotAuthor));
                 }
             }
@@ -753,7 +753,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                return Ok(self.mentions_user_id(cache.current_user_id()));
+                return Ok(self.mentions_user_id(cache.current_user().id));
             }
         }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -195,7 +195,7 @@ impl Reaction {
             #[cfg(feature = "cache")]
             {
                 if let Some(cache) = cache_http.cache() {
-                    return Ok(User::from(&cache.current_user()));
+                    return Ok(User::from(&*cache.current_user()));
                 }
             }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -808,7 +808,7 @@ impl User {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "~help" {
     ///             let url =
-    ///                 match ctx.cache.current_user().invite_url(&ctx, Permissions::empty()).await {
+    ///                 match ctx.cache.current_user().clone().invite_url(&ctx, Permissions::empty()).await {
     ///                     Ok(v) => v,
     ///                     Err(why) => {
     ///                         println!("Error creating invite url: {:?}", why);

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -807,15 +807,15 @@ impl User {
     /// #   #[cfg(feature = "cache")]
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "~help" {
-    ///             let url =
-    ///                 match ctx.cache.current_user().clone().invite_url(&ctx, Permissions::empty()).await {
-    ///                     Ok(v) => v,
-    ///                     Err(why) => {
-    ///                         println!("Error creating invite url: {:?}", why);
+    ///             let current_user = ctx.cache.current_user().clone();
+    ///             let url = match current_user.invite_url(&ctx, Permissions::empty()).await {
+    ///                 Ok(v) => v,
+    ///                 Err(why) => {
+    ///                     println!("Error creating invite url: {:?}", why);
     ///
-    ///                         return;
-    ///                     },
-    ///                 };
+    ///                     return;
+    ///                 },
+    ///             };
     ///
     ///             let help = format!("Helpful info here. Invite me with this link: <{}>", url,);
     ///


### PR DESCRIPTION
Removes `cache.current_user_id` and `current_user_field` and makes `cache.current_user` return a `CacheRef` by reworking the internals of `CacheRef` to hold an enum of different guard types, currently only a dashmap `Ref` or a `parking_lot::RwLockReadGuard`. This prevents unnecessary cloning of the current user and monomorphization bloat from the `_field` method. 