### PR TITLE
Fix deserialization error introduced in 0a53345.

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -131,7 +131,7 @@ pub struct GuildChannel {
     /// This is currently saturated at 255 to prevent breaking.
     ///
     /// **Note**: This is only available on thread channels.
-    #[serde(deserialize_with = "message_count_patch")]
+    #[serde(default, deserialize_with = "message_count_patch")]
     pub message_count: Option<u8>,
     /// An approximate count of users in a thread, stops counting at 50.
     ///


### PR DESCRIPTION
Every channel without a `message_count` field (i.e. all non-thread channels) would fail to deserialize.
This was fixed by adding `default` to the field, thus not attempting a deserialization if the field is missing.