### PR TITLE
Cleanup collector module by replacing duplication with generics

### DIFF
--- a/src/collector/base_collector.rs
+++ b/src/collector/base_collector.rs
@@ -1,0 +1,37 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context as FutContext, Poll};
+
+use futures::Future;
+use tokio::sync::mpsc::UnboundedReceiver as Receiver;
+use tokio::time::Sleep;
+
+pub struct Collector<Item> {
+    pub(super) receiver: Pin<Box<Receiver<Arc<Item>>>>,
+    pub(super) timeout: Option<Pin<Box<Sleep>>>,
+}
+
+impl<Item> Collector<Item> {
+    /// Stops collecting, this will implicitly be done once the
+    /// collector drops.
+    /// In case the drop does not appear until later, it is preferred to
+    /// stop the collector early.
+    pub fn stop(self) {}
+}
+
+impl<Item> futures::stream::Stream for Collector<Item> {
+    type Item = Arc<Item>;
+
+    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(timeout) = &mut self.timeout {
+            match timeout.as_mut().poll(ctx) {
+                Poll::Ready(_) => {
+                    return Poll::Ready(None);
+                },
+                Poll::Pending => (),
+            }
+        }
+
+        self.receiver.as_mut().poll_recv(ctx)
+    }
+}

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -1,50 +1,16 @@
-use std::fmt;
-use std::future::Future;
 use std::num::NonZeroU64;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context as FutContext, Poll};
 
-use futures::future::BoxFuture;
-use futures::stream::{Stream, StreamExt};
 use tokio::sync::mpsc::{
     unbounded_channel,
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-use tokio::time::Sleep;
 
+use super::macros::*;
 use crate::client::bridge::gateway::ShardMessenger;
-use crate::collector::macros::*;
 use crate::collector::{FilterFn, LazyArc};
 use crate::model::application::interaction::message_component::MessageComponentInteraction;
-
-macro_rules! impl_component_interaction_collector {
-    ($($name:ident;)*) => {
-        $(
-            impl $name {
-                /// Sets a filter function where interactions passed to the function must
-                /// return `true`, otherwise the interaction won't be collected.
-                /// This is the last instance to pass for an interaction to count as *collected*.
-                ///
-                /// This function is intended to be an interaction filter.
-                pub fn filter<F: Fn(&MessageComponentInteraction) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
-                    self.filter.as_mut().unwrap().filter = Some(FilterFn(Arc::new(function)));
-
-                    self
-                }
-
-                impl_filter_limit!("Limits how many interactions will attempt to be filtered. The filter checks whether the message has been sent in the right guild, channel, and by the right author.");
-                impl_collect_limit!("Limits how many interactions can be collected. An interaction is considered *collected*, if the interaction passes all the requirements.");
-                impl_channel_id!("Sets the channel on which the interaction must occur. If an interaction is not on a message with this channel ID, it won't be received.");
-                impl_guild_id!("Sets the guild in which the interaction must occur. If an interaction is not on a message with this guild ID, it won't be received.");
-                impl_message_id!("Sets the message on which the interaction must occur. If an interaction is not on a message with this ID, it won't be received.");
-                impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received");
-                impl_timeout!("Sets a `duration` for how long the collector shall receive interactions.");
-            }
-        )*
-    }
-}
 
 /// Filters events on the shard's end and sends them to the collector.
 #[derive(Clone, Debug)]
@@ -53,18 +19,30 @@ pub struct ComponentInteractionFilter {
     collected: u32,
     options: FilterOptions,
     sender: Sender<Arc<MessageComponentInteraction>>,
+
+    filter_limit: Option<u32>,
+    collect_limit: Option<u32>,
+    filter: Option<FilterFn<MessageComponentInteraction>>,
 }
 
 impl ComponentInteractionFilter {
     /// Creates a new filter
-    fn new(options: FilterOptions) -> (Self, Receiver<Arc<MessageComponentInteraction>>) {
+    fn new(
+        options: FilterOptions,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<MessageComponentInteraction>>,
+    ) -> (Self, Receiver<Arc<MessageComponentInteraction>>) {
         let (sender, receiver) = unbounded_channel();
 
         let filter = Self {
             filtered: 0,
             collected: 0,
             sender,
+            filter,
             options,
+            filter_limit,
+            collect_limit,
         };
 
         (filter, receiver)
@@ -97,161 +75,59 @@ impl ComponentInteractionFilter {
             && self.options.message_id.map_or(true, |id| interaction.message.id.0 == id)
             && self.options.channel_id.map_or(true, |id| id == interaction.channel_id.as_ref().0)
             && self.options.author_id.map_or(true, |id| id == interaction.user.id.0)
-            && self.options.filter.as_ref().map_or(true, |f| f.0(interaction))
+            && self.filter.as_ref().map_or(true, |f| f.0(interaction))
     }
 
     /// Checks if the filter is within set receive and collect limits.
     /// An interaction is considered *received* even when it does not meet the
     /// constraints.
     fn is_within_limits(&self) -> bool {
-        self.options.filter_limit.map_or(true, |limit| self.filtered < limit)
-            && self.options.collect_limit.map_or(true, |limit| self.collected < limit)
+        self.filter_limit.map_or(true, |limit| self.filtered < limit)
+            && self.collect_limit.map_or(true, |limit| self.collected < limit)
     }
 }
 
-#[derive(Clone, Default)]
-struct FilterOptions {
-    filter_limit: Option<u32>,
-    collect_limit: Option<u32>,
-    filter: Option<FilterFn<MessageComponentInteraction>>,
+#[derive(Clone, Debug, Default)]
+pub struct FilterOptions {
     channel_id: Option<NonZeroU64>,
     guild_id: Option<NonZeroU64>,
     author_id: Option<NonZeroU64>,
     message_id: Option<NonZeroU64>,
 }
 
-impl fmt::Debug for FilterOptions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ComponentInteractionFilter")
-            .field("collect_limit", &self.collect_limit)
-            .field("filter", &"Option<Arc<dyn Fn(&Arc<Reaction>) -> bool + 'static + Send + Sync>>")
-            .field("channel_id", &self.channel_id)
-            .field("guild_id", &self.guild_id)
-            .field("author_id", &self.author_id)
-            .finish()
+impl super::CollectorBuilder<'_, MessageComponentInteraction> {
+    impl_channel_id!("Sets the channel on which the interaction must occur. If an interaction is not on a message with this channel ID, it won't be received.");
+    impl_guild_id!("Sets the guild in which the interaction must occur. If an interaction is not on a message with this guild ID, it won't be received.");
+    impl_message_id!("Sets the message on which the interaction must occur. If an interaction is not on a message with this ID, it won't be received.");
+    impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received");
+}
+
+impl super::FilterOptions<MessageComponentInteraction> for FilterOptions {
+    type FilterItem = MessageComponentInteraction;
+
+    fn build(
+        self,
+        messenger: &ShardMessenger,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<Self::FilterItem>>,
+    ) -> Receiver<Arc<MessageComponentInteraction>> {
+        let (filter, recv) =
+            ComponentInteractionFilter::new(self, filter_limit, collect_limit, filter);
+        messenger.set_component_interaction_filter(filter);
+
+        recv
     }
 }
 
-// Implement the common setters for all component interaction collector types.
-// This avoids using a trait that the user would need to import in
-// order to use any of these methods.
-impl_component_interaction_collector! {
-    CollectComponentInteraction;
-    ComponentInteractionCollectorBuilder;
+impl super::Collectable for MessageComponentInteraction {
+    type FilterOptions = FilterOptions;
 }
 
-#[must_use = "Builders do nothing unless built"]
-pub struct ComponentInteractionCollectorBuilder {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
+/// A component interaction collector receives interactions matching a the given filter for a set duration.
+pub type ComponentInteractionCollector = super::Collector<MessageComponentInteraction>;
+pub type ComponentInteractionCollectorBuilder<'a> =
+    super::CollectorBuilder<'a, MessageComponentInteraction>;
 
-impl ComponentInteractionCollectorBuilder {
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
-        }
-    }
-
-    /// Use the given configuration to build the [`ComponentInteractionCollector`].
-    #[allow(clippy::unwrap_used)]
-    #[must_use]
-    pub fn build(self) -> ComponentInteractionCollector {
-        let shard_messenger = self.shard.unwrap();
-        let (filter, receiver) = ComponentInteractionFilter::new(self.filter.unwrap());
-        let timeout = self.timeout;
-
-        shard_messenger.set_component_interaction_filter(filter);
-
-        ComponentInteractionCollector {
-            receiver: Box::pin(receiver),
-            timeout,
-        }
-    }
-}
-
-#[must_use = "Builders do nothing unless awaited"]
-pub struct CollectComponentInteraction {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'static, Option<Arc<MessageComponentInteraction>>>>,
-}
-
-impl CollectComponentInteraction {
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
-            fut: None,
-        }
-    }
-}
-
-impl Future for CollectComponentInteraction {
-    type Output = Option<Arc<MessageComponentInteraction>>;
-    #[allow(clippy::unwrap_used)]
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            let shard_messenger = self.shard.take().unwrap();
-            let (filter, receiver) = ComponentInteractionFilter::new(self.filter.take().unwrap());
-            let timeout = self.timeout.take();
-
-            self.fut = Some(Box::pin(async move {
-                shard_messenger.set_component_interaction_filter(filter);
-
-                ComponentInteractionCollector {
-                    receiver: Box::pin(receiver),
-                    timeout,
-                }
-                .next()
-                .await
-            }));
-        }
-
-        self.fut.as_mut().unwrap().as_mut().poll(ctx)
-    }
-}
-
-/// A component interaction collector receives interactions matching a the given filter for a
-/// set duration.
-pub struct ComponentInteractionCollector {
-    receiver: Pin<Box<Receiver<Arc<MessageComponentInteraction>>>>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
-
-impl ComponentInteractionCollector {
-    /// Stops collecting, this will implicitly be done once the
-    /// collector drops.
-    /// In case the drop does not appear until later, it is preferred to
-    /// stop the collector early.
-    pub fn stop(mut self) {
-        self.receiver.close();
-    }
-}
-
-impl Stream for ComponentInteractionCollector {
-    type Item = Arc<MessageComponentInteraction>;
-    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(ref mut timeout) = self.timeout {
-            match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
-                    return Poll::Ready(None);
-                },
-                Poll::Pending => (),
-            }
-        }
-
-        self.receiver.as_mut().poll_recv(ctx)
-    }
-}
-
-impl Drop for ComponentInteractionCollector {
-    fn drop(&mut self) {
-        self.receiver.close();
-    }
-}
+#[deprecated = "Use ComponentInteractionCollectorBuilder::collect_single"]
+pub type CollectComponentInteraction<'a> = ComponentInteractionCollectorBuilder<'a>;

