### PR TITLE
Test JSON instead of serde tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,9 +151,6 @@ optional = true
 version = "0.2"
 package = "http"
 
-[dev-dependencies.serde_test]
-version = "1"
-
 [dev-dependencies.tokio-test]
 version = "0.4"
 

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -191,7 +191,7 @@ macro_rules! bitflags {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::Token;
+    use crate::json::{assert_json, json};
 
     #[test]
     fn enum_number() {
@@ -209,9 +209,9 @@ mod tests {
             }
         }
 
-        serde_test::assert_tokens(&T::A, &[Token::U8(1)]);
-        serde_test::assert_tokens(&T::B, &[Token::U8(2)]);
-        serde_test::assert_tokens(&T::C, &[Token::U8(3)]);
-        serde_test::assert_tokens(&T::Unknown(123), &[Token::U8(123)]);
+        assert_json(&T::A, json!(1));
+        assert_json(&T::B, json!(2));
+        assert_json(&T::C, json!(3));
+        assert_json(&T::Unknown(123), json!(123));
     }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -89,7 +89,7 @@ where
     Ok(result)
 }
 
-#[cfg(all(any(feature = "builder", feature = "http"), test))]
+#[cfg(test)]
 pub(crate) fn to_value<T>(value: T) -> Result<Value>
 where
     T: Serialize,
@@ -99,6 +99,15 @@ where
     #[cfg(feature = "simd-json")]
     let result = simd_json::serde::to_owned_value(value)?;
     Ok(result)
+}
+
+#[cfg(test)]
+pub(crate) fn assert_json<T>(data: &T, json: crate::json::Value)
+where
+    T: serde::Serialize + for<'de> serde::Deserialize<'de> + PartialEq + std::fmt::Debug,
+{
+    assert_eq!(to_value(data).unwrap(), json); // test deserialization
+    assert_eq!(&from_value::<T>(json).unwrap(), data); // test deserialization
 }
 
 pub mod prelude {

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -854,9 +854,8 @@ impl From<TargetId> for UserId {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::Token;
-
     use super::*;
+    use crate::json::{assert_json, json};
 
     #[test]
     fn nested_options() {
@@ -871,50 +870,18 @@ mod tests {
             }]),
         };
 
-        serde_test::assert_tokens(&value, &[
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 3,
-            },
-            Token::Str("name"),
-            Token::Str("subcommand_group"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::SubCommandGroup.into()),
-            Token::Str("options"),
-            Token::Seq {
-                len: Some(1),
-            },
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 3,
-            },
-            Token::Str("name"),
-            Token::Str("subcommand"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::SubCommand.into()),
-            Token::Str("options"),
-            Token::Seq {
-                len: Some(1),
-            },
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 3,
-            },
-            Token::Str("name"),
-            Token::Str("channel"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::Channel.into()),
-            Token::Str("value"),
-            Token::NewtypeStruct {
-                name: "ChannelId",
-            },
-            Token::Str("3"),
-            Token::StructEnd,
-            Token::SeqEnd,
-            Token::StructEnd,
-            Token::SeqEnd,
-            Token::StructEnd,
-        ]);
+        assert_json(
+            &value,
+            json!({
+                "name": "subcommand_group",
+                "type": 2,
+                "options": [{
+                    "name": "subcommand",
+                    "type": 1,
+                    "options": [{"name": "channel", "type": 7, "value": "3"}],
+                }]
+            }),
+        );
     }
 
     #[test]
@@ -949,82 +916,16 @@ mod tests {
             },
         ];
 
