### PR TITLE
Fix guild delete return type

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1011,8 +1011,8 @@ impl Http {
     }
 
     /// Deletes a guild, only if connected account owns it.
-    pub async fn delete_guild(&self, guild_id: u64) -> Result<PartialGuild> {
-        self.fire(Request {
+    pub async fn delete_guild(&self, guild_id: u64) -> Result<()> {
+        self.wind(204, Request {
             body: None,
             multipart: None,
             headers: None,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -382,7 +382,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user is not the owner of the guild.
     #[inline]
-    pub async fn delete(self, http: impl AsRef<Http>) -> Result<PartialGuild> {
+    pub async fn delete(self, http: impl AsRef<Http>) -> Result<()> {
         http.as_ref().delete_guild(self.get()).await
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -939,7 +939,7 @@ impl Guild {
     ///
     /// Otherwise returns [`Error::Http`] if the current user is not the
     /// owner of the guild.
-    pub async fn delete(&self, cache_http: impl CacheHttp) -> Result<PartialGuild> {
+    pub async fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -592,7 +592,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user is not the owner of
     /// the guild.
     #[inline]
-    pub async fn delete(&self, http: impl AsRef<Http>) -> Result<PartialGuild> {
+    pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
         self.id.delete(&http).await
     }
 


### PR DESCRIPTION
Note: since this has just been reported now, and has been broken since initial commit, no one has used this endpoint ever in serenity's history

Closes #2029 