### PR TITLE
Simplify CreateAllowedMentions API

### DIFF
--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -26,7 +26,7 @@ enum ParseValue {
 /// # let http = Http::new("token");
 /// # let b = CreateMessage::new();
 /// # let msg = ChannelId::new(7).message(&http, MessageId::new(8)).await?;
-/// use serenity::builder::{CreateAllowedMentions as Am, ParseValue};
+/// use serenity::builder::CreateAllowedMentions as Am;
 ///
 /// // Mention only the user 110372470472613888
 /// # let m = b.clone();
@@ -34,25 +34,25 @@ enum ParseValue {
 ///
 /// // Mention all users and the role 182894738100322304
 /// # let m = b.clone();
-/// m.allowed_mentions(Am::new().parse(ParseValue::Users).roles(vec![182894738100322304]));
+/// m.allowed_mentions(Am::new().all_users(true).roles(vec![182894738100322304]));
 ///
 /// // Mention all roles and nothing else
 /// # let m = b.clone();
-/// m.allowed_mentions(Am::new().parse(ParseValue::Roles));
+/// m.allowed_mentions(Am::new().all_roles(true));
 ///
 /// // Mention all roles and users, but not everyone
 /// # let m = b.clone();
-/// m.allowed_mentions(Am::new().parse(ParseValue::Users).parse(ParseValue::Roles));
+/// m.allowed_mentions(Am::new().all_users(true).all_roles(true));
 ///
 /// // Mention everyone and the users 182891574139682816, 110372470472613888
 /// # let m = b.clone();
 /// m.allowed_mentions(
-///     Am::new().parse(ParseValue::Everyone).users(vec![182891574139682816, 110372470472613888]),
+///     Am::new().everyone(true).users(vec![182891574139682816, 110372470472613888]),
 /// );
 ///
 /// // Mention everyone and the message author.
 /// # let m = b.clone();
-/// m.allowed_mentions(Am::new().parse(ParseValue::Everyone).users(vec![msg.author.id]));
+/// m.allowed_mentions(Am::new().everyone(true).users(vec![msg.author.id]));
 /// # Ok(())
 /// # }
 /// ```

--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -75,7 +75,7 @@ impl CreateAllowedMentions {
         Self::default()
     }
 
-    /// Toggles mentions for all users. Overrides [`users`] if it was previously set.
+    /// Toggles mentions for all users. Overrides [`Self::users`] if it was previously set.
     pub fn all_users(mut self, allow: bool) -> Self {
         if allow {
             self.parse.insert(ParseValue::Users);
@@ -85,7 +85,7 @@ impl CreateAllowedMentions {
         self
     }
 
-    /// Toggles mentions for all roles. Overrides [`roles`] if it was previously set.
+    /// Toggles mentions for all roles. Overrides [`Self::roles`] if it was previously set.
     pub fn all_roles(mut self, allow: bool) -> Self {
         if allow {
             self.parse.insert(ParseValue::Roles);

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -50,7 +50,7 @@ mod get_messages;
 
 pub use self::add_member::AddMember;
 pub use self::bot_auth_parameters::CreateBotAuthParameters;
-pub use self::create_allowed_mentions::{CreateAllowedMentions, ParseValue};
+pub use self::create_allowed_mentions::CreateAllowedMentions;
 pub use self::create_application_command::{
     CreateApplicationCommand,
     CreateApplicationCommandOption,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 use std::fmt::Write;
 
 #[cfg(all(feature = "model", feature = "utils"))]
-use crate::builder::{CreateAllowedMentions, CreateMessage, EditMessage, ParseValue};
+use crate::builder::{CreateAllowedMentions, CreateMessage, EditMessage};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "collector")]
@@ -667,9 +667,9 @@ impl Message {
                 .replied_user(ping_user)
                 // By providing allowed_mentions, Discord disabled _all_ pings by default so we
                 // need to re-enable them
-                .parse(ParseValue::Everyone)
-                .parse(ParseValue::Users)
-                .parse(ParseValue::Roles);
+                .everyone(true)
+                .all_users(true)
+                .all_roles(true);
             builder = builder.reference_message(self).allowed_mentions(allowed_mentions);
         }
         self.channel_id.send_message(cache_http, builder).await


### PR DESCRIPTION
Fixes #1362 

Replaces the `CreateAllowedMentions::parse(ParseValue)` method and `ParseValue` enum with new methods: `all_users(bool)`, `all_roles(bool)` and `everyone(bool)`.

The name "parse" is quite unintuitive here, and it's clunky to have a separate enum. Having clearly named methods is more understandable.

There's room for bikeshedding (enabling pings by default to make `.allowed_mentions(|m| m)` a no-op like in other builders? Rename users => specific_users, roles => specific_roles, all_users => users, all_roles => roles? Change CreateAllowedMentions internal fields to match new exposed API? Move replied_user out of CreateAllowedMentions entirely?) but I decided to make this PR as unintrusive and non-breaking as possible because bikeshedding is exhausting