-        serde_test::assert_tokens(&value, &[
-            Token::Seq {
-                len: Some(value.len()),
-            },
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 3,
-            },
-            Token::Str("name"),
-            Token::Str("boolean"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::Boolean.into()),
-            Token::Str("value"),
-            Token::Bool(true),
-            Token::StructEnd,
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 3,
-            },
-            Token::Str("name"),
-            Token::Str("integer"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::Integer.into()),
-            Token::Str("value"),
-            Token::I64(1),
-            Token::StructEnd,
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 3,
-            },
-            Token::Str("name"),
-            Token::Str("number"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::Number.into()),
-            Token::Str("value"),
-            Token::F64(2.0),
-            Token::StructEnd,
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 3,
-            },
-            Token::Str("name"),
-            Token::Str("string"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::String.into()),
-            Token::Str("value"),
-            Token::Str("foobar"),
-            Token::StructEnd,
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 2,
-            },
-            Token::Str("name"),
-            Token::Str("empty_subcommand"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::SubCommand.into()),
-            Token::Str("options"),
-            Token::Seq {
-                len: Some(0),
-            },
-            Token::SeqEnd,
-            Token::StructEnd,
-            Token::Struct {
-                name: "CommandDataOption",
-                len: 4,
-            },
-            Token::Str("name"),
-            Token::Str("autocomplete"),
-            Token::Str("type"),
-            Token::U8(CommandOptionType::Integer.into()),
-            Token::Str("value"),
-            Token::Str("not an integer"),
-            Token::Str("focused"),
-            Token::Bool(true),
-            Token::StructEnd,
-            Token::SeqEnd,
-        ]);
+        assert_json(
+            &value,
+            json!([
+                {"name": "boolean", "type": 5, "value": true},
+                {"name": "integer", "type": 4, "value": 1},
+                {"name": "number", "type": 10, "value": 2.0},
+                {"name": "string", "type": 3, "value": "foobar"},
+                {"name": "empty_subcommand", "type": 1, "options": []},
+                {"name": "autocomplete", "type": 4, "value": "not an integer", "focused": true},
+            ]),
+        );
     }
 }

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -888,9 +888,8 @@ enum Key {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::{assert_tokens, Token};
-
     use super::*;
+    use crate::json::{assert_json, json};
 
     #[test]
     fn afk_channel_id_variant() {
@@ -898,27 +897,7 @@ mod tests {
             old: Some(ChannelId::new(1)),
             new: Some(ChannelId::new(2)),
         };
-        assert_tokens(&value, &[
-            Token::Struct {
-                name: "Change",
-                len: 3,
-            },
-            Token::Str("key"),
-            Token::Str("afk_channel_id"),
-            Token::Str("old_value"),
-            Token::Some,
-            Token::NewtypeStruct {
-                name: "ChannelId",
-            },
-            Token::Str("1"),
-            Token::Str("new_value"),
-            Token::Some,
-            Token::NewtypeStruct {
-                name: "ChannelId",
-            },
-            Token::Str("2"),
-            Token::StructEnd,
-        ]);
+        assert_json(&value, json!({"key": "afk_channel_id", "old_value": "1", "new_value": "2"}));
     }
 
     #[test]
@@ -927,40 +906,12 @@ mod tests {
             old: None,
             new: Some(ChannelId::new(2)),
         };
-        assert_tokens(&value, &[
-            Token::Struct {
-                name: "Change",
-                len: 2,
-            },
-            Token::Str("key"),
-            Token::Str("afk_channel_id"),
-            Token::Str("new_value"),
-            Token::Some,
-            Token::NewtypeStruct {
-                name: "ChannelId",
-            },
-            Token::Str("2"),
-            Token::StructEnd,
-        ]);
+        assert_json(&value, json!({"key": "afk_channel_id", "new_value": "2"}));
         let value = Change::AfkChannelId {
             old: Some(ChannelId::new(1)),
             new: None,
         };
-        assert_tokens(&value, &[
-            Token::Struct {
-                name: "Change",
-                len: 2,
-            },
-            Token::Str("key"),
-            Token::Str("afk_channel_id"),
-            Token::Str("old_value"),
-            Token::Some,
-            Token::NewtypeStruct {
-                name: "ChannelId",
-            },
-            Token::Str("1"),
-            Token::StructEnd,
-        ]);
+        assert_json(&value, json!({"key": "afk_channel_id", "old_value": "1"}));
     }
 
     #[test]
