### PR TITLE
Add cached messages to channel_delete event handler

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -78,9 +78,9 @@ impl CacheUpdate for ChannelCreateEvent {
 }
 
 impl CacheUpdate for ChannelDeleteEvent {
-    type Output = ();
+    type Output = Vec<Message>;
 
-    fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<Vec<Message>> {
         match &self.channel {
             Channel::Guild(channel) => {
                 let (guild_id, channel_id) = (channel.guild_id, channel.id);
@@ -97,9 +97,12 @@ impl CacheUpdate for ChannelDeleteEvent {
         };
 
         // Remove the cached messages for the channel.
-        cache.messages.remove(&self.channel.id());
-
-        None
+        match cache.messages.remove(&self.channel.id()) {
+            Some((_, messages)) => {
+                Some(messages.values().map(|msg| msg.to_owned()).collect::<Vec<_>>())
+            },
+            None => None,
+        }
     }
 }
 

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -100,7 +100,7 @@ impl CacheUpdate for ChannelDeleteEvent {
         cache
             .messages
             .remove(&self.channel.id())
-            .map(|(_, messages)| messages.values().cloned().collect())
+            .map(|(_, messages)| messages.into_values().collect())
     }
 }
 

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -97,12 +97,10 @@ impl CacheUpdate for ChannelDeleteEvent {
         };
 
         // Remove the cached messages for the channel.
-        match cache.messages.remove(&self.channel.id()) {
-            Some((_, messages)) => {
-                Some(messages.values().map(|msg| msg.to_owned()).collect::<Vec<_>>())
-            },
-            None => None,
-        }
+        cache
+            .messages
+            .remove(&self.channel.id())
+            .map(|(_, messages)| messages.values().cloned().collect())
     }
 }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1043,7 +1043,7 @@ mod test {
         let mut delete = ChannelDeleteEvent {
             channel: Channel::Guild(channel.clone()),
         };
-        assert!(cache.update(&mut delete).is_none());
+        assert!(cache.update(&mut delete).is_some());
         assert!(!cache.messages.contains_key(&delete.channel.id()));
 
         // Test deletion of a guild channel's message cache when a GuildDeleteEvent

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -376,7 +376,7 @@ async fn handle_event(
             }
         },
         Event::ChannelDelete(mut event) => {
-            update(&cache_and_http, &mut event);
+            let cached_messages = if_cache!(update(&cache_and_http, &mut event));
 
             match event.channel {
                 Channel::Private(_) => {},
@@ -387,7 +387,7 @@ async fn handle_event(
                         });
                     } else {
                         spawn_named("dispatch::event_handler::channel_delete", async move {
-                            event_handler.channel_delete(context, &channel).await;
+                            event_handler.channel_delete(context, &channel, cached_messages).await;
                         });
                     }
                 },

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -76,7 +76,13 @@ pub trait EventHandler: Send + Sync {
     /// Dispatched when a channel is deleted.
     ///
     /// Provides said channel's data.
-    async fn channel_delete(&self, _ctx: Context, _channel: &GuildChannel) {}
+    async fn channel_delete(
+        &self,
+        _ctx: Context,
+        _channel: &GuildChannel,
+        _messages: Option<Vec<Message>>,
+    ) {
+    }
 
     /// Dispatched when a pin is added, deleted.
     ///


### PR DESCRIPTION
The Reason I'm making this PR is issue #2180

If there is a better way to do this I'd be happy to implement that instead (especially if it doesn't introduce a breaking change). 

Updating the cache after the event is handled is not possible without having to clone `event.channel` which I didn't wanna do.

Closes #2180