### PR TITLE
Replace usage of `CacheAndHttp` in dispatch with `Context`

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::Arc;
 
 use futures::channel::mpsc::UnboundedSender as Sender;
@@ -44,6 +45,16 @@ pub struct Context {
     pub http: Arc<Http>,
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,
+}
+
+// Used by the #[instrument] macro on client::dispatch::handle_event
+impl fmt::Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field("shard", &self.shard)
+            .field("shard_id", &self.shard_id)
+            .finish()
+    }
 }
 
 impl Context {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -1,12 +1,6 @@
-#[cfg(feature = "cache")]
-use std::fmt;
 use std::sync::Arc;
 
-use futures::channel::mpsc::UnboundedSender as Sender;
-use futures::future::{BoxFuture, FutureExt};
-use tokio::sync::RwLock;
 use tracing::{debug, instrument};
-use typemap_rev::TypeMap;
 
 #[cfg(feature = "gateway")]
 use super::bridge::gateway::event::ClientEvent;
@@ -17,45 +11,12 @@ use super::Context;
 use crate::cache::CacheUpdate;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
-use crate::gateway::InterMessage;
 use crate::internal::tokio::spawn_named;
 use crate::model::channel::{Channel, ChannelType, Message};
 use crate::model::event::Event;
 use crate::model::guild::Member;
 #[cfg(feature = "cache")]
 use crate::model::id::GuildId;
-use crate::CacheAndHttp;
-
-#[inline]
-#[cfg(feature = "cache")]
-fn update<E: CacheUpdate + fmt::Debug>(
-    cache_and_http: &CacheAndHttp,
-    event: &mut E,
-) -> Option<E::Output> {
-    cache_and_http.cache.update(event)
-}
-
-#[inline]
-#[cfg(not(feature = "cache"))]
-fn update<E>(_cache_and_http: &CacheAndHttp, _event: &mut E) -> Option<()> {
-    None
-}
-
-fn context(
-    data: &Arc<RwLock<TypeMap>>,
-    runner_tx: &Sender<InterMessage>,
-    shard_id: u32,
-    cache_and_http: &CacheAndHttp,
-) -> Context {
-    Context::new(
-        Arc::clone(data),
-        runner_tx.clone(),
-        shard_id,
-        Arc::clone(&cache_and_http.http),
-        #[cfg(feature = "cache")]
-        Arc::clone(&cache_and_http.cache),
-    )
-}
 
 // Once we can use `Box` as part of a pattern, we will reconsider boxing.
 #[allow(clippy::large_enum_variant)]
@@ -66,105 +27,129 @@ pub(crate) enum DispatchEvent {
 }
 
 impl DispatchEvent {
-    #[instrument(skip(self, cache_and_http))]
-    fn update(&mut self, cache_and_http: &CacheAndHttp) {
+    fn update_cache(&mut self, context: &Context) {
         match self {
             Self::Model(Event::ChannelCreate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::ChannelDelete(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::ChannelUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildCreate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildDelete(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildEmojisUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildMemberAdd(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildMemberRemove(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildMemberUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildMembersChunk(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildRoleCreate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildRoleDelete(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildRoleUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::GuildStickersUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             // Already handled by the framework check macro
             Self::Model(Event::MessageCreate(_)) => {},
             Self::Model(Event::MessageUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::PresencesReplace(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::PresenceUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::Ready(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::UserUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::VoiceStateUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::ThreadCreate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::ThreadUpdate(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             Self::Model(Event::ThreadDelete(event)) => {
-                update(cache_and_http, event);
+                update_cache(context, event);
             },
             _ => (),
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn dispatch<'rec>(
-    // #[allow(unused_variables)]
+#[cfg(feature = "cache")]
+fn update_cache<E: CacheUpdate>(context: &Context, event: &mut E) -> Option<E::Output> {
+    context.cache.update(event)
+}
+
+#[cfg(not(feature = "cache"))]
+fn update_cache<E>(_: &Context, _: &mut E) -> Option<()> {
+    None
+}
+
+pub(crate) async fn dispatch<'rec>(
     mut event: DispatchEvent,
+    context: Context,
     #[cfg(feature = "framework")] framework: &'rec Option<Arc<dyn Framework + Send + Sync>>,
-    data: &'rec Arc<RwLock<TypeMap>>,
     event_handler: &'rec Option<Arc<dyn EventHandler>>,
     raw_event_handler: &'rec Option<Arc<dyn RawEventHandler>>,
-    runner_tx: &'rec Sender<InterMessage>,
-    shard_id: u32,
-    cache_and_http: &'rec CacheAndHttp,
-) -> BoxFuture<'rec, ()> {
-    async move {
-        match (event_handler, raw_event_handler) {
-            (None, None) => {
-                event.update(cache_and_http);
+) {
+    match (event_handler, raw_event_handler) {
+        (None, None) => {
+            event.update_cache(&context);
+
+            #[cfg(feature = "framework")]
+            if let DispatchEvent::Model(Event::MessageCreate(event)) = event {
+                if let Some(framework) = framework {
+                    let framework = Arc::clone(framework);
+
+                    spawn_named("dispatch::framework::message", async move {
+                        framework.dispatch(context, event.message).await;
+                    });
+                }
+            }
+        },
+        (Some(handler), None) => match event {
+            DispatchEvent::Model(Event::MessageCreate(mut event)) => {
+                update_cache(&context, &mut event);
+
+                #[cfg(not(feature = "framework"))]
+                {
+                    // Avoid cloning if there will be no framework dispatch.
+                    dispatch_message(context, event.message, handler).await;
+                }
 
                 #[cfg(feature = "framework")]
-                if let DispatchEvent::Model(Event::MessageCreate(event)) = event {
-                    let context = context(data, runner_tx, shard_id, cache_and_http);
+                {
+                    dispatch_message(context.clone(), event.message.clone(), handler).await;
 
                     if let Some(framework) = framework {
                         let framework = Arc::clone(framework);
@@ -175,21 +160,59 @@ pub(crate) fn dispatch<'rec>(
                     }
                 }
             },
-            (Some(h), None) => match event {
-                DispatchEvent::Model(Event::MessageCreate(mut event)) => {
-                    update(cache_and_http, &mut event);
+            other => {
+                handle_event(context, other, handler).await;
+            },
+        },
+        (None, Some(raw_handler)) => {
+            event.update_cache(&context);
 
-                    let context = context(data, runner_tx, shard_id, cache_and_http);
+            if let DispatchEvent::Model(event) = event {
+                #[cfg(not(feature = "framework"))]
+                {
+                    // No clone needed, as there will be no framework dispatch.
+                    raw_handler.raw_event(context, event).await;
+                }
 
+                #[cfg(feature = "framework")]
+                {
+                    if let Event::MessageCreate(msg_event) = &event {
+                        // Must clone in order to dispatch the framework too.
+                        let message = msg_event.message.clone();
+                        raw_handler.raw_event(context.clone(), event).await;
+
+                        if let Some(framework) = framework {
+                            let framework = Arc::clone(framework);
+
+                            spawn_named("dispatch::framework::message", async move {
+                                framework.dispatch(context, message).await;
+                            });
+                        }
+                    } else {
+                        // Avoid cloning if there will be no framework dispatch.
+                        raw_handler.raw_event(context, event).await;
+                    }
+                }
+            }
+        },
+        // We call this function again, passing `None` for each event handler
+        // and passing no framework, as we dispatch once we are done right here.
+        (Some(handler), Some(raw_handler)) => {
+            if let DispatchEvent::Model(event) = &event {
+                raw_handler.raw_event(context.clone(), event.clone()).await;
+            }
+
+            match event {
+                DispatchEvent::Model(Event::MessageCreate(event)) => {
                     #[cfg(not(feature = "framework"))]
                     {
                         // Avoid cloning if there will be no framework dispatch.
-                        dispatch_message(context, event.message, h).await;
+                        dispatch_message(context, event.message, handler).await;
                     }
 
                     #[cfg(feature = "framework")]
                     {
-                        dispatch_message(context.clone(), event.message.clone(), h).await;
+                        dispatch_message(context.clone(), event.message.clone(), handler).await;
 
                         if let Some(framework) = framework {
                             let framework = Arc::clone(framework);
@@ -201,83 +224,11 @@ pub(crate) fn dispatch<'rec>(
                     }
                 },
                 other => {
-                    handle_event(other, data, h, runner_tx, shard_id, cache_and_http).await;
+                    handle_event(context, other, handler).await;
                 },
-            },
-            (None, Some(rh)) => {
-                event.update(cache_and_http);
-
-                if let DispatchEvent::Model(event) = event {
-                    let event_handler = Arc::clone(rh);
-
-                    let context = context(data, runner_tx, shard_id, cache_and_http);
-
-                    #[cfg(not(feature = "framework"))]
-                    {
-                        // No clone needed, as there will be no framework dispatch.
-                        event_handler.raw_event(context, event).await;
-                    }
-
-                    #[cfg(feature = "framework")]
-                    {
-                        if let Event::MessageCreate(msg_event) = &event {
-                            // Must clone in order to dispatch the framework too.
-                            let message = msg_event.message.clone();
-                            event_handler.raw_event(context.clone(), event).await;
-
-                            if let Some(framework) = framework {
-                                let framework = Arc::clone(framework);
-
-                                spawn_named("dispatch::framework::message", async move {
-                                    framework.dispatch(context, message).await;
-                                });
-                            }
-                        } else {
-                            // Avoid cloning if there will be no framework dispatch.
-                            event_handler.raw_event(context, event).await;
-                        }
-                    }
-                }
-            },
-            // We call this function again, passing `None` for each event handler
-            // and passing no framework, as we dispatch once we are done right here.
-            (Some(handler), Some(raw_handler)) => {
-                let context = context(data, runner_tx, shard_id, cache_and_http);
-
-                if let DispatchEvent::Model(event) = &event {
-                    raw_handler.raw_event(context.clone(), event.clone()).await;
-                }
-
-                match event {
-                    DispatchEvent::Model(Event::MessageCreate(event)) => {
-                        #[cfg(not(feature = "framework"))]
-                        {
-                            // Avoid cloning if there will be no framework dispatch.
-                            dispatch_message(context, event.message, handler).await;
-                        }
-
-                        #[cfg(feature = "framework")]
-                        {
-                            dispatch_message(context.clone(), event.message.clone(), handler).await;
-
-                            if let Some(framework) = framework {
-                                let framework = Arc::clone(framework);
-
-                                spawn_named("dispatch::framework::message", async move {
-                                    framework.dispatch(context, event.message).await;
-                                });
-                            }
-                        }
-                    },
-                    other => {
-                        handle_event(other, data, handler, runner_tx, shard_id, cache_and_http)
-                            .await;
-                    },
-                }
-            },
-        }
+            }
+        },
     }
-    .boxed()
 }
 
 async fn dispatch_message(
@@ -294,21 +245,13 @@ async fn dispatch_message(
 // Once we can use `Box` as part of a pattern, we will reconsider boxing.
 #[allow(clippy::too_many_arguments)]
 #[cfg_attr(feature = "cache", allow(clippy::used_underscore_binding))]
-#[instrument(skip(event, data, event_handler, cache_and_http))]
+#[instrument(skip(event, event_handler))]
 async fn handle_event(
+    context: Context,
     event: DispatchEvent,
-    data: &Arc<RwLock<TypeMap>>,
     event_handler: &Arc<dyn EventHandler>,
-    runner_tx: &Sender<InterMessage>,
-    shard_id: u32,
-    cache_and_http: &CacheAndHttp,
 ) {
-    let context = context(data, runner_tx, shard_id, cache_and_http);
-
     let event_handler = Arc::clone(event_handler);
-    let cache_and_http = cache_and_http.clone();
-    #[cfg(feature = "cache")]
-    let cache = cache_and_http.cache.clone();
 
     // Handle ClientEvent or return back Event
     let model_event = match event {
@@ -358,7 +301,7 @@ async fn handle_event(
             });
         },
         Event::ChannelCreate(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
             match event.channel {
                 Channel::Guild(channel) => {
                     if channel.kind == ChannelType::Category {
@@ -376,7 +319,7 @@ async fn handle_event(
             }
         },
         Event::ChannelDelete(mut event) => {
-            let cached_messages = if_cache!(update(&cache_and_http, &mut event));
+            let cached_messages = if_cache!(update_cache(&context, &mut event));
 
             match event.channel {
                 Channel::Private(_) => {},
@@ -400,8 +343,8 @@ async fn handle_event(
         },
         Event::ChannelUpdate(mut event) => {
             spawn_named("dispatch::event_handler::channel_update", async move {
-                let old_channel = if_cache!(cache.channel(event.channel.id()));
-                update(&cache_and_http, &mut event);
+                let old_channel = if_cache!(context.cache.channel(event.channel.id()));
+                update_cache(&context, &mut event);
 
                 event_handler.channel_update(context, old_channel, event.channel).await;
             });
@@ -417,21 +360,18 @@ async fn handle_event(
             });
         },
         Event::GuildCreate(mut event) => {
-            let _is_new = if_cache!(Some(cache.unavailable_guilds.contains(&event.guild.id)));
+            let is_new =
+                if_cache!(Some(context.cache.unavailable_guilds.contains(&event.guild.id)));
 
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             #[cfg(feature = "cache")]
             {
                 let context = context.clone();
 
-                if cache_and_http.cache.unavailable_guilds.is_empty() {
-                    let guild_amount = cache_and_http
-                        .cache
-                        .guilds
-                        .iter()
-                        .map(|i| *i.key())
-                        .collect::<Vec<GuildId>>();
+                if context.cache.unavailable_guilds.is_empty() {
+                    let guild_amount =
+                        context.cache.guilds.iter().map(|i| *i.key()).collect::<Vec<GuildId>>();
                     let event_handler = Arc::clone(&event_handler);
 
                     spawn_named("dispatch::event_handler::cache_ready", async move {
@@ -441,18 +381,18 @@ async fn handle_event(
             }
 
             spawn_named("dispatch::event_handler::guild_create", async move {
-                event_handler.guild_create(context, event.guild, _is_new).await;
+                event_handler.guild_create(context, event.guild, is_new).await;
             });
         },
         Event::GuildDelete(mut event) => {
-            let _full = if_cache!(update(&cache_and_http, &mut event));
+            let full = if_cache!(update_cache(&context, &mut event));
 
             spawn_named("dispatch::event_handler::guild_delete", async move {
-                event_handler.guild_delete(context, event.guild, _full).await;
+                event_handler.guild_delete(context, event.guild, full).await;
             });
         },
         Event::GuildEmojisUpdate(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::guild_emojis_update", async move {
                 event_handler.guild_emojis_update(context, event.guild_id, event.emojis).await;
@@ -464,61 +404,60 @@ async fn handle_event(
             });
         },
         Event::GuildMemberAdd(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::guild_member_addition", async move {
                 event_handler.guild_member_addition(context, event.member).await;
             });
         },
         Event::GuildMemberRemove(mut event) => {
-            let _member = if_cache!(update(&cache_and_http, &mut event));
+            let member = if_cache!(update_cache(&context, &mut event));
 
             spawn_named("dispatch::event_handler::guild_member_removal", async move {
                 event_handler
-                    .guild_member_removal(context, event.guild_id, event.user, _member)
+                    .guild_member_removal(context, event.guild_id, event.user, member)
                     .await;
             });
         },
         Event::GuildMemberUpdate(mut event) => {
-            let _before = if_cache!(update(&cache_and_http, &mut event));
-            let _after: Option<Member> = if_cache!(cache.member(event.guild_id, event.user.id));
+            let before = if_cache!(update_cache(&context, &mut event));
+            let after: Option<Member> =
+                if_cache!(context.cache.member(event.guild_id, event.user.id));
 
             spawn_named("dispatch::event_handler::guild_member_update", async move {
-                event_handler.guild_member_update(context, _before, _after, event).await;
+                event_handler.guild_member_update(context, before, after, event).await;
             });
         },
         Event::GuildMembersChunk(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::guild_members_chunk", async move {
                 event_handler.guild_members_chunk(context, event).await;
             });
         },
         Event::GuildRoleCreate(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::guild_role_create", async move {
                 event_handler.guild_role_create(context, event.role).await;
             });
         },
         Event::GuildRoleDelete(mut event) => {
-            let _role = if_cache!(update(&cache_and_http, &mut event));
+            let role = if_cache!(update_cache(&context, &mut event));
 
             spawn_named("dispatch::event_handler::guild_role_delete", async move {
-                event_handler
-                    .guild_role_delete(context, event.guild_id, event.role_id, _role)
-                    .await;
+                event_handler.guild_role_delete(context, event.guild_id, event.role_id, role).await;
             });
         },
         Event::GuildRoleUpdate(mut event) => {
-            let _before = if_cache!(update(&cache_and_http, &mut event));
+            let before = if_cache!(update_cache(&context, &mut event));
 
             spawn_named("dispatch::event_handler::guild_role_update", async move {
-                event_handler.guild_role_update(context, _before, event.role).await;
+                event_handler.guild_role_update(context, before, event.role).await;
             });
         },
         Event::GuildStickersUpdate(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             tokio::spawn(async move {
                 event_handler.guild_stickers_update(context, event.guild_id, event.stickers).await;
@@ -526,9 +465,9 @@ async fn handle_event(
         },
         Event::GuildUpdate(mut event) => {
             spawn_named("dispatch::event_handler::guild_update", async move {
-                let before = if_cache!(cache.guild(event.guild.id).map(|g| g.clone()));
+                let before = if_cache!(context.cache.guild(event.guild.id).map(|g| g.clone()));
 
-                update(&cache_and_http, &mut event);
+                update_cache(&context, &mut event);
 
                 event_handler.guild_update(context, before, event.guild).await;
             });
@@ -560,22 +499,22 @@ async fn handle_event(
             });
         },
         Event::MessageUpdate(mut event) => {
-            let _before = if_cache!(update(&cache_and_http, &mut event));
+            let before = if_cache!(update_cache(&context, &mut event));
 
             spawn_named("dispatch::event_handler::message_update", async move {
-                let _after = if_cache!(cache.message(event.channel_id, event.id));
-                event_handler.message_update(context, _before, _after, event).await;
+                let after = if_cache!(context.cache.message(event.channel_id, event.id));
+                event_handler.message_update(context, before, after, event).await;
             });
         },
         Event::PresencesReplace(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::presence_replace", async move {
                 event_handler.presence_replace(context, event.presences).await;
             });
         },
         Event::PresenceUpdate(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::presence_update", async move {
                 event_handler.presence_update(context, event.presence).await;
@@ -599,11 +538,11 @@ async fn handle_event(
             });
         },
         Event::Ready(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             #[cfg(feature = "cache")]
             {
-                let mut shards = cache_and_http.cache.shard_data.write();
+                let mut shards = context.cache.shard_data.write();
                 if shards.connected.len() as u32 == shards.total && !shards.has_sent_shards_ready {
                     shards.has_sent_shards_ready = true;
                     let total = shards.total;
@@ -633,10 +572,10 @@ async fn handle_event(
         },
         Event::Unknown => debug!("An unknown event was received"),
         Event::UserUpdate(mut event) => {
-            let _before = if_cache!(update(&cache_and_http, &mut event));
+            let before = if_cache!(update_cache(&context, &mut event));
 
             spawn_named("dispatch::event_handler::user_update", async move {
-                event_handler.user_update(context, _before, event.current_user).await;
+                event_handler.user_update(context, before, event.current_user).await;
             });
         },
         Event::VoiceServerUpdate(event) => {
@@ -645,10 +584,10 @@ async fn handle_event(
             });
         },
         Event::VoiceStateUpdate(mut event) => {
-            let _before = if_cache!(update(&cache_and_http, &mut event));
+            let before = if_cache!(update_cache(&context, &mut event));
 
             spawn_named("dispatch::event_handler::voice_state_update", async move {
-                event_handler.voice_state_update(context, _before, event.voice_state).await;
+                event_handler.voice_state_update(context, before, event.voice_state).await;
             });
         },
         Event::WebhookUpdate(event) => {
@@ -694,21 +633,21 @@ async fn handle_event(
             });
         },
         Event::ThreadCreate(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::thread_create", async move {
                 event_handler.thread_create(context, event.thread).await;
             });
         },
         Event::ThreadUpdate(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::thread_update", async move {
                 event_handler.thread_update(context, event.thread).await;
             });
         },
         Event::ThreadDelete(mut event) => {
-            update(&cache_and_http, &mut event);
+            update_cache(&context, &mut event);
 
             spawn_named("dispatch::event_handler::thread_delete", async move {
                 event_handler.thread_delete(context, event.thread).await;


### PR DESCRIPTION
This is part of an effort to split #2118 up to address some of the concerns raised there. This PR changes dispatch such that it passes a context around instead of constructing one over and over, simplifying method signatures and reducing the number of clones (the clones themselves were cheap anyways because it was just Arc cloning, which means just incrementing a refcount).

The whole `DispatchEvent::update_cache` thing is still really ugly, as its only used in the absence of an non-raw event handler. Ideally I'd like to get rid of it somehow.