### PR TITLE
Remove `CacheAndHttp`, plus cleanup of dispatch

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::Arc;
 
 use futures::channel::mpsc::UnboundedSender as Sender;
@@ -44,6 +45,16 @@ pub struct Context {
     pub http: Arc<Http>,
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,
+}
+
+// Used by the #[instrument] macro on client::dispatch::handle_event
+impl fmt::Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field("shard", &self.shard)
+            .field("shard_id", &self.shard_id)
+            .finish()
+    }
 }
 
 impl Context {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -46,8 +46,6 @@ use crate::cache::Cache;
 #[cfg(feature = "client")]
 use crate::client::Context;
 use crate::model::prelude::*;
-#[cfg(feature = "client")]
-use crate::CacheAndHttp;
 
 /// This trait will be required by functions that need [`Http`] and can
 /// optionally use a [`Cache`] to potentially avoid REST-requests.
@@ -99,17 +97,6 @@ where
 
 #[cfg(feature = "client")]
 impl CacheHttp for Context {
-    fn http(&self) -> &Http {
-        &self.http
-    }
-    #[cfg(feature = "cache")]
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        Some(&self.cache)
-    }
-}
-
-#[cfg(feature = "client")]
-impl CacheHttp for CacheAndHttp {
     fn http(&self) -> &Http {
         &self.http
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //! serenity = "0.11"
 //! ```
 //!
+//! [`Cache`]: crate::cache::Cache
 //! [`Context`]: crate::client::Context
 //! [`EventHandler::message`]: crate::client::EventHandler::message
 //! [`Event`]: crate::model::event::Event
@@ -112,39 +113,6 @@ pub mod utils;
 
 mod error;
 
-#[cfg(feature = "client")]
-use std::sync::Arc;
-
-#[cfg(all(feature = "client", feature = "cache"))]
-use crate::cache::Cache;
-#[cfg(all(feature = "client", feature = "gateway"))]
-pub use crate::client::Client;
-pub use crate::error::{Error, Result};
-#[cfg(feature = "client")]
-use crate::http::Http;
-
-#[cfg(feature = "client")]
-#[derive(Clone)]
-pub struct CacheAndHttp {
-    #[cfg(feature = "cache")]
-    pub cache: Arc<Cache>,
-    pub http: Arc<Http>,
-}
-
-#[cfg(all(feature = "client", feature = "cache"))]
-impl AsRef<Cache> for CacheAndHttp {
-    fn as_ref(&self) -> &Cache {
-        &self.cache
-    }
-}
-
-#[cfg(feature = "client")]
-impl AsRef<Http> for CacheAndHttp {
-    fn as_ref(&self) -> &Http {
-        &self.http
-    }
-}
-
 // For the procedural macros in `command_attr`.
 pub use async_trait::async_trait;
 pub use futures;
@@ -152,3 +120,7 @@ pub use futures::future::FutureExt;
 #[cfg(feature = "standard_framework")]
 #[doc(hidden)]
 pub use static_assertions;
+
+#[cfg(all(feature = "client", feature = "gateway"))]
+pub use crate::client::Client;
+pub use crate::error::{Error, Result};


### PR DESCRIPTION
The `CacheAndHttp` struct has too similar a name to the `CacheHttp` trait, which might cause confusion. Therefore, I've removed the struct, and inlined its fields where it was used before. In addition, cleaned up some of `client/dispatch.rs`, for example the `dispatch` and `handle_event` functions now take a `Context` as parameter (to reduce cloning), and `dispatch` is now a regular `async fn`, rather than returning a `BoxFuture`. Also introduced an impl of `Debug` to `Context` so that the tracing instrumentation on `handle_event` remains unchanged.