### PR TITLE
Remove superfluous link reference definitions for `crate::Error`

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -777,8 +777,6 @@ impl Args {
     /// # Errors
     ///
     /// Returns [`Error::Eos`] if no argument can be parsed.
-    ///
-    /// [`Error::Eos`]: Error::Eos
     pub fn find<T: FromStr>(&mut self) -> Result<T, T::Err> {
         if self.is_empty() {
             return Err(Error::Eos);
@@ -824,8 +822,6 @@ impl Args {
     /// # Errors
     ///
     /// Returns [`Error::Eos`] if no argument can be parsed.
-    ///
-    /// [`Error::Eos`]: Error::Eos
     pub fn find_n<T: FromStr>(&mut self) -> Result<T, T::Err> {
         if self.is_empty() {
             return Err(Error::Eos);

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -126,8 +126,6 @@ impl Shard {
     ///
     /// On Error, will return either [`Error::Gateway`], [`Error::Tungstenite`]
     /// or a Rustls/native TLS error.
-    ///
-    /// [`Error::Gateway`]: crate::Error::Gateway
     pub async fn new(
         ws_url: Arc<Mutex<String>>,
         token: &str,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -195,9 +195,6 @@ fn reason_into_header(reason: &str) -> Headers {
 
 /// **Note**: For all member functions that return a [`Result`], the
 /// Error kind will be either [`Error::Http`] or [`Error::Json`].
-///
-/// [`Error::Http`]: crate::error::Error::Http
-/// [`Error::Json`]: crate::error::Error::Json
 pub struct Http {
     pub(crate) client: Client,
     pub ratelimiter: Ratelimiter,
@@ -3914,9 +3911,6 @@ impl Http {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn fire<T: DeserializeOwned>(&self, req: Request<'_>) -> Result<T> {
         let response = self.request(req).await?;
 

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -147,8 +147,6 @@ impl Ratelimiter {
     /// # Errors
     ///
     /// Only error kind that may be returned is [`Error::Http`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[instrument]
     pub async fn perform(&self, req: RatelimitedRequest<'_>) -> Result<Response> {
         let RatelimitedRequest {

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -4,8 +4,8 @@ use tokio::sync::oneshot::error::TryRecvError;
 use tokio::sync::oneshot::{self, Sender};
 use tokio::time::{sleep, Duration};
 
-use crate::error::Result;
 use crate::http::Http;
+use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
 
 /// A struct to start typing in a [`Channel`] for an indefinite period of time.
@@ -61,7 +61,6 @@ impl Typing {
     /// Returns an  [`Error::Http`] if there is an error.
     ///
     /// [`Channel`]: crate::model::channel::Channel
-    /// [`Error::Http`]: crate::error::Error::Http
     pub fn start(http: Arc<Http>, channel_id: u64) -> Result<Self> {
         let (sx, mut rx) = oneshot::channel();
 

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "http")]
 use crate::builder::{CreateApplicationCommand, CreateApplicationCommands};
 #[cfg(feature = "http")]
-use crate::error::Result;
-#[cfg(feature = "http")]
 use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
 use crate::json::Value;
 #[cfg(feature = "http")]
 use crate::json::{self, JsonMap};
@@ -157,8 +157,6 @@ impl Command {
     ///
     /// [`InteractionCreate`]: crate::client::EventHandler::interaction_create
     /// [API Docs]: https://discord.com/developers/docs/interactions/slash-commands
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     /// [`choices`]: CommandOption::choices
     pub async fn create_global_application_command<F>(
         http: impl AsRef<Http>,
@@ -178,9 +176,6 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn set_global_application_commands<F>(
         http: impl AsRef<Http>,
         f: F,
@@ -200,9 +195,6 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_global_application_command<F>(
         http: impl AsRef<Http>,
         command_id: CommandId,
@@ -220,9 +212,6 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_global_application_commands(http: impl AsRef<Http>) -> Result<Vec<Command>> {
         http.as_ref().get_global_application_commands().await
     }
@@ -232,9 +221,6 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_global_application_command(
         http: impl AsRef<Http>,
         command_id: CommandId,
@@ -247,9 +233,6 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn delete_global_application_command(
         http: impl AsRef<Http>,
         command_id: CommandId,

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -83,8 +83,6 @@ impl ApplicationCommandInteraction {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if there is no interaction response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn get_interaction_response(&self, http: impl AsRef<Http>) -> Result<Message> {
         http.as_ref().get_original_interaction_response(&self.token).await
     }
@@ -99,10 +97,6 @@ impl ApplicationCommandInteraction {
     /// May also return an [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error in deserializing the
     /// API response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_interaction_response<'a, F>(
         &self,
         http: impl AsRef<Http>,
@@ -155,10 +149,6 @@ impl ApplicationCommandInteraction {
     /// Returns [`Error::Model`] if the edited content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_original_interaction_response<F>(
         &self,
         http: impl AsRef<Http>,
@@ -196,10 +186,6 @@ impl ApplicationCommandInteraction {
     /// Will return [`Error::Model`] if the content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_followup_message<'a, F>(
         &self,
         http: impl AsRef<Http>,
@@ -246,10 +232,6 @@ impl ApplicationCommandInteraction {
     /// Will return [`Error::Model`] if the content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
         &self,
         http: impl AsRef<Http>,
@@ -319,9 +301,6 @@ impl ApplicationCommandInteraction {
     /// May also return an [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error in deserializing the
     /// API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn defer(&self, http: impl AsRef<Http>) -> Result<()> {
         self.create_interaction_response(http, |f| {
             f.kind(InteractionResponseType::DeferredChannelMessageWithSource)

--- a/src/model/application/interaction/autocomplete.rs
+++ b/src/model/application/interaction/autocomplete.rs
@@ -64,8 +64,6 @@ impl AutocompleteInteraction {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the API returns an error.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn create_autocomplete_response<F>(&self, http: impl AsRef<Http>, f: F) -> Result<()>
     where
         F: FnOnce(&mut CreateAutocompleteResponse) -> &mut CreateAutocompleteResponse,

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -74,8 +74,6 @@ impl MessageComponentInteraction {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if there is no interaction response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn get_interaction_response(&self, http: impl AsRef<Http>) -> Result<Message> {
         http.as_ref().get_original_interaction_response(&self.token).await
     }
@@ -90,10 +88,6 @@ impl MessageComponentInteraction {
     /// May also return an [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error in deserializing the
     /// API response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_interaction_response<'a, F>(
         &self,
         http: impl AsRef<Http>,
@@ -142,10 +136,6 @@ impl MessageComponentInteraction {
     /// Returns [`Error::Model`] if the edited content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_original_interaction_response<F>(
         &self,
         http: impl AsRef<Http>,
@@ -184,10 +174,6 @@ impl MessageComponentInteraction {
     /// Will return [`Error::Model`] if the content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_followup_message<'a, F>(
         &self,
         http: impl AsRef<Http>,
@@ -218,10 +204,6 @@ impl MessageComponentInteraction {
     /// Will return [`Error::Model`] if the content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
         &self,
         http: impl AsRef<Http>,
@@ -283,9 +265,6 @@ impl MessageComponentInteraction {
     /// API response.
     ///
     /// # Errors
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn defer(&self, http: impl AsRef<Http>) -> Result<()> {
         self.create_interaction_response(http, |f| {
             f.kind(InteractionResponseType::DeferredUpdateMessage)

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -77,8 +77,6 @@ impl ModalSubmitInteraction {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if there is no interaction response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn get_interaction_response(&self, http: impl AsRef<Http>) -> Result<Message> {
         http.as_ref().get_original_interaction_response(&self.token).await
     }
@@ -93,10 +91,6 @@ impl ModalSubmitInteraction {
     /// May also return an [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error in deserializing the
     /// API response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_interaction_response<'a, F>(
         &self,
         http: impl AsRef<Http>,
@@ -145,10 +139,6 @@ impl ModalSubmitInteraction {
     /// Returns [`Error::Model`] if the edited content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_original_interaction_response<F>(
         &self,
         http: impl AsRef<Http>,
@@ -187,10 +177,6 @@ impl ModalSubmitInteraction {
     /// Will return [`Error::Model`] if the content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_followup_message<'a, F>(
         &self,
         http: impl AsRef<Http>,
@@ -221,10 +207,6 @@ impl ModalSubmitInteraction {
     /// Will return [`Error::Model`] if the content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or a [`Error::Json`] if there is an error in deserializing the response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
         &self,
         http: impl AsRef<Http>,
@@ -269,11 +251,6 @@ impl ModalSubmitInteraction {
     /// May also return an [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error in deserializing the
     /// API response.
-    ///
-    /// # Errors
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn defer(&self, http: impl AsRef<Http>) -> Result<()> {
         self.create_interaction_response(http, |f| {
             f.kind(InteractionResponseType::DeferredUpdateMessage)

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -128,8 +128,6 @@ impl Attachment {
     /// Returns an [`Error::Http`] when there is a problem retrieving the
     /// attachment.
     ///
-    /// [`Error::Http`]: crate::Error::Http
-    /// [`Error::Io`]: crate::Error::Io
     /// [`Message`]: super::Message
     pub async fn download(&self) -> Result<Vec<u8>> {
         let reqwest = ReqwestClient::new();

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -540,7 +540,6 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_emoji(
         self,
@@ -572,8 +571,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks the necessary permissions.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_member<F>(
         self,
@@ -602,7 +599,6 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Change Nickname]: Permissions::CHANGE_NICKNAME
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_nickname(
         self,
@@ -631,7 +627,6 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_role<F>(
         self,
@@ -690,7 +685,6 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
-    /// [`Error::Http`]: crate::error::Error::Http
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
     pub async fn edit_sticker<F>(
@@ -726,7 +720,6 @@ impl GuildId {
     /// Returns an [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_role_position(
         self,
@@ -742,8 +735,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if some mandatory fields are not provided.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn edit_welcome_screen<F>(
         &self,
         http: impl AsRef<Http>,
@@ -766,8 +757,6 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the bot does not have the `MANAGE_GUILD`
     /// permission.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn edit_widget<F>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildWidget>
     where
         F: FnOnce(&mut EditGuildWidget) -> &mut EditGuildWidget,
@@ -812,8 +801,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn to_partial_guild(self, http: impl AsRef<Http>) -> Result<PartialGuild> {
         http.as_ref().get_guild(self.0).await
@@ -827,8 +814,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn to_partial_guild_with_counts(
         self,
@@ -842,8 +827,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the guild is unavailable.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn emojis(&self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
         http.as_ref().get_emojis(self.0).await
@@ -854,8 +837,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if an emoji with that Id does not exist.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
         http.as_ref().get_emoji(self.0, emoji_id.0).await
@@ -866,8 +847,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the guild is unavailable.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn stickers(&self, http: impl AsRef<Http>) -> Result<Vec<Sticker>> {
         http.as_ref().get_guild_stickers(self.0).await
@@ -878,8 +857,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if an sticker with that Id does not exist.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn sticker(&self, http: impl AsRef<Http>, sticker_id: StickerId) -> Result<Sticker> {
         http.as_ref().get_guild_sticker(self.0, sticker_id.0).await
@@ -896,8 +873,6 @@ impl GuildId {
     /// the API response.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn integrations(self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {
         http.as_ref().get_guild_integrations(self.0).await
@@ -914,8 +889,6 @@ impl GuildId {
     /// deserializing the API response.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
         http.as_ref().get_guild_invites(self.0).await
@@ -930,7 +903,6 @@ impl GuildId {
     /// Returns [`Error::Http`] if the member cannot be kicked by
     /// the current user.
     ///
-    /// [`Error::Http`]: crate::error::Error::Http
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn kick(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
@@ -957,8 +929,6 @@ impl GuildId {
     ///
     /// May return an [`Error::Http`] if the current user
     /// cannot leave the guild, or currently is not in the guild.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn leave(self, http: impl AsRef<Http>) -> Result<()> {
         http.as_ref().leave_guild(self.0).await
@@ -973,8 +943,6 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the user is not in the guild,
     /// or if the guild is otherwise unavailable
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn member(
         self,
@@ -1008,8 +976,6 @@ impl GuildId {
     /// return [`Error::NotInRange`] if the input is not within range.
     ///
     /// [`User`]: crate::model::user::User
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::NotInRange`]: crate::error::Error::NotInRange
     #[inline]
     pub async fn members(
         self,
@@ -1061,7 +1027,6 @@ impl GuildId {
     /// in a voice channel for this [`Guild`].
     ///
     /// [Move Members]: Permissions::MOVE_MEMBERS
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn move_member(
         self,
@@ -1166,8 +1131,6 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the API returns an error.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn search_members(
         self,
@@ -1381,9 +1344,6 @@ impl GuildId {
     /// Will return an [`Error::Http`] if the bot is lacking permissions.
     /// Can also return an [`Error::Json`] if there is an error deserializing
     /// the API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
         http.as_ref().get_guild_webhooks(self.0).await
@@ -1469,9 +1429,6 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1500,9 +1457,6 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1524,9 +1478,6 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_commands(&self, http: impl AsRef<Http>) -> Result<Vec<Command>> {
         http.as_ref().get_guild_application_commands(self.0).await
     }
@@ -1536,9 +1487,6 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -1552,9 +1500,6 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1575,9 +1520,6 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -1591,9 +1533,6 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -1606,9 +1545,6 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -673,9 +673,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
@@ -694,9 +691,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -716,9 +710,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -737,9 +728,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_commands(&self, http: impl AsRef<Http>) -> Result<Vec<Command>> {
         self.id.get_application_commands(http).await
     }
@@ -749,9 +737,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -765,9 +750,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -785,9 +767,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -801,9 +780,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -816,9 +792,6 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -1132,7 +1105,6 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_emoji(
         &self,
@@ -1160,8 +1132,6 @@ impl Guild {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks the necessary permissions.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_member<F>(
         &self,
@@ -1190,7 +1160,6 @@ impl Guild {
     /// Otherwise will return [`Error::Http`] if the current user lacks permission.
     ///
     /// [Change Nickname]: Permissions::CHANGE_NICKNAME
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn edit_nickname(
         &self,
         cache_http: impl CacheHttp,
@@ -1257,7 +1226,6 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_role_position(
         &self,
@@ -1308,7 +1276,6 @@ impl Guild {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
-    /// [`Error::Http`]: crate::error::Error::Http
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
     pub async fn edit_sticker<F>(
@@ -1328,8 +1295,6 @@ impl Guild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if some mandatory fields are not provided.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn edit_welcome_screen<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1347,8 +1312,6 @@ impl Guild {
     ///
     /// Returns an [`Error::Http`] if the bot does not have the `MANAGE_GUILD`
     /// permission.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn edit_widget<F>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildWidget>
     where
         F: FnOnce(&mut EditGuildWidget) -> &mut EditGuildWidget,
@@ -1364,8 +1327,6 @@ impl Guild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn get(http: impl AsRef<Http>, guild_id: impl Into<GuildId>) -> Result<PartialGuild> {
         guild_id.into().to_partial_guild(&http).await
@@ -1461,8 +1422,6 @@ impl Guild {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the guild is unavailable
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn emojis(&self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
         self.id.emojis(http).await
@@ -1477,9 +1436,6 @@ impl Guild {
     ///
     /// May also return [`Error::Json`] if there is an error in deserializing
     /// the API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
         self.id.emoji(http, emoji_id).await
@@ -1498,7 +1454,6 @@ impl Guild {
     /// the API response.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {
         self.id.integrations(&http).await
@@ -1549,7 +1504,6 @@ impl Guild {
     /// Returns [`Error::Http`] if the member cannot be kicked by
     /// the current user.
     ///
-    /// [`Error::Http`]: crate::error::Error::Http
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn kick(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
@@ -1576,8 +1530,6 @@ impl Guild {
     ///
     /// May return an [`Error::Http`] if the current user
     /// cannot leave the guild, or currently is not in the guild.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn leave(&self, http: impl AsRef<Http>) -> Result<()> {
         self.id.leave(&http).await
@@ -1589,8 +1541,6 @@ impl Guild {
     ///
     /// Returns an [`Error::Http`] if the user is not in
     /// the guild or if the guild is otherwise unavailable.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn member(
         &self,
@@ -1613,8 +1563,6 @@ impl Guild {
     /// return [`Error::NotInRange`] if the input is not within range.
     ///
     /// [`User`]: crate::model::user::User
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::NotInRange`]: crate::error::Error::NotInRange
     #[inline]
     pub async fn members(
         &self,
@@ -2004,7 +1952,6 @@ impl Guild {
     /// in a voice channel for this [`Guild`].
     ///
     /// [Move Members]: Permissions::MOVE_MEMBERS
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn move_member(
         &self,
@@ -2021,8 +1968,6 @@ impl Guild {
     ///
     /// Returns [`Error::Model`] if the [`Member`] has a non-existent role
     /// for some reason.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
     #[inline]
     pub fn user_permissions_in(
         &self,
@@ -2122,8 +2067,6 @@ impl Guild {
     /// # Errors
     ///
     /// Will return an [`Error::Model`] if the [`Role`] or [`Channel`] is not from this [`Guild`].
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
     #[inline]
     pub fn role_permissions_in(&self, channel: &GuildChannel, role: &Role) -> Result<Permissions> {
         Self::_role_permissions_in(channel, role, self.id)
@@ -2177,8 +2120,6 @@ impl Guild {
     /// Can also return [`Error::Json`] if there is an error in deserializing the API response.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn prune_count(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
@@ -2248,7 +2189,6 @@ impl Guild {
     /// Returns an [`Error::Http`] if the current user is lacking permission.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn reorder_channels<It>(&self, http: impl AsRef<Http>, channels: It) -> Result<()>
     where
@@ -2268,8 +2208,6 @@ impl Guild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the API returns an error.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn search_members(
         &self,
@@ -2421,7 +2359,6 @@ impl Guild {
     /// or if an [`Integration`] with that Id does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn start_integration_sync(
         &self,
@@ -2449,8 +2386,6 @@ impl Guild {
     /// the API response.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn start_prune(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
@@ -2479,7 +2414,6 @@ impl Guild {
     /// have permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn unban(
         &self,
         cache_http: impl CacheHttp,
@@ -2510,9 +2444,6 @@ impl Guild {
     /// Will return [`Error::Http`] if the current user is lacking permissions.
     /// Can also return an [`Error::Json`] if there is an error deserializing
     /// the API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
         self.id.vanity_url(&http).await
@@ -2529,9 +2460,6 @@ impl Guild {
     /// Will return an [`Error::Http`] if the current user is lacking permissions.
     /// Can also return an [`Error::Json`] if there is an error deserializing
     /// the API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
         self.id.webhooks(&http).await

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -377,9 +377,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn set_application_commands<F>(
         &self,
         http: impl AsRef<Http>,
@@ -398,9 +395,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_application_command_permission<F>(
         &self,
         http: impl AsRef<Http>,
@@ -423,9 +417,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,
@@ -444,9 +435,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_commands(&self, http: impl AsRef<Http>) -> Result<Vec<Command>> {
         self.id.get_application_commands(http).await
     }
@@ -456,9 +444,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -472,9 +457,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_application_command<F>(
         &self,
         http: impl AsRef<Http>,
@@ -492,9 +474,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn delete_application_command(
         &self,
         http: impl AsRef<Http>,
@@ -508,9 +487,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_commands_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -523,9 +499,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_application_command_permissions(
         &self,
         http: impl AsRef<Http>,
@@ -834,7 +807,6 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn edit_role_position(
         &self,
@@ -861,7 +833,6 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
-    /// [`Error::Http`]: crate::error::Error::Http
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
     pub async fn edit_sticker<F>(
@@ -881,8 +852,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if some mandatory fields are not provided.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn edit_welcome_screen<F>(
         &self,
         http: impl AsRef<Http>,
@@ -900,8 +869,6 @@ impl PartialGuild {
     ///
     /// Returns an [`Error::Http`] if the bot does not have the `MANAGE_GUILD`
     /// permission.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn edit_widget<F>(&self, http: impl AsRef<Http>, f: F) -> Result<GuildWidget>
     where
         F: FnOnce(&mut EditGuildWidget) -> &mut EditGuildWidget,
@@ -1075,7 +1042,6 @@ impl PartialGuild {
     /// Returns an [`Error::Http`] if the current user is lacking permission.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn reorder_channels<It>(&self, http: impl AsRef<Http>, channels: It) -> Result<()>
     where
@@ -1095,8 +1061,6 @@ impl PartialGuild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the API returns an error.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn search_members(
         &self,
@@ -1125,8 +1089,6 @@ impl PartialGuild {
     /// the API response.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn start_prune(&self, cache_http: impl CacheHttp, days: u16) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -121,7 +121,6 @@ impl Invite {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     /// [permission]: super::permissions
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn delete(&self, cache_http: impl CacheHttp) -> Result<Invite> {
         #[cfg(feature = "cache")]
         {

--- a/src/model/sticker/mod.rs
+++ b/src/model/sticker/mod.rs
@@ -94,7 +94,6 @@ impl Sticker {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
-    /// [`Error::Http`]: crate::error::Error::Http
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
     pub async fn edit<F>(&self, http: impl AsRef<Http>, f: F) -> Result<Sticker>

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -260,9 +260,6 @@ impl CurrentUser {
     /// Returns an [`Error::Http`] if an invalid value is set.
     /// May also return an [`Error::Json`] if there is an error in
     /// deserializing the API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit<F>(&mut self, http: impl AsRef<Http>, f: F) -> Result<()>
     where
         F: FnOnce(&mut EditProfile) -> &mut EditProfile,
@@ -322,9 +319,6 @@ impl CurrentUser {
     /// May return an [`Error::Http`] if the Discord API returns an error.
     /// Also can return [`Error::Json`] if there is an error in deserializing
     /// the data returned by the API.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn guilds(&self, http: impl AsRef<Http>) -> Result<Vec<GuildInfo>> {
         let mut guilds = Vec::new();
         loop {
@@ -575,8 +569,6 @@ impl DefaultAvatar {
     /// # Errors
     ///
     /// May return a [`Error::Json`] if there is a serialization error.
-    ///
-    /// [`Error::Json`]: crate::error::Error::Json
     pub fn name(self) -> Result<String> {
         to_string(&self).map_err(From::from)
     }
@@ -864,9 +856,6 @@ impl User {
     ///
     /// [`Error::Json`] can also be returned if there is an error deserializing
     /// the API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn direct_message<'a, F>(&self, cache_http: impl CacheHttp, f: F) -> Result<Message>
     where
         for<'b> F: FnOnce(&'b mut CreateMessage<'a>) -> &'b mut CreateMessage<'a>,
@@ -920,9 +909,6 @@ impl User {
     ///
     /// May also return an [`Error::Json`] if there is an error in
     /// deserializing the API response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn has_role(
         &self,
@@ -1119,9 +1105,6 @@ impl UserId {
     ///
     /// May also return an [`Error::Json`] if there is an error in deserializing
     /// the channel data returned by the Discord API.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn create_dm_channel(self, cache_http: impl CacheHttp) -> Result<PrivateChannel> {
         #[cfg(feature = "cache")]
         {
@@ -1165,9 +1148,6 @@ impl UserId {
     ///
     /// May also return an [`Error::Json`] if there is an error in
     /// deserializing the user.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn to_user(self, cache_http: impl CacheHttp) -> Result<User> {
         #[cfg(feature = "cache")]

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -132,9 +132,6 @@ impl Webhook {
     /// not exist.
     ///
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn from_id(http: impl AsRef<Http>, webhook_id: impl Into<WebhookId>) -> Result<Self> {
         http.as_ref().get_webhook(webhook_id.into().0).await
     }
@@ -166,9 +163,6 @@ impl Webhook {
     /// Returns an [`Error::Http`] if the webhook does not exist, or if the token is invalid.
     ///
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn from_id_with_token(
         http: impl AsRef<Http>,
         webhook_id: impl Into<WebhookId>,
@@ -202,9 +196,6 @@ impl Webhook {
     /// Returns an [`Error::Http`] if the url is malformed, or otherwise if the webhook does not exist, or if the token is invalid.
     ///
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    ///
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn from_url(http: impl AsRef<Http>, url: &str) -> Result<Self> {
         http.as_ref().get_webhook_from_url(url).await
     }
@@ -221,9 +212,6 @@ impl Webhook {
     /// May also return an [`Error::Http`] if the webhook does not exist,
     /// the token is invalid, or if the webhook could not otherwise
     /// be deleted.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
     #[inline]
     pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
@@ -258,10 +246,6 @@ impl Webhook {
     /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
     ///
     /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_name(&mut self, http: impl AsRef<Http>, name: &str) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
         let mut map = JsonMap::new();
@@ -298,10 +282,6 @@ impl Webhook {
     /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
     ///
     /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_avatar<'a>(
         &mut self,
         http: impl AsRef<Http>,
@@ -343,10 +323,6 @@ impl Webhook {
     /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
     ///
     /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn delete_avatar(&mut self, http: impl AsRef<Http>) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
         let mut map = JsonMap::new();
@@ -416,10 +392,6 @@ impl Webhook {
     /// May also return an [`Error::Http`] if the content is malformed, or if the webhook's token is invalid.
     ///
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn execute<'a, F>(
         &self,
@@ -455,10 +427,6 @@ impl Webhook {
     /// the given message Id does not belong to the current webhook.
     ///
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn get_message(
         &self,
         http: impl AsRef<Http>,
@@ -479,10 +447,6 @@ impl Webhook {
     /// the given message Id does not belong to the current webhook.
     ///
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn edit_message<F>(
         &self,
         http: impl AsRef<Http>,
@@ -509,9 +473,6 @@ impl Webhook {
     ///
     /// May also return an [`Error::Http`] if the webhook's token is invalid or
     /// the given message Id does not belong to the current webhook.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
     pub async fn delete_message(
         &self,
         http: impl AsRef<Http>,
@@ -535,10 +496,6 @@ impl Webhook {
     /// Such as if the [`Webhook`] was deleted.
     ///
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     pub async fn refresh(&mut self, http: impl AsRef<Http>) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
         http.as_ref().get_webhook_with_token(self.id.0, token).await.map(|replacement| {
@@ -555,8 +512,6 @@ impl Webhook {
     /// # Errors
     ///
     /// Returns an [`Error::Model`] if the [`Self::token`] is [`None`].
-    ///
-    /// [`Error::Model`]: crate::error::Error::Model
     pub fn url(&self) -> Result<String> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
         Ok(format!("https://discord.com/api/webhooks/{}/{}", self.id, token))
@@ -577,8 +532,6 @@ impl WebhookId {
     /// May also return an [`Error::Json`] if there is an error in deserialising the response.
     ///
     /// [Manage Webhooks]: super::permissions::Permissions::MANAGE_WEBHOOKS
-    /// [`Error::Http`]: crate::error::Error::Http
-    /// [`Error::Json`]: crate::error::Error::Json
     #[inline]
     pub async fn to_webhook(self, http: impl AsRef<Http>) -> Result<Webhook> {
         http.as_ref().get_webhook(self.0).await


### PR DESCRIPTION
The `Error` type is imported via `internal::prelude::*` and therefore
the link reference definitions aren't needed for the intra-doc link
resolution.

Alternatively, the type could be imported explicitly with:
```rust
#[cfg(doc)]
use crate::Error;
```