### PR TITLE
Constify some functions that could be used in const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ serde_json = "1.0.75"
 serde-value = "0.7"
 async-trait = "0.1.9"
 
+[dependencies.rustversion]
+version = "1.0.7"
+
 [dependencies.simd-json]
 version = "0.4.14"
 optional = true

--- a/src/client/bridge/gateway/shard_messenger.rs
+++ b/src/client/bridge/gateway/shard_messenger.rs
@@ -33,7 +33,7 @@ impl ShardMessenger {
     /// [`Client`]: crate::Client
     #[inline]
     #[must_use]
-    pub fn new(tx: Sender<InterMessage>) -> Self {
+    pub const fn new(tx: Sender<InterMessage>) -> Self {
         Self {
             tx,
         }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -168,7 +168,7 @@ pub enum LightMethod {
 
 impl LightMethod {
     #[must_use]
-    pub fn reqwest_method(self) -> Method {
+    pub const fn reqwest_method(self) -> Method {
         match self {
             Self::Delete => Method::DELETE,
             Self::Get => Method::GET,

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -329,28 +329,28 @@ impl Ratelimit {
     /// The total number of requests that can be made in a period of time.
     #[inline]
     #[must_use]
-    pub fn limit(&self) -> i64 {
+    pub const fn limit(&self) -> i64 {
         self.limit
     }
 
     /// The number of requests remaining in the period of time.
     #[inline]
     #[must_use]
-    pub fn remaining(&self) -> i64 {
+    pub const fn remaining(&self) -> i64 {
         self.remaining
     }
 
     /// The absolute time in milliseconds when the interval resets.
     #[inline]
     #[must_use]
-    pub fn reset(&self) -> Option<SystemTime> {
+    pub const fn reset(&self) -> Option<SystemTime> {
         self.reset
     }
 
     /// The total time in milliseconds when the interval resets.
     #[inline]
     #[must_use]
-    pub fn reset_after(&self) -> Option<Duration> {
+    pub const fn reset_after(&self) -> Option<Duration> {
         self.reset_after
     }
 }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -27,7 +27,7 @@ pub struct RequestBuilder<'a> {
 
 impl<'a> RequestBuilder<'a> {
     #[must_use]
-    pub fn new(route_info: RouteInfo<'a>) -> Self {
+    pub const fn new(route_info: RouteInfo<'a>) -> Self {
         Self {
             body: None,
             multipart: None,

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -143,7 +143,7 @@ impl EmbedField {
         Self::_new(name.into(), value.into(), inline)
     }
 
-    pub(crate) fn _new(name: String, value: String, inline: bool) -> Self {
+    pub(crate) const fn _new(name: String, value: String, inline: bool) -> Self {
         Self {
             name,
             value,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -199,7 +199,7 @@ impl Channel {
     /// [`PrivateChannel`].
     #[inline]
     #[must_use]
-    pub fn id(&self) -> ChannelId {
+    pub const fn id(&self) -> ChannelId {
         match self {
             Self::Guild(ch) => ch.id,
             Self::Private(ch) => ch.id,
@@ -213,7 +213,7 @@ impl Channel {
     /// If other channel types are used it will return None.
     #[inline]
     #[must_use]
-    pub fn position(&self) -> Option<i64> {
+    pub const fn position(&self) -> Option<i64> {
         match self {
             Self::Guild(channel) => Some(channel.position),
             Self::Category(category) => Some(category.position),
@@ -317,7 +317,7 @@ enum_number! {
 impl ChannelType {
     #[inline]
     #[must_use]
-    pub fn name(&self) -> &str {
+    pub const fn name(&self) -> &str {
         match *self {
             Self::Private => "private",
             Self::Text => "text",

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -176,7 +176,7 @@ impl Error {
     /// Return `true` if the model error is related to an item missing in the
     /// cache.
     #[must_use]
-    pub fn is_cache_err(&self) -> bool {
+    pub const fn is_cache_err(&self) -> bool {
         matches!(
             self,
             Self::ItemMissing

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -841,7 +841,7 @@ pub enum Event {
 }
 
 #[cfg(feature = "model")]
-fn gid_from_channel(c: &Channel) -> RelatedId<GuildId> {
+const fn gid_from_channel(c: &Channel) -> RelatedId<GuildId> {
     match c {
         Channel::Guild(g) => RelatedId::Some(g.guild_id),
         _ => RelatedId::None,
@@ -1292,7 +1292,7 @@ macro_rules! define_event_related_id_methods {
 impl Event {
     /// Return the type of this event.
     #[must_use]
-    pub fn event_type(&self) -> EventType {
+    pub const fn event_type(&self) -> EventType {
         match self {
             Self::ApplicationCommandPermissionsUpdate(_) => {
                 EventType::ApplicationCommandPermissionsUpdate
@@ -1766,7 +1766,7 @@ impl EventType {
     /// the information to recover the original event name for these events, in which
     /// case this method returns [`None`].
     #[must_use]
-    pub fn name(&self) -> Option<&str> {
+    pub const fn name(&self) -> Option<&str> {
         match self {
             Self::ApplicationCommandPermissionsUpdate => {
                 Some(Self::APPLICATION_COMMAND_PERMISSIONS_UPDATE)

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -546,7 +546,7 @@ impl GatewayIntents {
 
     /// Checks if any of the included intents are privileged.
     #[must_use]
-    pub fn is_privileged(self) -> bool {
+    pub const fn is_privileged(self) -> bool {
         self.intersects(Self::privileged())
     }
 
@@ -555,7 +555,7 @@ impl GatewayIntents {
     ///
     /// [GUILDS]: Self::GUILDS
     #[must_use]
-    pub fn guilds(self) -> bool {
+    pub const fn guilds(self) -> bool {
         self.contains(Self::GUILDS)
     }
 
@@ -564,7 +564,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_MEMBERS]: Self::GUILD_MEMBERS
     #[must_use]
-    pub fn guild_members(self) -> bool {
+    pub const fn guild_members(self) -> bool {
         self.contains(Self::GUILD_MEMBERS)
     }
 
@@ -573,7 +573,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_BANS]: Self::GUILD_BANS
     #[must_use]
-    pub fn guild_bans(self) -> bool {
+    pub const fn guild_bans(self) -> bool {
         self.contains(Self::GUILD_BANS)
     }
 
@@ -582,7 +582,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_EMOJIS_AND_STICKERS]: Self::GUILD_EMOJIS_AND_STICKERS
     #[must_use]
-    pub fn guild_emojis_and_stickers(self) -> bool {
+    pub const fn guild_emojis_and_stickers(self) -> bool {
         self.contains(Self::GUILD_EMOJIS_AND_STICKERS)
     }
 
@@ -591,7 +591,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_INTEGRATIONS]: Self::GUILD_INTEGRATIONS
     #[must_use]
-    pub fn guild_integrations(self) -> bool {
+    pub const fn guild_integrations(self) -> bool {
         self.contains(Self::GUILD_INTEGRATIONS)
     }
 
@@ -600,7 +600,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_WEBHOOKS]: Self::GUILD_WEBHOOKS
     #[must_use]
-    pub fn guild_webhooks(self) -> bool {
+    pub const fn guild_webhooks(self) -> bool {
         self.contains(Self::GUILD_WEBHOOKS)
     }
 
@@ -609,7 +609,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_INVITES]: Self::GUILD_INVITES
     #[must_use]
-    pub fn guild_invites(self) -> bool {
+    pub const fn guild_invites(self) -> bool {
         self.contains(Self::GUILD_INVITES)
     }
 
@@ -618,7 +618,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_VOICE_STATES]: Self::GUILD_VOICE_STATES
     #[must_use]
-    pub fn guild_voice_states(self) -> bool {
+    pub const fn guild_voice_states(self) -> bool {
         self.contains(Self::GUILD_VOICE_STATES)
     }
 
@@ -627,7 +627,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_PRESENCES]: Self::GUILD_PRESENCES
     #[must_use]
-    pub fn guild_presences(self) -> bool {
+    pub const fn guild_presences(self) -> bool {
         self.contains(Self::GUILD_PRESENCES)
     }
 
@@ -636,7 +636,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_MESSAGE_REACTIONS]: Self::GUILD_MESSAGE_REACTIONS
     #[must_use]
-    pub fn guild_message_reactions(self) -> bool {
+    pub const fn guild_message_reactions(self) -> bool {
         self.contains(Self::GUILD_MESSAGE_REACTIONS)
     }
 
@@ -645,7 +645,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_MESSAGE_TYPING]: Self::GUILD_MESSAGE_TYPING
     #[must_use]
-    pub fn guild_message_typing(self) -> bool {
+    pub const fn guild_message_typing(self) -> bool {
         self.contains(Self::GUILD_MESSAGE_TYPING)
     }
 
@@ -654,7 +654,7 @@ impl GatewayIntents {
     ///
     /// [DIRECT_MESSAGES]: Self::DIRECT_MESSAGES
     #[must_use]
-    pub fn direct_messages(self) -> bool {
+    pub const fn direct_messages(self) -> bool {
         self.contains(Self::DIRECT_MESSAGES)
     }
 
@@ -663,7 +663,7 @@ impl GatewayIntents {
     ///
     /// [DIRECT_MESSAGE_REACTIONS]: Self::DIRECT_MESSAGE_REACTIONS
     #[must_use]
-    pub fn direct_message_reactions(self) -> bool {
+    pub const fn direct_message_reactions(self) -> bool {
         self.contains(Self::DIRECT_MESSAGE_REACTIONS)
     }
 
@@ -672,7 +672,7 @@ impl GatewayIntents {
     ///
     /// [DIRECT_MESSAGE_TYPING]: Self::DIRECT_MESSAGE_TYPING
     #[must_use]
-    pub fn direct_message_typing(self) -> bool {
+    pub const fn direct_message_typing(self) -> bool {
         self.contains(Self::DIRECT_MESSAGE_TYPING)
     }
 
@@ -681,7 +681,7 @@ impl GatewayIntents {
     ///
     /// [MESSAGE_CONTENT]: Self::MESSAGE_CONTENT
     #[must_use]
-    pub fn message_content(self) -> bool {
+    pub const fn message_content(self) -> bool {
         self.contains(Self::MESSAGE_CONTENT)
     }
 
@@ -690,7 +690,7 @@ impl GatewayIntents {
     ///
     /// [GUILD_SCHEDULED_EVENTS]: Self::GUILD_SCHEDULED_EVENTS
     #[must_use]
-    pub fn guild_scheduled_events(self) -> bool {
+    pub const fn guild_scheduled_events(self) -> bool {
         self.contains(Self::GUILD_SCHEDULED_EVENTS)
     }
 }

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -37,7 +37,7 @@ pub enum Action {
 
 impl Action {
     #[must_use]
-    pub fn num(self) -> u8 {
+    pub const fn num(self) -> u8 {
         match self {
             Self::GuildUpdate => 1,
             Self::Channel(x) => x as u8,

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -15,8 +15,13 @@ macro_rules! id_u64 {
                 /// Panics if the id is zero.
                 #[inline]
                 #[must_use]
+                #[track_caller]
+                #[rustversion::attr(since(1.57), const)]
                 pub fn new(id: u64) -> Self {
-                    Self(NonZeroU64::new(id).unwrap())
+                    match NonZeroU64::new(id) {
+                        Some(inner) => Self(inner),
+                        None => panic!("Attempted to call Id::new with invalid (0) value")
+                    }
                 }
 
                 /// Retrieves the inner ID as u64

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -410,7 +410,7 @@ impl Permissions {
     ///
     /// [Add Reactions]: Self::ADD_REACTIONS
     #[must_use]
-    pub fn add_reactions(self) -> bool {
+    pub const fn add_reactions(self) -> bool {
         self.contains(Self::ADD_REACTIONS)
     }
 
@@ -419,7 +419,7 @@ impl Permissions {
     ///
     /// [Administrator]: Self::ADMINISTRATOR
     #[must_use]
-    pub fn administrator(self) -> bool {
+    pub const fn administrator(self) -> bool {
         self.contains(Self::ADMINISTRATOR)
     }
 
@@ -428,7 +428,7 @@ impl Permissions {
     ///
     /// [Attach Files]: Self::ATTACH_FILES
     #[must_use]
-    pub fn attach_files(self) -> bool {
+    pub const fn attach_files(self) -> bool {
         self.contains(Self::ATTACH_FILES)
     }
 
@@ -437,7 +437,7 @@ impl Permissions {
     ///
     /// [Ban Members]: Self::BAN_MEMBERS
     #[must_use]
-    pub fn ban_members(self) -> bool {
+    pub const fn ban_members(self) -> bool {
         self.contains(Self::BAN_MEMBERS)
     }
 
@@ -446,7 +446,7 @@ impl Permissions {
     ///
     /// [Change Nickname]: Self::CHANGE_NICKNAME
     #[must_use]
-    pub fn change_nickname(self) -> bool {
+    pub const fn change_nickname(self) -> bool {
         self.contains(Self::CHANGE_NICKNAME)
     }
 
@@ -455,7 +455,7 @@ impl Permissions {
     ///
     /// [Connect]: Self::CONNECT
     #[must_use]
-    pub fn connect(self) -> bool {
+    pub const fn connect(self) -> bool {
         self.contains(Self::CONNECT)
     }
 
@@ -464,7 +464,7 @@ impl Permissions {
     ///
     /// [View Audit Log]: Self::VIEW_AUDIT_LOG
     #[must_use]
-    pub fn view_audit_log(self) -> bool {
+    pub const fn view_audit_log(self) -> bool {
         self.contains(Self::VIEW_AUDIT_LOG)
     }
 
@@ -473,7 +473,7 @@ impl Permissions {
     ///
     /// [View Channel]: Self::VIEW_CHANNEL
     #[must_use]
-    pub fn view_channel(self) -> bool {
+    pub const fn view_channel(self) -> bool {
         self.contains(Self::VIEW_CHANNEL)
     }
 
@@ -482,7 +482,7 @@ impl Permissions {
     ///
     /// [View Guild Insights]: Self::VIEW_GUILD_INSIGHTS
     #[must_use]
-    pub fn view_guild_insights(self) -> bool {
+    pub const fn view_guild_insights(self) -> bool {
         self.contains(Self::VIEW_GUILD_INSIGHTS)
     }
 
@@ -491,7 +491,7 @@ impl Permissions {
     ///
     /// [Priority Speaker]: Self::PRIORITY_SPEAKER
     #[must_use]
-    pub fn priority_speaker(self) -> bool {
+    pub const fn priority_speaker(self) -> bool {
         self.contains(Self::PRIORITY_SPEAKER)
     }
 
@@ -500,7 +500,7 @@ impl Permissions {
     ///
     /// [Stream]: Self::STREAM
     #[must_use]
-    pub fn stream(self) -> bool {
+    pub const fn stream(self) -> bool {
         self.contains(Self::STREAM)
     }
 
@@ -509,7 +509,7 @@ impl Permissions {
     ///
     /// [Create Instant Invite]: Self::CREATE_INSTANT_INVITE
     #[must_use]
-    pub fn create_instant_invite(self) -> bool {
+    pub const fn create_instant_invite(self) -> bool {
         self.contains(Self::CREATE_INSTANT_INVITE)
     }
 
@@ -518,7 +518,7 @@ impl Permissions {
     ///
     /// [Create Private Threads]: Self::CREATE_PRIVATE_THREADS
     #[must_use]
-    pub fn create_private_threads(self) -> bool {
+    pub const fn create_private_threads(self) -> bool {
         self.contains(Self::CREATE_PRIVATE_THREADS)
     }
 
@@ -527,7 +527,7 @@ impl Permissions {
     ///
     /// [Create Public Threads]: Self::CREATE_PUBLIC_THREADS
     #[must_use]
-    pub fn create_public_threads(self) -> bool {
+    pub const fn create_public_threads(self) -> bool {
         self.contains(Self::CREATE_PUBLIC_THREADS)
     }
 
@@ -536,7 +536,7 @@ impl Permissions {
     ///
     /// [Deafen Members]: Self::DEAFEN_MEMBERS
     #[must_use]
-    pub fn deafen_members(self) -> bool {
+    pub const fn deafen_members(self) -> bool {
         self.contains(Self::DEAFEN_MEMBERS)
     }
 
@@ -545,7 +545,7 @@ impl Permissions {
     ///
     /// [Embed Links]: Self::EMBED_LINKS
     #[must_use]
-    pub fn embed_links(self) -> bool {
+    pub const fn embed_links(self) -> bool {
         self.contains(Self::EMBED_LINKS)
     }
 
@@ -554,7 +554,7 @@ impl Permissions {
     ///
     /// [Use External Emojis]: Self::USE_EXTERNAL_EMOJIS
     #[must_use]
-    pub fn external_emojis(self) -> bool {
+    pub const fn external_emojis(self) -> bool {
         self.contains(Self::USE_EXTERNAL_EMOJIS)
     }
 
@@ -563,7 +563,7 @@ impl Permissions {
     ///
     /// [Kick Members]: Self::KICK_MEMBERS
     #[must_use]
-    pub fn kick_members(self) -> bool {
+    pub const fn kick_members(self) -> bool {
         self.contains(Self::KICK_MEMBERS)
     }
 
@@ -572,7 +572,7 @@ impl Permissions {
     ///
     /// [Manage Channels]: Self::MANAGE_CHANNELS
     #[must_use]
-    pub fn manage_channels(self) -> bool {
+    pub const fn manage_channels(self) -> bool {
         self.contains(Self::MANAGE_CHANNELS)
     }
 
@@ -581,7 +581,7 @@ impl Permissions {
     ///
     /// [Manage Emojis and Stickers]: Self::MANAGE_EMOJIS_AND_STICKERS
     #[must_use]
-    pub fn manage_emojis_and_stickers(self) -> bool {
+    pub const fn manage_emojis_and_stickers(self) -> bool {
         self.contains(Self::MANAGE_EMOJIS_AND_STICKERS)
     }
 
@@ -590,7 +590,7 @@ impl Permissions {
     ///
     /// [Manage Guild]: Self::MANAGE_GUILD
     #[must_use]
-    pub fn manage_guild(self) -> bool {
+    pub const fn manage_guild(self) -> bool {
         self.contains(Self::MANAGE_GUILD)
     }
 
@@ -599,7 +599,7 @@ impl Permissions {
     ///
     /// [Manage Messages]: Self::MANAGE_MESSAGES
     #[must_use]
-    pub fn manage_messages(self) -> bool {
+    pub const fn manage_messages(self) -> bool {
         self.contains(Self::MANAGE_MESSAGES)
     }
 
@@ -608,7 +608,7 @@ impl Permissions {
     ///
     /// [Manage Nicknames]: Self::MANAGE_NICKNAMES
     #[must_use]
-    pub fn manage_nicknames(self) -> bool {
+    pub const fn manage_nicknames(self) -> bool {
         self.contains(Self::MANAGE_NICKNAMES)
     }
 
@@ -617,7 +617,7 @@ impl Permissions {
     ///
     /// [Manage Roles]: Self::MANAGE_ROLES
     #[must_use]
-    pub fn manage_roles(self) -> bool {
+    pub const fn manage_roles(self) -> bool {
         self.contains(Self::MANAGE_ROLES)
     }
 
@@ -626,7 +626,7 @@ impl Permissions {
     ///
     /// [Manage Threads]: Self::MANAGE_THREADS
     #[must_use]
-    pub fn manage_threads(self) -> bool {
+    pub const fn manage_threads(self) -> bool {
         self.contains(Self::MANAGE_THREADS)
     }
 
@@ -635,7 +635,7 @@ impl Permissions {
     ///
     /// [Manage Webhooks]: Self::MANAGE_WEBHOOKS
     #[must_use]
-    pub fn manage_webhooks(self) -> bool {
+    pub const fn manage_webhooks(self) -> bool {
         self.contains(Self::MANAGE_WEBHOOKS)
     }
 
@@ -644,7 +644,7 @@ impl Permissions {
     ///
     /// [Mention Everyone]: Self::MENTION_EVERYONE
     #[must_use]
-    pub fn mention_everyone(self) -> bool {
+    pub const fn mention_everyone(self) -> bool {
         self.contains(Self::MENTION_EVERYONE)
     }
 
@@ -653,7 +653,7 @@ impl Permissions {
     ///
     /// [Moderate Members]: Self::MODERATE_MEMBERS
     #[must_use]
-    pub fn moderate_members(self) -> bool {
+    pub const fn moderate_members(self) -> bool {
         self.contains(Self::MODERATE_MEMBERS)
     }
 
@@ -662,7 +662,7 @@ impl Permissions {
     ///
     /// [Move Members]: Self::MOVE_MEMBERS
     #[must_use]
-    pub fn move_members(self) -> bool {
+    pub const fn move_members(self) -> bool {
         self.contains(Self::MOVE_MEMBERS)
     }
 
@@ -671,7 +671,7 @@ impl Permissions {
     ///
     /// [Mute Members]: Self::MUTE_MEMBERS
     #[must_use]
-    pub fn mute_members(self) -> bool {
+    pub const fn mute_members(self) -> bool {
         self.contains(Self::MUTE_MEMBERS)
     }
 
@@ -680,7 +680,7 @@ impl Permissions {
     ///
     /// [Read Message History]: Self::READ_MESSAGE_HISTORY
     #[must_use]
-    pub fn read_message_history(self) -> bool {
+    pub const fn read_message_history(self) -> bool {
         self.contains(Self::READ_MESSAGE_HISTORY)
     }
 
@@ -689,7 +689,7 @@ impl Permissions {
     ///
     /// [Send Messages]: Self::SEND_MESSAGES
     #[must_use]
-    pub fn send_messages(self) -> bool {
+    pub const fn send_messages(self) -> bool {
         self.contains(Self::SEND_MESSAGES)
     }
 
@@ -698,7 +698,7 @@ impl Permissions {
     ///
     /// [Send Messages in Threads]: Self::SEND_MESSAGES_IN_THREADS
     #[must_use]
-    pub fn send_messages_in_threads(self) -> bool {
+    pub const fn send_messages_in_threads(self) -> bool {
         self.contains(Self::SEND_MESSAGES_IN_THREADS)
     }
 
@@ -707,7 +707,7 @@ impl Permissions {
     ///
     /// [Send TTS Messages]: Self::SEND_TTS_MESSAGES
     #[must_use]
-    pub fn send_tts_messages(self) -> bool {
+    pub const fn send_tts_messages(self) -> bool {
         self.contains(Self::SEND_TTS_MESSAGES)
     }
 
@@ -716,7 +716,7 @@ impl Permissions {
     ///
     /// [Speak]: Self::SPEAK
     #[must_use]
-    pub fn speak(self) -> bool {
+    pub const fn speak(self) -> bool {
         self.contains(Self::SPEAK)
     }
 
@@ -725,7 +725,7 @@ impl Permissions {
     ///
     /// [Request To Speak]: Self::REQUEST_TO_SPEAK
     #[must_use]
-    pub fn request_to_speak(self) -> bool {
+    pub const fn request_to_speak(self) -> bool {
         self.contains(Self::REQUEST_TO_SPEAK)
     }
 
@@ -734,7 +734,7 @@ impl Permissions {
     ///
     /// [Use Embedded Activities]: Self::USE_EMBEDDED_ACTIVITIES
     #[must_use]
-    pub fn use_embedded_activities(self) -> bool {
+    pub const fn use_embedded_activities(self) -> bool {
         self.contains(Self::USE_EMBEDDED_ACTIVITIES)
     }
 
@@ -743,7 +743,7 @@ impl Permissions {
     ///
     /// [Use External Emojis]: Self::USE_EXTERNAL_EMOJIS
     #[must_use]
-    pub fn use_external_emojis(self) -> bool {
+    pub const fn use_external_emojis(self) -> bool {
         self.contains(Self::USE_EXTERNAL_EMOJIS)
     }
 
@@ -752,7 +752,7 @@ impl Permissions {
     ///
     /// [Use External Stickers]: Self::USE_EXTERNAL_STICKERS
     #[must_use]
-    pub fn use_external_stickers(self) -> bool {
+    pub const fn use_external_stickers(self) -> bool {
         self.contains(Self::USE_EXTERNAL_STICKERS)
     }
 
@@ -761,7 +761,7 @@ impl Permissions {
     ///
     /// [Use Application Commands]: Self::USE_APPLICATION_COMMANDS
     #[must_use]
-    pub fn use_application_commands(self) -> bool {
+    pub const fn use_application_commands(self) -> bool {
         self.contains(Self::USE_APPLICATION_COMMANDS)
     }
 
@@ -770,7 +770,7 @@ impl Permissions {
     ///
     /// [Use VAD]: Self::USE_VAD
     #[must_use]
-    pub fn use_vad(self) -> bool {
+    pub const fn use_vad(self) -> bool {
         self.contains(Self::USE_VAD)
     }
 }


### PR DESCRIPTION
This allows some functions that will actually be callable in const to be called, and introduces the `rustversion` dependency on next (already in current, but locked behind collector) to allow Id::new to be called in const on rust versions in which panicking is const stable.

I have purposfully left out quite a lot of methods that could be const, due to them being impossible to call, eg: `CustomMessage::build` cannot be called in const due to `CustomMessage::new` and `CustomMessage::default` not being const stable