### PR TITLE
Switch to `tokio-tungstenite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,7 @@ optional = true
 optional = true
 version = "1.1"
 
-[dependencies.async-tungstenite]
-default-features = false
-features = ["tokio-runtime"]
+[dependencies.tokio-tungstenite]
 optional = true
 version = "0.17"
 
@@ -192,7 +190,7 @@ temp_cache = ["cache", "moka"]
 # - Rustls Backends
 rustls_backend = [
     "reqwest/rustls-tls",
-    "async-tungstenite/tokio-rustls-webpki-roots",
+    "tokio-tungstenite/rustls-tls-webpki-roots",
     "tokio",
     "bytes",
 ]
@@ -200,7 +198,7 @@ rustls_backend = [
 # - Native TLS Backends
 native_tls_backend = [
     "reqwest/native-tls",
-    "async-tungstenite/tokio-native-tls",
+    "tokio-tungstenite/native-tls",
     "tokio",
     "bytes",
 ]

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -1,5 +1,5 @@
-use async_tungstenite::tungstenite::Message;
 use futures::channel::mpsc::{TrySendError, UnboundedSender as Sender};
+use tokio_tungstenite::tungstenite::Message;
 
 use super::{ChunkGuildFilter, ShardClientMessage, ShardRunnerMessage};
 #[cfg(feature = "collector")]

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use async_tungstenite::tungstenite;
-use async_tungstenite::tungstenite::error::Error as TungsteniteError;
-use async_tungstenite::tungstenite::protocol::frame::CloseFrame;
 use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use tokio::sync::RwLock;
+use tokio_tungstenite::tungstenite;
+use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
+use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 use tracing::{debug, error, info, instrument, trace, warn};
 use typemap_rev::TypeMap;
 

--- a/src/client/bridge/gateway/shard_runner_message.rs
+++ b/src/client/bridge/gateway/shard_runner_message.rs
@@ -1,4 +1,4 @@
-use async_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::Message;
 
 #[cfg(feature = "collector")]
 use crate::collector::{

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,11 @@ use std::error::Error as StdError;
 use std::fmt::{self, Error as FormatError};
 use std::io::Error as IoError;
 
-#[cfg(feature = "gateway")]
-use async_tungstenite::tungstenite::error::Error as TungsteniteError;
 #[cfg(feature = "http")]
 use reqwest::{header::InvalidHeaderValue, Error as ReqwestError};
 use serde_json::Error as JsonError;
+#[cfg(feature = "gateway")]
+use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 use tracing::instrument;
 
 #[cfg(feature = "client")]

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -1,7 +1,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use async_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 
 /// An error that occurred while attempting to deal with the gateway.
 ///

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -52,9 +52,9 @@ mod ws;
 
 use std::fmt;
 
-#[cfg(feature = "client")]
-use async_tungstenite::tungstenite;
 use reqwest::{IntoUrl, Url};
+#[cfg(feature = "client")]
+use tokio_tungstenite::tungstenite;
 
 pub use self::error::Error as GatewayError;
 pub use self::shard::Shard;

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 use std::time::{Duration as StdDuration, Instant};
 
-use async_tungstenite::tungstenite::error::Error as TungsteniteError;
-use async_tungstenite::tungstenite::protocol::frame::CloseFrame;
 use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
+use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 use tracing::{debug, error, info, instrument, trace, warn};
 use url::Url;
 

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -2,13 +2,13 @@ use std::env::consts;
 use std::io::Read;
 use std::time::SystemTime;
 
-use async_tungstenite::tokio::{connect_async_with_config, ConnectStream};
-use async_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
-use async_tungstenite::tungstenite::{Error as WsError, Message};
-use async_tungstenite::WebSocketStream;
 use flate2::read::ZlibDecoder;
 use futures::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
 use tokio::time::{timeout, Duration};
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
+use tokio_tungstenite::tungstenite::{Error as WsError, Message};
+use tokio_tungstenite::{connect_async_with_config, MaybeTlsStream, WebSocketStream};
 use tracing::{debug, instrument, trace, warn};
 use url::Url;
 
@@ -76,7 +76,7 @@ struct WebSocketMessage<'a> {
     d: WebSocketMessageData<'a>,
 }
 
-pub struct WsClient(WebSocketStream<ConnectStream>);
+pub struct WsClient(WebSocketStream<MaybeTlsStream<TcpStream>>);
 
 const TIMEOUT: Duration = Duration::from_millis(500);
 const DECOMPRESSION_MULTIPLIER: usize = 3;


### PR DESCRIPTION
There are no plans to support multiple async runtimes and it would also make it easier for `songbird` to reduce their dependencies for `twilight` users.
- https://github.com/serenity-rs/songbird/issues/129