### PR TITLE
Deserialize to JsonMap then recreate Value when needed

### DIFF
--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -42,11 +42,12 @@ pub enum ActionRowComponent {
 
 impl<'de> Deserialize<'de> for ActionRowComponent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        let value = Value::deserialize(deserializer)?;
-        let map = value.as_object().ok_or_else(|| DeError::custom("expected JsonMap"))?;
+        let map = JsonMap::deserialize(deserializer)?;
 
-        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?;
-        match deserialize_val(raw_kind.clone())? {
+        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
+        let value = Value::from(map);
+
+        match deserialize_val(raw_kind)? {
             ComponentType::Button => from_value(value).map(ActionRowComponent::Button),
             ComponentType::InputText => from_value(value).map(ActionRowComponent::InputText),
             ComponentType::SelectMenu => from_value(value).map(ActionRowComponent::SelectMenu),

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -132,11 +132,12 @@ impl Interaction {
 
 impl<'de> Deserialize<'de> for Interaction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        let value = Value::deserialize(deserializer)?;
-        let map = value.as_object().ok_or_else(|| DeError::custom("expected JsonMap"))?;
+        let map = JsonMap::deserialize(deserializer)?;
 
-        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?;
-        match deserialize_val(raw_kind.clone())? {
+        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
+        let value = Value::from(map);
+
+        match deserialize_val(raw_kind)? {
             InteractionType::ApplicationCommand => {
                 from_value(value).map(Interaction::ApplicationCommand)
             },

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -224,8 +224,7 @@ impl Channel {
 
 impl<'de> Deserialize<'de> for Channel {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let value = Value::deserialize(deserializer)?;
-        let map = value.as_object().ok_or_else(|| DeError::custom("expected a JsonMap"))?;
+        let map = JsonMap::deserialize(deserializer)?;
 
         let kind = {
             let kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?;
@@ -237,6 +236,7 @@ impl<'de> Deserialize<'de> for Channel {
             })?
         };
 
+        let value = Value::from(map);
         match kind {
             0 | 2 | 5 | 10 | 11 | 12 | 13 | 14 | 15 => from_value(value).map(Channel::Guild),
             1 => from_value(value).map(Channel::Private),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -88,17 +88,16 @@ pub struct GuildCreateEvent {
 
 impl<'de> Deserialize<'de> for GuildCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut value = Value::deserialize(deserializer)?;
-        let map = value.as_object_mut().ok_or_else(|| DeError::custom("expected JsonMap"))?;
+        let mut map = JsonMap::deserialize(deserializer)?;
 
         let id_val = map.get("id").ok_or_else(|| DeError::missing_field("id"))?;
         let id = deserialize_val(id_val.clone())?;
 
-        add_guild_id_to_map(map, "channels", id);
-        add_guild_id_to_map(map, "members", id);
-        add_guild_id_to_map(map, "roles", id);
+        add_guild_id_to_map(&mut map, "channels", id);
+        add_guild_id_to_map(&mut map, "members", id);
+        add_guild_id_to_map(&mut map, "roles", id);
 
-        deserialize_val(value).map(|guild| Self {
+        deserialize_val(Value::from(map)).map(|guild| Self {
             guild,
         })
     }
@@ -655,27 +654,27 @@ pub enum GatewayEvent {
 
 impl<'de> Deserialize<'de> for GatewayEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut value = Value::deserialize(deserializer)?;
-        let map = value.as_object_mut().ok_or_else(|| DeError::custom("expected JsonMap"))?;
+        let mut map = JsonMap::deserialize(deserializer)?;
+        let seq = remove_from_map_opt(&mut map, "s")?.flatten();
 
-        let seq = remove_from_map_opt(map, "s")?.flatten();
-
-        Ok(match remove_from_map(map, "op")? {
+        Ok(match remove_from_map(&mut map, "op")? {
             Opcode::Dispatch => Self::Dispatch(
                 seq.ok_or_else(|| DeError::missing_field("s"))?,
-                deserialize_val(value)?,
+                deserialize_val(Value::from(map))?,
             ),
             Opcode::Heartbeat => {
                 GatewayEvent::Heartbeat(seq.ok_or_else(|| DeError::missing_field("s"))?)
             },
-            Opcode::InvalidSession => GatewayEvent::InvalidateSession(remove_from_map(map, "d")?),
+            Opcode::InvalidSession => {
+                GatewayEvent::InvalidateSession(remove_from_map(&mut map, "d")?)
+            },
             Opcode::Hello => {
                 #[derive(Deserialize)]
                 struct HelloPayload {
                     heartbeat_interval: u64,
                 }
 
-                let inner: HelloPayload = remove_from_map(map, "d")?;
+                let inner: HelloPayload = remove_from_map(&mut map, "d")?;
                 GatewayEvent::Hello(inner.heartbeat_interval)
             },
             Opcode::Reconnect => GatewayEvent::Reconnect,


### PR DESCRIPTION
Speeds up deserialization by failing earlier if incorrect Value type, then cheaply recreating the Value when needed