### PR TITLE
Keep embeds in EditInteractionResponse by default

### DIFF
--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "testing"
+version = "0.1.0"
+authors = ["my name <my@email.address>"]
+edition = "2018"
+
+[dependencies]
+serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/testing/Makefile.toml
+++ b/examples/testing/Makefile.toml
@@ -1,0 +1,13 @@
+extend = "../../Makefile.toml"
+
+[tasks.examples_build]
+alias = "build"
+
+[tasks.examples_build_release]
+alias = "build_release"
+
+[tasks.examples_run]
+alias = "run"
+
+[tasks.examples_run_release]
+alias = "run_release"

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,0 +1,67 @@
+use serenity::builder::*;
+use serenity::model::prelude::interaction::application_command::*;
+use serenity::model::prelude::*;
+use serenity::prelude::*;
+
+async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
+    let guild_id = msg.guild_id.unwrap();
+    if msg.content == "register" {
+        guild_id
+            .create_application_command(
+                &ctx,
+                CreateApplicationCommand::new("editembeds").description("test command"),
+            )
+            .await?;
+    } else {
+        return Ok(());
+    }
+
+    msg.react(&ctx, '✅').await?;
+    Ok(())
+}
+
+async fn interaction(
+    ctx: &Context,
+    interaction: ApplicationCommandInteraction,
+) -> Result<(), serenity::Error> {
+    if interaction.data.name == "editembeds" {
+        interaction
+            .create_interaction_response(
+                &ctx,
+                CreateInteractionResponse::new().interaction_response_data(
+                    CreateInteractionResponseData::new()
+                        .content("hi")
+                        .embed(CreateEmbed::new().description("hi")),
+                ),
+            )
+            .await?;
+
+        // Pre-PR, this falsely deleted the embed
+        interaction
+            .edit_original_interaction_response(&ctx, EditInteractionResponse::new())
+            .await?;
+    }
+
+    Ok(())
+}
+
+struct Handler;
+#[serenity::async_trait]
+impl EventHandler for Handler {
+    async fn message(&self, ctx: Context, msg: Message) {
+        message(&ctx, msg).await.unwrap();
+    }
+
+    async fn interaction_create(&self, ctx: Context, i: Interaction) {
+        if let Interaction::ApplicationCommand(i) = i {
+            interaction(&ctx, i).await.unwrap();
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), serenity::Error> {
+    let token = std::env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
+    let intents = GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT;
+    Client::builder(token, intents).event_handler(Handler).await?.start().await
+}

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -13,7 +13,8 @@ use crate::utils::check_overflow;
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditInteractionResponse {
-    embeds: Vec<CreateEmbed>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    embeds: Option<Vec<CreateEmbed>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -54,10 +55,12 @@ impl EditInteractionResponse {
                 .map_err(|overflow| Error::Model(ModelError::MessageTooLong(overflow)))?;
         }
 
-        check_overflow(self.embeds.len(), constants::EMBED_MAX_COUNT)
-            .map_err(|_| Error::Model(ModelError::EmbedAmount))?;
-        for embed in &self.embeds {
-            embed.check_length()?;
+        if let Some(embeds) = &self.embeds {
+            check_overflow(embeds.len(), constants::EMBED_MAX_COUNT)
+                .map_err(|_| Error::Model(ModelError::EmbedAmount))?;
+            for embed in embeds {
+                embed.check_length()?;
+            }
         }
 
         Ok(())
@@ -75,14 +78,18 @@ impl EditInteractionResponse {
     }
 
     /// Adds an embed for the message.
+    ///
+    /// Embeds from the original message are reset when adding new embeds and must be re-added.
     pub fn add_embed(mut self, embed: CreateEmbed) -> Self {
-        self.embeds.push(embed);
+        self.embeds.get_or_insert(Vec::new()).push(embed);
         self
     }
 
     /// Adds multiple embeds to the message.
+    ///
+    /// Embeds from the original message are reset when adding new embeds and must be re-added.
     pub fn add_embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
-        self.embeds.extend(embeds);
+        self.embeds.get_or_insert(Vec::new()).extend(embeds);
         self
     }
 
@@ -90,8 +97,9 @@ impl EditInteractionResponse {
     ///
     /// Calling this will overwrite the embed list. To append embeds, call [`Self::add_embed`]
     /// instead.
-    pub fn embed(self, embed: CreateEmbed) -> Self {
-        self.embeds(vec![embed])
+    pub fn embed(mut self, embed: CreateEmbed) -> Self {
+        self.embeds = Some(vec![embed]);
+        self
     }
 
     /// Sets the embeds for the message.
@@ -101,7 +109,7 @@ impl EditInteractionResponse {
     /// Calling this will overwrite the embed list. To append embeds, call [`Self::add_embeds`]
     /// instead.
     pub fn embeds(mut self, embeds: Vec<CreateEmbed>) -> Self {
-        self.embeds = embeds;
+        self.embeds = Some(embeds);
         self
     }
 


### PR DESCRIPTION
Also, adds a new `testing` crate meant to host small snippets to verify correctness for all new PRs.