### PR TITLE
Remove `InterMessage::Json`

### DIFF
--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -477,10 +477,6 @@ impl ShardRunner {
                     },
                 },
             },
-            InterMessage::Json(value) => {
-                // Value must be forwarded over the websocket
-                self.shard.client.send_json(&value).await.is_ok()
-            },
         }
     }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -52,15 +52,16 @@ mod ws;
 
 use std::fmt;
 
+#[cfg(feature = "client")]
+use async_tungstenite::tungstenite;
 use reqwest::{IntoUrl, Url};
 
 pub use self::error::Error as GatewayError;
 pub use self::shard::Shard;
 pub use self::ws::WsClient;
 #[cfg(feature = "client")]
-use crate::client::bridge::gateway::ShardClientMessage;
+use crate::client::bridge::gateway::{ShardClientMessage, ShardRunnerMessage};
 use crate::internal::prelude::*;
-use crate::json::Value;
 use crate::model::gateway::{Activity, ActivityType};
 use crate::model::user::OnlineStatus;
 
@@ -239,7 +240,19 @@ impl fmt::Display for ConnectionStage {
 pub enum InterMessage {
     #[cfg(feature = "client")]
     Client(ShardClientMessage),
-    Json(Value),
+}
+
+impl InterMessage {
+    /// Constructs a custom message which will send the given `value` over the WebSocket.
+    ///
+    /// This is simply sugar for constructing and nesting [`ShardRunnerMessage::Message`].
+    #[cfg(feature = "client")]
+    #[must_use]
+    pub fn json(value: String) -> Self {
+        Self::Client(ShardClientMessage::Runner(Box::new(ShardRunnerMessage::Message(
+            tungstenite::Message::Text(value),
+        ))))
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This functionality is replicated by sending a `ShardRunnerMessage` with the `Value` serialized to `String`.

Adds a sugar method to `InterMessage` to do this nested construction in a simpler way, to replicate the old behavior. 