### PR TITLE
Use Id types everywhere (instead of u64 or NonZeroU64)

### DIFF
--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -49,7 +49,7 @@ impl AddMember {
         guild_id: GuildId,
         user_id: UserId,
     ) -> Result<Option<Member>> {
-        http.as_ref().add_guild_member(guild_id.into(), user_id.into(), &self).await
+        http.as_ref().add_guild_member(guild_id, user_id, &self).await
     }
 
     /// Sets the OAuth2 access token for this request, replacing the current one.

--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -377,13 +377,11 @@ impl CreateApplicationCommand {
         let http = http.as_ref();
         match (guild_id, command_id) {
             (Some(guild_id), Some(command_id)) => {
-                http.edit_guild_application_command(guild_id.into(), command_id.into(), &self).await
+                http.edit_guild_application_command(guild_id, command_id, &self).await
             },
-            (Some(guild_id), None) => {
-                http.create_guild_application_command(guild_id.into(), &self).await
-            },
+            (Some(guild_id), None) => http.create_guild_application_command(guild_id, &self).await,
             (None, Some(command_id)) => {
-                http.edit_global_application_command(command_id.into(), &self).await
+                http.edit_global_application_command(command_id, &self).await
             },
             (None, None) => http.create_global_application_command(&self).await,
         }

--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -5,6 +5,7 @@ use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::application::command::CommandPermission;
 use crate::model::application::command::CommandPermissionType;
+use crate::model::id::CommandPermissionId;
 #[cfg(feature = "http")]
 use crate::model::id::{CommandId, GuildId};
 
@@ -73,7 +74,7 @@ pub struct CreateApplicationCommandPermissionData {
     #[serde(skip_serializing_if = "Option::is_none")]
     kind: Option<CommandPermissionType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    id: Option<String>,
+    id: Option<CommandPermissionId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     permission: Option<bool>,
 }
@@ -95,8 +96,8 @@ impl CreateApplicationCommandPermissionData {
     /// Sets the CommandPermissionId for the [`CommandPermissionData`].
     ///
     /// [`CommandPermissionData`]: crate::model::application::command::CommandPermissionData
-    pub fn id(mut self, id: u64) -> Self {
-        self.id = Some(id.to_string());
+    pub fn id(mut self, id: CommandPermissionId) -> Self {
+        self.id = Some(id);
         self
     }
 

--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -42,9 +42,7 @@ impl CreateApplicationCommandPermissionsData {
         guild_id: GuildId,
         command_id: CommandId,
     ) -> Result<CommandPermission> {
-        http.as_ref()
-            .edit_guild_application_command_permissions(guild_id.into(), command_id.into(), &self)
-            .await
+        http.as_ref().edit_guild_application_command_permissions(guild_id, command_id, &self).await
     }
 
     /// Adds a permission for the application command.

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -77,7 +77,7 @@ impl<'a> CreateChannel<'a> {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, guild_id: GuildId) -> Result<GuildChannel> {
-        http.create_channel(guild_id.into(), &self, self.audit_log_reason).await
+        http.create_channel(guild_id, &self, self.audit_log_reason).await
     }
 
     /// Specify how to call this new channel, replacing the current value as set in [`Self::new`].

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -2,8 +2,6 @@ use super::{CreateAllowedMentions, CreateAttachment, CreateComponents, CreateEmb
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
-use crate::constants;
-#[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::application::interaction::InteractionResponseType;

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -2,6 +2,8 @@ use super::{CreateAllowedMentions, CreateAttachment, CreateComponents, CreateEmb
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
+use crate::constants;
+#[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::application::interaction::InteractionResponseType;

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -44,7 +44,7 @@ impl<'a> CreateInteractionResponse<'a> {
         self.check_length()?;
         let files = self.data.as_mut().map_or_else(Vec::new, |d| std::mem::take(&mut d.files));
 
-        http.as_ref().create_interaction_response(interaction_id.into(), token, &self, files).await
+        http.as_ref().create_interaction_response(interaction_id, token, &self, files).await
     }
 
     #[cfg(feature = "http")]
@@ -269,9 +269,7 @@ impl CreateAutocompleteResponse {
         interaction_id: InteractionId,
         token: &str,
     ) -> Result<()> {
-        http.as_ref()
-            .create_interaction_response(interaction_id.into(), token, &self, Vec::new())
-            .await
+        http.as_ref().create_interaction_response(interaction_id, token, &self, Vec::new()).await
     }
 
     /// For autocomplete responses this sets their autocomplete suggestions.

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -2,6 +2,8 @@ use super::{CreateAllowedMentions, CreateAttachment, CreateComponents, CreateEmb
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
+use crate::constants;
+#[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -2,8 +2,6 @@ use super::{CreateAllowedMentions, CreateAttachment, CreateComponents, CreateEmb
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
-use crate::constants;
-#[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -60,7 +60,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         let files = std::mem::take(&mut self.files);
 
         match message_id {
-            Some(id) => http.as_ref().edit_followup_message(token, id.into(), &self, files).await,
+            Some(id) => http.as_ref().edit_followup_message(token, id, &self, files).await,
             None => http.as_ref().create_followup_message(token, &self, files).await,
         }
     }

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -128,7 +128,7 @@ impl<'a> CreateInvite<'a> {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, channel_id: ChannelId) -> Result<RichInvite> {
-        http.create_invite(channel_id.into(), &self, self.audit_log_reason).await
+        http.create_invite(channel_id, &self, self.audit_log_reason).await
     }
 
     /// The duration that the invite will be valid for.

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -131,7 +131,7 @@ impl<'a> CreateMessage<'a> {
     async fn _execute(mut self, http: &Http, channel_id: ChannelId) -> Result<Message> {
         self.check_length()?;
         let files = std::mem::take(&mut self.files);
-        let message = http.send_message(channel_id.into(), files, &self).await?;
+        let message = http.send_message(channel_id, files, &self).await?;
 
         for reaction in self.reactions {
             channel_id.create_reaction(http, message.id, reaction).await?;

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -82,7 +82,7 @@ impl<'a> CreateScheduledEvent<'a> {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, guild_id: GuildId) -> Result<ScheduledEvent> {
-        http.create_scheduled_event(guild_id.into(), &self, self.audit_log_reason).await
+        http.create_scheduled_event(guild_id, &self, self.audit_log_reason).await
     }
 
     /// Sets the channel id of the scheduled event. Required if [`Self::kind`] is

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -71,7 +71,7 @@ impl<'a> CreateSticker<'a> {
         map.push(("tags".to_string(), self.tags));
         map.push(("description".to_string(), self.description));
 
-        http.create_sticker(guild_id.into(), map, self.file, self.audit_log_reason).await
+        http.create_sticker(guild_id, map, self.file, self.audit_log_reason).await
     }
 
     /// Set the name of the sticker, replacing the current value as set in [`Self::new`].

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -46,10 +46,10 @@ impl<'a> CreateThread<'a> {
         message_id: Option<MessageId>,
     ) -> Result<GuildChannel> {
         let http = http.as_ref();
-        let id = channel_id.into();
+        let id = channel_id;
         match message_id {
             Some(msg_id) => {
-                http.create_public_thread(id, msg_id.into(), &self, self.audit_log_reason).await
+                http.create_public_thread(id, msg_id, &self, self.audit_log_reason).await
             },
             None => http.create_private_thread(id, &self, self.audit_log_reason).await,
         }

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -70,7 +70,7 @@ impl<'a> CreateWebhook<'a> {
             return Err(Error::Model(ModelError::NameTooLong));
         }
 
-        http.create_webhook(channel_id.into(), &self, self.audit_log_reason).await
+        http.create_webhook(channel_id, &self, self.audit_log_reason).await
     }
 
     /// Set the webhook's name, replacing the current value as set in [`Self::new`].

--- a/src/builder/edit_automod_rule.rs
+++ b/src/builder/edit_automod_rule.rs
@@ -59,17 +59,11 @@ impl<'a> EditAutoModRule<'a> {
         let http = http.as_ref();
         match rule_id {
             Some(rule_id) => {
-                http.edit_automod_rule(
-                    guild_id.into(),
-                    rule_id.into(),
-                    &self,
-                    self.audit_log_reason,
-                )
-                .await
+                http.edit_automod_rule(guild_id, rule_id, &self, self.audit_log_reason).await
             },
             // Automod Rule creation has required fields, whereas modifying a rule does not.
             // TODO: Enforce these fields (maybe with a separate CreateAutoModRule builder).
-            None => http.create_automod_rule(guild_id.into(), &self, self.audit_log_reason).await,
+            None => http.create_automod_rule(guild_id, &self, self.audit_log_reason).await,
         }
     }
 

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -105,7 +105,7 @@ impl<'a> EditChannel<'a> {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, channel_id: ChannelId) -> Result<GuildChannel> {
-        http.edit_channel(channel_id.into(), &self, self.audit_log_reason).await
+        http.edit_channel(channel_id, &self, self.audit_log_reason).await
     }
 
     /// The bitrate of the channel in bits.

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -80,7 +80,7 @@ impl<'a> EditGuild<'a> {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, guild_id: GuildId) -> Result<PartialGuild> {
-        http.as_ref().edit_guild(guild_id.into(), &self, self.audit_log_reason).await
+        http.as_ref().edit_guild(guild_id, &self, self.audit_log_reason).await
     }
 
     /// Set the "AFK voice channel" that users are to move to if they have been AFK for an amount

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -42,7 +42,7 @@ impl<'a> EditGuildWelcomeScreen<'a> {
         http: impl AsRef<Http>,
         guild_id: GuildId,
     ) -> Result<GuildWelcomeScreen> {
-        http.as_ref().edit_guild_welcome_screen(guild_id.into(), &self, self.audit_log_reason).await
+        http.as_ref().edit_guild_welcome_screen(guild_id, &self, self.audit_log_reason).await
     }
 
     /// Whether the welcome screen is enabled or not.

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -36,7 +36,7 @@ impl<'a> EditGuildWidget<'a> {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[cfg(feature = "http")]
     pub async fn execute(self, http: impl AsRef<Http>, guild_id: GuildId) -> Result<GuildWidget> {
-        http.as_ref().edit_guild_widget(guild_id.into(), &self, self.audit_log_reason).await
+        http.as_ref().edit_guild_widget(guild_id, &self, self.audit_log_reason).await
     }
 
     /// Whether the widget is enabled or not.

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -8,6 +8,8 @@ use super::{
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
+use crate::constants;
+#[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -8,8 +8,6 @@ use super::{
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
-use crate::constants;
-#[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -46,9 +46,7 @@ impl<'a> EditMember<'a> {
         guild_id: GuildId,
         user_id: UserId,
     ) -> Result<Member> {
-        http.as_ref()
-            .edit_member(guild_id.into(), user_id.into(), &self, self.audit_log_reason)
-            .await
+        http.as_ref().edit_member(guild_id, user_id, &self, self.audit_log_reason).await
     }
 
     /// Whether to deafen the member.

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -8,6 +8,8 @@ use super::{
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
+use crate::constants;
+#[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -98,7 +98,7 @@ impl<'a> EditMessage<'a> {
     ) -> Result<Message> {
         self.check_length()?;
         let files = std::mem::take(&mut self.files);
-        http.as_ref().edit_message(channel_id.into(), message_id.into(), &self, files).await
+        http.as_ref().edit_message(channel_id, message_id, &self, files).await
     }
 
     #[cfg(feature = "http")]

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -8,8 +8,6 @@ use super::{
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
-use crate::constants;
-#[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -118,10 +118,9 @@ impl<'a> EditRole<'a> {
     ) -> Result<Role> {
         let role = match role_id {
             Some(role_id) => {
-                http.edit_role(guild_id.into(), role_id.into(), &self, self.audit_log_reason)
-                    .await?
+                http.edit_role(guild_id, role_id, &self, self.audit_log_reason).await?
             },
-            None => http.create_role(guild_id.into(), &self, self.audit_log_reason).await?,
+            None => http.create_role(guild_id, &self, self.audit_log_reason).await?,
         };
 
         if let Some(position) = self.position {

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -68,9 +68,7 @@ impl<'a> EditScheduledEvent<'a> {
         guild_id: GuildId,
         event_id: ScheduledEventId,
     ) -> Result<ScheduledEvent> {
-        http.as_ref()
-            .edit_scheduled_event(guild_id.into(), event_id.into(), &self, self.audit_log_reason)
-            .await
+        http.as_ref().edit_scheduled_event(guild_id, event_id, &self, self.audit_log_reason).await
     }
 
     /// Sets the channel id of the scheduled event. If the [`kind`] of the event is changed from

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -53,7 +53,7 @@ impl<'a> EditStageInstance<'a> {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, channel_id: ChannelId) -> Result<StageInstance> {
-        http.edit_stage_instance(channel_id.into(), &self, self.audit_log_reason).await
+        http.edit_stage_instance(channel_id, &self, self.audit_log_reason).await
     }
 
     /// Sets the topic of the stage channel instance.

--- a/src/builder/edit_sticker.rs
+++ b/src/builder/edit_sticker.rs
@@ -55,9 +55,7 @@ impl<'a> EditSticker<'a> {
         guild_id: GuildId,
         sticker_id: StickerId,
     ) -> Result<Sticker> {
-        http.as_ref()
-            .edit_sticker(guild_id.into(), sticker_id.into(), &self, self.audit_log_reason)
-            .await
+        http.as_ref().edit_sticker(guild_id, sticker_id, &self, self.audit_log_reason).await
     }
 
     /// The name of the sticker to set.

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -40,7 +40,7 @@ impl<'a> EditThread<'a> {
         http: impl AsRef<Http>,
         channel_id: ChannelId,
     ) -> Result<GuildChannel> {
-        http.as_ref().edit_thread(channel_id.into(), &self, self.audit_log_reason).await
+        http.as_ref().edit_thread(channel_id, &self, self.audit_log_reason).await
     }
 
     /// The name of the thread.

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -64,9 +64,9 @@ impl EditVoiceState {
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, guild_id: GuildId, user_id: Option<UserId>) -> Result<()> {
         if let Some(user_id) = user_id {
-            http.edit_voice_state(guild_id.into(), user_id.into(), &self).await
+            http.edit_voice_state(guild_id, user_id, &self).await
         } else {
-            http.edit_voice_state_me(guild_id.into(), &self).await
+            http.edit_voice_state_me(guild_id, &self).await
         }
     }
 

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -40,7 +40,7 @@ impl<'a> EditWebhook<'a> {
         webhook_id: WebhookId,
         token: Option<&str>,
     ) -> Result<Webhook> {
-        let id = webhook_id.into();
+        let id = webhook_id;
         match token {
             Some(token) => {
                 http.as_ref().edit_webhook_with_token(id, token, &self, self.audit_log_reason).await

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -54,7 +54,7 @@ impl EditWebhookMessage {
         token: &str,
     ) -> Result<Message> {
         self.check_length()?;
-        http.as_ref().edit_webhook_message(webhook_id.into(), token, message_id.into(), &self).await
+        http.as_ref().edit_webhook_message(webhook_id, token, message_id, &self).await
     }
 
     #[cfg(feature = "http")]

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -2,6 +2,8 @@ use super::{CreateAllowedMentions, CreateAttachment, CreateComponents, CreateEmb
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
+use crate::constants;
+#[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -2,8 +2,6 @@ use super::{CreateAllowedMentions, CreateAttachment, CreateComponents, CreateEmb
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
-use crate::constants;
-#[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -98,10 +98,8 @@ impl<'a> ExecuteWebhook<'a> {
         wait: bool,
     ) -> Result<Option<Message>> {
         self.check_length()?;
-        let webhook_id = webhook_id.into();
-        let thread_id = self.thread_id.map(Into::into);
         let files = std::mem::take(&mut self.files);
-        http.as_ref().execute_webhook(webhook_id, thread_id, token, wait, files, &self).await
+        http.as_ref().execute_webhook(webhook_id, self.thread_id, token, wait, files, &self).await
     }
 
     #[cfg(feature = "http")]

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -87,7 +87,7 @@ impl GetMessages {
             }
         }
 
-        http.as_ref().get_messages(channel_id.into(), &query).await
+        http.as_ref().get_messages(channel_id, &query).await
     }
 
     /// Indicates to retrieve the messages after a specific message, given its Id.

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -548,7 +548,7 @@ impl CacheUpdate for ReadyEvent {
         for guild_entry in cache.guilds.iter() {
             let guild = guild_entry.key();
             // Only handle data for our shard.
-            if crate::utils::shard_id(guild.0, shard_data.total) == shard_data.id
+            if crate::utils::shard_id(*guild, shard_data.total) == shard_data.id
                 && !ready_guilds_hashset.contains(guild)
             {
                 guilds_to_remove.push(*guild);

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -184,7 +184,7 @@ impl ShardQueuer {
         .await?;
 
         let cloned_http = self.cache_and_http.http.clone();
-        shard.set_application_id_callback(move |id| cloned_http.set_application_id(id.get()));
+        shard.set_application_id_callback(move |id| cloned_http.set_application_id(id));
 
         let mut runner = ShardRunner::new(ShardRunnerOptions {
             data: Arc::clone(&self.data),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -144,7 +144,7 @@ impl ClientBuilder {
     }
 
     /// Sets the application id.
-    pub fn application_id(self, application_id: u64) -> Self {
+    pub fn application_id(self, application_id: ApplicationId) -> Self {
         if let Some(http) = &self.http {
             http.set_application_id(application_id);
         }
@@ -154,7 +154,7 @@ impl ClientBuilder {
 
     /// Gets the application ID, if already initialized. See [`Self::application_id`] for more info.
     pub fn get_application_id(&self) -> Option<ApplicationId> {
-        self.http.as_ref().and_then(Http::application_id).map(ApplicationId)
+        self.http.as_ref().and_then(Http::application_id)
     }
 
     /// Sets the entire [`TypeMap`] that will be available in [`Context`]s.

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -1,9 +1,8 @@
-use std::num::NonZeroU64;
-
 use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::macros::*;
 use crate::collector::{Filter, FilterTrait, LazyArc};
 use crate::model::application::interaction::message_component::MessageComponentInteraction;
+use crate::model::id::{ChannelId, GuildId, MessageId, UserId};
 
 impl FilterTrait<MessageComponentInteraction> for Filter<MessageComponentInteraction> {
     fn register(self, messenger: &ShardMessenger) {
@@ -17,20 +16,20 @@ impl FilterTrait<MessageComponentInteraction> for Filter<MessageComponentInterac
         &self,
         interaction: &mut LazyArc<'_, MessageComponentInteraction>,
     ) -> bool {
-        self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id.map(|g| g.0))
-            && self.options.message_id.map_or(true, |id| interaction.message.id.0 == id)
-            && self.options.channel_id.map_or(true, |id| id == interaction.channel_id.0)
-            && self.options.author_id.map_or(true, |id| id == interaction.user.id.0)
+        self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id)
+            && self.options.message_id.map_or(true, |id| interaction.message.id == id)
+            && self.options.channel_id.map_or(true, |id| id == interaction.channel_id)
+            && self.options.author_id.map_or(true, |id| id == interaction.user.id)
             && self.common_options.filter.as_ref().map_or(true, |f| f.0(interaction))
     }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct FilterOptions {
-    channel_id: Option<NonZeroU64>,
-    guild_id: Option<NonZeroU64>,
-    author_id: Option<NonZeroU64>,
-    message_id: Option<NonZeroU64>,
+    channel_id: Option<ChannelId>,
+    guild_id: Option<GuildId>,
+    author_id: Option<UserId>,
+    message_id: Option<MessageId>,
 }
 
 impl super::CollectorBuilder<'_, MessageComponentInteraction> {

--- a/src/collector/macros.rs
+++ b/src/collector/macros.rs
@@ -11,8 +11,8 @@ macro_rules! gen_macro {
 
 gen_macro!(
     impl_author_id,
-    pub fn author_id(mut self, author_id: impl Into<u64>) -> Self {
-        self.filter_options.author_id = std::num::NonZeroU64::new(author_id.into());
+    pub fn author_id(mut self, author_id: UserId) -> Self {
+        self.filter_options.author_id = Some(author_id);
 
         self
     }
@@ -20,8 +20,8 @@ gen_macro!(
 
 gen_macro!(
     impl_channel_id,
-    pub fn channel_id(mut self, channel_id: impl Into<u64>) -> Self {
-        self.filter_options.channel_id = std::num::NonZeroU64::new(channel_id.into());
+    pub fn channel_id(mut self, channel_id: ChannelId) -> Self {
+        self.filter_options.channel_id = Some(channel_id);
 
         self
     }
@@ -29,8 +29,8 @@ gen_macro!(
 
 gen_macro!(
     impl_guild_id,
-    pub fn guild_id(mut self, guild_id: impl Into<u64>) -> Self {
-        self.filter_options.guild_id = std::num::NonZeroU64::new(guild_id.into());
+    pub fn guild_id(mut self, guild_id: GuildId) -> Self {
+        self.filter_options.guild_id = Some(guild_id);
 
         self
     }
@@ -38,8 +38,8 @@ gen_macro!(
 
 gen_macro!(
     impl_message_id,
-    pub fn message_id(mut self, message_id: impl Into<u64>) -> Self {
-        self.filter_options.message_id = std::num::NonZeroU64::new(message_id.into());
+    pub fn message_id(mut self, message_id: MessageId) -> Self {
+        self.filter_options.message_id = Some(message_id);
 
         self
     }

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -1,10 +1,9 @@
-use std::num::NonZeroU64;
-
 use super::Filter;
 use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::macros::*;
 use crate::collector::LazyArc;
 use crate::model::channel::Message;
+use crate::model::id::{ChannelId, GuildId, UserId};
 
 impl super::FilterTrait<Message> for Filter<Message> {
     fn register(self, messenger: &ShardMessenger) {
@@ -15,18 +14,18 @@ impl super::FilterTrait<Message> for Filter<Message> {
     /// Constraints are optional, as it is possible to limit messages to
     /// be sent by a specific author or in a specific guild.
     fn is_passing_constraints(&self, message: &mut LazyArc<'_, Message>) -> bool {
-        self.options.guild_id.map_or(true, |g| Some(g) == message.guild_id.map(|g| g.0))
-            && self.options.channel_id.map_or(true, |g| g == message.channel_id.0)
-            && self.options.author_id.map_or(true, |g| g == message.author.id.0)
+        self.options.guild_id.map_or(true, |g| Some(g) == message.guild_id)
+            && self.options.channel_id.map_or(true, |g| g == message.channel_id)
+            && self.options.author_id.map_or(true, |g| g == message.author.id)
             && self.common_options.filter.as_ref().map_or(true, |f| f.0(message))
     }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct FilterOptions {
-    channel_id: Option<NonZeroU64>,
-    guild_id: Option<NonZeroU64>,
-    author_id: Option<NonZeroU64>,
+    channel_id: Option<ChannelId>,
+    guild_id: Option<GuildId>,
+    author_id: Option<UserId>,
 }
 
 impl super::CollectorBuilder<'_, Message> {

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -2,6 +2,10 @@
 //! filter lets them pass, and collects if the receive, collect, or time limits
 //! are not reached yet.
 
+// triggered by Derivative
+// can't put it on the derived type itself for some reason
+#![allow(clippy::let_underscore_must_use)]
+
 use std::fmt;
 use std::num::NonZeroU32;
 use std::pin::Pin;

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -1,9 +1,8 @@
-use std::num::NonZeroU64;
-
 use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::macros::*;
 use crate::collector::{Filter, LazyArc};
 use crate::model::application::interaction::modal::ModalSubmitInteraction;
+use crate::model::id::{ChannelId, GuildId, MessageId, UserId};
 
 impl super::FilterTrait<ModalSubmitInteraction> for Filter<ModalSubmitInteraction> {
     fn register(self, messenger: &ShardMessenger) {
@@ -14,23 +13,23 @@ impl super::FilterTrait<ModalSubmitInteraction> for Filter<ModalSubmitInteractio
         &self,
         interaction: &mut LazyArc<'_, ModalSubmitInteraction>,
     ) -> bool {
-        self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id.map(|g| g.0))
+        self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id)
             && self
                 .options
                 .message_id
-                .map_or(true, |id| Some(id) == interaction.message.as_ref().map(|m| m.id.0))
-            && self.options.channel_id.map_or(true, |id| id == interaction.channel_id.as_ref().0)
-            && self.options.author_id.map_or(true, |id| id == interaction.user.id.0)
+                .map_or(true, |id| Some(id) == interaction.message.as_ref().map(|m| m.id))
+            && self.options.channel_id.map_or(true, |id| id == interaction.channel_id)
+            && self.options.author_id.map_or(true, |id| id == interaction.user.id)
             && self.common_options.filter.as_ref().map_or(true, |f| f.0(interaction))
     }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct FilterOptions {
-    channel_id: Option<NonZeroU64>,
-    guild_id: Option<NonZeroU64>,
-    author_id: Option<NonZeroU64>,
-    message_id: Option<NonZeroU64>,
+    channel_id: Option<ChannelId>,
+    guild_id: Option<GuildId>,
+    author_id: Option<UserId>,
+    message_id: Option<MessageId>,
 }
 
 impl super::CollectorBuilder<'_, ModalSubmitInteraction> {

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -1,10 +1,10 @@
-use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::macros::*;
 use crate::collector::{Filter, LazyArc};
 use crate::model::channel::Reaction;
+use crate::model::id::{ChannelId, GuildId, MessageId, UserId};
 
 /// Marks whether the reaction has been added or removed.
 #[derive(Debug, Clone)]
@@ -90,20 +90,20 @@ impl super::FilterTrait<ReactionAction> for Filter<ReactionAction> {
             },
         };
 
-        self.options.guild_id.map_or(true, |id| Some(id) == reaction.guild_id.map(|g| g.0))
-            && self.options.message_id.map_or(true, |id| id == reaction.message_id.0)
-            && self.options.channel_id.map_or(true, |id| id == reaction.channel_id.0)
-            && self.options.author_id.map_or(true, |id| Some(id) == reaction.user_id.map(|u| u.0))
+        self.options.guild_id.map_or(true, |id| Some(id) == reaction.guild_id)
+            && self.options.message_id.map_or(true, |id| id == reaction.message_id)
+            && self.options.channel_id.map_or(true, |id| id == reaction.channel_id)
+            && self.options.author_id.map_or(true, |id| Some(id) == reaction.user_id)
             && self.common_options.filter.as_ref().map_or(true, |f| f.0(reaction))
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct FilterOptions {
-    channel_id: Option<NonZeroU64>,
-    guild_id: Option<NonZeroU64>,
-    author_id: Option<NonZeroU64>,
-    message_id: Option<NonZeroU64>,
+    channel_id: Option<ChannelId>,
+    guild_id: Option<GuildId>,
+    author_id: Option<UserId>,
+    message_id: Option<MessageId>,
     accept_added: bool,
     accept_removed: bool,
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -880,10 +880,11 @@ impl Http {
     /// ```rust,no_run
     /// use serenity::http::Http;
     /// use serenity::json::json;
+    /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #    let http = Http::new("token");
-    /// let channel_id = 81384788765712384;
+    /// let channel_id = ChannelId::new(81384788765712384);
     /// let map = json!({"name": "test"});
     ///
     /// let webhook = http.create_webhook(channel_id, &map, None).await?;
@@ -1114,7 +1115,7 @@ impl Http {
     /// let channel_id = ChannelId::new(7);
     /// let message_id = MessageId::new(8);
     ///
-    /// http.delete_message_reactions(channel_id.get(), message_id.get()).await?;
+    /// http.delete_message_reactions(channel_id, message_id).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -1292,13 +1293,15 @@ impl Http {
     ///
     /// ```rust,no_run
     /// use serenity::http::Http;
+    /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// // Due to the `delete_webhook` function requiring you to authenticate, you must have set
     /// // the token first.
     /// let http = Http::new("token");
     ///
-    /// http.delete_webhook(245037420704169985, None).await?;
+    /// let webhook_id = WebhookId::new(245037420704169985);
+    /// http.delete_webhook(webhook_id, None).await?;
     /// Ok(())
     /// # }
     /// ```
@@ -1328,10 +1331,11 @@ impl Http {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::prelude::*;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
-    /// let id = 245037420704169985;
+    /// let id = WebhookId::new(245037420704169985);
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
     /// http.delete_webhook_with_token(id, token, None).await?;
@@ -2018,11 +2022,12 @@ impl Http {
     /// ```rust,no_run
     /// use serenity::http::Http;
     /// use serenity::json::{json, prelude::*};
+    /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let guild_id = 187450744427773963;
-    /// let user_id = 150443906511667200;
+    /// let guild_id = GuildId::new(187450744427773963);
+    /// let user_id = UserId::new(150443906511667200);
     /// let map = json!({
     ///     "channel_id": "826929611849334784",
     ///     "suppress": true,
@@ -2069,10 +2074,11 @@ impl Http {
     /// ```rust,no_run
     /// use serenity::http::Http;
     /// use serenity::json::{json, prelude::*};
+    /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let guild_id = 187450744427773963;
+    /// let guild_id = GuildId::new(187450744427773963);
     /// let map = json!({
     ///     "channel_id": "826929611849334784",
     ///     "suppress": false,
@@ -2118,10 +2124,11 @@ impl Http {
     /// ```rust,no_run
     /// use serenity::http::Http;
     /// use serenity::json::json;
+    /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let id = 245037420704169985;
+    /// let id = WebhookId::new(245037420704169985);
     /// let image = serenity::utils::read_image("./webhook_img.png")?;
     /// let map = json!({
     ///     "avatar": image,
@@ -2161,10 +2168,11 @@ impl Http {
     /// ```rust,no_run
     /// use serenity::http::Http;
     /// use serenity::json::prelude::*;
+    /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let id = 245037420704169985;
+    /// let id = WebhookId::new(245037420704169985);
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let value = json!({"name": "new name"});
     /// let map = value.as_object().unwrap();
@@ -2230,10 +2238,11 @@ impl Http {
     /// ```rust,no_run
     /// use serenity::http::Http;
     /// use serenity::json::prelude::*;
+    /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let id = 245037420704169985;
+    /// let id = WebhookId::new(245037420704169985);
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let value = json!({"content": "test"});
     /// let map = value.as_object().unwrap();
@@ -2690,10 +2699,11 @@ impl Http {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::prelude::*;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http = Http::new("token");
-    /// let channel_id = 81384788765712384;
+    /// let channel_id = ChannelId::new(81384788765712384);
     ///
     /// let webhooks = http.get_channel_webhooks(channel_id).await?;
     /// #     Ok(())
@@ -3262,10 +3272,11 @@ impl Http {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::prelude::*;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let guild_id = 81384788765712384;
+    /// let guild_id = GuildId::new(81384788765712384);
     ///
     /// let webhooks = http.get_guild_webhooks(guild_id).await?;
     /// #     Ok(())
@@ -3599,10 +3610,11 @@ impl Http {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
-    /// #
+    /// # use serenity::model::prelude::*;
+    ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let id = 245037420704169985;
+    /// let id = WebhookId::new(245037420704169985);
     /// let webhook = http.get_webhook(id).await?;
     /// #     Ok(())
     /// # }
@@ -3629,10 +3641,11 @@ impl Http {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::prelude::*;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let id = 245037420704169985;
+    /// let id = WebhookId::new(245037420704169985);
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     ///
     /// let webhook = http.get_webhook_with_token(id, token).await?;
@@ -3915,12 +3928,14 @@ impl Http {
     /// # use std::sync::Arc;
     /// # use serenity::http::{Http, Typing};
     /// # use serenity::Result;
+    /// # use serenity::model::prelude::*;
     /// #
     /// # fn long_process() {}
     /// # fn main() -> Result<()> {
     /// # let http = Arc::new(Http::new("token"));
     /// // Initiate typing (assuming http is `Arc<Http>`)
-    /// let typing = http.start_typing(7)?;
+    /// let channel_id = ChannelId::new(7);
+    /// let typing = http.start_typing(channel_id)?;
     ///
     /// // Run some long-running process
     /// long_process();
@@ -3975,13 +3990,13 @@ impl Http {
     ///         routing::RouteInfo,
     ///         request::Request,
     ///     },
-    ///     model::channel::Message,
+    ///     model::prelude::*,
     /// };
     ///
     /// let bytes = vec![
     ///     // payload bytes here
     /// ];
-    /// let channel_id = 381880193700069377;
+    /// let channel_id = ChannelId::new(381880193700069377);
     /// let route_info = RouteInfo::CreateMessage { channel_id };
     ///
     /// let mut request = Request::new(route_info);
@@ -4014,6 +4029,7 @@ impl Http {
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
+    /// # use serenity::model::prelude::*;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
@@ -4025,7 +4041,7 @@ impl Http {
     /// let bytes = vec![
     ///     // payload bytes here
     /// ];
-    /// let channel_id = 381880193700069377;
+    /// let channel_id = ChannelId::new(381880193700069377);
     /// let route_info = RouteInfo::CreateMessage { channel_id };
     ///
     /// let mut request = Request::new(route_info);

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -148,7 +148,7 @@ impl HttpBuilder {
     pub fn build(self) -> Http {
         let token = self.token;
 
-        let application_id = AtomicU64::new(self.application_id.map_or(0, |id| id.get()));
+        let application_id = AtomicU64::new(self.application_id.map_or(0, ApplicationId::get));
 
         let client = self.client.unwrap_or_else(|| {
             let builder = configure_client_backend(Client::builder());

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -148,13 +148,15 @@ impl Ratelimiter {
     /// ```rust,no_run
     /// use serenity::http::ratelimiting::Route;
     /// # use serenity::http::Http;
+    /// # use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
     /// let routes = http.ratelimiter.routes();
     /// let reader = routes.read().await;
     ///
-    /// if let Some(route) = reader.get(&Route::ChannelsId(7)) {
+    /// let channel_id = ChannelId::new(7);
+    /// if let Some(route) = reader.get(&Route::ChannelsId(channel_id)) {
     ///     if let Some(reset) = route.lock().await.reset() {
     ///         println!("Reset time at: {:?}", reset);
     ///     }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -3,162 +3,73 @@ use std::fmt::{Display, Write};
 
 use super::LightMethod;
 use crate::constants;
+use crate::model::id::*;
 
 /// A representation of all routes registered within the library. These are safe
 /// and memory-efficient representations of each path that functions exist for
 /// in the [`http`] module.
+///
+/// Used as ratelimit buckets.
 ///
 /// [`http`]: crate::http
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Route {
     /// Route for the `/channels/:channel_id` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsId(u64),
+    ChannelsId(ChannelId),
     /// Route for the `/channels/:channel_id/invites` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdInvites(u64),
+    ChannelsIdInvites(ChannelId),
     /// Route for the `/channels/:channel_id/messages` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdMessages(u64),
+    ChannelsIdMessages(ChannelId),
     /// Route for the `/channels/:channel_id/messages/bulk-delete` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdMessagesBulkDelete(u64),
+    ChannelsIdMessagesBulkDelete(ChannelId),
     /// Route for the `/channels/:channel_id/messages/:message_id` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
     ///
     /// This route is a unique case. The ratelimit for message _deletions_ is
     /// different than the overall route ratelimit.
     ///
     /// Refer to the docs on [Rate Limits] in the yellow warning section.
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
     /// [Rate Limits]: https://discord.com/developers/docs/topics/rate-limits
-    ChannelsIdMessagesId(LightMethod, u64),
+    ChannelsIdMessagesId(LightMethod, ChannelId),
     /// Route for the `/channels/:channel_id/messages/:message_id/ack` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdMessagesIdAck(u64),
+    ChannelsIdMessagesIdAck(ChannelId),
     /// Route for the `/channels/:channel_id/messages/:message_id/reactions`
     /// path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdMessagesIdReactions(u64),
+    ChannelsIdMessagesIdReactions(ChannelId),
     /// Route for the
     /// `/channels/:channel_id/messages/:message_id/reactions/:reaction/@me`
     /// path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdMessagesIdReactionsUserIdType(u64),
+    ChannelsIdMessagesIdReactionsUserIdType(ChannelId),
     /// Route for the `/channels/:channel_id/permissions/:target_id` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdPermissionsOverwriteId(u64),
+    ChannelsIdPermissionsOverwriteId(ChannelId),
     /// Route for the `/channels/:channel_id/pins` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdPins(u64),
+    ChannelsIdPins(ChannelId),
     /// Route for the `/channels/:channel_id/pins/:message_id` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdPinsMessageId(u64),
+    ChannelsIdPinsMessageId(ChannelId),
     /// Route for the `/channels/:channel_id/message/:message_id/crosspost` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdCrosspostsMessageId(u64),
+    ChannelsIdCrosspostsMessageId(ChannelId),
     /// Route for the `/channels/:channel_id/typing` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdTyping(u64),
+    ChannelsIdTyping(ChannelId),
     /// Route for the `/channels/:channel_id/webhooks` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdWebhooks(u64),
+    ChannelsIdWebhooks(ChannelId),
     /// Route for the `/channels/:channel_id/messages/:message_id/threads` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdMessagesIdThreads(u64),
+    ChannelsIdMessagesIdThreads(ChannelId),
     /// Route for the `/channels/:channel_id/threads` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdThreads(u64),
+    ChannelsIdThreads(ChannelId),
     /// Route for the `/channels/:channel_id/thread-members/@me` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdThreadMembersMe(u64),
+    ChannelsIdThreadMembersMe(ChannelId),
     /// Route for the `/channels/:channel_id/thread-members/:user_id` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdThreadMembersUserId(u64),
+    ChannelsIdThreadMembersUserId(ChannelId),
     /// Route for the `/channels/channel_id/thread-members` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdThreadMembers(u64),
+    ChannelsIdThreadMembers(ChannelId),
     /// Route for the `/channels/:channel_id/threads/archived/public` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdArchivedPublicThreads(u64),
+    ChannelsIdArchivedPublicThreads(ChannelId),
     /// Route for the `/channels/:channel_id/threads/archived/private` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdArchivedPrivateThreads(u64),
+    ChannelsIdArchivedPrivateThreads(ChannelId),
     /// Route for the `/channels/:channel_id/users/@me/threads/archived/private` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    ChannelsIdMeJoindedArchivedPrivateThreads(u64),
+    ChannelsIdMeJoindedArchivedPrivateThreads(ChannelId),
     /// Route for the `/channels/{channel.id}/followers` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    FollowNewsChannel(u64),
+    FollowNewsChannel(ChannelId),
     /// Route for the `/gateway` path.
     Gateway,
     /// Route for the `/gateway/bot` path.
@@ -166,212 +77,78 @@ pub enum Route {
     /// Route for the `/guilds` path.
     Guilds,
     /// Route for the `/guilds/:guild_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsId(u64),
+    GuildsId(GuildId),
     /// Route for the `/guilds/:guild_id/auto-moderation/rules` path.
-    GuildsIdAutoModRules(u64),
+    GuildsIdAutoModRules(GuildId),
     /// Route for the `/guilds/:guild_id/auto-moderation/rules/:rule_id` path.
-    GuildsIdAutoModRulesId(u64),
+    GuildsIdAutoModRulesId(GuildId),
     /// Route for the `/guilds/:guild_id/bans` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdBans(u64),
-    /// Route for the `/guilds/:guild_id/audit-logs` path.
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdAuditLogs(u64),
+    GuildsIdBans(GuildId),
+    GuildsIdAuditLogs(GuildId),
     /// Route for the `/guilds/:guild_id/bans/:user_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdBansUserId(u64),
+    GuildsIdBansUserId(GuildId),
     /// Route for the `/guilds/:guild_id/channels/:channel_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdChannels(u64),
+    GuildsIdChannels(GuildId),
     /// Route for the `/guilds/:guild_id/widget` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdWidget(u64),
+    GuildsIdWidget(GuildId),
     /// Route for the `/guilds/:guild_id/preview` path.
     ///
-    /// The data is the relevant [`GuildPreview`].
-    ///
     /// [`GuildPreview`]: crate::model::guild::GuildPreview
-    GuildsIdPreview(u64),
+    GuildsIdPreview(GuildId),
     /// Route for the `/guilds/:guild_id/emojis` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdEmojis(u64),
+    GuildsIdEmojis(GuildId),
     /// Route for the `/guilds/:guild_id/emojis/:emoji_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdEmojisId(u64),
+    GuildsIdEmojisId(GuildId),
     /// Route for the `/guilds/:guild_id/integrations` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdIntegrations(u64),
+    GuildsIdIntegrations(GuildId),
     /// Route for the `/guilds/:guild_id/integrations/:integration_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdIntegrationsId(u64),
+    GuildsIdIntegrationsId(GuildId),
     /// Route for the `/guilds/:guild_id/integrations/:integration_id/sync`
     /// path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdIntegrationsIdSync(u64),
+    GuildsIdIntegrationsIdSync(GuildId),
     /// Route for the `/guilds/:guild_id/invites` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdInvites(u64),
+    GuildsIdInvites(GuildId),
     /// Route for the `/guilds/:guild_id/members` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdMembers(u64),
+    GuildsIdMembers(GuildId),
     /// Route for the `/guilds/:guild_id/members/:user_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdMembersId(u64),
+    GuildsIdMembersId(GuildId),
     /// Route for the `/guilds/:guild_id/members/:user_id/roles/:role_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdMembersIdRolesId(u64),
+    GuildsIdMembersIdRolesId(GuildId),
     /// Route for the `/guilds/:guild_id/members/@me` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdMembersMe(u64),
+    GuildsIdMembersMe(GuildId),
     /// Route for the `/guilds/:guild_id/members/@me/nick` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdMembersMeNick(u64),
+    GuildsIdMembersMeNick(GuildId),
     /// Route for the `/guilds/:guild_id/members/search` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdMembersSearch(u64),
+    GuildsIdMembersSearch(GuildId),
     /// Route for the `/guilds/:guild_id/prune` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdPrune(u64),
+    GuildsIdPrune(GuildId),
     /// Route for the `/guilds/:guild_id/regions` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdRegions(u64),
+    GuildsIdRegions(GuildId),
     /// Route for the `/guilds/:guild_id/roles` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdRoles(u64),
+    GuildsIdRoles(GuildId),
     /// Route for the `/guilds/:guild_id/roles/:role_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdRolesId(u64),
+    GuildsIdRolesId(GuildId),
     /// Route for the `/guilds/:guild_id/scheduled-events` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdScheduledEvents(u64),
+    GuildsIdScheduledEvents(GuildId),
     /// Route for the `/guilds/:guild_id/scheduled-events/:event_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdScheduledEventsId(u64),
+    GuildsIdScheduledEventsId(GuildId),
     /// Route for the `/guilds/:guild_id/scheduled-events/:event_id/users` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdScheduledEventsIdUsers(u64),
+    GuildsIdScheduledEventsIdUsers(GuildId),
     /// Route for the `/guilds/:guild_id/stickers` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdStickers(u64),
+    GuildsIdStickers(GuildId),
     /// Route for the `/guilds/:guild_id/stickers/:sticker_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdStickersId(u64),
+    GuildsIdStickersId(GuildId),
     /// Route for the `/guilds/:guild_id/vanity-url` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdVanityUrl(u64),
+    GuildsIdVanityUrl(GuildId),
     /// Route for the `/guilds/:guild_id/voice-states/:user_id` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdVoiceStates(u64),
+    GuildsIdVoiceStates(GuildId),
     /// Route for the `/guilds/:guild_id/voice-states/@me` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdVoiceStatesMe(u64),
+    GuildsIdVoiceStatesMe(GuildId),
     /// Route for the `/guilds/:guild_id/webhooks` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdWebhooks(u64),
+    GuildsIdWebhooks(GuildId),
     /// Route for the `/guilds/:guild_id/welcome-screen` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
-    GuildsIdWelcomeScreen(u64),
+    GuildsIdWelcomeScreen(GuildId),
     /// Route for the `/guilds/:guild_id/threads/active` path.
-    ///
-    /// The data is the relevant [`GuildId`].
-    ///
-    /// [`GuildId`]: crate::model::id::GuildId
     GuildsIdThreadsActive,
     /// Route for the `/invites/:code` path.
     InvitesCode,
@@ -394,73 +171,29 @@ pub enum Route {
     /// Route for the `/voice/regions` path.
     VoiceRegions,
     /// Route for the `/webhooks/:webhook_id` path.
-    WebhooksId(u64),
+    WebhooksId(WebhookId),
     /// Route for the `/webhooks/:webhook_id/:token/messages/:message_id` path.
-    ///
-    /// The data is the relevant [`WebhookId`].
-    ///
-    /// [`WebhookId`]: crate::model::id::WebhookId
-    WebhooksIdMessagesId(u64),
+    WebhooksIdMessagesId(WebhookId),
     /// Route for the `/webhooks/:application_id` path.
-    ///
-    /// The data is the relevant [`ApplicationId`].
-    ///
-    /// [`ApplicationId`]: crate::model::id::ApplicationId
-    WebhooksApplicationId(u64),
+    WebhooksApplicationId(ApplicationId),
     /// Route for the `/interactions/:interaction_id` path.
-    ///
-    /// The data is the relevant [`InteractionId`].
-    ///
-    /// [`InteractionId`]: crate::model::id::InteractionId
-    InteractionsId(u64),
+    InteractionsId(InteractionId),
     /// Route for the `/applications/:application_id` path.
-    ///
-    /// The data is the relevant [`ApplicationId`].
-    ///
-    /// [`ApplicationId`]: crate::model::id::ApplicationId
-    ApplicationsIdCommands(u64),
+    ApplicationsIdCommands(ApplicationId),
     /// Route for the `/applications/:application_id/commands/:command_id` path.
-    ///
-    /// The data is the relevant [`ApplicationId`].
-    ///
-    /// [`ApplicationId`]: crate::model::id::ApplicationId
-    ApplicationsIdCommandsId(u64),
+    ApplicationsIdCommandsId(ApplicationId),
     /// Route for the `/applications/:application_id/guilds/:guild_id` path.
-    ///
-    /// The data is the relevant [`ApplicationId`].
-    ///
-    /// [`ApplicationId`]: crate::model::id::ApplicationId
-    ApplicationsIdGuildsIdCommands(u64),
+    ApplicationsIdGuildsIdCommands(ApplicationId),
     /// Route for the `/applications/:application_id/guilds/:guild_id/commands/permissions` path.
-    ///
-    /// The data is the relevant [`ApplicationId`].
-    ///
-    /// [`ApplicationId`]: crate::model::id::ApplicationId
-    ApplicationsIdGuildsIdCommandsPermissions(u64),
+    ApplicationsIdGuildsIdCommandsPermissions(ApplicationId),
     /// Route for the `/applications/:application_id/guilds/:guild_id/commands/:command_id/permissions` path.
-    ///
-    /// The data is the relevant [`ApplicationId`].
-    ///
-    /// [`ApplicationId`]: crate::model::id::ApplicationId
-    ApplicationsIdGuildsIdCommandIdPermissions(u64),
+    ApplicationsIdGuildsIdCommandIdPermissions(ApplicationId),
     /// Route for the `/applications/:application_id/guilds/:guild_id` path.
-    ///
-    /// The data is the relevant [`ApplicationId`].
-    ///
-    /// [`ApplicationId`]: crate::model::id::ApplicationId
-    ApplicationsIdGuildsIdCommandsId(u64),
+    ApplicationsIdGuildsIdCommandsId(ApplicationId),
     /// Route for the `/stage-instances` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
     StageInstances,
     /// Route for the `/stage-instances/:channel_id` path.
-    ///
-    /// The data is the relevant [`ChannelId`].
-    ///
-    /// [`ChannelId`]: crate::model::id::ChannelId
-    StageInstancesChannelId(u64),
+    StageInstancesChannelId(ChannelId),
     /// Route where no ratelimit headers are in place (i.e. user account-only
     /// routes).
     ///
@@ -471,29 +204,29 @@ pub enum Route {
 
 impl Route {
     #[must_use]
-    pub fn channel(channel_id: u64) -> String {
+    pub fn channel(channel_id: ChannelId) -> String {
         api!("/channels/{}", channel_id)
     }
 
     #[must_use]
-    pub fn channel_invites(channel_id: u64) -> String {
+    pub fn channel_invites(channel_id: ChannelId) -> String {
         api!("/channels/{}/invites", channel_id)
     }
 
     #[must_use]
-    pub fn channel_message(channel_id: u64, message_id: u64) -> String {
+    pub fn channel_message(channel_id: ChannelId, message_id: MessageId) -> String {
         api!("/channels/{}/messages/{}", channel_id, message_id)
     }
 
     #[must_use]
-    pub fn channel_message_crosspost(channel_id: u64, message_id: u64) -> String {
+    pub fn channel_message_crosspost(channel_id: ChannelId, message_id: MessageId) -> String {
         api!("/channels/{}/messages/{}/crosspost", channel_id, message_id)
     }
 
     #[must_use]
     pub fn channel_message_reaction<D, T>(
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
         user_id: D,
         reaction_type: T,
     ) -> String
@@ -512,8 +245,8 @@ impl Route {
 
     #[must_use]
     pub fn channel_message_reaction_emoji<T>(
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
         reaction_type: T,
     ) -> String
     where
@@ -523,14 +256,14 @@ impl Route {
     }
 
     #[must_use]
-    pub fn channel_message_reactions(channel_id: u64, message_id: u64) -> String {
+    pub fn channel_message_reactions(channel_id: ChannelId, message_id: MessageId) -> String {
         api!("/channels/{}/messages/{}/reactions", channel_id, message_id)
     }
 
     #[must_use]
     pub fn channel_message_reactions_list(
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
         reaction: &str,
         limit: u8,
         after: Option<u64>,
@@ -551,73 +284,73 @@ impl Route {
     }
 
     #[must_use]
-    pub fn channel_messages(channel_id: u64, query: Option<&str>) -> String {
+    pub fn channel_messages(channel_id: ChannelId, query: Option<&str>) -> String {
         api!("/channels/{}/messages{}", channel_id, query.unwrap_or(""))
     }
 
     #[must_use]
-    pub fn channel_messages_bulk_delete(channel_id: u64) -> String {
+    pub fn channel_messages_bulk_delete(channel_id: ChannelId) -> String {
         api!("/channels/{}/messages/bulk-delete", channel_id)
     }
 
     #[must_use]
-    pub fn channel_follow_news(channel_id: u64) -> String {
+    pub fn channel_follow_news(channel_id: ChannelId) -> String {
         api!("/channels/{}/followers", channel_id)
     }
 
     #[must_use]
-    pub fn channel_permission(channel_id: u64, target_id: u64) -> String {
+    pub fn channel_permission(channel_id: ChannelId, target_id: TargetId) -> String {
         api!("/channels/{}/permissions/{}", channel_id, target_id)
     }
 
     #[must_use]
-    pub fn channel_pin(channel_id: u64, message_id: u64) -> String {
+    pub fn channel_pin(channel_id: ChannelId, message_id: MessageId) -> String {
         api!("/channels/{}/pins/{}", channel_id, message_id)
     }
 
     #[must_use]
-    pub fn channel_pins(channel_id: u64) -> String {
+    pub fn channel_pins(channel_id: ChannelId) -> String {
         api!("/channels/{}/pins", channel_id)
     }
 
     #[must_use]
-    pub fn channel_typing(channel_id: u64) -> String {
+    pub fn channel_typing(channel_id: ChannelId) -> String {
         api!("/channels/{}/typing", channel_id)
     }
 
     #[must_use]
-    pub fn channel_webhooks(channel_id: u64) -> String {
+    pub fn channel_webhooks(channel_id: ChannelId) -> String {
         api!("/channels/{}/webhooks", channel_id)
     }
 
     #[must_use]
-    pub fn channel_public_threads(channel_id: u64, message_id: u64) -> String {
+    pub fn channel_public_threads(channel_id: ChannelId, message_id: MessageId) -> String {
         api!("/channels/{}/messages/{}/threads", channel_id, message_id)
     }
 
     #[must_use]
-    pub fn channel_private_threads(channel_id: u64) -> String {
+    pub fn channel_private_threads(channel_id: ChannelId) -> String {
         api!("/channels/{}/threads", channel_id)
     }
 
     #[must_use]
-    pub fn channel_thread_member(channel_id: u64, user_id: u64) -> String {
+    pub fn channel_thread_member(channel_id: ChannelId, user_id: UserId) -> String {
         api!("/channels/{}/thread-members/{}", channel_id, user_id)
     }
 
     #[must_use]
-    pub fn channel_thread_member_me(channel_id: u64) -> String {
+    pub fn channel_thread_member_me(channel_id: ChannelId) -> String {
         api!("/channels/{}/thread-members/@me", channel_id)
     }
 
     #[must_use]
-    pub fn channel_thread_members(channel_id: u64) -> String {
+    pub fn channel_thread_members(channel_id: ChannelId) -> String {
         api!("/channels/{}/thread-members", channel_id)
     }
 
     #[must_use]
     pub fn channel_archived_public_threads(
-        channel_id: u64,
+        channel_id: ChannelId,
         before: Option<u64>,
         limit: Option<u64>,
     ) -> String {
@@ -636,7 +369,7 @@ impl Route {
 
     #[must_use]
     pub fn channel_archived_private_threads(
-        channel_id: u64,
+        channel_id: ChannelId,
         before: Option<u64>,
         limit: Option<u64>,
     ) -> String {
@@ -655,7 +388,7 @@ impl Route {
 
     #[must_use]
     pub fn channel_joined_private_threads(
-        channel_id: u64,
+        channel_id: ChannelId,
         before: Option<u64>,
         limit: Option<u64>,
     ) -> String {
@@ -683,20 +416,20 @@ impl Route {
     }
 
     #[must_use]
-    pub fn guild(guild_id: u64) -> String {
+    pub fn guild(guild_id: GuildId) -> String {
         api!("/guilds/{}", guild_id)
     }
 
     #[must_use]
-    pub fn guild_with_counts(guild_id: u64) -> String {
+    pub fn guild_with_counts(guild_id: GuildId) -> String {
         api!("/guilds/{}?with_counts=true", guild_id)
     }
 
     #[must_use]
     pub fn guild_audit_logs(
-        guild_id: u64,
+        guild_id: GuildId,
         action_type: Option<u8>,
-        user_id: Option<u64>,
+        user_id: Option<UserId>,
         before: Option<u64>,
         limit: Option<u8>,
     ) -> String {
@@ -722,97 +455,101 @@ impl Route {
     }
 
     #[must_use]
-    pub fn guild_automod_rule(guild_id: u64, rule_id: u64) -> String {
+    pub fn guild_automod_rule(guild_id: GuildId, rule_id: RuleId) -> String {
         api!("/guilds/{}/auto-moderation/rules/{}", guild_id, rule_id)
     }
 
     #[must_use]
-    pub fn guild_automod_rules(guild_id: u64) -> String {
+    pub fn guild_automod_rules(guild_id: GuildId) -> String {
         api!("/guilds/{}/auto-moderation/rules", guild_id)
     }
 
     #[must_use]
-    pub fn guild_ban(guild_id: u64, user_id: u64) -> String {
+    pub fn guild_ban(guild_id: GuildId, user_id: UserId) -> String {
         api!("/guilds/{}/bans/{}", guild_id, user_id)
     }
 
     #[must_use]
-    pub fn guild_ban_optioned(guild_id: u64, user_id: u64, delete_message_days: u8) -> String {
+    pub fn guild_ban_optioned(
+        guild_id: GuildId,
+        user_id: UserId,
+        delete_message_days: u8,
+    ) -> String {
         api!("/guilds/{}/bans/{}?delete_message_days={}", guild_id, user_id, delete_message_days)
     }
 
     #[must_use]
-    pub fn guild_kick_optioned(guild_id: u64, user_id: u64) -> String {
+    pub fn guild_kick_optioned(guild_id: GuildId, user_id: UserId) -> String {
         api!("/guilds/{}/members/{}", guild_id, user_id)
     }
 
     #[must_use]
-    pub fn guild_bans(guild_id: u64) -> String {
+    pub fn guild_bans(guild_id: GuildId) -> String {
         api!("/guilds/{}/bans", guild_id)
     }
 
     #[must_use]
-    pub fn guild_channels(guild_id: u64) -> String {
+    pub fn guild_channels(guild_id: GuildId) -> String {
         api!("/guilds/{}/channels", guild_id)
     }
 
     #[must_use]
-    pub fn guild_widget(guild_id: u64) -> String {
+    pub fn guild_widget(guild_id: GuildId) -> String {
         api!("/guilds/{}/widget", guild_id)
     }
 
     #[must_use]
-    pub fn guild_preview(guild_id: u64) -> String {
+    pub fn guild_preview(guild_id: GuildId) -> String {
         api!("/guilds/{}/preview", guild_id)
     }
 
     #[must_use]
-    pub fn guild_emojis(guild_id: u64) -> String {
+    pub fn guild_emojis(guild_id: GuildId) -> String {
         api!("/guilds/{}/emojis", guild_id)
     }
 
     #[must_use]
-    pub fn guild_emoji(guild_id: u64, emoji_id: u64) -> String {
+    pub fn guild_emoji(guild_id: GuildId, emoji_id: EmojiId) -> String {
         api!("/guilds/{}/emojis/{}", guild_id, emoji_id)
     }
 
     #[must_use]
-    pub fn guild_integration(guild_id: u64, integration_id: u64) -> String {
+    pub fn guild_integration(guild_id: GuildId, integration_id: IntegrationId) -> String {
         api!("/guilds/{}/integrations/{}", guild_id, integration_id)
     }
 
     #[must_use]
-    pub fn guild_integration_sync(guild_id: u64, integration_id: u64) -> String {
+    pub fn guild_integration_sync(guild_id: GuildId, integration_id: IntegrationId) -> String {
         api!("/guilds/{}/integrations/{}/sync", guild_id, integration_id)
     }
 
     #[must_use]
-    pub fn guild_integrations(guild_id: u64) -> String {
+    pub fn guild_integrations(guild_id: GuildId) -> String {
         api!("/guilds/{}/integrations", guild_id)
     }
 
     #[must_use]
-    pub fn guild_invites(guild_id: u64) -> String {
+    pub fn guild_invites(guild_id: GuildId) -> String {
         api!("/guilds/{}/invites", guild_id)
     }
 
     #[must_use]
-    pub fn guild_member(guild_id: u64, user_id: u64) -> String {
+    pub fn guild_member(guild_id: GuildId, user_id: UserId) -> String {
         api!("/guilds/{}/members/{}", guild_id, user_id)
     }
 
     #[must_use]
-    pub fn guild_member_role(guild_id: u64, user_id: u64, role_id: u64) -> String {
+    pub fn guild_member_role(guild_id: GuildId, user_id: UserId, role_id: RoleId) -> String {
         api!("/guilds/{}/members/{}/roles/{}", guild_id, user_id, role_id)
     }
 
     #[must_use]
-    pub fn guild_members(guild_id: u64) -> String {
+    pub fn guild_members(guild_id: GuildId) -> String {
         api!("/guilds/{}/members", guild_id)
     }
 
     #[must_use]
-    pub fn guild_members_search(guild_id: u64, query: &str, limit: Option<u64>) -> String {
+    pub fn guild_members_search(guild_id: GuildId, query: &str, limit: Option<u64>) -> String {
         let mut s = api!("/guilds/{}/members/search?", guild_id);
 
         write!(s, "&query={}&limit={}", query, limit.unwrap_or(constants::MEMBER_FETCH_LIMIT))
@@ -821,7 +558,11 @@ impl Route {
     }
 
     #[must_use]
-    pub fn guild_members_optioned(guild_id: u64, after: Option<u64>, limit: Option<u64>) -> String {
+    pub fn guild_members_optioned(
+        guild_id: GuildId,
+        after: Option<u64>,
+        limit: Option<u64>,
+    ) -> String {
         let mut s = api!("/guilds/{}/members?", guild_id);
 
         if let Some(after) = after {
@@ -833,39 +574,39 @@ impl Route {
     }
 
     #[must_use]
-    pub fn guild_member_me(guild_id: u64) -> String {
+    pub fn guild_member_me(guild_id: GuildId) -> String {
         api!("/guilds/{}/members/@me", guild_id)
     }
 
     #[must_use]
-    pub fn guild_nickname(guild_id: u64) -> String {
+    pub fn guild_nickname(guild_id: GuildId) -> String {
         api!("/guilds/{}/members/@me/nick", guild_id)
     }
 
     #[must_use]
-    pub fn guild_prune(guild_id: u64, days: u8) -> String {
+    pub fn guild_prune(guild_id: GuildId, days: u8) -> String {
         api!("/guilds/{}/prune?days={}", guild_id, days)
     }
 
     #[must_use]
-    pub fn guild_regions(guild_id: u64) -> String {
+    pub fn guild_regions(guild_id: GuildId) -> String {
         api!("/guilds/{}/regions", guild_id)
     }
 
     #[must_use]
-    pub fn guild_role(guild_id: u64, role_id: u64) -> String {
+    pub fn guild_role(guild_id: GuildId, role_id: RoleId) -> String {
         api!("/guilds/{}/roles/{}", guild_id, role_id)
     }
 
     #[must_use]
-    pub fn guild_roles(guild_id: u64) -> String {
+    pub fn guild_roles(guild_id: GuildId) -> String {
         api!("/guilds/{}/roles", guild_id)
     }
 
     #[must_use]
     pub fn guild_scheduled_event(
-        guild_id: u64,
-        event_id: u64,
+        guild_id: GuildId,
+        event_id: ScheduledEventId,
         with_user_count: Option<bool>,
     ) -> String {
         let mut s = api!("/guilds/{}/scheduled-events/{}", guild_id, event_id);
@@ -876,7 +617,7 @@ impl Route {
     }
 
     #[must_use]
-    pub fn guild_scheduled_events(guild_id: u64, with_user_count: Option<bool>) -> String {
+    pub fn guild_scheduled_events(guild_id: GuildId, with_user_count: Option<bool>) -> String {
         let mut s = api!("/guilds/{}/scheduled-events", guild_id);
         if let Some(b) = with_user_count {
             write!(s, "?with_user_count={}", b).unwrap();
@@ -886,8 +627,8 @@ impl Route {
 
     #[must_use]
     pub fn guild_scheduled_event_users(
-        guild_id: u64,
-        event_id: u64,
+        guild_id: GuildId,
+        event_id: ScheduledEventId,
         after: Option<u64>,
         before: Option<u64>,
         limit: Option<u64>,
@@ -915,42 +656,42 @@ impl Route {
     }
 
     #[must_use]
-    pub fn guild_sticker(guild_id: u64, sticker_id: u64) -> String {
+    pub fn guild_sticker(guild_id: GuildId, sticker_id: StickerId) -> String {
         api!("/guilds/{}/stickers/{}", guild_id, sticker_id)
     }
 
     #[must_use]
-    pub fn guild_stickers(guild_id: u64) -> String {
+    pub fn guild_stickers(guild_id: GuildId) -> String {
         api!("/guilds/{}/stickers", guild_id)
     }
 
     #[must_use]
-    pub fn guild_vanity_url(guild_id: u64) -> String {
+    pub fn guild_vanity_url(guild_id: GuildId) -> String {
         api!("/guilds/{}/vanity-url", guild_id)
     }
 
     #[must_use]
-    pub fn guild_voice_states(guild_id: u64, user_id: u64) -> String {
+    pub fn guild_voice_states(guild_id: GuildId, user_id: UserId) -> String {
         api!("/guilds/{}/voice-states/{}", guild_id, user_id)
     }
 
     #[must_use]
-    pub fn guild_voice_states_me(guild_id: u64) -> String {
+    pub fn guild_voice_states_me(guild_id: GuildId) -> String {
         api!("/guilds/{}/voice-states/@me", guild_id)
     }
 
     #[must_use]
-    pub fn guild_webhooks(guild_id: u64) -> String {
+    pub fn guild_webhooks(guild_id: GuildId) -> String {
         api!("/guilds/{}/webhooks", guild_id)
     }
 
     #[must_use]
-    pub fn guild_welcome_screen(guild_id: u64) -> String {
+    pub fn guild_welcome_screen(guild_id: GuildId) -> String {
         api!("/guilds/{}/welcome-screen", guild_id)
     }
 
     #[must_use]
-    pub fn guild_threads_active(guild_id: u64) -> String {
+    pub fn guild_threads_active(guild_id: GuildId) -> String {
         api!("/guilds/{}/threads/active", guild_id)
     }
 
@@ -969,7 +710,7 @@ impl Route {
         code: &str,
         member_counts: bool,
         expiration: bool,
-        event_id: Option<u64>,
+        event_id: Option<ScheduledEventId>,
     ) -> String {
         api!(
             "/invites/{}?with_counts={}&with_expiration={}{}",
@@ -1006,7 +747,7 @@ impl Route {
     }
 
     #[must_use]
-    pub fn sticker(sticker_id: u64) -> String {
+    pub fn sticker(sticker_id: StickerId) -> String {
         api!("/stickers/{}", sticker_id)
     }
 
@@ -1031,7 +772,7 @@ impl Route {
     }
 
     #[must_use]
-    pub fn user_guild<D: Display>(target: D, guild_id: u64) -> String {
+    pub fn user_guild<D: Display>(target: D, guild_id: GuildId) -> String {
         api!("/users/{}/guilds/{}", target, guild_id)
     }
 
@@ -1070,12 +811,12 @@ impl Route {
     }
 
     #[must_use]
-    pub fn webhook(webhook_id: u64) -> String {
+    pub fn webhook(webhook_id: WebhookId) -> String {
         api!("/webhooks/{}", webhook_id)
     }
 
     #[must_use]
-    pub fn webhook_with_token<D>(webhook_id: u64, token: D) -> String
+    pub fn webhook_with_token<D>(webhook_id: WebhookId, token: D) -> String
     where
         D: Display,
     {
@@ -1084,8 +825,8 @@ impl Route {
 
     #[must_use]
     pub fn webhook_with_token_optioned<D>(
-        webhook_id: u64,
-        thread_id: Option<u64>,
+        webhook_id: WebhookId,
+        thread_id: Option<ChannelId>,
         token: D,
         wait: bool,
     ) -> String
@@ -1102,7 +843,7 @@ impl Route {
     }
 
     #[must_use]
-    pub fn webhook_message<D>(webhook_id: u64, token: D, message_id: u64) -> String
+    pub fn webhook_message<D>(webhook_id: WebhookId, token: D, message_id: MessageId) -> String
     where
         D: Display,
     {
@@ -1111,7 +852,7 @@ impl Route {
 
     #[must_use]
     pub fn webhook_original_interaction_response<D: Display>(
-        application_id: u64,
+        application_id: ApplicationId,
         token: D,
     ) -> String {
         api!("/webhooks/{}/{}/messages/@original", application_id, token)
@@ -1119,47 +860,50 @@ impl Route {
 
     #[must_use]
     pub fn webhook_followup_message<D: Display>(
-        application_id: u64,
+        application_id: ApplicationId,
         token: D,
-        message_id: u64,
+        message_id: MessageId,
     ) -> String {
         api!("/webhooks/{}/{}/messages/{}", application_id, token, message_id)
     }
 
     #[must_use]
-    pub fn webhook_followup_messages<D: Display>(application_id: u64, token: D) -> String {
+    pub fn webhook_followup_messages<D: Display>(
+        application_id: ApplicationId,
+        token: D,
+    ) -> String {
         api!("/webhooks/{}/{}", application_id, token)
     }
 
     #[must_use]
-    pub fn interaction_response<D: Display>(application_id: u64, token: D) -> String {
-        api!("/interactions/{}/{}/callback", application_id, token)
+    pub fn interaction_response<D: Display>(interaction_id: InteractionId, token: D) -> String {
+        api!("/interactions/{}/{}/callback", interaction_id, token)
     }
 
     #[must_use]
-    pub fn application_command(application_id: u64, command_id: u64) -> String {
+    pub fn application_command(application_id: ApplicationId, command_id: CommandId) -> String {
         api!("/applications/{}/commands/{}", application_id, command_id)
     }
 
     #[must_use]
-    pub fn application_commands(application_id: u64) -> String {
+    pub fn application_commands(application_id: ApplicationId) -> String {
         api!("/applications/{}/commands", application_id)
     }
 
     #[must_use]
     pub fn application_guild_command(
-        application_id: u64,
-        guild_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
+        command_id: CommandId,
     ) -> String {
         api!("/applications/{}/guilds/{}/commands/{}", application_id, guild_id, command_id)
     }
 
     #[must_use]
     pub fn application_guild_command_permissions(
-        application_id: u64,
-        guild_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
+        command_id: CommandId,
     ) -> String {
         api!(
             "/applications/{}/guilds/{}/commands/{}/permissions",
@@ -1170,12 +914,15 @@ impl Route {
     }
 
     #[must_use]
-    pub fn application_guild_commands(application_id: u64, guild_id: u64) -> String {
+    pub fn application_guild_commands(application_id: ApplicationId, guild_id: GuildId) -> String {
         api!("/applications/{}/guilds/{}/commands", application_id, guild_id)
     }
 
     #[must_use]
-    pub fn application_guild_commands_permissions(application_id: u64, guild_id: u64) -> String {
+    pub fn application_guild_commands_permissions(
+        application_id: ApplicationId,
+        guild_id: GuildId,
+    ) -> String {
         api!("/applications/{}/guilds/{}/commands/permissions", application_id, guild_id)
     }
 
@@ -1185,7 +932,7 @@ impl Route {
     }
 
     #[must_use]
-    pub fn stage_instance(channel_id: u64) -> String {
+    pub fn stage_instance(channel_id: ChannelId) -> String {
         api!("/stage-instances/{}", channel_id)
     }
 }
@@ -1194,478 +941,478 @@ impl Route {
 #[non_exhaustive]
 pub enum RouteInfo<'a> {
     AddGuildMember {
-        guild_id: u64,
-        user_id: u64,
+        guild_id: GuildId,
+        user_id: UserId,
     },
     AddMemberRole {
-        guild_id: u64,
-        role_id: u64,
-        user_id: u64,
+        guild_id: GuildId,
+        role_id: RoleId,
+        user_id: UserId,
     },
     GuildBanUser {
-        guild_id: u64,
-        user_id: u64,
+        guild_id: GuildId,
+        user_id: UserId,
         delete_message_days: Option<u8>,
     },
     BroadcastTyping {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     CreateAutoModRule {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     CreateChannel {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     CreateStageInstance,
     CreatePublicThread {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
     },
     CreatePrivateThread {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     CreateEmoji {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     CreateFollowupMessage {
-        application_id: u64,
+        application_id: ApplicationId,
         interaction_token: &'a str,
     },
     CreateGlobalApplicationCommand {
-        application_id: u64,
+        application_id: ApplicationId,
     },
     CreateGlobalApplicationCommands {
-        application_id: u64,
+        application_id: ApplicationId,
     },
     CreateGuild,
     CreateGuildApplicationCommand {
-        application_id: u64,
-        guild_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
     },
     CreateGuildApplicationCommands {
-        application_id: u64,
-        guild_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
     },
     CreateGuildIntegration {
-        guild_id: u64,
-        integration_id: u64,
+        guild_id: GuildId,
+        integration_id: IntegrationId,
     },
     CreateInteractionResponse {
-        interaction_id: u64,
+        interaction_id: InteractionId,
         interaction_token: &'a str,
     },
     CreateInvite {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     CreateMessage {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     CreatePermission {
-        channel_id: u64,
-        target_id: u64,
+        channel_id: ChannelId,
+        target_id: TargetId,
     },
     CreatePrivateChannel,
     CreateReaction {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
         reaction: &'a str,
     },
     CreateRole {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     CreateScheduledEvent {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     CreateSticker {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     CreateWebhook {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     DeleteAutoModRule {
-        guild_id: u64,
-        rule_id: u64,
+        guild_id: GuildId,
+        rule_id: RuleId,
     },
     DeleteChannel {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     DeleteStageInstance {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     DeleteEmoji {
-        guild_id: u64,
-        emoji_id: u64,
+        guild_id: GuildId,
+        emoji_id: EmojiId,
     },
     DeleteFollowupMessage {
-        application_id: u64,
+        application_id: ApplicationId,
         interaction_token: &'a str,
-        message_id: u64,
+        message_id: MessageId,
     },
     DeleteGlobalApplicationCommand {
-        application_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        command_id: CommandId,
     },
     DeleteGuild {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     DeleteGuildApplicationCommand {
-        application_id: u64,
-        guild_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
+        command_id: CommandId,
     },
     DeleteGuildIntegration {
-        guild_id: u64,
-        integration_id: u64,
+        guild_id: GuildId,
+        integration_id: IntegrationId,
     },
     DeleteInvite {
         code: &'a str,
     },
     DeleteMessage {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
     },
     DeleteMessages {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     DeleteMessageReactions {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
     },
     DeleteMessageReactionEmoji {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
         reaction: &'a str,
     },
     DeleteOriginalInteractionResponse {
-        application_id: u64,
+        application_id: ApplicationId,
         interaction_token: &'a str,
     },
     DeletePermission {
-        channel_id: u64,
-        target_id: u64,
+        channel_id: ChannelId,
+        target_id: TargetId,
     },
     DeleteReaction {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
         user: &'a str,
         reaction: &'a str,
     },
     DeleteRole {
-        guild_id: u64,
-        role_id: u64,
+        guild_id: GuildId,
+        role_id: RoleId,
     },
     DeleteScheduledEvent {
-        guild_id: u64,
-        event_id: u64,
+        guild_id: GuildId,
+        event_id: ScheduledEventId,
     },
     DeleteSticker {
-        guild_id: u64,
-        sticker_id: u64,
+        guild_id: GuildId,
+        sticker_id: StickerId,
     },
     DeleteWebhook {
-        webhook_id: u64,
+        webhook_id: WebhookId,
     },
     DeleteWebhookWithToken {
         token: &'a str,
-        webhook_id: u64,
+        webhook_id: WebhookId,
     },
     DeleteWebhookMessage {
         token: &'a str,
-        webhook_id: u64,
-        message_id: u64,
+        webhook_id: WebhookId,
+        message_id: MessageId,
     },
     EditAutoModRule {
-        guild_id: u64,
-        rule_id: u64,
+        guild_id: GuildId,
+        rule_id: RuleId,
     },
     EditChannel {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     EditStageInstance {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     EditEmoji {
-        guild_id: u64,
-        emoji_id: u64,
+        guild_id: GuildId,
+        emoji_id: EmojiId,
     },
     EditFollowupMessage {
-        application_id: u64,
+        application_id: ApplicationId,
         interaction_token: &'a str,
-        message_id: u64,
+        message_id: MessageId,
     },
     EditGlobalApplicationCommand {
-        application_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        command_id: CommandId,
     },
     EditGuild {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     EditGuildApplicationCommand {
-        application_id: u64,
-        guild_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
+        command_id: CommandId,
     },
     EditGuildApplicationCommandPermission {
-        application_id: u64,
-        guild_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
+        command_id: CommandId,
     },
     EditGuildApplicationCommandsPermissions {
-        application_id: u64,
-        guild_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
     },
     EditGuildChannels {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     EditGuildWidget {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     EditGuildWelcomeScreen {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     EditMember {
-        guild_id: u64,
-        user_id: u64,
+        guild_id: GuildId,
+        user_id: UserId,
     },
     EditMessage {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
     },
     CrosspostMessage {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
     },
     EditMemberMe {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     EditNickname {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetOriginalInteractionResponse {
-        application_id: u64,
+        application_id: ApplicationId,
         interaction_token: &'a str,
     },
     EditOriginalInteractionResponse {
-        application_id: u64,
+        application_id: ApplicationId,
         interaction_token: &'a str,
     },
     EditProfile,
     EditRole {
-        guild_id: u64,
-        role_id: u64,
+        guild_id: GuildId,
+        role_id: RoleId,
     },
     EditRolePosition {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     EditScheduledEvent {
-        guild_id: u64,
-        event_id: u64,
+        guild_id: GuildId,
+        event_id: ScheduledEventId,
     },
     EditSticker {
-        guild_id: u64,
-        sticker_id: u64,
+        guild_id: GuildId,
+        sticker_id: StickerId,
     },
     EditThread {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     EditVoiceState {
-        guild_id: u64,
-        user_id: u64,
+        guild_id: GuildId,
+        user_id: UserId,
     },
     EditVoiceStateMe {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     EditWebhook {
-        webhook_id: u64,
+        webhook_id: WebhookId,
     },
     EditWebhookWithToken {
         token: &'a str,
-        webhook_id: u64,
+        webhook_id: WebhookId,
     },
     EditWebhookMessage {
         token: &'a str,
-        webhook_id: u64,
-        message_id: u64,
+        webhook_id: WebhookId,
+        message_id: MessageId,
     },
     ExecuteWebhook {
         token: &'a str,
         wait: bool,
-        webhook_id: u64,
-        thread_id: Option<u64>,
+        webhook_id: WebhookId,
+        thread_id: Option<ChannelId>,
     },
     FollowNewsChannel {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     JoinThread {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     LeaveThread {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     AddThreadMember {
-        channel_id: u64,
-        user_id: u64,
+        channel_id: ChannelId,
+        user_id: UserId,
     },
     RemoveThreadMember {
-        channel_id: u64,
-        user_id: u64,
+        channel_id: ChannelId,
+        user_id: UserId,
     },
     GetActiveMaintenance,
     GetAuditLogs {
         action_type: Option<u8>,
         before: Option<u64>,
-        guild_id: u64,
+        guild_id: GuildId,
         limit: Option<u8>,
-        user_id: Option<u64>,
+        user_id: Option<UserId>,
     },
     GetAutoModRules {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetAutoModRule {
-        guild_id: u64,
-        rule_id: u64,
+        guild_id: GuildId,
+        rule_id: RuleId,
     },
     GetBans {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetBotGateway,
     GetChannel {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     GetChannelInvites {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     GetChannelWebhooks {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     GetChannels {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetStageInstance {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     GetChannelThreadMembers {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     GetChannelArchivedPublicThreads {
-        channel_id: u64,
+        channel_id: ChannelId,
         before: Option<u64>,
         limit: Option<u64>,
     },
     GetChannelArchivedPrivateThreads {
-        channel_id: u64,
+        channel_id: ChannelId,
         before: Option<u64>,
         limit: Option<u64>,
     },
     GetChannelJoinedPrivateArchivedThreads {
-        channel_id: u64,
+        channel_id: ChannelId,
         before: Option<u64>,
         limit: Option<u64>,
     },
     GetCurrentApplicationInfo,
     GetCurrentUser,
     GetEmojis {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetEmoji {
-        guild_id: u64,
-        emoji_id: u64,
+        guild_id: GuildId,
+        emoji_id: EmojiId,
     },
     GetFollowupMessage {
-        application_id: u64,
+        application_id: ApplicationId,
         interaction_token: &'a str,
-        message_id: u64,
+        message_id: MessageId,
     },
     GetGateway,
     GetGlobalApplicationCommands {
-        application_id: u64,
+        application_id: ApplicationId,
     },
     GetGlobalApplicationCommand {
-        application_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        command_id: CommandId,
     },
     GetGuild {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildWithCounts {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildApplicationCommands {
-        application_id: u64,
-        guild_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
     },
     GetGuildApplicationCommand {
-        application_id: u64,
-        guild_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
+        command_id: CommandId,
     },
     GetGuildApplicationCommandsPermissions {
-        application_id: u64,
-        guild_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
     },
     GetGuildApplicationCommandPermissions {
-        application_id: u64,
-        guild_id: u64,
-        command_id: u64,
+        application_id: ApplicationId,
+        guild_id: GuildId,
+        command_id: CommandId,
     },
     GetGuildWidget {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildActiveThreads {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildPreview {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildWelcomeScreen {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildIntegrations {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildInvites {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildMembers {
         after: Option<u64>,
         limit: Option<u64>,
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildPruneCount {
         days: u8,
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildRegions {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildRoles {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetScheduledEvent {
-        guild_id: u64,
-        event_id: u64,
+        guild_id: GuildId,
+        event_id: ScheduledEventId,
         with_user_count: bool,
     },
     GetScheduledEvents {
-        guild_id: u64,
+        guild_id: GuildId,
         with_user_count: bool,
     },
     GetScheduledEventUsers {
-        guild_id: u64,
-        event_id: u64,
+        guild_id: GuildId,
+        event_id: ScheduledEventId,
         after: Option<u64>,
         before: Option<u64>,
         limit: Option<u64>,
         with_member: Option<bool>,
     },
     GetGuildStickers {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildVanityUrl {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuildWebhooks {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     GetGuilds {
         after: Option<u64>,
@@ -1676,100 +1423,97 @@ pub enum RouteInfo<'a> {
         code: &'a str,
         member_counts: bool,
         expiration: bool,
-        event_id: Option<u64>,
+        event_id: Option<ScheduledEventId>,
     },
     GetMember {
-        guild_id: u64,
-        user_id: u64,
+        guild_id: GuildId,
+        user_id: UserId,
     },
     GetMessage {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
     },
     GetMessages {
-        channel_id: u64,
+        channel_id: ChannelId,
         query: String,
     },
     GetPins {
-        channel_id: u64,
+        channel_id: ChannelId,
     },
     GetReactionUsers {
         after: Option<u64>,
-        channel_id: u64,
+        channel_id: ChannelId,
         limit: u8,
-        message_id: u64,
+        message_id: MessageId,
         reaction: String,
     },
     GetSticker {
-        sticker_id: u64,
+        sticker_id: StickerId,
     },
     GetStickerPacks,
     GetGuildSticker {
-        guild_id: u64,
-        sticker_id: u64,
+        guild_id: GuildId,
+        sticker_id: StickerId,
     },
     GetUnresolvedIncidents,
     GetUpcomingMaintenances,
     GetUser {
-        user_id: u64,
+        user_id: UserId,
     },
     GetUserConnections,
     GetUserDmChannels,
     GetVoiceRegions,
     GetWebhook {
-        webhook_id: u64,
+        webhook_id: WebhookId,
     },
     GetWebhookWithToken {
         token: &'a str,
-        webhook_id: u64,
+        webhook_id: WebhookId,
     },
     GetWebhookMessage {
         token: &'a str,
-        webhook_id: u64,
-        message_id: u64,
+        webhook_id: WebhookId,
+        message_id: MessageId,
     },
     KickMember {
-        guild_id: u64,
-        user_id: u64,
-    },
-    LeaveGroup {
-        group_id: u64,
+        guild_id: GuildId,
+        user_id: UserId,
     },
     LeaveGuild {
-        guild_id: u64,
+        guild_id: GuildId,
     },
     PinMessage {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
     },
     RemoveBan {
-        guild_id: u64,
-        user_id: u64,
+        guild_id: GuildId,
+        user_id: UserId,
     },
     RemoveMemberRole {
-        guild_id: u64,
-        role_id: u64,
-        user_id: u64,
+        guild_id: GuildId,
+        role_id: RoleId,
+        user_id: UserId,
     },
     SearchGuildMembers {
-        guild_id: u64,
+        guild_id: GuildId,
         query: &'a str,
         limit: Option<u64>,
     },
     StartGuildPrune {
         days: u8,
-        guild_id: u64,
+        guild_id: GuildId,
     },
     StartIntegrationSync {
-        guild_id: u64,
-        integration_id: u64,
+        guild_id: GuildId,
+        integration_id: IntegrationId,
     },
     StatusIncidentsUnresolved,
     StatusMaintenancesActive,
     StatusMaintenancesUpcoming,
     UnpinMessage {
-        channel_id: u64,
-        message_id: u64,
+        channel_id: ChannelId,
+        message_id: MessageId,
     },
 }
 
@@ -1859,7 +1603,7 @@ impl<'a> RouteInfo<'a> {
                 interaction_token,
             } => (
                 LightMethod::Post,
-                Route::WebhooksId(application_id),
+                Route::WebhooksId(WebhookId(application_id.0)),
                 Cow::from(Route::webhook_followup_messages(application_id, interaction_token)),
             ),
             RouteInfo::CreateGlobalApplicationCommand {
@@ -2081,7 +1825,7 @@ impl<'a> RouteInfo<'a> {
                 message_id,
             } => (
                 LightMethod::Delete,
-                Route::ChannelsIdMessagesId(LightMethod::Delete, message_id),
+                Route::ChannelsIdMessagesId(LightMethod::Delete, channel_id),
                 Cow::from(Route::channel_message(channel_id, message_id)),
             ),
             RouteInfo::DeleteMessages {
@@ -2907,13 +2651,6 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Delete,
                 Route::GuildsIdMembersId(guild_id),
                 Cow::from(Route::guild_kick_optioned(guild_id, user_id)),
-            ),
-            RouteInfo::LeaveGroup {
-                group_id,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsId(group_id),
-                Cow::from(Route::channel(group_id)),
             ),
             RouteInfo::LeaveGuild {
                 guild_id,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -29,7 +29,7 @@ pub enum Route {
     /// different than the overall route ratelimit.
     ///
     /// Refer to the docs on [Rate Limits] in the yellow warning section.
-    /// [Rate Limits]: https://discord.com/developers/docs/topics/rate-limits
+    /// [Rate Limits]: <https://discord.com/developers/docs/topics/rate-limits>
     ChannelsIdMessagesId(LightMethod, ChannelId),
     /// Route for the `/channels/:channel_id/messages/:message_id/ack` path.
     ChannelsIdMessagesIdAck(ChannelId),

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -7,6 +7,7 @@ use tokio::time::{sleep, Duration};
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
+use crate::model::id::ChannelId;
 
 /// A struct to start typing in a [`Channel`] for an indefinite period of time.
 ///
@@ -61,7 +62,7 @@ impl Typing {
     /// Returns an  [`Error::Http`] if there is an error.
     ///
     /// [`Channel`]: crate::model::channel::Channel
-    pub fn start(http: Arc<Http>, channel_id: u64) -> Result<Self> {
+    pub fn start(http: Arc<Http>, channel_id: ChannelId) -> Result<Self> {
         let (sx, mut rx) = oneshot::channel();
 
         spawn_named("typing::start", async move {

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -27,14 +27,15 @@ use crate::model::id::ChannelId;
 /// ## Examples
 ///
 /// ```rust,no_run
-/// # use serenity::{http::{Http, Typing}, Result};
+/// # use serenity::{http::{Http, Typing}, Result, model::prelude::*};
 /// # use std::sync::Arc;
 /// #
 /// # fn long_process() {}
 /// # fn main() -> Result<()> {
 /// # let http = Http::new("token");
+/// let channel_id = ChannelId::new(7);
 /// // Initiate typing (assuming `http` is bound)
-/// let typing = Typing::start(Arc::new(http), 7)?;
+/// let typing = Typing::start(Arc::new(http), channel_id)?;
 ///
 /// // Run some long-running process
 /// long_process();

--- a/src/model/application.rs
+++ b/src/model/application.rs
@@ -5,8 +5,6 @@ pub mod component;
 pub mod interaction;
 pub mod oauth;
 
-use std::num::NonZeroU64;
-
 pub use interaction::{
     Interaction,
     InteractionResponseType,
@@ -16,7 +14,7 @@ pub use interaction::{
 };
 
 use self::oauth::Scope;
-use super::id::{snowflake, ApplicationId, GuildId, SkuId, UserId};
+use super::id::{ApplicationId, GenericId, GuildId, SkuId, UserId};
 use super::user::User;
 use super::Permissions;
 
@@ -77,8 +75,7 @@ pub struct Team {
     /// The icon of the team.
     pub icon: Option<String>,
     /// The snowflake ID of the team.
-    #[serde(with = "snowflake")]
-    pub id: NonZeroU64,
+    pub id: GenericId,
     /// The name of the team.
     pub name: String,
     /// The members of the team
@@ -99,8 +96,7 @@ pub struct TeamMember {
     /// NOTE: Will always be ["*"] for now.
     pub permissions: Vec<String>,
     /// The ID of the team they are a member of.
-    #[serde(with = "snowflake")]
-    pub team_id: NonZeroU64,
+    pub team_id: GenericId,
     /// The user type of the team member.
     pub user: User,
 }

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -190,7 +190,7 @@ impl Command {
         http: impl AsRef<Http>,
         command_id: CommandId,
     ) -> Result<Command> {
-        http.as_ref().get_global_application_command(command_id.into()).await
+        http.as_ref().get_global_application_command(command_id).await
     }
 
     /// Deletes a global command by its Id.
@@ -202,7 +202,7 @@ impl Command {
         http: impl AsRef<Http>,
         command_id: CommandId,
     ) -> Result<()> {
-        http.as_ref().delete_global_application_command(command_id.into()).await
+        http.as_ref().delete_global_application_command(command_id).await
     }
 }
 

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -191,7 +191,7 @@ impl ApplicationCommandInteraction {
         http: impl AsRef<Http>,
         message_id: M,
     ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id.into().into()).await
+        http.as_ref().delete_followup_message(&self.token, message_id.into()).await
     }
 
     /// Gets a followup message.
@@ -205,7 +205,7 @@ impl ApplicationCommandInteraction {
         http: impl AsRef<Http>,
         message_id: M,
     ) -> Result<Message> {
-        http.as_ref().get_followup_message(&self.token, message_id.into().into()).await
+        http.as_ref().get_followup_message(&self.token, message_id.into()).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -165,7 +165,7 @@ impl MessageComponentInteraction {
         http: impl AsRef<Http>,
         message_id: M,
     ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id.into().into()).await
+        http.as_ref().delete_followup_message(&self.token, message_id.into()).await
     }
 
     /// Gets a followup message.
@@ -179,7 +179,7 @@ impl MessageComponentInteraction {
         http: impl AsRef<Http>,
         message_id: M,
     ) -> Result<Message> {
-        http.as_ref().get_followup_message(&self.token, message_id.into().into()).await
+        http.as_ref().get_followup_message(&self.token, message_id.into()).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -167,7 +167,7 @@ impl ModalSubmitInteraction {
         http: impl AsRef<Http>,
         message_id: M,
     ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id.into().into()).await
+        http.as_ref().delete_followup_message(&self.token, message_id.into()).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -828,7 +828,7 @@ impl ChannelId {
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this channel.
     #[cfg(feature = "collector")]
     pub fn reply_collector(self, shard_messenger: &ShardMessenger) -> MessageCollectorBuilder<'_> {
-        MessageCollectorBuilder::new(shard_messenger).channel_id(self.0)
+        MessageCollectorBuilder::new(shard_messenger).channel_id(self)
     }
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent in this channel.
@@ -837,7 +837,7 @@ impl ChannelId {
         self,
         shard_messenger: &ShardMessenger,
     ) -> ReactionCollectorBuilder<'_> {
-        ReactionCollectorBuilder::new(shard_messenger).channel_id(self.0)
+        ReactionCollectorBuilder::new(shard_messenger).channel_id(self)
     }
 
     /// Gets a stage instance.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -967,7 +967,7 @@ impl ChannelId {
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
     pub async fn add_thread_member(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
-        http.as_ref().add_thread_channel_member(self, user_id.into()).await
+        http.as_ref().add_thread_channel_member(self, user_id).await
     }
 
     /// Removes a thread member, if this channel is a thread.
@@ -976,7 +976,7 @@ impl ChannelId {
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
     pub async fn remove_thread_member(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
-        http.as_ref().remove_thread_channel_member(self, user_id.into()).await
+        http.as_ref().remove_thread_channel_member(self, user_id).await
     }
 
     /// Gets private archived threads of a channel.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -62,7 +62,7 @@ impl ChannelId {
     /// [Send Messages]: Permissions::SEND_MESSAGES
     #[inline]
     pub async fn broadcast_typing(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().broadcast_typing(self.get()).await
+        http.as_ref().broadcast_typing(self).await
     }
 
     /// Creates an invite for the given channel.
@@ -110,7 +110,7 @@ impl ChannelId {
         target: PermissionOverwrite,
     ) -> Result<()> {
         let data: PermissionOverwriteData = target.into();
-        http.as_ref().create_permission(self.get(), data.id.get(), &data, None).await
+        http.as_ref().create_permission(self, data.id, &data, None).await
     }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
@@ -133,9 +133,7 @@ impl ChannelId {
         message_id: impl Into<MessageId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.as_ref()
-            .create_reaction(self.get(), message_id.into().get(), &reaction_type.into())
-            .await
+        http.as_ref().create_reaction(self, message_id.into(), &reaction_type.into()).await
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
@@ -149,7 +147,7 @@ impl ChannelId {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
     pub async fn delete(self, http: impl AsRef<Http>) -> Result<Channel> {
-        http.as_ref().delete_channel(self.get(), None).await
+        http.as_ref().delete_channel(self, None).await
     }
 
     /// Deletes a [`Message`] given its Id.
@@ -171,7 +169,7 @@ impl ChannelId {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        http.as_ref().delete_message(self.get(), message_id.into().get(), None).await
+        http.as_ref().delete_message(self, message_id.into(), None).await
     }
 
     /// Deletes all messages by Ids from the given vector in the given channel.
@@ -211,7 +209,7 @@ impl ChannelId {
         } else {
             let map = json!({ "messages": ids });
 
-            http.as_ref().delete_messages(self.get(), &map, None).await
+            http.as_ref().delete_messages(self, &map, None).await
         }
     }
 
@@ -230,10 +228,10 @@ impl ChannelId {
         permission_type: PermissionOverwriteType,
     ) -> Result<()> {
         let id = match permission_type {
-            PermissionOverwriteType::Member(id) => id.get(),
-            PermissionOverwriteType::Role(id) => id.get(),
+            PermissionOverwriteType::Member(id) => TargetId(id.0),
+            PermissionOverwriteType::Role(id) => TargetId(id.0),
         };
-        http.as_ref().delete_permission(self.get(), id, None).await
+        http.as_ref().delete_permission(self, id, None).await
     }
 
     /// Deletes the given [`Reaction`] from the channel.
@@ -255,14 +253,7 @@ impl ChannelId {
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.as_ref()
-            .delete_reaction(
-                self.get(),
-                message_id.into().get(),
-                user_id.map(UserId::get),
-                &reaction_type.into(),
-            )
-            .await
+        http.as_ref().delete_reaction(self, message_id.into(), user_id, &reaction_type.into()).await
     }
 
     /// Deletes all [`Reaction`]s of the given emoji to a message within the channel.
@@ -282,11 +273,7 @@ impl ChannelId {
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
         http.as_ref()
-            .delete_message_reaction_emoji(
-                self.get(),
-                message_id.into().get(),
-                &reaction_type.into(),
-            )
+            .delete_message_reaction_emoji(self, message_id.into(), &reaction_type.into())
             .await
     }
 
@@ -375,7 +362,7 @@ impl ChannelId {
         http: impl AsRef<Http>,
         target_channel_id: impl Into<ChannelId>,
     ) -> Result<FollowedChannel> {
-        http.as_ref().follow_news_channel(self.get(), target_channel_id.into().get()).await
+        http.as_ref().follow_news_channel(self, target_channel_id.into()).await
     }
 
     /// Attempts to find a [`Channel`] by its Id in the cache.
@@ -407,7 +394,7 @@ impl ChannelId {
             }
         }
 
-        let channel = cache_http.http().get_channel(self.get()).await?;
+        let channel = cache_http.http().get_channel(self).await?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
         {
@@ -432,7 +419,7 @@ impl ChannelId {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
     pub async fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
-        http.as_ref().get_channel_invites(self.get()).await
+        http.as_ref().get_channel_invites(self).await
     }
 
     /// Gets a message from the channel.
@@ -462,7 +449,7 @@ impl ChannelId {
             }
         }
 
-        cache_http.http().get_message(self.get(), message_id.get()).await
+        cache_http.http().get_message(self, message_id).await
     }
 
     /// Gets messages from the channel.
@@ -544,7 +531,7 @@ impl ChannelId {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
     pub async fn pin(self, http: impl AsRef<Http>, message_id: impl Into<MessageId>) -> Result<()> {
-        http.as_ref().pin_message(self.get(), message_id.into().get(), None).await
+        http.as_ref().pin_message(self, message_id.into(), None).await
     }
 
     /// Crossposts a [`Message`].
@@ -559,11 +546,11 @@ impl ChannelId {
     /// and if the user is not the author of the message.
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn crosspost(
-        &self,
+        self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<Message> {
-        http.as_ref().crosspost_message(self.get(), message_id.into().get()).await
+        http.as_ref().crosspost_message(self, message_id.into()).await
     }
 
     /// Gets the list of [`Message`]s which are pinned to the channel.
@@ -579,7 +566,7 @@ impl ChannelId {
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     #[inline]
     pub async fn pins(self, http: impl AsRef<Http>) -> Result<Vec<Message>> {
-        http.as_ref().get_pins(self.get()).await
+        http.as_ref().get_pins(self).await
     }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a
@@ -616,8 +603,8 @@ impl ChannelId {
 
         http.as_ref()
             .get_reaction_users(
-                self.get(),
-                message_id.into().get(),
+                self,
+                message_id.into(),
                 &reaction_type.into(),
                 limit,
                 after.into().map(UserId::get),
@@ -790,7 +777,7 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission
     /// to send messages in this channel.
     pub fn start_typing(self, http: &Arc<Http>) -> Result<Typing> {
-        http.start_typing(self.get())
+        http.start_typing(self)
     }
 
     /// Unpins a [`Message`] in the channel given by its Id.
@@ -808,7 +795,7 @@ impl ChannelId {
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {
-        http.as_ref().unpin_message(self.get(), message_id.into().get(), None).await
+        http.as_ref().unpin_message(self, message_id.into(), None).await
     }
 
     /// Retrieves the channel's webhooks.
@@ -822,7 +809,7 @@ impl ChannelId {
     /// [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
     #[inline]
     pub async fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
-        http.as_ref().get_channel_webhooks(self.get()).await
+        http.as_ref().get_channel_webhooks(self).await
     }
 
     /// Creates a webhook in the channel.
@@ -841,7 +828,7 @@ impl ChannelId {
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this channel.
     #[cfg(feature = "collector")]
     pub fn reply_collector<'a>(
-        &self,
+        self,
         shard_messenger: &'a ShardMessenger,
     ) -> MessageCollectorBuilder<'a> {
         MessageCollectorBuilder::new(shard_messenger).channel_id(self.0)
@@ -850,7 +837,7 @@ impl ChannelId {
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent in this channel.
     #[cfg(feature = "collector")]
     pub fn reaction_collector<'a>(
-        &self,
+        self,
         shard_messenger: &'a ShardMessenger,
     ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).channel_id(self.0)
@@ -862,8 +849,8 @@ impl ChannelId {
     ///
     /// Returns [`Error::Http`] if the channel is not a stage channel,
     /// or if there is no stage instance currently.
-    pub async fn get_stage_instance(&self, http: impl AsRef<Http>) -> Result<StageInstance> {
-        http.as_ref().get_stage_instance(self.get()).await
+    pub async fn get_stage_instance(self, http: impl AsRef<Http>) -> Result<StageInstance> {
+        http.as_ref().get_stage_instance(self).await
     }
 
     /// Creates a stage instance.
@@ -916,8 +903,8 @@ impl ChannelId {
     ///
     /// Returns [`Error::Http`] if the channel is not a stage channel,
     /// or if there is no stage instance currently.
-    pub async fn delete_stage_instance(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_stage_instance(self.get(), None).await
+    pub async fn delete_stage_instance(self, http: impl AsRef<Http>) -> Result<()> {
+        http.as_ref().delete_stage_instance(self, None).await
     }
 
     /// Creates a public thread that is connected to a message.
@@ -952,8 +939,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn get_thread_members(&self, http: impl AsRef<Http>) -> Result<Vec<ThreadMember>> {
-        http.as_ref().get_channel_thread_members(self.get()).await
+    pub async fn get_thread_members(self, http: impl AsRef<Http>) -> Result<Vec<ThreadMember>> {
+        http.as_ref().get_channel_thread_members(self).await
     }
 
     /// Joins the thread, if this channel is a thread.
@@ -961,8 +948,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn join_thread(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().join_thread_channel(self.get()).await
+    pub async fn join_thread(self, http: impl AsRef<Http>) -> Result<()> {
+        http.as_ref().join_thread_channel(self).await
     }
 
     /// Leaves the thread, if this channel is a thread.
@@ -970,8 +957,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn leave_thread(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().leave_thread_channel(self.get()).await
+    pub async fn leave_thread(self, http: impl AsRef<Http>) -> Result<()> {
+        http.as_ref().leave_thread_channel(self).await
     }
 
     /// Adds a thread member, if this channel is a thread.
@@ -979,8 +966,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn add_thread_member(&self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
-        http.as_ref().add_thread_channel_member(self.get(), user_id.into()).await
+    pub async fn add_thread_member(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+        http.as_ref().add_thread_channel_member(self, user_id.into()).await
     }
 
     /// Removes a thread member, if this channel is a thread.
@@ -988,12 +975,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn remove_thread_member(
-        &self,
-        http: impl AsRef<Http>,
-        user_id: UserId,
-    ) -> Result<()> {
-        http.as_ref().remove_thread_channel_member(self.get(), user_id.into()).await
+    pub async fn remove_thread_member(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+        http.as_ref().remove_thread_channel_member(self, user_id.into()).await
     }
 
     /// Gets private archived threads of a channel.
@@ -1003,12 +986,12 @@ impl ChannelId {
     /// It may return an [`Error::Http`] if the bot doesn't have the
     /// permission to get it.
     pub async fn get_archived_private_threads(
-        &self,
+        self,
         http: impl AsRef<Http>,
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.as_ref().get_channel_archived_private_threads(self.get(), before, limit).await
+        http.as_ref().get_channel_archived_private_threads(self, before, limit).await
     }
 
     /// Gets public archived threads of a channel.
@@ -1018,12 +1001,12 @@ impl ChannelId {
     /// It may return an [`Error::Http`] if the bot doesn't have the
     /// permission to get it.
     pub async fn get_archived_public_threads(
-        &self,
+        self,
         http: impl AsRef<Http>,
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.as_ref().get_channel_archived_public_threads(self.get(), before, limit).await
+        http.as_ref().get_channel_archived_public_threads(self, before, limit).await
     }
 
     /// Gets private archived threads joined by the current user of a channel.
@@ -1033,12 +1016,12 @@ impl ChannelId {
     /// It may return an [`Error::Http`] if the bot doesn't have the
     /// permission to get it.
     pub async fn get_joined_archived_private_threads(
-        &self,
+        self,
         http: impl AsRef<Http>,
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.as_ref().get_channel_joined_archived_private_threads(self.get(), before, limit).await
+        http.as_ref().get_channel_joined_archived_private_threads(self, before, limit).await
     }
 }
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -827,19 +827,16 @@ impl ChannelId {
 
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this channel.
     #[cfg(feature = "collector")]
-    pub fn reply_collector<'a>(
-        self,
-        shard_messenger: &'a ShardMessenger,
-    ) -> MessageCollectorBuilder<'a> {
+    pub fn reply_collector(self, shard_messenger: &ShardMessenger) -> MessageCollectorBuilder<'_> {
         MessageCollectorBuilder::new(shard_messenger).channel_id(self.0)
     }
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent in this channel.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector<'a>(
+    pub fn reaction_collector(
         self,
-        shard_messenger: &'a ShardMessenger,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: &ShardMessenger,
+    ) -> ReactionCollectorBuilder<'_> {
         ReactionCollectorBuilder::new(shard_messenger).channel_id(self.0)
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -967,7 +967,7 @@ impl GuildChannel {
     /// ```
     #[allow(clippy::missing_errors_doc)]
     pub fn start_typing(&self, http: &Arc<Http>) -> Result<Typing> {
-        http.start_typing(self.id.get())
+        http.start_typing(self.id)
     }
 
     /// Unpins a [`Message`] in the channel given by its Id.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1059,7 +1059,7 @@ impl GuildChannel {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> MessageCollectorBuilder<'a> {
-        MessageCollectorBuilder::new(shard_messenger).channel_id(self.id.0)
+        MessageCollectorBuilder::new(shard_messenger).channel_id(self.id)
     }
 
     /// Returns a stream builder which can be awaited to obtain a reaction or stream of reactions sent by this guild channel.
@@ -1068,7 +1068,7 @@ impl GuildChannel {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> ReactionCollectorBuilder<'a> {
-        ReactionCollectorBuilder::new(shard_messenger).channel_id(self.id.0)
+        ReactionCollectorBuilder::new(shard_messenger).channel_id(self.id)
     }
 
     /// Creates a webhook in the channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -767,7 +767,7 @@ impl Message {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> ReactionCollectorBuilder<'a> {
-        ReactionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
+        ReactionCollectorBuilder::new(shard_messenger).message_id(self.id)
     }
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of component interactions on this message.
@@ -776,7 +776,7 @@ impl Message {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> ComponentInteractionCollectorBuilder<'a> {
-        ComponentInteractionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
+        ComponentInteractionCollectorBuilder::new(shard_messenger).message_id(self.id)
     }
 
     /// Returns a builder which can be awaited to obtain a model submit interaction or stream of modal submit interactions on this message.
@@ -785,7 +785,7 @@ impl Message {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> ModalInteractionCollectorBuilder<'a> {
-        ModalInteractionCollectorBuilder::new(shard_messenger).message_id(self.id.0)
+        ModalInteractionCollectorBuilder::new(shard_messenger).message_id(self.id)
     }
 
     /// Retrieves the message channel's category ID if the channel has one.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -248,11 +248,7 @@ impl Message {
             }
         }
 
-        cache_http
-            .http()
-            .as_ref()
-            .delete_message_reactions(self.channel_id.get(), self.id.get())
-            .await
+        cache_http.http().as_ref().delete_message_reactions(self.channel_id, self.id).await
     }
 
     /// Deletes all of the [`Reaction`]s of a given emoji associated with the message.
@@ -286,11 +282,7 @@ impl Message {
         cache_http
             .http()
             .as_ref()
-            .delete_message_reaction_emoji(
-                self.channel_id.get(),
-                self.id.get(),
-                &reaction_type.into(),
-            )
+            .delete_message_reaction_emoji(self.channel_id, self.id, &reaction_type.into())
             .await
     }
 
@@ -553,10 +545,7 @@ impl Message {
             }
         }
 
-        cache_http
-            .http()
-            .create_reaction(self.channel_id.get(), self.id.get(), &reaction_type)
-            .await?;
+        cache_http.http().create_reaction(self.channel_id, self.id, &reaction_type).await?;
 
         Ok(Reaction {
             channel_id: self.channel_id,
@@ -744,7 +733,7 @@ impl Message {
             }
         }
 
-        cache_http.http().unpin_message(self.channel_id.get(), self.id.get(), None).await
+        cache_http.http().unpin_message(self.channel_id, self.id, None).await
     }
 
     /// Tries to return author's nickname in the current channel's guild.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -12,7 +12,6 @@ mod reaction;
 #[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
 use std::error::Error as StdError;
 use std::fmt;
-use std::num::NonZeroU64;
 
 use serde::de::{Error as DeError, Unexpected};
 
@@ -281,8 +280,7 @@ impl ChannelType {
 pub(crate) struct PermissionOverwriteData {
     allow: Permissions,
     deny: Permissions,
-    #[serde(with = "snowflake")]
-    id: NonZeroU64,
+    id: TargetId,
     #[serde(rename = "type")]
     kind: u8,
 }
@@ -300,8 +298,8 @@ impl std::convert::TryFrom<PermissionOverwriteData> for PermissionOverwrite {
 
     fn try_from(data: PermissionOverwriteData) -> StdResult<Self, Self::Error> {
         let kind = match data.kind {
-            0 => PermissionOverwriteType::Role(RoleId(data.id)),
-            1 => PermissionOverwriteType::Member(UserId(data.id)),
+            0 => PermissionOverwriteType::Role(RoleId(data.id.0)),
+            1 => PermissionOverwriteType::Member(UserId(data.id.0)),
             raw => return Err(InvalidPermissionOverwriteType(raw)),
         };
 
@@ -316,8 +314,8 @@ impl std::convert::TryFrom<PermissionOverwriteData> for PermissionOverwrite {
 impl From<PermissionOverwrite> for PermissionOverwriteData {
     fn from(data: PermissionOverwrite) -> Self {
         let (kind, id) = match data.kind {
-            PermissionOverwriteType::Role(id) => (0, id.0),
-            PermissionOverwriteType::Member(id) => (1, id.0),
+            PermissionOverwriteType::Role(id) => (0, TargetId(id.0)),
+            PermissionOverwriteType::Member(id) => (1, TargetId(id.0)),
         };
 
         PermissionOverwriteData {

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -366,7 +366,7 @@ impl PrivateChannel {
     /// May return [`Error::Http`] if the current user cannot send a direct message
     /// to this user.
     pub fn start_typing(self, http: &Arc<Http>) -> Result<Typing> {
-        http.start_typing(self.id.get())
+        http.start_typing(self.id)
     }
 
     /// Unpins a [`Message`] in the channel given by its Id.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -125,12 +125,7 @@ impl Reaction {
 
         cache_http
             .http()
-            .delete_reaction(
-                self.channel_id.get(),
-                self.message_id.get(),
-                user_id.map(UserId::get),
-                &self.emoji,
-            )
+            .delete_reaction(self.channel_id, self.message_id, user_id, &self.emoji)
             .await
     }
 
@@ -163,11 +158,7 @@ impl Reaction {
         cache_http
             .http()
             .as_ref()
-            .delete_message_reaction_emoji(
-                self.channel_id.get(),
-                self.message_id.get(),
-                &self.emoji,
-            )
+            .delete_message_reaction_emoji(self.channel_id, self.message_id, &self.emoji)
             .await
     }
 
@@ -265,8 +256,8 @@ impl Reaction {
 
         http.as_ref()
             .get_reaction_users(
-                self.channel_id.get(),
-                self.message_id.get(),
+                self.channel_id,
+                self.message_id,
                 reaction_type,
                 limit,
                 after.map(UserId::get),

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -100,7 +100,7 @@ impl Emoji {
     #[inline]
     pub async fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
         let guild_id = self.try_find_guild_id(&cache_http)?;
-        cache_http.http().delete_emoji(guild_id.get(), self.id.get(), None).await
+        cache_http.http().delete_emoji(guild_id, self.id, None).await
     }
 
     /// Edits the emoji by updating it with a new name.
@@ -119,7 +119,7 @@ impl Emoji {
         let guild_id = self.try_find_guild_id(&cache_http)?;
         let map = json!({ "name": name });
 
-        *self = cache_http.http().edit_emoji(guild_id.get(), self.id.get(), &map, None).await?;
+        *self = cache_http.http().edit_emoji(guild_id, self.id, &map, None).await?;
 
         Ok(())
     }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1399,19 +1399,16 @@ impl GuildId {
     }
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn reply_collector<'a>(
-        self,
-        shard_messenger: &'a ShardMessenger,
-    ) -> MessageCollectorBuilder<'a> {
+    pub fn reply_collector(self, shard_messenger: &ShardMessenger) -> MessageCollectorBuilder<'_> {
         MessageCollectorBuilder::new(shard_messenger).guild_id(self.0)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector<'a>(
+    pub fn reaction_collector(
         self,
-        shard_messenger: &'a ShardMessenger,
-    ) -> ReactionCollectorBuilder<'a> {
+        shard_messenger: &ShardMessenger,
+    ) -> ReactionCollectorBuilder<'_> {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.0)
     }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1400,7 +1400,7 @@ impl GuildId {
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
     pub fn reply_collector(self, shard_messenger: &ShardMessenger) -> MessageCollectorBuilder<'_> {
-        MessageCollectorBuilder::new(shard_messenger).guild_id(self.0)
+        MessageCollectorBuilder::new(shard_messenger).guild_id(self)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
@@ -1409,7 +1409,7 @@ impl GuildId {
         self,
         shard_messenger: &ShardMessenger,
     ) -> ReactionCollectorBuilder<'_> {
-        ReactionCollectorBuilder::new(shard_messenger).guild_id(self.0)
+        ReactionCollectorBuilder::new(shard_messenger).guild_id(self)
     }
 
     /// Create a guild specific application [`Command`].

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -51,7 +51,7 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn automod_rules(self, http: impl AsRef<Http>) -> Result<Vec<Rule>> {
-        http.as_ref().get_automod_rules(self.get()).await
+        http.as_ref().get_automod_rules(self).await
     }
 
     /// Gets an auto moderation [`Rule`] of this guild by its ID via HTTP.
@@ -69,7 +69,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
     ) -> Result<Rule> {
-        http.as_ref().get_automod_rule(self.get(), rule_id.into().get()).await
+        http.as_ref().get_automod_rule(self, rule_id.into()).await
     }
 
     /// Creates an auto moderation [`Rule`] in the guild.
@@ -147,7 +147,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         rule_id: impl Into<RuleId>,
     ) -> Result<()> {
-        http.as_ref().delete_automod_rule(self.get(), rule_id.into().get(), None).await
+        http.as_ref().delete_automod_rule(self, rule_id.into(), None).await
     }
 
     /// Adds a [`User`] to this guild with a valid OAuth2 access token.
@@ -237,7 +237,7 @@ impl GuildId {
             return Err(Error::ExceededLimit(reason.to_string(), 512));
         }
 
-        http.as_ref().ban_user(self.get(), user.get(), dmd, reason).await
+        http.as_ref().ban_user(self, user, dmd, reason).await
     }
 
     /// Gets a list of the guild's bans.
@@ -251,7 +251,7 @@ impl GuildId {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn bans(self, http: impl AsRef<Http>) -> Result<Vec<Ban>> {
-        http.as_ref().get_bans(self.get()).await
+        http.as_ref().get_bans(self).await
     }
 
     /// Gets a list of the guild's audit log entries
@@ -274,13 +274,7 @@ impl GuildId {
         limit: Option<u8>,
     ) -> Result<AuditLogs> {
         http.as_ref()
-            .get_audit_logs(
-                self.get(),
-                action_type,
-                user_id.map(UserId::get),
-                before.map(AuditLogEntryId::get),
-                limit,
-            )
+            .get_audit_logs(self, action_type, user_id, before.map(AuditLogEntryId::get), limit)
             .await
     }
 
@@ -294,7 +288,7 @@ impl GuildId {
         self,
         http: impl AsRef<Http>,
     ) -> Result<HashMap<ChannelId, GuildChannel>> {
-        let channels = http.as_ref().get_channels(self.get()).await?;
+        let channels = http.as_ref().get_channels(self).await?;
 
         Ok(channels.into_iter().map(|c| (c.id, c)).collect())
     }
@@ -370,7 +364,7 @@ impl GuildId {
             "image": image,
         });
 
-        http.as_ref().create_emoji(self.get(), &map, None).await
+        http.as_ref().create_emoji(self, &map, None).await
     }
 
     /// Creates an integration for the guild.
@@ -395,7 +389,7 @@ impl GuildId {
             "type": kind,
         });
 
-        http.as_ref().create_guild_integration(self.get(), integration_id.get(), &map, None).await
+        http.as_ref().create_guild_integration(self, integration_id, &map, None).await
     }
 
     /// Creates a new role in the guild with the data set, if any.
@@ -468,7 +462,7 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user is not the owner of the guild.
     #[inline]
     pub async fn delete(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_guild(self.get()).await
+        http.as_ref().delete_guild(self).await
     }
 
     /// Deletes an [`Emoji`] from the guild.
@@ -487,7 +481,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         emoji_id: impl Into<EmojiId>,
     ) -> Result<()> {
-        http.as_ref().delete_emoji(self.get(), emoji_id.into().get(), None).await
+        http.as_ref().delete_emoji(self, emoji_id.into(), None).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -506,7 +500,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        http.as_ref().delete_guild_integration(self.get(), integration_id.into().get(), None).await
+        http.as_ref().delete_guild_integration(self, integration_id.into(), None).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -528,7 +522,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         role_id: impl Into<RoleId>,
     ) -> Result<()> {
-        http.as_ref().delete_role(self.get(), role_id.into().get(), None).await
+        http.as_ref().delete_role(self, role_id.into(), None).await
     }
 
     /// Deletes a specified scheduled event in the guild.
@@ -546,7 +540,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         event_id: impl Into<ScheduledEventId>,
     ) -> Result<()> {
-        http.as_ref().delete_scheduled_event(self.get(), event_id.into().get()).await
+        http.as_ref().delete_scheduled_event(self, event_id.into()).await
     }
 
     /// Deletes a [`Sticker`] by Id from the guild.
@@ -565,7 +559,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         sticker_id: impl Into<StickerId>,
     ) -> Result<()> {
-        http.as_ref().delete_sticker(self.get(), sticker_id.into().get(), None).await
+        http.as_ref().delete_sticker(self, sticker_id.into(), None).await
     }
 
     /// Edits the current guild with new data where specified.
@@ -610,7 +604,7 @@ impl GuildId {
             "name": name,
         });
 
-        http.as_ref().edit_emoji(self.get(), emoji_id.into().get(), &map, None).await
+        http.as_ref().edit_emoji(self, emoji_id.into(), &map, None).await
     }
 
     /// Edits the properties a guild member, such as muting or nicknaming them. Returns the new
@@ -668,7 +662,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         new_nickname: Option<&str>,
     ) -> Result<()> {
-        http.as_ref().edit_nickname(self.get(), new_nickname, None).await
+        http.as_ref().edit_nickname(self, new_nickname, None).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.
@@ -791,7 +785,7 @@ impl GuildId {
         role_id: impl Into<RoleId>,
         position: u32,
     ) -> Result<Vec<Role>> {
-        http.as_ref().edit_role_position(self.get(), role_id.into().get(), position, None).await
+        http.as_ref().edit_role_position(self, role_id.into(), position, None).await
     }
 
     /// Edits the guild's welcome screen.
@@ -835,7 +829,7 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user is not in
     /// the guild.
     pub async fn roles(self, http: impl AsRef<Http>) -> Result<HashMap<RoleId, Role>> {
-        let roles = http.as_ref().get_guild_roles(self.get()).await?;
+        let roles = http.as_ref().get_guild_roles(self).await?;
 
         Ok(roles.into_iter().map(|r| (r.id, r)).collect())
     }
@@ -866,7 +860,7 @@ impl GuildId {
             }
         }
 
-        cache_http.http().get_guild(self.get()).await
+        cache_http.http().get_guild(self).await
     }
 
     /// Requests [`PartialGuild`] over REST API with counts.
@@ -882,7 +876,7 @@ impl GuildId {
         self,
         http: impl AsRef<Http>,
     ) -> Result<PartialGuild> {
-        http.as_ref().get_guild_with_counts(self.get()).await
+        http.as_ref().get_guild_with_counts(self).await
     }
 
     /// Gets all [`Emoji`]s of this guild via HTTP.
@@ -891,8 +885,8 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the guild is unavailable.
     #[inline]
-    pub async fn emojis(&self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
-        http.as_ref().get_emojis(self.get()).await
+    pub async fn emojis(self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
+        http.as_ref().get_emojis(self).await
     }
 
     /// Gets an [`Emoji`] of this guild by its ID via HTTP.
@@ -901,8 +895,8 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if an emoji with that Id does not exist.
     #[inline]
-    pub async fn emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
-        http.as_ref().get_emoji(self.get(), emoji_id.get()).await
+    pub async fn emoji(self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
+        http.as_ref().get_emoji(self, emoji_id).await
     }
 
     /// Gets all [`Sticker`]s of this guild via HTTP.
@@ -911,8 +905,8 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the guild is unavailable.
     #[inline]
-    pub async fn stickers(&self, http: impl AsRef<Http>) -> Result<Vec<Sticker>> {
-        http.as_ref().get_guild_stickers(self.get()).await
+    pub async fn stickers(self, http: impl AsRef<Http>) -> Result<Vec<Sticker>> {
+        http.as_ref().get_guild_stickers(self).await
     }
 
     /// Gets an [`Sticker`] of this guild by its ID via HTTP.
@@ -921,8 +915,8 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if an sticker with that Id does not exist.
     #[inline]
-    pub async fn sticker(&self, http: impl AsRef<Http>, sticker_id: StickerId) -> Result<Sticker> {
-        http.as_ref().get_guild_sticker(self.get(), sticker_id.get()).await
+    pub async fn sticker(self, http: impl AsRef<Http>, sticker_id: StickerId) -> Result<Sticker> {
+        http.as_ref().get_guild_sticker(self, sticker_id).await
     }
 
     /// Gets all integration of the guild.
@@ -938,7 +932,7 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn integrations(self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {
-        http.as_ref().get_guild_integrations(self.get()).await
+        http.as_ref().get_guild_integrations(self).await
     }
 
     /// Gets all of the guild's invites.
@@ -954,7 +948,7 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
-        http.as_ref().get_guild_invites(self.get()).await
+        http.as_ref().get_guild_invites(self).await
     }
 
     /// Kicks a [`Member`] from the guild.
@@ -969,7 +963,7 @@ impl GuildId {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn kick(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        http.as_ref().kick_member(self.get(), user_id.into().get()).await
+        http.as_ref().kick_member(self, user_id.into()).await
     }
 
     /// # Errors
@@ -983,7 +977,7 @@ impl GuildId {
         user_id: impl Into<UserId>,
         reason: &str,
     ) -> Result<()> {
-        http.as_ref().kick_member_with_reason(self.get(), user_id.into().get(), reason).await
+        http.as_ref().kick_member_with_reason(self, user_id.into(), reason).await
     }
 
     /// Leaves the guild.
@@ -994,7 +988,7 @@ impl GuildId {
     /// cannot leave the guild, or currently is not in the guild.
     #[inline]
     pub async fn leave(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().leave_guild(self.get()).await
+        http.as_ref().leave_guild(self).await
     }
 
     /// Gets a user's [`Member`] for the guild by Id.
@@ -1023,7 +1017,7 @@ impl GuildId {
             }
         }
 
-        cache_http.http().get_member(self.get(), user_id.get()).await
+        cache_http.http().get_member(self, user_id).await
     }
 
     /// Gets a list of the guild's members.
@@ -1046,7 +1040,7 @@ impl GuildId {
         limit: Option<u64>,
         after: impl Into<Option<UserId>>,
     ) -> Result<Vec<Member>> {
-        http.as_ref().get_guild_members(self.get(), limit, after.into().map(UserId::get)).await
+        http.as_ref().get_guild_members(self, limit, after.into().map(UserId::get)).await
     }
 
     /// Streams over all the members in a guild.
@@ -1138,7 +1132,7 @@ impl GuildId {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn prune_count(self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
-        http.as_ref().get_guild_prune_count(self.get(), days).await
+        http.as_ref().get_guild_prune_count(self, days).await
     }
 
     /// Re-orders the channels of the guild.
@@ -1172,7 +1166,7 @@ impl GuildId {
             })
             .collect::<Vec<_>>();
 
-        http.as_ref().edit_guild_channel_positions(self.get(), &Value::from(items)).await
+        http.as_ref().edit_guild_channel_positions(self, &Value::from(items)).await
     }
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname
@@ -1191,7 +1185,7 @@ impl GuildId {
         query: &str,
         limit: Option<u64>,
     ) -> Result<Vec<Member>> {
-        http.as_ref().search_guild_members(self.get(), query, limit).await
+        http.as_ref().search_guild_members(self, query, limit).await
     }
 
     /// Fetches a specified scheduled event in the guild, by Id. If `with_user_count` is set to
@@ -1212,7 +1206,7 @@ impl GuildId {
         event_id: impl Into<ScheduledEventId>,
         with_user_count: bool,
     ) -> Result<ScheduledEvent> {
-        http.as_ref().get_scheduled_event(self.get(), event_id.into().get(), with_user_count).await
+        http.as_ref().get_scheduled_event(self, event_id.into(), with_user_count).await
     }
 
     /// Fetches a list of all scheduled events in the guild. If `with_user_count` is set to `true`,
@@ -1230,7 +1224,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         with_user_count: bool,
     ) -> Result<Vec<ScheduledEvent>> {
-        http.as_ref().get_scheduled_events(self.get(), with_user_count).await
+        http.as_ref().get_scheduled_events(self, with_user_count).await
     }
 
     /// Fetches a list of interested users for the specified event.
@@ -1251,9 +1245,7 @@ impl GuildId {
         event_id: impl Into<ScheduledEventId>,
         limit: Option<u64>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        http.as_ref()
-            .get_scheduled_event_users(self.get(), event_id.into().get(), limit, None, None)
-            .await
+        http.as_ref().get_scheduled_event_users(self, event_id.into(), limit, None, None).await
     }
 
     /// Fetches a list of interested users for the specified event, with additional options and
@@ -1276,13 +1268,7 @@ impl GuildId {
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
         http.as_ref()
-            .get_scheduled_event_users(
-                self.get(),
-                event_id.into().get(),
-                limit,
-                target,
-                with_member,
-            )
+            .get_scheduled_event_users(self, event_id.into(), limit, target, with_member)
             .await
     }
 
@@ -1347,7 +1333,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         integration_id: impl Into<IntegrationId>,
     ) -> Result<()> {
-        http.as_ref().start_integration_sync(self.get(), integration_id.into().get()).await
+        http.as_ref().start_integration_sync(self, integration_id.into()).await
     }
 
     /// Starts a prune of [`Member`]s.
@@ -1363,7 +1349,7 @@ impl GuildId {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn start_prune(self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
-        http.as_ref().start_guild_prune(self.get(), days, None).await
+        http.as_ref().start_guild_prune(self, days, None).await
     }
 
     /// Unbans a [`User`] from the guild.
@@ -1377,7 +1363,7 @@ impl GuildId {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn unban(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        http.as_ref().remove_ban(self.get(), user_id.into().get(), None).await
+        http.as_ref().remove_ban(self, user_id.into(), None).await
     }
 
     /// Retrieve's the guild's vanity URL.
@@ -1393,7 +1379,7 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[inline]
     pub async fn vanity_url(self, http: impl AsRef<Http>) -> Result<String> {
-        http.as_ref().get_guild_vanity_url(self.get()).await
+        http.as_ref().get_guild_vanity_url(self).await
     }
 
     /// Retrieves the guild's webhooks.
@@ -1409,12 +1395,12 @@ impl GuildId {
     /// the API response.
     #[inline]
     pub async fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
-        http.as_ref().get_guild_webhooks(self.get()).await
+        http.as_ref().get_guild_webhooks(self).await
     }
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
     pub fn reply_collector<'a>(
-        &self,
+        self,
         shard_messenger: &'a ShardMessenger,
     ) -> MessageCollectorBuilder<'a> {
         MessageCollectorBuilder::new(shard_messenger).guild_id(self.0)
@@ -1423,7 +1409,7 @@ impl GuildId {
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
     pub fn reaction_collector<'a>(
-        &self,
+        self,
         shard_messenger: &'a ShardMessenger,
     ) -> ReactionCollectorBuilder<'a> {
         ReactionCollectorBuilder::new(shard_messenger).guild_id(self.0)
@@ -1454,7 +1440,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         commands: Vec<CreateApplicationCommand>,
     ) -> Result<Vec<Command>> {
-        http.as_ref().create_guild_application_commands(self.get(), &commands).await
+        http.as_ref().create_guild_application_commands(self, &commands).await
     }
 
     /// Create a guild specific [`CommandPermission`].
@@ -1478,8 +1464,8 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_application_commands(&self, http: impl AsRef<Http>) -> Result<Vec<Command>> {
-        http.as_ref().get_guild_application_commands(self.get()).await
+    pub async fn get_application_commands(self, http: impl AsRef<Http>) -> Result<Vec<Command>> {
+        http.as_ref().get_guild_application_commands(self).await
     }
 
     /// Get a specific guild application command by its Id.
@@ -1488,11 +1474,11 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_application_command(
-        &self,
+        self,
         http: impl AsRef<Http>,
         command_id: CommandId,
     ) -> Result<Command> {
-        http.as_ref().get_guild_application_command(self.get(), command_id.into()).await
+        http.as_ref().get_guild_application_command(self, command_id.into()).await
     }
 
     /// Edit a guild application command, given its Id.
@@ -1515,11 +1501,11 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn delete_application_command(
-        &self,
+        self,
         http: impl AsRef<Http>,
         command_id: CommandId,
     ) -> Result<()> {
-        http.as_ref().delete_guild_application_command(self.get(), command_id.into()).await
+        http.as_ref().delete_guild_application_command(self, command_id.into()).await
     }
 
     /// Get all guild application commands permissions only.
@@ -1528,10 +1514,10 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_application_commands_permissions(
-        &self,
+        self,
         http: impl AsRef<Http>,
     ) -> Result<Vec<CommandPermission>> {
-        http.as_ref().get_guild_application_commands_permissions(self.get()).await
+        http.as_ref().get_guild_application_commands_permissions(self).await
     }
 
     /// Get permissions for specific guild application command by its Id.
@@ -1540,11 +1526,11 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_application_command_permissions(
-        &self,
+        self,
         http: impl AsRef<Http>,
         command_id: CommandId,
     ) -> Result<CommandPermission> {
-        http.as_ref().get_guild_application_command_permissions(self.get(), command_id.into()).await
+        http.as_ref().get_guild_application_command_permissions(self, command_id.into()).await
     }
 
     /// Get the guild welcome screen.
@@ -1552,8 +1538,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the guild does not have a welcome screen.
-    pub async fn get_welcome_screen(&self, http: impl AsRef<Http>) -> Result<GuildWelcomeScreen> {
-        http.as_ref().get_guild_welcome_screen(self.get()).await
+    pub async fn get_welcome_screen(self, http: impl AsRef<Http>) -> Result<GuildWelcomeScreen> {
+        http.as_ref().get_guild_welcome_screen(self).await
     }
 
     /// Get the guild preview.
@@ -1564,8 +1550,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the bot cannot see the guild preview, see the note.
-    pub async fn get_preview(&self, http: impl AsRef<Http>) -> Result<GuildPreview> {
-        http.as_ref().get_guild_preview(self.get()).await
+    pub async fn get_preview(self, http: impl AsRef<Http>) -> Result<GuildPreview> {
+        http.as_ref().get_guild_preview(self).await
     }
 
     /// Get the guild widget.
@@ -1573,14 +1559,14 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the bot does not have `MANAGE_MESSAGES` permission.
-    pub async fn get_widget(&self, http: impl AsRef<Http>) -> Result<GuildWidget> {
-        http.as_ref().get_guild_widget(self.get()).await
+    pub async fn get_widget(self, http: impl AsRef<Http>) -> Result<GuildWidget> {
+        http.as_ref().get_guild_widget(self).await
     }
 
     /// Get the widget image URL.
     #[must_use]
-    pub fn widget_image_url(&self, style: GuildWidgetStyle) -> String {
-        api!("/guilds/{}/widget.png?style={}", self.get(), style)
+    pub fn widget_image_url(self, style: GuildWidgetStyle) -> String {
+        api!("/guilds/{}/widget.png?style={}", self, style)
     }
 
     /// Gets the guild active threads.
@@ -1589,8 +1575,8 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if there is an error in the deserialization, or
     /// if the bot issuing the request is not in the guild.
-    pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
-        http.as_ref().get_guild_active_threads(self.get()).await
+    pub async fn get_active_threads(self, http: impl AsRef<Http>) -> Result<ThreadsData> {
+        http.as_ref().get_guild_active_threads(self).await
     }
 }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1478,7 +1478,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         command_id: CommandId,
     ) -> Result<Command> {
-        http.as_ref().get_guild_application_command(self, command_id.into()).await
+        http.as_ref().get_guild_application_command(self, command_id).await
     }
 
     /// Edit a guild application command, given its Id.
@@ -1505,7 +1505,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         command_id: CommandId,
     ) -> Result<()> {
-        http.as_ref().delete_guild_application_command(self, command_id.into()).await
+        http.as_ref().delete_guild_application_command(self, command_id).await
     }
 
     /// Get all guild application commands permissions only.
@@ -1530,7 +1530,7 @@ impl GuildId {
         http: impl AsRef<Http>,
         command_id: CommandId,
     ) -> Result<CommandPermission> {
-        http.as_ref().get_guild_application_command_permissions(self, command_id.into()).await
+        http.as_ref().get_guild_application_command_permissions(self, command_id).await
     }
 
     /// Get the guild welcome screen.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -536,7 +536,7 @@ impl Member {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn unban(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().remove_ban(self.guild_id.get(), self.user.id.get(), None).await
+        http.as_ref().remove_ban(self.guild_id, self.user.id, None).await
     }
 
     /// Returns the formatted URL of the member's per guild avatar, if one exists.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1546,7 +1546,7 @@ impl Guild {
         if let Some(member) = self.members.get(&user_id) {
             Ok(Cow::Borrowed(member))
         } else {
-            cache_http.http().get_member(self.id.get(), user_id.get()).await.map(Cow::Owned)
+            cache_http.http().get_member(self.id, user_id).await.map(Cow::Owned)
         }
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2522,7 +2522,7 @@ impl Guild {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> MessageCollectorBuilder<'a> {
-        MessageCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
+        MessageCollectorBuilder::new(shard_messenger).guild_id(self.id)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
@@ -2531,7 +2531,7 @@ impl Guild {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> ReactionCollectorBuilder<'a> {
-        ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
+        ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id)
     }
 
     /// Gets the guild active threads.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1544,7 +1544,7 @@ impl PartialGuild {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> MessageCollectorBuilder<'a> {
-        MessageCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
+        MessageCollectorBuilder::new(shard_messenger).guild_id(self.id)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
@@ -1553,7 +1553,7 @@ impl PartialGuild {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> ReactionCollectorBuilder<'a> {
-        ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id.0)
+        ReactionCollectorBuilder::new(shard_messenger).guild_id(self.id)
     }
 
     /// Gets the guild active threads.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -132,7 +132,7 @@ impl Role {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[inline]
     pub async fn delete(&mut self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_role(self.guild_id.get(), self.id.get(), None).await
+        http.as_ref().delete_role(self.guild_id, self.id, None).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -324,7 +324,8 @@ mod tests {
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
         struct S {
-            id: GenericId,
+            #[serde(with = "snowflake")]
+            id: NonZeroU64,
         }
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -324,8 +324,7 @@ mod tests {
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
         struct S {
-            #[serde(with = "snowflake")]
-            id: NonZeroU64,
+            id: GenericId,
         }
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -134,7 +134,7 @@ impl Invite {
         code: &str,
         member_counts: bool,
         expiration: bool,
-        event_id: Option<u64>,
+        event_id: Option<ScheduledEventId>,
     ) -> Result<Invite> {
         let mut invite = code;
 

--- a/src/model/sticker/mod.rs
+++ b/src/model/sticker/mod.rs
@@ -170,5 +170,5 @@ fn sticker_url(sticker_id: StickerId, sticker_format_type: StickerFormatType) ->
         StickerFormatType::Unknown(_) => return None,
     };
 
-    Some(cdn!("/stickers/{}.{}", sticker_id.get(), ext))
+    Some(cdn!("/stickers/{}.{}", sticker_id, ext))
 }

--- a/src/model/sticker/sticker_id.rs
+++ b/src/model/sticker/sticker_id.rs
@@ -18,7 +18,7 @@ impl StickerId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Emojis and Stickers]: crate::model::permissions::Permissions::MANAGE_EMOJIS_AND_STICKERS
-    pub async fn delete(&self, http: impl AsRef<Http>, guild_id: impl Into<GuildId>) -> Result<()> {
+    pub async fn delete(self, http: impl AsRef<Http>, guild_id: impl Into<GuildId>) -> Result<()> {
         guild_id.into().delete_sticker(http, self).await
     }
 
@@ -29,8 +29,8 @@ impl StickerId {
     ///
     /// Returns [`Error::Http`] if a [`Sticker`] with that [`StickerId`] does not exist, or is
     /// otherwise unavailable.
-    pub async fn to_sticker(&self, http: impl AsRef<Http>) -> Result<Sticker> {
-        http.as_ref().get_sticker(self.get()).await
+    pub async fn to_sticker(self, http: impl AsRef<Http>) -> Result<Sticker> {
+        http.as_ref().get_sticker(self).await
     }
 
     /// Edits the sticker.
@@ -43,7 +43,7 @@ impl StickerId {
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
     pub async fn edit(
-        &self,
+        self,
         http: impl AsRef<Http>,
         guild_id: impl Into<GuildId>,
         builder: EditSticker<'_>,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1096,7 +1096,7 @@ impl UserId {
             }
         }
 
-        let user = cache_http.http().get_user(self.get()).await?;
+        let user = cache_http.http().get_user(self).await?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
         {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1007,7 +1007,7 @@ impl User {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> MessageCollectorBuilder<'a> {
-        MessageCollectorBuilder::new(shard_messenger).author_id(self.id.0)
+        MessageCollectorBuilder::new(shard_messenger).author_id(self.id)
     }
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent by this user.
@@ -1016,7 +1016,7 @@ impl User {
         &self,
         shard_messenger: &'a ShardMessenger,
     ) -> ReactionCollectorBuilder<'a> {
-        ReactionCollectorBuilder::new(shard_messenger).author_id(self.id.0)
+        ReactionCollectorBuilder::new(shard_messenger).author_id(self.id)
     }
 }
 

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -129,7 +129,7 @@ impl Webhook {
     ///
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's response.
     pub async fn from_id(http: impl AsRef<Http>, webhook_id: impl Into<WebhookId>) -> Result<Self> {
-        http.as_ref().get_webhook(webhook_id.into().get()).await
+        http.as_ref().get_webhook(webhook_id.into()).await
     }
 
     /// Retrieves a webhook given its Id and unique token.
@@ -164,7 +164,7 @@ impl Webhook {
         webhook_id: impl Into<WebhookId>,
         token: &str,
     ) -> Result<Self> {
-        http.as_ref().get_webhook_with_token(webhook_id.into().get(), token).await
+        http.as_ref().get_webhook_with_token(webhook_id.into(), token).await
     }
 
     /// Retrieves a webhook given its url.
@@ -209,8 +209,8 @@ impl Webhook {
     pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
         let http = http.as_ref();
         match self.token.as_deref() {
-            Some(token) => http.delete_webhook_with_token(self.id.get(), token, None).await,
-            None => http.delete_webhook(self.id.get(), None).await,
+            Some(token) => http.delete_webhook_with_token(self.id, token, None).await,
+            None => http.delete_webhook(self.id, None).await,
         }
     }
 
@@ -334,7 +334,7 @@ impl Webhook {
     ) -> Result<Message> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
 
-        http.as_ref().get_webhook_message(self.id.get(), token, message_id.get()).await
+        http.as_ref().get_webhook_message(self.id, token, message_id).await
     }
 
     /// Edits a webhook message with the fields set via the given builder.
@@ -374,7 +374,7 @@ impl Webhook {
         message_id: MessageId,
     ) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
-        http.as_ref().delete_webhook_message(self.id.get(), token, message_id.get()).await
+        http.as_ref().delete_webhook_message(self.id, token, message_id).await
     }
 
     /// Retrieves the latest information about the webhook, editing the
@@ -393,7 +393,7 @@ impl Webhook {
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     pub async fn refresh(&mut self, http: impl AsRef<Http>) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
-        http.as_ref().get_webhook_with_token(self.id.get(), token).await.map(|replacement| {
+        http.as_ref().get_webhook_with_token(self.id, token).await.map(|replacement| {
             *self = replacement;
         })
     }
@@ -429,6 +429,6 @@ impl WebhookId {
     /// [Manage Webhooks]: super::permissions::Permissions::MANAGE_WEBHOOKS
     #[inline]
     pub async fn to_webhook(self, http: impl AsRef<Http>) -> Result<Webhook> {
-        http.as_ref().get_webhook(self.get()).await
+        http.as_ref().get_webhook(self).await
     }
 }

--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -66,8 +66,7 @@ async fn lookup_channel_global(
     }
 
     if let Some(guild_id) = guild_id {
-        let channels =
-            ctx.http().get_channels(guild_id.get()).await.map_err(ChannelParseError::Http)?;
+        let channels = ctx.http().get_channels(guild_id).await.map_err(ChannelParseError::Http)?;
         if let Some(channel) =
             channels.into_iter().find(|channel| channel.name.eq_ignore_ascii_case(s))
         {

--- a/src/utils/argument_convert/message.rs
+++ b/src/utils/argument_convert/message.rs
@@ -75,10 +75,7 @@ impl ArgumentConvert for Message {
         }
 
         if cfg!(feature = "http") {
-            ctx.http()
-                .get_message(channel_id.get(), message_id.get())
-                .await
-                .map_err(MessageParseError::Http)
+            ctx.http().get_message(channel_id, message_id).await.map_err(MessageParseError::Http)
         } else {
             Err(MessageParseError::HttpNotAvailable)
         }

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -63,8 +63,7 @@ impl ArgumentConvert for Role {
         let roles =
             ctx.cache().and_then(|c| c.guild_roles(guild_id)).ok_or(RoleParseError::NotInCache)?;
         #[cfg(not(feature = "cache"))]
-        let roles =
-            ctx.http().get_guild_roles(guild_id.get()).await.map_err(RoleParseError::Http)?;
+        let roles = ctx.http().get_guild_roles(guild_id).await.map_err(RoleParseError::Http)?;
 
         if let Some(role_id) = s.parse().ok().map(RoleId).or_else(|| crate::utils::parse_role(s)) {
             #[cfg(feature = "cache")]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -433,7 +433,7 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
 /// assert_eq!(token, "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV");
 /// ```
 #[must_use]
-pub fn parse_webhook(url: &Url) -> Option<(u64, &str)> {
+pub fn parse_webhook(url: &Url) -> Option<(WebhookId, &str)> {
     let (webhook_id, token) = url.path().strip_prefix("/api/webhooks/")?.split_once('/')?;
     if !["http", "https"].contains(&url.scheme())
         || !["discord.com", "discordapp.com"].contains(&url.domain()?)
@@ -442,7 +442,7 @@ pub fn parse_webhook(url: &Url) -> Option<(u64, &str)> {
     {
         return None;
     }
-    Some((webhook_id.parse().ok()?, token))
+    Some((WebhookId(webhook_id.parse().ok()?), token))
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -542,9 +542,10 @@ pub(crate) fn user_has_perms(
 /// 17 shards:
 ///
 /// ```rust
+/// use serenity::model::id::GuildId;
 /// use serenity::utils;
 ///
-/// assert_eq!(utils::shard_id(81384788765712384 as u64, 17), 7);
+/// assert_eq!(utils::shard_id(GuildId::new(81384788765712384), 17), 7);
 /// ```
 #[inline]
 #[must_use]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -547,8 +547,9 @@ pub(crate) fn user_has_perms(
 /// assert_eq!(utils::shard_id(81384788765712384 as u64, 17), 7);
 /// ```
 #[inline]
-pub fn shard_id(guild_id: impl Into<u64>, shard_count: u32) -> u32 {
-    ((guild_id.into() >> 22) % (shard_count as u64)) as u32
+#[must_use]
+pub fn shard_id(guild_id: GuildId, shard_count: u32) -> u32 {
+    ((guild_id.get() >> 22) % (shard_count as u64)) as u32
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Type safety, yay! This PR actually revealed a bug, maybe two:
- The message delete endpoint was rate limited using message ID as bucket, not Channel ID: https://github.com/serenity-rs/serenity/compare/next...kangalioo:id-types-everywhere?expand=1#diff-235176c24a85ae6dd7f1d22902684c132ba7e40fea30ae1420de3ad674359bdcR1831
- Many webhook-related endpoints share the same rate limit bucket; potentially causing the rate limit exceeding issues https://github.com/serenity-rs/serenity/issues/1121#issuecomment-1250652911

In addition, I found and removed an unused route in the HTTP routing code: LeaveGroup, ~~bots can't be in group DMs~~ (wrong, see below, thanks @GnomedDev)