### PR TITLE
MSRV-related cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bitflags = "1.3"
 serde_json = "1.0.75"
 serde-value = "0.7"
 async-trait = "0.1.54"
-rustversion = "1.0.7"
 fxhash = "0.2.1"
 
 [dependencies.nougat]

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -395,12 +395,7 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         strike_text.push('.');
-
-        if is_any_option_strike {
-            Some(strike_text)
-        } else {
-            None
-        }
+        is_any_option_strike.then_some(strike_text)
     }
 
     if options.strikethrough_commands_tip_in_dm.is_none() {

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -66,10 +66,7 @@ impl<'a> CreateSticker<'a> {
 
     #[cfg(feature = "http")]
     async fn _execute(self, http: &Http, guild_id: GuildId) -> Result<Sticker> {
-        let mut map = Vec::with_capacity(3);
-        map.push(("name".to_string(), self.name));
-        map.push(("tags".to_string(), self.tags));
-        map.push(("description".to_string(), self.description));
+        let map = vec![("name", self.name), ("tags", self.tags), ("description", self.description)];
 
         http.create_sticker(guild_id, map, self.file, self.audit_log_reason).await
     }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -509,15 +509,15 @@ fn nested_group_command_search<'rec, 'a: 'rec>(
                     .checks
                     .iter()
                     .chain(group.options.checks.iter())
-                    .filter_map(|check| check.display_in_help.then(|| check.name.to_string()))
+                    .filter(|check| check.display_in_help)
+                    .map(|check| check.name.to_string())
                     .collect();
 
                 let sub_command_names: Vec<String> = options
                     .sub_commands
                     .iter()
-                    .filter_map(|cmd| {
-                        cmd.options.help_available.then(|| cmd.options.names[0].to_string())
-                    })
+                    .filter(|cmd| cmd.options.help_available)
+                    .map(|cmd| cmd.options.names[0].to_string())
                     .collect();
 
                 return Ok(CustomisedHelpData::SingleCommand {

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -509,24 +509,14 @@ fn nested_group_command_search<'rec, 'a: 'rec>(
                     .checks
                     .iter()
                     .chain(group.options.checks.iter())
-                    .filter_map(|check| {
-                        if check.display_in_help {
-                            Some(check.name.to_string())
-                        } else {
-                            None
-                        }
-                    })
+                    .filter_map(|check| check.display_in_help.then(|| check.name.to_string()))
                     .collect();
 
                 let sub_command_names: Vec<String> = options
                     .sub_commands
                     .iter()
                     .filter_map(|cmd| {
-                        if cmd.options.help_available {
-                            Some(cmd.options.names[0].to_string())
-                        } else {
-                            None
-                        }
+                        cmd.options.help_available.then(|| cmd.options.names[0].to_string())
                     })
                     .collect();
 
@@ -841,7 +831,7 @@ pub async fn create_customised_help_data<'a>(
     ctx: &Context,
     msg: &Message,
     args: &'a Args,
-    groups: &'a [&'static CommandGroup],
+    groups: &[&'static CommandGroup],
     owners: &HashSet<UserId, impl std::hash::BuildHasher + Send + Sync>,
     help_options: &'a HelpOptions,
 ) -> CustomisedHelpData<'a> {

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -172,7 +172,6 @@ pub fn mention<'a>(stream: &mut Stream<'a>, config: &Configuration) -> Option<&'
     }
 }
 
-#[allow(clippy::needless_lifetimes)] // Clippy and the compiler disagree
 async fn find_prefix<'a>(
     ctx: &Context,
     msg: &Message,
