### PR TITLE
Fix some docstrings and typos

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -129,7 +129,7 @@ impl Default for CreateButton {
 }
 
 impl CreateButton {
-    // Creates a primary button. Equivalent to [`Self::default`].
+    /// Creates a primary button. Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
     }
@@ -193,8 +193,8 @@ pub struct CreateSelectMenu {
 }
 
 impl CreateSelectMenu {
-    // Creates a builder with given custom id (a developer-defined identifier), and a list of
-    // options, leaving all other fields empty.
+    /// Creates a builder with given custom id (a developer-defined identifier), and a list of
+    /// options, leaving all other fields empty.
     pub fn new(custom_id: impl Into<String>, options: Vec<CreateSelectMenuOption>) -> Self {
         Self {
             custom_id: custom_id.into(),

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -437,7 +437,7 @@ pub struct CreateEmbedFooter {
 }
 
 impl CreateEmbedFooter {
-    // Creates a new footer object with the given text, leaving all other fields empty.
+    /// Creates a new footer object with the given text, leaving all other fields empty.
     pub fn new(text: impl Into<String>) -> Self {
         Self {
             text: text.into(),

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -62,7 +62,7 @@ pub struct CreateMessage<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
 
-    // The following fields are handled seperately.
+    // The following fields are handled separately.
     #[serde(skip)]
     files: Vec<AttachmentType<'a>>,
     #[serde(skip)]
@@ -221,7 +221,7 @@ impl<'a> CreateMessage<'a> {
 
     /// Appends a file to the message.
     ///
-    /// **Note**: Requres the [Attach Files] permission.
+    /// **Note**: Requires the [Attach Files] permission.
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
     pub fn add_file<T: Into<AttachmentType<'a>>>(mut self, file: T) -> Self {
@@ -231,7 +231,7 @@ impl<'a> CreateMessage<'a> {
 
     /// Appends a list of files to the message.
     ///
-    /// **Note**: Requres the [Attach Files] permission.
+    /// **Note**: Requires the [Attach Files] permission.
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
     pub fn add_files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
@@ -247,7 +247,7 @@ impl<'a> CreateMessage<'a> {
     /// Calling this multiple times will overwrite the file list. To append files, call
     /// [`Self::add_file`] or [`Self::add_files`] instead.
     ///
-    /// **Note**: Requres the [Attach Files] permission.
+    /// **Note**: Requires the [Attach Files] permission.
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
     pub fn files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -86,7 +86,7 @@ impl<'a> CreateSticker<'a> {
         self
     }
 
-    /// The Discord name of a unicode emoji representing the sticker's expression. Replaces teh
+    /// The Discord name of a unicode emoji representing the sticker's expression. Replaces the
     /// current value as set in [`Self::new`].
     ///
     /// **Note**: Must be between 2 and 200 characters long.

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -18,7 +18,7 @@ impl FilterTrait<Event> for Filter<Event> {
 
     /// Checks if the `event` passes set constraints.
     /// Constraints are optional, as it is possible to limit events to
-    /// be sent by a specific user or in a specifc guild.
+    /// be sent by a specific user or in a specific guild.
     fn is_passing_constraints(&self, event: &mut LazyArc<'_, Event>) -> bool {
         fn empty_or_any<T, F>(slice: &[T], f: F) -> bool
         where

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1057,7 +1057,7 @@ impl GuildChannel {
         }
     }
 
-    /// Returns a builder which can be awaited to obtain a mesage or stream of messages sent in this guild channel.
+    /// Returns a builder which can be awaited to obtain a message or stream of messages sent in this guild channel.
     #[cfg(feature = "collector")]
     pub fn reply_collector<'a>(
         &self,


### PR DESCRIPTION
Some of the docstrings added in #2087 only had 2 slashes, not 3. I blame treesitter (the rust parser highlights docstrings no different from comments, as compared to `rust.vim` which does).

I also ran `codespell` and fixed some typos.