### PR TITLE
fix discord API message_count u8 -> u32

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -110,7 +110,7 @@ pub struct GuildChannel {
     /// An approximate count of messages in the thread, stops counting at 50.
     ///
     /// **Note**: This is only available on thread channels.
-    pub message_count: Option<u8>,
+    pub message_count: Option<u32>,
     /// An approximate count of users in a thread, stops counting at 50.
     ///
     /// **Note**: This is only available on thread channels.


### PR DESCRIPTION
error: `WARN run:recv_event:handle_event{event=Err(Json(Error("invalid value: integer 368`

info about change I've found: https://github.com/twilight-rs/twilight/pull/1822

should be cherry picked to `current` branch too.