### PR TITLE
Deprecate modifying command application permissions in bulk

### DIFF
--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -8,6 +8,7 @@ use crate::model::application::command::CommandPermissionType;
 ///
 /// [`CommandPermission`]: crate::model::application::command::CommandPermission
 #[derive(Clone, Debug, Default)]
+#[deprecated(note = "use `CreateApplicationCommandPermissionsData`")]
 pub struct CreateApplicationCommandsPermissions(pub Vec<Value>);
 
 impl CreateApplicationCommandsPermissions {
@@ -57,6 +58,7 @@ impl CreateApplicationCommandsPermissions {
 ///
 /// [`CommandPermission`]: crate::model::application::command::CommandPermission
 #[derive(Clone, Debug, Default)]
+#[deprecated(note = "use `CreateApplicationCommandPermissionsData`")]
 pub struct CreateApplicationCommandPermissions(pub HashMap<&'static str, Value>);
 
 impl CreateApplicationCommandPermissions {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1583,6 +1583,7 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    #[deprecated(note = "use `create_appliction_command_permission`.")]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -821,6 +821,7 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    #[deprecated(note = "use `create_appliction_command_permission`.")]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -526,6 +526,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
+    #[deprecated(note = "use `create_appliction_command_permission`.")]
     pub async fn set_application_commands_permissions<F>(
         &self,
         http: impl AsRef<Http>,


### PR DESCRIPTION
As per the [Discord docs](https://discord.com/developers/docs/interactions/application-commands#batch-edit-application-command-permissions), the endpoint for modifying guild application command permissions in bulk has been disabled. Therefore, we should deprecate the related methods and builders, and remove them on `next`.