### PR TITLE
Use fallback endpoints in `Webhook::{edit,delete}` if no token is set

### DIFF
--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -21,7 +21,7 @@ impl EditWebhook {
         Self::default()
     }
 
-    /// Edits the webhook corresponding to the provided Id and token, and returns the resulting ne
+    /// Edits the webhook corresponding to the provided Id and token, and returns the resulting new
     /// [`Webhook`].
     ///
     /// # Errors
@@ -34,9 +34,13 @@ impl EditWebhook {
         self,
         http: impl AsRef<Http>,
         webhook_id: WebhookId,
-        token: &str,
+        token: Option<&str>,
     ) -> Result<Webhook> {
-        http.as_ref().edit_webhook_with_token(webhook_id.into(), token, &self).await
+        let id = webhook_id.into();
+        match token {
+            Some(token) => http.as_ref().edit_webhook_with_token(id, token, &self, None).await,
+            None => http.as_ref().edit_webhook(id, &self, None).await,
+        }
     }
 
     /// Set the webhook's name.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2072,15 +2072,12 @@ impl Http {
     ///
     /// The Value is a map with optional values of:
     ///
-    /// - **avatar**: base64-encoded 128x128 image for the webhook's default avatar
-    ///   (_optional_);
-    /// - **name**: the name of the webhook, limited to between 2 and 100 characters
-    ///   long.
+    /// - **avatar**: base64-encoded 128x128 image for the webhook's default avatar (_optional_);
+    /// - **name**: the name of the webhook, limited to between 2 and 100 characters long.
     ///
     /// Note that, unlike with [`Self::create_webhook`], _all_ values are optional.
     ///
-    /// This method requires authentication, whereas [`Self::edit_webhook_with_token`]
-    /// does not.
+    /// This method requires authentication, whereas [`Self::edit_webhook_with_token`] does not.
     ///
     /// # Examples
     ///
@@ -2105,7 +2102,7 @@ impl Http {
     pub async fn edit_webhook(
         &self,
         webhook_id: u64,
-        map: &Value,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Webhook> {
         self.fire(Request {
@@ -2149,13 +2146,14 @@ impl Http {
         webhook_id: u64,
         token: &str,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<Webhook> {
         let body = to_vec(map)?;
 
         self.fire(Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditWebhookWithToken {
                 token,
                 webhook_id,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2137,7 +2137,7 @@ impl Http {
     /// let value = json!({"name": "new name"});
     /// let map = value.as_object().unwrap();
     ///
-    /// let edited = http.edit_webhook_with_token(id, token, map).await?;
+    /// let edited = http.edit_webhook_with_token(id, token, map, None).await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -165,7 +165,7 @@ impl Webhook {
 
     /// Retrieves a webhook given its url.
     ///
-    /// This method does _not_ require authentication
+    /// This method does _not_ require authentication.
     ///
     /// # Examples
     ///
@@ -194,25 +194,25 @@ impl Webhook {
 
     /// Deletes the webhook.
     ///
-    /// As this calls the [`Http::delete_webhook_with_token`] function,
-    /// authentication is not required.
+    /// If [`Self::token`] is set, then authentication is _not_ required. Otherwise, if it is
+    /// [`None`], then authentication _is_ required.
     ///
     /// # Errors
     ///
-    /// Returns an [`Error::Model`] if the [`Self::token`] is [`None`].
-    ///
-    /// May also return an [`Error::Http`] if the webhook does not exist,
-    /// the token is invalid, or if the webhook could not otherwise
-    /// be deleted.
+    /// Returns [`Error::Http`] if the webhook does not exist, the token is invalid, or if the
+    /// webhook could not otherwise be deleted.
     #[inline]
     pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
-        let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
-        http.as_ref().delete_webhook_with_token(self.id.get(), token).await
+        match self.token.as_deref() {
+            Some(token) => http.as_ref().delete_webhook_with_token(self.id.get(), token).await,
+            None => http.as_ref().delete_webhook(self.id.get()).await,
+        }
     }
 
     /// Edits the webhook.
     ///
-    /// Does not require authentication, as a token is required.
+    /// If [`Self::token`] is set, then authentication is _not_ required. Otherwise, if it is
+    /// [`None`], then authentication _is_ required.
     ///
     /// # Examples
     ///
@@ -240,8 +240,7 @@ impl Webhook {
     ///
     /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
     pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditWebhook) -> Result<()> {
-        let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
-        *self = builder.execute(http, self.id, token).await?;
+        *self = builder.execute(http, self.id, self.token.as_deref()).await?;
         Ok(())
     }
 


### PR DESCRIPTION
If the `Webhook::token` field is `None` when these functions are called, attempt to use the alternate authenticated endpoint instead of erroring. Also, add audit_log_reason parameter to `Http::edit_webhook_with_token` to bring it in line with the authenticated endpoint (see the [Discord docs](https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token)). 