### PR TITLE
feat: support setting presence when identifying

### DIFF
--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -21,6 +21,7 @@ use crate::client::bridge::voice::VoiceGatewayManager;
 use crate::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
+use crate::gateway::PresenceData;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
 use crate::model::gateway::GatewayIntents;
@@ -89,6 +90,7 @@ use crate::CacheAndHttp;
 ///     ws_url,
 ///     # cache_and_http,
 ///     intents: GatewayIntents::non_privileged(),
+///     presence: None,
 /// });
 /// #     Ok(())
 /// # }
@@ -141,6 +143,7 @@ impl ShardManager {
             ws_url: opt.ws_url,
             cache_and_http: opt.cache_and_http,
             intents: opt.intents,
+            presence: opt.presence,
         };
 
         spawn_named("shard_queuer::run", async move {
@@ -359,4 +362,5 @@ pub struct ShardManagerOptions {
     pub ws_url: Arc<Mutex<String>>,
     pub cache_and_http: Arc<CacheAndHttp>,
     pub intents: GatewayIntents,
+    pub presence: Option<PresenceData>,
 }

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -71,7 +71,7 @@ impl ShardMessenger {
     /// #         id: 0,
     /// #         total: 1,
     /// #     };
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all()).await?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -98,7 +98,7 @@ impl ShardMessenger {
     /// #         total: 1,
     /// #     };
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all()).await?;;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -148,7 +148,7 @@ impl ShardMessenger {
     /// #         total: 1,
     /// #     };
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all()).await?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
     /// use serenity::gateway::ActivityData;
     ///
     /// shard.set_activity(Some(ActivityData::playing("Heroes of the Storm")));
@@ -224,7 +224,7 @@ impl ShardMessenger {
     /// #         total: 1,
     /// #     };
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all()).await?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
     /// #
     /// use serenity::model::user::OnlineStatus;
     ///

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -23,7 +23,7 @@ use crate::client::bridge::voice::VoiceGatewayManager;
 use crate::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
-use crate::gateway::{ConnectionStage, InterMessage, Shard};
+use crate::gateway::{ConnectionStage, InterMessage, PresenceData, Shard};
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
 use crate::model::gateway::{GatewayIntents, ShardInfo};
@@ -80,6 +80,7 @@ pub struct ShardQueuer {
     pub ws_url: Arc<Mutex<String>>,
     pub cache_and_http: Arc<CacheAndHttp>,
     pub intents: GatewayIntents,
+    pub presence: Option<PresenceData>,
 }
 
 impl ShardQueuer {
@@ -178,6 +179,7 @@ impl ShardQueuer {
             &self.cache_and_http.http.token,
             shard_info,
             self.intents,
+            self.presence.clone(),
         )
         .await?;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -57,18 +57,20 @@ pub use crate::cache::Cache;
 use crate::cache::Settings as CacheSettings;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
+use crate::gateway::{ActivityData, PresenceData};
 use crate::http::Http;
 use crate::internal::prelude::*;
 #[cfg(feature = "gateway")]
 use crate::model::gateway::GatewayIntents;
 use crate::model::id::ApplicationId;
+use crate::model::user::OnlineStatus;
 pub use crate::CacheAndHttp;
 
 /// A builder implementing [`Future`] building a [`Client`] to interact with Discord.
 #[cfg(feature = "gateway")]
 #[must_use = "Builders do nothing unless they are awaited"]
 pub struct ClientBuilder {
-    // TODO: data, http and cache_settings are Options in order to take() them out in the Future impl.
+    // TODO: data, http, cache_settings and presence are Options in order to take() them out in the Future impl.
     // This should be changed after the stabilization of std::future::IntoFuture.
     data: Option<TypeMap>,
     http: Option<Http>,
@@ -82,6 +84,7 @@ pub struct ClientBuilder {
     voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
     event_handler: Option<Arc<dyn EventHandler>>,
     raw_event_handler: Option<Arc<dyn RawEventHandler>>,
+    presence: Option<PresenceData>,
 }
 
 #[cfg(feature = "gateway")]
@@ -100,6 +103,7 @@ impl ClientBuilder {
             voice_manager: None,
             event_handler: None,
             raw_event_handler: None,
+            presence: Some(PresenceData::default()),
         }
     }
 
@@ -346,6 +350,26 @@ impl ClientBuilder {
     pub fn get_raw_event_handler(&self) -> Option<Arc<dyn RawEventHandler>> {
         self.raw_event_handler.clone()
     }
+
+    /// Sets the initial activity.
+    pub fn activity(mut self, activity: ActivityData) -> Self {
+        self.presence.get_or_insert(PresenceData::default()).activity = Some(activity);
+
+        self
+    }
+
+    /// Sets the initial status.
+    pub fn status(mut self, status: OnlineStatus) -> Self {
+        self.presence.get_or_insert(PresenceData::default()).status = status;
+
+        self
+    }
+
+    /// Gets the initial presence. See [`Self::activity`] and [`Self::status`] for more info.
+    /// This can be unwrapped safely unless used after awaiting the builder.
+    pub fn get_presence(&self) -> Option<&PresenceData> {
+        self.presence.as_ref()
+    }
 }
 
 #[cfg(feature = "gateway")]
@@ -362,6 +386,7 @@ impl Future for ClientBuilder {
             let event_handler = self.event_handler.take();
             let raw_event_handler = self.raw_event_handler.take();
             let intents = self.intents;
+            let presence = self.presence.take();
             let http = Arc::new(self.http.take().unwrap());
 
             #[cfg(feature = "voice")]
@@ -391,6 +416,7 @@ impl Future for ClientBuilder {
                         ws_url: Arc::clone(&ws_url),
                         cache_and_http: Arc::clone(&cache_and_http),
                         intents,
+                        presence,
                     });
 
                 Ok(Client {

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -137,11 +137,12 @@ impl Shard {
         token: &str,
         shard_info: ShardInfo,
         intents: GatewayIntents,
+        presence: Option<PresenceData>,
     ) -> Result<Shard> {
         let url = ws_url.lock().await.clone();
         let client = connect(&url).await?;
 
-        let presence = PresenceData::default();
+        let presence = presence.unwrap_or_default();
         let heartbeat_instants = (None, None);
         let heartbeat_interval = None;
         let last_heartbeat_acknowledged = true;
@@ -709,7 +710,9 @@ impl Shard {
     /// - the `stage` to [`ConnectionStage::Identifying`]
     #[instrument(skip(self))]
     pub async fn identify(&mut self) -> Result<()> {
-        self.client.send_identify(&self.shard_info, &self.token, self.intents).await?;
+        self.client
+            .send_identify(&self.shard_info, &self.token, self.intents, &self.presence)
+            .await?;
 
         self.heartbeat_instants.0 = Some(Instant::now());
         self.stage = ConnectionStage::Identifying;

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -118,7 +118,7 @@ impl Shard {
     ///
     /// // retrieve the gateway response, which contains the URL to connect to
     /// let gateway = Arc::new(Mutex::new(http.get_gateway().await?.url));
-    /// let shard = Shard::new(gateway, &token, shard_info, GatewayIntents::all()).await?;
+    /// let shard = Shard::new(gateway, &token, shard_info, GatewayIntents::all(), None).await?;
     ///
     /// // at this point, you can create a `loop`, and receive events and match
     /// // their variants
@@ -645,7 +645,7 @@ impl Shard {
     /// #          total: 1,
     /// #     };
     /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all()).await?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
     /// #
     /// use serenity::model::id::GuildId;
     ///
@@ -672,7 +672,7 @@ impl Shard {
     /// #          id: 0,
     /// #          total: 1,
     /// #     };
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all()).await?;
+    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
     /// #
     /// use serenity::model::id::GuildId;
     ///


### PR DESCRIPTION
This adds a new shard manager option together with new client builder methods to support setting an initial presence with the identify gateway command.

Reference: https://discord.com/developers/docs/topics/gateway#identify