### PR TITLE
Fix "missing field `discriminator`" serde error for presence updates

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -410,7 +410,7 @@ pub struct PresenceUser {
     pub id: UserId,
     pub avatar: Option<String>,
     pub bot: Option<bool>,
-    #[serde(with = "discriminator::option")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator::option")]
     pub discriminator: Option<u16>,
     pub email: Option<String>,
     pub mfa_enabled: Option<bool>,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1321,7 +1321,11 @@ mod test {
         }
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
         struct UserOpt {
-            #[serde(with = "discriminator::option")]
+            #[serde(
+                default,
+                skip_serializing_if = "Option::is_none",
+                with = "discriminator::option"
+            )]
             discriminator: Option<u16>,
         }
 
@@ -1368,6 +1372,17 @@ mod test {
             Token::Str("discriminator"),
             Token::Some,
             Token::U16(123),
+            Token::StructEnd,
+        ]);
+
+        let user_no_discriminator = UserOpt {
+            discriminator: None,
+        };
+        assert_tokens(&user_no_discriminator, &[
+            Token::Struct {
+                name: "UserOpt",
+                len: 0,
+            },
             Token::StructEnd,
         ]);
     }


### PR DESCRIPTION
closes: #2022 