### PR TITLE
Fix `BucketBuilder::delay_action` being poorly documented

### DIFF
--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -520,7 +520,6 @@ impl BucketBuilder {
     /// #     Ok(())
     /// # }
     /// ```
-    /// You can use this to for example send a custom response when someone exceeds the amount of commands they're allowed to make.
     #[inline]
     pub fn delay_action(&mut self, action: DelayHook) -> &mut Self {
         self.delay_action = Some(action);

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -476,20 +476,24 @@ impl BucketBuilder {
     /// # Examples
     ///
     /// ```rust
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::framework::standard::macros::{command, group};
     /// use serenity::framework::standard::{CommandResult, StandardFramework};
     /// use serenity::model::channel::Message;
     /// use serenity::prelude::*;
+    ///
     /// #[command]
-    /// #[bucket="example_bucket"]
+    /// #[bucket = "example_bucket"]
     /// async fn example_command(ctx: &Context, msg: &Message) -> CommandResult {
-    ///     msg.reply(ctx,"Example message, You can only repeat this once every 10 seconds").await?;
+    ///     msg.reply(ctx, "Example message, You can only repeat this once every 10 seconds").await?;
     ///
     ///     Ok(())
     /// }
+    ///
     /// async fn example_overuse_response(ctx: &Context, msg: &Message) {
-    ///     msg.reply(ctx,"I told you that you can't call this command less than every 10 seconds").await?;
+    ///     msg.reply(ctx, "I told you that you can't call this command less than every 10 seconds!").await?;
     /// }
+    ///
     /// #[group]
     /// #[commands(example_command)]
     /// struct General;
@@ -498,24 +502,23 @@ impl BucketBuilder {
     ///
     /// let framework = StandardFramework::new()
     ///     .configure(|c| c.prefix("~"))
-    ///     //we initialise the bucket with the closure
-    ///     .bucket("example_bucket", |b|b.delay_action(|msg,ctx| {
-    ///     //we return a future for the function we want to run
-    ///         Box::pin(example_overuse_response(ctx,msg))
+    ///     .bucket("example_bucket", |b| {
+    ///         // We initialise the bucket with the function we want to run
+    ///         b.delay_action(|msg, ctx| {
+    ///             Box::pin(example_overuse_response(ctx,msg))
+    ///         })
     ///     })
-    ///         //we set the delay to 10 seconds
-    ///         .delay(10)
-    ///         //we override the default behavior so that the function actually gets ran
-    ///         .await_ratelimits(1)
-    ///     //we await the return of the bucket
-    ///     ).await
+    ///     .delay(10) // We set the delay to 10 seconds
+    ///     .await_ratelimits(1)).await // We override the default behavior so that the function actually gets run
     ///     .group(&GENERAL_GROUP);
     ///
     /// let mut client = Client::builder(&token, GatewayIntents::default())
     /// .framework(framework)
     /// .await?;
     ///
-    /// //presumably you'd then start the client
+    /// client.start().await?;
+    /// #     Ok(())
+    /// # }
     /// ```
     /// You can use this to for example send a custom response when someone exceeds the amount of commands they're allowed to make.
     #[inline]

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -470,8 +470,10 @@ impl BucketBuilder {
     }
 
     /// This function is called when a user's command invocation is delayed when:
-    /// 1. await_ratelimits is set to a non zero value (the default is 0).
-    /// 2. user's message rests comfortably within await_ratelimits (ex. if you set it to 1 then it will only respond once when the delay is first exceeded).
+    /// 1. `await_ratelimits` is set to a non zero value (the default is 0).
+    /// 2. user's message rests comfortably within `await_ratelimits` (ex. if you set it to 1 then it will only respond once when the delay is first exceeded).
+    ///
+    /// You can use this to, for example, send a custom response when someone exceeds the amount of commands they're allowed to make.
     ///
     /// # Examples
     ///

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -493,7 +493,7 @@ impl BucketBuilder {
     /// }
     ///
     /// async fn example_overuse_response(ctx: &Context, msg: &Message) {
-    ///     msg.reply(ctx, "I told you that you can't call this command less than every 10 seconds!").await?;
+    ///     msg.reply(ctx, "I told you that you can't call this command less than every 10 seconds!").await.unwrap();
     /// }
     ///
     /// #[group]

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -507,11 +507,12 @@ impl BucketBuilder {
     ///     .bucket("example_bucket", |b| {
     ///         // We initialise the bucket with the function we want to run
     ///         b.delay_action(|msg, ctx| {
-    ///             Box::pin(example_overuse_response(ctx,msg))
+    ///             Box::pin(example_overuse_response(ctx, msg))
     ///         })
+    ///         .delay(10) // We set the delay to 10 seconds
+    ///         .await_ratelimits(1) // We override the default behavior so that the function actually gets run
     ///     })
-    ///     .delay(10) // We set the delay to 10 seconds
-    ///     .await_ratelimits(1)).await // We override the default behavior so that the function actually gets run
+    ///     .await
     ///     .group(&GENERAL_GROUP);
     ///
     /// let mut client = Client::builder(&token, GatewayIntents::default())

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -469,55 +469,53 @@ impl BucketBuilder {
         self
     }
 
-    /**
-    This function is called when a user's command invocation is delayed when:
-    1. await_ratelimits is set to a non zero value (the default is 0).
-    2. user's message rests comfortably within await_ratelimits (ex. if you set it to 1 then it will only respond once when the delay is first exceeded).
-    Example:
-    ```rust
-    use serenity::framework::standard::macros::{command, group};
-    use serenity::framework::standard::{CommandResult, StandardFramework};
-    use serenity::model::channel::Message;
-    use serenity::prelude::*;
-    #[command]
-    #[bucket="example_bucket"]
-    async fn example_command(ctx: &Context, msg: &Message) -> CommandResult {
-        msg.reply(ctx,"Example message, You can only repeat this once every 10 seconds").await?;
-
-        Ok(())
-    }
-    async fn example_overuse_response(ctx: &Context, msg: &Message) {
-        msg.reply(ctx,"I told you that you can't call this command less than every 10 seconds").await?;
-    }
-    #[group]
-    #[commands(example_command)]
-    struct General;
-
-    let token = std::env::var("DISCORD_TOKEN")?;
-
-    let framework = StandardFramework::new()
-        .configure(|c| c.prefix("~"))
-        //we initialise the bucket with the closure
-        .bucket("example_bucket", |b|b.delay_action(|msg,ctx| {
-            //we return a future for the function we want to run
-            Box::pin(example_overuse_response(ctx,msg))
-        })
-            //we set the delay to 10 seconds
-            .delay(10)
-            //we override the default behavior so that the function actually gets ran
-            .await_ratelimits(1)
-        //we await the return of the bucket
-        ).await
-        .group(&GENERAL_GROUP);
-    
-    let mut client = Client::builder(&token, GatewayIntents::default())
-    .framework(framework)
-    .await?;
-
-    //presumably you'd then start the client
-    ```
-    You can use this to for example send a custom response when someone exceeds the amount of commands they're allowed to make.
-    */
+    /// This function is called when a user's command invocation is delayed when:
+    /// 1. await_ratelimits is set to a non zero value (the default is 0).
+    /// 2. user's message rests comfortably within await_ratelimits (ex. if you set it to 1 then it will only respond once when the delay is first exceeded).
+    /// Example:
+    /// ```rust
+    /// use serenity::framework::standard::macros::{command, group};
+    /// use serenity::framework::standard::{CommandResult, StandardFramework};
+    /// use serenity::model::channel::Message;
+    /// use serenity::prelude::*;
+    /// #[command]
+    /// #[bucket="example_bucket"]
+    /// async fn example_command(ctx: &Context, msg: &Message) -> CommandResult {
+    ///     msg.reply(ctx,"Example message, You can only repeat this once every 10 seconds").await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// async fn example_overuse_response(ctx: &Context, msg: &Message) {
+    ///     msg.reply(ctx,"I told you that you can't call this command less than every 10 seconds").await?;
+    /// }
+    /// #[group]
+    /// #[commands(example_command)]
+    /// struct General;
+    ///
+    /// let token = std::env::var("DISCORD_TOKEN")?;
+    ///
+    /// let framework = StandardFramework::new()
+    ///     .configure(|c| c.prefix("~"))
+    ///     //we initialise the bucket with the closure
+    ///     .bucket("example_bucket", |b|b.delay_action(|msg,ctx| {
+    ///     //we return a future for the function we want to run
+    ///         Box::pin(example_overuse_response(ctx,msg))
+    ///     })
+    ///         //we set the delay to 10 seconds
+    ///         .delay(10)
+    ///         //we override the default behavior so that the function actually gets ran
+    ///         .await_ratelimits(1)
+    ///     //we await the return of the bucket
+    ///     ).await
+    ///     .group(&GENERAL_GROUP);
+    ///
+    /// let mut client = Client::builder(&token, GatewayIntents::default())
+    /// .framework(framework)
+    /// .await?;
+    ///
+    /// //presumably you'd then start the client
+    /// ```
+    /// You can use this to for example send a custom response when someone exceeds the amount of commands they're allowed to make.
     #[inline]
     pub fn delay_action(&mut self, action: DelayHook) -> &mut Self {
         self.delay_action = Some(action);

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -506,7 +506,7 @@ impl BucketBuilder {
     ///     .configure(|c| c.prefix("~"))
     ///     .bucket("example_bucket", |b| {
     ///         // We initialise the bucket with the function we want to run
-    ///         b.delay_action(|msg, ctx| {
+    ///         b.delay_action(|ctx, msg| {
     ///             Box::pin(example_overuse_response(ctx, msg))
     ///         })
     ///         .delay(10) // We set the delay to 10 seconds

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -472,7 +472,9 @@ impl BucketBuilder {
     /// This function is called when a user's command invocation is delayed when:
     /// 1. await_ratelimits is set to a non zero value (the default is 0).
     /// 2. user's message rests comfortably within await_ratelimits (ex. if you set it to 1 then it will only respond once when the delay is first exceeded).
-    /// Example:
+    ///
+    /// # Examples
+    ///
     /// ```rust
     /// use serenity::framework::standard::macros::{command, group};
     /// use serenity::framework::standard::{CommandResult, StandardFramework};

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -486,7 +486,7 @@ impl BucketBuilder {
 
         Ok(())
     }
-    async fn example_overuse_response(ctx: &Context, msg: &Message) -> CommandResult {
+    async fn example_overuse_response(ctx: &Context, msg: &Message) {
         msg.reply(ctx,"I told you that you can't call this command less than every 10 seconds").await?;
     }
     #[group]


### PR DESCRIPTION
fixes #2099 

This pull request adds better documentation of the usage of delay_action by adding an example along with more clear documentation.