### PR TITLE
Cleanup dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,126 +22,33 @@ serde_json = "1.0.75"
 serde-value = "0.7"
 async-trait = "0.1.54"
 fxhash = { version = "0.2.1", optional = true }
-
-[dependencies.nougat]
-version = "0.2.0"
-optional = true
-
-[dependencies.derivative]
-version = "2.2.0"
-optional = true
-
-[dependencies.simd-json]
-version = "0.6"
-optional = true
-
-[dependencies.tracing]
-version = "0.1.23"
-features = ["log"]
-
-[dependencies.command_attr]
-path = "./command_attr"
-version = "0.4.1"
-optional = true
-
-[dependencies.serde]
-version = "1.0.130"
-features = ["derive"]
-
-[dependencies.url]
-version = "^2.1"
-features = ["serde"]
-
-[dependencies.uwl]
-optional = true
-version = "0.6.0"
-
-[dependencies.base64]
-optional = true
-version = "0.13"
-
-[dependencies.levenshtein]
-optional = true
-version = "1.0.5"
-
-[dependencies.dep_time]
-package = "time"
-version = "0.3.6"
-features = ["formatting", "parsing", "serde-well-known"]
-
-[dependencies.chrono]
-default-features = false
-features = ["clock", "serde"]
-optional = true
-version = "0.4.10"
-
-[dependencies.flate2]
-optional = true
-version = "1.0.13"
-
-[dependencies.reqwest]
-default-features = false
-features = ["multipart", "stream"]
-optional = true
-version = "0.11.7"
-
-[dependencies.serenity-voice-model]
-path = "./voice-model"
-version = "0.1.1"
-optional = true
-
-[dependencies.static_assertions]
-optional = true
-version = "1.1"
-
-[dependencies.tokio-tungstenite]
-optional = true
-version = "0.17"
-
-[dependencies.typemap_rev]
-optional = true
-version = "0.1.3"
-
-[dependencies.bytes]
-optional = true
-version = "1.0"
-
-[dependencies.tokio]
-version = "1"
-default-features = true
-features = ["fs", "macros", "rt", "sync", "time", "io-util"]
-
-[dependencies.futures]
-version = "0.3"
-default-features = false
-features = ["std"]
-
-[dependencies.percent-encoding]
-version = "2.1"
-optional = true
-
-[dependencies.moka]
-version = "0.9"
-default-features = false
-features = ["dash"]
-optional = true
-
-[dependencies.mime_guess]
-version = "2.0"
-optional = true
-
-[dependencies.dashmap]
-version = "5.1.0"
-features = ["serde"]
-optional = true
-
-[dependencies.parking_lot]
-version = "0.12"
-optional = true
-
-[dependencies.ed25519-dalek]
-version = "1.0.1"
-optional = true
+nougat = { version = "0.2.0", optional = true }
+derivative = { version = "2.2.0", optional = true }
+simd-json = { version = "0.6", optional = true }
+tracing = { version = "0.1.23", features = ["log"] }
+command_attr = { version = "0.4.1", path = "./command_attr", optional = true }
+serde = { version = "1.0.130", features = ["derive"] }
+url = { version = "^2.1", features = ["serde"] }
+uwl = { version = "0.6.0", optional = true }
+base64 = { version = "0.13", optional = true }
+levenshtein = { version = "1.0.5", optional = true }
+dep_time = { version = "0.3.6", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
+chrono = { version = "0.4.10", default-features = false, features = ["clock", "serde"], optional = true }
+flate2 = { version = "1.0.13", optional = true }
+reqwest = { version = "0.11.7", default-features = false, features = ["multipart", "stream"], optional = true }
+serenity-voice-model = { version = "0.1.1", path = "./voice-model", optional = true }
+static_assertions = { version = "1.1", optional = true }
+tokio-tungstenite = { version = "0.17", optional = true }
+typemap_rev = { version = "0.1.3", optional = true }
+bytes = { version = "1.0", optional = true }
+tokio = { version = "1", default-features = false, features = ["fs", "macros", "rt", "sync", "time", "io-util"] }
+futures = { version = "0.3", default-features = false, features = ["std"] }
+percent-encoding = { version = "2.1", optional = true }
+moka = { version = "0.9", default-features = false, features = ["dash"], optional = true }
+mime_guess = { version = "2.0", optional = true }
+dashmap = { version = "5.1.0", features = ["serde"], optional = true }
+parking_lot = { version = "0.12", optional = true }
+ed25519-dalek = { version = "1.0.1", optional = true }
 
 [dev-dependencies.http_crate]
 version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ features = ["std"]
 
 [dependencies.percent-encoding]
 version = "2.1"
+optional = true
 
 [dependencies.moka]
 version = "0.9"
@@ -188,7 +189,7 @@ framework = ["client", "model", "utils"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["flate2"]
 # Enables HTTP, which enables bots to execute actions on Discord.
-http = []
+http = ["percent-encoding"]
 absolute_ratelimits = ["http"]
 # Enables wrapper methods around HTTP requests on model types.
 # Requires "builder" to configure the requests and "http" to execute them.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = "1.3"
 serde_json = "1.0.75"
 serde-value = "0.7"
 async-trait = "0.1.54"
-fxhash = "0.2.1"
+fxhash = { version = "0.2.1", optional = true }
 
 [dependencies.nougat]
 version = "0.2.0"
@@ -126,11 +126,9 @@ default-features = false
 features = ["dash"]
 optional = true
 
-[dependencies.mime]
-version = "0.3.16"
-
 [dependencies.mime_guess]
 version = "2.0"
+optional = true
 
 [dependencies.dashmap]
 version = "5.1.0"
@@ -148,9 +146,6 @@ optional = true
 [dev-dependencies.http_crate]
 version = "0.2"
 package = "http"
-
-[dev-dependencies.tokio-test]
-version = "0.4"
 
 [features]
 # Defaults with different backends
@@ -177,7 +172,7 @@ default_no_backend = [
 builder = ["utils"]
 # Enables the cache, which stores the data received from Discord gateway to provide access to
 # complete guild data, channels, users and more without needing HTTP requests.
-cache = ["dashmap", "parking_lot"]
+cache = ["fxhash", "dashmap", "parking_lot"]
 # Enables collectors, a utility feature that lets you await interaction events in code with
 # zero setup, without needing to setup an InteractionCreate event listener.
 collector = ["gateway", "model", "derivative", "nougat"]
@@ -189,7 +184,7 @@ framework = ["client", "model", "utils"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["flate2"]
 # Enables HTTP, which enables bots to execute actions on Discord.
-http = ["percent-encoding"]
+http = ["mime_guess", "percent-encoding"]
 absolute_ratelimits = ["http"]
 # Enables wrapper methods around HTTP requests on model types.
 # Requires "builder" to configure the requests and "http" to execute them.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,9 +140,6 @@ optional = true
 version = "0.12"
 optional = true
 
-[dependencies.cfg-if]
-version = "1.0.0"
-
 [dependencies.ed25519-dalek]
 version = "1.0.1"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,38 +17,41 @@ include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
 members = ["examples/*"]
 
 [dependencies]
+# Required dependencies
 bitflags = "1.3"
 serde_json = "1.0.75"
 serde-value = "0.7"
 async-trait = "0.1.54"
+tracing = { version = "0.1.23", features = ["log"] }
+serde = { version = "1.0.130", features = ["derive"] }
+url = { version = "^2.1", features = ["serde"] }
+tokio = { version = "1", features = ["fs", "macros", "rt", "sync", "time", "io-util"] }
+futures = { version = "0.3", default-features = false, features = ["std"] }
+dep_time = { version = "0.3.6", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
+# Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
 nougat = { version = "0.2.0", optional = true }
 derivative = { version = "2.2.0", optional = true }
 simd-json = { version = "0.6", optional = true }
-tracing = { version = "0.1.23", features = ["log"] }
-command_attr = { version = "0.4.1", path = "./command_attr", optional = true }
-serde = { version = "1.0.130", features = ["derive"] }
-url = { version = "^2.1", features = ["serde"] }
 uwl = { version = "0.6.0", optional = true }
 base64 = { version = "0.13", optional = true }
 levenshtein = { version = "1.0.5", optional = true }
-dep_time = { version = "0.3.6", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
 chrono = { version = "0.4.10", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.13", optional = true }
 reqwest = { version = "0.11.7", default-features = false, features = ["multipart", "stream"], optional = true }
-serenity-voice-model = { version = "0.1.1", path = "./voice-model", optional = true }
 static_assertions = { version = "1.1", optional = true }
 tokio-tungstenite = { version = "0.17", optional = true }
 typemap_rev = { version = "0.1.3", optional = true }
 bytes = { version = "1.0", optional = true }
-tokio = { version = "1", default-features = false, features = ["fs", "macros", "rt", "sync", "time", "io-util"] }
-futures = { version = "0.3", default-features = false, features = ["std"] }
 percent-encoding = { version = "2.1", optional = true }
 moka = { version = "0.9", default-features = false, features = ["dash"], optional = true }
 mime_guess = { version = "2.0", optional = true }
 dashmap = { version = "5.1.0", features = ["serde"], optional = true }
 parking_lot = { version = "0.12", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
+# Serenity workspace crates
+command_attr = { version = "0.4.1", path = "./command_attr", optional = true }
+serenity-voice-model = { version = "0.1.1", path = "./voice-model", optional = true }
 
 [dev-dependencies.http_crate]
 version = "0.2"

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -60,6 +60,14 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
                 .add_existing_attachment(msg.attachments[0].id),
         )
         .await?;
+    } else if msg.content == "auditlog" {
+        // Test special characters in audit log reason
+        msg.channel_id
+            .edit(
+                ctx,
+                EditChannel::new().name("new-channel-name").audit_log_reason("hello\nworld\n🙂"),
+            )
+            .await?;
     } else {
         return Ok(());
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::missing_errors_doc)]
 
-use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::fmt;
 use std::num::NonZeroU64;
 use std::str::FromStr;
@@ -186,11 +184,11 @@ fn parse_token(token: impl AsRef<str>) -> String {
 fn reason_into_header(reason: &str) -> Headers {
     let mut headers = Headers::new();
 
-    let header_value = match Cow::from(utf8_percent_encode(reason, NON_ALPHANUMERIC)) {
-        Cow::Borrowed(value) => HeaderValue::from_str(value),
-        Cow::Owned(value) => HeaderValue::try_from(value),
-    }
-    .expect("Invalid header value even after percent encode");
+    // "The X-Audit-Log-Reason header supports 1-512 URL-encoded UTF-8 characters."
+    // https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object
+    let header_value =
+        HeaderValue::from_str(&utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string())
+            .expect("Invalid header value even after percent encode");
 
     headers.insert("X-Audit-Log-Reason", header_value);
     headers

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -291,7 +291,7 @@ mod tests {
     fn from_unix_timestamp() {
         let timestamp = Timestamp::from_unix_timestamp(1462015105).unwrap();
         assert_eq!(timestamp.unix_timestamp(), 1462015105);
-        if cfg!(all(feature = "chrono", not(feature = "time"))) {
+        if cfg!(feature = "chrono") {
             assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.000Z");
         } else {
             assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25Z");

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -37,195 +37,204 @@ use serde::{Deserialize, Serialize};
 /// Discord's epoch starts at "2015-01-01T00:00:00+00:00"
 const DISCORD_EPOCH: u64 = 1_420_070_400_000;
 
-cfg_if::cfg_if! {
-    if #[cfg(all(feature = "chrono", not(feature = "time")))] {
-        use chrono::{DateTime, NaiveDateTime, ParseError as InnerError, SecondsFormat, TimeZone, Utc};
+#[cfg(feature = "chrono")]
+mod imp {
+    pub(super) use chrono::ParseError as InnerError;
+    use chrono::{DateTime, NaiveDateTime, SecondsFormat, TimeZone, Utc};
 
-        /// Representation of a Unix timestamp.
+    use super::*;
+
+    /// Representation of a Unix timestamp.
+    ///
+    /// The struct implements the `std::fmt::Display` trait to format the underlying type as
+    /// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
+    ///
+    /// ```
+    /// # use serenity::model::id::GuildId;
+    /// # use serenity::model::Timestamp;
+    /// #
+    /// let timestamp: Timestamp = GuildId::new(175928847299117063).created_at();
+    /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
+    /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
+    /// ```
+    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(transparent)]
+    pub struct Timestamp(DateTime<Utc>);
+
+    impl Timestamp {
+        pub(crate) fn from_discord_id(id: u64) -> Timestamp {
+            Self(Utc.timestamp_millis(((id >> 22) + DISCORD_EPOCH) as i64))
+        }
+
+        /// Create a new `Timestamp` with the current date and time in UTC.
+        #[must_use]
+        pub fn now() -> Self {
+            Self(Utc::now())
+        }
+
+        /// Create a new `Timestamp` from a UNIX timestamp.
         ///
-        /// The struct implements the `std::fmt::Display` trait to format the underlying type as
-        /// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
+        /// # Errors
         ///
+        /// Returns `Err` if the value is invalid.
+        pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
+            let dt = NaiveDateTime::from_timestamp_opt(secs, 0).ok_or(InvalidTimestamp)?;
+            Ok(Self(DateTime::from_utc(dt, Utc)))
+        }
+
+        /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
+        #[must_use]
+        pub fn unix_timestamp(&self) -> i64 {
+            self.0.timestamp()
+        }
+
+        /// Parse a timestamp from an RFC 3339 date and time string.
+        ///
+        /// # Examples
         /// ```
-        /// # use serenity::model::id::GuildId;
         /// # use serenity::model::Timestamp;
         /// #
-        /// let timestamp: Timestamp = GuildId::new(175928847299117063).created_at();
-        /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
-        /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
-        /// ```
-        #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-        #[serde(transparent)]
-        pub struct Timestamp(DateTime<Utc>);
-
-        impl Timestamp {
-            pub(crate) fn from_discord_id(id: u64) -> Timestamp {
-                Self(Utc.timestamp_millis(((id >> 22) + DISCORD_EPOCH) as i64))
-            }
-
-            /// Create a new `Timestamp` with the current date and time in UTC.
-            #[must_use]
-            pub fn now() -> Self {
-                Self(Utc::now())
-            }
-
-            /// Create a new `Timestamp` from a UNIX timestamp.
-            ///
-            /// # Errors
-            ///
-            /// Returns `Err` if the value is invalid.
-            pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
-                let dt = NaiveDateTime::from_timestamp_opt(secs, 0).ok_or(InvalidTimestamp)?;
-                Ok(Self(DateTime::from_utc(dt, Utc)))
-            }
-
-            /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
-            #[must_use]
-            pub fn unix_timestamp(&self) -> i64 {
-                self.0.timestamp()
-            }
-
-            /// Parse a timestamp from an RFC 3339 date and time string.
-            ///
-            /// # Examples
-            /// ```
-            /// # use serenity::model::Timestamp;
-            /// #
-            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25Z").unwrap();
-            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25+00:00").unwrap();
-            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25.796Z").unwrap();
-            ///
-            /// assert!(Timestamp::parse("2016-04-30T11:18:25").is_err());
-            /// assert!(Timestamp::parse("2016-04-30T11:18").is_err());
-            /// ```
-            ///
-            /// # Errors
-            ///
-            /// Returns `Err` if the string is not a valid RFC 3339 date and time string.
-            pub fn parse(input: &str) -> Result<Timestamp, ParseError> {
-                DateTime::parse_from_rfc3339(input).map(|d| Self(d.with_timezone(&Utc))).map_err(ParseError)
-            }
-        }
-
-        impl fmt::Display for Timestamp {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let s = self.0.to_rfc3339_opts(SecondsFormat::Millis, true);
-                f.write_str(&s)
-            }
-        }
-
-        impl std::ops::Deref for Timestamp {
-            type Target = DateTime<Utc>;
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        impl<Tz: TimeZone> From<DateTime<Tz>> for Timestamp {
-            fn from(dt: DateTime<Tz>) -> Self {
-                Self(dt.with_timezone(&Utc))
-            }
-        }
-    } else {
-        use dep_time::format_description::well_known::Rfc3339;
-        use dep_time::serde::rfc3339;
-        use dep_time::{Duration, OffsetDateTime};
-        use dep_time::error::Parse as InnerError;
-
-        /// Representation of a Unix timestamp.
+        /// let timestamp = Timestamp::parse("2016-04-30T11:18:25Z").unwrap();
+        /// let timestamp = Timestamp::parse("2016-04-30T11:18:25+00:00").unwrap();
+        /// let timestamp = Timestamp::parse("2016-04-30T11:18:25.796Z").unwrap();
         ///
-        /// The struct implements the `std::fmt::Display` trait to format the underlying type as
-        /// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
+        /// assert!(Timestamp::parse("2016-04-30T11:18:25").is_err());
+        /// assert!(Timestamp::parse("2016-04-30T11:18").is_err());
+        /// ```
         ///
-        /// ```
-        /// # use serenity::model::id::GuildId;
-        /// # use serenity::model::Timestamp;
-        /// #
-        /// let timestamp: Timestamp = GuildId::new(175928847299117063).created_at();
-        /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
-        /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
-        /// ```
-        #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-        #[serde(transparent)]
-        pub struct Timestamp(#[serde(with = "rfc3339")] OffsetDateTime);
-
-
-        impl Timestamp {
-            pub(crate) fn from_discord_id(id: u64) -> Timestamp {
-                let ns = Duration::milliseconds(((id >> 22) + DISCORD_EPOCH) as i64).whole_nanoseconds();
-                // This can't fail because of the bit shifting
-                // `(u64::MAX >> 22) + DISCORD_EPOCH` = 5818116911103 = "Wed May 15 2154 07:35:11 GMT+0000"
-                Self(OffsetDateTime::from_unix_timestamp_nanos(ns).expect("can't fail"))
-            }
-
-            /// Create a new `Timestamp` with the current date and time in UTC.
-            #[must_use]
-            pub fn now() -> Self {
-                Self(OffsetDateTime::now_utc())
-            }
-
-            /// Create a new `Timestamp` from a UNIX timestamp.
-            ///
-            /// # Errors
-            ///
-            /// Returns `Err` if the value is invalid. The valid range of the value may vary depending on
-            /// the feature flags enabled (`time` with `large-dates`).
-            pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
-                let dt = OffsetDateTime::from_unix_timestamp(secs).map_err(|_| InvalidTimestamp)?;
-                Ok(Self(dt))
-            }
-
-            /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
-            #[must_use]
-            pub fn unix_timestamp(&self) -> i64 {
-                self.0.unix_timestamp()
-            }
-
-            /// Parse a timestamp from an RFC 3339 date and time string.
-            ///
-            /// # Examples
-            /// ```
-            /// # use serenity::model::Timestamp;
-            /// #
-            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25Z").unwrap();
-            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25+00:00").unwrap();
-            /// let timestamp = Timestamp::parse("2016-04-30T11:18:25.796Z").unwrap();
-            ///
-            /// assert!(Timestamp::parse("2016-04-30T11:18:25").is_err());
-            /// assert!(Timestamp::parse("2016-04-30T11:18").is_err());
-            /// ```
-            ///
-            /// # Errors
-            ///
-            /// Returns `Err` if the string is not a valid RFC 3339 date and time string.
-            pub fn parse(input: &str) -> Result<Timestamp, ParseError> {
-                OffsetDateTime::parse(input, &Rfc3339).map(Self).map_err(ParseError)
-            }
+        /// # Errors
+        ///
+        /// Returns `Err` if the string is not a valid RFC 3339 date and time string.
+        pub fn parse(input: &str) -> Result<Timestamp, ParseError> {
+            DateTime::parse_from_rfc3339(input)
+                .map(|d| Self(d.with_timezone(&Utc)))
+                .map_err(ParseError)
         }
+    }
 
-        impl fmt::Display for Timestamp {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let s = self.0.format(&Rfc3339).map_err(|_| fmt::Error)?;
-                f.write_str(&s)
-            }
+    impl std::fmt::Display for Timestamp {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let s = self.0.to_rfc3339_opts(SecondsFormat::Millis, true);
+            f.write_str(&s)
         }
+    }
 
-        impl std::ops::Deref for Timestamp {
-            type Target = OffsetDateTime;
+    impl std::ops::Deref for Timestamp {
+        type Target = DateTime<Utc>;
 
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
+        fn deref(&self) -> &Self::Target {
+            &self.0
         }
+    }
 
-        impl From<OffsetDateTime> for Timestamp {
-            fn from(dt: OffsetDateTime) -> Self {
-                Self(dt)
-            }
+    impl<Tz: TimeZone> From<DateTime<Tz>> for Timestamp {
+        fn from(dt: DateTime<Tz>) -> Self {
+            Self(dt.with_timezone(&Utc))
         }
     }
 }
+#[cfg(not(feature = "chrono"))]
+mod imp {
+    pub(super) use dep_time::error::Parse as InnerError;
+    use dep_time::format_description::well_known::Rfc3339;
+    use dep_time::serde::rfc3339;
+    use dep_time::{Duration, OffsetDateTime};
+
+    use super::*;
+
+    /// Representation of a Unix timestamp.
+    ///
+    /// The struct implements the `std::fmt::Display` trait to format the underlying type as
+    /// an RFC 3339 date and string such as `2016-04-30T11:18:25.796Z`.
+    ///
+    /// ```
+    /// # use serenity::model::id::GuildId;
+    /// # use serenity::model::Timestamp;
+    /// #
+    /// let timestamp: Timestamp = GuildId::new(175928847299117063).created_at();
+    /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
+    /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
+    /// ```
+    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[serde(transparent)]
+    pub struct Timestamp(#[serde(with = "rfc3339")] OffsetDateTime);
+
+    impl Timestamp {
+        pub(crate) fn from_discord_id(id: u64) -> Timestamp {
+            let ns =
+                Duration::milliseconds(((id >> 22) + DISCORD_EPOCH) as i64).whole_nanoseconds();
+            // This can't fail because of the bit shifting
+            // `(u64::MAX >> 22) + DISCORD_EPOCH` = 5818116911103 = "Wed May 15 2154 07:35:11 GMT+0000"
+            Self(OffsetDateTime::from_unix_timestamp_nanos(ns).expect("can't fail"))
+        }
+
+        /// Create a new `Timestamp` with the current date and time in UTC.
+        #[must_use]
+        pub fn now() -> Self {
+            Self(OffsetDateTime::now_utc())
+        }
+
+        /// Create a new `Timestamp` from a UNIX timestamp.
+        ///
+        /// # Errors
+        ///
+        /// Returns `Err` if the value is invalid. The valid range of the value may vary depending on
+        /// the feature flags enabled (`time` with `large-dates`).
+        pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
+            let dt = OffsetDateTime::from_unix_timestamp(secs).map_err(|_| InvalidTimestamp)?;
+            Ok(Self(dt))
+        }
+
+        /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
+        #[must_use]
+        pub fn unix_timestamp(&self) -> i64 {
+            self.0.unix_timestamp()
+        }
+
+        /// Parse a timestamp from an RFC 3339 date and time string.
+        ///
+        /// # Examples
+        /// ```
+        /// # use serenity::model::Timestamp;
+        /// #
+        /// let timestamp = Timestamp::parse("2016-04-30T11:18:25Z").unwrap();
+        /// let timestamp = Timestamp::parse("2016-04-30T11:18:25+00:00").unwrap();
+        /// let timestamp = Timestamp::parse("2016-04-30T11:18:25.796Z").unwrap();
+        ///
+        /// assert!(Timestamp::parse("2016-04-30T11:18:25").is_err());
+        /// assert!(Timestamp::parse("2016-04-30T11:18").is_err());
+        /// ```
+        ///
+        /// # Errors
+        ///
+        /// Returns `Err` if the string is not a valid RFC 3339 date and time string.
+        pub fn parse(input: &str) -> Result<Timestamp, ParseError> {
+            OffsetDateTime::parse(input, &Rfc3339).map(Self).map_err(ParseError)
+        }
+    }
+
+    impl std::fmt::Display for Timestamp {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let s = self.0.format(&Rfc3339).map_err(|_| std::fmt::Error)?;
+            f.write_str(&s)
+        }
+    }
+
+    impl std::ops::Deref for Timestamp {
+        type Target = OffsetDateTime;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl From<OffsetDateTime> for Timestamp {
+        fn from(dt: OffsetDateTime) -> Self {
+            Self(dt)
+        }
+    }
+}
+pub use imp::*;
 
 #[derive(Debug)]
 pub struct InvalidTimestamp;


### PR DESCRIPTION
- Removes dependencies: cfg-if, mime, tokio-test
- Makes dependencies optional: fxhash, mime_guess
- Puts each dependency in Cargo.toml on a single line
- Put dependency attributes in consistent order (version, package/path, default-features, features, optional)
- Group dependencies by category