### PR TITLE
Add Discord doc links to almost all model types

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -49,6 +49,8 @@ pub static JOIN_MESSAGES: &[&str] = &[
 ];
 
 /// Enum to map gateway opcodes.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum OpCode {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2913,6 +2913,8 @@ impl Http {
     }
 
     /// Gets a guild widget information.
+    // TODO: according to Discord, this returns different data; namely https://discord.com/developers/docs/resources/guild#guild-widget-object-guild-widget-structure.
+    // Should investigate if this endpoint actually works
     pub async fn get_guild_widget(&self, guild_id: u64) -> Result<GuildWidget> {
         self.fire(Request {
             body: None,

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -5,8 +5,10 @@ pub mod component;
 pub mod interaction;
 pub mod oauth;
 
-use super::id::{snowflake, ApplicationId, UserId};
+use self::oauth::Scope;
+use super::id::{snowflake, ApplicationId, GuildId, SkuId, UserId};
 use super::user::User;
+use super::Permissions;
 
 /// Partial information about the given application.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -18,22 +20,48 @@ pub struct PartialCurrentApplicationInfo {
 }
 
 /// Information about the current application and its owner.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/application#application-object-application-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CurrentApplicationInfo {
-    pub description: String,
-    pub icon: Option<String>,
     pub id: ApplicationId,
     pub name: String,
-    pub owner: User,
+    pub icon: Option<String>,
+    pub description: String,
     #[serde(default)]
     pub rpc_origins: Vec<String>,
     pub bot_public: bool,
     pub bot_require_code_grant: bool,
+    #[serde(default)]
+    pub terms_of_service_url: Option<String>,
+    #[serde(default)]
+    pub privacy_policy_url: Option<String>,
+    // TODO: this is an optional field according to Discord and should be Option<User>
+    pub owner: User,
+    pub verify_key: String,
     pub team: Option<Team>,
+    #[serde(default)]
+    pub guild_id: Option<GuildId>,
+    #[serde(default)]
+    pub primary_sku_id: Option<SkuId>,
+    #[serde(default)]
+    pub slug: Option<String>,
+    #[serde(default)]
+    pub cover_image: Option<String>,
+    #[serde(default)]
+    pub flags: Option<ApplicationFlags>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub install_params: Option<InstallParams>,
+    #[serde(default)]
+    pub custom_install_url: Option<String>,
 }
 
 /// Information about the Team group of the application.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-team-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Team {
     /// The icon of the team.
@@ -50,6 +78,8 @@ pub struct Team {
 }
 
 /// Information about a Member on a Team.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-team-member-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TeamMember {
     /// The member's membership state.
@@ -65,6 +95,7 @@ pub struct TeamMember {
     pub user: User,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum).
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum MembershipState {
     Invited = 1,
@@ -79,6 +110,8 @@ enum_number!(MembershipState {
 
 bitflags! {
     /// The flags of the application.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/application#application-object-application-flags).
     #[derive(Default)]
     pub struct ApplicationFlags: u64 {
         const GATEWAY_PRESENCE = 1 << 12;
@@ -90,4 +123,12 @@ bitflags! {
         const GATEWAY_MESSAGE_CONTENT = 2 << 18;
         const GATEWAY_MESSAGE_CONTENT_LIMITED = 2 << 19;
     }
+}
+
+/// Settings for the application's default in-app authorization link
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/application#install-params-object-install-params-structure).
+pub struct InstallParams {
+    pub scopes: Vec<Scope>,
+    pub permissions: Permissions,
 }

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -128,6 +128,7 @@ bitflags! {
 /// Settings for the application's default in-app authorization link
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/application#install-params-object-install-params-structure).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstallParams {
     pub scopes: Vec<Scope>,
     pub permissions: Permissions,

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -429,7 +429,7 @@ pub enum CommandPermissionType {
 enum_number!(CommandPermissionType {
     Role,
     User,
-    Channel,
+    Channel
 });
 
 impl CommandPermissionId {

--- a/src/model/application/oauth.rs
+++ b/src/model/application/oauth.rs
@@ -1,85 +1,98 @@
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 /// The available OAuth2 Scopes.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum Scope {
     /// For oauth2 bots, this puts the bot in the user's selected guild by default.
+    #[serde(rename = "bot")]
     Bot,
     /// Allows your app to use Slash Commands in a guild.
+    #[serde(rename = "applications.commands")]
     ApplicationsCommands,
     /// Allows your app to update its Slash Commands via this bearer token - client credentials grant only.
+    #[serde(rename = "applications.commands.update")]
     ApplicationsCommandsUpdate,
+    /// Allows your app to update permissions for its commands in a guild a user has permissions to.
+    #[serde(rename = "applications.commands.permissions.update")]
+    ApplicationsCommandsPermissionsUpdate,
 
     /// Allows `/users/@me` without [`Self::Email`].
+    #[serde(rename = "identify")]
     Identify,
     /// Enables `/users/@me` to return an `email` field.
+    #[serde(rename = "email")]
     Email,
     /// Allows `/users/@me/connections` to return linked third-party accounts.
+    #[serde(rename = "connections")]
     Connections,
     /// Allows `/users/@me/guilds` to return basic information about all of a user's guilds.
+    #[serde(rename = "guilds")]
     Guilds,
     /// Allows `/guilds/{guild.id}/members/{user.id}` to be used for joining users to a guild.
+    #[serde(rename = "guilds.join")]
     GuildsJoin,
+    /// Allows `/users/@me/guilds/{guild.id}/member` to return a user's member information in a guild.
+    #[serde(rename = "guilds.members.read")]
+    GuildsMembersRead,
     /// Allows your app to join users to a group dm.
+    #[serde(rename = "gdm.join")]
     GdmJoin,
     /// For local rpc server access, this allows you to control a user's local Discord client -
     /// requires Discord approval.
+    #[serde(rename = "rpc")]
     Rpc,
     /// For local rpc server api access, this allows you to receive notifications pushed out to the user - requires Discord approval.
+    #[serde(rename = "rpc.notifications.read")]
     RpcNotificationsRead,
+    #[serde(rename = "rpc.voice.read")]
     RpcVoiceRead,
+    #[serde(rename = "rpc.voice.write")]
     RpcVoiceWrite,
+    #[serde(rename = "rpc.activities.write")]
     RpcActivitiesWrite,
     /// This generates a webhook that is returned in the oauth token response for authorization code grants.
-    WebhookIncomming,
+    #[serde(rename = "webhook.incoming")]
+    WebhookIncomming, // TODO: fix misspelling
     /// For local rpc server api access, this allows you to read messages from all client channels
     /// (otherwise restricted to channels/guilds your app creates).
+    #[serde(rename = "messages.read")]
     MessagesRead,
     /// Allows your app to upload/update builds for a user's applications - requires Discord approval.
+    #[serde(rename = "applications.builds.upload")]
     ApplicationsBuildsUpload,
     /// Allows your app to read build data for a user's applications.
+    #[serde(rename = "applications.builds.read")]
     ApplicationsBuildsRead,
     /// Allows your app to read and update store data (SKUs, store listings, achievements, etc.) for a user's applications.
+    #[serde(rename = "applications.store.update")]
     ApplicationsStoreUpdate,
     /// Allows your app to read entitlements for a user's applications.
+    #[serde(rename = "applications.entitlements")]
     ApplicationsEntitlements,
     /// Allows your app to fetch data from a user's "Now Playing/Recently Played" list - requires Discord approval.
+    #[serde(rename = "activities.read")]
     ActivitiesRead,
     /// allows your app to update a user's activity - requires Discord approval (Not required for gamesdk activity manager!).
+    #[serde(rename = "activities.write")]
     ActivitiesWrite,
     /// Allows your app to know a user's friends and implicit relationships - requires Discord approval.
+    #[serde(rename = "relationships.read")]
     RelactionshipsRead,
+    /// Allows your app to see information about the user's DMs and group DMs - requires Discord approval.
+    #[serde(rename = "dm_channels.read")]
+    DmChannelsRead,
+    /// Allows your app to connect to voice on user's behalf and see all the voice members - requires Discord approval.
+    #[serde(rename = "voice")]
+    Voice,
 }
 
 impl fmt::Display for Scope {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let val = match self {
-            Self::Bot => "bot",
-            Self::ApplicationsCommands => "applications.commands",
-            Self::ApplicationsCommandsUpdate => "applications.commands.update",
-            Self::Identify => "identify",
-            Self::Email => "email",
-            Self::Connections => "connections",
-            Self::Guilds => "guilds",
-            Self::GuildsJoin => "guilds.join",
-            Self::GdmJoin => "gdm.join",
-            Self::Rpc => "rpc",
-            Self::RpcNotificationsRead => "rpc.notifications.read",
-            Self::RpcVoiceRead => "rpc.voice.read",
-            Self::RpcVoiceWrite => "rpc.voice.write",
-            Self::RpcActivitiesWrite => "rpc.activities.write",
-            Self::WebhookIncomming => "webhook.incoming",
-            Self::MessagesRead => "messages.read",
-            Self::ApplicationsBuildsUpload => "applications.builds.upload",
-            Self::ApplicationsBuildsRead => "applications.builds.read",
-            Self::ApplicationsStoreUpdate => "applications.store.update",
-            Self::ApplicationsEntitlements => "applications.entitlements",
-            Self::ActivitiesRead => "activities.read",
-            Self::ActivitiesWrite => "activities.write",
-            Self::RelactionshipsRead => "relationships.read",
-        };
-
-        f.write_str(val)
+        self.serialize(f)
     }
 }

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -8,6 +8,8 @@ use crate::model::utils::is_false;
 
 /// A file uploaded with a message. Not to be confused with [`Embed`]s.
 ///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#attachment-object).
+///
 /// [`Embed`]: super::Embed
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/channel_category.rs
+++ b/src/model/channel/channel_category.rs
@@ -7,6 +7,8 @@ use crate::json;
 use crate::model::prelude::*;
 
 /// A category of [`GuildChannel`]s.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ChannelCategory {

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -16,6 +16,8 @@ use crate::utils::Colour;
 /// **Note**: Maximum amount of characters you can put is 256 in a field name,
 /// 1024 in a field value, and 2048 in a description.
 ///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object).
+///
 /// [slack's attachments]: https://api.slack.com/docs/message-attachments
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -103,6 +105,8 @@ impl Embed {
 }
 
 /// An author object in an embed.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedAuthor {
@@ -119,6 +123,8 @@ pub struct EmbedAuthor {
 }
 
 /// A field object in an embed.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedField {
@@ -158,6 +164,8 @@ impl EmbedField {
 }
 
 /// Footer information for an embed.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedFooter {
@@ -172,6 +180,8 @@ pub struct EmbedFooter {
 }
 
 /// An image object in an embed.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-image-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedImage {
@@ -188,6 +198,8 @@ pub struct EmbedImage {
 }
 
 /// The provider of an embed.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedProvider {
@@ -198,6 +210,8 @@ pub struct EmbedProvider {
 }
 
 /// The dimensions and URL of an embed thumbnail.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedThumbnail {
@@ -214,6 +228,8 @@ pub struct EmbedThumbnail {
 }
 
 /// Video information for an embed.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedVideo {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -54,6 +54,8 @@ fn message_count_patch<'de, D: serde::Deserializer<'de>>(
 /// only for voice channels and some are only available for text channels.
 /// News channels are a subset of text channels and lack slow mode hence
 /// [`Self::rate_limit_per_user`] will be [`None`].
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildChannel {
@@ -1326,6 +1328,9 @@ impl fmt::Display for GuildChannel {
 }
 
 /// A partial guild channel.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object),
+/// [subset description](https://discord.com/developers/docs/topics/gateway#thread-delete)
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PartialGuildChannel {
     /// The channel Id.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -40,6 +40,8 @@ use crate::{
 
 /// A representation of a message over a guild's text channel, a group, or a
 /// private channel.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Message {
@@ -1042,6 +1044,8 @@ impl<'a> From<&'a Message> for MessageId {
 /// Multiple of the same [reaction type] are sent into one [`MessageReaction`],
 /// with an associated [`Self::count`].
 ///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#reaction-object).
+///
 /// [reaction type]: ReactionType
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1057,6 +1061,8 @@ pub struct MessageReaction {
 }
 
 /// Differentiates between regular and different types of system messages.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum MessageType {
@@ -1139,6 +1145,7 @@ enum_number!(MessageType {
     AutoModerationAction,
 });
 
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-activity-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum MessageActivityKind {
@@ -1161,6 +1168,8 @@ enum_number!(MessageActivityKind {
 });
 
 /// Rich Presence application information.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/application#application-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageApplication {
@@ -1177,6 +1186,8 @@ pub struct MessageApplication {
 }
 
 /// Rich Presence activity information.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-activity-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageActivity {
@@ -1188,6 +1199,8 @@ pub struct MessageActivity {
 }
 
 /// Reference data sent with crossposted messages.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageReference {
@@ -1219,7 +1232,7 @@ impl From<(ChannelId, MessageId)> for MessageReference {
     }
 }
 
-/// Channel Mention Object
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-mention-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ChannelMention {
     /// ID of the channel.
@@ -1235,6 +1248,8 @@ pub struct ChannelMention {
 
 bitflags! {
     /// Describes extra features of the message.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-flags).
     #[derive(Default)]
     pub struct MessageFlags: u64 {
         /// This message has been published to subscribed channels (via Channel Following).

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -284,6 +284,8 @@ impl fmt::Display for Channel {
 }
 
 /// A representation of a type of channel.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -356,6 +358,7 @@ impl ChannelType {
     }
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object).
 #[derive(Deserialize, Serialize)]
 struct PermissionOverwriteData {
     allow: Permissions,
@@ -367,6 +370,8 @@ struct PermissionOverwriteData {
 }
 
 /// A channel-specific permission overwrite for a member or role.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object).
 #[derive(Clone, Debug, PartialEq)]
 pub struct PermissionOverwrite {
     pub allow: Permissions,
@@ -417,6 +422,8 @@ impl Serialize for PermissionOverwrite {
 /// The type of edit being made to a Channel's permissions.
 ///
 /// This is for use with methods such as [`GuildChannel::create_permission`].
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object-overwrite-structure) (field `type`).
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PermissionOverwriteType {
@@ -427,6 +434,8 @@ pub enum PermissionOverwriteType {
 }
 
 /// The video quality mode for a voice channel.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-video-quality-modes).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum VideoQualityMode {
@@ -444,6 +453,7 @@ enum_number!(VideoQualityMode {
     Full
 });
 
+/// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct StageInstance {
@@ -458,6 +468,8 @@ pub struct StageInstance {
 }
 
 /// A thread data.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ThreadMetadata {
@@ -484,6 +496,8 @@ pub struct ThreadMetadata {
 }
 
 /// A response to getting several threads channels.
+///
+/// Discord docs: scattered, but e.g. [here](https://discord.com/developers/docs/resources/channel#list-public-archived-threads-response-body).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ThreadsData {

--- a/src/model/channel/partial_channel.rs
+++ b/src/model/channel/partial_channel.rs
@@ -3,6 +3,8 @@ use crate::model::id::{ChannelId, WebhookId};
 use crate::model::Permissions;
 
 /// A container for any partial channel.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object), [subset specification](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct PartialChannel {
@@ -18,6 +20,8 @@ pub struct PartialChannel {
 }
 
 /// A container for the IDs returned by following a news channel.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#followed-channel-object).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct FollowedChannel {

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -13,6 +13,8 @@ use crate::model::utils::single_recipient;
 use crate::model::Timestamp;
 
 /// A Direct Message text channel with another user.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PrivateChannel {

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -17,6 +17,8 @@ use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// An emoji reaction to a message.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-reaction-add-message-reaction-add-event-fields).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct Reaction {

--- a/src/model/channel/sticker.rs
+++ b/src/model/channel/sticker.rs
@@ -3,6 +3,8 @@ use crate::model::id::{StickerId, StickerPackId};
 /// A sticker sent with a message.
 ///
 /// Bots currently can only receive messages with stickers, not send.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Sticker {
@@ -25,6 +27,8 @@ pub struct Sticker {
 }
 
 /// Differentiates between sticker formats.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum StickerFormatType {

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -3,6 +3,8 @@
 use super::prelude::*;
 
 /// Information about a connection between the current user and a third party service.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-connection-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Connection {
@@ -11,6 +13,8 @@ pub struct Connection {
     /// The username of the account on the other side of this connection.
     pub name: String,
     /// The service that this connection represents (e.g. twitch, youtube)
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-services).
     #[serde(rename = "type")]
     pub kind: String,
     /// Whether this connection has been revoked and is no longer valid.
@@ -30,6 +34,8 @@ pub struct Connection {
 }
 
 /// The visibility of a user connection on a user's profile.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-visibility-types).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -15,6 +15,7 @@ use crate::model::application::command::CommandPermission;
 use crate::model::application::interaction::Interaction;
 use crate::model::guild::automod::{ActionExecution, Rule};
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#application-command-permissions-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -22,6 +23,7 @@ pub struct ApplicationCommandPermissionsUpdateEvent {
     pub permission: CommandPermission,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -29,6 +31,7 @@ pub struct AutoModerationRuleCreateEvent {
     pub rule: Rule,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -36,6 +39,7 @@ pub struct AutoModerationRuleUpdateEvent {
     pub rule: Rule,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-delete).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -43,6 +47,7 @@ pub struct AutoModerationRuleDeleteEvent {
     pub rule: Rule,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#auto-moderation-action-execution).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -56,6 +61,8 @@ pub struct AutoModerationActionExecutionEvent {
 ///
 /// - A [`Channel`] is created in a [`Guild`]
 /// - A [`PrivateChannel`] is created
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#channel-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -64,6 +71,7 @@ pub struct ChannelCreateEvent {
     pub channel: Channel,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#channel-delete).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -71,6 +79,7 @@ pub struct ChannelDeleteEvent {
     pub channel: Channel,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#channel-pins-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ChannelPinsUpdateEvent {
@@ -79,6 +88,7 @@ pub struct ChannelPinsUpdateEvent {
     pub last_pin_timestamp: Option<Timestamp>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#channel-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -86,6 +96,7 @@ pub struct ChannelUpdateEvent {
     pub channel: Channel,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-ban-add).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildBanAddEvent {
@@ -93,6 +104,7 @@ pub struct GuildBanAddEvent {
     pub user: User,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-ban-remove).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildBanRemoveEvent {
@@ -100,6 +112,7 @@ pub struct GuildBanRemoveEvent {
     pub user: User,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -107,6 +120,7 @@ pub struct GuildCreateEvent {
     pub guild: Guild,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-delete).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -114,6 +128,7 @@ pub struct GuildDeleteEvent {
     pub guild: UnavailableGuild,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-emojis-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildEmojisUpdateEvent {
@@ -122,12 +137,14 @@ pub struct GuildEmojisUpdateEvent {
     pub guild_id: GuildId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-integrations-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildIntegrationsUpdateEvent {
     pub guild_id: GuildId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-member-add).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -135,6 +152,7 @@ pub struct GuildMemberAddEvent {
     pub member: Member,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-member-remove).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildMemberRemoveEvent {
@@ -142,6 +160,7 @@ pub struct GuildMemberRemoveEvent {
     pub user: User,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-member-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildMemberUpdateEvent {
@@ -161,6 +180,7 @@ pub struct GuildMemberUpdateEvent {
     pub communication_disabled_until: Option<Timestamp>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-members-chunk).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildMembersChunkEvent {
@@ -270,6 +290,7 @@ impl<'de> Deserialize<'de> for GuildMembersChunkEvent {
     }
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-role-create).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleCreateEvent {
@@ -284,6 +305,7 @@ impl<'de> Deserialize<'de> for GuildRoleCreateEvent {
     }
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-role-delete).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleDeleteEvent {
@@ -291,6 +313,7 @@ pub struct GuildRoleDeleteEvent {
     pub role_id: RoleId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-role-update).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleUpdateEvent {
@@ -305,6 +328,7 @@ impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
     }
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-stickers-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildStickersUpdateEvent {
@@ -313,6 +337,7 @@ pub struct GuildStickersUpdateEvent {
     pub guild_id: GuildId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#invite-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteCreateEvent {
@@ -325,6 +350,7 @@ pub struct InviteCreateEvent {
     pub temporary: bool,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#invite-delete).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteDeleteEvent {
@@ -340,6 +366,7 @@ pub struct GuildUnavailableEvent {
     pub guild_id: GuildId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -347,6 +374,7 @@ pub struct GuildUpdateEvent {
     pub guild: PartialGuild,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -354,6 +382,7 @@ pub struct MessageCreateEvent {
     pub message: Message,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-delete-bulk).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageDeleteBulkEvent {
@@ -362,6 +391,7 @@ pub struct MessageDeleteBulkEvent {
     pub ids: Vec<MessageId>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-delete).
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageDeleteEvent {
@@ -371,6 +401,7 @@ pub struct MessageDeleteEvent {
     pub message_id: MessageId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageUpdateEvent {
@@ -393,6 +424,7 @@ pub struct MessageUpdateEvent {
     pub flags: Option<MessageFlags>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#presence-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -407,6 +439,7 @@ pub struct PresencesReplaceEvent {
     pub presences: Vec<Presence>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-reaction-add).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -414,6 +447,7 @@ pub struct ReactionAddEvent {
     pub reaction: Reaction,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-reaction-remove).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -421,6 +455,7 @@ pub struct ReactionRemoveEvent {
     pub reaction: Reaction,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-reaction-remove-all).
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ReactionRemoveAllEvent {
@@ -430,6 +465,8 @@ pub struct ReactionRemoveAllEvent {
 }
 
 /// The "Ready" event, containing initial ready cache
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#ready).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -437,6 +474,7 @@ pub struct ReadyEvent {
     pub ready: Ready,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#resumed).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ResumedEvent {
@@ -444,6 +482,7 @@ pub struct ResumedEvent {
     pub trace: Vec<Option<String>>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#typing-start).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct TypingStartEvent {
@@ -460,6 +499,7 @@ pub struct UnknownEvent {
     pub value: Value,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#user-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -467,6 +507,7 @@ pub struct UserUpdateEvent {
     pub current_user: CurrentUser,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#voice-server-update).
 #[derive(Clone, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct VoiceServerUpdateEvent {
@@ -486,6 +527,7 @@ impl fmt::Debug for VoiceServerUpdateEvent {
     }
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#voice-state-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -493,6 +535,7 @@ pub struct VoiceStateUpdateEvent {
     pub voice_state: VoiceState,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#webhooks-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct WebhookUpdateEvent {
@@ -500,6 +543,7 @@ pub struct WebhookUpdateEvent {
     pub guild_id: GuildId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#interaction-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -507,6 +551,7 @@ pub struct InteractionCreateEvent {
     pub interaction: Interaction,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#integration-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -514,6 +559,7 @@ pub struct IntegrationCreateEvent {
     pub integration: Integration,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#integration-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -521,6 +567,7 @@ pub struct IntegrationUpdateEvent {
     pub integration: Integration,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#integration-delete).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct IntegrationDeleteEvent {
@@ -529,6 +576,7 @@ pub struct IntegrationDeleteEvent {
     pub application_id: Option<ApplicationId>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#stage-instance-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -536,6 +584,7 @@ pub struct StageInstanceCreateEvent {
     pub stage_instance: StageInstance,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#stage-instance-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -543,6 +592,7 @@ pub struct StageInstanceUpdateEvent {
     pub stage_instance: StageInstance,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#stage-instance-delete).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -550,6 +600,7 @@ pub struct StageInstanceDeleteEvent {
     pub stage_instance: StageInstance,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#thread-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -557,6 +608,7 @@ pub struct ThreadCreateEvent {
     pub thread: GuildChannel,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#thread-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -564,6 +616,7 @@ pub struct ThreadUpdateEvent {
     pub thread: GuildChannel,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#thread-delete).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -571,6 +624,7 @@ pub struct ThreadDeleteEvent {
     pub thread: PartialGuildChannel,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#thread-list-sync).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadListSyncEvent {
@@ -587,6 +641,7 @@ pub struct ThreadListSyncEvent {
     pub members: Vec<ThreadMember>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#thread-member-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -594,6 +649,7 @@ pub struct ThreadMemberUpdateEvent {
     pub member: ThreadMember,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#thread-members-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadMembersUpdateEvent {
@@ -611,6 +667,7 @@ pub struct ThreadMembersUpdateEvent {
     pub removed_members_ids: Vec<UserId>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-create).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -618,6 +675,7 @@ pub struct GuildScheduledEventCreateEvent {
     pub event: ScheduledEvent,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-update).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -625,6 +683,7 @@ pub struct GuildScheduledEventUpdateEvent {
     pub event: ScheduledEvent,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-delete).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -632,6 +691,7 @@ pub struct GuildScheduledEventDeleteEvent {
     pub event: ScheduledEvent,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-user-add).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildScheduledEventUserAddEvent {
@@ -641,6 +701,7 @@ pub struct GuildScheduledEventUserAddEvent {
     user_id: UserId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-user-remove).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildScheduledEventUserRemoveEvent {
@@ -650,6 +711,7 @@ pub struct GuildScheduledEventUserRemoveEvent {
     user_id: UserId,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#payloads-gateway-payload-structure).
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
@@ -740,6 +802,8 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 }
 
 /// Event received over a websocket connection
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events).
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1637,6 +1701,8 @@ pub fn deserialize_event_with_type(kind: EventType, v: Value) -> Result<Event> {
 /// A Deserialization implementation is provided for deserializing raw event
 /// dispatch type strings to this enum, e.g. deserializing `"CHANNEL_CREATE"` to
 /// [`EventType::ChannelCreate`].
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events).
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum EventType {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -11,6 +11,8 @@ use super::utils::*;
 /// shards that Discord recommends to use for a bot user.
 ///
 /// This is only applicable to bot users.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#get-gateway-bot-json-response).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct BotGateway {
@@ -25,6 +27,8 @@ pub struct BotGateway {
 }
 
 /// Representation of an activity that a [`User`] is performing.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Activity {
@@ -265,6 +269,7 @@ impl Activity {
     }
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-buttons).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ActivityButton {
@@ -278,6 +283,8 @@ pub struct ActivityButton {
 }
 
 /// The assets for an activity.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-assets).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivityAssets {
@@ -293,6 +300,8 @@ pub struct ActivityAssets {
 
 bitflags! {
     /// A set of flags defining what is in an activity's payload.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-flags).
     #[derive(Default)]
     pub struct ActivityFlags: u64 {
         /// Whether the activity is an instance activity.
@@ -317,6 +326,8 @@ bitflags! {
 }
 
 /// Information about an activity's party.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-party).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivityParty {
@@ -327,6 +338,8 @@ pub struct ActivityParty {
 }
 
 /// Secrets for an activity.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-secrets).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivitySecrets {
@@ -340,6 +353,8 @@ pub struct ActivitySecrets {
 }
 
 /// Representation of an emoji used in a custom status
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-emoji).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ActivityEmoji {
     /// The name of the emoji.
@@ -350,6 +365,7 @@ pub struct ActivityEmoji {
     pub animated: Option<bool>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-types).
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum ActivityType {
@@ -387,6 +403,8 @@ impl Default for ActivityType {
 /// A representation of the data retrieved from the gateway endpoint.
 ///
 /// For the bot-specific gateway, refer to [`BotGateway`].
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#get-gateway-example-response).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Gateway {
@@ -395,6 +413,8 @@ pub struct Gateway {
 }
 
 /// Information detailing the current active status of a [`User`].
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#client-status-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ClientStatus {
     pub desktop: Option<OnlineStatus>,
@@ -403,6 +423,8 @@ pub struct ClientStatus {
 }
 
 /// Information about the user of a [`Presence`] event.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#presence-update).
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 #[serde(default)]
@@ -473,6 +495,8 @@ impl PresenceUser {
 }
 
 /// Information detailing the current online status of a [`User`].
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#presence-update-presence-update-event-fields).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Presence {
@@ -491,6 +515,8 @@ pub struct Presence {
 }
 
 /// An initial set of information given after IDENTIFYing to the gateway.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#ready-ready-event-fields).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Ready {
@@ -511,6 +537,8 @@ pub struct Ready {
 
 /// Information describing how many gateway sessions you can initiate within a
 /// ratelimit period.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#session-start-limit-object-session-start-limit-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SessionStartLimit {
@@ -521,8 +549,12 @@ pub struct SessionStartLimit {
     pub reset_after: u64,
     /// The total number of session starts within the ratelimit period allowed.
     pub total: u64,
+    /// The number of identify requests allowed per 5 seconds.
+    pub max_concurrency: u64,
 }
 /// Timestamps of when a user started and/or is ending their activity.
+///
+/// [Discord docs](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytimestamps-struct).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivityTimestamps {
@@ -552,6 +584,8 @@ bitflags! {
     /// **Note**:
     /// Once the bot is in 100 guilds or more, [the bot must be verified] in
     /// order to use privileged intents.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/topics/gateway#list-of-intents).
     ///
     /// [gateway intent]: https://discord.com/developers/docs/topics/gateway#privileged-intents
     /// [Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents

--- a/src/model/guild/audit_log.rs
+++ b/src/model/guild/audit_log.rs
@@ -15,6 +15,8 @@ use utils::{optional_string, users, webhooks};
 use crate::model::prelude::*;
 
 /// Determines the action that was done on a target.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum Action {
@@ -102,6 +104,7 @@ impl Serialize for Action {
 #[deprecated(note = "use `ChannelAction`")]
 pub type ActionChannel = ChannelAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -114,6 +117,7 @@ pub enum ChannelAction {
 #[deprecated(note = "use `ChannelOverwriteAction`")]
 pub type ActionChannelOverwrite = ChannelOverwriteAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -126,6 +130,7 @@ pub enum ChannelOverwriteAction {
 #[deprecated(note = "use `MemberAction`")]
 pub type ActionMember = MemberAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -144,6 +149,7 @@ pub enum MemberAction {
 #[deprecated(note = "use `RoleAction`")]
 pub type ActionRole = RoleAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -156,6 +162,7 @@ pub enum RoleAction {
 #[deprecated(note = "use `InviteAction`")]
 pub type ActionInvite = InviteAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -168,6 +175,7 @@ pub enum InviteAction {
 #[deprecated(note = "use `WebhookAction`")]
 pub type ActionWebhook = WebhookAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -180,6 +188,7 @@ pub enum WebhookAction {
 #[deprecated(note = "use `EmojiAction`")]
 pub type ActionEmoji = EmojiAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -192,6 +201,7 @@ pub enum EmojiAction {
 #[deprecated(note = "use `MessageAction`")]
 pub type ActionMessage = MessageAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -205,6 +215,7 @@ pub enum MessageAction {
 #[deprecated(note = "use `IntegrationAction`")]
 pub type ActionIntegration = IntegrationAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -217,6 +228,7 @@ pub enum IntegrationAction {
 #[deprecated(note = "use `StageInstanceAction`")]
 pub type ActionStageInstance = StageInstanceAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -229,6 +241,7 @@ pub enum StageInstanceAction {
 #[deprecated(note = "use `StickerAction`")]
 pub type ActionSticker = StickerAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -238,6 +251,7 @@ pub enum StickerAction {
     Delete = 92,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -250,6 +264,7 @@ pub enum ScheduledEventAction {
 #[deprecated(note = "use `ThreadAction`")]
 pub type ActionThread = ThreadAction;
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -259,6 +274,7 @@ pub enum ThreadAction {
     Delete = 112,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -269,6 +285,7 @@ pub enum AutoModerationAction {
     BlockMessage = 143,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-object).
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct AuditLogs {
@@ -280,6 +297,7 @@ pub struct AuditLogs {
     pub webhooks: HashMap<WebhookId, Webhook>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object).
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct AuditLogEntry {
@@ -301,6 +319,7 @@ pub struct AuditLogEntry {
     pub options: Option<Options>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info).
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Options {

--- a/src/model/guild/automod.rs
+++ b/src/model/guild/automod.rs
@@ -14,6 +14,8 @@ use serde_value::{DeserializerError, Value};
 use crate::model::id::{ChannelId, GuildId, MessageId, RoleId, RuleId, UserId};
 
 /// Configured auto moderation rule.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object).
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Rule {
     /// ID of the rule.
@@ -44,6 +46,8 @@ pub struct Rule {
 }
 
 /// Indicates in what event context a rule should be checked.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[serde(from = "u8", into = "u8")]
 #[non_exhaustive]
@@ -71,6 +75,10 @@ impl From<EventType> for u8 {
 }
 
 /// Characterizes the type of content which can trigger the rule.
+///
+/// Discord docs:
+/// [type](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types),
+/// [metadata](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata)
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Trigger {
@@ -92,6 +100,8 @@ struct InterimTrigger<'a> {
 }
 
 /// Helper struct for the (de)serialization of `Trigger`.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata).
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "TriggerMetadata")]
 struct InterimTriggerMetadata<'a> {
@@ -157,6 +167,8 @@ impl Trigger {
 }
 
 /// Type of [`Trigger`].
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[serde(from = "u8", into = "u8")]
 #[non_exhaustive]
@@ -198,6 +210,8 @@ impl From<TriggerType> for u8 {
 /// See [`Change::TriggerMetadata`].
 ///
 /// [`Change::TriggerMetadata`]: crate::model::guild::audit_log::Change::TriggerMetadata
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata).
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct TriggerMetadata {
     keyword_filter: Option<Vec<String>>,
@@ -205,6 +219,8 @@ pub struct TriggerMetadata {
 }
 
 /// Internally pre-defined wordsets which will be searched for in content.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[serde(from = "u8", into = "u8")]
 #[non_exhaustive]
@@ -238,6 +254,8 @@ impl From<KeywordPresetType> for u8 {
 }
 
 /// An action which will execute whenever a rule is triggered.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object).
 #[derive(Clone, Debug, PartialEq)]
 pub enum Action {
     /// Blocks the content of a message according to the rule.
@@ -260,7 +278,7 @@ pub enum Action {
 /// Gateway event payload sent when a rule is triggered and an action is executed (e.g. message is
 /// blocked).
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#auto-moderation-action-execution)
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#auto-moderation-action-execution).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ActionExecution {
     /// ID of the guild in which the action was executed.
@@ -427,6 +445,8 @@ impl Action {
 }
 
 /// Type of [`Action`].
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[serde(from = "u8", into = "u8")]
 #[non_exhaustive]
@@ -491,14 +511,14 @@ mod tests {
 
         assert_eq!(
             crate::json::to_string(&Rule {
-                trigger: Trigger::HarmfulLink,
+                trigger: Trigger::HarmfulLink
             })?,
             r#"{"trigger_type":2,"trigger_metadata":{}}"#,
         );
 
         assert_eq!(
             crate::json::to_string(&Rule {
-                trigger: Trigger::Spam,
+                trigger: Trigger::Spam
             })?,
             r#"{"trigger_type":3,"trigger_metadata":{}}"#,
         );
@@ -516,7 +536,7 @@ mod tests {
 
         assert_eq!(
             crate::json::to_string(&Rule {
-                trigger: Trigger::Unknown(123),
+                trigger: Trigger::Unknown(123)
             })?,
             r#"{"trigger_type":123,"trigger_metadata":{}}"#,
         );

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -19,6 +19,8 @@ use crate::model::ModelError;
 /// Represents a custom guild emoji, which can either be created using the API,
 /// or via an integration. Emojis created using the API only work within the
 /// guild it was created in.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/emoji#emoji-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Emoji {

--- a/src/model/guild/guild_preview.rs
+++ b/src/model/guild/guild_preview.rs
@@ -4,6 +4,8 @@ use crate::model::id::GuildId;
 /// Preview [`Guild`] information.
 ///
 /// [`Guild`]: super::Guild
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-preview-object).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct GuildPreview {

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::model::Timestamp;
 
 /// Various information about integrations.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Integration {
@@ -26,6 +28,8 @@ pub struct Integration {
 }
 
 /// The behavior once the integration expires.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -48,6 +52,8 @@ impl From<Integration> for IntegrationId {
 }
 
 /// Integration account object.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-account-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct IntegrationAccount {
@@ -56,6 +62,8 @@ pub struct IntegrationAccount {
 }
 
 /// Integration application object.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-application-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct IntegrationApplication {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -21,6 +21,8 @@ use crate::model::Timestamp;
 use crate::utils::Colour;
 
 /// Information about a member of a guild.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-member-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Member {
@@ -652,6 +654,8 @@ impl fmt::Display for Member {
 /// A partial amount of data for a member.
 ///
 /// This is used in [`Message`]s from [`Guild`]s.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-member-object), subset specification unknown
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PartialMember {
@@ -695,6 +699,7 @@ fn avatar_url(guild_id: GuildId, user_id: UserId, hash: Option<&String>) -> Opti
     })
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-member-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadMember {
@@ -710,6 +715,8 @@ pub struct ThreadMember {
 
 bitflags! {
     /// Describes extra features of the message.
+    ///
+    /// Discord docs: flags field on [Thread Member](https://discord.com/developers/docs/resources/channel#thread-member-object).
     #[derive(Default)]
     pub struct ThreadMemberFlags: u64 {
         // Not documented.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -82,6 +82,8 @@ use crate::model::utils::{emojis, presences, roles, stickers};
 use crate::model::Timestamp;
 
 /// A representation of a banning of a user.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#ban-object).
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize)]
 pub struct Ban {
     /// The reason given for this ban.
@@ -91,6 +93,9 @@ pub struct Ban {
 }
 
 /// Information about a Discord guild, such as channels, emojis, etc.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object) plus
+/// [extension](https://discord.com/developers/docs/topics/gateway#guild-create).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct Guild {
@@ -3016,6 +3021,8 @@ pub enum GuildContainer {
 }
 
 /// A [`Guild`] widget.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-widget-settings-object).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct GuildWidget {
@@ -3027,6 +3034,8 @@ pub struct GuildWidget {
 
 /// Representation of the number of members that would be pruned by a guild
 /// prune operation.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#get-guild-prune-count).
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct GuildPrune {
     /// The number of members that would be pruned by the operation.
@@ -3034,6 +3043,9 @@ pub struct GuildPrune {
 }
 
 /// Basic information about a guild.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object), subset undocumented (closest thing is
+/// [this](https://discord.com/developers/docs/topics/rpc#getguilds-get-guilds-response-structure)).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GuildInfo {
     /// The unique Id of the guild.
@@ -3095,6 +3107,8 @@ impl InviteGuild {
 }
 
 /// Data for an unavailable guild.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#unavailable-guild-object).
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct UnavailableGuild {
     /// The Id of the [`Guild`] that may be unavailable.
@@ -3105,6 +3119,8 @@ pub struct UnavailableGuild {
 }
 
 /// Default message notification level for a guild.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum DefaultMessageNotificationLevel {
@@ -3122,6 +3138,8 @@ enum_number!(DefaultMessageNotificationLevel {
 });
 
 /// Setting used to filter explicit messages from members.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum ExplicitContentFilter {
@@ -3142,6 +3160,8 @@ enum_number!(ExplicitContentFilter {
 });
 
 /// Multi-Factor Authentication level for guild moderators.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-mfa-level).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum MfaLevel {
@@ -3160,6 +3180,8 @@ enum_number!(MfaLevel {
 
 /// The level to set as criteria prior to a user being able to send
 /// messages in a [`Guild`].
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-verification-level).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum VerificationLevel {
@@ -3186,6 +3208,8 @@ enum_number!(VerificationLevel {
 });
 
 /// The [`Guild`] nsfw level.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum NsfwLevel {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -42,6 +42,8 @@ use crate::model::utils::{emojis, roles, stickers};
 
 /// Partial information about a [`Guild`]. This does not include information
 /// like member data.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object).
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct PartialGuild {

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -1,4 +1,6 @@
 /// The guild's premium tier, depends on the amount of users boosting the guild currently
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-premium-tier).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[non_exhaustive]
 pub enum PremiumTier {

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -24,6 +24,8 @@ use crate::utils::parse_role;
 /// are unique per guild and do not cross over to other guilds in any way, and
 /// can have channel-specific permission overrides in addition to guild-level
 /// permissions.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Role {
@@ -302,6 +304,8 @@ impl FromStrAndCache for Role {
 }
 
 /// The tags of a [`Role`].
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[non_exhaustive]

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -1,6 +1,8 @@
 use crate::model::prelude::*;
 
 /// Information about a guild scheduled event.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ScheduledEvent {
@@ -46,6 +48,7 @@ pub struct ScheduledEvent {
     pub image: Option<String>,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status).
 #[derive(Copy, Clone, Debug)]
 pub enum ScheduledEventStatus {
     Scheduled = 1,
@@ -59,9 +62,10 @@ enum_number!(ScheduledEventStatus {
     Scheduled,
     Active,
     Completed,
-    Canceled,
+    Canceled
 });
 
+/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types).
 #[derive(Copy, Clone, Debug)]
 pub enum ScheduledEventType {
     StageInstance = 1,
@@ -73,9 +77,10 @@ pub enum ScheduledEventType {
 enum_number!(ScheduledEventType {
     StageInstance,
     Voice,
-    External,
+    External
 });
 
+/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ScheduledEventMetadata {
     // TODO: Change to `Option<String>` in next version.
@@ -83,6 +88,7 @@ pub struct ScheduledEventMetadata {
     pub location: String,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-user-object).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ScheduledEventUser {
     #[serde(rename = "guild_scheduled_event_id")]

--- a/src/model/guild/system_channel.rs
+++ b/src/model/guild/system_channel.rs
@@ -1,5 +1,7 @@
 bitflags! {
     /// Describes a system channel flags.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags).
     #[derive(Default)]
     pub struct SystemChannelFlags: u64 {
         /// Suppress member join notifications.

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::model::id::{ChannelId, EmojiId};
 
 /// Information relating to a guild's welcome screen.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GuildWelcomeScreen {
     /// The server description shown in the welcome screen.
@@ -14,6 +16,8 @@ pub struct GuildWelcomeScreen {
 }
 
 /// A channel shown in the [`GuildWelcomeScreen`].
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct GuildWelcomeChannel {
@@ -80,6 +84,8 @@ impl Serialize for GuildWelcomeChannel {
 }
 
 /// A [`GuildWelcomeScreen`] emoji.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]
 pub enum GuildWelcomeChannelEmoji {

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -99,6 +99,7 @@ pub struct EmojiId(#[serde(with = "snowflake")] pub u64);
 #[derive(
     Copy, Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize,
 )]
+// TODO: replace occurences of `#[serde(with = "snowflake")] u64` in the codebase with GenericId
 pub struct GenericId(#[serde(with = "snowflake")] pub u64);
 
 /// An identifier for a Guild

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -18,6 +18,8 @@ use crate::model::Timestamp;
 /// Information about an invite code.
 ///
 /// Information can not be accessed for guilds the current user is banned from.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Invite {
@@ -219,6 +221,8 @@ impl Invite {
 }
 
 /// A minimal amount of information about the channel an invite points to.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-example-invite-object).
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InviteChannel {
@@ -229,6 +233,8 @@ pub struct InviteChannel {
 }
 
 /// A minimal amount of information about the guild an invite points to.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-example-invite-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteGuild {
@@ -291,6 +297,8 @@ impl InviteGuild {
 /// the [`Invite`] struct.
 ///
 /// [Manage Guild]: Permissions::MANAGE_GUILD
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-metadata-object) (extends [`Invite`] fields).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct RichInvite {
@@ -407,6 +415,7 @@ impl RichInvite {
     }
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-stage-instance-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteStageInstance {
@@ -420,6 +429,7 @@ pub struct InviteStageInstance {
     topic: String,
 }
 
+/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum InviteTargetType {
@@ -432,5 +442,5 @@ pub enum InviteTargetType {
 enum_number!(InviteTargetType {
     Normal,
     Stream,
-    EmmbeddedApplication,
+    EmmbeddedApplication
 });

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -56,6 +56,8 @@ impl_from_str! {
 }
 
 /// A version of an emoji used only when solely the animated state, Id, and name are known.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-emoji).
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct EmojiIdentifier {
     /// Whether the emoji is animated

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -224,6 +224,8 @@ bitflags::bitflags! {
     /// [`PermissionOverwrite`]s, roles globally in a [`Guild`], and to
     /// [`GuildChannel`]s.
     ///
+    /// [Discord docs](https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags).
+    ///
     /// [`Guild`]: super::guild::Guild
     /// [`GuildChannel`]: super::channel::GuildChannel
     /// [`PermissionOverwrite`]: super::channel::PermissionOverwrite
@@ -402,6 +404,7 @@ generate_get_permission_names! {
     view_guild_insights: "View Guild Insights"
 }
 
+/// TODO: use a macro to shorten this entire file lol
 #[cfg(feature = "model")]
 impl Permissions {
     /// Shorthand for checking that the set of permissions contains the

--- a/src/model/prelude.rs
+++ b/src/model/prelude.rs
@@ -9,25 +9,26 @@
 //! ```rust,no_run
 //! use serenity::model::prelude::*;
 //! ```
-
-pub use super::application::*;
-pub use super::channel::*;
-pub use super::connection::*;
-pub use super::event::*;
-pub use super::gateway::*;
-pub use super::guild::audit_log::*;
-pub use super::guild::*;
-pub use super::id::*;
 #[allow(deprecated)]
-pub use super::interactions::*;
-pub use super::invite::*;
-pub use super::mention::*;
-pub use super::misc::*;
-#[allow(deprecated)]
-pub use super::oauth2::*;
-pub use super::permissions::*;
-pub use super::sticker::*;
-pub use super::user::*;
-pub use super::voice::*;
-pub use super::webhook::*;
-pub use super::*;
+#[doc(inline)]
+pub use super::{
+    application::*,
+    channel::*,
+    connection::*,
+    event::*,
+    gateway::*,
+    guild::audit_log::*,
+    guild::*,
+    id::*,
+    interactions::*,
+    invite::*,
+    mention::*,
+    misc::*,
+    oauth2::*,
+    permissions::*,
+    sticker::*,
+    user::*,
+    voice::*,
+    webhook::*,
+    *,
+};

--- a/src/model/sticker/mod.rs
+++ b/src/model/sticker/mod.rs
@@ -21,6 +21,8 @@ pub use self::sticker_pack::*;
 /// A sticker sent with a message.
 ///
 /// Bots cannot send stickers.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Sticker {
@@ -118,6 +120,8 @@ impl Sticker {
 }
 
 /// Differentiates between sticker types.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum StickerType {
@@ -136,6 +140,8 @@ enum_number!(StickerType {
 });
 
 /// Differentiates between sticker formats.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum StickerFormatType {

--- a/src/model/sticker/sticker_item.rs
+++ b/src/model/sticker/sticker_item.rs
@@ -7,6 +7,8 @@ use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// The smallest amount of data required to render a sticker.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-item-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct StickerItem {

--- a/src/model/sticker/sticker_pack.rs
+++ b/src/model/sticker/sticker_pack.rs
@@ -4,6 +4,8 @@ use crate::model::sticker::Sticker;
 /// A sticker sent with a message.
 ///
 /// Bots currently can only receive messages with stickers, not send.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-pack-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct StickerPack {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -169,6 +169,9 @@ pub(crate) mod discriminator {
 }
 
 /// Information about the current user.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#user-object).
+// TODO: replace this with User
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CurrentUser {
@@ -576,13 +579,7 @@ impl DefaultAvatar {
 
 /// The representation of a user's status.
 ///
-/// # Examples
-///
-/// - [`DoNotDisturb`];
-/// - [`Invisible`].
-///
-/// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb
-/// [`Invisible`]: OnlineStatus::Invisible
+/// [Discord docs](https://discord.com/developers/docs/topics/gateway#update-presence-status-types).
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 #[non_exhaustive]
 pub enum OnlineStatus {
@@ -618,6 +615,8 @@ impl Default for OnlineStatus {
 }
 
 /// Information about a user.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#user-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct User {
@@ -659,6 +658,8 @@ pub struct User {
 
 bitflags! {
     /// User's public flags
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-user-flags).
     #[derive(Default)]
     pub struct UserPublicFlags: u32 {
         /// User's flag as discord employee

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -9,6 +9,8 @@ use crate::model::id::{ChannelId, GuildId, UserId};
 use crate::model::Timestamp;
 
 /// Information about an available voice region.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/voice#voice-region-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct VoiceRegion {
@@ -25,6 +27,8 @@ pub struct VoiceRegion {
 }
 
 /// A user's state within a voice channel.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/voice#voice-state-object).
 #[derive(Clone, Serialize)]
 #[non_exhaustive]
 pub struct VoiceState {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -22,6 +22,8 @@ use crate::model::ModelError;
 use crate::utils::encode_image;
 
 /// A representation of a type of webhook.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum WebhookType {
@@ -40,7 +42,7 @@ pub enum WebhookType {
 enum_number!(WebhookType {
     Incoming,
     ChannelFollower,
-    Application,
+    Application
 });
 
 impl WebhookType {
@@ -59,6 +61,8 @@ impl WebhookType {
 /// A representation of a webhook, which is a low-effort way to post messages to
 /// channels. They do not necessarily require a bot user or authentication to
 /// use.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/webhook#webhook-object).
 #[derive(Clone, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Webhook {


### PR DESCRIPTION
Partly implements #2056

Wow this was a chore

There's a solid number of discrepancies in serenity's type definitions (missing fields, redundant fields, differently ordered fields) and, less importantly, there's also room for docs improvement by just copy-pasting Discord's official docs. Buuuut that can be done in a future PR