### PR TITLE
Band-aid fix `unused_async` errors

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -122,6 +122,7 @@ impl Context {
     ///
     /// [`Online`]: OnlineStatus::Online
     #[cfg(feature = "gateway")]
+    #[allow(clippy::unused_async)]
     #[inline]
     pub async fn online(&self) {
         self.shard.set_status(OnlineStatus::Online);
@@ -160,6 +161,7 @@ impl Context {
     ///
     /// [`Idle`]: OnlineStatus::Idle
     #[cfg(feature = "gateway")]
+    #[allow(clippy::unused_async)]
     #[inline]
     pub async fn idle(&self) {
         self.shard.set_status(OnlineStatus::Idle);
@@ -198,6 +200,7 @@ impl Context {
     ///
     /// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb
     #[cfg(feature = "gateway")]
+    #[allow(clippy::unused_async)]
     #[inline]
     pub async fn dnd(&self) {
         self.shard.set_status(OnlineStatus::DoNotDisturb);
@@ -236,6 +239,7 @@ impl Context {
     /// [`Event::Ready`]: crate::model::event::Event::Ready
     /// [`Invisible`]: OnlineStatus::Invisible
     #[cfg(feature = "gateway")]
+    #[allow(clippy::unused_async)]
     #[inline]
     pub async fn invisible(&self) {
         self.shard.set_status(OnlineStatus::Invisible);
@@ -275,6 +279,7 @@ impl Context {
     /// [`Event::Resumed`]: crate::model::event::Event::Resumed
     /// [`Online`]: OnlineStatus::Online
     #[cfg(feature = "gateway")]
+    #[allow(clippy::unused_async)]
     #[inline]
     pub async fn reset_presence(&self) {
         self.shard.set_presence(None::<Activity>, OnlineStatus::Online);
@@ -317,6 +322,7 @@ impl Context {
     ///
     /// [`Online`]: OnlineStatus::Online
     #[cfg(feature = "gateway")]
+    #[allow(clippy::unused_async)]
     #[inline]
     pub async fn set_activity(&self, activity: Activity) {
         self.shard.set_presence(Some(activity), OnlineStatus::Online);
@@ -386,6 +392,7 @@ impl Context {
     /// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb
     /// [`Idle`]: OnlineStatus::Idle
     #[cfg(feature = "gateway")]
+    #[allow(clippy::unused_async)]
     #[inline]
     pub async fn set_presence(&self, activity: Option<Activity>, status: OnlineStatus) {
         self.shard.set_presence(activity, status);
@@ -393,24 +400,27 @@ impl Context {
 
     /// Sets a new `filter` for the shard to check if a message event shall be
     /// sent back to `filter`'s paired receiver.
-    #[inline]
     #[cfg(feature = "collector")]
+    #[allow(clippy::unused_async)]
+    #[inline]
     pub async fn set_message_filter(&self, filter: MessageFilter) {
         self.shard.set_message_filter(filter);
     }
 
     /// Sets a new `filter` for the shard to check if a reaction event shall be
     /// sent back to `filter`'s paired receiver.
-    #[inline]
     #[cfg(feature = "collector")]
+    #[allow(clippy::unused_async)]
+    #[inline]
     pub async fn set_reaction_filter(&self, filter: ReactionFilter) {
         self.shard.set_reaction_filter(filter);
     }
 
     /// Sets a new `filter` for the shard to check if an interaction event shall be
     /// sent back to `filter`'s paired receiver.
-    #[inline]
     #[cfg(feature = "collector")]
+    #[allow(clippy::unused_async)]
+    #[inline]
     pub async fn set_component_interaction_filter(&self, filter: ComponentInteractionFilter) {
         self.shard.set_component_interaction_filter(filter);
     }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -554,6 +554,7 @@ impl ChannelId {
 
     /// Returns the name of whatever channel this id holds.
     #[cfg(feature = "cache")]
+    #[allow(clippy::unused_async)]
     pub async fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
         let channel = self.to_channel_cached(cache)?;
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -392,6 +392,7 @@ impl Guild {
     /// Returns the "default" channel of the guild for the passed user id.
     /// (This returns the first channel that can be read by the user, if there isn't one,
     /// returns [`None`])
+    #[allow(clippy::unused_async)]
     pub async fn default_channel(&self, uid: UserId) -> Option<&GuildChannel> {
         let member = self.members.get(&uid)?;
         for channel in self.channels.values() {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1023,6 +1023,7 @@ impl PartialGuild {
     }
 
     #[cfg(feature = "cache")]
+    #[allow(clippy::unused_async)]
     async fn _greater_member_hierarchy(
         &self,
         cache: impl AsRef<Cache>,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1129,6 +1129,7 @@ impl UserId {
 
     /// Attempts to find a [`User`] by its Id in the cache.
     #[cfg(feature = "cache")]
+    #[allow(clippy::unused_async)]
     #[inline]
     pub async fn to_user_cached(self, cache: impl AsRef<Cache>) -> Option<User> {
         cache.as_ref().user(self)


### PR DESCRIPTION
With the Rust 1.64 release, clippy now hard errors on `unused_async`, since we deny that lint in `lib.rs`. This turns off the lint for any functions that trigger it on `current`, as making them sync is a breaking change (and has already happened on `next`).