### PR TITLE
Reduce unknown event log to debug level

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use futures::channel::mpsc::UnboundedSender as Sender;
 use futures::future::{BoxFuture, FutureExt};
 use tokio::sync::RwLock;
-use tracing::{instrument, warn};
+use tracing::{debug, instrument, warn};
 use typemap_rev::TypeMap;
 
 #[cfg(feature = "gateway")]
@@ -691,7 +691,7 @@ async fn handle_event(
                 event_handler.typing_start(context, event).await;
             });
         },
-        Event::Unknown => warn!("An unknown event was received"),
+        Event::Unknown => debug!("An unknown event was received"),
         Event::UserUpdate(mut event) => {
             let _before = update(&cache_and_http, &mut event);
 

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use futures::channel::mpsc::UnboundedSender as Sender;
 use futures::future::{BoxFuture, FutureExt};
 use tokio::sync::RwLock;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument};
 use typemap_rev::TypeMap;
 
 #[cfg(feature = "gateway")]


### PR DESCRIPTION
Turns out that with the current state of this (not printing the event name) it is completely useless and spammy, especially when running on a large bot receiving a lot of events. This PR just reduces the warning log to a debug log, to prevent it appearing on production builds of bots (hopefully).

I've had this change on my personal branch for a while, and am just upstreaming it now to reduce the effort I need to do to rebase it. 