### PR TITLE
Remove #[must_use] from Typing::stop

### DIFF
--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -90,7 +90,7 @@ impl Typing {
     /// Typing may persist for a few seconds on some clients after this is called.
     ///
     /// [`Channel`]: crate::model::channel::Channel
-    #[must_use]
+    #[allow(clippy::must_use_candidate)]
     pub fn stop(self) -> Option<()> {
         self.0.send(()).ok()
     }


### PR DESCRIPTION
This was done on `next`, however with a breaking change to stop it being put on `current`. This backports the non-breaking portion which fixed the accidental must_use added while fixing `clippy::pedantic` warnings.