### PR TITLE
Channel id name getch

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -393,7 +393,10 @@ impl ChannelId {
     /// required permissions the HTTP-request will be issued. Additionally, you might want to
     /// enable the `temp_cache` feature to cache channel data retrieved by this function for a
     /// short duration.
-    #[allow(clippy::missing_errors_doc)]
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the channel retrieval request failed.
     #[inline]
     pub async fn to_channel(self, cache_http: impl CacheHttp) -> Result<Channel> {
         #[cfg(feature = "cache")]
@@ -517,6 +520,10 @@ impl ChannelId {
     /// Returns the name of whatever channel this id holds.
     ///
     /// DM channels don't have a name, so a name is generated according to [`PrivateChannel::name()`].
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::to_channel()`].
     pub async fn name(self, cache_http: impl CacheHttp) -> Result<String> {
         let channel = self.to_channel(cache_http).await?;
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -515,12 +515,13 @@ impl ChannelId {
     }
 
     /// Returns the name of whatever channel this id holds.
-    #[cfg(feature = "cache")]
-    pub fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
-        let channel = self.to_channel_cached(cache)?;
+    ///
+    /// DM channels don't have a name, so a name is generated according to [`PrivateChannel::name()`].
+    pub async fn name(self, cache_http: impl CacheHttp) -> Result<String> {
+        let channel = self.to_channel(cache_http).await?;
 
-        Some(match channel {
-            Channel::Guild(channel) => channel.name().to_string(),
+        Ok(match channel {
+            Channel::Guild(channel) => channel.name,
             Channel::Private(channel) => channel.name(),
         })
     }


### PR DESCRIPTION
Fixes #1911 

I have a git stash where I adapt dozens of cache-only functions to cache+HTTP. But to be honest some of those seem ridiculous; e.g. I had to change `Message::is_own()` to call `http.get_current_user()` if cache is disabled, but realistically nobody with cache disabled would want that behavior because it's way too expensive making a request for every is_own() check... So... not sure where to draw the line where it's worth it to support HTTP fallback. So I just kept this PR small to fix only #1911. Feel free to tell if I should publish my other changes as well