### PR TITLE
Voice channels are now text-based

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -157,7 +157,7 @@ impl GuildChannel {
     /// it is possible to send messages.
     #[must_use]
     pub fn is_text_based(&self) -> bool {
-        matches!(self.kind, ChannelType::Text | ChannelType::News)
+        matches!(self.kind, ChannelType::Text | ChannelType::News | ChannelType::Voice)
     }
 
     /// Broadcasts to the channel that the current user is typing.


### PR DESCRIPTION
Because every voice channel has an associated chat since a few weeks in Discord so you can use voice channels like text channels

Fixes #2085 