### PR TITLE
Change some model methods to take `&self` instead of `self`

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -572,7 +572,7 @@ impl GuildChannel {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
     pub async fn follow(
-        self,
+        &self,
         http: impl AsRef<Http>,
         target_channel_id: impl Into<ChannelId>,
     ) -> Result<FollowedChannel> {
@@ -970,7 +970,7 @@ impl GuildChannel {
     /// # }
     /// ```
     #[allow(clippy::missing_errors_doc)]
-    pub fn start_typing(self, http: &Arc<Http>) -> Result<Typing> {
+    pub fn start_typing(&self, http: &Arc<Http>) -> Result<Typing> {
         http.start_typing(self.id.get())
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -269,7 +269,7 @@ impl Guild {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
-    pub async fn automod_rules(self, http: impl AsRef<Http>) -> Result<Vec<Rule>> {
+    pub async fn automod_rules(&self, http: impl AsRef<Http>) -> Result<Vec<Rule>> {
         self.id.automod_rules(http).await
     }
 
@@ -284,7 +284,7 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn automod_rule(
-        self,
+        &self,
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
     ) -> Result<Rule> {
@@ -344,7 +344,7 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn delete_automod_rule(
-        self,
+        &self,
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
     ) -> Result<()> {
@@ -2233,7 +2233,7 @@ impl Guild {
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn scheduled_event(
-        self,
+        &self,
         http: impl AsRef<Http>,
         event_id: impl Into<ScheduledEventId>,
         with_user_count: bool,
@@ -2252,7 +2252,7 @@ impl Guild {
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn scheduled_events(
-        self,
+        &self,
         http: impl AsRef<Http>,
         with_user_count: bool,
     ) -> Result<Vec<ScheduledEvent>> {
@@ -2272,7 +2272,7 @@ impl Guild {
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn scheduled_event_users(
-        self,
+        &self,
         http: impl AsRef<Http>,
         event_id: impl Into<ScheduledEventId>,
         limit: Option<u64>,
@@ -2292,7 +2292,7 @@ impl Guild {
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn scheduled_event_users_optioned(
-        self,
+        &self,
         http: impl AsRef<Http>,
         event_id: impl Into<ScheduledEventId>,
         limit: Option<u64>,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -176,7 +176,7 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn automod_rule(
-        self,
+        &self,
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
     ) -> Result<Rule> {
@@ -236,7 +236,7 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn delete_automod_rule(
-        self,
+        &self,
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
     ) -> Result<()> {
@@ -318,7 +318,7 @@ impl PartialGuild {
     /// [View Audit Log]: Permissions::VIEW_AUDIT_LOG
     #[inline]
     pub async fn audit_logs(
-        self,
+        &self,
         http: impl AsRef<Http>,
         action_type: Option<u8>,
         user_id: Option<UserId>,
@@ -813,7 +813,7 @@ impl PartialGuild {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
     pub async fn edit_role(
-        self,
+        &self,
         cache_http: impl CacheHttp,
         role_id: impl Into<RoleId>,
         builder: EditRole,


### PR DESCRIPTION
Since the model types are not `Copy`, calling these methods before would consume the type, which seems unintended.