### PR TITLE
Modifying the e12 "owo" counter

### DIFF
--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -79,7 +79,7 @@ struct Handler;
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        // We are verifying if the bot id is the same as the message author id
+        // We are verifying if the bot id is the same as the message author id.
         if msg.author.id != ctx.cache.current_user_id()
             && msg.content.to_lowercase().contains("owo")
         {
@@ -89,10 +89,15 @@ impl EventHandler for Handler {
                 data_read.get::<MessageCount>().expect("Expected MessageCount in TypeMap.").clone()
             };
 
+            // To check how many "owo" there are in msg.content, we split the string with the "owo" pattern 
+            // and reduce the count of iterator returned by the split function by one.
+            let owo_in_msg = msg.content.to_lowercase().split("owo").count() - 1;
+
             // Atomic operations with ordering do not require mut to be modified.
             // In this case, we want to increase the message count by 1.
             // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
-            count.fetch_add(1, Ordering::SeqCst);
+
+            count.fetch_add(owo_in_msg, Ordering::SeqCst);
         }
     }
 

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -89,18 +89,13 @@ impl EventHandler for Handler {
                 data_read.get::<MessageCount>().expect("Expected MessageCount in TypeMap.").clone()
             };
 
-            // To check how many "owo" there are in msg.content, we split the string with the "owo" pattern 
-            // and reduce the count of iterator returned by the split function by one.
-            let owo_in_msg = msg.content.to_lowercase().split("owo").count() - 1;
+            // Here, we are checking how many "owo" there are in the message content.
+            let owo_in_msg = msg.content.to_ascii_lowercase().matches("owo").count();
             
             // Atomic operations with ordering do not require mut to be modified.
             // In this case, we want to increase the message count by 1.
             // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
-            if owo_in_msg == 0 {
-                count.fetch_add(1, Ordering::SeqCst);
-            } else {
                 count.fetch_add(owo_in_msg, Ordering::SeqCst);
-            }
         }
     }
 

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -91,11 +91,11 @@ impl EventHandler for Handler {
 
             // Here, we are checking how many "owo" there are in the message content.
             let owo_in_msg = msg.content.to_ascii_lowercase().matches("owo").count();
-            
+
             // Atomic operations with ordering do not require mut to be modified.
             // In this case, we want to increase the message count by 1.
             // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
-                count.fetch_add(owo_in_msg, Ordering::SeqCst);
+            count.fetch_add(owo_in_msg, Ordering::SeqCst);
         }
     }
 

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -92,12 +92,15 @@ impl EventHandler for Handler {
             // To check how many "owo" there are in msg.content, we split the string with the "owo" pattern 
             // and reduce the count of iterator returned by the split function by one.
             let owo_in_msg = msg.content.to_lowercase().split("owo").count() - 1;
-
+            
             // Atomic operations with ordering do not require mut to be modified.
             // In this case, we want to increase the message count by 1.
             // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
-
-            count.fetch_add(owo_in_msg, Ordering::SeqCst);
+            if owo_in_msg == 0 {
+                count.fetch_add(1, Ordering::SeqCst);
+            } else {
+                count.fetch_add(owo_in_msg, Ordering::SeqCst);
+            }
         }
     }
 


### PR DESCRIPTION
The counter was just increasing by 1 for each message that cointains "owo", and not by how many "owo" it had:
![2022-06-20_13-57](https://user-images.githubusercontent.com/107818001/174650145-49fab0f1-1397-483c-89f5-2c6e9a418689.png)

After the changes, it is counting in the right way:
![2022-06-20_13-57_1](https://user-images.githubusercontent.com/107818001/174650203-221b0f3b-568b-43ec-b951-5998e6d9a785.png)

It won't count "owo"s that intersect:
![2022-06-20_13-58](https://user-images.githubusercontent.com/107818001/174650373-5b509950-58a3-449e-b6dd-96fab1a0458f.png)


