### PR TITLE
Remove CreateSelectMenuOptions builder

### DIFF
--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -76,15 +76,15 @@ impl Animal {
     }
 
     fn select_menu() -> CreateSelectMenu {
-        let options = CreateSelectMenuOptions::default()
-            .add_option(Self::Cat.menu_option())
-            .add_option(Self::Dog.menu_option())
-            .add_option(Self::Horse.menu_option())
-            .add_option(Self::Alpaca.menu_option());
         CreateSelectMenu::default()
             .custom_id("animal_select")
             .placeholder("No animal selected")
-            .options(options)
+            .options(vec![
+                Self::Cat.menu_option(),
+                Self::Dog.menu_option(),
+                Self::Horse.menu_option(),
+                Self::Alpaca.menu_option(),
+            ])
     }
 
     fn action_row() -> CreateActionRow {

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -173,7 +173,7 @@ pub struct CreateSelectMenu {
     #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    options: Option<CreateSelectMenuOptions>,
+    options: Option<Vec<CreateSelectMenuOption>>,
 
     #[serde(rename = "type")]
     kind: u8,
@@ -224,29 +224,8 @@ impl CreateSelectMenu {
         self
     }
 
-    pub fn options(mut self, options: CreateSelectMenuOptions) -> Self {
+    pub fn options(mut self, options: Vec<CreateSelectMenuOption>) -> Self {
         self.options = Some(options);
-        self
-    }
-}
-
-/// A builder for creating several [`SelectMenuOption`].
-///
-/// [`SelectMenuOption`]: crate::model::application::component::SelectMenuOption
-#[derive(Clone, Debug, Default, Serialize)]
-#[must_use]
-pub struct CreateSelectMenuOptions(pub Vec<CreateSelectMenuOption>);
-
-impl CreateSelectMenuOptions {
-    /// Adds an option.
-    pub fn add_option(mut self, option: CreateSelectMenuOption) -> Self {
-        self.0.push(option);
-        self
-    }
-
-    /// Sets all the options.
-    pub fn set_options(mut self, options: Vec<CreateSelectMenuOption>) -> Self {
-        self.0.extend(options);
         self
     }
 }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -67,7 +67,6 @@ pub use self::create_components::{
     CreateInputText,
     CreateSelectMenu,
     CreateSelectMenuOption,
-    CreateSelectMenuOptions,
 };
 pub use self::create_embed::{CreateEmbed, CreateEmbedAuthor, CreateEmbedFooter};
 pub use self::create_interaction_response::{


### PR DESCRIPTION
Followup to #2078; the `CreateSelectMenuOptions` builder is redundant for the same reasons, as it simply acts as a plural, wrapping a vector of singular builders. Because of the builder rework, users can just pass around a vector instead.