@@ -969,21 +920,7 @@ mod tests {
             old: Some(EntityType::Int(123)),
             new: Some(EntityType::Str("discord".into())),
         };
-        assert_tokens(&value, &[
-            Token::Struct {
-                name: "Change",
-                len: 3,
-            },
-            Token::Str("key"),
-            Token::Str("type"),
-            Token::Str("old_value"),
-            Token::Some,
-            Token::U64(123),
-            Token::Str("new_value"),
-            Token::Some,
-            Token::Str("discord"),
-            Token::StructEnd,
-        ]);
+        assert_json(&value, json!({"key": "type", "old_value": 123, "new_value": "discord"}));
     }
 
     #[test]
@@ -992,20 +929,6 @@ mod tests {
             old: Some(Permissions::default()),
             new: Some(Permissions::MANAGE_GUILD),
         };
-        assert_tokens(&value, &[
-            Token::Struct {
-                name: "Change",
-                len: 3,
-            },
-            Token::Str("key"),
-            Token::Str("permissions"),
-            Token::Str("old_value"),
-            Token::Some,
-            Token::Str("0"),
-            Token::Str("new_value"),
-            Token::Some,
-            Token::Str("32"),
-            Token::StructEnd,
-        ]);
+        assert_json(&value, json!({"key": "permissions", "old_value": "0", "new_value": "32"}));
     }
 }

