### PR TITLE
Add optional min/max length fields for application command string options

### DIFF
--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -273,6 +273,24 @@ impl CreateApplicationCommandOption {
 
         self
     }
+
+    /// Sets the minimum permitted length for this string option.
+    ///
+    /// The value of `min_length` must be greater or equal to `0`.
+    pub fn min_length(&mut self, value: u16) -> &mut Self {
+        self.0.insert("min_length", value.into());
+
+        self
+    }
+
+    /// Sets the maximum permitted length for this string option.
+    ///
+    /// The value of `max_length` must be greater or equal to `1`.
+    pub fn max_length(&mut self, value: u16) -> &mut Self {
+        self.0.insert("max_length", value.into());
+
+        self
+    }
 }
 
 /// A builder for creating a new [`Command`].

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -322,6 +322,12 @@ pub struct CommandOption {
     /// Maximum permitted value for Integer or Number options
     #[serde(default)]
     pub max_value: Option<serde_json::Number>,
+    /// Minimum permitted length for String options
+    #[serde(default)]
+    pub min_length: Option<u16>,
+    /// Maximum permitted length for String options
+    #[serde(default)]
+    pub max_length: Option<u16>,
     #[serde(default)]
     pub autocomplete: bool,
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2128532/177467272-6df85de8-6181-48d3-b7ab-368ef0fb4440.png)
