### PR TITLE
Add EventHandler::shards_ready

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -583,7 +583,11 @@ impl CacheUpdate for ReadyEvent {
             cache.presences.insert(*user_id, presence.clone());
         }
 
-        *cache.shard_count.write() = ready.shard.map_or(1, |s| s.total);
+        {
+            let mut cached_shard_data = cache.shard_data.write();
+            cached_shard_data.total = shard_data.total;
+            cached_shard_data.connected.insert(shard_data.id);
+        }
         *cache.user.write() = ready.user;
 
         None

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -600,6 +600,23 @@ async fn handle_event(
         },
         Event::Ready(mut event) => {
             update(&cache_and_http, &mut event);
+
+            #[cfg(feature = "cache")]
+            {
+                let mut shards = cache_and_http.cache.shard_data.write();
+                if shards.connected.len() as u32 == shards.total && !shards.has_sent_shards_ready {
+                    shards.has_sent_shards_ready = true;
+                    let total = shards.total;
+                    drop(shards);
+
+                    let context = context.clone();
+                    let event_handler = event_handler.clone();
+                    spawn_named("dispatch::event_handler::shards_ready", async move {
+                        event_handler.shards_ready(context, total).await;
+                    });
+                }
+            }
+
             spawn_named("dispatch::event_handler::ready", async move {
                 event_handler.ready(context, event.ready).await;
             });

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -54,6 +54,10 @@ pub trait EventHandler: Send + Sync {
     #[cfg(feature = "cache")]
     async fn cache_ready(&self, _ctx: Context, _guilds: Vec<GuildId>) {}
 
+    /// Dispatched when every shard has received a Ready event
+    #[cfg(feature = "cache")]
+    async fn shards_ready(&self, _ctx: Context, _total_shards: u32) {}
+
     /// Dispatched when a channel is created.
     ///
     /// Provides said channel's data.


### PR DESCRIPTION
Fixes #1831

This doesn't factor in shards disconnecting, because I couldn't find how to run code on that event (it's not an EventHandler event, nor an Event enum variant). But the [suggested implementation](https://github.com/Headline/discord-compiler-bot/blob/80a615b74ce1295e475bb60c791d29a924d9bf07/src/events.rs#L245-L261) from the linked issue doesn't either, so it's probably fine