### PR TITLE
Add new `app_permissions` field for interactions

### DIFF
--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -35,6 +35,7 @@ use crate::model::id::{
 };
 use crate::model::user::User;
 use crate::model::utils::deserialize_options_with_resolved;
+use crate::model::Permissions;
 
 /// An interaction when a user invokes a slash command.
 ///
@@ -67,6 +68,8 @@ pub struct ApplicationCommandInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
+    /// Permissions the app or bot has within the channel the interaction was sent from.
+    pub app_permissions: Option<Permissions>,
     /// The selected language of the invoking user.
     pub locale: String,
     /// The guild's preferred locale.
@@ -412,6 +415,12 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteraction {
             .and_then(u8::deserialize)
             .map_err(DeError::custom)?;
 
+        let app_permissions = map
+            .remove("app_permissions")
+            .map(Permissions::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
+
         let guild_locale = map
             .remove("guild_locale")
             .map(String::deserialize)
@@ -435,6 +444,7 @@ impl<'de> Deserialize<'de> for ApplicationCommandInteraction {
             user,
             token,
             version,
+            app_permissions,
             locale,
             guild_locale,
         })

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -16,6 +16,7 @@ use crate::model::application::interaction::InteractionType;
 use crate::model::guild::Member;
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
+use crate::model::Permissions;
 
 /// An interaction received when the user fills in an autocomplete option
 ///
@@ -48,6 +49,8 @@ pub struct AutocompleteInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
+    /// Permissions the app or bot has within the channel the interaction was sent from.
+    pub app_permissions: Option<Permissions>,
     /// The selected language of the invoking user.
     pub locale: String,
     /// The guild's preferred locale.
@@ -165,6 +168,12 @@ impl<'de> Deserialize<'de> for AutocompleteInteraction {
             .and_then(u8::deserialize)
             .map_err(DeError::custom)?;
 
+        let app_permissions = map
+            .remove("app_permissions")
+            .map(Permissions::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
+
         let guild_locale = map
             .remove("guild_locale")
             .map(String::deserialize)
@@ -188,6 +197,7 @@ impl<'de> Deserialize<'de> for AutocompleteInteraction {
             user,
             token,
             version,
+            app_permissions,
             locale,
             guild_locale,
         })

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -23,6 +23,7 @@ use crate::model::guild::Member;
 use crate::model::id::MessageId;
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
+use crate::model::Permissions;
 
 /// An interaction triggered by a message component.
 ///
@@ -58,6 +59,8 @@ pub struct MessageComponentInteraction {
     /// The message this interaction was triggered by, if
     /// it is a component.
     pub message: Message,
+    /// Permissions the app or bot has within the channel the interaction was sent from.
+    pub app_permissions: Option<Permissions>,
     /// The selected language of the invoking user.
     pub locale: String,
     /// The guild's preferred locale.
@@ -385,6 +388,12 @@ impl<'de> Deserialize<'de> for MessageComponentInteraction {
             .and_then(u8::deserialize)
             .map_err(DeError::custom)?;
 
+        let app_permissions = map
+            .remove("app_permissions")
+            .map(Permissions::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
+
         let guild_locale = map
             .remove("guild_locale")
             .map(String::deserialize)
@@ -409,6 +418,7 @@ impl<'de> Deserialize<'de> for MessageComponentInteraction {
             token,
             version,
             message,
+            app_permissions,
             locale,
             guild_locale,
         })

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -15,6 +15,7 @@ use self::ping::PingInteraction;
 use crate::json::{from_value, JsonMap, Value};
 use crate::model::id::{ApplicationId, InteractionId};
 use crate::model::user::User;
+use crate::model::Permissions;
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object)
 #[derive(Clone, Debug)]
@@ -48,6 +49,18 @@ impl Interaction {
             Self::MessageComponent(_) => InteractionType::MessageComponent,
             Self::Autocomplete(_) => InteractionType::Autocomplete,
             Self::ModalSubmit(_) => InteractionType::ModalSubmit,
+        }
+    }
+
+    /// Permissions the app or bot has within the channel the interaction was sent from.
+    #[must_use]
+    pub fn app_permissions(&self) -> Option<Permissions> {
+        match self {
+            Self::Ping(_) => None,
+            Self::ApplicationCommand(i) => i.app_permissions,
+            Self::MessageComponent(i) => i.app_permissions,
+            Self::Autocomplete(i) => i.app_permissions,
+            Self::ModalSubmit(i) => i.app_permissions,
         }
     }
 

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -23,6 +23,7 @@ use crate::model::guild::Member;
 use crate::model::id::MessageId;
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
+use crate::model::Permissions;
 
 /// An interaction triggered by a modal submit.
 ///
@@ -61,6 +62,8 @@ pub struct ModalSubmitInteraction {
     /// an application command interaction
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<Message>,
+    /// Permissions the app or bot has within the channel the interaction was sent from.
+    pub app_permissions: Option<Permissions>,
     /// The selected language of the invoking user.
     pub locale: String,
     /// The guild's preferred locale.
@@ -370,6 +373,12 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
             .and_then(u8::deserialize)
             .map_err(DeError::custom)?;
 
+        let app_permissions = map
+            .remove("app_permissions")
+            .map(Permissions::deserialize)
+            .transpose()
+            .map_err(DeError::custom)?;
+
         let guild_locale = map
             .remove("guild_locale")
             .map(String::deserialize)
@@ -394,6 +403,7 @@ impl<'de> Deserialize<'de> for ModalSubmitInteraction {
             token,
             version,
             message,
+            app_permissions,
             locale,
             guild_locale,
         })


### PR DESCRIPTION
> Calculated Permissions in Interaction Payloads
👋 Say hey to the newest field on the block
>
> Interaction payloads now contain an app_permissions field whose value is the computed permissions for a bot or app in the context of a specific interaction. Similar to other permission fields, the value of `app_permissions` is a bitwise OR-ed set of permissions expressed as a string.
>
> `app_permissions` is meant to help identify the permissions your bot or app has without having to cache or store any server-specific permission settings or updates. It can be used before replying to an interaction in order to prevent any permission-related failures. Neat!

https://github.com/discord/discord-api-docs/commit/f4e3955f673c7f26b665f64411d8353bda7d0525