### PR TITLE
Add `UserRef` by wrapping temp cache values in `Arc`

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -187,7 +187,7 @@ impl CacheUpdate for GuildCreateEvent {
         for (user_id, member) in &mut guild.members {
             cache.update_user_entry(&member.user);
             if let Some(u) = cache.user(user_id) {
-                member.user = u;
+                member.user = u.clone();
             }
         }
 
@@ -265,7 +265,7 @@ impl CacheUpdate for GuildMemberAddEvent {
         let user_id = self.member.user.id;
         cache.update_user_entry(&self.member.user);
         if let Some(u) = cache.user(user_id) {
-            self.member.user = u;
+            self.member.user = u.clone();
         }
 
         if let Some(mut guild) = cache.guilds.get_mut(&self.member.guild_id) {
@@ -529,7 +529,7 @@ impl CacheUpdate for PresenceUpdateEvent {
         }
 
         if let Some(user) = cache.user(self.presence.user.id) {
-            self.presence.user.update_with_user(user);
+            self.presence.user.update_with_user(&user);
         }
 
         if let Some(guild_id) = self.presence.guild_id {
@@ -621,7 +621,7 @@ impl CacheUpdate for ReadyEvent {
                 cache.update_user_entry(&user);
             }
             if let Some(user) = cache.user(user_id) {
-                presence.user.update_with_user(user);
+                presence.user.update_with_user(&user);
             }
 
             cache.presences.insert(*user_id, presence.clone());

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -441,14 +441,14 @@ impl PresenceUser {
     }
 
     #[cfg(feature = "cache")] // method is only used with the cache feature enabled
-    pub(crate) fn update_with_user(&mut self, user: User) {
+    pub(crate) fn update_with_user(&mut self, user: &User) {
         self.id = user.id;
-        if let Some(avatar) = user.avatar {
-            self.avatar = Some(avatar);
+        if let Some(avatar) = &user.avatar {
+            self.avatar = Some(avatar.clone());
         }
         self.bot = Some(user.bot);
         self.discriminator = Some(user.discriminator);
-        self.name = Some(user.name);
+        self.name = Some(user.name.clone());
         if let Some(public_flags) = user.public_flags {
             self.public_flags = Some(public_flags);
         }

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -256,10 +256,10 @@ fn clean_mention(
                 }
                 .into()
             };
+
             cache
                 .user(id)
-                .as_ref()
-                .map(get_username)
+                .map(|u| get_username(&u))
                 .or_else(|| users.iter().find(|u| u.id == id).map(get_username))
                 .unwrap_or(Cow::Borrowed("@invalid-user"))
         },


### PR DESCRIPTION
This was not able to easily be done before due to the temp cache internally cloning the user, however it is possible to simply wrap the temp cache users in Arc and allow CacheRef to hold the Arc as a type of guard.