### PR TITLE
Fix behavior of `Guild::default_channel_guaranteed`

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -419,7 +419,7 @@ impl Guild {
                     .members
                     .values()
                     .filter_map(|member| self.user_permissions_in(channel, member).ok())
-                    .all(|permissions| permissions.view_channel())
+                    .all(Permissions::view_channel)
                 {
                     return Some(channel);
                 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -415,10 +415,13 @@ impl Guild {
     pub fn default_channel_guaranteed(&self) -> Option<&GuildChannel> {
         for channel in self.channels.values() {
             if let Channel::Guild(channel) = channel {
-                for member in self.members.values() {
-                    if self.user_permissions_in(channel, member).ok()?.view_channel() {
-                        return Some(channel);
+                if self.members.values().all(|member| {
+                    match self.user_permissions_in(channel, member) {
+                        Ok(permissions) => permissions.view_channel(),
+                        Err(_) => true, // We ignore any members with non-existent roles
                     }
+                }) {
+                    return Some(channel);
                 }
             }
         }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -415,12 +415,12 @@ impl Guild {
     pub fn default_channel_guaranteed(&self) -> Option<&GuildChannel> {
         for channel in self.channels.values() {
             if let Channel::Guild(channel) = channel {
-                if self.members.values().all(|member| {
-                    match self.user_permissions_in(channel, member) {
-                        Ok(permissions) => permissions.view_channel(),
-                        Err(_) => true, // We ignore any members with non-existent roles
-                    }
-                }) {
+                if self
+                    .members
+                    .values()
+                    .filter_map(|member| self.user_permissions_in(channel, member).ok())
+                    .all(|permissions| permissions.view_channel())
+                {
                     return Some(channel);
                 }
             }


### PR DESCRIPTION
Actually check that every member has access to a channel before christening it the default guild channel. Also, ignore any members with non-existent roles when checking for permissions, to prevent returning early. `Guild::default_channel` was left untouched, because if the bot user has a non-existent role, then the permissions check will always error for all channels, so the function will return `None` anyways.