### PR TITLE
Add note to reaction_users that emoji name is required

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -626,6 +626,10 @@ impl ChannelId {
     ///
     /// **Note**: Requires the [Read Message History] permission.
     ///
+    /// **Note**: If the passed reaction_type is a custom guild emoji, it must contain the name. So,
+    /// [`Emoji`] or [`EmojiIdentifier`] will always work, [`ReactionType`] only if
+    /// [`ReactionType::Custom::name`] is Some, and **[`EmojiId`] will never work**.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -900,6 +900,10 @@ impl GuildChannel {
     ///
     /// **Note**: Requires the [Read Message History] permission.
     ///
+    /// **Note**: If the passed reaction_type is a custom guild emoji, it must contain the name. So,
+    /// [`Emoji`] or [`EmojiIdentifier`] will always work, [`ReactionType`] only if
+    /// [`ReactionType::Custom::name`] is Some, and **[`EmojiId`] will never work**.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -442,6 +442,10 @@ impl Message {
     ///
     /// **Note**: Requires the [Read Message History] permission.
     ///
+    /// **Note**: If the passed reaction_type is a custom guild emoji, it must contain the name. So,
+    /// [`Emoji`] or [`EmojiIdentifier`] will always work, [`ReactionType`] only if
+    /// [`ReactionType::Custom::name`] is Some, and **[`EmojiId`] will never work**.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.


### PR DESCRIPTION
Fixes #811

I decided against introducing a new type like ReactionType that forbids not setting the name. Because then all the From implementations would have to be added for it again, and in any case we _already_ have too many emoji-esque types: Emoji, EmojiId, ActivityEmoji, EmojiIdentifier, Reaction, ReactionType, MessageReaction,