### PR TITLE
Add docs redirection HTML from /serenity to /serenity/current

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Redirect from /serenity to where rustdoc files are placed -->
+<meta http-equiv="refresh" content="0; url = current/serenity/index.html"/>
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
Fixes #1455 

That way, serenity-rs.github.io/serenity doesn't 404 anymore