### PR TITLE
Include new features in documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs
         run: |
-          cargo doc --no-deps --features collector,voice,unstable_discord_api
+          cargo doc --no-deps --features _docs
           cargo doc --no-deps -p command_attr
 
       - name: Prepare docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,7 @@ time = []
 interactions_endpoint = ["ed25519-dalek"]
 
 # Note: all feature-gated APIs to be documented should have their features listed here!
-_docs = ["default", "collector", "unstable_discord_api", "voice", "voice-model"]
+_docs = ["default", "collector", "unstable_discord_api", "voice", "voice_model", "interactions_endpoint"]
 
 # Enables simd accelerated parsing.
 simd_json = ["simd-json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,9 @@ tokio_task_builder = ["tokio/tracing"]
 time = []
 interactions_endpoint = ["ed25519-dalek"]
 
+# Note: all feature-gated APIs to be documented should have their features listed here!
+_docs = ["default", "collector", "unstable_discord_api", "voice", "voice-model"]
+
 # Enables simd accelerated parsing.
 simd_json = ["simd-json"]
 
@@ -236,5 +239,5 @@ native_tls_backend = [
 
 
 [package.metadata.docs.rs]
-features = ["default", "collector", "unstable_discord_api", "voice", "voice-model"]
+features = ["_docs"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Docs had a hard coded list of features (two duplicated copies of them, actually). The new interactions_endpoint was not among them, so that API was completely absent from the docs.

This PR adds an internal `_docs` feature that enables all features that should be documented. The doc generation now refers to `_docs` instead of writing out the features