### PR TITLE
Implement Default for some model types and shorten tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ simd-json = { version = "0.6", optional = true }
 uwl = { version = "0.6.0", optional = true }
 base64 = { version = "0.13", optional = true }
 levenshtein = { version = "1.0.5", optional = true }
-chrono = { version = "0.4.10", default-features = false, features = ["clock", "serde"], optional = true }
+chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.13", optional = true }
 reqwest = { version = "0.11.7", default-features = false, features = ["multipart", "stream"], optional = true }
 static_assertions = { version = "1.1", optional = true }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -945,46 +945,10 @@ mod test {
         let cache = Cache::new_with_settings(settings);
 
         // Test inserting one message into a channel's message cache.
-        let datetime = Timestamp::now();
         let mut event = MessageCreateEvent {
             message: Message {
                 id: MessageId::new(3),
-                attachments: vec![],
-                author: User {
-                    id: UserId::new(2),
-                    avatar: None,
-                    bot: false,
-                    discriminator: 1,
-                    name: "user 1".to_owned(),
-                    public_flags: None,
-                    banner: None,
-                    accent_colour: None,
-                },
-                channel_id: ChannelId::new(2),
-                guild_id: Some(GuildId::new(1)),
-                content: String::new(),
-                edited_timestamp: None,
-                embeds: vec![],
-                kind: MessageType::Regular,
-                member: None,
-                mention_everyone: false,
-                mention_roles: vec![],
-                mention_channels: vec![],
-                mentions: vec![],
-                nonce: Some(Nonce::Number(1)),
-                pinned: false,
-                reactions: vec![],
-                timestamp: datetime,
-                tts: false,
-                webhook_id: None,
-                activity: None,
-                application: None,
-                message_reference: None,
-                flags: None,
-                sticker_items: vec![],
-                referenced_message: None,
-                interaction: None,
-                components: vec![],
+                ..Default::default()
             },
         };
 
@@ -1016,26 +980,8 @@ mod test {
 
         let channel = GuildChannel {
             id: event.message.channel_id,
-            bitrate: None,
-            parent_id: None,
             guild_id: event.message.guild_id.unwrap(),
-            kind: ChannelType::Text,
-            last_message_id: None,
-            last_pin_timestamp: None,
-            name: String::new(),
-            permission_overwrites: vec![],
-            position: 0,
-            topic: None,
-            user_limit: None,
-            nsfw: false,
-            rate_limit_per_user: Some(0),
-            rtc_region: None,
-            video_quality_mode: None,
-            message_count: None,
-            member_count: None,
-            thread_metadata: None,
-            member: None,
-            default_auto_archive_duration: None,
+            ..Default::default()
         };
 
         // Add a channel delete event to the cache, the cached messages for that
@@ -1048,59 +994,12 @@ mod test {
 
         // Test deletion of a guild channel's message cache when a GuildDeleteEvent
         // is received.
-        let mut guild_create = {
-            let mut channels = HashMap::new();
-            channels.insert(ChannelId::new(2), channel);
-
-            GuildCreateEvent {
-                guild: Guild {
-                    id: GuildId::new(1),
-                    afk_channel_id: None,
-                    afk_timeout: 0,
-                    application_id: None,
-                    default_message_notifications: DefaultMessageNotificationLevel::All,
-                    emojis: HashMap::new(),
-                    explicit_content_filter: ExplicitContentFilter::None,
-                    features: vec![],
-                    icon: None,
-                    joined_at: datetime,
-                    large: false,
-                    member_count: 0,
-                    members: HashMap::new(),
-                    mfa_level: MfaLevel::None,
-                    name: String::new(),
-                    owner_id: UserId::new(3),
-                    presences: HashMap::new(),
-                    roles: HashMap::new(),
-                    splash: None,
-                    discovery_splash: None,
-                    system_channel_id: None,
-                    system_channel_flags: SystemChannelFlags::default(),
-                    rules_channel_id: None,
-                    public_updates_channel_id: None,
-                    verification_level: VerificationLevel::Low,
-                    voice_states: HashMap::new(),
-                    description: None,
-                    premium_tier: PremiumTier::Tier0,
-                    channels,
-                    premium_subscription_count: 0,
-                    banner: None,
-                    vanity_url_code: Some("bruhmoment".to_string()),
-                    preferred_locale: "en-US".to_string(),
-                    welcome_screen: None,
-                    approximate_member_count: None,
-                    approximate_presence_count: None,
-                    nsfw_level: NsfwLevel::Default,
-                    max_video_channel_users: None,
-                    max_presences: None,
-                    max_members: None,
-                    widget_enabled: Some(false),
-                    widget_channel_id: None,
-                    stage_instances: vec![],
-                    threads: vec![],
-                    stickers: HashMap::new(),
-                },
-            }
+        let mut guild_create = GuildCreateEvent {
+            guild: Guild {
+                id: GuildId::new(1),
+                channels: HashMap::from([(ChannelId::new(2), channel)]),
+                ..Default::default()
+            },
         };
         assert!(cache.update(&mut guild_create).is_none());
         assert!(cache.update(&mut event).is_none());

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -948,6 +948,7 @@ mod test {
         let mut event = MessageCreateEvent {
             message: Message {
                 id: MessageId::new(3),
+                guild_id: Some(GuildId::new(1)),
                 ..Default::default()
             },
         };

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -101,7 +101,9 @@ macro_rules! enum_number {
         $(#[$outer:meta])*
         $vis:vis enum $Enum:ident {
             $(
-                $(#[$inner:ident $($args:tt)*])*
+                $(#[doc = $doc:literal])*
+                $(#[cfg $($cfg:tt)*])?
+                $(#[default $($dummy:tt)?])?
                 $Variant:ident = $value:literal,
             )*
             _ => Unknown($T:ty),
@@ -110,7 +112,9 @@ macro_rules! enum_number {
         $(#[$outer])*
         $vis enum $Enum {
             $(
-                $(#[$inner $($args)*])*
+                $(#[doc = $doc])*
+                $(#[cfg $($cfg)*])?
+                $(#[default $($dummy:tt)?])?
                 $Variant,
             )*
             /// Variant value is unknown.
@@ -119,9 +123,8 @@ macro_rules! enum_number {
 
         impl From<$T> for $Enum {
             fn from(value: $T) -> Self {
-                #[allow(unused_doc_comments)]
                 match value {
-                    $($(#[$inner $($args)*])* $value => Self::$Variant,)*
+                    $($(#[cfg $($cfg)*])? $value => Self::$Variant,)*
                     unknown => Self::Unknown(unknown),
                 }
             }
@@ -129,9 +132,8 @@ macro_rules! enum_number {
 
         impl From<$Enum> for $T {
             fn from(value: $Enum) -> Self {
-                #[allow(unused_doc_comments)]
                 match value {
-                    $($(#[$inner $($args)*])* $Enum::$Variant => $value,)*
+                    $($(#[cfg $($cfg)*])? $Enum::$Variant => $value,)*
                     $Enum::Unknown(unknown) => unknown,
                 }
             }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -36,7 +36,7 @@ use crate::model::Timestamp;
 /// [`Self::rate_limit_per_user`] will be [`None`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildChannel {
     /// The unique Id of the channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -31,7 +31,7 @@ use crate::utils;
 /// private channel.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Message {
     /// The unique Id of the message. Can be used to calculate the creation date
@@ -825,11 +825,12 @@ enum_number! {
     /// Differentiates between regular and different types of system messages.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-types).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MessageType {
         /// A regular message.
+        #[default]
         Regular = 0,
         /// An indicator that a recipient was added by the author.
         GroupRecipientAddition = 1,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -218,11 +218,12 @@ enum_number! {
     /// A representation of a type of channel.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ChannelType {
         /// An indicator that the channel is a text [`GuildChannel`].
+        #[default]
         Text = 0,
         /// An indicator that the channel is a [`PrivateChannel`].
         Private = 1,
@@ -432,54 +433,9 @@ mod test {
     mod model_utils {
         use crate::model::prelude::*;
 
-        fn guild_channel() -> GuildChannel {
-            GuildChannel {
-                id: ChannelId::new(1),
-                bitrate: None,
-                parent_id: None,
-                guild_id: GuildId::new(2),
-                kind: ChannelType::Text,
-                last_message_id: None,
-                last_pin_timestamp: None,
-                name: "nsfw-stuff".to_string(),
-                permission_overwrites: vec![],
-                position: 0,
-                topic: None,
-                user_limit: None,
-                nsfw: false,
-                rate_limit_per_user: Some(0),
-                rtc_region: None,
-                video_quality_mode: None,
-                message_count: None,
-                member_count: None,
-                thread_metadata: None,
-                member: None,
-                default_auto_archive_duration: None,
-            }
-        }
-
-        fn private_channel() -> PrivateChannel {
-            PrivateChannel {
-                id: ChannelId::new(1),
-                last_message_id: None,
-                last_pin_timestamp: None,
-                kind: ChannelType::Private,
-                recipient: User {
-                    id: UserId::new(2),
-                    avatar: None,
-                    bot: false,
-                    discriminator: 1,
-                    name: "ab".to_string(),
-                    public_flags: None,
-                    banner: None,
-                    accent_colour: None,
-                },
-            }
-        }
-
         #[test]
         fn nsfw_checks() {
-            let mut channel = guild_channel();
+            let mut channel = GuildChannel::default();
             assert!(!channel.is_nsfw());
             channel.kind = ChannelType::Voice;
             assert!(!channel.is_nsfw());
@@ -503,7 +459,7 @@ mod test {
             let channel = Channel::Guild(channel);
             assert!(!channel.is_nsfw());
 
-            let private_channel = private_channel();
+            let private_channel = PrivateChannel::default();
             assert!(!private_channel.is_nsfw());
         }
     }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -15,7 +15,7 @@ use crate::model::Timestamp;
 /// A Direct Message text channel with another user.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PrivateChannel {
     /// The unique Id of the private channel.

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -68,7 +68,7 @@
 /// ```
 ///
 /// [`Role`]: crate::model::guild::Role
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct Colour(pub u32);
 
 impl Colour {
@@ -320,13 +320,6 @@ impl Colour {
     pub const ROSEWATER: Colour = Colour(0xF6DBD8);
     /// Creates a new [`Colour`], setting its RGB value to `(26, 188, 156)`.
     pub const TEAL: Colour = Colour(0x1ABC9C);
-}
-
-impl Default for Colour {
-    /// Creates a default value for a [`Colour`], setting the inner value to `0`.
-    fn default() -> Colour {
-        Colour(0)
-    }
 }
 
 /// Colour constants used by Discord for their branding, role colour palette, etc.

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -174,11 +174,12 @@ pub struct ActivityEmoji {
 
 enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-types).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ActivityType {
         /// An indicator that the user is playing a game.
+        #[default]
         Playing = 0,
         /// An indicator that the user is streaming to a service.
         Streaming = 1,
@@ -191,12 +192,6 @@ enum_number! {
         /// An indicator that the user is competing somewhere.
         Competing = 5,
         _ => Unknown(u8),
-    }
-}
-
-impl Default for ActivityType {
-    fn default() -> Self {
-        ActivityType::Playing
     }
 }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -19,7 +19,7 @@ use crate::model::Timestamp;
 /// Information about a member of a guild.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-member-object).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Member {
     /// Indicator of whether the member can hear in voice channels.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -86,7 +86,7 @@ pub struct Ban {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object) plus
 /// [extension](https://discord.com/developers/docs/topics/gateway#guild-create).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Guild {
     /// Id of a voice channel that's considered the AFK channel.
@@ -2635,11 +2635,12 @@ enum_number! {
     /// Default message notification level for a guild.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum DefaultMessageNotificationLevel {
         /// Receive notifications for everything.
+        #[default]
         All = 0,
         /// Receive only mentions.
         Mentions = 1,
@@ -2651,11 +2652,12 @@ enum_number! {
     /// Setting used to filter explicit messages from members.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ExplicitContentFilter {
         /// Don't scan any messages.
+        #[default]
         None = 0,
         /// Scan messages from members without a role.
         WithoutRole = 1,
@@ -2669,11 +2671,12 @@ enum_number! {
     /// Multi-Factor Authentication level for guild moderators.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-mfa-level).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MfaLevel {
         /// MFA is disabled.
+        #[default]
         None = 0,
         /// MFA is enabled.
         Elevated = 1,
@@ -2686,11 +2689,12 @@ enum_number! {
     /// messages in a [`Guild`].
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-verification-level).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum VerificationLevel {
         /// Does not require any verification.
+        #[default]
         None = 0,
         /// Must have a verified email on the user's Discord account.
         Low = 1,
@@ -2708,11 +2712,12 @@ enum_number! {
     /// The [`Guild`] nsfw level.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum NsfwLevel {
         /// The nsfw level is not specified.
+        #[default]
         Default = 0,
         /// The guild is considered as explicit.
         Explicit = 1,
@@ -2732,98 +2737,24 @@ mod test {
 
         use crate::model::prelude::*;
 
-        fn gen_user() -> User {
-            User::default()
-        }
-
         fn gen_member() -> Member {
-            let dt = Timestamp::now();
-
-            let vec1 = Vec::new();
-            let u = gen_user();
-
             Member {
-                deaf: false,
-                guild_id: GuildId::new(1),
-                joined_at: Some(dt),
-                mute: false,
                 nick: Some("aaaa".to_string()),
-                roles: vec1,
-                user: u,
-                pending: false,
-                premium_since: None,
-                permissions: None,
-                avatar: None,
-                communication_disabled_until: None,
+                user: User {
+                    name: "test".into(),
+                    discriminator: 1432,
+                    ..User::default()
+                },
+                ..Default::default()
             }
         }
 
         fn gen() -> Guild {
-            let u = gen_user();
             let m = gen_member();
 
-            let hm1 = HashMap::new();
-            let hm2 = HashMap::new();
-            let vec1 = Vec::new();
-
-            let dt = Timestamp::now();
-
-            let mut hm3 = HashMap::new();
-            let hm4 = HashMap::new();
-            let hm5 = HashMap::new();
-            let hm6 = HashMap::new();
-            let hm7 = HashMap::new();
-
-            hm3.insert(u.id, m);
-
-            let notifications = DefaultMessageNotificationLevel::All;
-
             Guild {
-                afk_channel_id: Some(ChannelId::new(1)),
-                afk_timeout: 0,
-                channels: hm1,
-                default_message_notifications: notifications,
-                emojis: hm2,
-                features: vec1,
-                icon: Some("/avatars/210/a_aaa.webp?size=1024".to_string()),
-                id: GuildId::new(1),
-                joined_at: dt,
-                large: false,
-                member_count: 1,
-                members: hm3,
-                mfa_level: MfaLevel::Elevated,
-                name: "Spaghetti".to_string(),
-                owner_id: UserId::new(210),
-                presences: hm4,
-                roles: hm5,
-                splash: Some("asdf".to_string()),
-                verification_level: VerificationLevel::None,
-                voice_states: hm6,
-                description: None,
-                premium_tier: PremiumTier::Tier1,
-                application_id: Some(ApplicationId::new(1)),
-                explicit_content_filter: ExplicitContentFilter::None,
-                system_channel_id: Some(ChannelId::new(1)),
-                system_channel_flags: SystemChannelFlags::default(),
-                rules_channel_id: None,
-                premium_subscription_count: 12,
-                banner: None,
-                vanity_url_code: Some("bruhmoment".to_string()),
-                preferred_locale: "en-US".to_string(),
-                welcome_screen: None,
-                approximate_member_count: None,
-                approximate_presence_count: None,
-                nsfw_level: NsfwLevel::Default,
-                max_video_channel_users: None,
-                max_presences: None,
-                max_members: None,
-                widget_enabled: Some(false),
-                discovery_splash: None,
-                widget_channel_id: None,
-                public_updates_channel_id: None,
-                stage_instances: vec![],
-                threads: vec![],
-                stickers: hm7,
+                members: HashMap::from([(m.user.id, m)]),
+                ..Default::default()
             }
         }
 

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -2,21 +2,16 @@ enum_number! {
     /// The guild's premium tier, depends on the amount of users boosting the guild currently
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-premium-tier).
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum PremiumTier {
         /// No tier, considered None
+        #[default]
         Tier0 = 0,
         Tier1 = 1,
         Tier2 = 2,
         Tier3 = 3,
         _ => Unknown(u8),
-    }
-}
-
-impl Default for PremiumTier {
-    fn default() -> Self {
-        PremiumTier::Tier0
     }
 }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -26,7 +26,7 @@ use crate::utils::parse_role;
 /// permissions.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Role {
     /// The Id of the role. Can be used to calculate the role's creation date.

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -44,6 +44,17 @@ macro_rules! id_u64 {
                 }
             }
 
+            impl Default for $name {
+                fn default() -> Self {
+                    // Have the possible panic at compile time. `unwrap()` is not const-stable
+                    const ONE: NonZeroU64 = match NonZeroU64::new(1) {
+                        Some(x) => x,
+                        None => unreachable!(),
+                    };
+                    Self(ONE)
+                }
+            }
+
             // This is a hack so functions can accept iterators that either:
             // 1. return the id itself (e.g: `MessageId`)
             // 2. return a reference to it (`&MessageId`).

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -193,65 +193,20 @@ mod test {
     #[test]
     fn test_mention() {
         let channel = Channel::Guild(GuildChannel {
-            bitrate: None,
-            parent_id: None,
-            guild_id: GuildId::new(1),
-            kind: ChannelType::Text,
             id: ChannelId::new(4),
-            last_message_id: None,
-            last_pin_timestamp: None,
-            name: "a".to_string(),
-            permission_overwrites: vec![],
-            position: 1,
-            topic: None,
-            user_limit: None,
-            nsfw: false,
-            rate_limit_per_user: Some(0),
-            rtc_region: None,
-            video_quality_mode: None,
-            message_count: None,
-            member_count: None,
-            thread_metadata: None,
-            member: None,
-            default_auto_archive_duration: None,
+            ..Default::default()
         });
         let role = Role {
             id: RoleId::new(2),
-            guild_id: GuildId::new(1),
-            colour: Colour::ROSEWATER,
-            hoist: false,
-            managed: false,
-            mentionable: false,
-            name: "fake role".to_string(),
-            permissions: Permissions::empty(),
-            position: 1,
-            tags: RoleTags::default(),
-            icon: None,
-            unicode_emoji: None,
+            ..Default::default()
         };
         let user = User {
             id: UserId::new(6),
-            avatar: None,
-            bot: false,
-            discriminator: 4132,
-            name: "fake".to_string(),
-            public_flags: None,
-            banner: None,
-            accent_colour: None,
+            ..Default::default()
         };
         let member = Member {
-            deaf: false,
-            guild_id: GuildId::new(2),
-            joined_at: None,
-            mute: false,
-            nick: None,
-            roles: vec![],
             user: user.clone(),
-            pending: false,
-            premium_since: None,
-            permissions: None,
-            avatar: None,
-            communication_disabled_until: None,
+            ..Default::default()
         };
 
         assert_eq!(ChannelId::new(1).mention().to_string(), "<#1>");

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -57,7 +57,9 @@ mod imp {
     /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
     /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
     /// ```
-    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(
+        Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+    )]
     #[serde(transparent)]
     pub struct Timestamp(DateTime<Utc>);
 
@@ -231,6 +233,12 @@ mod imp {
     impl From<OffsetDateTime> for Timestamp {
         fn from(dt: OffsetDateTime) -> Self {
             Self(dt)
+        }
+    }
+
+    impl Default for Timestamp {
+        fn default() -> Self {
+            Self(OffsetDateTime::UNIX_EPOCH)
         }
     }
 }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -165,7 +165,7 @@ pub(crate) mod discriminator {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object).
 // TODO: replace this with User
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CurrentUser {
     pub id: UserId,
@@ -515,24 +515,6 @@ impl CurrentUser {
     }
 }
 
-impl Default for CurrentUser {
-    fn default() -> Self {
-        Self {
-            id: UserId::new(1),
-            avatar: None,
-            bot: Default::default(),
-            discriminator: Default::default(),
-            email: None,
-            mfa_enabled: Default::default(),
-            name: String::default(),
-            verified: None,
-            public_flags: None,
-            banner: None,
-            accent_colour: None,
-        }
-    }
-}
-
 /// An enum that represents a default avatar.
 ///
 /// The default avatar is calculated via the result of `discriminator % 5`.
@@ -572,7 +554,9 @@ impl DefaultAvatar {
 /// The representation of a user's status.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#update-presence-status-types).
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
 #[non_exhaustive]
 pub enum OnlineStatus {
     #[serde(rename = "dnd")]
@@ -584,6 +568,7 @@ pub enum OnlineStatus {
     #[serde(rename = "offline")]
     Offline,
     #[serde(rename = "online")]
+    #[default]
     Online,
 }
 
@@ -600,16 +585,10 @@ impl OnlineStatus {
     }
 }
 
-impl Default for OnlineStatus {
-    fn default() -> OnlineStatus {
-        OnlineStatus::Online
-    }
-}
-
 /// Information about a user.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct User {
     /// The unique Id of the user. Can be used to calculate the account's
@@ -680,28 +659,6 @@ bitflags! {
         const DISCORD_CERTIFIED_MODERATOR = 1 << 18;
         /// Bot's running with HTTP interactions
         const BOT_HTTP_INTERACTIONS = 1 << 19;
-    }
-}
-
-impl Default for User {
-    /// Initializes a [`User`] with default values. Setting the following:
-    /// - **id** to `UserId::new(210)`
-    /// - **avatar** to `Some("abc")`
-    /// - **bot** to `true`.
-    /// - **discriminator** to `1432`.
-    /// - **name** to `"test"`.
-    /// - **public_flags** to [`None`].
-    fn default() -> Self {
-        User {
-            id: UserId::new(210),
-            avatar: Some("abc".to_string()),
-            bot: true,
-            discriminator: 1432,
-            name: "test".to_string(),
-            public_flags: None,
-            banner: None,
-            accent_colour: None,
-        }
     }
 }
 
@@ -1260,11 +1217,18 @@ mod test {
 
     #[cfg(feature = "model")]
     mod model {
+        use crate::model::id::UserId;
         use crate::model::user::User;
 
         #[test]
         fn test_core() {
-            let mut user = User::default();
+            let mut user = User {
+                id: UserId::new(210),
+                avatar: Some("abc".to_string()),
+                discriminator: 1432,
+                name: "test".to_string(),
+                ..Default::default()
+            };
 
             assert!(user.avatar_url().unwrap().ends_with("/avatars/210/abc.webp?size=1024"));
             assert!(user.static_avatar_url().unwrap().ends_with("/avatars/210/abc.webp?size=1024"));

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -269,141 +269,48 @@ fn clean_mention(
 #[allow(clippy::non_ascii_literal)]
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     use super::*;
     use crate::model::channel::*;
-    use crate::model::colour::Colour;
     use crate::model::guild::*;
     use crate::model::id::{ChannelId, RoleId, UserId};
     use crate::model::user::User;
-    use crate::model::{Permissions, Timestamp};
 
     #[test]
     fn test_content_safe() {
         let user = User {
             id: UserId::new(100000000000000000),
-            avatar: None,
-            bot: false,
-            discriminator: 0000,
             name: "Crab".to_string(),
-            public_flags: None,
-            banner: None,
-            accent_colour: None,
+            ..Default::default()
         };
 
         let outside_cache_user = User {
             id: UserId::new(100000000000000001),
-            avatar: None,
-            bot: false,
-            discriminator: 0000,
             name: "Boat".to_string(),
-            public_flags: None,
-            banner: None,
-            accent_colour: None,
+            ..Default::default()
         };
 
         let mut guild = Guild {
-            afk_channel_id: None,
-            afk_timeout: 0,
-            application_id: None,
-            channels: HashMap::new(),
-            default_message_notifications: DefaultMessageNotificationLevel::All,
-            emojis: HashMap::new(),
-            explicit_content_filter: ExplicitContentFilter::None,
-            features: Vec::new(),
-            icon: None,
             id: GuildId::new(381880193251409931),
-            joined_at: Timestamp::now(),
-            large: false,
-            member_count: 1,
-            members: HashMap::new(),
-            mfa_level: MfaLevel::None,
-            name: "serenity".to_string(),
-            owner_id: UserId::new(114941315417899012),
-            presences: HashMap::new(),
-            roles: HashMap::new(),
-            splash: None,
-            discovery_splash: None,
-            system_channel_id: None,
-            system_channel_flags: SystemChannelFlags::default(),
-            rules_channel_id: None,
-            public_updates_channel_id: None,
-            verification_level: VerificationLevel::None,
-            voice_states: HashMap::new(),
-            description: None,
-            premium_tier: PremiumTier::Tier0,
-            premium_subscription_count: 0,
-            banner: None,
-            vanity_url_code: Some("bruhmoment1".to_string()),
-            preferred_locale: "en-US".to_string(),
-            welcome_screen: None,
-            approximate_member_count: None,
-            approximate_presence_count: None,
-            nsfw_level: NsfwLevel::Default,
-            max_video_channel_users: None,
-            max_presences: None,
-            max_members: None,
-            widget_enabled: Some(false),
-            widget_channel_id: None,
-            stage_instances: vec![],
-            threads: vec![],
-            stickers: HashMap::new(),
+            ..Default::default()
         };
 
         let member = Member {
-            deaf: false,
-            guild_id: guild.id,
-            joined_at: None,
-            mute: false,
             nick: Some("Ferris".to_string()),
-            roles: Vec::new(),
-            user: user.clone(),
-            pending: false,
-            premium_since: None,
-            permissions: None,
-            avatar: None,
-            communication_disabled_until: None,
+            ..Default::default()
         };
 
         let role = Role {
             id: RoleId::new(333333333333333333),
-            colour: Colour::ORANGE,
-            guild_id: guild.id,
-            hoist: true,
-            managed: false,
-            mentionable: true,
             name: "ferris-club-member".to_string(),
-            permissions: Permissions::all(),
-            position: 0,
-            tags: RoleTags::default(),
-            icon: None,
-            unicode_emoji: None,
+            ..Default::default()
         };
 
         let channel = GuildChannel {
             id: ChannelId::new(111880193700067777),
-            bitrate: None,
-            parent_id: None,
-            guild_id: guild.id,
-            kind: ChannelType::Text,
-            last_message_id: None,
-            last_pin_timestamp: None,
             name: "general".to_string(),
-            permission_overwrites: Vec::new(),
-            position: 0,
-            topic: None,
-            user_limit: None,
-            nsfw: false,
-            rate_limit_per_user: Some(0),
-            rtc_region: None,
-            video_quality_mode: None,
-            message_count: None,
-            member_count: None,
-            thread_metadata: None,
-            member: None,
-            default_auto_archive_duration: None,
+            ..Default::default()
         };
 
         let cache = Arc::new(Cache::default());

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -6,7 +6,7 @@ use crate::model::Timestamp;
 /// but you don't have a message in hand, or just have a fragment of its data.
 ///
 /// [`dispatch`]: crate::framework::Framework::dispatch
-#[derive(Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct CustomMessage {
     msg: Message,
 }
@@ -224,57 +224,5 @@ impl CustomMessage {
     #[must_use]
     pub fn build(self) -> Message {
         self.msg
-    }
-}
-
-impl Default for CustomMessage {
-    #[inline]
-    fn default() -> Self {
-        CustomMessage {
-            msg: dummy_message(),
-        }
-    }
-}
-
-#[inline]
-fn dummy_message() -> Message {
-    Message {
-        id: MessageId::new(1),
-        attachments: Vec::new(),
-        author: User {
-            id: UserId::new(1),
-            avatar: None,
-            bot: false,
-            discriminator: 0x0000,
-            name: String::new(),
-            public_flags: None,
-            banner: None,
-            accent_colour: None,
-        },
-        channel_id: ChannelId::new(1),
-        content: String::new(),
-        edited_timestamp: None,
-        embeds: Vec::new(),
-        guild_id: None,
-        kind: MessageType::Regular,
-        member: None,
-        mention_everyone: false,
-        mention_roles: Vec::new(),
-        mention_channels: Vec::new(),
-        mentions: Vec::new(),
-        nonce: None,
-        pinned: false,
-        reactions: Vec::new(),
-        tts: false,
-        webhook_id: None,
-        timestamp: Timestamp::now(),
-        activity: None,
-        application: None,
-        message_reference: None,
-        flags: None,
-        sticker_items: Vec::new(),
-        referenced_message: None,
-        interaction: None,
-        components: vec![],
     }
 }


### PR DESCRIPTION
Some model types already had Default implementations. I added more Default impls; to all model types that are constructed in tests. Leveraging Default shortens the tests a lot. And it's also useful for end users as placeholder values or to use model types in places that require Default, like the tinyvec crate.