### PR TITLE
Fix new clippy warnings

### DIFF
--- a/command_attr/src/attributes.rs
+++ b/command_attr/src/attributes.rs
@@ -8,7 +8,7 @@ use syn::{Attribute, Ident, Lit, LitStr, Meta, NestedMeta, Path};
 use crate::structures::{Checks, Colour, HelpBehaviour, OnlyIn, Permissions};
 use crate::util::{AsOption, LitExt};
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ValueKind {
     // #[<name>]
     Name,

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -24,7 +24,7 @@ use syn::{
 use crate::consts::CHECK;
 use crate::util::{self, Argument, AsOption, IdentExt2, Parenthesised};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum OnlyIn {
     Dm,
     Guild,
@@ -369,7 +369,7 @@ impl ToTokens for Permissions {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Colour(pub u32);
 
 impl Colour {
@@ -470,7 +470,7 @@ impl Options {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum HelpBehaviour {
     Strike,
     Hide,
@@ -499,7 +499,7 @@ impl ToTokens for HelpBehaviour {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct HelpOptions {
     pub suggestion_text: String,
     pub no_help_available_text: String,

--- a/examples/e16_sqlite_database/src/main.rs
+++ b/examples/e16_sqlite_database/src/main.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use serenity::async_trait;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
@@ -52,7 +54,7 @@ impl EventHandler for Bot {
 
             let mut response = format!("You have {} pending tasks:\n", todos.len());
             for (i, todo) in todos.iter().enumerate() {
-                response += &format!("{}. {}\n", i + 1, todo.task);
+                writeln!(response, "{}. {}", i + 1, todo.task).unwrap()
             }
 
             msg.channel_id.say(&ctx, response).await.unwrap();

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -98,9 +98,9 @@ impl<K: Eq + Hash, V> std::ops::Deref for CacheRef<'_, K, V> {
     fn deref(&self) -> &Self::Target {
         match &self.inner {
             #[cfg(feature = "temp_cache")]
-            CacheRefInner::Arc(inner) => &*inner,
+            CacheRefInner::Arc(inner) => inner,
             CacheRefInner::DashRef(inner) => inner.value(),
-            CacheRefInner::ReadGuard(inner) => &*inner,
+            CacheRefInner::ReadGuard(inner) => inner,
         }
     }
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1056,7 +1056,7 @@ async fn send_single_command_embed(
                 }
 
                 if let Some(usage) = command.usage {
-                    let full_usage_text = if let Some(first_prefix) = command.group_prefixes.get(0)
+                    let full_usage_text = if let Some(first_prefix) = command.group_prefixes.first()
                     {
                         format!("`{} {} {}`", first_prefix, command.name, usage)
                     } else {
@@ -1068,7 +1068,7 @@ async fn send_single_command_embed(
 
                 if !command.usage_sample.is_empty() {
                     let full_example_text = if let Some(first_prefix) =
-                        command.group_prefixes.get(0)
+                        command.group_prefixes.first()
                     {
                         let format_example =
                             |example| format!("`{} {} {}`\n", first_prefix, command.name, example);
@@ -1197,7 +1197,7 @@ pub async fn with_embeds(
     let formatted_help =
         create_customised_help_data(ctx, msg, &args, groups, &owners, help_options).await;
 
-    let response_result = match formatted_help {
+    match formatted_help {
         CustomisedHelpData::SuggestedCommands {
             ref help_description,
             ref suggestions,
@@ -1248,9 +1248,7 @@ pub async fn with_embeds(
             )
             .await
         },
-    };
-
-    response_result
+    }
 }
 
 /// Turns grouped commands into a [`String`] taking plain help format into account.
@@ -1291,7 +1289,7 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
     };
 
     if let Some(usage) = command.usage {
-        if let Some(first_prefix) = command.group_prefixes.get(0) {
+        if let Some(first_prefix) = command.group_prefixes.first() {
             writeln!(
                 result,
                 "**{}**: `{} {} {}`",
@@ -1305,7 +1303,7 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
     }
 
     if !command.usage_sample.is_empty() {
-        if let Some(first_prefix) = command.group_prefixes.get(0) {
+        if let Some(first_prefix) = command.group_prefixes.first() {
             let format_example = |example| {
                 writeln!(
                     result,

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -139,7 +139,7 @@ pub enum HelpBehaviour {
     Hide,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HelpOptions {
     /// Which names should the help command use for dispatching.
     /// Defaults to `["help"]`

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -7,7 +7,7 @@ use url::ParseError as UrlError;
 
 use crate::http::utils::deserialize_errors;
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct DiscordJsonError {
     /// The error code.
@@ -20,7 +20,7 @@ pub struct DiscordJsonError {
     pub errors: Vec<DiscordJsonSingleError>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DiscordJsonSingleError {
     /// The error code.
     pub code: String,
@@ -30,7 +30,7 @@ pub struct DiscordJsonSingleError {
     pub path: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ErrorResponse {
     pub status_code: StatusCode,
     pub url: Url,

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -198,7 +198,7 @@ mod tests {
     #[test]
     fn enum_number() {
         enum_number! {
-            #[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
+            #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
             #[serde(from = "u8", into = "u8")]
             pub enum T {
                 /// AAA

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -384,7 +384,7 @@ impl From<PermissionOverwrite> for PermissionOverwriteData {
 }
 
 /// A channel-specific permission overwrite for a member or role.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PermissionOverwrite {
     pub allow: Permissions,
     pub deny: Permissions,

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -16,14 +16,14 @@ use crate::model::id::{ApplicationId, ChannelId, GenericId, GuildId, RoleId, Use
 use crate::model::sticker::StickerFormatType;
 use crate::model::{Permissions, Timestamp};
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct AffectedRole {
     pub id: RoleId,
     pub name: String,
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum EntityType {
@@ -31,7 +31,7 @@ pub enum EntityType {
     Str(String),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Change {
     /// AFK channel was changed.

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -31,7 +31,8 @@ pub enum EntityType {
     Str(String),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(simd_json), allow(clippy::derive_partial_eq_without_eq))]
+#[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Change {
     /// AFK channel was changed.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -302,8 +302,7 @@ impl FromStrAndCache for Role {
 }
 
 /// The tags of a [`Role`].
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct RoleTags {
     /// The Id of the bot the [`Role`] belongs to.


### PR DESCRIPTION
Fixes:
- `derive_partial_eq_without_eq`
- `borrow_deref_ref`
- `let_and_return`
- `get_first`