### PR TITLE
Lookup user by ID globally in ArgumentConvert impl

### DIFF
--- a/src/utils/argument_convert/user.rs
+++ b/src/utils/argument_convert/user.rs
@@ -92,6 +92,15 @@ impl ArgumentConvert for User {
             return Ok(member.user);
         }
 
+        // If string is a raw user ID or a mention
+        if let Some(user_id) = s.parse().ok().or_else(|| crate::utils::parse_username(s)) {
+            // Now, we can still try UserId::to_user because it works for all users from all guilds the
+            // bot is joined
+            if let Ok(user) = UserId(user_id).to_user(ctx).await {
+                return Ok(user);
+            }
+        }
+
         Err(UserParseError::NotFoundOrMalformed)
     }
 }


### PR DESCRIPTION
Fixes #2093

Tested with a small poise bot with a `User` parameter. Passing the user argument to the bot in DMs via ID or mention didn't work before this PR, but it now does