### PR TITLE
Don't claim that the default channel ID equals guild ID

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -60,8 +60,6 @@ fn message_count_patch<'de, D: serde::Deserializer<'de>>(
 #[non_exhaustive]
 pub struct GuildChannel {
     /// The unique Id of the channel.
-    ///
-    /// The default channel Id shares the Id of the guild and the default role.
     pub id: ChannelId,
     /// The bitrate of the channel.
     ///

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -160,8 +160,7 @@ pub struct Guild {
     pub icon: Option<String>,
     /// The unique Id identifying the guild.
     ///
-    /// This is equivalent to the Id of the default role (`@everyone`) and also
-    /// that of the default channel (typically `#general`).
+    /// This is equivalent to the Id of the default role (`@everyone`).
     pub id: GuildId,
     /// The date that the current user joined the guild.
     pub joined_at: Timestamp,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -51,8 +51,7 @@ pub struct PartialGuild {
     pub application_id: Option<ApplicationId>,
     /// The unique Id identifying the guild.
     ///
-    /// This is equivalent to the Id of the default role (`@everyone`) and also
-    /// that of the default channel (typically `#general`).
+    /// This is equivalent to the Id of the default role (`@everyone`).
     pub id: GuildId,
     /// Id of a voice channel that's considered the AFK channel.
     pub afk_channel_id: Option<ChannelId>,


### PR DESCRIPTION
Fixes #1570 