### PR TITLE
Make Member::edit in-place

### DIFF
--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -130,7 +130,10 @@ impl Member {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn add_roles(&mut self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
-        self.edit(http, |b| b.roles(self.roles.iter().chain(role_ids.iter()))).await
+        let mut target_roles = self.roles.clone();
+        target_roles.extend_from_slice(role_ids);
+
+        self.edit(http, |b| b.roles(target_roles)).await
     }
 
     /// Ban a [`User`] from the guild, deleting a number of
@@ -499,7 +502,10 @@ impl Member {
         http: impl AsRef<Http>,
         role_ids: &[RoleId],
     ) -> Result<()> {
-        self.edit(http, |b| b.roles(self.roles.iter().filter(|r| !role_ids.contains(r)))).await
+        let mut target_roles = self.roles.clone();
+        target_roles.retain(|r| !role_ids.contains(r));
+
+        self.edit(http, |b| b.roles(target_roles)).await
     }
 
     /// Retrieves the full role data for the user's roles.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -130,7 +130,7 @@ impl Member {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn add_roles(&mut self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
-        self.edit(http, |b| b.roles(role_ids)).await
+        self.edit(http, |b| b.roles(self.roles.iter().chain(role_ids.iter()))).await
     }
 
     /// Ban a [`User`] from the guild, deleting a number of

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -499,7 +499,7 @@ impl Member {
         http: impl AsRef<Http>,
         role_ids: &[RoleId],
     ) -> Result<()> {
-        self.edit(http, |b| b.roles(role_ids)).await
+        self.edit(http, |b| b.roles(self.roles.iter().filter(|r| !role_ids.contains(r)))).await
     }
 
     /// Retrieves the full role data for the user's roles.


### PR DESCRIPTION
This allows for the weirdness in add_role, add_roles, remove_role, and remove_roles to just pass through to `self.edit`.

This could cause monomorphization bloat? Although I doubt it, it's much less code in edit than was in all the methods anyway, although I could make a `_edit` which directly takes a Builder? That would need a `guild_id._edit_member` though, so not much point