### PR TITLE
Remove workaround for deserialization error in Scheduled Event endpoints

### DIFF
--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -31,14 +31,6 @@ fn loop_errors(value: &Value, errors: &mut Vec<DiscordJsonSingleError>, path: &[
                 .expect("expected array")
                 .clone();
 
-            // FIXME: This is a workaround to a bug in the {Create,Edit}ScheduledEvent endpoints.
-            // Occasionally there will be an additional nested _errors field. See the relevant
-            // github issue: https://github.com/discord/discord-api-docs/issues/4811
-            let found_errors = match found_errors[0].get("_errors") {
-                Some(array) => array.as_array().expect("expected array"),
-                None => &found_errors,
-            };
-
             for error in found_errors {
                 let error_object = error.as_object().expect("expected object");
                 let mut object_path = path.to_owned();


### PR DESCRIPTION
When scheduled event support was initially added, it was noted that the Create and Edit endpoints returned incorrectly-structured data if the user omitted certain fields, which was causing deserialization errors. A hack was implemented and an issue was filed in discord/discord-api-docs#4811. The problem has since been fixed, so the workaround is no longer needed. I verified that the endpoint now works as intended.