### PR TITLE
Remove lifetime from CreateAttachment (make owned)

### DIFF
--- a/examples/e19_interactions_endpoint/src/main.rs
+++ b/examples/e19_interactions_endpoint/src/main.rs
@@ -5,9 +5,7 @@ use serenity::model::application::interaction::*;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-fn handle_command(
-    interaction: ApplicationCommandInteraction,
-) -> CreateInteractionResponse<'static> {
+fn handle_command(interaction: ApplicationCommandInteraction) -> CreateInteractionResponse {
     CreateInteractionResponse::new().interaction_response_data(
         CreateInteractionResponseData::new().content(format!(
             "Hello from interactions webhook HTTP server! <@{}>",

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -26,20 +26,18 @@ pub(crate) struct ExistingAttachment {
 /// [`send_files`]: crate::model::id::ChannelId::send_files
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub struct CreateAttachment<'a> {
+pub struct CreateAttachment {
     pub data: Vec<u8>,
     pub filename: String,
-    pub _ok: &'a (),
 }
 
-impl<'a> CreateAttachment<'a> {
+impl CreateAttachment {
     /// Builds an [`CreateAttachment`] from the raw attachment data.
     #[must_use]
-    pub fn bytes(data: impl Into<Vec<u8>>, filename: impl Into<String>) -> CreateAttachment<'a> {
+    pub fn bytes(data: impl Into<Vec<u8>>, filename: impl Into<String>) -> CreateAttachment {
         CreateAttachment {
             data: data.into(),
             filename: filename.into(),
-            _ok: &(),
         }
     }
 
@@ -49,7 +47,7 @@ impl<'a> CreateAttachment<'a> {
     ///
     /// [`Error::Io`] if reading the file fails.
 
-    pub async fn path(path: impl AsRef<Path>) -> Result<CreateAttachment<'static>> {
+    pub async fn path(path: impl AsRef<Path>) -> Result<CreateAttachment> {
         let mut file = File::open(path.as_ref()).await?;
         let mut data = Vec::new();
         file.read_to_end(&mut data).await?;
@@ -64,7 +62,6 @@ impl<'a> CreateAttachment<'a> {
         Ok(CreateAttachment {
             data,
             filename: filename.to_string_lossy().to_string(),
-            _ok: &(),
         })
     }
 
@@ -74,17 +71,13 @@ impl<'a> CreateAttachment<'a> {
     ///
     /// [`Error::Io`] error if reading the file fails.
 
-    pub async fn file(
-        file: &File,
-        filename: impl Into<String>,
-    ) -> Result<CreateAttachment<'static>> {
+    pub async fn file(file: &File, filename: impl Into<String>) -> Result<CreateAttachment> {
         let mut data = Vec::new();
         file.try_clone().await?.read_to_end(&mut data).await?;
 
         Ok(CreateAttachment {
             data,
             filename: filename.into(),
-            _ok: &(),
         })
     }
 
@@ -94,7 +87,7 @@ impl<'a> CreateAttachment<'a> {
     ///
     /// [`Error::Url`] if the URL is invalid, [`Error::Http`] if downloading the data fails.
     #[cfg(feature = "http")]
-    pub async fn url(http: impl AsRef<Http>, url: &str) -> Result<CreateAttachment<'static>> {
+    pub async fn url(http: impl AsRef<Http>, url: &str) -> Result<CreateAttachment> {
         let url = Url::parse(url).map_err(|_| Error::Url(url.to_string()))?;
 
         let response = http.as_ref().client.get(url.clone()).send().await?;
@@ -108,7 +101,6 @@ impl<'a> CreateAttachment<'a> {
         Ok(CreateAttachment {
             data,
             filename: filename.to_string(),
-            _ok: &(),
         })
     }
 

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::path::Path;
 
 use tokio::fs::File;
@@ -28,17 +27,19 @@ pub(crate) struct ExistingAttachment {
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct CreateAttachment<'a> {
-    pub data: Cow<'a, [u8]>,
+    pub data: Vec<u8>,
     pub filename: String,
+    pub _ok: &'a (),
 }
 
 impl<'a> CreateAttachment<'a> {
     /// Builds an [`CreateAttachment`] from the raw attachment data.
     #[must_use]
-    pub fn bytes(data: &'a [u8], filename: impl Into<String>) -> CreateAttachment<'a> {
+    pub fn bytes(data: impl Into<Vec<u8>>, filename: impl Into<String>) -> CreateAttachment<'a> {
         CreateAttachment {
-            data: Cow::Borrowed(data),
+            data: data.into(),
             filename: filename.into(),
+            _ok: &(),
         }
     }
 
@@ -61,8 +62,9 @@ impl<'a> CreateAttachment<'a> {
         })?;
 
         Ok(CreateAttachment {
-            data: Cow::Owned(data),
+            data,
             filename: filename.to_string_lossy().to_string(),
+            _ok: &(),
         })
     }
 
@@ -80,8 +82,9 @@ impl<'a> CreateAttachment<'a> {
         file.try_clone().await?.read_to_end(&mut data).await?;
 
         Ok(CreateAttachment {
-            data: Cow::Owned(data),
+            data,
             filename: filename.into(),
+            _ok: &(),
         })
     }
 
@@ -103,8 +106,9 @@ impl<'a> CreateAttachment<'a> {
             .ok_or_else(|| Error::Url(url.to_string()))?;
 
         Ok(CreateAttachment {
-            data: Cow::Owned(data),
+            data,
             filename: filename.to_string(),
+            _ok: &(),
         })
     }
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -11,14 +11,14 @@ use crate::utils::check_overflow;
 
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
-pub struct CreateInteractionResponse<'a> {
+pub struct CreateInteractionResponse {
     #[serde(rename = "type")]
     kind: InteractionResponseType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<CreateInteractionResponseData<'a>>,
+    data: Option<CreateInteractionResponseData>,
 }
 
-impl<'a> CreateInteractionResponse<'a> {
+impl CreateInteractionResponse {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -74,14 +74,14 @@ impl<'a> CreateInteractionResponse<'a> {
     }
 
     /// Sets the data for the message. See [`CreateInteractionResponseData`] for details on fields.
-    pub fn interaction_response_data(mut self, data: CreateInteractionResponseData<'a>) -> Self {
+    pub fn interaction_response_data(mut self, data: CreateInteractionResponseData) -> Self {
         self.data = Some(data);
         self
     }
 }
 
-impl<'a> Default for CreateInteractionResponse<'a> {
-    fn default() -> CreateInteractionResponse<'a> {
+impl Default for CreateInteractionResponse {
+    fn default() -> CreateInteractionResponse {
         Self {
             kind: InteractionResponseType::ChannelMessageWithSource,
             data: None,
@@ -91,7 +91,7 @@ impl<'a> Default for CreateInteractionResponse<'a> {
 
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct CreateInteractionResponseData<'a> {
+pub struct CreateInteractionResponseData {
     embeds: Vec<CreateEmbed>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tts: Option<bool>,
@@ -109,10 +109,10 @@ pub struct CreateInteractionResponseData<'a> {
     title: Option<String>,
 
     #[serde(skip)]
-    files: Vec<CreateAttachment<'a>>,
+    files: Vec<CreateAttachment>,
 }
 
-impl<'a> CreateInteractionResponseData<'a> {
+impl CreateInteractionResponseData {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -129,13 +129,13 @@ impl<'a> CreateInteractionResponseData<'a> {
     }
 
     /// Appends a file to the message.
-    pub fn add_file(mut self, file: CreateAttachment<'a>) -> Self {
+    pub fn add_file(mut self, file: CreateAttachment) -> Self {
         self.files.push(file);
         self
     }
 
     /// Appends a list of files to the message.
-    pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment<'a>>) -> Self {
+    pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
         self.files.extend(files);
         self
     }
@@ -144,7 +144,7 @@ impl<'a> CreateInteractionResponseData<'a> {
     ///
     /// Calling this multiple times will overwrite the file list. To append files, call
     /// [`Self::add_file`] or [`Self::add_files`] instead.
-    pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment<'a>>) -> Self {
+    pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
         self.files = files.into_iter().collect();
         self
     }

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -11,7 +11,7 @@ use crate::utils::check_overflow;
 
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct CreateInteractionResponseFollowup<'a> {
+pub struct CreateInteractionResponseFollowup {
     embeds: Vec<CreateEmbed>,
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
@@ -29,10 +29,10 @@ pub struct CreateInteractionResponseFollowup<'a> {
     components: Option<CreateComponents>,
 
     #[serde(skip)]
-    files: Vec<CreateAttachment<'a>>,
+    files: Vec<CreateAttachment>,
 }
 
-impl<'a> CreateInteractionResponseFollowup<'a> {
+impl CreateInteractionResponseFollowup {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -115,12 +115,12 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     /// Appends a file to the message.
-    pub fn add_file(self, file: CreateAttachment<'a>) -> Self {
+    pub fn add_file(self, file: CreateAttachment) -> Self {
         self.add_files(vec![file])
     }
 
     /// Appends a list of files to the message.
-    pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment<'a>>) -> Self {
+    pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
         self.files.extend(files);
         self
     }
@@ -129,7 +129,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ///
     /// Calling this multiple times will overwrite the file list.
     /// To append files, call [`Self::add_file`] or [`Self::add_files`] instead.
-    pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment<'a>>) -> Self {
+    pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
         self.files = files.into_iter().collect();
         self
     }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -49,7 +49,7 @@ use crate::utils::check_overflow;
 /// [`Http::send_message`]: crate::http::client::Http::send_message
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct CreateMessage<'a> {
+pub struct CreateMessage {
     tts: bool,
     embeds: Vec<CreateEmbed>,
     sticker_ids: Vec<StickerId>,
@@ -66,12 +66,12 @@ pub struct CreateMessage<'a> {
 
     // The following fields are handled separately.
     #[serde(skip)]
-    files: Vec<CreateAttachment<'a>>,
+    files: Vec<CreateAttachment>,
     #[serde(skip)]
     reactions: Vec<ReactionType>,
 }
 
-impl<'a> CreateMessage<'a> {
+impl CreateMessage {
     pub fn new() -> Self {
         Self::default()
     }
@@ -228,7 +228,7 @@ impl<'a> CreateMessage<'a> {
     /// **Note**: Requires the [Attach Files] permission.
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
-    pub fn add_file(mut self, file: CreateAttachment<'a>) -> Self {
+    pub fn add_file(mut self, file: CreateAttachment) -> Self {
         self.files.push(file);
         self
     }
@@ -238,7 +238,7 @@ impl<'a> CreateMessage<'a> {
     /// **Note**: Requires the [Attach Files] permission.
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
-    pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment<'a>>) -> Self {
+    pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
         self.files.extend(files);
         self
     }
@@ -251,7 +251,7 @@ impl<'a> CreateMessage<'a> {
     /// **Note**: Requires the [Attach Files] permission.
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
-    pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment<'a>>) -> Self {
+    pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
         self.files = files.into_iter().collect();
         self
     }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -137,7 +137,7 @@ impl<'a> CreateScheduledEvent<'a> {
     }
 
     /// Sets the cover image for the scheduled event.
-    pub fn image(mut self, image: &CreateAttachment<'_>) -> Self {
+    pub fn image(mut self, image: &CreateAttachment) -> Self {
         self.image = Some(image.to_base64());
         self
     }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -19,7 +19,7 @@ pub struct CreateSticker<'a> {
     name: String,
     tags: String,
     description: String,
-    file: CreateAttachment<'a>,
+    file: CreateAttachment,
     audit_log_reason: Option<&'a str>,
 }
 
@@ -29,7 +29,7 @@ impl<'a> CreateSticker<'a> {
         name: impl Into<String>,
         tags: impl Into<String>,
         description: impl Into<String>,
-        file: CreateAttachment<'a>,
+        file: CreateAttachment,
     ) -> Self {
         Self {
             name: name.into(),
@@ -102,7 +102,7 @@ impl<'a> CreateSticker<'a> {
     /// Set the sticker file. Replaces the current value as set in [`Self::new`].
     ///
     /// **Note**: Must be a PNG, APNG, or Lottie JSON file, max 500 KB.
-    pub fn file(mut self, file: CreateAttachment<'a>) -> Self {
+    pub fn file(mut self, file: CreateAttachment) -> Self {
         self.file = file;
         self
     }

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -82,7 +82,7 @@ impl<'a> CreateWebhook<'a> {
     }
 
     /// Set the webhook's default avatar.
-    pub fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Self {
+    pub fn avatar(mut self, avatar: &CreateAttachment) -> Self {
         self.avatar = Some(avatar.to_base64());
         self
     }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -17,7 +17,7 @@ use crate::utils::check_overflow;
 
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditInteractionResponse<'a> {
+pub struct EditInteractionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     embeds: Option<Vec<CreateEmbed>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,10 +30,10 @@ pub struct EditInteractionResponse<'a> {
     attachments: Option<Vec<ExistingAttachment>>,
 
     #[serde(skip)]
-    files: Vec<CreateAttachment<'a>>,
+    files: Vec<CreateAttachment>,
 }
 
-impl<'a> EditInteractionResponse<'a> {
+impl EditInteractionResponse {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -142,7 +142,7 @@ impl<'a> EditInteractionResponse<'a> {
     ///
     /// If this is called one or more times, existing attachments will reset. To keep them, provide
     /// their IDs to [`Self::keep_existing_attachment`].
-    pub fn new_attachment(mut self, attachment: CreateAttachment<'a>) -> Self {
+    pub fn new_attachment(mut self, attachment: CreateAttachment) -> Self {
         self.files.push(attachment);
         self
     }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -42,7 +42,7 @@ use crate::utils::check_overflow;
 /// [`Message`]: crate::model::channel::Message
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct EditMessage<'a> {
+pub struct EditMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,10 +57,10 @@ pub struct EditMessage<'a> {
     attachments: Option<Vec<ExistingAttachment>>,
 
     #[serde(skip)]
-    files: Vec<CreateAttachment<'a>>,
+    files: Vec<CreateAttachment>,
 }
 
-impl<'a> EditMessage<'a> {
+impl EditMessage {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -196,7 +196,7 @@ impl<'a> EditMessage<'a> {
     /// Add a new attachment for the message.
     ///
     /// This can be called multiple times.
-    pub fn attachment(mut self, attachment: CreateAttachment<'a>) -> Self {
+    pub fn attachment(mut self, attachment: CreateAttachment) -> Self {
         self.files.push(attachment);
         self
     }

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -50,7 +50,7 @@ impl EditProfile {
     /// current_user.edit(http, EditProfile::new().avatar(&avatar)).await?;
     /// # Ok(()) }
     /// ```
-    pub fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Self {
+    pub fn avatar(mut self, avatar: &CreateAttachment) -> Self {
         self.avatar = Some(Some(avatar.to_base64()));
         self
     }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -175,7 +175,7 @@ impl<'a> EditRole<'a> {
     }
 
     /// Set the role icon to a custom image.
-    pub fn icon(mut self, icon: &CreateAttachment<'_>) -> Self {
+    pub fn icon(mut self, icon: &CreateAttachment) -> Self {
         self.icon = Some(icon.to_base64());
         self.unicode_emoji = None;
         self

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -175,7 +175,7 @@ impl<'a> EditScheduledEvent<'a> {
     }
 
     /// Sets the cover image for the scheduled event.
-    pub fn image(mut self, image: &CreateAttachment<'_>) -> Self {
+    pub fn image(mut self, image: &CreateAttachment) -> Self {
         self.image = Some(image.to_base64());
         self
     }

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -64,7 +64,7 @@ impl<'a> EditWebhook<'a> {
     }
 
     /// Set the webhook's default avatar.
-    pub fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Self {
+    pub fn avatar(mut self, avatar: &CreateAttachment) -> Self {
         self.avatar = Some(Some(avatar.to_base64()));
         self
     }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -49,7 +49,7 @@ use crate::utils::check_overflow;
 /// ```
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-pub struct ExecuteWebhook<'a> {
+pub struct ExecuteWebhook {
     tts: bool,
     embeds: Vec<CreateEmbed>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -68,10 +68,10 @@ pub struct ExecuteWebhook<'a> {
     #[serde(skip)]
     thread_id: Option<ChannelId>,
     #[serde(skip)]
-    files: Vec<CreateAttachment<'a>>,
+    files: Vec<CreateAttachment>,
 }
 
-impl<'a> ExecuteWebhook<'a> {
+impl ExecuteWebhook {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
@@ -207,13 +207,13 @@ impl<'a> ExecuteWebhook<'a> {
     }
 
     /// Appends a file to the webhook message.
-    pub fn add_file(mut self, file: CreateAttachment<'a>) -> Self {
+    pub fn add_file(mut self, file: CreateAttachment) -> Self {
         self.files.push(file);
         self
     }
 
     /// Appends a list of files to the webhook message.
-    pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment<'a>>) -> Self {
+    pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
         self.files.extend(files);
         self
     }
@@ -222,7 +222,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// Calling this multiple times will overwrite the file list. To append files, call
     /// [`Self::add_file`] or [`Self::add_files`] instead.
-    pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment<'a>>) -> Self {
+    pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
         self.files = files.into_iter().collect();
         self
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -481,7 +481,7 @@ impl Http {
         &self,
         interaction_token: &str,
         map: &impl serde::Serialize,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<CreateAttachment>,
     ) -> Result<Message> {
         let mut request = Request {
             body: None,
@@ -671,7 +671,7 @@ impl Http {
         interaction_id: InteractionId,
         interaction_token: &str,
         map: &impl serde::Serialize,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<CreateAttachment>,
     ) -> Result<()> {
         let mut request = Request {
             body: None,
@@ -843,7 +843,7 @@ impl Http {
         &self,
         guild_id: GuildId,
         map: Vec<(String, String)>,
-        file: CreateAttachment<'a>,
+        file: CreateAttachment,
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {
         self.fire(Request {
@@ -1430,7 +1430,7 @@ impl Http {
         interaction_token: &str,
         message_id: MessageId,
         map: &impl serde::Serialize,
-        new_attachments: Vec<CreateAttachment<'_>>,
+        new_attachments: Vec<CreateAttachment>,
     ) -> Result<Message> {
         let mut request = Request {
             body: None,
@@ -1695,7 +1695,7 @@ impl Http {
         channel_id: ChannelId,
         message_id: MessageId,
         map: &impl serde::Serialize,
-        new_attachments: Vec<CreateAttachment<'_>>,
+        new_attachments: Vec<CreateAttachment>,
     ) -> Result<Message> {
         let mut request = Request {
             body: None,
@@ -1829,7 +1829,7 @@ impl Http {
         &self,
         interaction_token: &str,
         map: &impl serde::Serialize,
-        new_attachments: Vec<CreateAttachment<'_>>,
+        new_attachments: Vec<CreateAttachment>,
     ) -> Result<Message> {
         let mut request = Request {
             body: None,
@@ -2260,7 +2260,7 @@ impl Http {
         thread_id: Option<ChannelId>,
         token: &str,
         wait: bool,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<CreateAttachment>,
         map: &impl serde::Serialize,
     ) -> Result<Option<Message>> {
         let mut request = Request {
@@ -3751,7 +3751,7 @@ impl Http {
     pub async fn send_message(
         &self,
         channel_id: ChannelId,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<CreateAttachment>,
         map: &impl serde::Serialize,
     ) -> Result<Message> {
         let mut request = Request {

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -19,18 +19,18 @@ pub struct Multipart<'a> {
 }
 
 impl<'a> Multipart<'a> {
-    pub(crate) fn build_form(&mut self) -> Result<Form> {
+    pub(crate) fn build_form(self) -> Result<Form> {
         let mut multipart = Form::new();
 
-        for (file_num, file) in self.files.iter_mut().enumerate() {
+        for (file_num, file) in self.files.into_iter().enumerate() {
             // For endpoints that require a single file (e.g. create sticker),
             // it will error if the part name is not `file`.
             // https://github.com/discord/discord-api-docs/issues/2064#issuecomment-691650970
             let part_name =
                 if file_num == 0 { "file".to_string() } else { format!("file{}", file_num) };
 
-            let mut part = Part::bytes(file.data.to_vec());
-            let filename = file.filename.clone();
+            let mut part = Part::bytes(file.data);
+            let filename = file.filename;
             part = guess_mime_str(part, &filename)?;
             part = part.file_name(filename);
             multipart = multipart.part(part_name, part);

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -8,8 +8,8 @@ use crate::internal::prelude::*;
 /// Holder for multipart body. Contains files, multipart fields, and
 /// payload_json for creating requests with attachments.
 #[derive(Clone, Debug)]
-pub struct Multipart<'a> {
-    pub files: Vec<CreateAttachment<'a>>,
+pub struct Multipart {
+    pub files: Vec<CreateAttachment>,
     /// Multipart text fields that are sent with the form data as individual
     /// fields. If a certain endpoint does not support passing JSON body via
     /// `payload_json`, this must be used instead.
@@ -18,7 +18,7 @@ pub struct Multipart<'a> {
     pub payload_json: Option<String>,
 }
 
-impl<'a> Multipart<'a> {
+impl Multipart {
     pub(crate) fn build_form(self) -> Result<Form> {
         let mut multipart = Form::new();
 
@@ -40,7 +40,7 @@ impl<'a> Multipart<'a> {
             multipart = multipart.text(name.clone(), value.clone());
         }
 
-        if let Some(payload_json) = self.payload_json.clone() {
+        if let Some(payload_json) = self.payload_json {
             multipart = multipart.text("payload_json", payload_json);
         }
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -24,7 +24,7 @@ pub type RequestBuilder<'a> = Request<'a>;
 #[derive(Clone, Debug)]
 pub struct Request<'a> {
     pub(super) body: Option<Vec<u8>>,
-    pub(super) multipart: Option<Multipart<'a>>,
+    pub(super) multipart: Option<Multipart>,
     pub(super) headers: Option<Headers>,
     pub(super) route: RouteInfo<'a>,
 }
@@ -46,7 +46,7 @@ impl<'a> Request<'a> {
         self
     }
 
-    pub fn multipart(&mut self, multipart: Option<Multipart<'a>>) -> &mut Self {
+    pub fn multipart(&mut self, multipart: Option<Multipart>) -> &mut Self {
         self.multipart = multipart;
 
         self

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -66,14 +66,14 @@ impl<'a> Request<'a> {
 
     #[instrument(skip(token))]
     pub fn build(
-        mut self,
+        self,
         client: &Client,
         token: &str,
         proxy: Option<&Url>,
     ) -> Result<ReqwestRequestBuilder> {
         let Request {
             body,
-            ref mut multipart,
+            multipart,
             headers: ref request_headers,
             route: ref route_info,
         } = self;

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -95,10 +95,10 @@ impl ApplicationCommandInteraction {
     /// Returns an [`Error::Model`] if the message content is too long. May also return an
     /// [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is an error in
     /// deserializing the API response.
-    pub async fn create_interaction_response<'a>(
+    pub async fn create_interaction_response(
         &self,
         http: impl AsRef<Http>,
-        builder: CreateInteractionResponse<'a>,
+        builder: CreateInteractionResponse,
     ) -> Result<()> {
         builder.execute(http, self.id, &self.token).await
     }
@@ -128,7 +128,7 @@ impl ApplicationCommandInteraction {
     pub async fn edit_original_interaction_response(
         &self,
         http: impl AsRef<Http>,
-        builder: EditInteractionResponse<'_>,
+        builder: EditInteractionResponse,
     ) -> Result<Message> {
         builder.execute(http, &self.token).await
     }
@@ -154,10 +154,10 @@ impl ApplicationCommandInteraction {
     /// Returns [`Error::Model`] if the content is too long. May also return [`Error::Http`] if the
     /// API returns an error, or [`Error::Json`] if there is an error in deserializing the
     /// response.
-    pub async fn create_followup_message<'a>(
+    pub async fn create_followup_message(
         &self,
         http: impl AsRef<Http>,
-        builder: CreateInteractionResponseFollowup<'a>,
+        builder: CreateInteractionResponseFollowup,
     ) -> Result<Message> {
         builder.execute(http, None, &self.token).await
     }
@@ -171,11 +171,11 @@ impl ApplicationCommandInteraction {
     /// Returns [`Error::Model`] if the content is too long. May also return [`Error::Http`] if the
     /// API returns an error, or [`Error::Json`] if there is an error in deserializing the
     /// response.
-    pub async fn edit_followup_message<'a>(
+    pub async fn edit_followup_message(
         &self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: CreateInteractionResponseFollowup<'a>,
+        builder: CreateInteractionResponseFollowup,
     ) -> Result<Message> {
         builder.execute(http, Some(message_id.into()), &self.token).await
     }

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -82,10 +82,10 @@ impl MessageComponentInteraction {
     /// Returns an [`Error::Model`] if the message content is too long. May also return an
     /// [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is an error in
     /// deserializing the API response.
-    pub async fn create_interaction_response<'a>(
+    pub async fn create_interaction_response(
         &self,
         http: impl AsRef<Http>,
-        builder: CreateInteractionResponse<'a>,
+        builder: CreateInteractionResponse,
     ) -> Result<()> {
         builder.execute(http, self.id, &self.token).await
     }
@@ -102,7 +102,7 @@ impl MessageComponentInteraction {
     pub async fn edit_original_interaction_response(
         &self,
         http: impl AsRef<Http>,
-        builder: EditInteractionResponse<'_>,
+        builder: EditInteractionResponse,
     ) -> Result<Message> {
         builder.execute(http, &self.token).await
     }
@@ -128,10 +128,10 @@ impl MessageComponentInteraction {
     /// Returns [`Error::Model`] if the content is too long. May also return [`Error::Http`] if the
     /// API returns an error, or [`Error::Json`] if there is an error in deserializing the
     /// response.
-    pub async fn create_followup_message<'a>(
+    pub async fn create_followup_message(
         &self,
         http: impl AsRef<Http>,
-        builder: CreateInteractionResponseFollowup<'a>,
+        builder: CreateInteractionResponseFollowup,
     ) -> Result<Message> {
         builder.execute(http, None, &self.token).await
     }
@@ -145,11 +145,11 @@ impl MessageComponentInteraction {
     /// Returns [`Error::Model`] if the content is too long. May also return [`Error::Http`] if the
     /// API returns an error, or [`Error::Json`] if there is an error in deserializing the
     /// response.
-    pub async fn edit_followup_message<'a>(
+    pub async fn edit_followup_message(
         &self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: CreateInteractionResponseFollowup<'a>,
+        builder: CreateInteractionResponseFollowup,
     ) -> Result<Message> {
         builder.execute(http, Some(message_id.into()), &self.token).await
     }

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -84,10 +84,10 @@ impl ModalSubmitInteraction {
     /// Returns an [`Error::Model`] if the message content is too long. May also return an
     /// [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is an error in
     /// deserializing the API response.
-    pub async fn create_interaction_response<'a>(
+    pub async fn create_interaction_response(
         &self,
         http: impl AsRef<Http>,
-        builder: CreateInteractionResponse<'a>,
+        builder: CreateInteractionResponse,
     ) -> Result<()> {
         builder.execute(http, self.id, &self.token).await
     }
@@ -104,7 +104,7 @@ impl ModalSubmitInteraction {
     pub async fn edit_original_interaction_response(
         &self,
         http: impl AsRef<Http>,
-        builder: EditInteractionResponse<'_>,
+        builder: EditInteractionResponse,
     ) -> Result<Message> {
         builder.execute(http, &self.token).await
     }
@@ -130,10 +130,10 @@ impl ModalSubmitInteraction {
     /// Returns [`Error::Model`] if the content is too long. May also return [`Error::Http`] if the
     /// API returns an error, or [`Error::Json`] if there is an error in deserializing the
     /// response.
-    pub async fn create_followup_message<'a>(
+    pub async fn create_followup_message(
         &self,
         http: impl AsRef<Http>,
-        builder: CreateInteractionResponseFollowup<'a>,
+        builder: CreateInteractionResponseFollowup,
     ) -> Result<Message> {
         builder.execute(http, None, &self.token).await
     }
@@ -147,11 +147,11 @@ impl ModalSubmitInteraction {
     /// Returns [`Error::Model`] if the content is too long. May also return [`Error::Http`] if the
     /// API returns an error, or [`Error::Json`] if there is an error in deserializing the
     /// response.
-    pub async fn edit_followup_message<'a>(
+    pub async fn edit_followup_message(
         &self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: CreateInteractionResponseFollowup<'a>,
+        builder: CreateInteractionResponseFollowup,
     ) -> Result<Message> {
         builder.execute(http, Some(message_id.into()), &self.token).await
     }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -342,7 +342,7 @@ impl ChannelId {
         self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: EditMessage<'_>,
+        builder: EditMessage,
     ) -> Result<Message> {
         builder.execute(http, self, message_id.into()).await
     }
@@ -696,11 +696,11 @@ impl ChannelId {
     /// reasons.
     ///
     /// [`File`]: tokio::fs::File
-    pub async fn send_files<'a>(
+    pub async fn send_files(
         self,
         cache_http: impl CacheHttp,
-        files: impl IntoIterator<Item = CreateAttachment<'a>>,
-        builder: CreateMessage<'a>,
+        files: impl IntoIterator<Item = CreateAttachment>,
+        builder: CreateMessage,
     ) -> Result<Message> {
         builder
             .files(files)
@@ -725,7 +725,7 @@ impl ChannelId {
     pub async fn send_message(
         self,
         cache_http: impl CacheHttp,
-        builder: CreateMessage<'_>,
+        builder: CreateMessage,
     ) -> Result<Message> {
         builder
             .execute(

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -440,11 +440,11 @@ impl GuildChannel {
     /// See [`EditMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
     #[inline]
-    pub async fn edit_message<'a>(
+    pub async fn edit_message(
         &self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: EditMessage<'a>,
+        builder: EditMessage,
     ) -> Result<Message> {
         self.id.edit_message(http, message_id, builder).await
     }
@@ -879,11 +879,11 @@ impl GuildChannel {
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
     #[inline]
-    pub async fn send_files<'a>(
+    pub async fn send_files(
         self,
         cache_http: impl CacheHttp,
-        files: impl IntoIterator<Item = CreateAttachment<'a>>,
-        builder: CreateMessage<'a>,
+        files: impl IntoIterator<Item = CreateAttachment>,
+        builder: CreateMessage,
     ) -> Result<Message> {
         builder
             .files(files)
@@ -905,10 +905,10 @@ impl GuildChannel {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
-    pub async fn send_message<'a>(
+    pub async fn send_message(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateMessage<'a>,
+        builder: CreateMessage,
     ) -> Result<Message> {
         builder
             .execute(

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -324,11 +324,7 @@ impl Message {
     /// Returns a [`ModelError::MessageTooLong`] if the message contents are too long.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn edit<'a>(
-        &mut self,
-        cache_http: impl CacheHttp,
-        builder: EditMessage<'a>,
-    ) -> Result<()> {
+    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditMessage) -> Result<()> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -38,7 +38,7 @@ use crate::utils::parse_channel;
 
 #[deprecated = "use CreateAttachment instead"]
 #[cfg(feature = "model")]
-pub type AttachmentType<'a> = crate::builder::CreateAttachment<'a>;
+pub type AttachmentType<'a> = crate::builder::CreateAttachment;
 
 /// A container for any channel.
 #[derive(Clone, Debug, Serialize)]

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -154,11 +154,11 @@ impl PrivateChannel {
     /// See [`EditMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
     #[inline]
-    pub async fn edit_message<'a>(
+    pub async fn edit_message(
         &self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
-        builder: EditMessage<'a>,
+        builder: EditMessage,
     ) -> Result<Message> {
         self.id.edit_message(http, message_id, builder).await
     }
@@ -289,11 +289,11 @@ impl PrivateChannel {
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
     #[inline]
-    pub async fn send_files<'a>(
+    pub async fn send_files(
         self,
         cache_http: impl CacheHttp,
-        files: impl IntoIterator<Item = CreateAttachment<'a>>,
-        builder: CreateMessage<'a>,
+        files: impl IntoIterator<Item = CreateAttachment>,
+        builder: CreateMessage,
     ) -> Result<Message> {
         self.id.send_files(cache_http, files, builder).await
     }
@@ -308,10 +308,10 @@ impl PrivateChannel {
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
     #[inline]
-    pub async fn send_message<'a>(
+    pub async fn send_message(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateMessage<'a>,
+        builder: CreateMessage,
     ) -> Result<Message> {
         self.id.send_message(cache_http, builder).await
     }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -843,10 +843,10 @@ impl User {
     /// May also return an [`Error::Http`] if the user cannot be sent a direct message.
     ///
     /// Returns an [`Error::Json`] if there is an error deserializing the API response.
-    pub async fn direct_message<'a>(
+    pub async fn direct_message(
         &self,
         cache_http: impl CacheHttp,
-        builder: CreateMessage<'a>,
+        builder: CreateMessage,
     ) -> Result<Message> {
         self.create_dm_channel(&cache_http).await?.send_message(cache_http, builder).await
     }
@@ -854,11 +854,7 @@ impl User {
     /// This is an alias of [`Self::direct_message`].
     #[allow(clippy::missing_errors_doc)]
     #[inline]
-    pub async fn dm<'a>(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: CreateMessage<'a>,
-    ) -> Result<Message> {
+    pub async fn dm(&self, cache_http: impl CacheHttp, builder: CreateMessage) -> Result<Message> {
         self.direct_message(cache_http, builder).await
     }
 

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -307,11 +307,11 @@ impl Webhook {
     ///
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     #[inline]
-    pub async fn execute<'a>(
+    pub async fn execute(
         &self,
         http: impl AsRef<Http>,
         wait: bool,
-        builder: ExecuteWebhook<'a>,
+        builder: ExecuteWebhook,
     ) -> Result<Option<Message>> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?;
         builder.execute(http, self.id, token, wait).await


### PR DESCRIPTION
First commit is the actual implementation ad878b86c45ceb25e9fccb611edaeb27e51e1e32, second commit is just mechanical removal of lifetimes throughout the codebase 511e6f6e5db6028f444bb0ee6d2c8183b247cf39.

We're not losing any performance here. Reqwest's [multipart API](https://docs.rs/reqwest/latest/reqwest/multipart/struct.Form.html) only supports passing 'static data, so serenity unconditionally converted attachment data into `Vec<u8>` anyways:

https://github.com/serenity-rs/serenity/blob/93fa816f4aa47b213d069868109938e432aabe3d/src/http/multipart.rs#L32

In fact, this PR _removes_ redundant clones, because Multipart will not needlessly clone attachment data or filename anymore:

```diff
-            let mut part = Part::bytes(file.data.to_vec());
-            let filename = file.filename.clone();
+            let mut part = Part::bytes(file.data);
+            let filename = file.filename;
```

https://github.com/serenity-rs/serenity/commit/ad878b86c45ceb25e9fccb611edaeb27e51e1e32#diff-8167392c298f8e25d340482af73c1185903b9a7542c8d9ac678876d125a3e6eaL32-R33