### PR TITLE
Remove needless borrows of `impl AsRef<Http>` and `impl CacheHttp`

### DIFF
--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -125,7 +125,7 @@ impl<'a> CreateMessage<'a> {
         };
 
         for reaction in self.reactions {
-            channel_id.create_reaction(&http, message.id, reaction).await?;
+            channel_id.create_reaction(http, message.id, reaction).await?;
         }
 
         Ok(message)

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -52,7 +52,7 @@ impl ChannelCategory {
         http: impl AsRef<Http>,
         target: PermissionOverwrite,
     ) -> Result<()> {
-        self.id.create_permission(&http, target).await
+        self.id.create_permission(http, target).await
     }
 
     /// Deletes all permission overrides in the category from the channels.
@@ -70,7 +70,7 @@ impl ChannelCategory {
         http: impl AsRef<Http>,
         permission_type: PermissionOverwriteType,
     ) -> Result<()> {
-        self.id.delete_permission(&http, permission_type).await
+        self.id.delete_permission(http, permission_type).await
     }
 
     /// Deletes this category.
@@ -84,7 +84,7 @@ impl ChannelCategory {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
     pub async fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
-        self.id.delete(&cache_http.http()).await.map(|_| ())
+        self.id.delete(cache_http.http()).await.map(|_| ())
     }
 
     /// Edits the category's settings.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -154,7 +154,7 @@ impl GuildChannel {
     /// [Send Messages]: Permissions::SEND_MESSAGES
     #[inline]
     pub async fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> {
-        self.id.broadcast_typing(&http).await
+        self.id.broadcast_typing(http).await
     }
 
     /// Creates an invite for the given channel.
@@ -283,7 +283,7 @@ impl GuildChannel {
         http: impl AsRef<Http>,
         target: PermissionOverwrite,
     ) -> Result<()> {
-        self.id.create_permission(&http, target).await
+        self.id.create_permission(http, target).await
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
@@ -311,7 +311,7 @@ impl GuildChannel {
             }
         }
 
-        self.id.delete(&cache_http.http()).await
+        self.id.delete(cache_http.http()).await
     }
 
     /// Deletes all messages by Ids from the given vector in the channel.
@@ -339,7 +339,7 @@ impl GuildChannel {
         T: AsRef<MessageId>,
         It: IntoIterator<Item = T>,
     {
-        self.id.delete_messages(&http, message_ids).await
+        self.id.delete_messages(http, message_ids).await
     }
 
     /// Deletes all permission overrides in the channel from a member
@@ -358,7 +358,7 @@ impl GuildChannel {
         http: impl AsRef<Http>,
         permission_type: PermissionOverwriteType,
     ) -> Result<()> {
-        self.id.delete_permission(&http, permission_type).await
+        self.id.delete_permission(http, permission_type).await
     }
 
     /// Deletes the given [`Reaction`] from the channel.
@@ -378,7 +378,7 @@ impl GuildChannel {
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        self.id.delete_reaction(&http, message_id, user_id, reaction_type).await
+        self.id.delete_reaction(http, message_id, user_id, reaction_type).await
     }
 
     /// Edits the channel's settings.
@@ -597,7 +597,7 @@ impl GuildChannel {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
     pub async fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
-        self.id.invites(&http).await
+        self.id.invites(http).await
     }
 
     /// Determines if the channel is NSFW.
@@ -626,7 +626,7 @@ impl GuildChannel {
         cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
     ) -> Result<Message> {
-        self.id.message(&cache_http, message_id).await
+        self.id.message(cache_http, message_id).await
     }
 
     /// Gets messages from the channel.
@@ -807,7 +807,7 @@ impl GuildChannel {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        self.id.pin(&http, message_id).await
+        self.id.pin(http, message_id).await
     }
 
     /// Gets all channel's pins.
@@ -822,7 +822,7 @@ impl GuildChannel {
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     #[inline]
     pub async fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> {
-        self.id.pins(&http).await
+        self.id.pins(http).await
     }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a
@@ -850,7 +850,7 @@ impl GuildChannel {
         limit: Option<u8>,
         after: impl Into<Option<UserId>>,
     ) -> Result<Vec<User>> {
-        self.id.reaction_users(&http, message_id, reaction_type, limit, after).await
+        self.id.reaction_users(http, message_id, reaction_type, limit, after).await
     }
 
     /// Sends a message with just the given message content in the channel.
@@ -989,7 +989,7 @@ impl GuildChannel {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        self.id.unpin(&http, message_id).await
+        self.id.unpin(http, message_id).await
     }
 
     /// Retrieves the channel's webhooks.
@@ -1003,7 +1003,7 @@ impl GuildChannel {
     /// [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
     #[inline]
     pub async fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
-        self.id.webhooks(&http).await
+        self.id.webhooks(http).await
     }
 
     /// Retrieves [`Member`]s from the current channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -217,7 +217,7 @@ impl Message {
             }
         }
 
