### PR TITLE
Introduce `rustversion` dependency and `backports` module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   rust_min: 1.53.0
-  rust_nightly: nightly-2022-03-22
+  rust_nightly: nightly-2022-06-23
 
 jobs:
   test:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
       - next
 
 env:
-  rust_nightly: nightly-2022-03-22
+  rust_nightly: nightly-2022-06-23
 
 jobs:
   docs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ serde_json = "1.0.75"
 serde-value = "0.7"
 async-trait = "0.1.9"
 
+[dependencies.rustversion]
+version = "1.0.7"
+optional = true
+
 [dependencies.simd-json]
 version = "0.4.14"
 optional = true
@@ -166,7 +170,7 @@ default_no_backend = [
 
 builder = ["utils"]
 cache = ["dashmap", "parking_lot"]
-collector = ["gateway", "model"]
+collector = ["gateway", "model", "rustversion"]
 client = ["http", "typemap_rev"]
 extras = []
 framework = ["client", "model", "utils"]

--- a/src/utils/backports.rs
+++ b/src/utils/backports.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "collector")]
+#[rustversion::since(1.61)]
+pub fn retain_mut<T>(vec: &mut Vec<T>, f: impl FnMut(&mut T) -> bool) {
+    vec.retain_mut(f);
+}
+
+#[cfg(feature = "collector")]
+#[rustversion::not(since(1.61))]
+pub fn retain_mut<T>(vec: &mut Vec<T>, mut f: impl FnMut(&mut T) -> bool) {
+    let len = vec.len();
+    let mut del = 0;
+    {
+        let v = &mut **vec;
+
+        for i in 0..len {
+            if !f(&mut v[i]) {
+                del += 1;
+            } else if del > 0 {
+                v.swap(i - del, i);
+            }
+        }
+    }
+
+    if del > 0 {
+        vec.truncate(len - del);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@
 
 #[cfg(feature = "client")]
 mod argument_convert;
+pub(crate) mod backports;
 mod colour;
 #[cfg(feature = "cache")]
 mod content_safe;


### PR DESCRIPTION
This means, with the collector feature, serenity now depends on `rustversion` to conditionally compile depending on the rust version. This PR starts off using it to use the stdlib implementation of `retain_mut` if it is stable, or fall back to our slower backport of it.