--- a/src/collector/error.rs
+++ b/src/collector/error.rs
@@ -16,8 +16,7 @@ pub enum Error {
     /// assert!(matches!(
     ///     EventCollectorBuilder::new(&ctx)
     ///         .add_event_type(EventType::GuildCreate)
-    ///         .add_user_id(UserId::new(1))
-    ///         .build(),
+    ///         .add_user_id(UserId::new(1)),
     ///     Err(SerenityError::Collector(CollectorError::InvalidEventIdFilters)),
     /// ));
     /// ```

--- a/src/collector/error.rs
+++ b/src/collector/error.rs
@@ -5,10 +5,6 @@ use std::fmt;
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    /// No event types were passed to [add_event_type].
-    ///
-    /// [add_event_type]: crate::collector::EventCollectorBuilder::add_event_type
-    NoEventTypes,
     /// The combination of event types and ID filters used with [EventCollectorBuilder] is invalid
     /// and will never match any events.
     ///
@@ -32,7 +28,6 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NoEventTypes => f.write_str("No event types provided"),
             Self::InvalidEventIdFilters => {
                 f.write_str("Invalid event type + id filters, would never match any events")
             },

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -1,18 +1,11 @@
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context as FutContext, Poll};
 
-use futures::stream::Stream;
 use tokio::sync::mpsc::{
     unbounded_channel,
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-use tokio::time::Sleep;
 
-use crate::client::bridge::gateway::ShardMessenger;
-use crate::collector::macros::*;
 use crate::collector::{CollectorError, FilterFn, LazyArc};
 use crate::model::event::{Event, EventType, RelatedIdsForEventType};
 use crate::model::id::{ChannelId, GuildId, MessageId, UserId};
@@ -25,48 +18,33 @@ pub struct EventFilter {
     collected: u32,
     options: FilterOptions,
     sender: Sender<Arc<Event>>,
+
+    filter_limit: Option<u32>,
+    collect_limit: Option<u32>,
+    filter: Option<FilterFn<Event>>,
 }
 
 impl EventFilter {
     /// Creates a new filter
-    fn new(options: FilterOptions) -> Result<(Self, Receiver<Arc<Event>>)> {
-        Self::validate_options(&options)?;
-
+    fn new(
+        options: FilterOptions,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<Event>>,
+    ) -> (Self, Receiver<Arc<Event>>) {
         let (sender, receiver) = unbounded_channel();
 
         let filter = Self {
             filtered: 0,
             collected: 0,
             sender,
+            filter,
             options,
+            filter_limit,
+            collect_limit,
         };
 
-        Ok((filter, receiver))
-    }
-
-    fn validate_options(options: &FilterOptions) -> Result<()> {
-        if options.event_types.is_empty() {
-            return Err(Error::Collector(CollectorError::NoEventTypes));
-        }
-        let related = options.event_types.iter().map(EventType::related_ids).fold(
-            RelatedIdsForEventType::default(),
-            |mut acc, e| {
-                acc.user_id |= e.user_id;
-                acc.guild_id |= e.guild_id;
-                acc.channel_id |= e.channel_id;
-                acc.message_id |= e.message_id;
-                acc
-            },
-        );
-        if (options.user_id.is_empty() || related.user_id)
-            && (options.guild_id.is_empty() || related.guild_id)
-            && (options.channel_id.is_empty() || related.channel_id)
-            && (options.message_id.is_empty() || related.message_id)
-        {
-            Ok(())
-        } else {
-            Err(Error::Collector(CollectorError::InvalidEventIdFilters))
-        }
+        (filter, receiver)
     }
 
     /// Sends a `event` to the consuming collector if the `event` conforms
@@ -110,164 +88,124 @@ impl EventFilter {
             && empty_or_any(&self.options.user_id, |id| event.user_id().contains(id))
             && empty_or_any(&self.options.channel_id, |id| event.channel_id().contains(id))
             && empty_or_any(&self.options.message_id, |id| event.message_id().contains(id))
-            && self.options.filter.as_ref().map_or(true, |f| f.0(event))
+            && self.filter.as_ref().map_or(true, |f| f.0(event))
     }
 
     /// Checks if the filter is within set receive and collect limits.
     /// A event is considered *received* even when it does not meet the
     /// constraints.
     fn is_within_limits(&self) -> bool {
-        self.options.filter_limit.as_ref().map_or(true, |limit| self.filtered < *limit)
-            && self.options.collect_limit.as_ref().map_or(true, |limit| self.collected < *limit)
+        self.filter_limit.as_ref().map_or(true, |limit| self.filtered < *limit)
+            && self.collect_limit.as_ref().map_or(true, |limit| self.collected < *limit)
     }
 }
 
 #[derive(Clone, Debug, Default)]
-struct FilterOptions {
+pub struct FilterOptions {
     event_types: Vec<EventType>,
-    filter_limit: Option<u32>,
-    collect_limit: Option<u32>,
-    filter: Option<FilterFn<Event>>,
     channel_id: Vec<ChannelId>,
     guild_id: Vec<GuildId>,
     user_id: Vec<UserId>,
     message_id: Vec<MessageId>,
 }
 
-/// Future building a stream of events.
-#[must_use = "Builders do nothing unless built"]
-pub struct EventCollectorBuilder {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
+impl super::CollectorBuilder<'_, Event> {
+    fn validate_related_ids(self) -> Result<Self> {
+        let related = self.filter_options.event_types.iter().map(EventType::related_ids).fold(
+            RelatedIdsForEventType::default(),
+            |mut acc, e| {
+                acc.user_id |= e.user_id;
+                acc.guild_id |= e.guild_id;
+                acc.channel_id |= e.channel_id;
+                acc.message_id |= e.message_id;
+                acc
+            },
+        );
 
-impl EventCollectorBuilder {
-    /// A future that builds an [`EventCollector`] based on the settings.
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
+        if (self.filter_options.user_id.is_empty() || related.user_id)
+            && (self.filter_options.guild_id.is_empty() || related.guild_id)
+            && (self.filter_options.channel_id.is_empty() || related.channel_id)
+            && (self.filter_options.message_id.is_empty() || related.message_id)
+        {
+            Ok(self)
+        } else {
+            Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         }
-    }
-
-    /// Sets a filter function where events passed to the `function` must
-    /// return `true`, otherwise the event won't be collected and failed the filter
-    /// process.
-    /// This is the last step to pass for a event to count as *collected*.
-    #[allow(clippy::unwrap_used)]
-    pub fn filter<F: Fn(&Event) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
-        self.filter.as_mut().unwrap().filter = Some(FilterFn(Arc::new(function)));
-
-        self
     }
 
     /// Adds an [`EventType`] that this collector will collect.
     /// If an event does not have one of these types, it won't be received.
-    #[allow(clippy::unwrap_used)]
     pub fn add_event_type(mut self, event_type: EventType) -> Self {
-        self.filter.as_mut().unwrap().event_types.push(event_type);
-
+        self.filter_options.event_types.push(event_type);
         self
     }
 
     /// Sets the required user ID of an event.
     /// If an event does not have this ID, it won't be received.
-    #[allow(clippy::unwrap_used)]
-    pub fn add_user_id(mut self, user_id: impl Into<UserId>) -> Self {
-        self.filter.as_mut().unwrap().user_id.push(user_id.into());
-
-        self
+    ///
+    /// # Errors
+    /// Errors if a relevant [`EventType`] has not been added.
+    pub fn add_user_id(mut self, user_id: impl Into<UserId>) -> Result<Self> {
+        self.filter_options.user_id.push(user_id.into());
+        self.validate_related_ids()
     }
 
     /// Sets the required channel ID of an event.
     /// If an event does not have this ID, it won't be received.
-    #[allow(clippy::unwrap_used)]
-    pub fn add_channel_id(mut self, channel_id: impl Into<ChannelId>) -> Self {
-        self.filter.as_mut().unwrap().channel_id.push(channel_id.into());
-
-        self
+    ///
+    /// # Errors
+    /// Errors if a relevant [`EventType`] has not been added.
+    pub fn add_channel_id(mut self, channel_id: impl Into<ChannelId>) -> Result<Self> {
+        self.filter_options.channel_id.push(channel_id.into());
+        self.validate_related_ids()
     }
 
     /// Sets the required guild ID of an event.
     /// If an event does not have this ID, it won't be received.
-    #[allow(clippy::unwrap_used)]
-    pub fn add_guild_id(mut self, guild_id: impl Into<GuildId>) -> Self {
-        self.filter.as_mut().unwrap().guild_id.push(guild_id.into());
-
-        self
+    ///
+    /// # Errors
+    /// Errors if a relevant [`EventType`] has not been added.
+    pub fn add_guild_id(mut self, guild_id: impl Into<GuildId>) -> Result<Self> {
+        self.filter_options.guild_id.push(guild_id.into());
+        self.validate_related_ids()
     }
 
     /// Sets the required message ID of an event.
     /// If an event does not have this ID, it won't be received.
-    #[allow(clippy::unwrap_used)]
-    pub fn add_message_id(mut self, message_id: impl Into<MessageId>) -> Self {
-        self.filter.as_mut().unwrap().message_id.push(message_id.into());
-
-        self
-    }
-
-    impl_filter_limit!("Limits how many events will attempt to be filtered. The filter checks whether the event has the right related guild, channel, user, and message. Only events with types passed to [`Self::add_event_type`] as counted towards this limit.");
-    impl_collect_limit!("Limits how many events can be collected. An event is considered *collected*, if the event passes all the requirements.");
-    impl_timeout!("Sets a `duration` for how long the collector shall receive events.");
-
-    /// Use the given configuration to build the [`EventCollector`].
     ///
     /// # Errors
-    ///
-    /// Returns [`Error::Collector`] if the filter option validation fails.
-    #[allow(clippy::unwrap_used)]
-    pub fn build(self) -> Result<EventCollector> {
-        let shard_messenger = self.shard.unwrap();
-        let (filter, receiver) = EventFilter::new(self.filter.unwrap())?;
-        let timeout = self.timeout;
-
-        shard_messenger.set_event_filter(filter);
-
-        Ok(EventCollector {
-            receiver: Box::pin(receiver),
-            timeout,
-        })
+    /// Errors if a relevant [`EventType`] has not been added.
+    pub fn add_message_id(mut self, message_id: impl Into<MessageId>) -> Result<Self> {
+        self.filter_options.message_id.push(message_id.into());
+        self.validate_related_ids()
     }
 }
 
 /// An event collector receives events matching the given filter for a set duration.
-pub struct EventCollector {
-    receiver: Pin<Box<Receiver<Arc<Event>>>>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
+pub type EventCollector = super::Collector<Event>;
+pub type EventCollectorBuilder<'a> = super::CollectorBuilder<'a, Event>;
 
-impl EventCollector {
-    /// Stops collecting, this will implicitly be done once the
-    /// collector drops.
-    /// In case the drop does not appear until later, it is preferred to
-    /// stop the collector early.
-    pub fn stop(mut self) {
-        self.receiver.close();
+// No deprecated CollectSingle alias as EventCollector never had a CollectSingle version.
+
+impl super::FilterOptions<Event> for FilterOptions {
+    type FilterItem = Event;
+
+    fn build(
+        self,
+        messenger: &crate::client::bridge::gateway::ShardMessenger,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<Self::FilterItem>>,
+    ) -> Receiver<Arc<Event>> {
+        let (filter, recv) = EventFilter::new(self, filter_limit, collect_limit, filter);
+        messenger.set_event_filter(filter);
+
+        recv
     }
 }
 
-impl Stream for EventCollector {
-    type Item = Arc<Event>;
-    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(ref mut timeout) = self.timeout {
-            match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
-                    return Poll::Ready(None);
-                },
-                Poll::Pending => (),
-            }
-        }
-
-        self.receiver.as_mut().poll_recv(ctx)
-    }
-}
-
-impl Drop for EventCollector {
-    fn drop(&mut self) {
-        self.receiver.close();
-    }
+impl super::Collectable for Event {
+    type FilterOptions = FilterOptions;
 }
 
 #[cfg(test)]
@@ -278,20 +216,6 @@ mod test {
     use crate::client::bridge::gateway::ShardMessenger;
 
     #[test]
-    fn test_no_event_types() {
-        let (sender, _) = unbounded();
-        let msg = ShardMessenger::new(sender);
-        assert!(matches!(
-            EventCollectorBuilder::new(&msg).build(),
-            Err(Error::Collector(CollectorError::NoEventTypes))
-        ));
-        assert!(matches!(
-            EventCollectorBuilder::new(&msg).add_channel_id(ChannelId::new(1)).build(),
-            Err(Error::Collector(CollectorError::NoEventTypes))
-        ));
-    }
-
-    #[test]
     fn test_build_with_single_id_filter() {
         let (sender, _) = unbounded();
         let msg = ShardMessenger::new(sender);
@@ -299,56 +223,52 @@ mod test {
         assert!(matches!(
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::GuildCreate)
-                .add_user_id(UserId::new(1))
-                .build(),
+                .add_user_id(UserId::new(1)),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
         assert!(matches!(
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::GuildCreate)
                 .add_event_type(EventType::GuildRoleCreate)
-                .add_user_id(UserId::new(1))
-                .build(),
+                .add_user_id(UserId::new(1)),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
 
         assert!(matches!(
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::GuildBanAdd)
-                .add_user_id(UserId::new(1))
-                .build(),
+                .add_user_id(UserId::new(1)),
             Ok(_)
         ));
         assert!(matches!(
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::GuildBanAdd)
                 .add_event_type(EventType::GuildCreate)
-                .add_user_id(UserId::new(1))
-                .build(),
+                .add_user_id(UserId::new(1)),
             Ok(_)
         ));
     }
 
     #[test]
-    fn test_build_with_multiple_id_filters() {
+    fn test_build_with_multiple_id_filters() -> Result<()> {
         let (sender, _) = unbounded();
         let msg = ShardMessenger::new(sender);
 
         assert!(matches!(
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::UserUpdate)
-                .add_user_id(UserId::new(1))
-                .add_guild_id(GuildId::new(1))
-                .build(),
+                .add_user_id(UserId::new(1))?
+                .add_guild_id(GuildId::new(1)),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
         assert!(matches!(
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::UserUpdate)
-                .add_user_id(UserId::new(1))
-                .build(),
+                .add_user_id(UserId::new(1)),
             Ok(_)
         ));
+
+        Ok(())
     }
 
     #[test]
@@ -362,8 +282,7 @@ mod test {
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::GuildCreate)
                 .add_event_type(EventType::GuildMemberAdd)
-                .add_user_id(UserId::new(1))
-                .build(),
+                .add_user_id(UserId::new(1)),
             Ok(_)
         ));
         // But if none of the events have that ID type, that's an error.
@@ -371,8 +290,7 @@ mod test {
             EventCollectorBuilder::new(&msg)
                 .add_event_type(EventType::GuildCreate)
                 .add_event_type(EventType::UserUpdate)
-                .add_channel_id(ChannelId::new(1))
-                .build(),
+                .add_channel_id(ChannelId::new(1)),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
     }

--- a/src/collector/macros.rs
+++ b/src/collector/macros.rs
@@ -12,7 +12,7 @@ macro_rules! gen_macro {
 gen_macro!(
     impl_author_id,
     pub fn author_id(mut self, author_id: impl Into<u64>) -> Self {
-        self.filter.as_mut().unwrap().author_id = std::num::NonZeroU64::new(author_id.into());
+        self.filter_options.author_id = std::num::NonZeroU64::new(author_id.into());
 
         self
     }
@@ -21,25 +21,7 @@ gen_macro!(
 gen_macro!(
     impl_channel_id,
     pub fn channel_id(mut self, channel_id: impl Into<u64>) -> Self {
-        self.filter.as_mut().unwrap().channel_id = std::num::NonZeroU64::new(channel_id.into());
-
-        self
-    }
-);
-
-gen_macro!(
-    impl_collect_limit,
-    pub fn collect_limit(mut self, limit: u32) -> Self {
-        self.filter.as_mut().unwrap().collect_limit = Some(limit);
-
-        self
-    }
-);
-
-gen_macro!(
-    impl_filter_limit,
-    pub fn filter_limit(mut self, limit: u32) -> Self {
-        self.filter.as_mut().unwrap().filter_limit = Some(limit);
+        self.filter_options.channel_id = std::num::NonZeroU64::new(channel_id.into());
 
         self
     }
@@ -48,7 +30,7 @@ gen_macro!(
 gen_macro!(
     impl_guild_id,
     pub fn guild_id(mut self, guild_id: impl Into<u64>) -> Self {
-        self.filter.as_mut().unwrap().guild_id = std::num::NonZeroU64::new(guild_id.into());
+        self.filter_options.guild_id = std::num::NonZeroU64::new(guild_id.into());
 
         self
     }
@@ -57,27 +39,10 @@ gen_macro!(
 gen_macro!(
     impl_message_id,
     pub fn message_id(mut self, message_id: impl Into<u64>) -> Self {
-        self.filter.as_mut().unwrap().message_id = std::num::NonZeroU64::new(message_id.into());
+        self.filter_options.message_id = std::num::NonZeroU64::new(message_id.into());
 
         self
     }
 );
 
-gen_macro!(
-    impl_timeout,
-    pub fn timeout(mut self, duration: std::time::Duration) -> Self {
-        self.timeout = Some(Box::pin(tokio::time::sleep(duration)));
-
-        self
-    }
-);
-
-pub(super) use {
-    impl_author_id,
-    impl_channel_id,
-    impl_collect_limit,
-    impl_filter_limit,
-    impl_guild_id,
-    impl_message_id,
-    impl_timeout,
-};
+pub(super) use {impl_author_id, impl_channel_id, impl_guild_id, impl_message_id};

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -1,48 +1,16 @@
-use std::future::Future;
 use std::num::NonZeroU64;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context as FutContext, Poll};
 
-use futures::future::BoxFuture;
-use futures::stream::{Stream, StreamExt};
 use tokio::sync::mpsc::{
     unbounded_channel,
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-use tokio::time::Sleep;
 
 use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::macros::*;
 use crate::collector::{FilterFn, LazyArc};
 use crate::model::channel::Message;
-
-macro_rules! impl_message_collector {
-    ($($name:ident;)*) => {
-        $(
-            impl $name {
-                /// Sets a filter function where messages passed to the `function` must
-                /// return `true`, otherwise the message won't be collected and failed the filter
-                /// process.
-                /// This is the last instance to pass for a message to count as *collected*.
-                ///
-                /// This function is intended to be a message content filter.
-                pub fn filter<F: Fn(&Message) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
-                    self.filter.as_mut().unwrap().filter = Some(FilterFn(Arc::new(function)));
-
-                    self
-                }
-
-                impl_filter_limit!("Limits how many messages will attempt to be filtered. The filter checks whether the message has been sent in the right guild, channel, and by the right author.");
-                impl_channel_id!("Sets the required channel ID of a message. If a message does not meet this ID, it won't be received.");
-                impl_author_id!("Sets the required author ID of a message. If a message does not meet this ID, it won't be received.");
-                impl_guild_id!("Sets the required guild ID of a message. If a message does not meet this ID, it won't be received.");
-                impl_timeout!("Sets a `duration` for how long the collector shall receive messages.");
-            }
-        )*
-    }
-}
 
 /// Filters events on the shard's end and sends them to the collector.
 #[derive(Clone, Debug)]
@@ -51,18 +19,30 @@ pub struct MessageFilter {
     collected: u32,
     options: FilterOptions,
     sender: Sender<Arc<Message>>,
+
+    filter_limit: Option<u32>,
+    collect_limit: Option<u32>,
+    filter: Option<FilterFn<Message>>,
 }
 
 impl MessageFilter {
     /// Creates a new filter
-    fn new(options: FilterOptions) -> (Self, Receiver<Arc<Message>>) {
+    fn new(
+        options: FilterOptions,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<Message>>,
+    ) -> (Self, Receiver<Arc<Message>>) {
         let (sender, receiver) = unbounded_channel();
 
         let filter = Self {
             filtered: 0,
             collected: 0,
             sender,
+            filter,
             options,
+            filter_limit,
+            collect_limit,
         };
 
         (filter, receiver)
@@ -71,9 +51,7 @@ impl MessageFilter {
     /// Sends a `message` to the consuming collector if the `message` conforms
     /// to the constraints and the limits are not reached yet.
     pub(crate) fn send_message(&mut self, message: &mut LazyArc<'_, Message>) -> bool {
-        if self.is_passing_constraints(message)
-            && self.options.filter.as_ref().map_or(true, |f| f.0(message))
-        {
+        if self.is_passing_constraints(message) {
             self.collected += 1;
 
             if self.sender.send(message.as_arc()).is_err() {
@@ -93,149 +71,55 @@ impl MessageFilter {
         self.options.guild_id.map_or(true, |g| Some(g) == message.guild_id.map(|g| g.0))
             && self.options.channel_id.map_or(true, |g| g == message.channel_id.0)
             && self.options.author_id.map_or(true, |g| g == message.author.id.0)
+            && self.filter.as_ref().map_or(true, |f| f.0(message))
     }
 
     /// Checks if the filter is within set receive and collect limits.
     /// A message is considered *received* even when it does not meet the
     /// constraints.
     fn is_within_limits(&self) -> bool {
-        self.options.filter_limit.as_ref().map_or(true, |limit| self.filtered < *limit)
-            && self.options.collect_limit.as_ref().map_or(true, |limit| self.collected < *limit)
+        self.filter_limit.as_ref().map_or(true, |limit| self.filtered < *limit)
+            && self.collect_limit.as_ref().map_or(true, |limit| self.collected < *limit)
     }
 }
 
 #[derive(Clone, Debug, Default)]
-struct FilterOptions {
-    filter_limit: Option<u32>,
-    collect_limit: Option<u32>,
-    filter: Option<FilterFn<Message>>,
+pub struct FilterOptions {
     channel_id: Option<NonZeroU64>,
     guild_id: Option<NonZeroU64>,
     author_id: Option<NonZeroU64>,
 }
 
-// Implement the common setters for all message collector types.
-impl_message_collector! {
-    CollectReply;
-    MessageCollectorBuilder;
+impl super::CollectorBuilder<'_, Message> {
+    impl_channel_id!("Sets the required channel ID of a message. If a message does not meet this ID, it won't be received.");
+    impl_author_id!("Sets the required author ID of a message. If a message does not meet this ID, it won't be received.");
+    impl_guild_id!("Sets the required guild ID of a message. If a message does not meet this ID, it won't be received.");
 }
 
-/// Future building a stream of messages.
-#[must_use = "Builders do nothing unless built"]
-pub struct MessageCollectorBuilder {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
+impl super::FilterOptions<Message> for FilterOptions {
+    type FilterItem = Message;
 
-impl MessageCollectorBuilder {
-    /// A future that builds a [`MessageCollector`] based on the settings.
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
-        }
-    }
+    fn build(
+        self,
+        messenger: &ShardMessenger,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<Self::FilterItem>>,
+    ) -> Receiver<Arc<Message>> {
+        let (filter, recv) = MessageFilter::new(self, filter_limit, collect_limit, filter);
+        messenger.set_message_filter(filter);
 
-    impl_collect_limit!("Limits how many messages can be collected. A message is considered *collected*, if the message passes all the requirements.");
-
-    /// Use the given configuration to build the [`MessageCollector`].
-    #[allow(clippy::unwrap_used)]
-    #[must_use]
-    pub fn build(self) -> MessageCollector {
-        let shard_messenger = self.shard.unwrap();
-        let (filter, receiver) = MessageFilter::new(self.filter.unwrap());
-        let timeout = self.timeout;
-
-        shard_messenger.set_message_filter(filter);
-
-        MessageCollector {
-            receiver: Box::pin(receiver),
-            timeout,
-        }
+        recv
     }
 }
 
-#[must_use]
-pub struct CollectReply {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'static, Option<Arc<Message>>>>,
+impl super::Collectable for Message {
+    type FilterOptions = FilterOptions;
 }
 
-impl CollectReply {
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
-            fut: None,
-        }
-    }
-}
+/// A message collector receives messages matching the given filter for a set duration.
+pub type MessageCollectorBuilder<'a> = super::CollectorBuilder<'a, Message>;
+pub type MessageCollector = super::Collector<Message>;
 
-impl Future for CollectReply {
-    type Output = Option<Arc<Message>>;
-    #[allow(clippy::unwrap_used)]
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            let shard_messenger = self.shard.take().unwrap();
-            let (filter, receiver) = MessageFilter::new(self.filter.take().unwrap());
-            let timeout = self.timeout.take();
-
-            self.fut = Some(Box::pin(async move {
-                shard_messenger.set_message_filter(filter);
-
-                MessageCollector {
-                    receiver: Box::pin(receiver),
-                    timeout,
-                }
-                .next()
-                .await
-            }));
-        }
-
-        self.fut.as_mut().unwrap().as_mut().poll(ctx)
-    }
-}
-
-/// A message collector receives messages matching the given filter for a
-/// set duration.
-pub struct MessageCollector {
-    receiver: Pin<Box<Receiver<Arc<Message>>>>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
-
-impl MessageCollector {
-    /// Stops collecting, this will implicitly be done once the
-    /// collector drops.
-    /// In case the drop does not appear until later, it is preferred to
-    /// stop the collector early.
-    pub fn stop(mut self) {
-        self.receiver.close();
-    }
-}
-
-impl Stream for MessageCollector {
-    type Item = Arc<Message>;
-    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(ref mut timeout) = self.timeout {
-            match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
-                    return Poll::Ready(None);
-                },
-                Poll::Pending => (),
-            }
-        }
-
-        self.receiver.as_mut().poll_recv(ctx)
-    }
-}
-
-impl Drop for MessageCollector {
-    fn drop(&mut self) {
-        self.receiver.close();
-    }
-}
+#[deprecated = "Use MessageCollectorBuilder::collect_single"]
+pub type CollectReply<'a> = MessageCollectorBuilder<'a>;

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -72,11 +72,7 @@ impl MessageFilter {
     /// constraints.
     fn is_within_limits(&self) -> bool {
         self.common_options.filter_limit.as_ref().map_or(true, |limit| self.filtered < *limit)
-            && self
-                .common_options
-                .collect_limit
-                .as_ref()
-                .map_or(true, |limit| self.collected < *limit)
+            && self.common_options.collect_limit.map_or(true, |limit| self.collected < limit)
     }
 }
 

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -1,49 +1,17 @@
-use std::fmt;
-use std::future::Future;
 use std::num::NonZeroU64;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context as FutContext, Poll};
 
-use futures::future::BoxFuture;
-use futures::stream::{Stream, StreamExt};
 use tokio::sync::mpsc::{
     unbounded_channel,
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-use tokio::time::Sleep;
 
+use super::FilterFn;
 use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::macros::*;
-use crate::collector::{FilterFn, LazyArc};
+use crate::collector::LazyArc;
 use crate::model::application::interaction::modal::ModalSubmitInteraction;
-
-macro_rules! impl_modal_interaction_collector {
-    ($($name:ident;)*) => {
-        $(
-            impl $name {
-                /// Sets a filter function where interactions passed to the function must
-                /// return `true`, otherwise the interaction won't be collected.
-                /// This is the last instance to pass for an interaction to count as *collected*.
-                ///
-                /// This function is intended to be an interaction filter.
-                pub fn filter<F: Fn(&ModalSubmitInteraction) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
-                    self.filter.as_mut().unwrap().filter = Some(FilterFn(Arc::new(function)));
-
-                    self
-                }
-
-                impl_collect_limit!("Limits how many interactions can be collected. An interaction is considered *collected*, if the interaction passes all the requirements.");
-                impl_channel_id!("Sets the channel on which the interaction must occur. If an interaction is not on a message with this channel ID, it won't be received.");
-                impl_guild_id!("Sets the guild in which the interaction must occur. If an interaction is not on a message with this guild ID, it won't be received.");
-                impl_message_id!("Sets the message on which the interaction must occur. If an interaction is not on a message with this ID, it won't be received.");
-                impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received");
-                impl_timeout!("Sets a `duration` for how long the collector shall receive interactions.");
-            }
-        )*
-    }
-}
 
 /// Filters events on the shard's end and sends them to the collector.
 #[derive(Clone, Debug)]
@@ -52,18 +20,30 @@ pub struct ModalInteractionFilter {
     collected: u32,
     options: FilterOptions,
     sender: Sender<Arc<ModalSubmitInteraction>>,
+
+    filter_limit: Option<u32>,
+    collect_limit: Option<u32>,
+    filter: Option<FilterFn<ModalSubmitInteraction>>,
 }
 
 impl ModalInteractionFilter {
     /// Creates a new filter
-    fn new(options: FilterOptions) -> (Self, Receiver<Arc<ModalSubmitInteraction>>) {
+    fn new(
+        options: FilterOptions,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<ModalSubmitInteraction>>,
+    ) -> (Self, Receiver<Arc<ModalSubmitInteraction>>) {
         let (sender, receiver) = unbounded_channel();
 
         let filter = Self {
             filtered: 0,
             collected: 0,
             sender,
+            filter,
             options,
+            filter_limit,
+            collect_limit,
         };
 
         (filter, receiver)
@@ -99,161 +79,56 @@ impl ModalInteractionFilter {
                 .map_or(true, |id| Some(id) == interaction.message.as_ref().map(|m| m.id.0))
             && self.options.channel_id.map_or(true, |id| id == interaction.channel_id.as_ref().0)
             && self.options.author_id.map_or(true, |id| id == interaction.user.id.0)
-            && self.options.filter.as_ref().map_or(true, |f| f.0(interaction))
+            && self.filter.as_ref().map_or(true, |f| f.0(interaction))
     }
 
     /// Checks if the filter is within set receive and collect limits.
     /// An interaction is considered *received* even when it does not meet the
     /// constraints.
     fn is_within_limits(&self) -> bool {
-        self.options.filter_limit.map_or(true, |limit| self.filtered < limit)
-            && self.options.collect_limit.map_or(true, |limit| self.collected < limit)
+        self.filter_limit.map_or(true, |limit| self.filtered < limit)
+            && self.collect_limit.map_or(true, |limit| self.collected < limit)
     }
 }
 
-#[derive(Clone, Default)]
-struct FilterOptions {
-    filter_limit: Option<u32>,
-    collect_limit: Option<u32>,
-    filter: Option<FilterFn<ModalSubmitInteraction>>,
+#[derive(Clone, Debug, Default)]
+pub struct FilterOptions {
     channel_id: Option<NonZeroU64>,
     guild_id: Option<NonZeroU64>,
     author_id: Option<NonZeroU64>,
     message_id: Option<NonZeroU64>,
 }
 
-impl fmt::Debug for FilterOptions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ModalInteractionFilter")
-            .field("collect_limit", &self.collect_limit)
-            .field("filter", &"Option<Arc<dyn Fn(&Arc<Reaction>) -> bool + 'static + Send + Sync>>")
-            .field("channel_id", &self.channel_id)
-            .field("guild_id", &self.guild_id)
-            .field("author_id", &self.author_id)
-            .finish()
+impl super::CollectorBuilder<'_, ModalSubmitInteraction> {
+    impl_channel_id!("Sets the channel on which the interaction must occur. If an interaction is not on a message with this channel ID, it won't be received.");
+    impl_guild_id!("Sets the guild in which the interaction must occur. If an interaction is not on a message with this guild ID, it won't be received.");
+    impl_message_id!("Sets the message on which the interaction must occur. If an interaction is not on a message with this ID, it won't be received.");
+    impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received");
+}
+
+impl super::FilterOptions<ModalSubmitInteraction> for FilterOptions {
+    type FilterItem = ModalSubmitInteraction;
+
+    fn build(
+        self,
+        messenger: &ShardMessenger,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<Self::FilterItem>>,
+    ) -> Receiver<Arc<ModalSubmitInteraction>> {
+        let (filter, recv) = ModalInteractionFilter::new(self, filter_limit, collect_limit, filter);
+        messenger.set_modal_interaction_filter(filter);
+
+        recv
     }
 }
-
-// Implement the common setters for all modal interaction collector types.
-// This avoids using a trait that the user would need to import in
-// order to use any of these methods.
-impl_modal_interaction_collector! {
-    CollectModalInteraction;
-    ModalInteractionCollectorBuilder;
+impl super::Collectable for ModalSubmitInteraction {
+    type FilterOptions = FilterOptions;
 }
 
-#[must_use = "Builders do nothing unless built"]
-pub struct ModalInteractionCollectorBuilder {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
+/// A modal interaction collector receives interactions matching a the given filter for a set duration.
+pub type ModalInteractionCollector = super::Collector<ModalSubmitInteraction>;
+pub type ModalInteractionCollectorBuilder<'a> = super::CollectorBuilder<'a, ModalSubmitInteraction>;
 
-impl ModalInteractionCollectorBuilder {
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
-        }
-    }
-
-    /// Use the given configuration to build the [`ModalInteractionCollector`].
-    #[allow(clippy::unwrap_used)]
-    #[must_use]
-    pub fn build(self) -> ModalInteractionCollector {
-        let shard_messenger = self.shard.unwrap();
-        let (filter, receiver) = ModalInteractionFilter::new(self.filter.unwrap());
-        let timeout = self.timeout;
-
-        shard_messenger.set_modal_interaction_filter(filter);
-
-        ModalInteractionCollector {
-            receiver: Box::pin(receiver),
-            timeout,
-        }
-    }
-}
-
-#[must_use = "builders do nothing unless awaited"]
-pub struct CollectModalInteraction {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'static, Option<Arc<ModalSubmitInteraction>>>>,
-}
-
-impl CollectModalInteraction {
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
-            fut: None,
-        }
-    }
-}
-
-impl Future for CollectModalInteraction {
-    type Output = Option<Arc<ModalSubmitInteraction>>;
-    #[allow(clippy::unwrap_used)]
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            let shard_messenger = self.shard.take().unwrap();
-            let (filter, receiver) = ModalInteractionFilter::new(self.filter.take().unwrap());
-            let timeout = self.timeout.take();
-
-            self.fut = Some(Box::pin(async move {
-                shard_messenger.set_modal_interaction_filter(filter);
-
-                ModalInteractionCollector {
-                    receiver: Box::pin(receiver),
-                    timeout,
-                }
-                .next()
-                .await
-            }));
-        }
-
-        self.fut.as_mut().unwrap().as_mut().poll(ctx)
-    }
-}
-
-/// A modal interaction collector receives interactions matching a the given filter for a
-/// set duration.
-pub struct ModalInteractionCollector {
-    receiver: Pin<Box<Receiver<Arc<ModalSubmitInteraction>>>>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
-
-impl ModalInteractionCollector {
-    /// Stops collecting, this will implicitly be done once the
-    /// collector drops.
-    /// In case the drop does not appear until later, it is preferred to
-    /// stop the collector early.
-    pub fn stop(mut self) {
-        self.receiver.close();
-    }
-}
-
-impl Stream for ModalInteractionCollector {
-    type Item = Arc<ModalSubmitInteraction>;
-    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(ref mut timeout) = self.timeout {
-            match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
-                    return Poll::Ready(None);
-                },
-                Poll::Pending => (),
-            }
-        }
-
-        self.receiver.as_mut().poll_recv(ctx)
-    }
-}
-
-impl Drop for ModalInteractionCollector {
-    fn drop(&mut self) {
-        self.receiver.close();
-    }
-}
+#[deprecated = "Use ModalInteractionCollectorBuilder::collect_single"]
+pub type CollectModalInteraction<'a> = ModalInteractionCollectorBuilder<'a>;

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -1,68 +1,16 @@
-use std::fmt;
-use std::future::Future;
 use std::num::NonZeroU64;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context as FutContext, Poll};
 
-use futures::future::BoxFuture;
-use futures::stream::{Stream, StreamExt};
 use tokio::sync::mpsc::{
     unbounded_channel,
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-use tokio::time::Sleep;
 
 use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::macros::*;
 use crate::collector::{FilterFn, LazyArc};
 use crate::model::channel::Reaction;
-
-macro_rules! impl_reaction_collector {
-    ($($name:ident;)*) => {
-        $(
-            impl $name {
-                /// Sets a filter function where reactions passed to the function must
-                /// return `true`, otherwise the reaction won't be collected.
-                /// This is the last instance to pass for a reaction to count as *collected*.
-                ///
-                /// This function is intended to be a reaction content filter.
-                pub fn filter<F: Fn(&Reaction) -> bool + 'static + Send + Sync>(mut self, function: F) -> Self {
-                    self.filter.as_mut().unwrap().filter = Some(FilterFn(Arc::new(function)));
-
-                    self
-                }
-
-                /// If set to `true`, added reactions will be collected.
-                ///
-                /// Set to `true` by default.
-                pub fn added(mut self, is_accepted: bool) -> Self {
-                    self.filter.as_mut().unwrap().accept_added = is_accepted;
-
-                    self
-                }
-
-                /// If set to `true`, removed reactions will be collected.
-                ///
-                /// Set to `false` by default.
-                pub fn removed(mut self, is_accepted: bool) -> Self {
-                    self.filter.as_mut().unwrap().accept_removed = is_accepted;
-
-                    self
-                }
-
-                impl_filter_limit!("Limits how many messages will attempt to be filtered.\n\nThe filter checks whether the message has been sent in the right guild, channel, and by the right author.");
-                impl_collect_limit!("Limits how many reactions can be collected. A reaction is considered *collected*, if the reaction passes all the requirements.");
-                impl_channel_id!("Sets the channel on which the reaction must occur. If a reaction is not on a message with this channel ID, it won't be received.");
-                impl_guild_id!("Sets the guild in which the reaction must occur. If a reaction is not on a message with this guild ID, it won't be received.");
-                impl_message_id!("Sets the message on which the reaction must occur. If a reaction is not on a message with this ID, it won't be received.");
-                impl_author_id!("Sets the required author ID of a reaction. If a reaction is not issued by a user with this ID, it won't be received.");
-                impl_timeout!("Sets a `duration` for how long the collector shall receive reactions.");
-            }
-        )*
-    }
-}
 
 /// Marks whether the reaction has been added or removed.
 #[derive(Debug)]
@@ -128,18 +76,30 @@ pub struct ReactionFilter {
     collected: u32,
     options: FilterOptions,
     sender: Sender<Arc<ReactionAction>>,
+
+    filter_limit: Option<u32>,
+    collect_limit: Option<u32>,
+    filter: Option<FilterFn<Reaction>>,
 }
 
 impl ReactionFilter {
     /// Creates a new filter
-    fn new(options: FilterOptions) -> (Self, Receiver<Arc<ReactionAction>>) {
+    fn new(
+        options: FilterOptions,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<Reaction>>,
+    ) -> (Self, Receiver<Arc<ReactionAction>>) {
         let (sender, receiver) = unbounded_channel();
 
         let filter = Self {
             filtered: 0,
             collected: 0,
             sender,
+            filter,
             options,
+            filter_limit,
+            collect_limit,
         };
 
         (filter, receiver)
@@ -186,23 +146,20 @@ impl ReactionFilter {
             && self.options.message_id.map_or(true, |id| id == reaction.message_id.0)
             && self.options.channel_id.map_or(true, |id| id == reaction.channel_id.0)
             && self.options.author_id.map_or(true, |id| Some(id) == reaction.user_id.map(|u| u.0))
-            && self.options.filter.as_ref().map_or(true, |f| f.0(reaction))
+            && self.filter.as_ref().map_or(true, |f| f.0(reaction))
     }
 
     /// Checks if the filter is within set receive and collect limits.
     /// A reaction is considered *received* even when it does not meet the
     /// constraints.
     fn is_within_limits(&self) -> bool {
-        self.options.filter_limit.map_or(true, |limit| self.filtered < limit)
-            && self.options.collect_limit.map_or(true, |limit| self.collected < limit)
+        self.filter_limit.map_or(true, |limit| self.filtered < limit)
+            && self.collect_limit.map_or(true, |limit| self.collected < limit)
     }
 }
 
-#[derive(Clone)]
-struct FilterOptions {
-    filter_limit: Option<u32>,
-    collect_limit: Option<u32>,
-    filter: Option<FilterFn<Reaction>>,
+#[derive(Clone, Debug)]
+pub struct FilterOptions {
     channel_id: Option<NonZeroU64>,
     guild_id: Option<NonZeroU64>,
     author_id: Option<NonZeroU64>,
@@ -214,9 +171,6 @@ struct FilterOptions {
 impl Default for FilterOptions {
     fn default() -> Self {
         Self {
-            filter_limit: None,
-            collect_limit: None,
-            filter: None,
             channel_id: None,
             guild_id: None,
             author_id: None,
@@ -227,138 +181,55 @@ impl Default for FilterOptions {
     }
 }
 
-// Implement the common setters for all reaction collector types.
-// This avoids using a trait that the user would need to import in
-// order to use any of these methods.
-impl_reaction_collector! {
-    CollectReaction;
-    ReactionCollectorBuilder;
-}
+impl super::CollectorBuilder<'_, ReactionAction> {
+    /// If set to `true`, added reactions will be collected.
+    ///
+    /// Set to `true` by default.
+    pub fn added(mut self, is_accepted: bool) -> Self {
+        self.filter_options.accept_added = is_accepted;
 
-#[must_use = "builders do nothing until built"]
-pub struct ReactionCollectorBuilder {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
-
-impl ReactionCollectorBuilder {
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
-        }
+        self
     }
 
-    /// Use the given configuration to build the [`ReactionCollector`].
-    #[allow(clippy::unwrap_used)]
-    #[must_use]
-    pub fn build(self) -> ReactionCollector {
-        let shard_messenger = self.shard.unwrap();
-        let (filter, receiver) = ReactionFilter::new(self.filter.unwrap());
-        let timeout = self.timeout;
+    /// If set to `true`, removed reactions will be collected.
+    ///
+    /// Set to `false` by default.
+    pub fn removed(mut self, is_accepted: bool) -> Self {
+        self.filter_options.accept_removed = is_accepted;
 
-        shard_messenger.set_reaction_filter(filter);
-
-        ReactionCollector {
-            receiver: Box::pin(receiver),
-            timeout,
-        }
+        self
     }
+
+    impl_channel_id!("Sets the channel on which the reaction must occur. If a reaction is not on a message with this channel ID, it won't be received.");
+    impl_guild_id!("Sets the guild in which the reaction must occur. If a reaction is not on a message with this guild ID, it won't be received.");
+    impl_message_id!("Sets the message on which the reaction must occur. If a reaction is not on a message with this ID, it won't be received.");
+    impl_author_id!("Sets the required author ID of a reaction. If a reaction is not issued by a user with this ID, it won't be received.");
 }
 
-#[must_use = "builders do nothing unless awaited"]
-pub struct CollectReaction {
-    filter: Option<FilterOptions>,
-    shard: Option<ShardMessenger>,
-    timeout: Option<Pin<Box<Sleep>>>,
-    fut: Option<BoxFuture<'static, Option<Arc<ReactionAction>>>>,
-}
+impl super::FilterOptions<ReactionAction> for FilterOptions {
+    type FilterItem = Reaction;
 
-impl CollectReaction {
-    pub fn new(shard_messenger: impl AsRef<ShardMessenger>) -> Self {
-        Self {
-            filter: Some(FilterOptions::default()),
-            shard: Some(shard_messenger.as_ref().clone()),
-            timeout: None,
-            fut: None,
-        }
+    fn build(
+        self,
+        messenger: &ShardMessenger,
+        filter_limit: Option<u32>,
+        collect_limit: Option<u32>,
+        filter: Option<FilterFn<Self::FilterItem>>,
+    ) -> Receiver<Arc<ReactionAction>> {
+        let (filter, recv) = ReactionFilter::new(self, filter_limit, collect_limit, filter);
+        messenger.set_reaction_filter(filter);
+
+        recv
     }
 }
 
-impl Future for CollectReaction {
-    type Output = Option<Arc<ReactionAction>>;
-    #[allow(clippy::unwrap_used)]
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            let shard_messenger = self.shard.take().unwrap();
-            let (filter, receiver) = ReactionFilter::new(self.filter.take().unwrap());
-            let timeout = self.timeout.take();
-
-            self.fut = Some(Box::pin(async move {
-                shard_messenger.set_reaction_filter(filter);
-
-                ReactionCollector {
-                    receiver: Box::pin(receiver),
-                    timeout,
-                }
-                .next()
-                .await
-            }));
-        }
-
-        self.fut.as_mut().unwrap().as_mut().poll(ctx)
-    }
+impl super::Collectable for ReactionAction {
+    type FilterOptions = FilterOptions;
 }
 
-impl fmt::Debug for FilterOptions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ReactionFilter")
-            .field("collect_limit", &self.collect_limit)
-            .field("filter", &"Option<Arc<dyn Fn(&Arc<Reaction>) -> bool + 'static + Send + Sync>>")
-            .field("channel_id", &self.channel_id)
-            .field("guild_id", &self.guild_id)
-            .field("author_id", &self.author_id)
-            .finish()
-    }
-}
+/// A reaction collector receives reactions matching a the given filter for a set duration.
+pub type ReactionCollector = super::Collector<ReactionAction>;
+pub type ReactionCollectorBuilder<'a> = super::CollectorBuilder<'a, ReactionAction>;
 
-/// A reaction collector receives reactions matching a the given filter for a
-/// set duration.
-pub struct ReactionCollector {
-    receiver: Pin<Box<Receiver<Arc<ReactionAction>>>>,
-    timeout: Option<Pin<Box<Sleep>>>,
-}
-
-impl ReactionCollector {
-    /// Stops collecting, this will implicitly be done once the
-    /// collector drops.
-    /// In case the drop does not appear until later, it is preferred to
-    /// stop the collector early.
-    pub fn stop(mut self) {
-        self.receiver.close();
-    }
-}
-
-impl Stream for ReactionCollector {
-    type Item = Arc<ReactionAction>;
-    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(ref mut timeout) = self.timeout {
-            match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
-                    return Poll::Ready(None);
-                },
-                Poll::Pending => (),
-            }
-        }
-
-        self.receiver.as_mut().poll_recv(ctx)
-    }
-}
-
-impl Drop for ReactionCollector {
-    fn drop(&mut self) {
-        self.receiver.close();
-    }
-}
+#[deprecated = "Use ReactionCollectorBuilder::collect_single"]
+pub type CollectReaction<'a> = ReactionCollectorBuilder<'a>;

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -25,12 +25,7 @@ use crate::cache::Cache;
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
-use crate::collector::{
-    CollectReaction,
-    CollectReply,
-    MessageCollectorBuilder,
-    ReactionCollectorBuilder,
-};
+use crate::collector::{MessageCollectorBuilder, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(feature = "model")]
@@ -886,33 +881,21 @@ impl ChannelId {
         http.as_ref().create_webhook(self.get(), &builder, None).await
     }
 
-    /// Returns a future that will await one message sent in this channel.
+    /// Returns a builder which can be awaited to obtain a message or stream of messages in this channel.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
-        CollectReply::new(shard_messenger).channel_id(self.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of messages in this channel.
-    #[cfg(feature = "collector")]
-    pub fn await_replies(
+    pub fn reply_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> MessageCollectorBuilder<'a> {
         MessageCollectorBuilder::new(shard_messenger).channel_id(self.0)
     }
 
-    /// Await a single reaction in this guild.
+    /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent in this channel.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
-        CollectReaction::new(shard_messenger).channel_id(self.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this channel.
-    #[cfg(feature = "collector")]
-    pub fn await_reactions(
+    pub fn reaction_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).channel_id(self.0)
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -21,12 +21,7 @@ use crate::cache::{self, Cache};
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
-use crate::collector::{
-    CollectReaction,
-    CollectReply,
-    MessageCollectorBuilder,
-    ReactionCollectorBuilder,
-};
+use crate::collector::{MessageCollectorBuilder, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 #[cfg(all(feature = "cache", feature = "model"))]
@@ -1108,33 +1103,21 @@ impl GuildChannel {
         }
     }
 
-    /// Returns a future that will await one message by this guild channel.
+    /// Returns a builder which can be awaited to obtain a mesage or stream of messages sent in this guild channel.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
-        CollectReply::new(shard_messenger).channel_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this guild channel.
-    #[cfg(feature = "collector")]
-    pub fn await_replies(
+    pub fn reply_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> MessageCollectorBuilder<'a> {
         MessageCollectorBuilder::new(shard_messenger).channel_id(self.id.0)
     }
 
-    /// Await a single reaction by this guild channel.
+    /// Returns a stream builder which can be awaited to obtain a reaction or stream of reactions sent by this guild channel.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
-        CollectReaction::new(shard_messenger).channel_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this guild channel.
-    #[cfg(feature = "collector")]
-    pub fn await_reactions(
+    pub fn reaction_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).channel_id(self.id.0)
     }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -844,7 +844,7 @@ impl Message {
 
     /// Returns a builder which can be awaited to obtain a model submit interaction or stream of modal submit interactions on this message.
     #[cfg(feature = "collector")]
-    pub fn await_modal_interactions<'a>(
+    pub fn modal_interaction_collector<'a>(
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> ModalInteractionCollectorBuilder<'a> {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -13,9 +13,6 @@ use crate::cache::{Cache, GuildRef};
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
 use crate::collector::{
-    CollectComponentInteraction,
-    CollectModalInteraction,
-    CollectReaction,
     ComponentInteractionCollectorBuilder,
     ModalInteractionCollectorBuilder,
     ReactionCollectorBuilder,
@@ -827,54 +824,30 @@ impl Message {
         self.id.link_ensured(cache_http, self.channel_id, self.guild_id).await
     }
 
-    /// Await a single reaction on this message.
+    /// Returns a builder which can be awaited to obtain a reaction or stream of reactions on this message.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
-        CollectReaction::new(shard_messenger).message_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of reactions on this message.
-    #[cfg(feature = "collector")]
-    pub fn await_reactions(
+    pub fn reaction_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 
-    /// Await a single component interaction on this message.
+    /// Returns a builder which can be awaited to obtain a reaction or stream of component interactions on this message.
     #[cfg(feature = "collector")]
-    pub fn await_component_interaction(
+    pub fn component_interaction_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> CollectComponentInteraction {
-        CollectComponentInteraction::new(shard_messenger).message_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of component interactions on this message.
-    #[cfg(feature = "collector")]
-    pub fn await_component_interactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ComponentInteractionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ComponentInteractionCollectorBuilder<'a> {
         ComponentInteractionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 
-    /// Await a single modal submit interaction on this message.
+    /// Returns a builder which can be awaited to obtain a model submit interaction or stream of modal submit interactions on this message.
     #[cfg(feature = "collector")]
-    pub fn await_modal_interaction(
+    pub fn await_modal_interactions<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> CollectModalInteraction {
-        CollectModalInteraction::new(shard_messenger).message_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of modal submit interactions on this message.
-    #[cfg(feature = "collector")]
-    pub fn await_modal_interactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ModalInteractionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ModalInteractionCollectorBuilder<'a> {
         ModalInteractionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
     }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -30,12 +30,7 @@ use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
-use crate::collector::{
-    CollectReaction,
-    CollectReply,
-    MessageCollectorBuilder,
-    ReactionCollectorBuilder,
-};
+use crate::collector::{MessageCollectorBuilder, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, UserPagination};
 #[cfg(feature = "model")]
@@ -1359,34 +1354,21 @@ impl GuildId {
     pub async fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
         http.as_ref().get_guild_webhooks(self.get()).await
     }
-
-    /// Returns a future that will await one message sent in this guild.
+    /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
-        CollectReply::new(shard_messenger).guild_id(self.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
-    #[cfg(feature = "collector")]
-    pub fn await_replies(
+    pub fn reply_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> MessageCollectorBuilder<'a> {
         MessageCollectorBuilder::new(shard_messenger).guild_id(self.0)
     }
 
-    /// Await a single reaction in this guild.
+    /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
-        CollectReaction::new(shard_messenger).guild_id(self.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
-    #[cfg(feature = "collector")]
-    pub fn await_reactions(
+    pub fn reaction_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.0)
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -59,12 +59,7 @@ use crate::cache::Cache;
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
-use crate::collector::{
-    CollectReaction,
-    CollectReply,
-    MessageCollectorBuilder,
-    ReactionCollectorBuilder,
-};
+use crate::collector::{MessageCollectorBuilder, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::constants::LARGE_THRESHOLD;
 #[cfg(feature = "model")]
@@ -2600,33 +2595,21 @@ impl Guild {
         self.roles.values().find(|role| role_name == role.name)
     }
 
-    /// Returns a future that will await one message sent in this guild.
+    /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
-        CollectReply::new(shard_messenger).guild_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
-    #[cfg(feature = "collector")]
-    pub fn await_replies(
+    pub fn reply_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> MessageCollectorBuilder<'a> {
         MessageCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 
-    /// Await a single reaction in this guild.
+    /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
-        CollectReaction::new(shard_messenger).guild_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
-    #[cfg(feature = "collector")]
-    pub fn await_reactions(
+    pub fn reaction_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -22,12 +22,7 @@ use crate::cache::Cache;
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
-use crate::collector::{
-    CollectReaction,
-    CollectReply,
-    MessageCollectorBuilder,
-    ReactionCollectorBuilder,
-};
+use crate::collector::{MessageCollectorBuilder, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
 use crate::json::prelude::*;
@@ -1523,33 +1518,21 @@ impl PartialGuild {
         self.roles.values().find(|role| role_name == role.name)
     }
 
-    /// Returns a future that will await one message sent in this guild.
+    /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
-        CollectReply::new(shard_messenger).guild_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of messages in this guild.
-    #[cfg(feature = "collector")]
-    pub fn await_replies(
+    pub fn reply_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> MessageCollectorBuilder<'a> {
         MessageCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 
-    /// Await a single reaction in this guild.
+    /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
-        CollectReaction::new(shard_messenger).guild_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of reactions sent in this guild.
-    #[cfg(feature = "collector")]
-    pub fn await_reactions(
+    pub fn reaction_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
     }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -16,12 +16,7 @@ use crate::cache::{Cache, UserRef};
 #[cfg(feature = "collector")]
 use crate::client::bridge::gateway::ShardMessenger;
 #[cfg(feature = "collector")]
-use crate::collector::{
-    CollectReaction,
-    CollectReply,
-    MessageCollectorBuilder,
-    ReactionCollectorBuilder,
-};
+use crate::collector::{MessageCollectorBuilder, ReactionCollectorBuilder};
 #[cfg(feature = "model")]
 use crate::http::GuildPagination;
 #[cfg(feature = "model")]
@@ -1035,33 +1030,21 @@ impl User {
         guild_id.member(cache_http, &self.id).await.ok().and_then(|member| member.nick)
     }
 
-    /// Returns a future that will await one message by this user.
+    /// Returns a builder which can be awaited to obtain a message or stream of messages sent by this user.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReply {
-        CollectReply::new(shard_messenger).author_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of messages sent by this user.
-    #[cfg(feature = "collector")]
-    pub fn await_replies(
+    pub fn reply_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> MessageCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> MessageCollectorBuilder<'a> {
         MessageCollectorBuilder::new(shard_messenger).author_id(self.id.0)
     }
 
-    /// Await a single reaction by this user.
+    /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent by this user.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> CollectReaction {
-        CollectReaction::new(shard_messenger).author_id(self.id.0)
-    }
-
-    /// Returns a stream builder which can be awaited to obtain a stream of reactions sent by this user.
-    #[cfg(feature = "collector")]
-    pub fn await_reactions(
+    pub fn reaction_collector<'a>(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollectorBuilder {
+        shard_messenger: &'a ShardMessenger,
+    ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).author_id(self.id.0)
     }
 }


### PR DESCRIPTION
This prevents the duplicate `Future` and `Stream` implementations on each collector by de-duplicating them all into `Collector<Item>`, and removes duplication on the Builders for each collector by de-duplicating them all into `CollectorBuilder<Item>`

Points of note:
- `FilterOptions` (the structs in each collector) had to be made public, is this avoidable?
- Type aliases were made to prevent breaking too much, although should they be deprecated/removed?
- The weird `manager: impl AsRef<ShardManager>` -> `manager.as_ref().clone()` was removed, as just... why?