### PR TITLE
Fix incorrect documentation for `GuildChannel::create_permission`

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -258,7 +258,7 @@ impl GuildChannel {
     /// let overwrite = PermissionOverwrite {
     ///     allow,
     ///     deny,
-    ///     kind: PermissionOverwriteType::Member(user_id),
+    ///     kind: PermissionOverwriteType::Role(role_id),
     /// };
     ///
     /// let channel = cache.guild_channel(channel_id).ok_or(ModelError::ItemMissing)?;


### PR DESCRIPTION
The documentation for `GuildChannel::create_permission` explains how to create both kinds of permission overwrites but was using `PermissionOverwriteType::Member` for both. This PR fixes said issue.