### PR TITLE
Fix some builders returning unsendable Futures

### DIFF
--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -49,17 +49,8 @@ impl CreateChannel {
         guild_id: GuildId,
     ) -> Result<GuildChannel> {
         #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = cache.guild(guild_id) {
-                    let req = Permissions::MANAGE_CHANNELS;
-
-                    if !guild.has_perms(&cache_http, req).await {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
-                }
-            }
-        }
+        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_CHANNELS)
+            .await?;
 
         self._execute(cache_http.http(), guild_id).await
     }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -48,17 +48,8 @@ impl CreateScheduledEvent {
         guild_id: GuildId,
     ) -> Result<ScheduledEvent> {
         #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = cache.guild(guild_id) {
-                    let req = Permissions::MANAGE_EVENTS;
-
-                    if !guild.has_perms(&cache_http, req).await {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
-                }
-            }
-        }
+        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_EVENTS)
+            .await?;
 
         self._execute(cache_http.http(), guild_id).await
     }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -36,17 +36,12 @@ impl<'a> CreateSticker<'a> {
     #[inline]
     pub async fn execute(self, cache_http: impl CacheHttp, guild_id: GuildId) -> Result<Sticker> {
         #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = cache.guild(guild_id) {
-                    let req = Permissions::MANAGE_EMOJIS_AND_STICKERS;
-
-                    if !guild.has_perms(&cache_http, req).await {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
-                }
-            }
-        }
+        crate::utils::user_has_guild_perms(
+            &cache_http,
+            guild_id,
+            Permissions::MANAGE_EMOJIS_AND_STICKERS,
+        )
+        .await?;
 
         self._execute(cache_http.http(), guild_id).await
     }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -64,17 +64,8 @@ impl EditGuild {
         guild_id: GuildId,
     ) -> Result<PartialGuild> {
         #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = cache.guild(guild_id) {
-                    let req = Permissions::MANAGE_GUILD;
-
-                    if !guild.has_perms(&cache_http, req).await {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
-                }
-            }
-        }
+        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_GUILD)
+            .await?;
 
         self._execute(cache_http.http(), guild_id).await
     }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -81,17 +81,8 @@ impl EditRole {
         role_id: Option<RoleId>,
     ) -> Result<Role> {
         #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = cache.guild(guild_id) {
-                    let req = Permissions::MANAGE_ROLES;
-
-                    if !guild.has_perms(&cache_http, req).await {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
-                }
-            }
-        }
+        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_ROLES)
+            .await?;
 
         self._execute(cache_http.http(), guild_id, role_id).await
     }

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -48,17 +48,8 @@ impl EditScheduledEvent {
         event_id: ScheduledEventId,
     ) -> Result<ScheduledEvent> {
         #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(guild) = cache.guild(guild_id) {
-                    let req = Permissions::MANAGE_EVENTS;
-
-                    if !guild.has_perms(&cache_http, req).await {
-                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                    }
-                }
-            }
-        }
+        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_EVENTS)
+            .await?;
 
         self._execute(cache_http.http(), guild_id, event_id).await
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -33,6 +33,8 @@ use std::path::Path;
 
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::Cache;
+#[cfg(all(feature = "cache", feature = "model"))]
+use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
@@ -443,6 +445,25 @@ pub fn parse_webhook(url: &Url) -> Option<(u64, &str)> {
         return None;
     }
     Some((webhook_id.parse().ok()?, token))
+}
+
+#[cfg(all(feature = "cache", feature = "model"))]
+pub(crate) async fn user_has_guild_perms(
+    cache_http: impl CacheHttp,
+    guild_id: GuildId,
+    permissions: Permissions,
+) -> Result<()> {
+    if let Some(cache) = cache_http.cache() {
+        // Unfortunately have to clone the guild because CacheRef is not `Send` and
+        // `Guild::has_perms` is an async fn, but we want the returned Future to be `Send`.
+        let lookup = cache.guild(guild_id).as_deref().cloned();
+        if let Some(guild) = lookup {
+            if !guild.has_perms(&cache_http, permissions).await {
+                return Err(Error::Model(ModelError::InvalidPermissions(permissions)));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Tries to find a user's permissions using the cache.


### PR DESCRIPTION
Due to how the permissions lookups were being performed in #2024, the Futures were being marked `!Send` because `GuildRef` and `CacheRef` in general is also `!Send`. So, we unfortunately have to clone the guild we get from the cache. Also factored out the permissions lookup into a function.