### PR TITLE
Fix unused async warnings

### DIFF
--- a/examples/e13_parallel_loops/src/main.rs
+++ b/examples/e13_parallel_loops/src/main.rs
@@ -52,9 +52,7 @@ impl EventHandler for Handler {
             // the application.
             tokio::spawn(async move {
                 loop {
-                    // We clone Context again here, because Arc is owned, so it moves to the
-                    // new function.
-                    log_system_load(Arc::clone(&ctx1)).await;
+                    log_system_load(&ctx1).await;
                     tokio::time::sleep(Duration::from_secs(120)).await;
                 }
             });
@@ -63,7 +61,7 @@ impl EventHandler for Handler {
             let ctx2 = Arc::clone(&ctx);
             tokio::spawn(async move {
                 loop {
-                    set_activity_to_current_time(Arc::clone(&ctx2)).await;
+                    set_activity_to_current_time(&ctx2);
                     tokio::time::sleep(Duration::from_secs(60)).await;
                 }
             });
@@ -74,7 +72,7 @@ impl EventHandler for Handler {
     }
 }
 
-async fn log_system_load(ctx: Arc<Context>) {
+async fn log_system_load(ctx: &Context) {
     let cpu_load = sys_info::loadavg().unwrap();
     let mem_use = sys_info::mem_info().unwrap();
 
@@ -99,11 +97,11 @@ async fn log_system_load(ctx: Arc<Context>) {
     };
 }
 
-async fn set_activity_to_current_time(ctx: Arc<Context>) {
+fn set_activity_to_current_time(ctx: &Context) {
     let current_time = Utc::now();
     let formatted_time = current_time.to_rfc2822();
 
-    ctx.set_activity(Some(ActivityData::playing(formatted_time))).await;
+    ctx.set_activity(Some(ActivityData::playing(formatted_time)));
 }
 
 #[tokio::main]

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -124,7 +124,7 @@ impl Context {
     /// [`Online`]: OnlineStatus::Online
     #[cfg(feature = "gateway")]
     #[inline]
-    pub async fn online(&self) {
+    pub fn online(&self) {
         self.shard.set_status(OnlineStatus::Online);
     }
 
@@ -162,7 +162,7 @@ impl Context {
     /// [`Idle`]: OnlineStatus::Idle
     #[cfg(feature = "gateway")]
     #[inline]
-    pub async fn idle(&self) {
+    pub fn idle(&self) {
         self.shard.set_status(OnlineStatus::Idle);
     }
 
@@ -200,7 +200,7 @@ impl Context {
     /// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb
     #[cfg(feature = "gateway")]
     #[inline]
-    pub async fn dnd(&self) {
+    pub fn dnd(&self) {
         self.shard.set_status(OnlineStatus::DoNotDisturb);
     }
 
@@ -238,7 +238,7 @@ impl Context {
     /// [`Invisible`]: OnlineStatus::Invisible
     #[cfg(feature = "gateway")]
     #[inline]
-    pub async fn invisible(&self) {
+    pub fn invisible(&self) {
         self.shard.set_status(OnlineStatus::Invisible);
     }
 
@@ -277,7 +277,7 @@ impl Context {
     /// [`Online`]: OnlineStatus::Online
     #[cfg(feature = "gateway")]
     #[inline]
-    pub async fn reset_presence(&self) {
+    pub fn reset_presence(&self) {
         self.shard.set_presence(None, OnlineStatus::Online);
     }
 
@@ -317,7 +317,7 @@ impl Context {
     /// ```
     #[cfg(feature = "gateway")]
     #[inline]
-    pub async fn set_activity(&self, activity: Option<ActivityData>) {
+    pub fn set_activity(&self, activity: Option<ActivityData>) {
         self.shard.set_activity(activity);
     }
 
@@ -386,7 +386,7 @@ impl Context {
     /// [`Idle`]: OnlineStatus::Idle
     #[cfg(feature = "gateway")]
     #[inline]
-    pub async fn set_presence(&self, activity: Option<ActivityData>, status: OnlineStatus) {
+    pub fn set_presence(&self, activity: Option<ActivityData>, status: OnlineStatus) {
         self.shard.set_presence(activity, status);
     }
 
@@ -394,7 +394,7 @@ impl Context {
     /// sent back to `filter`'s paired receiver.
     #[inline]
     #[cfg(feature = "collector")]
-    pub async fn set_message_filter(&self, filter: MessageFilter) {
+    pub fn set_message_filter(&self, filter: MessageFilter) {
         self.shard.set_message_filter(filter);
     }
 
@@ -402,7 +402,7 @@ impl Context {
     /// sent back to `filter`'s paired receiver.
     #[inline]
     #[cfg(feature = "collector")]
-    pub async fn set_reaction_filter(&self, filter: ReactionFilter) {
+    pub fn set_reaction_filter(&self, filter: ReactionFilter) {
         self.shard.set_reaction_filter(filter);
     }
 
@@ -410,7 +410,7 @@ impl Context {
     /// sent back to `filter`'s paired receiver.
     #[inline]
     #[cfg(feature = "collector")]
-    pub async fn set_component_interaction_filter(&self, filter: ComponentInteractionFilter) {
+    pub fn set_component_interaction_filter(&self, filter: ComponentInteractionFilter) {
         self.shard.set_component_interaction_filter(filter);
     }
 }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -107,7 +107,7 @@ impl Context {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "!online" {
-    ///             ctx.online().await;
+    ///             ctx.online();
     ///         }
     ///     }
     /// }
@@ -145,7 +145,7 @@ impl Context {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "!idle" {
-    ///             ctx.idle().await;
+    ///             ctx.idle();
     ///         }
     ///     }
     /// }
@@ -183,7 +183,7 @@ impl Context {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "!dnd" {
-    ///             ctx.dnd().await;
+    ///             ctx.dnd();
     ///         }
     ///     }
     /// }
@@ -221,7 +221,7 @@ impl Context {
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
     ///     async fn ready(&self, ctx: Context, _: Ready) {
-    ///         ctx.invisible().await;
+    ///         ctx.invisible();
     ///     }
     /// }
     ///
@@ -260,7 +260,7 @@ impl Context {
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
     ///     async fn resume(&self, ctx: Context, _: ResumedEvent) {
-    ///         ctx.reset_presence().await;
+    ///         ctx.reset_presence();
     ///     }
     /// }
     ///
@@ -302,7 +302,7 @@ impl Context {
     ///         let mut args = msg.content.splitn(2, ' ');
     ///
     ///         if let (Some("~setgame"), Some(game)) = (args.next(), args.next()) {
-    ///             ctx.set_activity(Some(ActivityData::playing(game))).await;
+    ///             ctx.set_activity(Some(ActivityData::playing(game)));
     ///         }
     ///     }
     /// }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -517,7 +517,7 @@ impl ChannelId {
 
     /// Returns the name of whatever channel this id holds.
     #[cfg(feature = "cache")]
-    pub async fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
+    pub fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
         let channel = self.to_channel_cached(cache)?;
 
         Some(match channel {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -367,7 +367,8 @@ impl Guild {
     /// Returns the "default" channel of the guild for the passed user id.
     /// (This returns the first channel that can be read by the user, if there isn't one,
     /// returns [`None`])
-    pub async fn default_channel(&self, uid: UserId) -> Option<&GuildChannel> {
+    #[must_use]
+    pub fn default_channel(&self, uid: UserId) -> Option<&GuildChannel> {
         let member = self.members.get(&uid)?;
         for channel in self.channels.values() {
             if let Channel::Guild(channel) = channel {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -947,17 +947,17 @@ impl PartialGuild {
     /// [`position`]: Role::position
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn greater_member_hierarchy(
+    pub fn greater_member_hierarchy(
         &self,
         cache: impl AsRef<Cache>,
         lhs_id: impl Into<UserId>,
         rhs_id: impl Into<UserId>,
     ) -> Option<UserId> {
-        self._greater_member_hierarchy(&cache, lhs_id.into(), rhs_id.into()).await
+        self._greater_member_hierarchy(&cache, lhs_id.into(), rhs_id.into())
     }
 
     #[cfg(feature = "cache")]
-    async fn _greater_member_hierarchy(
+    fn _greater_member_hierarchy(
         &self,
         cache: impl AsRef<Cache>,
         lhs_id: UserId,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1065,7 +1065,7 @@ impl UserId {
     /// Attempts to find a [`User`] by its Id in the cache.
     #[cfg(feature = "cache")]
     #[inline]
-    pub async fn to_user_cached(self, cache: &impl AsRef<Cache>) -> Option<UserRef<'_>> {
+    pub fn to_user_cached(self, cache: &impl AsRef<Cache>) -> Option<UserRef<'_>> {
         cache.as_ref().user(self)
     }
 


### PR DESCRIPTION
This was caught by https://github.com/rust-lang/rust-clippy/pull/9025 being merged, fixing the lint on methods.