### PR TITLE
Remove unnecessary generics

### DIFF
--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -125,7 +125,7 @@ impl ApplicationCommandInteraction {
     /// Returns an [`Error::Model`] if the message content is too long. May also return an
     /// [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is an error in
     /// deserializing the API response.
-    pub async fn edit_original_interaction_response<F>(
+    pub async fn edit_original_interaction_response(
         &self,
         http: impl AsRef<Http>,
         builder: EditInteractionResponse,

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -99,7 +99,7 @@ impl MessageComponentInteraction {
     /// Returns an [`Error::Model`] if the message content is too long. May also return an
     /// [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is an error in
     /// deserializing the API response.
-    pub async fn edit_original_interaction_response<F>(
+    pub async fn edit_original_interaction_response(
         &self,
         http: impl AsRef<Http>,
         builder: EditInteractionResponse,

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -101,7 +101,7 @@ impl ModalSubmitInteraction {
     /// Returns an [`Error::Model`] if the message content is too long. May also return an
     /// [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is an error in
     /// deserializing the API response.
-    pub async fn edit_original_interaction_response<F>(
+    pub async fn edit_original_interaction_response(
         &self,
         http: impl AsRef<Http>,
         builder: EditInteractionResponse,


### PR DESCRIPTION
These generics were mistakenly left behind after #2024 and can be removed