### PR TITLE
Stop using serde_json in http with simd-json enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ version = "2.2.0"
 optional = true
 
 [dependencies.simd-json]
-version = "0.4.14"
+version = "0.6"
 optional = true
 
 [dependencies.tracing]
@@ -80,7 +80,7 @@ version = "1.0.13"
 
 [dependencies.reqwest]
 default-features = false
-features = ["json", "multipart", "stream"]
+features = ["multipart", "stream"]
 optional = true
 version = "0.11.7"
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1644,7 +1644,7 @@ impl Http {
     ) -> Result<Member> {
         let body = to_vec(map)?;
 
-        let mut value = self
+        let mut value: Value = self
             .fire(Request {
                 body: Some(body),
                 multipart: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -287,7 +287,7 @@ impl Http {
         if response.status() == 204 {
             Ok(None)
         } else {
-            Ok(Some(response.json().await?))
+            Ok(Some(decode_resp(response).await?))
         }
     }
 
@@ -815,8 +815,8 @@ impl Http {
         body: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Role> {
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: Some(to_vec(body)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
@@ -824,8 +824,6 @@ impl Http {
                     guild_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(map) = value.as_object_mut() {
@@ -1647,7 +1645,7 @@ impl Http {
         let body = to_vec(map)?;
 
         let mut value = self
-            .request(Request {
+            .fire(Request {
                 body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
@@ -1656,8 +1654,6 @@ impl Http {
                     user_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(map) = value.as_object_mut() {
@@ -1828,16 +1824,13 @@ impl Http {
     pub async fn edit_profile(&self, map: &impl serde::Serialize) -> Result<CurrentUser> {
         let body = to_vec(map)?;
 
-        let request = self
-            .request(Request {
-                body: Some(body),
-                multipart: None,
-                headers: None,
-                route: RouteInfo::EditProfile,
-            })
-            .await?;
-
-        Ok(request.json::<CurrentUser>().await?)
+        self.fire(Request {
+            body: Some(body),
+            multipart: None,
+            headers: None,
+            route: RouteInfo::EditProfile,
+        })
+        .await
     }
 
     /// Changes a role in a guild.
@@ -1848,8 +1841,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Role> {
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: Some(to_vec(map)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
@@ -1858,8 +1851,6 @@ impl Http {
                     role_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(map) = value.as_object_mut() {
@@ -1882,8 +1873,8 @@ impl Http {
             "position": position,
         }]))?;
 
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
@@ -1891,8 +1882,6 @@ impl Http {
                     guild_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(array) = value.as_array_mut() {
@@ -1944,8 +1933,9 @@ impl Http {
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {
         let body = to_vec(&map)?;
-        let mut value = self
-            .request(Request {
+
+        let mut value: Value = self
+            .fire(Request {
                 body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
@@ -1954,8 +1944,6 @@ impl Http {
                     sticker_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(map) = value.as_object_mut() {
@@ -2254,7 +2242,7 @@ impl Http {
             return Ok(None);
         }
 
-        response.json::<Message>().await.map(Some).map_err(From::from)
+        decode_resp(response).await.map(Some)
     }
 
     /// Send file(s) over a webhook.
@@ -2362,8 +2350,8 @@ impl Http {
             scheduled_maintenances: Vec<Maintenance>,
         }
 
-        let response = self
-            .request(Request {
+        let status: StatusResponse = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -2371,7 +2359,6 @@ impl Http {
             })
             .await?;
 
-        let status: StatusResponse = response.json().await?;
         Ok(status.scheduled_maintenances)
     }
 
@@ -2993,7 +2980,7 @@ impl Http {
             code: String,
         }
 
-        self.request(Request {
+        self.fire::<GuildVanityUrl>(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -3001,11 +2988,8 @@ impl Http {
                 guild_id,
             },
         })
-        .await?
-        .json::<GuildVanityUrl>()
         .await
         .map(|x| x.code)
-        .map_err(From::from)
     }
 
     /// Gets the members of a guild. Optionally pass a `limit` and the Id of the
@@ -3022,8 +3006,8 @@ impl Http {
             }
         }
 
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -3033,8 +3017,6 @@ impl Http {
                     limit,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(values) = value.as_array_mut() {
@@ -3045,7 +3027,7 @@ impl Http {
             }
         }
 
-        from_value::<Vec<Member>>(value).map_err(From::from)
+        from_value(value).map_err(From::from)
     }
 
     /// Gets the amount of users that can be pruned.
@@ -3078,8 +3060,8 @@ impl Http {
 
     /// Retrieves a list of roles in a [`Guild`].
     pub async fn get_guild_roles(&self, guild_id: u64) -> Result<Vec<Role>> {
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -3087,8 +3069,6 @@ impl Http {
                     guild_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(array) = value.as_array_mut() {
@@ -3197,8 +3177,8 @@ impl Http {
 
     /// Retrieves a list of stickers in a [`Guild`].
     pub async fn get_guild_stickers(&self, guild_id: u64) -> Result<Vec<Sticker>> {
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -3206,8 +3186,6 @@ impl Http {
                     guild_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(array) = value.as_array_mut() {
@@ -3223,8 +3201,8 @@ impl Http {
 
     /// Retrieves a single sticker in a [`Guild`].
     pub async fn get_guild_sticker(&self, guild_id: u64, sticker_id: u64) -> Result<Sticker> {
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -3233,8 +3211,6 @@ impl Http {
                     sticker_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(map) = value.as_object_mut() {
@@ -3367,8 +3343,8 @@ impl Http {
 
     /// Gets member of a guild.
     pub async fn get_member(&self, guild_id: u64, user_id: u64) -> Result<Member> {
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -3377,15 +3353,13 @@ impl Http {
                     user_id,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(map) = value.as_object_mut() {
             map.insert("guild_id".to_string(), guild_id.into());
         }
 
-        from_value::<Member>(value).map_err(From::from)
+        from_value(value).map_err(From::from)
     }
 
     /// Gets a message by an Id, bots only.
@@ -3423,17 +3397,14 @@ impl Http {
             sticker_packs: Vec<StickerPack>,
         }
 
-        self.request(Request {
+        self.fire::<StickerPacks>(Request {
             body: None,
             multipart: None,
             headers: None,
             route: RouteInfo::GetStickerPacks,
         })
-        .await?
-        .json::<StickerPacks>()
         .await
         .map(|s| s.sticker_packs)
-        .map_err(From::from)
     }
 
     /// Gets all pins of a channel.
@@ -3498,8 +3469,8 @@ impl Http {
             incidents: Vec<Incident>,
         }
 
-        let response = self
-            .request(Request {
+        let status: StatusResponse = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -3507,7 +3478,6 @@ impl Http {
             })
             .await?;
 
-        let status: StatusResponse = response.json().await?;
         Ok(status.incidents)
     }
 
@@ -3521,8 +3491,8 @@ impl Http {
             scheduled_maintenances: Vec<Maintenance>,
         }
 
-        let response = self
-            .request(Request {
+        let status: StatusResponse = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -3530,7 +3500,6 @@ impl Http {
             })
             .await?;
 
-        let status: StatusResponse = response.json().await?;
         Ok(status.scheduled_maintenances)
     }
 
@@ -3838,8 +3807,8 @@ impl Http {
         query: &str,
         limit: Option<u64>,
     ) -> Result<Vec<Member>> {
-        let mut value = self
-            .request(Request {
+        let mut value: Value = self
+            .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -3849,8 +3818,6 @@ impl Http {
                     limit,
                 },
             })
-            .await?
-            .json::<Value>()
             .await?;
 
         if let Some(members) = value.as_array_mut() {
@@ -4001,8 +3968,7 @@ impl Http {
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn fire<T: DeserializeOwned>(&self, req: Request<'_>) -> Result<T> {
         let response = self.request(req).await?;
-
-        response.json::<T>().await.map_err(From::from)
+        decode_resp(response).await
     }
 
     /// Performs a request, ratelimiting it if necessary.

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -6,6 +6,7 @@ use reqwest::{Error as ReqwestError, Response, StatusCode, Url};
 use url::ParseError as UrlError;
 
 use crate::http::utils::deserialize_errors;
+use crate::json::decode_resp;
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -44,7 +45,7 @@ impl ErrorResponse {
         ErrorResponse {
             status_code: r.status(),
             url: r.url().clone(),
-            error: r.json().await.unwrap_or_else(|_| DiscordJsonError {
+            error: decode_resp(r).await.unwrap_or_else(|_| DiscordJsonError {
                 code: -1,
                 message:
                     "[Serenity] Could not decode json when receiving error response from discord!"

--- a/src/json.rs
+++ b/src/json.rs
@@ -36,7 +36,7 @@ pub const NULL: Value = Value::Null;
 #[cfg(feature = "simd-json")]
 pub const NULL: Value = Value::Static(simd_json::StaticNode::Null);
 
-#[cfg(not(feature = "simd-json"))]
+#[cfg(all(http, not(feature = "simd-json")))]
 pub(crate) async fn decode_resp<T: serde::de::DeserializeOwned>(
     resp: reqwest::Response,
 ) -> Result<T> {
@@ -44,7 +44,7 @@ pub(crate) async fn decode_resp<T: serde::de::DeserializeOwned>(
     serde_json::from_slice(&bytes).map_err(From::from)
 }
 
-#[cfg(feature = "simd-json")]
+#[cfg(all(http, feature = "simd-json"))]
 pub(crate) async fn decode_resp<T: serde::de::DeserializeOwned>(
     resp: reqwest::Response,
 ) -> Result<T> {

--- a/src/json.rs
+++ b/src/json.rs
@@ -36,6 +36,22 @@ pub const NULL: Value = Value::Null;
 #[cfg(feature = "simd-json")]
 pub const NULL: Value = Value::Static(simd_json::StaticNode::Null);
 
+#[cfg(not(feature = "simd-json"))]
+pub(crate) async fn decode_resp<T: serde::de::DeserializeOwned>(
+    resp: reqwest::Response,
+) -> Result<T> {
+    let bytes = resp.bytes().await?;
+    serde_json::from_slice(&bytes).map_err(From::from)
+}
+
+#[cfg(feature = "simd-json")]
+pub(crate) async fn decode_resp<T: serde::de::DeserializeOwned>(
+    resp: reqwest::Response,
+) -> Result<T> {
+    let mut bytes = resp.bytes().await?.to_vec();
+    simd_json::from_slice(&mut bytes).map_err(From::from)
+}
+
 /// Converts a HashMap into a final [`JsonMap`] representation.
 pub fn hashmap_to_json_map<H, T>(map: HashMap<T, Value, H>) -> JsonMap
 where

--- a/src/json.rs
+++ b/src/json.rs
@@ -36,7 +36,7 @@ pub const NULL: Value = Value::Null;
 #[cfg(feature = "simd-json")]
 pub const NULL: Value = Value::Static(simd_json::StaticNode::Null);
 
-#[cfg(all(http, not(feature = "simd-json")))]
+#[cfg(all(feature = "http", not(feature = "simd-json")))]
 pub(crate) async fn decode_resp<T: serde::de::DeserializeOwned>(
     resp: reqwest::Response,
 ) -> Result<T> {
@@ -44,7 +44,7 @@ pub(crate) async fn decode_resp<T: serde::de::DeserializeOwned>(
     serde_json::from_slice(&bytes).map_err(From::from)
 }
 
-#[cfg(all(http, feature = "simd-json"))]
+#[cfg(all(feature = "http", feature = "simd-json"))]
 pub(crate) async fn decode_resp<T: serde::de::DeserializeOwned>(
     resp: reqwest::Response,
 ) -> Result<T> {


### PR DESCRIPTION
`reqwest::Response::json` was using `serde_json` even with `serenity`'s `simd-json` feature enabled. This fixes this by disabling the `json` feature of `reqwest` and adding a private `decode_resp` function to the `json` module.

It also uses Http::fire more, which saves some lines and repetition.