@@ -182,12 +181,7 @@ async fn find_prefix<'a>(
     let try_match = |prefix: &str| {
         let peeked = stream.peek_for_char(prefix.chars().count());
         let peeked = to_lowercase(config, peeked);
-
-        if prefix == peeked {
-            Some(peeked)
-        } else {
-            None
-        }
+        (prefix == peeked).then_some(peeked)
     };
 
     for f in &config.dynamic_prefixes {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -836,13 +836,10 @@ impl Http {
     /// **Note**: Requires the [Manage Emojis and Stickers] permission.
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
-    // We take a `Vec<(String, String)>` rather than `Vec<(&'static str, String)>` to avoid a compiler
-    // bug around `async fn` and lifetime unification. TODO: change this back once MSRV is on 1.58.
-    // Relevant issue: https://github.com/rust-lang/rust/issues/63033
     pub async fn create_sticker<'a>(
         &self,
         guild_id: GuildId,
-        map: Vec<(String, String)>,
+        map: Vec<(&'static str, String)>,
         file: CreateAttachment,
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1038,15 +1038,10 @@ impl GuildChannel {
                 .members
                 .iter()
                 .filter_map(|e| {
-                    if self
-                        .permissions_for_user(cache, e.0)
+                    self.permissions_for_user(cache, e.0)
                         .map(|p| p.contains(Permissions::VIEW_CHANNEL))
                         .unwrap_or(false)
-                    {
-                        Some(e.1.clone())
-                    } else {
-                        None
-                    }
+                        .then(|| e.1.clone())
                 })
                 .collect::<Vec<Member>>()),
             _ => Err(Error::from(ModelError::InvalidChannelType)),

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1037,12 +1037,12 @@ impl GuildChannel {
             ChannelType::News | ChannelType::Text => Ok(guild
                 .members
                 .iter()
-                .filter_map(|e| {
+                .filter(|e| {
                     self.permissions_for_user(cache, e.0)
                         .map(|p| p.contains(Permissions::VIEW_CHANNEL))
                         .unwrap_or(false)
-                        .then(|| e.1.clone())
                 })
+                .map(|e| e.1.clone())
                 .collect::<Vec<Member>>()),
             _ => Err(Error::from(ModelError::InvalidChannelType)),
         }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -454,10 +454,7 @@ impl Message {
     /// inner value of how many unicode code points the message is over.
     #[must_use]
     pub fn overflow_length(content: &str) -> Option<usize> {
-        match utils::check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT) {
-            Ok(()) => None,
-            Err(overflow) => Some(overflow),
-        }
+        utils::check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT).err()
     }
 
     /// Pins this message to its channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -24,7 +24,7 @@ use crate::http::{CacheHttp, Http};
 use crate::model::application::component::ActionRow;
 use crate::model::application::interaction::MessageInteraction;
 use crate::model::prelude::*;
-#[cfg(all(feature = "cache", feature = "model"))]
+#[cfg(feature = "model")]
 use crate::utils;
 
 /// A representation of a message over a guild's text channel, a group, or a
@@ -448,22 +448,15 @@ impl Message {
         }
     }
 
-    /// Checks the length of a string to ensure that it is within Discord's
-    /// maximum message length limit.
+    /// Checks the length of a message to ensure that it is within Discord's maximum length limit.
     ///
-    /// Returns [`None`] if the message is within the limit, otherwise returns
-    /// [`Some`] with an inner value of how many unicode code points the message
-    /// is over.
+    /// Returns [`None`] if the message is within the limit, otherwise returns [`Some`] with an
+    /// inner value of how many unicode code points the message is over.
     #[must_use]
     pub fn overflow_length(content: &str) -> Option<usize> {
-        // Check if the content is over the maximum number of unicode code
-        // points.
-        let count = content.chars().count();
-
-        if count > constants::MESSAGE_CODE_LIMIT {
-            Some(count - constants::MESSAGE_CODE_LIMIT)
-        } else {
-            None
+        match utils::check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT) {
+            Ok(()) => None,
+            Err(overflow) => Some(overflow),
         }
     }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -518,7 +518,8 @@ impl Member {
                 .guild(self.guild_id)?
                 .roles
                 .iter()
-                .filter_map(|(id, role)| self.roles.contains(id).then(|| role.clone()))
+                .filter(|(id, _)| self.roles.contains(id))
+                .map(|(_, role)| role.clone())
                 .collect(),
         )
     }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -518,8 +518,7 @@ impl Member {
                 .guild(self.guild_id)?
                 .roles
                 .iter()
-                .filter(|(id, _)| self.roles.contains(id))
-                .map(|(_, v)| v.clone())
+                .filter_map(|(id, role)| self.roles.contains(id).then(|| role.clone()))
                 .collect(),
         )
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1653,9 +1653,12 @@ impl Guild {
         case_sensitive: bool,
         sorted: bool,
     ) -> Vec<(&Member, String)> {
-        fn starts_with(prefix: &str, case_sensitive: bool, name: &str) -> bool {
-            case_sensitive && name.starts_with(prefix)
-                || !case_sensitive && starts_with_case_insensitive(name, prefix)
+        fn starts_with(name: &str, prefix: &str, case_sensitive: bool) -> bool {
+            if case_sensitive {
+                name.starts_with(prefix)
+            } else {
+                name.to_lowercase().starts_with(&prefix.to_lowercase())
+            }
         }
 
         let mut members = self
@@ -1664,17 +1667,12 @@ impl Guild {
             .filter_map(|member| {
                 let username = &member.user.name;
 
-                if starts_with(prefix, case_sensitive, username) {
+                if starts_with(username, prefix, case_sensitive) {
                     Some((member, username.clone()))
                 } else {
                     match &member.nick {
-                        Some(nick) => {
-                            if starts_with(prefix, case_sensitive, nick) {
-                                Some((member, nick.clone()))
-                            } else {
-                                None
-                            }
-                        },
+                        Some(nick) => starts_with(nick, prefix, case_sensitive)
+                            .then(|| (member, nick.clone())),
                         None => None,
                     }
                 }
@@ -1727,28 +1725,18 @@ impl Guild {
         case_sensitive: bool,
         sorted: bool,
     ) -> Vec<(&Member, String)> {
-        fn contains(substring: &str, case_sensitive: bool, name: &str) -> bool {
-            case_sensitive && name.contains(substring)
-                || !case_sensitive && contains_case_insensitive(name, substring)
-        }
-
         let mut members = self
             .members
             .values()
             .filter_map(|member| {
                 let username = &member.user.name;
 
-                if contains(substring, case_sensitive, username) {
+                if contains(username, substring, case_sensitive) {
                     Some((member, username.clone()))
                 } else {
                     match &member.nick {
-                        Some(nick) => {
-                            if contains(substring, case_sensitive, nick) {
-                                Some((member, nick.clone()))
-                            } else {
-                                None
-                            }
-                        },
+                        Some(nick) => contains(nick, substring, case_sensitive)
+                            .then(|| (member, nick.clone())),
                         None => None,
                     }
                 }
@@ -1801,14 +1789,7 @@ impl Guild {
             .values()
             .filter_map(|member| {
                 let name = &member.user.name;
-
-                if (case_sensitive && name.contains(substring))
-                    || contains_case_insensitive(name, substring)
-                {
-                    Some((member, name.to_string()))
-                } else {
-                    None
-                }
+                contains(name, substring, case_sensitive).then(|| (member, name.clone()))
             })
             .collect::<Vec<(&Member, String)>>();
 
@@ -1861,14 +1842,7 @@ impl Guild {
             .values()
             .filter_map(|member| {
                 let nick = member.nick.as_ref().unwrap_or(&member.user.name);
-
-                if case_sensitive && nick.contains(substring)
-                    || !case_sensitive && contains_case_insensitive(nick, substring)
-                {
-                    Some((member, nick.clone()))
-                } else {
-                    None
-                }
+                contains(nick, substring, case_sensitive).then(|| (member, nick.clone()))
             })
             .collect::<Vec<(&Member, String)>>();
 
@@ -2547,14 +2521,12 @@ impl Guild {
 
 /// Checks if a `&str` contains another `&str`.
 #[cfg(feature = "model")]
-fn contains_case_insensitive(to_look_at: &str, to_find: &str) -> bool {
-    to_look_at.to_lowercase().contains(&to_find.to_lowercase())
-}
-
-/// Checks if a `&str` starts with another `&str`.
-#[cfg(feature = "model")]
-fn starts_with_case_insensitive(to_look_at: &str, to_find: &str) -> bool {
-    to_look_at.to_lowercase().starts_with(&to_find.to_lowercase())
+fn contains(haystack: &str, needle: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        haystack.contains(needle)
+    } else {
+        haystack.to_lowercase().contains(&needle.to_lowercase())
+    }
 }
 
 /// Takes a `&str` as `origin` and tests if either

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -16,8 +16,7 @@ macro_rules! id_u64 {
                 #[inline]
                 #[must_use]
                 #[track_caller]
-                #[rustversion::attr(since(1.57), const)]
-                pub fn new(id: u64) -> Self {
+                pub const fn new(id: u64) -> Self {
                     match NonZeroU64::new(id) {
                         Some(inner) => Self(inner),
                         None => panic!("Attempted to call Id::new with invalid (0) value")

--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -55,11 +55,7 @@ async fn lookup_channel_global(
     if let Some(cache) = ctx.cache() {
         if let Some(channel) = cache.channels.iter().find_map(|m| {
             let channel = m.value();
-            if channel.name.eq_ignore_ascii_case(s) {
-                Some(channel.clone())
-            } else {
-                None
-            }
+            channel.name.eq_ignore_ascii_case(s).then(|| channel.clone())
         }) {
             return Ok(Channel::Guild(channel));
         }

--- a/src/utils/argument_convert/guild.rs
+++ b/src/utils/argument_convert/guild.rs
@@ -49,11 +49,7 @@ impl ArgumentConvert for Guild {
         let lookup_by_name = || {
             guilds.iter().find_map(|m| {
                 let guild = m.value();
-                if guild.name.eq_ignore_ascii_case(s) {
-                    Some(guild.clone())
-                } else {
-                    None
-                }
+                guild.name.eq_ignore_ascii_case(s).then(|| guild.clone())
             })
         };
 

--- a/src/utils/argument_convert/user.rs
+++ b/src/utils/argument_convert/user.rs
@@ -35,22 +35,15 @@ fn lookup_by_global_cache(ctx: impl CacheHttp, s: &str) -> Option<User> {
         let (name, discrim) = crate::utils::parse_user_tag(s)?;
         users.iter().find_map(|m| {
             let user = m.value();
-            if user.discriminator == discrim && user.name.eq_ignore_ascii_case(name) {
-                Some(user.clone())
-            } else {
-                None
-            }
+            (user.discriminator == discrim && user.name.eq_ignore_ascii_case(name))
+                .then(|| user.clone())
         })
     };
 
     let lookup_by_name = || {
         users.iter().find_map(|m| {
             let user = m.value();
-            if user.name == s {
-                Some(user.clone())
-            } else {
-                None
-            }
+            (user.name == s).then(|| user.clone())
         })
     };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -35,9 +35,8 @@ use crate::model::prelude::*;
 
 #[cfg(all(feature = "builder", feature = "http"))]
 pub(crate) fn check_overflow(len: usize, max: usize) -> StdResult<(), usize> {
-    let overflow = len.saturating_sub(max);
-    if overflow > 0 {
-        Err(overflow)
+    if len > max {
+        Err(len - max)
     } else {
         Ok(())
     }


### PR DESCRIPTION
Remove any workarounds contingent on the MSRV, did some misc cleanup, plus applied the `if_then_some_else_none` lint to the codebase (without actually enabling it). Some of the resultant changes to using `bool::then` are debatable in terms of readability, so feedback welcome.