--- a/src/model/guild/audit_log/utils.rs
+++ b/src/model/guild/audit_log/utils.rs
@@ -95,9 +95,8 @@ pub mod optional_string {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::Token;
-
     use super::optional_string;
+    use crate::json::{assert_json, json};
 
     #[test]
     fn optional_string_module() {
@@ -111,25 +110,6 @@ mod tests {
             opt: Some(12345),
         };
 
-        serde_test::assert_tokens(&value, &[
-            Token::Struct {
-                name: "T",
-                len: 1,
-            },
-            Token::Str("opt"),
-            Token::Some,
-            Token::Str("12345"),
-            Token::StructEnd,
-        ]);
-
-        serde_test::assert_de_tokens(&value, &[
-            Token::Struct {
-                name: "T",
-                len: 1,
-            },
-            Token::Str("opt"),
-            Token::Str("12345"),
-            Token::StructEnd,
-        ]);
+        assert_json(&value, json!({"opt": "12345"}));
     }
 }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -336,9 +336,8 @@ mod premium_subscriber {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::{assert_tokens, Token};
-
     use super::RoleTags;
+    use crate::json::{assert_json, json};
 
     #[test]
     fn premium_subscriber_role_serde() {
@@ -348,19 +347,10 @@ mod tests {
             premium_subscriber: true,
         };
 
-        assert_tokens(&value, &[
-            Token::Struct {
-                name: "RoleTags",
-                len: 3,
-            },
-            Token::Str("bot_id"),
-            Token::None,
-            Token::Str("integration_id"),
-            Token::None,
-            Token::Str("premium_subscriber"),
-            Token::None,
-            Token::StructEnd,
-        ]);
+        assert_json(
+            &value,
+            json!({"bot_id": null, "integration_id": null, "premium_subscriber": null}),
+        );
     }
 
     #[test]
@@ -371,16 +361,6 @@ mod tests {
             premium_subscriber: false,
         };
 
-        assert_tokens(&value, &[
-            Token::Struct {
-                name: "RoleTags",
-                len: 2,
-            },
-            Token::Str("bot_id"),
-            Token::None,
-            Token::Str("integration_id"),
-            Token::None,
-            Token::StructEnd,
-        ]);
+        assert_json(&value, json!({"bot_id": null, "integration_id": null}));
     }
 }

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -318,9 +318,9 @@ mod tests {
     #[test]
     fn test_id_serde() {
         use serde::{Deserialize, Serialize};
-        use serde_test::{assert_de_tokens, assert_tokens, Token};
 
         use super::snowflake;
+        use crate::json::{assert_json, json};
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
         struct S {
@@ -334,47 +334,16 @@ mod tests {
         }
 
         let id = GuildId::new(17_5928_8472_9911_7063);
-        assert_tokens(&id, &[
-            Token::NewtypeStruct {
-                name: "GuildId",
-            },
-            Token::Str("175928847299117063"),
-        ]);
-        assert_de_tokens(&id, &[
-            Token::NewtypeStruct {
-                name: "GuildId",
-            },
-            Token::U64(17_5928_8472_9911_7063),
-        ]);
+        assert_json(&id, json!("175928847299117063"));
 
         let s = S {
             id: NonZeroU64::new(17_5928_8472_9911_7063).unwrap(),
         };
-        assert_tokens(&s, &[
-            Token::Struct {
-                name: "S",
-                len: 1,
-            },
-            Token::Str("id"),
-            Token::Str("175928847299117063"),
-            Token::StructEnd,
-        ]);
+        assert_json(&s, json!({"id": "175928847299117063"}));
 
         let s = Opt {
             id: Some(GuildId::new(17_5928_8472_9911_7063)),
         };
-        assert_tokens(&s, &[
-            Token::Struct {
-                name: "Opt",
-                len: 1,
-            },
-            Token::Str("id"),
-            Token::Some,
-            Token::NewtypeStruct {
-                name: "GuildId",
-            },
-            Token::Str("175928847299117063"),
-            Token::StructEnd,
-        ]);
+        assert_json(&s, json!({"id": "175928847299117063"}));
     }
 }

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -827,13 +827,12 @@ impl fmt::Display for Permissions {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::{assert_tokens, Token};
-
     use super::*;
+    use crate::json::{assert_json, json};
 
     #[test]
     fn permissions_serde() {
         let value = Permissions::MANAGE_GUILD | Permissions::MANAGE_ROLES;
-        assert_tokens(&value, &[Token::Str("268435488")]);
+        assert_json(&value, json!("268435488"));
     }
 }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1227,9 +1227,9 @@ mod test {
     #[test]
     fn test_discriminator_serde() {
         use serde::{Deserialize, Serialize};
-        use serde_test::{assert_de_tokens, assert_tokens, Token};
 
         use super::discriminator;
+        use crate::json::{assert_json, json};
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
         struct User {
@@ -1249,59 +1249,17 @@ mod test {
         let user = User {
             discriminator: 123,
         };
-        assert_tokens(&user, &[
-            Token::Struct {
-                name: "User",
-                len: 1,
-            },
-            Token::Str("discriminator"),
-            Token::Str("0123"),
-            Token::StructEnd,
-        ]);
-        assert_de_tokens(&user, &[
-            Token::Struct {
-                name: "User",
-                len: 1,
-            },
-            Token::Str("discriminator"),
-            Token::U16(123),
-            Token::StructEnd,
-        ]);
+        assert_json(&user, json!({"discriminator": "0123"}));
 
         let user = UserOpt {
             discriminator: Some(123),
         };
-        assert_tokens(&user, &[
-            Token::Struct {
-                name: "UserOpt",
-                len: 1,
-            },
-            Token::Str("discriminator"),
-            Token::Some,
-            Token::Str("0123"),
-            Token::StructEnd,
-        ]);
-        assert_de_tokens(&user, &[
-            Token::Struct {
-                name: "UserOpt",
-                len: 1,
-            },
-            Token::Str("discriminator"),
-            Token::Some,
-            Token::U16(123),
-            Token::StructEnd,
-        ]);
+        assert_json(&user, json!({"discriminator": "0123"}));
 
         let user_no_discriminator = UserOpt {
             discriminator: None,
         };
-        assert_tokens(&user_no_discriminator, &[
-            Token::Struct {
-                name: "UserOpt",
-                len: 0,
-            },
-            Token::StructEnd,
-        ]);
+        assert_json(&user_no_discriminator, json!({}));
     }
 
     #[cfg(feature = "model")]


### PR DESCRIPTION
Removes serde_test dependency and cuts down on needless verbosity by testing only what we really need to test. We need to verify _JSON_ de-/serialization is correct; where a lot of serde's extra metadata doesn't apply.