### PR TITLE
Temporarily fix GuildChannel::message_count in a non-breaking way

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -126,7 +126,9 @@ pub struct GuildChannel {
     pub rtc_region: Option<String>,
     /// The video quality mode for a voice channel.
     pub video_quality_mode: Option<VideoQualityMode>,
-    /// An approximate count of messages in the thread, stops counting at 50.
+    /// An approximate count of messages in the thread.
+    ///
+    /// This is currently saturated at 255 to prevent breaking.
     ///
     /// **Note**: This is only available on thread channels.
     #[serde(deserialize_with = "message_count_patch")]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1,7 +1,7 @@
+use std::convert::TryFrom;
 use std::fmt;
 #[cfg(feature = "model")]
 use std::sync::Arc;
-use std::convert::TryFrom;
 
 #[cfg(feature = "cache")]
 use futures::stream::StreamExt;
@@ -43,7 +43,9 @@ use crate::model::prelude::*;
 use crate::model::Timestamp;
 
 // HACK(Gnome!): Prevent having to change the type of message_count on serenity@current
-fn message_count_patch<'de, D: serde::Deserializer<'de>>(deserializer: D) -> StdResult<Option<u8>, D::Error> {
+fn message_count_patch<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> StdResult<Option<u8>, D::Error> {
     let real_count = Option::<u32>::deserialize(deserializer)?;
     Ok(real_count.map(u8::try_from).transpose().unwrap_or(Some(u8::MAX)))
 }


### PR DESCRIPTION
This is purely to prevent Guild caching errors on startup for people using current, and should be removed when the next serenity release happens