### PR TITLE
Make AutocompleteChoice constructable

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -243,8 +243,7 @@ impl<'a> CreateInteractionResponseData<'a> {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-#[non_exhaustive]
+#[derive(Clone, Default, Debug, Serialize)]
 pub struct AutocompleteChoice {
     pub name: String,
     pub value: Value,


### PR DESCRIPTION
In https://github.com/serenity-rs/serenity/commit/86293b0e264a8de180644dc46e80783204abb32d#diff-382dd172af6f81cac859f9d4e6462872cbd65ba90025c425bca969a4d328092bR246, the Default impl on AutocompleteChoice was (accidentally?) removed, which, on top of AutocompleteChoice being #[non_exhaustive], made it completely inconstructable.

This PR adds back the Default impl. The #[non_exhaustive] attribute is also removed: AutocompleteChoice isn't expected to grow beyond its two fields because its a very specialized and simple struct.

I hit this problem while porting [poise](https://github.com/kangalioo/poise/) to serenity next branch