### PR TITLE
Make `description` field optional when creating slash commands

### DIFF
--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -74,13 +74,13 @@ impl EventHandler for Handler {
                 .expect("GUILD_ID must be an integer"),
         );
 
-        let c1 = CreateCommand::new("ping", "A ping command");
+        let c1 = CreateCommand::new("ping").description("A ping command");
 
-        let c2 = CreateCommand::new("id", "Get a user id").add_option(
+        let c2 = CreateCommand::new("id").description("Get a user id").add_option(
             CreateOption::new(CommandOptionType::User, "id", "The user to lookup").required(true),
         );
 
-        let c3 = CreateCommand::new("welcome", "Welcome a user")
+        let c3 = CreateCommand::new("welcome").description("Welcome a user")
             .name_localized("de", "begrüßen")
             .description_localized("de", "Einen Nutzer begrüßen")
             .add_option(
@@ -116,9 +116,10 @@ impl EventHandler for Handler {
                     ),
             );
 
-        let c4 = CreateCommand::new("numberinput", "Test command for number input")
+        let c4 = CreateCommand::new("numberinput")
+            .description("Test command for number input")
             .add_option(
-                CreateOption::new(CommandOptionType::Integer, "int", "An integer fro 5 to 10")
+                CreateOption::new(CommandOptionType::Integer, "int", "An integer from 5 to 10")
                     .min_int_value(5)
                     .max_int_value(10)
                     .required(true),
@@ -130,7 +131,8 @@ impl EventHandler for Handler {
                     .required(true),
             );
 
-        let c5 = CreateCommand::new("attachmentinput", "Test command for attachment input")
+        let c5 = CreateCommand::new("attachmentinput")
+            .description("Test command for attachment input")
             .add_option(
                 CreateOption::new(CommandOptionType::Attachment, "attachment", "A file")
                     .required(true),
@@ -142,7 +144,7 @@ impl EventHandler for Handler {
 
         let guild_command = Command::create_global_application_command(
             &ctx.http,
-            CreateCommand::new("wonderful_command", "An amazing command"),
+            CreateCommand::new("wonderful_command").description("An amazing command"),
         )
         .await;
 

--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -325,7 +325,8 @@ pub struct CreateApplicationCommand {
 
     name: String,
     name_localizations: HashMap<String, String>,
-    description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
     description_localizations: HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_member_permissions: Option<String>,
@@ -337,13 +338,13 @@ pub struct CreateApplicationCommand {
 
 impl CreateApplicationCommand {
     /// Creates a new builder with the given name and description, leaving all other fields empty.
-    pub fn new(name: impl Into<String>, description: impl Into<String>) -> Self {
+    pub fn new(name: impl Into<String>) -> Self {
         Self {
             kind: None,
 
             name: name.into(),
             name_localizations: HashMap::new(),
-            description: description.into(),
+            description: None,
             description_localizations: HashMap::new(),
             default_member_permissions: None,
             dm_permission: None,
@@ -402,7 +403,7 @@ impl CreateApplicationCommand {
     /// Specifies a localized name of the application command.
     ///
     /// ```rust
-    /// # serenity::builder::CreateApplicationCommand::new("", "")
+    /// # serenity::builder::CreateApplicationCommand::new("")
     /// .name("birthday")
     /// .name_localized("zh-CN", "生日")
     /// .name_localized("el", "γενέθλια")
@@ -436,14 +437,14 @@ impl CreateApplicationCommand {
     ///
     /// **Note**: Must be between 1 and 100 characters long.
     pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = description.into();
+        self.description = Some(description.into());
         self
     }
 
     /// Specifies a localized description of the application command.
     ///
     /// ```rust
-    /// # serenity::builder::CreateApplicationCommand::new("", "")
+    /// # serenity::builder::CreateApplicationCommand::new("")
     /// .description("Wish a friend a happy birthday")
     /// .description_localized("zh-CN", "祝你朋友生日快乐")
     /// # ;

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -105,7 +105,7 @@ impl Command {
     /// use serenity::model::application::command::Command;
     /// use serenity::model::id::ApplicationId;
     ///
-    /// let builder = CreateApplicationCommand::new("ping", "A simple ping command");
+    /// let builder = CreateApplicationCommand::new("ping").description("A simple ping command");
     /// let _ = Command::create_global_application_command(&http, builder).await;
     /// # }
     /// ```
@@ -125,10 +125,12 @@ impl Command {
     /// use serenity::model::application::command::{Command, CommandOptionType};
     /// use serenity::model::id::ApplicationId;
     ///
-    /// let builder = CreateApplicationCommand::new("echo", "Makes the bot send a message").add_option(
-    ///     CreateOption::new(CommandOptionType::String, "message", "The message to send")
-    ///         .required(true),
-    /// );
+    /// let builder = CreateApplicationCommand::new("echo")
+    ///     .description("Makes the bot send a message")
+    ///     .add_option(
+    ///         CreateOption::new(CommandOptionType::String, "message", "The message to send")
+    ///             .required(true),
+    ///     );
     /// let _ = Command::create_global_application_command(&http, builder).await;
     /// # }
     /// ```


### PR DESCRIPTION
This field is not allowed when creating user (context) commands, but is required for all other slash commands. Best to just make it optional again.