### PR TITLE
Unify `derive` & `#[non_exhaustive]` attributes for number enums

### DIFF
--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -67,7 +67,8 @@ pub struct TeamMember {
     pub user: User,
 }
 
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum MembershipState {
     Invited = 1,
     Accepted = 2,

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -263,7 +263,7 @@ impl Command {
 /// The type of an application command.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum CommandType {
@@ -335,7 +335,7 @@ pub struct CommandOption {
 /// The type of an [`CommandOption`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum CommandOptionType {
@@ -416,7 +416,7 @@ pub struct CommandPermissionData {
 /// The type of an [`CommandPermissionData`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum CommandPermissionType {

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -7,7 +7,7 @@ use crate::model::channel::ReactionType;
 use crate::model::utils::deserialize_val;
 
 /// The type of a component
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum ComponentType {
@@ -105,7 +105,7 @@ pub struct Button {
 }
 
 /// The style of a button.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum ButtonStyle {
@@ -173,7 +173,7 @@ pub struct InputText {
 }
 
 /// The style of the input text
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum InputTextStyle {

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -173,7 +173,7 @@ impl Serialize for Interaction {
 /// The type of an Interaction.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type).
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum InteractionType {

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -30,7 +30,7 @@ pub struct Connection {
 }
 
 /// The visibility of a user connection on a user's profile.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum ConnectionVisibility {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -334,7 +334,7 @@ pub struct ActivityEmoji {
     pub animated: Option<bool>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum ActivityType {
     /// An indicator that the user is playing a game.

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -26,7 +26,7 @@ pub struct Integration {
 }
 
 /// The behavior once the integration expires.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum IntegrationExpireBehaviour {

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -1,5 +1,5 @@
 /// The guild's premium tier, depends on the amount of users boosting the guild currently
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum PremiumTier {
     /// No tier, considered None

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -46,7 +46,8 @@ pub struct ScheduledEvent {
     pub image: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum ScheduledEventStatus {
     Scheduled = 1,
     Active = 2,
@@ -62,7 +63,8 @@ enum_number!(ScheduledEventStatus {
     Canceled,
 });
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum ScheduledEventType {
     StageInstance = 1,
     Voice = 2,


### PR DESCRIPTION
BREAKING CHANGE: Some enums were missing the `[non_exhaustive]` attribute.