### PR TITLE
Fix timestamp having fallible From impl

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -226,7 +226,7 @@ impl CreateEmbed {
     ///     async fn message(&self, context: Context, mut msg: Message) {
     ///         if msg.content == "~embed" {
     ///             let timestamp: Timestamp =
-    ///                 "2004-06-08T16:04:23".parse().expect("Invalid timestamp!");
+    ///                 "2004-06-08T16:04:23Z".parse().expect("Invalid timestamp!");
     ///             let _ = msg
     ///                 .channel_id
     ///                 .send_message(&context.http, |m| {

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -57,7 +57,7 @@ pub struct CreateEmbed {
     #[serde(skip_serializing_if = "Option::is_none")]
     thumbnail: Option<HoldsUrl>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    timestamp: Option<String>,
+    timestamp: Option<Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -206,16 +206,7 @@ impl CreateEmbed {
 
     /// Set the timestamp.
     ///
-    /// You may pass a direct string:
-    ///
-    /// - `2017-01-03T23:00:00`
-    /// - `2004-06-08T16:04:23`
-    /// - `2004-06-08T16:04:23`
-    ///
-    /// This timestamp must be in ISO-8601 format. It must also be in UTC format.
-    ///
-    /// You can also pass an instance of `chrono::DateTime<Utc>`,
-    /// which will construct the timestamp string out of it.
+    /// See the documentation of [`Timestamp`] for more information.
     ///
     /// # Examples
     ///
@@ -225,6 +216,7 @@ impl CreateEmbed {
     /// # #[cfg(feature = "client")]
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::model::channel::Message;
+    /// use serenity::model::Timestamp;
     /// use serenity::prelude::*;
     ///
     /// struct Handler;
@@ -233,10 +225,12 @@ impl CreateEmbed {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, mut msg: Message) {
     ///         if msg.content == "~embed" {
+    ///             let timestamp: Timestamp =
+    ///                 "2004-06-08T16:04:23".parse().expect("Invalid timestamp!");
     ///             let _ = msg
     ///                 .channel_id
     ///                 .send_message(&context.http, |m| {
-    ///                     m.embed(|e| e.title("hello").timestamp("2004-06-08T16:04:23"))
+    ///                     m.embed(|e| e.title("hello").timestamp(timestamp))
     ///                 })
     ///                 .await;
     ///         }
@@ -301,7 +295,7 @@ impl CreateEmbed {
     /// ```
     #[inline]
     pub fn timestamp<T: Into<Timestamp>>(&mut self, timestamp: T) -> &mut Self {
-        self.timestamp = Some(timestamp.into().to_string());
+        self.timestamp = Some(timestamp.into());
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 #![doc(html_root_url = "https://docs.rs/serenity/*")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rust_2018_idioms)]
-#![warn(clippy::pedantic)]
+#![warn(clippy::pedantic, clippy::fallible_impl_from)]
 #![allow(
     // Allowed to avoid breaking changes.
     clippy::module_name_repetitions,

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "model")]
 use crate::builder::CreateEmbed;
+use crate::model::Timestamp;
 #[cfg(feature = "utils")]
 use crate::utils::Colour;
 
@@ -51,7 +52,7 @@ pub struct Embed {
     /// Thumbnail information of the embed.
     pub thumbnail: Option<EmbedThumbnail>,
     /// Timestamp information.
-    pub timestamp: Option<String>,
+    pub timestamp: Option<Timestamp>,
     /// The title of the embed.
     pub title: Option<String>,
     /// The URL of the embed.

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -257,28 +257,18 @@ impl fmt::Display for ParseError {
 impl FromStr for Timestamp {
     type Err = ParseError;
 
+    /// Parses an RFC 3339 date and time string such as `2016-04-30T11:18:25.796Z`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Timestamp::parse(s)
     }
 }
 
-impl From<String> for Timestamp {
-    /// Parses an RFC 3339 date and time string such as `2016-04-30T11:18:25.796Z`.
-    ///
-    /// Panics on invalid value.
-    fn from(s: String) -> Self {
-        #[allow(clippy::unwrap_used)]
-        Timestamp::parse(&s).unwrap()
-    }
-}
+impl<'a> std::convert::TryFrom<&'a str> for Timestamp {
+    type Error = ParseError;
 
-impl<'a> From<&'a str> for Timestamp {
     /// Parses an RFC 3339 date and time string such as `2016-04-30T11:18:25.796Z`.
-    ///
-    /// Panics on invalid value.
-    fn from(s: &'a str) -> Self {
-        #[allow(clippy::unwrap_used)]
-        Timestamp::parse(s).unwrap()
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Timestamp::parse(s)
     }
 }
 


### PR DESCRIPTION
This swaps the `From` impl into a `TryFrom` implementation defined in terms of `FromStr`. It also removes the redundant `From` implementation on `String` that was a small footgun (consumed `String` when only needed `&str`).

This also adds a warn for the nursery lint `clippy::fallible_impl_from` to detect for this usage again, as this lint has existed for ages with no open issues referring to it on the clippy repo, so I consider it stable enough for usage here, although if wanted to, I can remove the warn.