### PR TITLE
Preserve values for unknown enum variants

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -31,54 +31,41 @@ pub const USER_AGENT: &str = concat!(
     ")"
 );
 
-/// An enum representing the [gateway opcodes].
-///
-/// [gateway opcodes]: https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum Opcode {
-    /// Dispatches an event.
-    Dispatch = 0,
-    /// Used for ping checking.
-    Heartbeat = 1,
-    /// Used for client handshake.
-    Identify = 2,
-    /// Used to update the client status.
-    PresenceUpdate = 3,
-    /// Used to join/move/leave voice channels.
-    VoiceStateUpdate = 4,
-    /// Used for voice ping checking.
-    VoiceServerPing = 5,
-    /// Used to resume a closed connection.
-    Resume = 6,
-    /// Used to tell clients to reconnect to the gateway.
-    Reconnect = 7,
-    /// Used to request guild members.
-    RequestGuildMembers = 8,
-    /// Used to notify clients that they have an invalid session Id.
-    InvalidSession = 9,
-    /// Sent immediately after connection, contains heartbeat + server info.
-    Hello = 10,
-    /// Sent immediately following a client heartbeat that was received.
-    HeartbeatAck = 11,
-    /// Unknown opcode.
-    Unknown = !0,
+enum_number! {
+    /// An enum representing the [gateway opcodes].
+    ///
+    /// [gateway opcodes]: https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum Opcode {
+        /// Dispatches an event.
+        Dispatch = 0,
+        /// Used for ping checking.
+        Heartbeat = 1,
+        /// Used for client handshake.
+        Identify = 2,
+        /// Used to update the client status.
+        PresenceUpdate = 3,
+        /// Used to join/move/leave voice channels.
+        VoiceStateUpdate = 4,
+        /// Used for voice ping checking.
+        VoiceServerPing = 5,
+        /// Used to resume a closed connection.
+        Resume = 6,
+        /// Used to tell clients to reconnect to the gateway.
+        Reconnect = 7,
+        /// Used to request guild members.
+        RequestGuildMembers = 8,
+        /// Used to notify clients that they have an invalid session Id.
+        InvalidSession = 9,
+        /// Sent immediately after connection, contains heartbeat + server info.
+        Hello = 10,
+        /// Sent immediately following a client heartbeat that was received.
+        HeartbeatAck = 11,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(Opcode {
-    Dispatch,
-    Heartbeat,
-    Identify,
-    PresenceUpdate,
-    VoiceStateUpdate,
-    VoiceServerPing,
-    Resume,
-    Reconnect,
-    RequestGuildMembers,
-    InvalidSession,
-    Hello,
-    HeartbeatAck,
-});
 
 pub mod close_codes {
     /// Unknown error; try reconnecting?

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -67,18 +67,16 @@ pub struct TeamMember {
     pub user: User,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum MembershipState {
-    Invited = 1,
-    Accepted = 2,
-    Unknown = !0,
+enum_number! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum MembershipState {
+        Invited = 1,
+        Accepted = 2,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(MembershipState {
-    Invited,
-    Accepted
-});
 
 bitflags! {
     /// The flags of the application.

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -260,24 +260,20 @@ impl Command {
     }
 }
 
-/// The type of an application command.
-///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum CommandType {
-    ChatInput = 1,
-    User = 2,
-    Message = 3,
-    Unknown = !0,
+enum_number! {
+    /// The type of an application command.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum CommandType {
+        ChatInput = 1,
+        User = 2,
+        Message = 3,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(CommandType {
-    ChatInput,
-    User,
-    Message
-});
 
 /// The parameters for an [`Command`].
 ///
@@ -332,40 +328,28 @@ pub struct CommandOption {
     pub autocomplete: bool,
 }
 
-/// The type of an [`CommandOption`].
-///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum CommandOptionType {
-    SubCommand = 1,
-    SubCommandGroup = 2,
-    String = 3,
-    Integer = 4,
-    Boolean = 5,
-    User = 6,
-    Channel = 7,
-    Role = 8,
-    Mentionable = 9,
-    Number = 10,
-    Attachment = 11,
-    Unknown = !0,
+enum_number! {
+    /// The type of an [`CommandOption`].
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum CommandOptionType {
+        SubCommand = 1,
+        SubCommandGroup = 2,
+        String = 3,
+        Integer = 4,
+        Boolean = 5,
+        User = 6,
+        Channel = 7,
+        Role = 8,
+        Mentionable = 9,
+        Number = 10,
+        Attachment = 11,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(CommandOptionType {
-    SubCommand,
-    SubCommandGroup,
-    String,
-    Integer,
-    Boolean,
-    User,
-    Channel,
-    Role,
-    Mentionable,
-    Number,
-    Attachment
-});
 
 /// The only valid values a user can pick in an [`CommandOption`].
 ///
@@ -413,24 +397,20 @@ pub struct CommandPermissionData {
     pub permission: bool,
 }
 
-/// The type of an [`CommandPermissionData`].
-///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum CommandPermissionType {
-    Role = 1,
-    User = 2,
-    Channel = 3,
-    Unknown = !0,
+enum_number! {
+    /// The type of an [`CommandPermissionData`].
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum CommandPermissionType {
+        Role = 1,
+        User = 2,
+        Channel = 3,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(CommandPermissionType {
-    Role,
-    User,
-    Channel,
-});
 
 impl CommandPermissionId {
     /// Converts this [`CommandPermissionId`] to [`UserId`].

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -6,24 +6,19 @@ use crate::json::from_value;
 use crate::model::channel::ReactionType;
 use crate::model::utils::deserialize_val;
 
-/// The type of a component
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum ComponentType {
-    ActionRow = 1,
-    Button = 2,
-    SelectMenu = 3,
-    InputText = 4,
-    Unknown = !0,
+enum_number! {
+    /// The type of a component
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ComponentType {
+        ActionRow = 1,
+        Button = 2,
+        SelectMenu = 3,
+        InputText = 4,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(ComponentType {
-    ActionRow,
-    Button,
-    SelectMenu,
-    InputText
-});
 
 /// An action row.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -104,26 +99,20 @@ pub struct Button {
     pub disabled: bool,
 }
 
-/// The style of a button.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum ButtonStyle {
-    Primary = 1,
-    Secondary = 2,
-    Success = 3,
-    Danger = 4,
-    Link = 5,
-    Unknown = !0,
+enum_number! {
+    /// The style of a button.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ButtonStyle {
+        Primary = 1,
+        Secondary = 2,
+        Success = 3,
+        Danger = 4,
+        Link = 5,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(ButtonStyle {
-    Primary,
-    Secondary,
-    Success,
-    Danger,
-    Link
-});
 
 /// A select menu component.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -172,18 +161,14 @@ pub struct InputText {
     pub value: String,
 }
 
-/// The style of the input text
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum InputTextStyle {
-    Short = 1,
-    Paragraph = 2,
-    Unknown = !0,
+enum_number! {
+    /// The style of the input text
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum InputTextStyle {
+        Short = 1,
+        Paragraph = 2,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(InputTextStyle {
-    Short,
-    Paragraph,
-    Unknown
-});

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -324,7 +324,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         CommandDataOptionValue::SubCommandGroup(options()?)
                     },
                     CommandOptionType::SubCommand => CommandDataOptionValue::SubCommand(options()?),
-                    CommandOptionType::Unknown => CommandDataOptionValue::Unknown,
+                    CommandOptionType::Unknown(unknown) => CommandDataOptionValue::Unknown(unknown),
                 };
 
                 Ok(CommandDataOption {
@@ -347,7 +347,7 @@ impl Serialize for CommandDataOption {
             CommandDataOptionValue::SubCommand(o) | CommandDataOptionValue::SubCommandGroup(o) => {
                 (!o.is_empty(), false)
             },
-            CommandDataOptionValue::Unknown => (false, false),
+            CommandDataOptionValue::Unknown(_) => (false, false),
             _ => (true, false),
         };
         let len = 2 + usize::from(value_or_options) + usize::from(focused);
@@ -404,7 +404,7 @@ pub enum CommandDataOptionValue {
     Mentionable(GenericId),
     Role(RoleId),
     User(UserId),
-    Unknown,
+    Unknown(u8),
 }
 
 impl CommandDataOptionValue {
@@ -426,7 +426,7 @@ impl CommandDataOptionValue {
             Self::Mentionable(_) => CommandOptionType::Mentionable,
             Self::Role(_) => CommandOptionType::Role,
             Self::User(_) => CommandOptionType::User,
-            Self::Unknown => CommandOptionType::Unknown,
+            Self::Unknown(unknown) => CommandOptionType::Unknown(*unknown),
         }
     }
 

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -152,7 +152,7 @@ impl<'de> Deserialize<'de> for Interaction {
             InteractionType::Autocomplete => from_value(value).map(Interaction::Autocomplete),
             InteractionType::ModalSubmit => from_value(value).map(Interaction::ModalSubmit),
             InteractionType::Ping => from_value(value).map(Interaction::Ping),
-            InteractionType::Unknown => return Err(DeError::custom("Unknown interaction type")),
+            InteractionType::Unknown(_) => return Err(DeError::custom("Unknown interaction type")),
         }
         .map_err(DeError::custom)
     }
@@ -170,28 +170,22 @@ impl Serialize for Interaction {
     }
 }
 
-/// The type of an Interaction.
-///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type).
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum InteractionType {
-    Ping = 1,
-    ApplicationCommand = 2,
-    MessageComponent = 3,
-    Autocomplete = 4,
-    ModalSubmit = 5,
-    Unknown = !0,
+enum_number! {
+    /// The type of an Interaction.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type).
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum InteractionType {
+        Ping = 1,
+        ApplicationCommand = 2,
+        MessageComponent = 3,
+        Autocomplete = 4,
+        ModalSubmit = 5,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(InteractionType {
-    Ping,
-    MessageComponent,
-    ApplicationCommand,
-    Autocomplete,
-    ModalSubmit
-});
 
 bitflags! {
     /// The flags for an interaction response message.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1012,102 +1012,74 @@ pub struct MessageReaction {
     pub reaction_type: ReactionType,
 }
 
-/// Differentiates between regular and different types of system messages.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum MessageType {
-    /// A regular message.
-    Regular = 0,
-    /// An indicator that a recipient was added by the author.
-    GroupRecipientAddition = 1,
-    /// An indicator that a recipient was removed by the author.
-    GroupRecipientRemoval = 2,
-    /// An indicator that a call was started by the author.
-    GroupCallCreation = 3,
-    /// An indicator that the group name was modified by the author.
-    GroupNameUpdate = 4,
-    /// An indicator that the group icon was modified by the author.
-    GroupIconUpdate = 5,
-    /// An indicator that a message was pinned by the author.
-    PinsAdd = 6,
-    /// An indicator that a member joined the guild.
-    MemberJoin = 7,
-    /// An indicator that someone has boosted the guild.
-    NitroBoost = 8,
-    /// An indicator that the guild has reached nitro tier 1
-    NitroTier1 = 9,
-    /// An indicator that the guild has reached nitro tier 2
-    NitroTier2 = 10,
-    /// An indicator that the guild has reached nitro tier 3
-    NitroTier3 = 11,
-    /// An indicator that the channel is now following a news channel
-    ChannelFollowAdd = 12,
-    /// An indicator that the guild is disqualified for Discovery Feature
-    GuildDiscoveryDisqualified = 14,
-    /// An indicator that the guild is requalified for Discovery Feature
-    GuildDiscoveryRequalified = 15,
-    /// The first warning before guild discovery removal.
-    GuildDiscoveryGracePeriodInitialWarning = 16,
-    /// The last warning before guild discovery removal.
-    GuildDiscoveryGracePeriodFinalWarning = 17,
-    /// Message sent to inform users that a thread was created.
-    ThreadCreated = 18,
-    /// A message reply.
-    InlineReply = 19,
-    /// A slash command.
-    ChatInputCommand = 20,
-    /// A thread start message.
-    ThreadStarterMessage = 21,
-    /// Server setup tips.
-    GuildInviteReminder = 22,
-    /// A context menu command.
-    ContextMenuCommand = 23,
-    /// An indicator that the message is of unknown type.
-    Unknown = !0,
+enum_number! {
+    /// Differentiates between regular and different types of system messages.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum MessageType {
+        /// A regular message.
+        Regular = 0,
+        /// An indicator that a recipient was added by the author.
+        GroupRecipientAddition = 1,
+        /// An indicator that a recipient was removed by the author.
+        GroupRecipientRemoval = 2,
+        /// An indicator that a call was started by the author.
+        GroupCallCreation = 3,
+        /// An indicator that the group name was modified by the author.
+        GroupNameUpdate = 4,
+        /// An indicator that the group icon was modified by the author.
+        GroupIconUpdate = 5,
+        /// An indicator that a message was pinned by the author.
+        PinsAdd = 6,
+        /// An indicator that a member joined the guild.
+        MemberJoin = 7,
+        /// An indicator that someone has boosted the guild.
+        NitroBoost = 8,
+        /// An indicator that the guild has reached nitro tier 1
+        NitroTier1 = 9,
+        /// An indicator that the guild has reached nitro tier 2
+        NitroTier2 = 10,
+        /// An indicator that the guild has reached nitro tier 3
+        NitroTier3 = 11,
+        /// An indicator that the channel is now following a news channel
+        ChannelFollowAdd = 12,
+        /// An indicator that the guild is disqualified for Discovery Feature
+        GuildDiscoveryDisqualified = 14,
+        /// An indicator that the guild is requalified for Discovery Feature
+        GuildDiscoveryRequalified = 15,
+        /// The first warning before guild discovery removal.
+        GuildDiscoveryGracePeriodInitialWarning = 16,
+        /// The last warning before guild discovery removal.
+        GuildDiscoveryGracePeriodFinalWarning = 17,
+        /// Message sent to inform users that a thread was created.
+        ThreadCreated = 18,
+        /// A message reply.
+        InlineReply = 19,
+        /// A slash command.
+        ChatInputCommand = 20,
+        /// A thread start message.
+        ThreadStarterMessage = 21,
+        /// Server setup tips.
+        GuildInviteReminder = 22,
+        /// A context menu command.
+        ContextMenuCommand = 23,
+        _ => Unknown(u8),
+    }
 }
 
-enum_number!(MessageType {
-    Regular,
-    GroupRecipientAddition,
-    GroupRecipientRemoval,
-    GroupCallCreation,
-    GroupNameUpdate,
-    GroupIconUpdate,
-    PinsAdd,
-    MemberJoin,
-    NitroBoost,
-    NitroTier1,
-    NitroTier2,
-    NitroTier3,
-    ChannelFollowAdd,
-    GuildDiscoveryDisqualified,
-    GuildDiscoveryRequalified,
-    GuildDiscoveryGracePeriodInitialWarning,
-    GuildDiscoveryGracePeriodFinalWarning
-    ThreadCreated,
-    InlineReply,
-    ChatInputCommand,
-    ThreadStarterMessage,
-    GuildInviteReminder,
-    ContextMenuCommand,
-});
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum MessageActivityKind {
-    Join = 1,
-    Spectate = 2,
-    Listen = 3,
-    JoinRequest = 5,
-    Unknown = !0,
+enum_number! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum MessageActivityKind {
+        Join = 1,
+        Spectate = 2,
+        Listen = 3,
+        JoinRequest = 5,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(MessageActivityKind {
-    Join,
-    Spectate,
-    Listen,
-    JoinRequest,
-});
 
 /// Rich Presence application information.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -278,56 +278,42 @@ impl fmt::Display for Channel {
     }
 }
 
-/// A representation of a type of channel.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum ChannelType {
-    /// An indicator that the channel is a text [`GuildChannel`].
-    Text = 0,
-    /// An indicator that the channel is a [`PrivateChannel`].
-    Private = 1,
-    /// An indicator that the channel is a voice [`GuildChannel`].
-    Voice = 2,
-    /// An indicator that the channel is the channel of a [`ChannelCategory`].
-    Category = 4,
-    /// An indicator that the channel is a `NewsChannel`.
-    ///
-    /// Note: `NewsChannel` is serialized into a [`GuildChannel`]
-    News = 5,
-    /// An indicator that the channel is a news thread [`GuildChannel`].
-    NewsThread = 10,
-    /// An indicator that the channel is a public thread [`GuildChannel`].
-    PublicThread = 11,
-    /// An indicator that the channel is a private thread [`GuildChannel`].
-    PrivateThread = 12,
-    /// An indicator that the channel is a stage [`GuildChannel`].
-    Stage = 13,
-    /// An indicator that the channel is a directory [`GuildChannel`] in a [hub].
-    ///
-    /// [hub]: https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
-    Directory = 14,
-    /// An indicator that the channel is a forum [`GuildChannel`].
-    #[cfg(feature = "unstable_discord_api")]
-    Forum = 15,
-    /// An indicator that the channel is of unknown type.
-    Unknown = !0,
+enum_number! {
+    /// A representation of a type of channel.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ChannelType {
+        /// An indicator that the channel is a text [`GuildChannel`].
+        Text = 0,
+        /// An indicator that the channel is a [`PrivateChannel`].
+        Private = 1,
+        /// An indicator that the channel is a voice [`GuildChannel`].
+        Voice = 2,
+        /// An indicator that the channel is the channel of a [`ChannelCategory`].
+        Category = 4,
+        /// An indicator that the channel is a `NewsChannel`.
+        ///
+        /// Note: `NewsChannel` is serialized into a [`GuildChannel`]
+        News = 5,
+        /// An indicator that the channel is a news thread [`GuildChannel`].
+        NewsThread = 10,
+        /// An indicator that the channel is a public thread [`GuildChannel`].
+        PublicThread = 11,
+        /// An indicator that the channel is a private thread [`GuildChannel`].
+        PrivateThread = 12,
+        /// An indicator that the channel is a stage [`GuildChannel`].
+        Stage = 13,
+        /// An indicator that the channel is a directory [`GuildChannel`] in a [hub].
+        ///
+        /// [hub]: https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
+        Directory = 14,
+        /// An indicator that the channel is a forum [`GuildChannel`].
+        #[cfg(feature = "unstable_discord_api")]
+        Forum = 15,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(ChannelType {
-    Text,
-    Private,
-    Voice,
-    Category,
-    News,
-    NewsThread,
-    PublicThread,
-    PrivateThread,
-    Stage,
-    Directory,
-    #[cfg(feature = "unstable_discord_api")]
-    Forum,
-});
 
 impl ChannelType {
     #[inline]
@@ -346,7 +332,7 @@ impl ChannelType {
             Self::Directory => "directory",
             #[cfg(feature = "unstable_discord_api")]
             Self::Forum => "forum",
-            Self::Unknown => "unknown",
+            Self::Unknown(_) => "unknown",
         }
     }
 }
@@ -433,23 +419,20 @@ pub enum PermissionOverwriteType {
     Role(RoleId),
 }
 
-/// The video quality mode for a voice channel.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum VideoQualityMode {
-    /// An indicator that the video quality is chosen by Discord for optimal
-    /// performance.
-    Auto = 1,
-    /// An indicator that the video quality is 720p.
-    Full = 2,
-    /// An indicator that video quality is of unknown type.
-    Unknown = !0,
+enum_number! {
+    /// The video quality mode for a voice channel.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum VideoQualityMode {
+        /// An indicator that the video quality is chosen by Discord for optimal
+        /// performance.
+        Auto = 1,
+        /// An indicator that the video quality is 720p.
+        Full = 2,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(VideoQualityMode {
-    Auto,
-    Full
-});
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -29,17 +29,14 @@ pub struct Connection {
     pub visibility: ConnectionVisibility,
 }
 
-/// The visibility of a user connection on a user's profile.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum ConnectionVisibility {
-    None = 0,
-    Everyone = 1,
-    Unknown = !0,
+enum_number! {
+    /// The visibility of a user connection on a user's profile.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ConnectionVisibility {
+        None = 0,
+        Everyone = 1,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(ConnectionVisibility {
-    None,
-    Everyone
-});

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -335,33 +335,26 @@ pub struct ActivityEmoji {
     pub animated: Option<bool>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum ActivityType {
-    /// An indicator that the user is playing a game.
-    Playing = 0,
-    /// An indicator that the user is streaming to a service.
-    Streaming = 1,
-    /// An indicator that the user is listening to something.
-    Listening = 2,
-    /// An indicator that the user is watching something.
-    Watching = 3,
-    /// An indicator that the user uses custom statuses
-    Custom = 4,
-    /// An indicator that the user is competing somewhere.
-    Competing = 5,
-    /// An indicator that the activity is of unknown type.
-    Unknown = !0,
+enum_number! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ActivityType {
+        /// An indicator that the user is playing a game.
+        Playing = 0,
+        /// An indicator that the user is streaming to a service.
+        Streaming = 1,
+        /// An indicator that the user is listening to something.
+        Listening = 2,
+        /// An indicator that the user is watching something.
+        Watching = 3,
+        /// An indicator that the user uses custom statuses
+        Custom = 4,
+        /// An indicator that the user is competing somewhere.
+        Competing = 5,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(ActivityType {
-    Playing,
-    Streaming,
-    Listening,
-    Watching,
-    Custom,
-    Competing
-});
 
 impl Default for ActivityType {
     fn default() -> Self {

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -25,20 +25,17 @@ pub struct Integration {
     pub application: Option<IntegrationApplication>,
 }
 
-/// The behavior once the integration expires.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum IntegrationExpireBehaviour {
-    RemoveRole = 0,
-    Kick = 1,
-    Unknown = !0,
+enum_number! {
+    /// The behavior once the integration expires.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum IntegrationExpireBehaviour {
+        RemoveRole = 0,
+        Kick = 1,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(IntegrationExpireBehaviour {
-    RemoveRole,
-    Kick
-});
 
 impl From<Integration> for IntegrationId {
     /// Gets the Id of integration.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2746,109 +2746,88 @@ pub struct UnavailableGuild {
     pub unavailable: bool,
 }
 
-/// Default message notification level for a guild.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum DefaultMessageNotificationLevel {
-    /// Receive notifications for everything.
-    All = 0,
-    /// Receive only mentions.
-    Mentions = 1,
-    /// Unknown notification level.
-    Unknown = !0,
+enum_number! {
+    /// Default message notification level for a guild.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum DefaultMessageNotificationLevel {
+        /// Receive notifications for everything.
+        All = 0,
+        /// Receive only mentions.
+        Mentions = 1,
+        _ => Unknown(u8),
+    }
 }
 
-enum_number!(DefaultMessageNotificationLevel {
-    All,
-    Mentions
-});
-
-/// Setting used to filter explicit messages from members.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum ExplicitContentFilter {
-    /// Don't scan any messages.
-    None = 0,
-    /// Scan messages from members without a role.
-    WithoutRole = 1,
-    /// Scan messages sent by all members.
-    All = 2,
-    /// Unknown content filter.
-    Unknown = !0,
+enum_number! {
+    /// Setting used to filter explicit messages from members.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ExplicitContentFilter {
+        /// Don't scan any messages.
+        None = 0,
+        /// Scan messages from members without a role.
+        WithoutRole = 1,
+        /// Scan messages sent by all members.
+        All = 2,
+        _ => Unknown(u8),
+    }
 }
 
-enum_number!(ExplicitContentFilter {
-    None,
-    WithoutRole,
-    All
-});
-
-/// Multi-Factor Authentication level for guild moderators.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum MfaLevel {
-    /// MFA is disabled.
-    None = 0,
-    /// MFA is enabled.
-    Elevated = 1,
-    /// Unknown MFA level.
-    Unknown = !0,
+enum_number! {
+    /// Multi-Factor Authentication level for guild moderators.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum MfaLevel {
+        /// MFA is disabled.
+        None = 0,
+        /// MFA is enabled.
+        Elevated = 1,
+        _ => Unknown(u8),
+    }
 }
 
-enum_number!(MfaLevel {
-    None,
-    Elevated
-});
-
-/// The level to set as criteria prior to a user being able to send
-/// messages in a [`Guild`].
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum VerificationLevel {
-    /// Does not require any verification.
-    None = 0,
-    /// Must have a verified email on the user's Discord account.
-    Low = 1,
-    /// Must also be a registered user on Discord for longer than 5 minutes.
-    Medium = 2,
-    /// Must also be a member of the guild for longer than 10 minutes.
-    High = 3,
-    /// Must have a verified phone on the user's Discord account.
-    Higher = 4,
-    /// Unknown verification level.
-    Unknown = !0,
+enum_number! {
+    /// The level to set as criteria prior to a user being able to send
+    /// messages in a [`Guild`].
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum VerificationLevel {
+        /// Does not require any verification.
+        None = 0,
+        /// Must have a verified email on the user's Discord account.
+        Low = 1,
+        /// Must also be a registered user on Discord for longer than 5 minutes.
+        Medium = 2,
+        /// Must also be a member of the guild for longer than 10 minutes.
+        High = 3,
+        /// Must have a verified phone on the user's Discord account.
+        Higher = 4,
+        _ => Unknown(u8),
+    }
 }
 
-enum_number!(VerificationLevel {
-    None,
-    Low,
-    Medium,
-    High,
-    Higher
-});
-
-/// The [`Guild`] nsfw level.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum NsfwLevel {
-    /// The nsfw level is not specified.
-    Default = 0,
-    /// The guild is considered as explicit.
-    Explicit = 1,
-    /// The guild is considered as safe.
-    Safe = 2,
-    /// The guild is age restricted.
-    AgeRestricted = 3,
-    /// Unknown nsfw level.
-    Unknown = !0,
+enum_number! {
+    /// The [`Guild`] nsfw level.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum NsfwLevel {
+        /// The nsfw level is not specified.
+        Default = 0,
+        /// The guild is considered as explicit.
+        Explicit = 1,
+        /// The guild is considered as safe.
+        Safe = 2,
+        /// The guild is age restricted.
+        AgeRestricted = 3,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(NsfwLevel {
-    Default,
-    Explicit,
-    Safe,
-    AgeRestricted
-});
 
 #[cfg(test)]
 mod test {

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -1,21 +1,17 @@
-/// The guild's premium tier, depends on the amount of users boosting the guild currently
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum PremiumTier {
-    /// No tier, considered None
-    Tier0,
-    Tier1,
-    Tier2,
-    Tier3,
-    Unknown = !0,
+enum_number! {
+    /// The guild's premium tier, depends on the amount of users boosting the guild currently
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum PremiumTier {
+        /// No tier, considered None
+        Tier0 = 0,
+        Tier1 = 1,
+        Tier2 = 2,
+        Tier3 = 3,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(PremiumTier {
-    Tier0,
-    Tier1,
-    Tier2,
-    Tier3
-});
 
 impl Default for PremiumTier {
     fn default() -> Self {

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -46,37 +46,30 @@ pub struct ScheduledEvent {
     pub image: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum ScheduledEventStatus {
-    Scheduled = 1,
-    Active = 2,
-    Completed = 3,
-    Canceled = 4,
-    Unknown = !0,
+enum_number! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ScheduledEventStatus {
+        Scheduled = 1,
+        Active = 2,
+        Completed = 3,
+        Canceled = 4,
+        _ => Unknown(u8),
+    }
 }
 
-enum_number!(ScheduledEventStatus {
-    Scheduled,
-    Active,
-    Completed,
-    Canceled,
-});
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum ScheduledEventType {
-    StageInstance = 1,
-    Voice = 2,
-    External = 3,
-    Unknown = !0,
+enum_number! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ScheduledEventType {
+        StageInstance = 1,
+        Voice = 2,
+        External = 3,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(ScheduledEventType {
-    StageInstance,
-    Voice,
-    External,
-});
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScheduledEventMetadata {

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -419,17 +419,14 @@ pub struct InviteStageInstance {
     topic: String,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum InviteTargetType {
-    Normal = 0,
-    Stream = 1,
-    EmmbeddedApplication = 2,
-    Unknown = !0,
+enum_number! {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum InviteTargetType {
+        Normal = 0,
+        Stream = 1,
+        EmmbeddedApplication = 2,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(InviteTargetType {
-    Normal,
-    Stream,
-    EmmbeddedApplication,
-});

--- a/src/model/sticker/mod.rs
+++ b/src/model/sticker/mod.rs
@@ -118,50 +118,43 @@ impl Sticker {
     }
 }
 
-/// Differentiates between sticker types.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum StickerType {
-    /// An official sticker in a pack, part of Nitro or in a removed purchasable
-    /// pack.
-    Standard = 1,
-    /// A sticker uploaded to a Boosted guild for the guild's members.
-    Guild = 2,
-    /// Unknown sticker type.
-    Unknown = !0,
+enum_number! {
+    /// Differentiates between sticker types.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum StickerType {
+        /// An official sticker in a pack, part of Nitro or in a removed purchasable
+        /// pack.
+        Standard = 1,
+        /// A sticker uploaded to a Boosted guild for the guild's members.
+        Guild = 2,
+        _ => Unknown(u8),
+    }
 }
 
-enum_number!(StickerType {
-    Standard,
-    Guild
-});
-
-/// Differentiates between sticker formats.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum StickerFormatType {
-    /// A PNG format sticker.
-    Png = 1,
-    /// An APNG format animated sticker.
-    Apng = 2,
-    /// A LOTTIE format animated sticker.
-    Lottie = 3,
-    /// Unknown sticker format type.
-    Unknown = !0,
+enum_number! {
+    /// Differentiates between sticker formats.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum StickerFormatType {
+        /// A PNG format sticker.
+        Png = 1,
+        /// An APNG format animated sticker.
+        Apng = 2,
+        /// A LOTTIE format animated sticker.
+        Lottie = 3,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(StickerFormatType {
-    Png,
-    Apng,
-    Lottie
-});
 
 #[cfg(feature = "model")]
 fn sticker_url(sticker_id: StickerId, sticker_format_type: StickerFormatType) -> Option<String> {
     let ext = match sticker_format_type {
         StickerFormatType::Png | StickerFormatType::Apng => "png",
         StickerFormatType::Lottie => "json",
-        StickerFormatType::Unknown => return None,
+        StickerFormatType::Unknown(_) => return None,
     };
 
     Some(cdn!("/stickers/{}.{}", sticker_id.get(), ext))

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -17,27 +17,23 @@ use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::ModelError;
 
-/// A representation of a type of webhook.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum WebhookType {
-    /// An indicator that the webhook can post messages to channels with
-    /// a token.
-    Incoming = 1,
-    /// An indicator that the webhook is managed by Discord for posting new
-    /// messages to channels without a token.
-    ChannelFollower = 2,
-    /// Application webhooks are webhooks used with Interactions.
-    Application = 3,
-    /// An indicator that the webhook is of unknown type.
-    Unknown = !0,
+enum_number! {
+    /// A representation of a type of webhook.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum WebhookType {
+        /// An indicator that the webhook can post messages to channels with
+        /// a token.
+        Incoming = 1,
+        /// An indicator that the webhook is managed by Discord for posting new
+        /// messages to channels without a token.
+        ChannelFollower = 2,
+        /// Application webhooks are webhooks used with Interactions.
+        Application = 3,
+        _ => Unknown(u8),
+    }
 }
-
-enum_number!(WebhookType {
-    Incoming,
-    ChannelFollower,
-    Application,
-});
 
 impl WebhookType {
     #[inline]
@@ -47,7 +43,7 @@ impl WebhookType {
             Self::Incoming => "incoming",
             Self::ChannelFollower => "channel follower",
             Self::Application => "application",
-            Self::Unknown => "unknown",
+            Self::Unknown(_) => "unknown",
         }
     }
 }


### PR DESCRIPTION
The `enum_number!` macro now takes the whole enum definition and generates
`From` trait implementations to convert a value to the enum and back.

The implementations can then be picked up by `serde` with
`#[serde(from = "u8", into = "u8")]` to (de)serialize the types.

```rust
enum_number! {
    #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
    #[serde(from = "u8", into = "u8")]
    pub enum Foo {
        A = 1,
        B = 2,
        _ => Unknown(u8),
    }
}
```

**BREAKING CHANGE**: The `Unknown` variant now takes the unknown value
and the removed `fn num() -> u64` method can be replaced
with `let v = u8::from(kind)`.