### PR TITLE
Add missing audit log reason support to Http and relevant builders

### DIFF
--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -67,7 +67,7 @@ use crate::model::prelude::*;
 /// ```
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct CreateInvite {
+pub struct CreateInvite<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     max_age: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -82,9 +82,12 @@ pub struct CreateInvite {
     target_user_id: Option<UserId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_application_id: Option<ApplicationId>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl CreateInvite {
+impl<'a> CreateInvite<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -125,7 +128,7 @@ impl CreateInvite {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, channel_id: ChannelId) -> Result<RichInvite> {
-        http.create_invite(channel_id.into(), &self, None).await
+        http.create_invite(channel_id.into(), &self, self.audit_log_reason).await
     }
 
     /// The duration that the invite will be valid for.
@@ -288,6 +291,12 @@ impl CreateInvite {
     /// chess: `832012774040141894`
     pub fn target_application_id(mut self, target_application_id: ApplicationId) -> Self {
         self.target_application_id = Some(target_application_id);
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/create_stage_instance.rs
+++ b/src/builder/create_stage_instance.rs
@@ -7,17 +7,21 @@ use crate::model::prelude::*;
 /// Builder for creating a [`StageInstance`].
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
-pub struct CreateStageInstance {
+pub struct CreateStageInstance<'a> {
     channel_id: ChannelId,
     topic: String,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl CreateStageInstance {
+impl<'a> CreateStageInstance<'a> {
     /// Creates a builder with the provided Channel Id and topic.
     pub fn new(channel_id: impl Into<ChannelId>, topic: impl Into<String>) -> Self {
         Self {
             channel_id: channel_id.into(),
             topic: topic.into(),
+            audit_log_reason: None,
         }
     }
 
@@ -47,7 +51,7 @@ impl CreateStageInstance {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http) -> Result<StageInstance> {
-        http.create_stage_instance(&self).await
+        http.create_stage_instance(&self, self.audit_log_reason).await
     }
 
     /// Sets the stage channel id of the stage channel instance, replacing the current value as set
@@ -61,6 +65,12 @@ impl CreateStageInstance {
     /// [`Self::new`].
     pub fn topic(mut self, topic: impl Into<String>) -> Self {
         self.topic = topic.into();
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -18,6 +18,7 @@ pub struct CreateSticker<'a> {
     tags: String,
     description: String,
     file: AttachmentType<'a>,
+    audit_log_reason: Option<&'a str>,
 }
 
 impl<'a> CreateSticker<'a> {
@@ -33,6 +34,7 @@ impl<'a> CreateSticker<'a> {
             tags: tags.into(),
             description: description.into(),
             file: file.into(),
+            audit_log_reason: None,
         }
     }
 
@@ -67,7 +69,7 @@ impl<'a> CreateSticker<'a> {
         map.push(("tags".to_string(), self.tags));
         map.push(("description".to_string(), self.description));
 
-        http.create_sticker(guild_id.into(), map, self.file, None).await
+        http.create_sticker(guild_id.into(), map, self.file, self.audit_log_reason).await
     }
 
     /// Set the name of the sticker, replacing the current value as set in [`Self::new`].
@@ -100,6 +102,12 @@ impl<'a> CreateSticker<'a> {
     /// **Note**: Must be a PNG, APNG, or Lottie JSON file, max 500 KB.
     pub fn file(mut self, file: impl Into<AttachmentType<'a>>) -> Self {
         self.file = file.into();
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -27,7 +27,7 @@ use crate::model::prelude::*;
 /// ```
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditChannel {
+pub struct EditChannel<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     bitrate: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -50,9 +50,12 @@ pub struct EditChannel {
     rate_limit_per_user: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     permission_overwrites: Option<Vec<PermissionOverwriteData>>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl EditChannel {
+impl<'a> EditChannel<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -102,7 +105,7 @@ impl EditChannel {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, channel_id: ChannelId) -> Result<GuildChannel> {
-        http.edit_channel(channel_id.into(), &self, None).await
+        http.edit_channel(channel_id.into(), &self, self.audit_log_reason).await
     }
 
     /// The bitrate of the channel in bits.
@@ -246,6 +249,12 @@ impl EditChannel {
         let overwrites = perms.into_iter().map(Into::into).collect::<Vec<_>>();
 
         self.permission_overwrites = Some(overwrites);
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -7,7 +7,7 @@ use crate::model::prelude::*;
 /// A builder to optionally edit certain fields of a [`Guild`].
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditGuild {
+pub struct EditGuild<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_channel_id: Option<Option<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -44,9 +44,12 @@ pub struct EditGuild {
     verification_level: Option<VerificationLevel>,
     #[serde(skip_serializing_if = "Option::is_none")]
     system_channel_flags: Option<SystemChannelFlags>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl EditGuild {
+impl<'a> EditGuild<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -77,7 +80,7 @@ impl EditGuild {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, guild_id: GuildId) -> Result<PartialGuild> {
-        http.as_ref().edit_guild(guild_id.into(), &self, None).await
+        http.as_ref().edit_guild(guild_id.into(), &self, self.audit_log_reason).await
     }
 
     /// Set the "AFK voice channel" that users are to move to if they have been AFK for an amount
@@ -318,6 +321,12 @@ impl EditGuild {
     /// ```
     pub fn system_channel_flags(mut self, system_channel_flags: SystemChannelFlags) -> Self {
         self.system_channel_flags = Some(system_channel_flags);
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -9,16 +9,19 @@ use crate::model::prelude::*;
 /// [`GuildWelcomeScreen`]: crate::model::guild::GuildWelcomeScreen
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditGuildWelcomeScreen {
+pub struct EditGuildWelcomeScreen<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     welcome_channels: Vec<CreateGuildWelcomeChannel>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl EditGuildWelcomeScreen {
+impl<'a> EditGuildWelcomeScreen<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -39,7 +42,7 @@ impl EditGuildWelcomeScreen {
         http: impl AsRef<Http>,
         guild_id: GuildId,
     ) -> Result<GuildWelcomeScreen> {
-        http.as_ref().edit_guild_welcome_screen(guild_id.into(), &self).await
+        http.as_ref().edit_guild_welcome_screen(guild_id.into(), &self, self.audit_log_reason).await
     }
 
     /// Whether the welcome screen is enabled or not.
@@ -61,6 +64,12 @@ impl EditGuildWelcomeScreen {
 
     pub fn set_welcome_channels(mut self, channels: Vec<CreateGuildWelcomeChannel>) -> Self {
         self.welcome_channels = channels;
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -9,14 +9,17 @@ use crate::model::prelude::*;
 /// [`GuildWidget`]: crate::model::guild::GuildWidget
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditGuildWidget {
+pub struct EditGuildWidget<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<ChannelId>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl EditGuildWidget {
+impl<'a> EditGuildWidget<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -33,7 +36,7 @@ impl EditGuildWidget {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[cfg(feature = "http")]
     pub async fn execute(self, http: impl AsRef<Http>, guild_id: GuildId) -> Result<GuildWidget> {
-        http.as_ref().edit_guild_widget(guild_id.into(), &self).await
+        http.as_ref().edit_guild_widget(guild_id.into(), &self, self.audit_log_reason).await
     }
 
     /// Whether the widget is enabled or not.
@@ -45,6 +48,12 @@ impl EditGuildWidget {
     /// The server description shown in the welcome screen.
     pub fn channel_id(mut self, id: impl Into<ChannelId>) -> Self {
         self.channel_id = Some(id.into());
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 /// [`Member::edit`].
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditMember {
+pub struct EditMember<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     deaf: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -21,9 +21,12 @@ pub struct EditMember {
     channel_id: Option<Option<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     communication_disabled_until: Option<Option<String>>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl EditMember {
+impl<'a> EditMember<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -43,7 +46,9 @@ impl EditMember {
         guild_id: GuildId,
         user_id: UserId,
     ) -> Result<Member> {
-        http.as_ref().edit_member(guild_id.into(), user_id.into(), &self, None).await
+        http.as_ref()
+            .edit_member(guild_id.into(), user_id.into(), &self, self.audit_log_reason)
+            .await
     }
 
     /// Whether to deafen the member.
@@ -141,6 +146,12 @@ impl EditMember {
     #[doc(alias = "timeout")]
     pub fn enable_communication(mut self) -> Self {
         self.communication_disabled_until = Some(None);
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -8,12 +8,15 @@ use crate::model::prelude::*;
 /// Edits a [`StageInstance`].
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditStageInstance {
+pub struct EditStageInstance<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     topic: Option<String>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl EditStageInstance {
+impl<'a> EditStageInstance<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -50,12 +53,18 @@ impl EditStageInstance {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, channel_id: ChannelId) -> Result<StageInstance> {
-        http.edit_stage_instance(channel_id.into(), &self).await
+        http.edit_stage_instance(channel_id.into(), &self, self.audit_log_reason).await
     }
 
     /// Sets the topic of the stage channel instance.
     pub fn topic(mut self, topic: impl Into<String>) -> Self {
         self.topic = Some(topic.into());
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/edit_sticker.rs
+++ b/src/builder/edit_sticker.rs
@@ -21,16 +21,19 @@ use crate::model::prelude::*;
 /// [`Sticker::edit`]: crate::model::sticker::Sticker::edit
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditSticker {
+pub struct EditSticker<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tags: Option<String>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl EditSticker {
+impl<'a> EditSticker<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -52,7 +55,9 @@ impl EditSticker {
         guild_id: GuildId,
         sticker_id: StickerId,
     ) -> Result<Sticker> {
-        http.as_ref().edit_sticker(guild_id.into(), sticker_id.into(), &self, None).await
+        http.as_ref()
+            .edit_sticker(guild_id.into(), sticker_id.into(), &self, self.audit_log_reason)
+            .await
     }
 
     /// The name of the sticker to set.
@@ -76,6 +81,12 @@ impl EditSticker {
     /// **Note**: Must be between 2 and 200 characters long.
     pub fn tags(mut self, tags: impl Into<String>) -> Self {
         self.tags = Some(tags.into());
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -7,7 +7,7 @@ use crate::model::prelude::*;
 
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditThread {
+pub struct EditThread<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18,9 +18,12 @@ pub struct EditThread {
     locked: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     invitable: Option<bool>,
+
+    #[serde(skip)]
+    audit_log_reason: Option<&'a str>,
 }
 
-impl EditThread {
+impl<'a> EditThread<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -37,7 +40,7 @@ impl EditThread {
         http: impl AsRef<Http>,
         channel_id: ChannelId,
     ) -> Result<GuildChannel> {
-        http.as_ref().edit_thread(channel_id.into(), &self).await
+        http.as_ref().edit_thread(channel_id.into(), &self, self.audit_log_reason).await
     }
 
     /// The name of the thread.
@@ -76,6 +79,12 @@ impl EditThread {
     /// **Note**: Only available on private threads.
     pub fn invitable(mut self, invitable: bool) -> Self {
         self.invitable = Some(invitable);
+        self
+    }
+
+    /// Sets the request's audit log reason.
+    pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
+        self.audit_log_reason = Some(reason);
         self
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -396,11 +396,12 @@ impl Http {
     pub async fn create_stage_instance(
         &self,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<StageInstance> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateStageInstance,
         })
         .await
@@ -413,13 +414,14 @@ impl Http {
         channel_id: u64,
         message_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<GuildChannel> {
         let body = to_vec(map)?;
 
         self.fire(Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreatePublicThread {
                 channel_id,
                 message_id,
@@ -433,13 +435,14 @@ impl Http {
         &self,
         channel_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<GuildChannel> {
         let body = to_vec(map)?;
 
         self.fire(Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreatePrivateThread {
                 channel_id,
             },
@@ -1351,11 +1354,12 @@ impl Http {
         &self,
         channel_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<StageInstance> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditStageInstance {
                 channel_id,
             },
@@ -1601,13 +1605,14 @@ impl Http {
         &self,
         guild_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<GuildWidget> {
         let body = to_vec(map)?;
 
         self.fire(Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditGuildWidget {
                 guild_id,
             },
@@ -1620,13 +1625,14 @@ impl Http {
         &self,
         guild_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<GuildWelcomeScreen> {
         let body = to_vec(map)?;
 
         self.fire(Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditGuildWelcomeScreen {
                 guild_id,
             },
@@ -1958,11 +1964,12 @@ impl Http {
         &self,
         channel_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<GuildChannel> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditThread {
                 channel_id,
             },
@@ -2435,13 +2442,14 @@ impl Http {
         &self,
         guild_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<Rule> {
         let body = to_vec(map)?;
 
         self.fire(Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateAutoModRule {
                 guild_id,
             },
@@ -2457,13 +2465,14 @@ impl Http {
         guild_id: u64,
         rule_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<Rule> {
         let body = to_vec(map)?;
 
         self.fire(Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditAutoModRule {
                 guild_id,
                 rule_id,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -762,13 +762,14 @@ impl Http {
         channel_id: u64,
         target_id: u64,
         map: &impl serde::Serialize,
+        audit_log_reason: Option<&str>,
     ) -> Result<()> {
         let body = to_vec(map)?;
 
         self.wind(204, Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreatePermission {
                 channel_id,
                 target_id,
@@ -940,11 +941,15 @@ impl Http {
     }
 
     /// Deletes a private channel or a channel in a guild.
-    pub async fn delete_channel(&self, channel_id: u64) -> Result<Channel> {
+    pub async fn delete_channel(
+        &self,
+        channel_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<Channel> {
         self.fire(Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteChannel {
                 channel_id,
             },
@@ -953,11 +958,15 @@ impl Http {
     }
 
     /// Deletes a stage instance.
-    pub async fn delete_stage_instance(&self, channel_id: u64) -> Result<()> {
+    pub async fn delete_stage_instance(
+        &self,
+        channel_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteStageInstance {
                 channel_id,
             },
@@ -966,11 +975,16 @@ impl Http {
     }
 
     /// Deletes an emoji from a server.
-    pub async fn delete_emoji(&self, guild_id: u64, emoji_id: u64) -> Result<()> {
+    pub async fn delete_emoji(
+        &self,
+        guild_id: u64,
+        emoji_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteEmoji {
                 guild_id,
                 emoji_id,
@@ -1045,11 +1059,16 @@ impl Http {
     }
 
     /// Removes an integration from a guild.
-    pub async fn delete_guild_integration(&self, guild_id: u64, integration_id: u64) -> Result<()> {
+    pub async fn delete_guild_integration(
+        &self,
+        guild_id: u64,
+        integration_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteGuildIntegration {
                 guild_id,
                 integration_id,
@@ -1059,11 +1078,15 @@ impl Http {
     }
 
     /// Deletes an invite by code.
-    pub async fn delete_invite(&self, code: &str) -> Result<Invite> {
+    pub async fn delete_invite(
+        &self,
+        code: &str,
+        audit_log_reason: Option<&str>,
+    ) -> Result<Invite> {
         self.fire(Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteInvite {
                 code,
             },
@@ -1071,13 +1094,17 @@ impl Http {
         .await
     }
 
-    /// Deletes a message if created by us or we have
-    /// specific permissions.
-    pub async fn delete_message(&self, channel_id: u64, message_id: u64) -> Result<()> {
+    /// Deletes a message if created by us or we have specific permissions.
+    pub async fn delete_message(
+        &self,
+        channel_id: u64,
+        message_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteMessage {
                 channel_id,
                 message_id,
@@ -1087,11 +1114,16 @@ impl Http {
     }
 
     /// Deletes a bunch of messages, only works for bots.
-    pub async fn delete_messages(&self, channel_id: u64, map: &Value) -> Result<()> {
+    pub async fn delete_messages(
+        &self,
+        channel_id: u64,
+        map: &Value,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: Some(to_vec(map)?),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteMessages {
                 channel_id,
             },
@@ -1168,11 +1200,16 @@ impl Http {
     }
 
     /// Deletes a permission override from a role or a member in a channel.
-    pub async fn delete_permission(&self, channel_id: u64, target_id: u64) -> Result<()> {
+    pub async fn delete_permission(
+        &self,
+        channel_id: u64,
+        target_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeletePermission {
                 channel_id,
                 target_id,
@@ -1208,11 +1245,16 @@ impl Http {
     }
 
     /// Deletes a role from a server. Can't remove the default everyone role.
-    pub async fn delete_role(&self, guild_id: u64, role_id: u64) -> Result<()> {
+    pub async fn delete_role(
+        &self,
+        guild_id: u64,
+        role_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteRole {
                 guild_id,
                 role_id,
@@ -1265,8 +1307,7 @@ impl Http {
 
     /// Deletes a [`Webhook`] given its Id.
     ///
-    /// This method requires authentication, whereas [`Self::delete_webhook_with_token`]
-    /// does not.
+    /// This method requires authentication, whereas [`Self::delete_webhook_with_token`] does not.
     ///
     /// # Examples
     ///
@@ -1276,19 +1317,23 @@ impl Http {
     /// use serenity::http::Http;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// // Due to the `delete_webhook` function requiring you to authenticate, you
-    /// // must have set the token first.
+    /// // Due to the `delete_webhook` function requiring you to authenticate, you must have set
+    /// // the token first.
     /// let http = Http::new("token");
     ///
-    /// http.delete_webhook(245037420704169985).await?;
+    /// http.delete_webhook(245037420704169985, None).await?;
     /// Ok(())
     /// # }
     /// ```
-    pub async fn delete_webhook(&self, webhook_id: u64) -> Result<()> {
+    pub async fn delete_webhook(
+        &self,
+        webhook_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteWebhook {
                 webhook_id,
             },
@@ -1312,15 +1357,20 @@ impl Http {
     /// let id = 245037420704169985;
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
-    /// http.delete_webhook_with_token(id, token).await?;
+    /// http.delete_webhook_with_token(id, token, None).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    pub async fn delete_webhook_with_token(&self, webhook_id: u64, token: &str) -> Result<()> {
+    pub async fn delete_webhook_with_token(
+        &self,
+        webhook_id: u64,
+        token: &str,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteWebhookWithToken {
                 token,
                 webhook_id,
@@ -1735,13 +1785,18 @@ impl Http {
     }
 
     /// Edits the current member for the provided [`Guild`] via its Id.
-    pub async fn edit_member_me(&self, guild_id: u64, map: &JsonMap) -> Result<Member> {
+    pub async fn edit_member_me(
+        &self,
+        guild_id: u64,
+        map: &JsonMap,
+        audit_log_reason: Option<&str>,
+    ) -> Result<Member> {
         let body = to_vec(map)?;
 
         self.fire(Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditMemberMe {
                 guild_id,
             },
@@ -1752,14 +1807,19 @@ impl Http {
     /// Edits the current user's nickname for the provided [`Guild`] via its Id.
     ///
     /// Pass [`None`] to reset the nickname.
-    pub async fn edit_nickname(&self, guild_id: u64, new_nickname: Option<&str>) -> Result<()> {
+    pub async fn edit_nickname(
+        &self,
+        guild_id: u64,
+        new_nickname: Option<&str>,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         let map = json!({ "nick": new_nickname });
         let body = to_vec(&map)?;
 
         self.wind(200, Request {
             body: Some(body),
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditMemberMe {
                 guild_id,
             },
@@ -1874,10 +1934,11 @@ impl Http {
         position: u64,
         audit_log_reason: Option<&str>,
     ) -> Result<Vec<Role>> {
-        let body = to_vec(&json!([{
+        let map = json!([{
             "id": role_id,
             "position": position,
-        }]))?;
+        }]);
+        let body = to_vec(&map)?;
 
         let mut value: Value = self
             .fire(Request {
@@ -2484,11 +2545,16 @@ impl Http {
     /// Deletes an auto moderation rule in a guild.
     ///
     /// This method requires `MANAGE_GUILD` permissions.
-    pub async fn delete_automod_rule(&self, guild_id: u64, rule_id: u64) -> Result<()> {
+    pub async fn delete_automod_rule(
+        &self,
+        guild_id: u64,
+        rule_id: u64,
+        audit_log_reason: Option<&str>,
+    ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: None,
+            headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::DeleteAutoModRule {
                 guild_id,
                 rule_id,

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -117,7 +117,11 @@ impl ChannelCategory {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditChannel) -> Result<()> {
+    pub async fn edit(
+        &mut self,
+        cache_http: impl CacheHttp,
+        builder: EditChannel<'_>,
+    ) -> Result<()> {
         let GuildChannel {
             id,
             guild_id,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -862,10 +862,10 @@ impl ChannelId {
     /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
     ///
     /// Returns [`Error::Http`] if there is already a stage instance currently.
-    pub async fn create_stage_instance(
+    pub async fn create_stage_instance<'a>(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateStageInstance,
+        builder: CreateStageInstance<'a>,
     ) -> Result<StageInstance> {
         builder.channel_id(self).execute(cache_http).await
     }
@@ -878,10 +878,10 @@ impl ChannelId {
     ///
     /// Returns [`Error::Http`] if the channel is not a stage channel, or there is no stage
     /// instance currently.
-    pub async fn edit_stage_instance(
+    pub async fn edit_stage_instance<'a>(
         self,
         cache_http: impl CacheHttp,
-        builder: EditStageInstance,
+        builder: EditStageInstance<'a>,
     ) -> Result<StageInstance> {
         builder.execute(cache_http, self).await
     }
@@ -891,10 +891,10 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn edit_thread(
+    pub async fn edit_thread<'a>(
         self,
         http: impl AsRef<Http>,
-        builder: EditThread,
+        builder: EditThread<'a>,
     ) -> Result<GuildChannel> {
         builder.execute(http, self).await
     }
@@ -914,11 +914,11 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    pub async fn create_public_thread(
+    pub async fn create_public_thread<'a>(
         self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: CreateThread,
+        builder: CreateThread<'a>,
     ) -> Result<GuildChannel> {
         builder.execute(http, self, Some(message_id.into())).await
     }
@@ -928,10 +928,10 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    pub async fn create_private_thread(
+    pub async fn create_private_thread<'a>(
         self,
         http: impl AsRef<Http>,
-        builder: CreateThread,
+        builder: CreateThread<'a>,
     ) -> Result<GuildChannel> {
         builder.kind(ChannelType::PrivateThread).execute(http, self, None).await
     }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -111,7 +111,7 @@ impl ChannelId {
         target: PermissionOverwrite,
     ) -> Result<()> {
         let data: PermissionOverwriteData = target.into();
-        http.as_ref().create_permission(self.get(), data.id.get(), &data).await
+        http.as_ref().create_permission(self.get(), data.id.get(), &data, None).await
     }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
@@ -150,7 +150,7 @@ impl ChannelId {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
     pub async fn delete(self, http: impl AsRef<Http>) -> Result<Channel> {
-        http.as_ref().delete_channel(self.get()).await
+        http.as_ref().delete_channel(self.get(), None).await
     }
 
     /// Deletes a [`Message`] given its Id.
@@ -172,7 +172,7 @@ impl ChannelId {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        http.as_ref().delete_message(self.get(), message_id.into().get()).await
+        http.as_ref().delete_message(self.get(), message_id.into().get(), None).await
     }
 
     /// Deletes all messages by Ids from the given vector in the given channel.
@@ -212,7 +212,7 @@ impl ChannelId {
         } else {
             let map = json!({ "messages": ids });
 
-            http.as_ref().delete_messages(self.get(), &map).await
+            http.as_ref().delete_messages(self.get(), &map, None).await
         }
     }
 
@@ -230,12 +230,11 @@ impl ChannelId {
         http: impl AsRef<Http>,
         permission_type: PermissionOverwriteType,
     ) -> Result<()> {
-        http.as_ref()
-            .delete_permission(self.get(), match permission_type {
-                PermissionOverwriteType::Member(id) => id.get(),
-                PermissionOverwriteType::Role(id) => id.get(),
-            })
-            .await
+        let id = match permission_type {
+            PermissionOverwriteType::Member(id) => id.get(),
+            PermissionOverwriteType::Role(id) => id.get(),
+        };
+        http.as_ref().delete_permission(self.get(), id, None).await
     }
 
     /// Deletes the given [`Reaction`] from the channel.
@@ -906,7 +905,7 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the channel is not a stage channel,
     /// or if there is no stage instance currently.
     pub async fn delete_stage_instance(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_stage_instance(self.get()).await
+        http.as_ref().delete_stage_instance(self.get(), None).await
     }
 
     /// Creates a public thread that is connected to a message.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -79,7 +79,7 @@ impl ChannelId {
     pub async fn create_invite(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateInvite,
+        builder: CreateInvite<'_>,
     ) -> Result<RichInvite> {
         builder
             .execute(
@@ -323,10 +323,10 @@ impl ChannelId {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn edit(
+    pub async fn edit<'a>(
         self,
         cache_http: impl CacheHttp,
-        builder: EditChannel,
+        builder: EditChannel<'_>,
     ) -> Result<GuildChannel> {
         builder
             .execute(
@@ -819,10 +819,10 @@ impl ChannelId {
     /// # Errors
     ///
     /// See [`CreateWebhook::execute`] for a detailed list of possible errors.
-    pub async fn create_webhook(
+    pub async fn create_webhook<'a>(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateWebhook,
+        builder: CreateWebhook<'a>,
     ) -> Result<Webhook> {
         builder.execute(cache_http, self).await
     }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -456,7 +456,11 @@ impl GuildChannel {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn edit_thread(&mut self, http: impl AsRef<Http>, builder: EditThread) -> Result<()> {
+    pub async fn edit_thread(
+        &mut self,
+        http: impl AsRef<Http>,
+        builder: EditThread<'_>,
+    ) -> Result<()> {
         *self = self.id.edit_thread(http, builder).await?;
         Ok(())
     }
@@ -1116,7 +1120,7 @@ impl GuildChannel {
     pub async fn create_stage_instance(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateStageInstance,
+        builder: CreateStageInstance<'_>,
     ) -> Result<StageInstance> {
         self.id.create_stage_instance(cache_http, builder).await
     }
@@ -1132,7 +1136,7 @@ impl GuildChannel {
     pub async fn edit_stage_instance(
         &self,
         cache_http: impl CacheHttp,
-        builder: EditStageInstance,
+        builder: EditStageInstance<'_>,
     ) -> Result<StageInstance> {
         self.id.edit_stage_instance(cache_http, builder).await
     }
@@ -1160,7 +1164,7 @@ impl GuildChannel {
         &self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: CreateThread,
+        builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
         self.id.create_public_thread(http, message_id, builder).await
     }
@@ -1173,7 +1177,7 @@ impl GuildChannel {
     pub async fn create_private_thread(
         &self,
         http: impl AsRef<Http>,
-        builder: CreateThread,
+        builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
         self.id.create_private_thread(http, builder).await
     }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -181,7 +181,7 @@ impl GuildChannel {
     pub async fn create_invite(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateInvite,
+        builder: CreateInvite<'_>,
     ) -> Result<RichInvite> {
         builder
             .execute(
@@ -411,7 +411,11 @@ impl GuildChannel {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditChannel) -> Result<()> {
+    pub async fn edit(
+        &mut self,
+        cache_http: impl CacheHttp,
+        builder: EditChannel<'_>,
+    ) -> Result<()> {
         *self = builder
             .execute(
                 cache_http,
@@ -1083,7 +1087,7 @@ impl GuildChannel {
     pub async fn create_webhook(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateWebhook,
+        builder: CreateWebhook<'_>,
     ) -> Result<Webhook> {
         self.id.create_webhook(cache_http, builder).await
     }

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -98,7 +98,7 @@ impl Emoji {
     #[inline]
     pub async fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
         let guild_id = self.try_find_guild_id(&cache_http)?;
-        cache_http.http().delete_emoji(guild_id.get(), self.id.get()).await
+        cache_http.http().delete_emoji(guild_id.get(), self.id.get(), None).await
     }
 
     /// Edits the emoji by updating it with a new name.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -69,7 +69,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
     ) -> Result<Rule> {
-        http.as_ref().get_automod_rule(self.get(), rule_id.into().0.get()).await
+        http.as_ref().get_automod_rule(self.get(), rule_id.into().get()).await
     }
 
     /// Creates an auto moderation [`Rule`] in the guild.
@@ -147,7 +147,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
     ) -> Result<()> {
-        http.as_ref().delete_automod_rule(self.get(), rule_id.into().0.get()).await
+        http.as_ref().delete_automod_rule(self.get(), rule_id.into().get(), None).await
     }
 
     /// Adds a [`User`] to this guild with a valid OAuth2 access token.
@@ -487,7 +487,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         emoji_id: impl Into<EmojiId>,
     ) -> Result<()> {
-        http.as_ref().delete_emoji(self.get(), emoji_id.into().get()).await
+        http.as_ref().delete_emoji(self.get(), emoji_id.into().get(), None).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -506,7 +506,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        http.as_ref().delete_guild_integration(self.get(), integration_id.into().get()).await
+        http.as_ref().delete_guild_integration(self.get(), integration_id.into().get(), None).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -528,7 +528,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
     ) -> Result<()> {
-        http.as_ref().delete_role(self.get(), role_id.into().get()).await
+        http.as_ref().delete_role(self.get(), role_id.into().get(), None).await
     }
 
     /// Deletes a specified scheduled event in the guild.
@@ -668,7 +668,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         new_nickname: Option<&str>,
     ) -> Result<()> {
-        http.as_ref().edit_nickname(self.get(), new_nickname).await
+        http.as_ref().edit_nickname(self.get(), new_nickname, None).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -104,10 +104,10 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
-    pub async fn create_automod_rule(
+    pub async fn create_automod_rule<'a>(
         self,
         http: impl AsRef<Http>,
-        builder: EditAutoModRule,
+        builder: EditAutoModRule<'a>,
     ) -> Result<Rule> {
         builder.execute(http, self, None).await
     }
@@ -122,11 +122,11 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
-    pub async fn edit_automod_rule(
+    pub async fn edit_automod_rule<'a>(
         self,
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
-        builder: EditAutoModRule,
+        builder: EditAutoModRule<'a>,
     ) -> Result<Rule> {
         builder.execute(http, self, Some(rule_id.into())).await
     }
@@ -803,10 +803,10 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit_welcome_screen(
+    pub async fn edit_welcome_screen<'a>(
         self,
         http: impl AsRef<Http>,
-        builder: EditGuildWelcomeScreen,
+        builder: EditGuildWelcomeScreen<'a>,
     ) -> Result<GuildWelcomeScreen> {
         builder.execute(http, self).await
     }
@@ -820,10 +820,10 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit_widget(
+    pub async fn edit_widget<'a>(
         self,
         http: impl AsRef<Http>,
-        builder: EditGuildWidget,
+        builder: EditGuildWidget<'a>,
     ) -> Result<GuildWidget> {
         builder.execute(http, self).await
     }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -333,7 +333,7 @@ impl GuildId {
     pub async fn create_channel(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateChannel,
+        builder: CreateChannel<'_>,
     ) -> Result<GuildChannel> {
         builder.execute(cache_http, self).await
     }
@@ -411,7 +411,11 @@ impl GuildId {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn create_role(self, cache_http: impl CacheHttp, builder: EditRole) -> Result<Role> {
+    pub async fn create_role<'a>(
+        self,
+        cache_http: impl CacheHttp,
+        builder: EditRole<'a>,
+    ) -> Result<Role> {
         builder.execute(cache_http, self, None).await
     }
 
@@ -425,10 +429,10 @@ impl GuildId {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn create_scheduled_event(
+    pub async fn create_scheduled_event<'a>(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateScheduledEvent,
+        builder: CreateScheduledEvent<'a>,
     ) -> Result<ScheduledEvent> {
         builder.execute(cache_http, self).await
     }
@@ -575,10 +579,10 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
-    pub async fn edit(
+    pub async fn edit<'a>(
         self,
         cache_http: impl CacheHttp,
-        builder: EditGuild,
+        builder: EditGuild<'a>,
     ) -> Result<PartialGuild> {
         builder.execute(cache_http, self).await
     }
@@ -638,11 +642,11 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     #[inline]
-    pub async fn edit_member(
+    pub async fn edit_member<'a>(
         self,
         http: impl AsRef<Http>,
         user_id: impl Into<UserId>,
-        builder: EditMember,
+        builder: EditMember<'a>,
     ) -> Result<Member> {
         builder.execute(http, self, user_id.into()).await
     }
@@ -700,11 +704,11 @@ impl GuildId {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn edit_role(
+    pub async fn edit_role<'a>(
         self,
         cache_http: impl CacheHttp,
         role_id: impl Into<RoleId>,
-        builder: EditRole,
+        builder: EditRole<'a>,
     ) -> Result<Role> {
         builder.execute(cache_http, self, Some(role_id.into())).await
     }
@@ -719,11 +723,11 @@ impl GuildId {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn edit_scheduled_event(
+    pub async fn edit_scheduled_event<'a>(
         self,
         cache_http: impl CacheHttp,
         event_id: impl Into<ScheduledEventId>,
-        builder: EditScheduledEvent,
+        builder: EditScheduledEvent<'a>,
     ) -> Result<ScheduledEvent> {
         builder.execute(cache_http, self, event_id.into()).await
     }
@@ -755,11 +759,11 @@ impl GuildId {
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    pub async fn edit_sticker(
+    pub async fn edit_sticker<'a>(
         self,
         http: impl AsRef<Http>,
         sticker_id: impl Into<StickerId>,
-        builder: EditSticker,
+        builder: EditSticker<'a>,
     ) -> Result<Sticker> {
         builder.execute(http, self, sticker_id.into()).await
     }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -261,7 +261,7 @@ impl Member {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks necessary permissions.
-    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditMember) -> Result<()> {
+    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditMember<'_>) -> Result<()> {
         *self = self.guild_id.edit_member(http, self.user.id, builder).await?;
         Ok(())
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -678,7 +678,7 @@ impl Guild {
     pub async fn create_channel(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateChannel,
+        builder: CreateChannel<'_>,
     ) -> Result<GuildChannel> {
         self.id.create_channel(cache_http, builder).await
     }
@@ -868,7 +868,11 @@ impl Guild {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn create_role(&self, cache_http: impl CacheHttp, builder: EditRole) -> Result<Role> {
+    pub async fn create_role(
+        &self,
+        cache_http: impl CacheHttp,
+        builder: EditRole<'_>,
+    ) -> Result<Role> {
         self.id.create_role(cache_http, builder).await
     }
 
@@ -885,7 +889,7 @@ impl Guild {
     pub async fn create_scheduled_event(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateScheduledEvent,
+        builder: CreateScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
         self.id.create_scheduled_event(cache_http, builder).await
     }
@@ -1062,7 +1066,7 @@ impl Guild {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditGuild) -> Result<()> {
+    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditGuild<'_>) -> Result<()> {
         let guild = self.id.edit(cache_http, builder).await?;
 
         self.afk_channel_id = guild.afk_channel_id;
@@ -1121,7 +1125,7 @@ impl Guild {
         &self,
         http: impl AsRef<Http>,
         user_id: impl Into<UserId>,
-        builder: EditMember,
+        builder: EditMember<'_>,
     ) -> Result<Member> {
         self.id.edit_member(http, user_id, builder).await
     }
@@ -1179,7 +1183,7 @@ impl Guild {
         &self,
         cache_http: impl CacheHttp,
         role_id: impl Into<RoleId>,
-        builder: EditRole,
+        builder: EditRole<'_>,
     ) -> Result<Role> {
         self.id.edit_role(cache_http, role_id, builder).await
     }
@@ -1225,7 +1229,7 @@ impl Guild {
         &self,
         cache_http: impl CacheHttp,
         event_id: impl Into<ScheduledEventId>,
-        builder: EditScheduledEvent,
+        builder: EditScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
         self.id.edit_scheduled_event(cache_http, event_id, builder).await
     }
@@ -1264,7 +1268,7 @@ impl Guild {
         &self,
         http: impl AsRef<Http>,
         sticker_id: impl Into<StickerId>,
-        builder: EditSticker,
+        builder: EditSticker<'_>,
     ) -> Result<Sticker> {
         self.id.edit_sticker(http, sticker_id, builder).await
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -308,7 +308,7 @@ impl Guild {
     pub async fn create_automod_rule(
         &self,
         http: impl AsRef<Http>,
-        builder: EditAutoModRule,
+        builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
         self.id.create_automod_rule(http, builder).await
     }
@@ -327,7 +327,7 @@ impl Guild {
         &self,
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
-        builder: EditAutoModRule,
+        builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
         self.id.edit_automod_rule(http, rule_id, builder).await
     }
@@ -1285,7 +1285,7 @@ impl Guild {
     pub async fn edit_welcome_screen(
         &self,
         http: impl AsRef<Http>,
-        builder: EditGuildWelcomeScreen,
+        builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
         self.id.edit_welcome_screen(http, builder).await
     }
@@ -1302,7 +1302,7 @@ impl Guild {
     pub async fn edit_widget(
         &self,
         http: impl AsRef<Http>,
-        builder: EditGuildWidget,
+        builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
         self.id.edit_widget(http, builder).await
     }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -200,7 +200,7 @@ impl PartialGuild {
     pub async fn create_automod_rule(
         &self,
         http: impl AsRef<Http>,
-        builder: EditAutoModRule,
+        builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
         self.id.create_automod_rule(http, builder).await
     }
@@ -219,7 +219,7 @@ impl PartialGuild {
         &self,
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
-        builder: EditAutoModRule,
+        builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
         self.id.edit_automod_rule(http, rule_id, builder).await
     }
@@ -903,7 +903,7 @@ impl PartialGuild {
     pub async fn edit_welcome_screen(
         &self,
         http: impl AsRef<Http>,
-        builder: EditGuildWelcomeScreen,
+        builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
         self.id.edit_welcome_screen(http, builder).await
     }
@@ -920,7 +920,7 @@ impl PartialGuild {
     pub async fn edit_widget(
         &self,
         http: impl AsRef<Http>,
-        builder: EditGuildWidget,
+        builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
         self.id.edit_widget(http, builder).await
     }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -399,7 +399,7 @@ impl PartialGuild {
     pub async fn create_channel(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateChannel,
+        builder: CreateChannel<'_>,
     ) -> Result<GuildChannel> {
         self.id.create_channel(cache_http, builder).await
     }
@@ -586,7 +586,11 @@ impl PartialGuild {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn create_role(&self, cache_http: impl CacheHttp, builder: EditRole) -> Result<Role> {
+    pub async fn create_role(
+        &self,
+        cache_http: impl CacheHttp,
+        builder: EditRole<'_>,
+    ) -> Result<Role> {
         self.id.create_role(cache_http, builder).await
     }
 
@@ -711,7 +715,7 @@ impl PartialGuild {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditGuild) -> Result<()> {
+    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditGuild<'_>) -> Result<()> {
         let guild = self.id.edit(cache_http, builder).await?;
 
         self.afk_channel_id = guild.afk_channel_id;
@@ -771,7 +775,7 @@ impl PartialGuild {
         &self,
         http: impl AsRef<Http>,
         user_id: impl Into<UserId>,
-        builder: EditMember,
+        builder: EditMember<'_>,
     ) -> Result<Member> {
         self.id.edit_member(http, user_id, builder).await
     }
@@ -816,7 +820,7 @@ impl PartialGuild {
         self,
         cache_http: impl CacheHttp,
         role_id: impl Into<RoleId>,
-        builder: EditRole,
+        builder: EditRole<'_>,
     ) -> Result<Role> {
         self.id.edit_role(cache_http, role_id, builder).await
     }
@@ -882,7 +886,7 @@ impl PartialGuild {
         &self,
         http: impl AsRef<Http>,
         sticker_id: impl Into<StickerId>,
-        builder: EditSticker,
+        builder: EditSticker<'_>,
     ) -> Result<Sticker> {
         self.id.edit_sticker(http, sticker_id, builder).await
     }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -130,7 +130,7 @@ impl Role {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
     pub async fn delete(&mut self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_role(self.guild_id.get(), self.id.get()).await
+        http.as_ref().delete_role(self.guild_id.get(), self.id.get(), None).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -148,7 +148,7 @@ impl Role {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditRole) -> Result<()> {
+    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditRole<'_>) -> Result<()> {
         *self = self.guild_id.edit_role(http.as_ref(), self.id, builder).await?;
         Ok(())
     }

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -106,7 +106,7 @@ impl Invite {
             }
         }
 
-        cache_http.http().as_ref().delete_invite(&self.code).await
+        cache_http.http().as_ref().delete_invite(&self.code, None).await
     }
 
     /// Gets information about an invite.
@@ -315,7 +315,6 @@ impl RichInvite {
         {
             if let Some(cache) = cache_http.cache() {
                 let guild_id = self.guild.as_ref().map(|g| g.id);
-
                 crate::utils::user_has_perms_cache(
                     cache,
                     self.channel.id,
@@ -325,7 +324,7 @@ impl RichInvite {
             }
         }
 
-        cache_http.http().as_ref().delete_invite(&self.code).await
+        cache_http.http().as_ref().delete_invite(&self.code, None).await
     }
 
     /// Returns a URL to use for the invite.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -70,10 +70,10 @@ impl Invite {
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     #[inline]
-    pub async fn create(
+    pub async fn create<'a>(
         cache_http: impl CacheHttp,
         channel_id: impl Into<ChannelId>,
-        builder: CreateInvite,
+        builder: CreateInvite<'a>,
     ) -> Result<RichInvite> {
         channel_id.into().create_invite(cache_http, builder).await
     }

--- a/src/model/sticker/mod.rs
+++ b/src/model/sticker/mod.rs
@@ -106,7 +106,7 @@ impl Sticker {
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditSticker) -> Result<()> {
+    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditSticker<'_>) -> Result<()> {
         if let Some(guild_id) = self.guild_id {
             *self = self.id.edit(http, guild_id, builder).await?;
             Ok(())

--- a/src/model/sticker/sticker_id.rs
+++ b/src/model/sticker/sticker_id.rs
@@ -46,7 +46,7 @@ impl StickerId {
         &self,
         http: impl AsRef<Http>,
         guild_id: impl Into<GuildId>,
-        builder: EditSticker,
+        builder: EditSticker<'_>,
     ) -> Result<Sticker> {
         guild_id.into().edit_sticker(http, self, builder).await
     }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -239,7 +239,7 @@ impl Webhook {
     /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
     ///
     /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditWebhook) -> Result<()> {
+    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditWebhook<'_>) -> Result<()> {
         *self = builder.execute(http, self.id, self.token.as_deref()).await?;
         Ok(())
     }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -203,9 +203,10 @@ impl Webhook {
     /// webhook could not otherwise be deleted.
     #[inline]
     pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
+        let http = http.as_ref();
         match self.token.as_deref() {
-            Some(token) => http.as_ref().delete_webhook_with_token(self.id.get(), token).await,
-            None => http.as_ref().delete_webhook(self.id.get()).await,
+            Some(token) => http.delete_webhook_with_token(self.id.get(), token, None).await,
+            None => http.delete_webhook(self.id.get(), None).await,
         }
     }
 


### PR DESCRIPTION
Adds audit log reason support to all remaining Http endpoints that support it. This PR succeeds #2021, which was opened before the builder rework. I've split this into three commits:

1. The first commit focuses on builders, and adds an `audit_log_reason: Option<&'a str>` field to builders that support the header, plus an `audit_log_reason` method. This introduces a lifetime parameter to the builder, so model methods had their signatures adjusted accordingly.
2. The second commit does more of the same, however the corresponding `Http` methods were missing an `audit_log_reason` parameter, so it was added to those as well.
3. The third commit adds an `audit_log_reason` parameter to all remaining `Http` methods that aren't called by any builder. These methods are wrapped directly by methods on model types. However, unlike #2021 I chose not to add an additional parameter to the wrapper methods to avoid excess breakage. These methods are all thin wrappers around the `Http` methods anyway, so users can opt-in to the audit log by calling the `Http` methods directly.