### PR TITLE
Implement AsRef<Cache> and AsRef<Http> for CacheAndHttp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,20 @@ pub struct CacheAndHttp {
     pub http: Arc<Http>,
 }
 
+#[cfg(all(feature = "client", feature = "cache"))]
+impl AsRef<Cache> for CacheAndHttp {
+    fn as_ref(&self) -> &Cache {
+        &self.cache
+    }
+}
+
+#[cfg(feature = "client")]
+impl AsRef<Http> for CacheAndHttp {
+    fn as_ref(&self) -> &Http {
+        &self.http
+    }
+}
+
 // For the procedural macros in `command_attr`.
 pub use async_trait::async_trait;
 pub use futures;


### PR DESCRIPTION
Serenity often takes Cache/Http by parameter using utility traits. The situation there is a bit confusing; I compiled all involved types, traits, and trait impls here:

```
Types: Cache, Http, CacheAndHttp, Context
Traits: AsRef<Cache>, AsRef<Http>, CacheHttp


impl AsRef<Cache> for Context
impl AsRef<Cache> for Arc<Context>
impl AsRef<Cache> for Cache
impl AsRef<Cache> for (&Arc<Cache>, &Http)

impl AsRef<Http> for Context
impl AsRef<Http> for Arc<Context>
impl AsRef<Http> for Http
impl AsRef<Http> for (&Arc<Cache>, &Http)

impl<T: CacheHttp> CacheHttp for &T
impl<T: CacheHttp> CacheHttp for Arc<T>
impl CacheHttp for (&Arc<Cache>, &Http)
impl CacheHttp for Context
impl CacheHttp for CacheAndHttp
impl CacheHttp for Http
```

Notably, `AsRef<Http>` is implemented for all types that can provide an Http, and `AsRef<Cache>` is implemented for all types that can provide a Cache, _except_ CacheAndHttp (which contains both). This PR adds the two missing trait implementations

Rationale: people often ask about running HTTP functions standalone (without being triggered by a gateway event). For that, they need to access `Client::cache_and_http`. It's easier to explain and more ergonomic if just that cache_and_http could be used for all Discord request functions. Previously, you sometimes needed `cache_and_http`, sometimes `cache_and_http.http` and sometimes `cache_and_http.cache`

(Relatedly, I think those traits probably shouldn't be implemented on Arc. Those implementations for `(&Arc<Cache>, &Http)` are weird too because that tuple type doesn't even appear in the codebase. I think there should only be trait implementations for Cache, Http, CacheHttp, and Context. This is subject to debate though)