### PR TITLE
Change channel/role position and bitrate type to u32

### DIFF
--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -55,7 +55,7 @@ pub struct EditRole<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     permissions: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    position: Option<i64>,
+    position: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     unicode_emoji: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -126,7 +126,7 @@ impl<'a> EditRole<'a> {
         };
 
         if let Some(position) = self.position {
-            guild_id.edit_role_position(http, role.id, position as u64).await?;
+            guild_id.edit_role_position(http, role.id, position).await?;
         }
         Ok(role)
     }
@@ -164,7 +164,7 @@ impl<'a> EditRole<'a> {
 
     /// Set the role's position in the role list. This correlates to the role's position in the
     /// user list.
-    pub fn position(mut self, position: i64) -> Self {
+    pub fn position(mut self, position: u32) -> Self {
         self.position = Some(position);
         self
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1931,7 +1931,7 @@ impl Http {
         &self,
         guild_id: u64,
         role_id: u64,
-        position: u64,
+        position: u32,
         audit_log_reason: Option<&str>,
     ) -> Result<Vec<Role>> {
         let map = json!([{

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -47,7 +47,7 @@ pub struct GuildChannel {
     /// The bitrate of the channel.
     ///
     /// **Note**: This is only available for voice and stage channels.
-    pub bitrate: Option<u64>,
+    pub bitrate: Option<u32>,
     /// The Id of the parent category for a channel, or of the parent text channel for a thread.
     ///
     /// **Note**: This is only available for channels in a category and thread channels.
@@ -77,10 +77,9 @@ pub struct GuildChannel {
     pub permission_overwrites: Vec<PermissionOverwrite>,
     /// The position of the channel.
     ///
-    /// The default text channel will _almost always_ have a position of `-1` or
-    /// `0`.
+    /// The default text channel will _almost always_ have a position of `0`.
     #[serde(default)]
-    pub position: i64,
+    pub position: u32,
     /// The topic of the channel.
     ///
     /// **Note**: This is only available for text and stage channels.
@@ -88,7 +87,7 @@ pub struct GuildChannel {
     /// The maximum number of members allowed in the channel.
     ///
     /// **Note**: This is only available for voice channels.
-    pub user_limit: Option<u64>,
+    pub user_limit: Option<u32>,
     /// Used to tell if the channel is not safe for work.
     /// Note however, it's recommended to use [`Self::is_nsfw`] as it's gonna be more accurate.
     // This field can or can not be present sometimes, but if it isn't

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -165,7 +165,7 @@ impl Channel {
     /// In DMs (private channel) it will return None.
     #[inline]
     #[must_use]
-    pub const fn position(&self) -> Option<i64> {
+    pub const fn position(&self) -> Option<u32> {
         match self {
             Self::Guild(channel) => Some(channel.position),
             Self::Private(_) => None,

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -91,8 +91,8 @@ pub enum Change {
     },
     /// Voice channel bitrate was changed.
     Bitrate {
-        old: Option<u64>,
-        new: Option<u64>,
+        old: Option<u32>,
+        new: Option<u32>,
     },
     /// Channel for invite code or guild scheduled event was changed.
     ChannelId {
@@ -292,8 +292,8 @@ pub enum Change {
     },
     /// Channel or role position was changed.
     Position {
-        old: Option<u64>,
-        new: Option<u64>,
+        old: Option<u32>,
+        new: Option<u32>,
     },
     /// Preferred locale of a guild was changed.
     PreferredLocale {
@@ -718,7 +718,7 @@ impl<'de> Visitor<'de> for ChangeVisitor {
             Available: bool,
             AvatarHash: String,
             BannerHash: String,
-            Bitrate: u64,
+            Bitrate: u32,
             ChannelId: ChannelId,
             Code: String,
             Colour: u64,
@@ -759,7 +759,7 @@ impl<'de> Visitor<'de> for ChangeVisitor {
             OwnerId: UserId,
             PermissionOverwrites: Vec<PermissionOverwrite>,
             Permissions: Permissions,
-            Position: u64,
+            Position: u32,
             PreferredLocale: String,
             PrivacyLevel: u64,
             PruneDeleteDays: u64,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -789,7 +789,7 @@ impl GuildId {
         self,
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
-        position: u64,
+        position: u32,
     ) -> Result<Vec<Role>> {
         http.as_ref().edit_role_position(self.get(), role_id.into().get(), position, None).await
     }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -297,7 +297,7 @@ impl Member {
     /// position. If two or more roles have the same highest position, then the
     /// role with the lowest ID is the highest.
     #[cfg(feature = "cache")]
-    pub fn highest_role_info(&self, cache: impl AsRef<Cache>) -> Option<(RoleId, i64)> {
+    pub fn highest_role_info(&self, cache: impl AsRef<Cache>) -> Option<(RoleId, u32)> {
         let guild = cache.as_ref().guild(self.guild_id)?;
 
         let mut highest = None;

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1215,7 +1215,7 @@ impl Guild {
         &self,
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
-        position: u64,
+        position: u32,
     ) -> Result<Vec<Role>> {
         self.id.edit_role_position(http, role_id, position).await
     }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -849,7 +849,7 @@ impl PartialGuild {
         &self,
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
-        position: u64,
+        position: u32,
     ) -> Result<Vec<Role>> {
         self.id.edit_role_position(http, role_id, position).await
     }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -62,7 +62,7 @@ pub struct Role {
     /// hierarchy if their position is higher.
     ///
     /// The `@everyone` role is usually either `-1` or `0`.
-    pub position: i64,
+    pub position: u32,
     /// The tags this role has. It can be used to determine if this role is a special role in this guild
     /// such as guild subscriber role, or if the role is linked to an [`Integration`] or a bot.
     ///
@@ -94,7 +94,7 @@ pub(crate) struct InterimRole {
     pub mentionable: bool,
     pub name: String,
     pub permissions: Permissions,
-    pub position: i64,
+    pub position: u32,
     #[serde(default)]
     pub tags: RoleTags,
 }


### PR DESCRIPTION
Fixes #1484 

Position type was inconsistent before; either i32 or u64. I tested a bit and negative numbers aren't really supported (they outright fail in channel position, and role position edit doesn't do anything at all however I use it... but the position numbers in role position edit seem to be relative to each other anyways so it doesn't matter which integers they are)