### PR TITLE
Fix order of "direct message" and "server messages"

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -404,12 +404,12 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     if options.strikethrough_commands_tip_in_dm == None {
-        options.strikethrough_commands_tip_in_dm = produce_strike_text(&options, "direct messages");
+        options.strikethrough_commands_tip_in_dm = produce_strike_text(&options, "server messages");
     }
 
     if options.strikethrough_commands_tip_in_guild == None {
         options.strikethrough_commands_tip_in_guild =
-            produce_strike_text(&options, "server messages");
+            produce_strike_text(&options, "direct messages");
     }
 
     let HelpOptions {


### PR DESCRIPTION
Fixes #2103 

Funnily enough the entire infrastructure for changing text depending on guild/DM was already there... but it was precisely the wrong way around. In DMs it said "limited to direct messages" and in servers "limited to server messages" regarding strikethrough commands. I fixed the order and tested via e05_command_framework