### PR TITLE
Fix clippy warnings

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -403,11 +403,11 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
 
-    if options.strikethrough_commands_tip_in_dm == None {
+    if options.strikethrough_commands_tip_in_dm.is_none() {
         options.strikethrough_commands_tip_in_dm = produce_strike_text(&options, "server messages");
     }
 
-    if options.strikethrough_commands_tip_in_guild == None {
+    if options.strikethrough_commands_tip_in_guild.is_none() {
         options.strikethrough_commands_tip_in_guild =
             produce_strike_text(&options, "direct messages");
     }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -443,7 +443,7 @@ impl AsRef<Cache> for Context {
 #[cfg(feature = "cache")]
 impl AsRef<Cache> for Arc<Context> {
     fn as_ref(&self) -> &Cache {
-        &*self.cache
+        &self.cache
     }
 }
 

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -526,7 +526,7 @@ async fn handle_event(
         },
         Event::GuildUpdate(mut event) => {
             spawn_named("dispatch::event_handler::guild_update", async move {
-                let before = if_cache!(cache.guild(&event.guild.id).map(|g| g.clone()));
+                let before = if_cache!(cache.guild(event.guild.id).map(|g| g.clone()));
 
                 update(&cache_and_http, &mut event);
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -194,14 +194,14 @@ pub fn has_all_requirements(cache: impl AsRef<Cache>, cmd: &CommandOptions, msg:
     let cache = cache.as_ref();
 
     if let Some(guild_id) = msg.guild_id {
-        if let Some(member) = cache.member(guild_id, &msg.author.id) {
-            if let Ok(permissions) = member.permissions(&cache) {
+        if let Some(member) = cache.member(guild_id, msg.author.id) {
+            if let Ok(permissions) = member.permissions(cache) {
                 return if cmd.allowed_roles.is_empty() {
-                    permissions.administrator() || has_correct_permissions(&cache, &cmd, msg)
+                    permissions.administrator() || has_correct_permissions(cache, &cmd, msg)
                 } else if let Some(roles) = cache.guild_roles(guild_id) {
                     permissions.administrator()
                         || (has_correct_roles(&cmd, &roles, &member)
-                            && has_correct_permissions(&cache, &cmd, msg))
+                            && has_correct_permissions(cache, &cmd, msg))
                 } else {
                     warn!("Failed to find the guild and its roles.");
 
@@ -276,7 +276,7 @@ async fn check_command_behaviour(
     owners: &HashSet<UserId, impl std::hash::BuildHasher + Send + Sync>,
     help_options: &HelpOptions,
 ) -> HelpBehaviour {
-    let behaviour = check_common_behaviour(&ctx, msg, &options, owners, help_options);
+    let behaviour = check_common_behaviour(ctx, msg, &options, owners, help_options);
 
     if behaviour == HelpBehaviour::Nothing
         && (!options.owner_privilege || !owners.contains(&msg.author.id))
@@ -455,7 +455,7 @@ fn nested_group_command_search<'rec, 'a: 'rec>(
         for group in groups {
             let group = *group;
             let group_behaviour =
-                check_common_behaviour(&ctx, msg, &group.options, owners, help_options);
+                check_common_behaviour(ctx, msg, &group.options, owners, help_options);
 
             match &group_behaviour {
                 HelpBehaviour::Nothing => (),
@@ -522,8 +522,8 @@ fn nested_group_command_search<'rec, 'a: 'rec>(
                     .sub_commands
                     .iter()
                     .filter_map(|cmd| {
-                        if (*cmd).options.help_available {
-                            Some((*cmd).options.names[0].to_string())
+                        if cmd.options.help_available {
+                            Some(cmd.options.names[0].to_string())
                         } else {
                             None
                         }
@@ -614,7 +614,7 @@ async fn fill_eligible_commands<'a>(
         } else {
             std::cmp::max(
                 *highest_formatter,
-                check_common_behaviour(&ctx, msg, &group.options, owners, help_options),
+                check_common_behaviour(ctx, msg, &group.options, owners, help_options),
             )
         }
     };

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -252,7 +252,7 @@ impl StandardFramework {
 
             #[cfg(feature = "cache")]
             {
-                if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx) {
+                if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(ctx) {
                     let guild_id = channel.guild_id;
 
                     if config.blocked_guilds.contains(&guild_id) {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -138,7 +138,7 @@ impl CacheHttp for Http {
 #[cfg(feature = "cache")]
 impl AsRef<Cache> for (&Arc<Cache>, &Http) {
     fn as_ref(&self) -> &Cache {
-        &**self.0
+        self.0
     }
 }
 

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -976,10 +976,7 @@ impl Route {
             code,
             member_counts,
             expiration,
-            match event_id {
-                Some(id) => format!("&event_id={}", id),
-                None => "".to_string(),
-            }
+            event_id.map(|id| format!("&event_id={}", id)).unwrap_or_default()
         )
     }
 

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -379,7 +379,7 @@ impl CommandData {
             options
         }
 
-        resolve_options(&*self.options, &self.resolved)
+        resolve_options(&self.options, &self.resolved)
     }
 
     /// The target resolved data of [`target_id`]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -375,15 +375,12 @@ impl Guild {
     #[must_use]
     pub fn default_channel(&self, uid: UserId) -> Option<&GuildChannel> {
         let member = self.members.get(&uid)?;
-        for channel in self.channels.values() {
-            if channel.kind != ChannelType::Category
-                && self.user_permissions_in(channel, member).ok()?.view_channel()
-            {
-                return Some(channel);
-            }
-        }
-
-        None
+        self.channels.values().find(|&channel| {
+            channel.kind != ChannelType::Category
+                && self
+                    .user_permissions_in(channel, member)
+                    .map_or(false, Permissions::view_channel)
+        })
     }
 
     /// Returns the guaranteed "default" channel of the guild.
@@ -435,7 +432,7 @@ impl Guild {
         name: impl AsRef<str>,
     ) -> Option<ChannelId> {
         let name = name.as_ref();
-        let guild_channels = cache.as_ref().guild_channels(&self.id)?;
+        let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
         for channel_entry in guild_channels.iter() {
             let (id, channel) = channel_entry.pair();

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -351,7 +351,7 @@ impl PartialGuild {
         name: impl AsRef<str>,
     ) -> Option<ChannelId> {
         let name = name.as_ref();
-        let guild_channels = cache.as_ref().guild_channels(&self.id)?;
+        let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
         for channel_entry in guild_channels.iter() {
             let (id, channel) = channel_entry.pair();

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -128,17 +128,15 @@ pub mod presences {
 pub fn deserialize_buttons<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<Vec<ActivityButton>, D::Error> {
-    let labels = Vec::deserialize(deserializer)?;
-    let mut buttons = vec![];
-
-    for label in labels {
-        buttons.push(ActivityButton {
-            label,
-            url: "".to_owned(),
-        });
-    }
-
-    Ok(buttons)
+    Vec::deserialize(deserializer).map(|labels| {
+        labels
+            .into_iter()
+            .map(|l| ActivityButton {
+                label: l,
+                url: String::new(),
+            })
+            .collect()
+    })
 }
 
 /// Used with `#[serde(with = "private_channels")]`

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -225,18 +225,18 @@ fn clean_mention(
     let cache = cache.as_ref();
     match mention {
         Mention::Channel(id) => {
-            if let Some(Channel::Guild(channel)) = id.to_channel_cached(&cache) {
+            if let Some(Channel::Guild(channel)) = id.to_channel_cached(cache) {
                 format!("#{}", channel.name).into()
             } else {
                 "#deleted-channel".into()
             }
         },
         Mention::Role(id) => id
-            .to_role_cached(&cache)
+            .to_role_cached(cache)
             .map_or(Cow::Borrowed("@deleted-role"), |role| format!("@{}", role.name).into()),
         Mention::User(id) => {
             if let Some(guild_id) = options.guild_reference {
-                if let Some(guild) = cache.guild(&guild_id) {
+                if let Some(guild) = cache.guild(guild_id) {
                     if let Some(member) = guild.members.get(&id) {
                         return if options.show_discriminator {
                             format!("@{}", member.distinct())

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1150,10 +1150,6 @@ fn normalize(text: &str) -> String {
         .replace("discordservers.com", "discordservers\u{2024}com")
         .replace("discord.com/invite", "discord\u{2024}com/invite")
         .replace("discordapp.com/invite", "discordapp\u{2024}com/invite")
-        // Remove everyone and here mentions. Has to be put after ZWS replacement
-        // because it utilises it itself.
-        .replace("@everyone", "@\u{200B}everyone")
-        .replace("@here", "@\u{200B}here")
         // Remove right-to-left override and other similar annoying symbols
         .replace([
             '\u{202E}', // RTL Override
@@ -1163,6 +1159,10 @@ fn normalize(text: &str) -> String {
             '\u{200D}', // Zero-width joiner
             '\u{200C}', // Zero-width non-joiner
         ], " ")
+        // Remove everyone and here mentions. Has to be put after ZWS replacement
+        // because it utilises it itself.
+        .replace("@everyone", "@\u{200B}everyone")
+        .replace("@here", "@\u{200B}here")
 }
 
 #[cfg(test)]

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1150,17 +1150,19 @@ fn normalize(text: &str) -> String {
         .replace("discordservers.com", "discordservers\u{2024}com")
         .replace("discord.com/invite", "discord\u{2024}com/invite")
         .replace("discordapp.com/invite", "discordapp\u{2024}com/invite")
-        // Remove right-to-left override and other similar annoying symbols
-        .replace('\u{202E}', " ") // RTL Override
-        .replace('\u{200F}', " ") // RTL Mark
-        .replace('\u{202B}', " ") // RTL Embedding
-        .replace('\u{200B}', " ") // Zero-width space
-        .replace('\u{200D}', " ") // Zero-width joiner
-        .replace('\u{200C}', " ") // Zero-width non-joiner
         // Remove everyone and here mentions. Has to be put after ZWS replacement
         // because it utilises it itself.
         .replace("@everyone", "@\u{200B}everyone")
         .replace("@here", "@\u{200B}here")
+        // Remove right-to-left override and other similar annoying symbols
+        .replace([
+            '\u{202E}', // RTL Override
+            '\u{200F}', // RTL Mark
+            '\u{202B}', // RTL Embedding
+            '\u{200B}', // Zero-width space
+            '\u{200D}', // Zero-width joiner
+            '\u{200C}', // Zero-width non-joiner
+        ], " ")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
New clippy warnings popped up recently due to some additions and improvements (manual_find, manual_string_new, partialeq_to_none, explicit_auto_deref, needless_borrow, collapsible_str_replace), so I fixed them