### PR TITLE
Move Colour to utils and remove feature guards

### DIFF
--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -421,7 +421,7 @@ impl Colour {
 impl ToTokens for Colour {
     fn to_tokens(&self, stream: &mut TokenStream2) {
         let value = self.0;
-        let path = quote!(serenity::utils::Colour);
+        let path = quote!(serenity::model::colour::Colour);
 
         stream.extend(quote! {
             #path(#value)

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -17,8 +17,6 @@
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-#[cfg(feature = "utils")]
-use crate::utils::Colour;
 
 #[derive(Clone, Debug, Serialize)]
 struct HoldsUrl {
@@ -66,7 +64,7 @@ pub struct CreateEmbed {
     url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "color")]
-    colour: Option<u32>,
+    colour: Option<Colour>,
 
     #[serde(rename = "type")]
     kind: &'static str,
@@ -94,28 +92,7 @@ impl CreateEmbed {
     #[cfg(feature = "utils")]
     #[inline]
     pub fn colour<C: Into<Colour>>(mut self, colour: C) -> Self {
-        self._colour(colour.into());
-        self
-    }
-
-    #[cfg(feature = "utils")]
-    fn _colour(&mut self, colour: Colour) {
-        self.colour = Some(colour.0);
-    }
-
-    /// Set the colour of the left-hand side of the embed.
-    ///
-    /// This is an alias of [`colour`].
-    #[cfg(not(feature = "utils"))]
-    #[inline]
-    pub fn color(self, colour: u32) -> Self {
-        self.colour(colour)
-    }
-
-    /// Set the colour of the left-hand side of the embed.
-    #[cfg(not(feature = "utils"))]
-    pub fn colour(mut self, colour: u32) -> Self {
-        self.colour = Some(colour);
+        self.colour = Some(colour.into());
         self
     }
 
@@ -482,7 +459,7 @@ mod test {
     use super::CreateEmbed;
     use crate::json::{json, to_value};
     use crate::model::channel::{Embed, EmbedField, EmbedFooter, EmbedImage, EmbedVideo};
-    use crate::utils::Colour;
+    use crate::model::colour::Colour;
 
     #[test]
     fn test_from_embed() {

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -45,7 +45,7 @@ use crate::utils::encode_image;
 pub struct EditRole {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "color")]
-    colour: Option<u32>,
+    colour: Option<Colour>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -116,33 +116,21 @@ impl EditRole {
 
     /// Creates a new builder with the values of the given [`Role`].
     pub fn new(role: &Role) -> Self {
-        let colour;
-
-        #[cfg(feature = "utils")]
-        {
-            colour = role.colour.0;
-        }
-
-        #[cfg(not(feature = "utils"))]
-        {
-            colour = role.colour;
-        }
-
         EditRole {
             hoist: Some(role.hoist),
             mentionable: Some(role.mentionable),
             name: Some(role.name.clone()),
             permissions: Some(role.permissions.bits()),
             position: Some(role.position),
-            colour: Some(colour),
+            colour: Some(role.colour),
             unicode_emoji: role.unicode_emoji.clone(),
             icon: role.icon.clone(),
         }
     }
 
     /// Set the colour of the role.
-    pub fn colour(mut self, colour: u32) -> Self {
-        self.colour = Some(colour);
+    pub fn colour(mut self, colour: impl Into<Colour>) -> Self {
+        self.colour = Some(colour.into());
         self
     }
 

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -17,7 +17,7 @@ use crate::model::prelude::*;
 /// use serenity::builder::{CreateEmbed, ExecuteWebhook};
 /// use serenity::http::Http;
 /// use serenity::model::webhook::Webhook;
-/// use serenity::utils::Colour;
+/// use serenity::model::colour::Colour;
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// # let http = Http::new("token");

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -82,8 +82,8 @@ use crate::{
     framework::standard::CommonOptions,
     http::CacheHttp,
     model::channel::Message,
+    model::colour::Colour,
     model::id::{ChannelId, UserId},
-    utils::Colour,
     Error,
 };
 

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -7,9 +7,9 @@ use futures::future::BoxFuture;
 use super::Args;
 use crate::client::Context;
 use crate::model::channel::Message;
+use crate::model::colour::Colour;
 use crate::model::id::UserId;
 use crate::model::permissions::Permissions;
-use crate::utils::Colour;
 
 pub mod buckets;
 mod check;

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -1,6 +1,4 @@
-use crate::model::Timestamp;
-#[cfg(feature = "utils")]
-use crate::utils::Colour;
+use crate::model::{Colour, Timestamp};
 
 /// Represents a rich embed which allows using richer markdown, multiple fields
 /// and more. This was heavily inspired by [slack's attachments].
@@ -18,13 +16,8 @@ pub struct Embed {
     /// Information about the author of the embed.
     pub author: Option<EmbedAuthor>,
     /// The colour code of the embed.
-    #[cfg(feature = "utils")]
     #[serde(rename = "color")]
     pub colour: Option<Colour>,
-    /// The colour code of the embed.
-    #[cfg(not(feature = "utils"))]
-    #[serde(default, rename = "color")]
-    pub colour: u32,
     /// The description of the embed.
     ///
     /// The maximum value for this field is 2048 unicode codepoints.

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -34,7 +34,7 @@
 /// #     "position": 7,
 /// # })).unwrap();
 /// #
-/// use serenity::utils::Colour;
+/// use serenity::model::colour::Colour;
 ///
 /// // assuming a `role` has already been bound
 ///
@@ -47,7 +47,7 @@
 /// Creating an instance with the [`Self::DARK_TEAL`] preset:
 ///
 /// ```rust
-/// use serenity::utils::Colour;
+/// use serenity::model::colour::Colour;
 ///
 /// let colour = Colour::DARK_TEAL;
 ///
@@ -57,7 +57,7 @@
 /// Colours can also be directly compared for equivalence:
 ///
 /// ```rust
-/// use serenity::utils::Colour;
+/// use serenity::model::colour::Colour;
 ///
 /// let blitz_blue = Colour::BLITZ_BLUE;
 /// let fooyoo = Colour::FOOYOO;
@@ -80,7 +80,7 @@ impl Colour {
     /// to a specific RGB value, retrieved via [`Self::tuple`]:
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// let colour = Colour::new(6573123);
     ///
@@ -100,7 +100,7 @@ impl Colour {
     /// Creating a [`Colour`] via its RGB values will set its inner u32 correctly:
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert!(Colour::from_rgb(255, 0, 0).0 == 0xFF0000);
     /// assert!(Colour::from_rgb(217, 23, 211).0 == 0xD917D3);
@@ -109,7 +109,7 @@ impl Colour {
     /// And you can then retrieve those same RGB values via its methods:
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// let colour = Colour::from_rgb(217, 45, 215);
     ///
@@ -131,7 +131,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).r(), 100);
     /// ```
@@ -145,7 +145,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).g(), 76);
     /// ```
@@ -159,7 +159,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).b(), 67);
     /// ```
@@ -176,7 +176,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).tuple(), (100, 76, 67));
     /// ```
@@ -193,7 +193,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).hex(), "644C43");
     /// ```
@@ -213,7 +213,7 @@ impl From<i32> for Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert_eq!(Colour::from(0xDEA584).tuple(), (222, 165, 132));
     /// ```
@@ -230,7 +230,7 @@ impl From<u32> for Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert_eq!(Colour::from(6573123u32).r(), 100);
     /// ```
@@ -247,7 +247,7 @@ impl From<u64> for Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::utils::Colour;
+    /// use serenity::model::colour::Colour;
     ///
     /// assert_eq!(Colour::from(6573123u64).r(), 100);
     /// ```
@@ -332,7 +332,7 @@ impl Default for Colour {
 /// Colour constants used by Discord for their branding, role colour palette, etc.
 pub mod colours {
     pub mod branding {
-        use crate::utils::Colour;
+        use super::super::Colour;
 
         /// Creates a new [`Colour`], setting its value to `rgb(88, 101, 242)`.
         pub const BLURPLE: Colour = Colour(0x5865F2);
@@ -350,7 +350,7 @@ pub mod colours {
         pub const BLACK: Colour = Colour(0x23272A);
     }
     pub mod css {
-        use crate::utils::Colour;
+        use super::super::Colour;
 
         /// Creates a new [`Colour`], setting its value to `hsl(139, 47.3%, 43.9%)`.
         pub const POSITIVE: Colour = Colour(0x3BA55D);
@@ -360,7 +360,7 @@ pub mod colours {
         pub const DANGER: Colour = Colour(0xED4245);
     }
     pub mod roles {
-        use crate::utils::Colour;
+        use super::super::Colour;
 
         /// Creates a new [`Colour`], setting its value to `rgb(153, 170, 181)`.
         pub const DEFAULT: Colour = Colour(0x99AAB5);

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -15,8 +15,6 @@ use crate::internal::prelude::*;
 use crate::model::permissions::Permissions;
 use crate::model::prelude::*;
 use crate::model::Timestamp;
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use crate::utils::Colour;
 
 /// Information about a member of a guild.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -31,15 +31,9 @@ pub struct Role {
     pub id: RoleId,
     /// The Id of the Guild the Role is in.
     pub guild_id: GuildId,
-    /// The colour of the role. This is an ergonomic representation of the inner
-    /// value.
-    #[cfg(feature = "utils")]
+    /// The colour of the role.
     #[serde(rename = "color")]
     pub colour: Colour,
-    /// The colour of the role.
-    #[cfg(not(feature = "utils"))]
-    #[serde(rename = "color")]
-    pub colour: u32,
     /// Indicator of whether the role is pinned above lesser roles.
     ///
     /// In the client, this causes [`Member`]s in the role to be seen above
@@ -90,12 +84,8 @@ pub(crate) struct InterimRole {
     pub id: RoleId,
     #[serde(default)]
     pub guild_id: Option<GuildId>,
-    #[cfg(feature = "utils")]
     #[serde(rename = "color")]
     pub colour: Colour,
-    #[cfg(not(feature = "utils"))]
-    #[serde(rename = "color")]
-    pub colour: u32,
     pub hoist: bool,
     pub managed: bool,
     #[serde(default)]

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -202,7 +202,6 @@ mentionable!(value:
 #[cfg(test)]
 mod test {
     use crate::model::prelude::*;
-    use crate::utils::Colour;
 
     #[test]
     fn test_mention() {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -24,6 +24,7 @@ mod utils;
 
 pub mod application;
 pub mod channel;
+pub mod colour;
 pub mod connection;
 pub mod error;
 pub mod event;
@@ -44,6 +45,7 @@ pub mod webhook;
 use std::collections::HashMap;
 use std::result::Result as StdResult;
 
+use colour::Colour;
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer};
 #[cfg(feature = "voice-model")]
@@ -53,5 +55,4 @@ pub use timestamp::Timestamp;
 pub use self::error::Error as ModelError;
 pub use self::permissions::Permissions;
 use crate::internal::prelude::*;
-#[cfg(feature = "utils")]
-use crate::utils::Colour;
+pub type Color = Colour;

--- a/src/model/prelude.rs
+++ b/src/model/prelude.rs
@@ -12,6 +12,7 @@
 
 pub use super::application::*;
 pub use super::channel::*;
+pub use super::colour::*;
 pub use super::connection::*;
 pub use super::event::*;
 pub use super::gateway::*;

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -178,10 +178,7 @@ pub struct CurrentUser {
     pub verified: Option<bool>,
     pub public_flags: Option<UserPublicFlags>,
     pub banner: Option<String>,
-    #[cfg(feature = "utils")]
     pub accent_colour: Option<Colour>,
-    #[cfg(not(feature = "utils"))]
-    pub accent_colour: Option<u32>,
 }
 
 #[cfg(feature = "model")]
@@ -644,12 +641,8 @@ pub struct User {
     ///
     /// **Note**: This will only be present if the user is fetched via Rest API,
     /// e.g. with [`Http::get_user`].
-    #[cfg(feature = "utils")]
     #[serde(rename = "accent_color")]
     pub accent_colour: Option<Colour>,
-    #[cfg(not(feature = "utils"))]
-    #[serde(rename = "accent_color")]
-    pub accent_colour: Option<u32>,
 }
 
 bitflags! {

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -275,11 +275,11 @@ mod tests {
 
     use super::*;
     use crate::model::channel::*;
+    use crate::model::colour::Colour;
     use crate::model::guild::*;
     use crate::model::id::{ChannelId, RoleId, UserId};
     use crate::model::user::User;
     use crate::model::{Permissions, Timestamp};
-    use crate::utils::Colour;
 
     #[test]
     fn test_content_safe() {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,7 +4,6 @@
 #[cfg(feature = "client")]
 mod argument_convert;
 pub(crate) mod backports;
-mod colour;
 #[cfg(feature = "cache")]
 mod content_safe;
 mod custom_message;
@@ -12,25 +11,22 @@ mod message_builder;
 
 pub mod token;
 
-#[cfg(feature = "client")]
-pub use argument_convert::*;
-#[cfg(feature = "cache")]
-pub use content_safe::*;
-use url::Url;
-
-pub use self::colour::{colours, Colour};
-pub use self::custom_message::CustomMessage;
-pub use self::message_builder::{Content, ContentModifier, EmbedMessageBuilding, MessageBuilder};
-#[doc(inline)]
-pub use self::token::{parse as parse_token, validate as validate_token};
-pub type Color = Colour;
-
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Read;
 use std::num::NonZeroU64;
 use std::path::Path;
 
+#[cfg(feature = "client")]
+pub use argument_convert::*;
+#[cfg(feature = "cache")]
+pub use content_safe::*;
+use url::Url;
+
+pub use self::custom_message::CustomMessage;
+pub use self::message_builder::{Content, ContentModifier, EmbedMessageBuilding, MessageBuilder};
+#[doc(inline)]
+pub use self::token::{parse as parse_token, validate as validate_token};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::Cache;
 use crate::internal::prelude::*;


### PR DESCRIPTION
This goes towards fixing #1856 by reducing the swap between `u32` and `Colour` with different features enabled. I chose not to feature guard the methods and constants as they are very simple and I can't imagine it taking any compile time, and doesn't bring any dependencies in.