-        self.channel_id.delete_message(&cache_http.http(), self.id).await
+        self.channel_id.delete_message(cache_http.http(), self.id).await
     }
 
     /// Deletes all of the [`Reaction`]s associated with the message.
@@ -410,7 +410,7 @@ impl Message {
         limit: Option<u8>,
         after: impl Into<Option<UserId>>,
     ) -> Result<Vec<User>> {
-        self.channel_id.reaction_users(&http, self.id, reaction_type, limit, after).await
+        self.channel_id.reaction_users(http, self.id, reaction_type, limit, after).await
     }
 
     /// Returns the associated [`Guild`] for the message if one is in the cache.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -44,7 +44,7 @@ impl PrivateChannel {
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> {
-        self.id.broadcast_typing(&http).await
+        self.id.broadcast_typing(http).await
     }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
@@ -63,7 +63,7 @@ impl PrivateChannel {
         message_id: impl Into<MessageId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        self.id.create_reaction(&http, message_id, reaction_type).await
+        self.id.create_reaction(http, message_id, reaction_type).await
     }
 
     /// Deletes the channel. This does not delete the contents of the channel,
@@ -72,7 +72,7 @@ impl PrivateChannel {
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn delete(&self, http: impl AsRef<Http>) -> Result<Channel> {
-        self.id.delete(&http).await
+        self.id.delete(http).await
     }
 
     /// Deletes all messages by Ids from the given vector in the channel.
@@ -100,7 +100,7 @@ impl PrivateChannel {
         T: AsRef<MessageId>,
         It: IntoIterator<Item = T>,
     {
-        self.id.delete_messages(&http, message_ids).await
+        self.id.delete_messages(http, message_ids).await
     }
 
     /// Deletes all permission overrides in the channel from a member
@@ -116,7 +116,7 @@ impl PrivateChannel {
         http: impl AsRef<Http>,
         permission_type: PermissionOverwriteType,
     ) -> Result<()> {
-        self.id.delete_permission(&http, permission_type).await
+        self.id.delete_permission(http, permission_type).await
     }
 
     /// Deletes the given [`Reaction`] from the channel.
@@ -136,7 +136,7 @@ impl PrivateChannel {
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        self.id.delete_reaction(&http, message_id, user_id, reaction_type).await
+        self.id.delete_reaction(http, message_id, user_id, reaction_type).await
     }
 
     /// Edits a [`Message`] in the channel given its Id.
@@ -186,7 +186,7 @@ impl PrivateChannel {
         cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
     ) -> Result<Message> {
-        self.id.message(&cache_http, message_id).await
+        self.id.message(cache_http, message_id).await
     }
 
     /// Gets messages from the channel.
@@ -237,7 +237,7 @@ impl PrivateChannel {
         limit: Option<u8>,
         after: impl Into<Option<UserId>>,
     ) -> Result<Vec<User>> {
-        self.id.reaction_users(&http, message_id, reaction_type, limit, after).await
+        self.id.reaction_users(http, message_id, reaction_type, limit, after).await
     }
 
     /// Pins a [`Message`] to the channel.
@@ -252,7 +252,7 @@ impl PrivateChannel {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        self.id.pin(&http, message_id).await
+        self.id.pin(http, message_id).await
     }
 
     /// Retrieves the list of messages that have been pinned in the private
@@ -260,7 +260,7 @@ impl PrivateChannel {
     #[allow(clippy::missing_errors_doc)]
     #[inline]
     pub async fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> {
-        self.id.pins(&http).await
+        self.id.pins(http).await
     }
 
     /// Sends a message with just the given message content in the channel.
@@ -386,7 +386,7 @@ impl PrivateChannel {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        self.id.unpin(&http, message_id).await
+        self.id.unpin(http, message_id).await
     }
 }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -181,7 +181,7 @@ impl Reaction {
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     #[inline]
     pub async fn message(&self, cache_http: impl CacheHttp) -> Result<Message> {
-        self.channel_id.message(&cache_http, self.message_id).await
+        self.channel_id.message(cache_http, self.message_id).await
     }
 
     /// Retrieves the user that made the reaction.
@@ -244,7 +244,7 @@ impl Reaction {
         R: Into<ReactionType>,
         U: Into<UserId>,
     {
-        self._users(&http, &reaction_type.into(), limit, after.map(Into::into)).await
+        self._users(http, &reaction_type.into(), limit, after.map(Into::into)).await
     }
 
     async fn _users(

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -149,7 +149,7 @@ impl Member {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn ban(&self, http: impl AsRef<Http>, dmd: u8) -> Result<()> {
-        self.ban_with_reason(&http, dmd, "").await
+        self.ban_with_reason(http, dmd, "").await
     }
 
     /// Ban the member from the guild with a reason. Refer to [`Self::ban`] to further documentation.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -411,7 +411,7 @@ impl Guild {
         if let Some(cache) = cache_http.cache() {
             let user_id = cache.current_user().id;
 
-            if let Ok(perms) = self.member_permissions(&cache_http, user_id).await {
+            if let Ok(perms) = self.member_permissions(cache_http, user_id).await {
                 permissions.remove(perms);
 
                 permissions.is_empty()
@@ -590,7 +590,7 @@ impl Guild {
         before: Option<AuditLogEntryId>,
         limit: Option<u8>,
     ) -> Result<AuditLogs> {
-        self.id.audit_logs(&http, action_type, user_id, before, limit).await
+        self.id.audit_logs(http, action_type, user_id, before, limit).await
     }
 
     /// Gets all of the guild's channels over the REST API.
@@ -603,7 +603,7 @@ impl Guild {
         &self,
         http: impl AsRef<Http>,
     ) -> Result<HashMap<ChannelId, GuildChannel>> {
-        self.id.channels(&http).await
+        self.id.channels(http).await
     }
 
     /// Creates a guild with the data provided.
@@ -713,7 +713,7 @@ impl Guild {
         name: &str,
         image: &str,
     ) -> Result<Emoji> {
-        self.id.create_emoji(&http, name, image).await
+        self.id.create_emoji(http, name, image).await
     }
 
     /// Creates an integration for the guild.
@@ -732,7 +732,7 @@ impl Guild {
         integration_id: impl Into<IntegrationId>,
         kind: &str,
     ) -> Result<()> {
-        self.id.create_integration(&http, integration_id, kind).await
+        self.id.create_integration(http, integration_id, kind).await
     }
 
     /// Create a guild specific application [`Command`].
@@ -950,7 +950,7 @@ impl Guild {
         http: impl AsRef<Http>,
         emoji_id: impl Into<EmojiId>,
     ) -> Result<()> {
-        self.id.delete_emoji(&http, emoji_id).await
+        self.id.delete_emoji(http, emoji_id).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -969,7 +969,7 @@ impl Guild {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        self.id.delete_integration(&http, integration_id).await
+        self.id.delete_integration(http, integration_id).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -991,7 +991,7 @@ impl Guild {
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
     ) -> Result<()> {
-        self.id.delete_role(&http, role_id).await
+        self.id.delete_role(http, role_id).await
     }
 
     /// Deletes a [Scheduled Event] by Id from the guild.
@@ -1010,7 +1010,7 @@ impl Guild {
         http: impl AsRef<Http>,
         event_id: impl Into<ScheduledEventId>,
     ) -> Result<()> {
-        self.id.delete_scheduled_event(&http, event_id).await
+        self.id.delete_scheduled_event(http, event_id).await
     }
 
     /// Deletes a [`Sticker`] by Id from the guild.
@@ -1029,7 +1029,7 @@ impl Guild {
         http: impl AsRef<Http>,
         sticker_id: impl Into<StickerId>,
     ) -> Result<()> {
-        self.id.delete_sticker(&http, sticker_id).await
+        self.id.delete_sticker(http, sticker_id).await
     }
 
     /// Edits the current guild with new data where specified.
@@ -1100,7 +1100,7 @@ impl Guild {
         emoji_id: impl Into<EmojiId>,
         name: &str,
     ) -> Result<Emoji> {
-        self.id.edit_emoji(&http, emoji_id, name).await
+        self.id.edit_emoji(http, emoji_id, name).await
     }
 
     /// Edits the properties a guild member, such as muting or nicknaming them. Returns the new
@@ -1208,7 +1208,7 @@ impl Guild {
         role_id: impl Into<RoleId>,
         position: u64,
     ) -> Result<Vec<Role>> {
-        self.id.edit_role_position(&http, role_id, position).await
+        self.id.edit_role_position(http, role_id, position).await
     }
 
     /// Modifies a scheduled event in the guild with the data set, if any.
@@ -1442,7 +1442,7 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {
-        self.id.integrations(&http).await
+        self.id.integrations(http).await
     }
 
     /// Retrieves the active invites for the guild.
@@ -1493,7 +1493,7 @@ impl Guild {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn kick(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        self.id.kick(&http, user_id).await
+        self.id.kick(http, user_id).await
     }
 
     /// # Errors
@@ -1507,7 +1507,7 @@ impl Guild {
         user_id: impl Into<UserId>,
         reason: &str,
     ) -> Result<()> {
-        self.id.kick_with_reason(&http, user_id, reason).await
+        self.id.kick_with_reason(http, user_id, reason).await
     }
 
     /// Leaves the guild.
@@ -1518,7 +1518,7 @@ impl Guild {
     /// cannot leave the guild, or currently is not in the guild.
     #[inline]
     pub async fn leave(&self, http: impl AsRef<Http>) -> Result<()> {
-        self.id.leave(&http).await
+        self.id.leave(http).await
     }
 
     /// Gets a user's [`Member`] for the guild by Id.
@@ -1565,7 +1565,7 @@ impl Guild {
         limit: Option<u64>,
         after: impl Into<Option<UserId>>,
     ) -> Result<Vec<Member>> {
-        self.id.members(&http, limit, after).await
+        self.id.members(http, limit, after).await
     }
 
     /// Gets a list of all the members (satisfying the status provided to the function) in this
@@ -1959,7 +1959,7 @@ impl Guild {
         user_id: impl Into<UserId>,
         channel_id: impl Into<ChannelId>,
     ) -> Result<Member> {
-        self.id.move_member(&http, user_id, channel_id).await
+        self.id.move_member(http, user_id, channel_id).await
     }
 
     /// Calculate a [`Member`]'s permissions in a given channel in the guild.
@@ -2196,7 +2196,7 @@ impl Guild {
     where
         It: IntoIterator<Item = (ChannelId, u64)>,
     {
-        self.id.reorder_channels(&http, channels).await
+        self.id.reorder_channels(http, channels).await
     }
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname
@@ -2238,7 +2238,7 @@ impl Guild {
         event_id: impl Into<ScheduledEventId>,
         with_user_count: bool,
     ) -> Result<ScheduledEvent> {
-        self.id.scheduled_event(&http, event_id, with_user_count).await
+        self.id.scheduled_event(http, event_id, with_user_count).await
     }
 
     /// Fetches a list of all scheduled events in the guild. If `with_user_count` is set to `true`,
@@ -2256,7 +2256,7 @@ impl Guild {
         http: impl AsRef<Http>,
         with_user_count: bool,
     ) -> Result<Vec<ScheduledEvent>> {
-        self.id.scheduled_events(&http, with_user_count).await
+        self.id.scheduled_events(http, with_user_count).await
     }
 
     /// Fetches a list of interested users for the specified event.
@@ -2277,7 +2277,7 @@ impl Guild {
         event_id: impl Into<ScheduledEventId>,
         limit: Option<u64>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        self.id.scheduled_event_users(&http, event_id, limit).await
+        self.id.scheduled_event_users(http, event_id, limit).await
     }
 
     /// Fetches a list of interested users for the specified event, with additional options and
@@ -2299,7 +2299,7 @@ impl Guild {
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        self.id.scheduled_event_users_optioned(&http, event_id, limit, target, with_member).await
+        self.id.scheduled_event_users_optioned(http, event_id, limit, target, with_member).await
     }
 
     /// Returns the Id of the shard associated with the guild.
@@ -2367,7 +2367,7 @@ impl Guild {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        self.id.start_integration_sync(&http, integration_id).await
+        self.id.start_integration_sync(http, integration_id).await
     }
 
     /// Starts a prune of [`Member`]s.
@@ -2434,7 +2434,7 @@ impl Guild {
             }
         }
 
-        self.id.unban(&cache_http.http(), user_id).await
+        self.id.unban(cache_http.http(), user_id).await
     }
 
     /// Retrieve's the guild's vanity URL.
@@ -2450,7 +2450,7 @@ impl Guild {
     /// the API response.
     #[inline]
     pub async fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
-        self.id.vanity_url(&http).await
+        self.id.vanity_url(http).await
     }
 
     /// Retrieves the guild's webhooks.
@@ -2466,7 +2466,7 @@ impl Guild {
     /// the API response.
     #[inline]
     pub async fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
-        self.id.webhooks(&http).await
+        self.id.webhooks(http).await
     }
 
     /// Obtain a reference to a role by its name.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -272,7 +272,7 @@ impl PartialGuild {
         user: impl Into<UserId>,
         dmd: u8,
     ) -> Result<()> {
-        self.ban_with_reason(&http, user, dmd, "").await
+        self.ban_with_reason(http, user, dmd, "").await
     }
 
     /// Ban a [`User`] from the guild with a reason. Refer to [`Self::ban`] to further documentation.
@@ -289,7 +289,7 @@ impl PartialGuild {
         dmd: u8,
         reason: impl AsRef<str>,
     ) -> Result<()> {
-        self.id.ban_with_reason(&http, user, dmd, reason).await
+        self.id.ban_with_reason(http, user, dmd, reason).await
     }
 
     /// Gets a list of the guild's bans.
@@ -303,7 +303,7 @@ impl PartialGuild {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn bans(&self, http: impl AsRef<Http>) -> Result<Vec<Ban>> {
-        self.id.bans(&http).await
+        self.id.bans(http).await
     }
 
     /// Gets a list of the guild's audit log entries
@@ -339,7 +339,7 @@ impl PartialGuild {
         &self,
         http: impl AsRef<Http>,
     ) -> Result<HashMap<ChannelId, GuildChannel>> {
-        self.id.channels(&http).await
+        self.id.channels(http).await
     }
 
     #[cfg(feature = "cache")]
@@ -432,7 +432,7 @@ impl PartialGuild {
         name: &str,
         image: &str,
     ) -> Result<Emoji> {
-        self.id.create_emoji(&http, name, image).await
+        self.id.create_emoji(http, name, image).await
     }
 
     /// Creates an integration for the guild.
@@ -451,7 +451,7 @@ impl PartialGuild {
         integration_id: impl Into<IntegrationId>,
         kind: &str,
     ) -> Result<()> {
-        self.id.create_integration(&http, integration_id, kind).await
+        self.id.create_integration(http, integration_id, kind).await
     }
 
     /// Create a guild specific application [`Command`].
@@ -619,7 +619,7 @@ impl PartialGuild {
     /// the guild.
     #[inline]
     pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
-        self.id.delete(&http).await
+        self.id.delete(http).await
     }
 
     /// Deletes an [`Emoji`] from the guild.
@@ -638,7 +638,7 @@ impl PartialGuild {
         http: impl AsRef<Http>,
         emoji_id: impl Into<EmojiId>,
     ) -> Result<()> {
-        self.id.delete_emoji(&http, emoji_id).await
+        self.id.delete_emoji(http, emoji_id).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -657,7 +657,7 @@ impl PartialGuild {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        self.id.delete_integration(&http, integration_id).await
+        self.id.delete_integration(http, integration_id).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -679,7 +679,7 @@ impl PartialGuild {
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
     ) -> Result<()> {
-        self.id.delete_role(&http, role_id).await
+        self.id.delete_role(http, role_id).await
     }
 
     /// Deletes a [`Sticker`] by Id from the guild.
@@ -698,7 +698,7 @@ impl PartialGuild {
         http: impl AsRef<Http>,
         sticker_id: impl Into<StickerId>,
     ) -> Result<()> {
-        self.id.delete_sticker(&http, sticker_id).await
+        self.id.delete_sticker(http, sticker_id).await
     }
 
     /// Edits the current guild with new data where specified.
@@ -750,7 +750,7 @@ impl PartialGuild {
         emoji_id: impl Into<EmojiId>,
         name: &str,
     ) -> Result<Emoji> {
-        self.id.edit_emoji(&http, emoji_id, name).await
+        self.id.edit_emoji(http, emoji_id, name).await
     }
 
     /// Edits the properties a guild member, such as muting or nicknaming them. Returns the new
@@ -794,7 +794,7 @@ impl PartialGuild {
         http: impl AsRef<Http>,
         new_nickname: Option<&str>,
     ) -> Result<()> {
-        self.id.edit_nickname(&http, new_nickname).await
+        self.id.edit_nickname(http, new_nickname).await
     }
 
     /// Edits a role, optionally setting its fields.
@@ -845,7 +845,7 @@ impl PartialGuild {
         role_id: impl Into<RoleId>,
         position: u64,
     ) -> Result<Vec<Role>> {
-        self.id.edit_role_position(&http, role_id, position).await
+        self.id.edit_role_position(http, role_id, position).await
     }
 
     /// Edits a sticker.
@@ -1093,7 +1093,7 @@ impl PartialGuild {
     where
         It: IntoIterator<Item = (ChannelId, u64)>,
     {
-        self.id.reorder_channels(&http, channels).await
+        self.id.reorder_channels(http, channels).await
     }
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname
@@ -1157,7 +1157,7 @@ impl PartialGuild {
         if let Some(cache) = cache_http.cache() {
             let user_id = cache.current_user().id;
 
-            if let Ok(perms) = self.member_permissions(&cache_http, user_id).await {
+            if let Ok(perms) = self.member_permissions(cache_http, user_id).await {
                 permissions.remove(perms);
 
                 permissions.is_empty()
@@ -1181,7 +1181,7 @@ impl PartialGuild {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn kick(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        self.id.kick(&http, user_id).await
+        self.id.kick(http, user_id).await
     }
 
     /// # Errors
@@ -1195,7 +1195,7 @@ impl PartialGuild {
         user_id: impl Into<UserId>,
         reason: &str,
     ) -> Result<()> {
-        self.id.kick_with_reason(&http, user_id, reason).await
+        self.id.kick_with_reason(http, user_id, reason).await
     }
 
     /// Returns a formatted URL of the guild's icon, if the guild has an icon.
@@ -1242,7 +1242,7 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {
-        self.id.integrations(&http).await
+        self.id.integrations(http).await
     }
 
     /// Gets all of the guild's invites.
@@ -1256,7 +1256,7 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
-        self.id.invites(&http).await
+        self.id.invites(http).await
     }
 
     /// Leaves the guild.
@@ -1267,7 +1267,7 @@ impl PartialGuild {
     /// leave the Guild, or currently is not in the guild.
     #[inline]
     pub async fn leave(&self, http: impl AsRef<Http>) -> Result<()> {
-        self.id.leave(&http).await
+        self.id.leave(http).await
     }
 
     /// Gets a user's [`Member`] for the guild by Id.
@@ -1306,7 +1306,7 @@ impl PartialGuild {
         limit: Option<u64>,
         after: impl Into<Option<UserId>>,
     ) -> Result<Vec<Member>> {
-        self.id.members(&http, limit, after).await
+        self.id.members(http, limit, after).await
     }
 
     /// Moves a member to a specific voice channel.
@@ -1326,7 +1326,7 @@ impl PartialGuild {
         user_id: impl Into<UserId>,
         channel_id: impl Into<ChannelId>,
     ) -> Result<Member> {
-        self.id.move_member(&http, user_id, channel_id).await
+        self.id.move_member(http, user_id, channel_id).await
     }
 
     /// Calculate a [`Member`]'s permissions in a given channel in the guild.
@@ -1369,7 +1369,7 @@ impl PartialGuild {
     /// [`Guild::prune_count`]: crate::model::guild::Guild::prune_count
     #[inline]
     pub async fn prune_count(&self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
-        self.id.prune_count(&http, days).await
+        self.id.prune_count(http, days).await
     }
 
     /// Returns the Id of the shard associated with the guild.
@@ -1437,7 +1437,7 @@ impl PartialGuild {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        self.id.start_integration_sync(&http, integration_id).await
+        self.id.start_integration_sync(http, integration_id).await
     }
 
     /// Unbans a [`User`] from the guild.
@@ -1452,7 +1452,7 @@ impl PartialGuild {
     /// [`Guild::unban`]: crate::model::guild::Guild::unban
     #[inline]
     pub async fn unban(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        self.id.unban(&http, user_id).await
+        self.id.unban(http, user_id).await
     }
 
     /// Retrieve's the guild's vanity URL.
@@ -1467,7 +1467,7 @@ impl PartialGuild {
     /// [`Guild::vanity_url`]: crate::model::guild::Guild::vanity_url
     #[inline]
     pub async fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
-        self.id.vanity_url(&http).await
+        self.id.vanity_url(http).await
     }
 
     /// Retrieves the guild's webhooks.
@@ -1482,7 +1482,7 @@ impl PartialGuild {
     /// [`Guild::webhooks`]: crate::model::guild::Guild::webhooks
     #[inline]
     pub async fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
-        self.id.webhooks(&http).await
+        self.id.webhooks(http).await
     }
 
     /// Obtain a reference to a role by its name.

--- a/src/model/sticker/mod.rs
+++ b/src/model/sticker/mod.rs
@@ -72,7 +72,7 @@ impl Sticker {
     #[inline]
     pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
         if let Some(guild_id) = self.guild_id {
-            guild_id.delete_sticker(&http, self.id).await
+            guild_id.delete_sticker(http, self.id).await
         } else {
             Err(Error::Model(ModelError::DeleteNitroSticker))
         }

--- a/src/model/sticker/sticker_item.rs
+++ b/src/model/sticker/sticker_item.rs
@@ -29,7 +29,7 @@ impl StickerItem {
     /// not exist, or is otherwise unavailable.
     #[inline]
     pub async fn to_sticker(&self, http: impl AsRef<Http>) -> Result<Sticker> {
-        self.id.to_sticker(&http).await
+        self.id.to_sticker(http).await
     }
 
     /// Retrieves the URL to the sticker image.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -454,7 +454,7 @@ pub(crate) async fn user_has_guild_perms(
         // `Guild::has_perms` is an async fn, but we want the returned Future to be `Send`.
         let lookup = cache.guild(guild_id).as_deref().cloned();
         if let Some(guild) = lookup {
-            if !guild.has_perms(&cache_http, permissions).await {
+            if !guild.has_perms(cache_http, permissions).await {
                 return Err(Error::Model(ModelError::InvalidPermissions(permissions)));
             }
         }


### PR DESCRIPTION
Since we already impl these traits for `&T` if `T` implements them, we can pass ownership of the variable if we're calling a nested function (since passing ownership of &T still keeps the borrow on the original T). Also having nested borrows gets optimized away in release mode anyway, but I thought to make this change for consistency's sake.