### PR TITLE
Fix e15 compilation by pinning `notify` to 5.0.0-pre.14

### DIFF
--- a/examples/e15_simple_dashboard/Cargo.toml
+++ b/examples/e15_simple_dashboard/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 rillrate = "0.41"
+notify = "=5.0.0-pre.14"
 
 tracing = "0.1"
 tracing-subscriber = "0.2"


### PR DESCRIPTION
The `5.0.0-pre.16` release changed a method signature and broke `rate-config` (as part of `rillrate`), which in turn broke e15. Also, the `5.0.0-pre.15` release bumped the MSRV to 1.56, which I decided to avoid as well (considering our own MSRV is 1.53, though it's a question of whether that applies to examples or not).