### PR TITLE
Changed ChannelId::message() to use Cache

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -451,29 +451,7 @@ impl CacheUpdate for MessageCreateEvent {
     type Output = Message;
 
     fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        let max = cache.settings().max_messages;
-
-        if max == 0 {
-            return None;
-        }
-
-        let messages =
-            cache.messages.entry(self.message.channel_id).or_insert_with(Default::default);
-        let mut queue =
-            cache.message_queue.entry(self.message.channel_id).or_insert_with(Default::default);
-
-        let mut removed_msg = None;
-
-        if messages.len() == max {
-            if let Some(id) = queue.pop_front() {
-                removed_msg = messages.remove(&id);
-            }
-        }
-
-        queue.push_back(self.message.id);
-        messages.insert(self.message.id, self.message.clone());
-
-        removed_msg.map(|i| i.1)
+        cache.add_message(&self.message)
     }
 }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -681,10 +681,10 @@ impl GuildChannel {
     #[inline]
     pub async fn message(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
     ) -> Result<Message> {
-        self.id.message(&http, message_id).await
+        self.id.message(cache_http, message_id).await
     }
 
     /// Gets messages from the channel.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditMessage, GetMessages};
 #[cfg(feature = "http")]
-use crate::http::{Http, Typing};
+use crate::http::{CacheHttp, Http, Typing};
 #[cfg(feature = "model")]
 use crate::model::channel::AttachmentType;
 use crate::model::prelude::*;
@@ -188,10 +188,10 @@ impl PrivateChannel {
     #[inline]
     pub async fn message(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
     ) -> Result<Message> {
-        self.id.message(&http, message_id).await
+        self.id.message(cache_http, message_id).await
     }
 
     /// Gets messages from the channel.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -206,8 +206,8 @@ impl Reaction {
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     #[inline]
-    pub async fn message(&self, http: impl AsRef<Http>) -> Result<Message> {
-        self.channel_id.message(&http, self.message_id).await
+    pub async fn message(&self, cache_http: impl CacheHttp) -> Result<Message> {
+        self.channel_id.message(cache_http, self.message_id).await
     }
 
     /// Retrieves the user that made the reaction.


### PR DESCRIPTION
I have looked for a solution to [this issue](https://github.com/serenity-rs/serenity/issues/2119) but it does not seem to exist.
Therefore, I have fixed this issue.
However, this PR breaks compatibility when passing Http directly.