### PR TITLE
Only run MSRV job on current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
   MSRV:
     runs-on: ubuntu-latest
 
+    # We only run this job on the current branch as keeping MSRV the same is not important on next.
+    if: (github.event_name == 'push' && github.ref_name == 'current') ||
+        (github.event_name == 'pull_request' && github.base_ref == 'current') 
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
This keeps our CI in line with our MSRV policy, and fixes a lot of CI failures currently in open PRs