### PR TITLE
Elide lifetimes on model methods

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -322,7 +322,7 @@ impl ChannelId {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn edit<'a>(
+    pub async fn edit(
         self,
         cache_http: impl CacheHttp,
         builder: EditChannel<'_>,
@@ -352,7 +352,7 @@ impl ChannelId {
     /// See [`EditMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
     #[inline]
-    pub async fn edit_message<'a>(
+    pub async fn edit_message(
         self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
@@ -723,7 +723,7 @@ impl ChannelId {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
-    pub async fn send_message<'a>(
+    pub async fn send_message(
         self,
         cache_http: impl CacheHttp,
         builder: CreateMessage<'_>,
@@ -818,10 +818,10 @@ impl ChannelId {
     /// # Errors
     ///
     /// See [`CreateWebhook::execute`] for a detailed list of possible errors.
-    pub async fn create_webhook<'a>(
+    pub async fn create_webhook(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateWebhook<'a>,
+        builder: CreateWebhook<'_>,
     ) -> Result<Webhook> {
         builder.execute(cache_http, self).await
     }
@@ -861,10 +861,10 @@ impl ChannelId {
     /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
     ///
     /// Returns [`Error::Http`] if there is already a stage instance currently.
-    pub async fn create_stage_instance<'a>(
+    pub async fn create_stage_instance(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateStageInstance<'a>,
+        builder: CreateStageInstance<'_>,
     ) -> Result<StageInstance> {
         builder.channel_id(self).execute(cache_http).await
     }
@@ -877,10 +877,10 @@ impl ChannelId {
     ///
     /// Returns [`Error::Http`] if the channel is not a stage channel, or there is no stage
     /// instance currently.
-    pub async fn edit_stage_instance<'a>(
+    pub async fn edit_stage_instance(
         self,
         cache_http: impl CacheHttp,
-        builder: EditStageInstance<'a>,
+        builder: EditStageInstance<'_>,
     ) -> Result<StageInstance> {
         builder.execute(cache_http, self).await
     }
@@ -890,10 +890,10 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn edit_thread<'a>(
+    pub async fn edit_thread(
         self,
         http: impl AsRef<Http>,
-        builder: EditThread<'a>,
+        builder: EditThread<'_>,
     ) -> Result<GuildChannel> {
         builder.execute(http, self).await
     }
@@ -913,11 +913,11 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    pub async fn create_public_thread<'a>(
+    pub async fn create_public_thread(
         self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: CreateThread<'a>,
+        builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
         builder.execute(http, self, Some(message_id.into())).await
     }
@@ -927,10 +927,10 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    pub async fn create_private_thread<'a>(
+    pub async fn create_private_thread(
         self,
         http: impl AsRef<Http>,
-        builder: CreateThread<'a>,
+        builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
         builder.kind(ChannelType::PrivateThread).execute(http, self, None).await
     }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -104,10 +104,10 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
-    pub async fn create_automod_rule<'a>(
+    pub async fn create_automod_rule(
         self,
         http: impl AsRef<Http>,
-        builder: EditAutoModRule<'a>,
+        builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
         builder.execute(http, self, None).await
     }
@@ -122,11 +122,11 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
-    pub async fn edit_automod_rule<'a>(
+    pub async fn edit_automod_rule(
         self,
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
-        builder: EditAutoModRule<'a>,
+        builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
         builder.execute(http, self, Some(rule_id.into())).await
     }
@@ -411,10 +411,10 @@ impl GuildId {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn create_role<'a>(
+    pub async fn create_role(
         self,
         cache_http: impl CacheHttp,
-        builder: EditRole<'a>,
+        builder: EditRole<'_>,
     ) -> Result<Role> {
         builder.execute(cache_http, self, None).await
     }
@@ -429,10 +429,10 @@ impl GuildId {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn create_scheduled_event<'a>(
+    pub async fn create_scheduled_event(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateScheduledEvent<'a>,
+        builder: CreateScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
         builder.execute(cache_http, self).await
     }
@@ -448,7 +448,7 @@ impl GuildId {
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    pub async fn create_sticker<'a>(
+    pub async fn create_sticker(
         self,
         cache_http: impl CacheHttp,
         builder: CreateSticker<'_>,
@@ -579,10 +579,10 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
-    pub async fn edit<'a>(
+    pub async fn edit(
         self,
         cache_http: impl CacheHttp,
-        builder: EditGuild<'a>,
+        builder: EditGuild<'_>,
     ) -> Result<PartialGuild> {
         builder.execute(cache_http, self).await
     }
@@ -642,11 +642,11 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     #[inline]
-    pub async fn edit_member<'a>(
+    pub async fn edit_member(
         self,
         http: impl AsRef<Http>,
         user_id: impl Into<UserId>,
-        builder: EditMember<'a>,
+        builder: EditMember<'_>,
     ) -> Result<Member> {
         builder.execute(http, self, user_id.into()).await
     }
@@ -704,11 +704,11 @@ impl GuildId {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn edit_role<'a>(
+    pub async fn edit_role(
         self,
         cache_http: impl CacheHttp,
         role_id: impl Into<RoleId>,
-        builder: EditRole<'a>,
+        builder: EditRole<'_>,
     ) -> Result<Role> {
         builder.execute(cache_http, self, Some(role_id.into())).await
     }
@@ -723,11 +723,11 @@ impl GuildId {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn edit_scheduled_event<'a>(
+    pub async fn edit_scheduled_event(
         self,
         cache_http: impl CacheHttp,
         event_id: impl Into<ScheduledEventId>,
-        builder: EditScheduledEvent<'a>,
+        builder: EditScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
         builder.execute(cache_http, self, event_id.into()).await
     }
@@ -759,11 +759,11 @@ impl GuildId {
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    pub async fn edit_sticker<'a>(
+    pub async fn edit_sticker(
         self,
         http: impl AsRef<Http>,
         sticker_id: impl Into<StickerId>,
-        builder: EditSticker<'a>,
+        builder: EditSticker<'_>,
     ) -> Result<Sticker> {
         builder.execute(http, self, sticker_id.into()).await
     }
@@ -803,10 +803,10 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit_welcome_screen<'a>(
+    pub async fn edit_welcome_screen(
         self,
         http: impl AsRef<Http>,
-        builder: EditGuildWelcomeScreen<'a>,
+        builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
         builder.execute(http, self).await
     }
@@ -820,10 +820,10 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit_widget<'a>(
+    pub async fn edit_widget(
         self,
         http: impl AsRef<Http>,
-        builder: EditGuildWidget<'a>,
+        builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
         builder.execute(http, self).await
     }

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -70,10 +70,10 @@ impl Invite {
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     #[inline]
-    pub async fn create<'a>(
+    pub async fn create(
         cache_http: impl CacheHttp,
         channel_id: impl Into<ChannelId>,
-        builder: CreateInvite<'a>,
+        builder: CreateInvite<'_>,
     ) -> Result<RichInvite> {
         channel_id.into().create_invite(cache_http, builder).await
     }


### PR DESCRIPTION
Turns out the extra lifetime parameters on model methods that were introduced in #2105 were unnecessary and can be elided. This would've been nice to catch before merge (as clippy was complaining about it), so unfortunately the git history is a little dirty now, but oh well  ¯\\\_(ツ)\_/¯