### PR TITLE
Deny rustdoc lints only in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: --cfg docsrs
+          RUSTDOCFLAGS: --cfg docsrs -D warnings
         run: |
           cargo doc --no-deps --features collector,voice,unstable_discord_api
           cargo doc --no-deps -p command_attr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@
     // Covered by other lints
     clippy::missing_panics_doc, // clippy::unwrap_used
 )]
-#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 #![deny(
     clippy::unwrap_used,
     clippy::non_ascii_literal,


### PR DESCRIPTION
Both those lints are warn-by-default, so all we need to do is deny warnings in CI to catch documentation errors

Setting those lints to deny always is quite annoying because if you're developing, and quickly wanna check out the docs of your current state of work, you're forced to fix up all links (context switch), which you'd normally do just once at the end of coding the PR