### PR TITLE
Enable `Invite::expires_at` field

### DIFF
--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -54,9 +54,9 @@ pub struct Invite {
     /// Only shows up if `target_type` is `EmmbeddedApplication`.
     pub target_application: Option<ApplicationId>,
 
-    // /// The expiration date of this invite, returned from `Http::get_invite` when
-    // /// `with_expiration` is true.
-    // pub expires_at: Option<Timestamp>,
+    /// The expiration date of this invite, returned from `Http::get_invite` when
+    /// `with_expiration` is true.
+    pub expires_at: Option<Timestamp>,
     /// The Stage instance data if there is a public Stage instance in the Stage
     /// channel this invite is for.
     pub stage_instance: Option<InviteStageInstance>,


### PR DESCRIPTION
This field was added in #1491 but left commented out because it depended on the value of the `with_expiration` query parameter, which the `Http` method did not yet support; therefore the field would always be set `None`. However, that query parameter was added in #1757 and is available since v11.0, so the `expires_at` field is now useful.