### PR TITLE
Use nightly Rust for docs, to use doc_auto_cfg

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
       - next
 
 env:
-  rust_toolchain: stable
+  rust_toolchain: nightly
 
 jobs:
   docs:


### PR DESCRIPTION
#2206 aimed to fix CI, but failed at that. Sorry about that.

This PR changes the Rust toolchain for building docs back to nightly (but latest nightly instead of some old pinned version), so that [this line](https://github.com/serenity-rs/serenity/blob/067b4a8088c3fbd32da6d19fbe1bd70241b3d278/src/lib.rs#L54) doesn't fail.

I pushed this to my fork's next branch to make sure the PR actually works now. Seems like it does: https://github.com/kangalioo/serenity/actions/runs/3177514329/jobs/5178041385. Generated docs: https://kangalioo.github.io/serenity/next/serenity/index.html