### PR TITLE
Attempt to fix lifetime bug around `CustomisedHelpData`

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -844,7 +844,7 @@ pub async fn create_customised_help_data<'a>(
     ctx: &Context,
     msg: &Message,
     args: &'a Args,
-    groups: &[&'static CommandGroup],
+    groups: &'a [&'static CommandGroup],
     owners: &HashSet<UserId, impl std::hash::BuildHasher + Send + Sync>,
     help_options: &'a HelpOptions,
 ) -> CustomisedHelpData<'a> {


### PR DESCRIPTION
This attempts to workaround a compiler bug around lifetimes that only sometimes happens, and is solved by invoking `cargo clean`. Potentially fixes #2001.