### PR TITLE
Implement custom_ids filter for CollectorBuilder

### DIFF
--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -42,7 +42,7 @@ impl super::CollectorBuilder<'_, MessageComponentInteraction> {
     impl_channel_id!("Sets the channel on which the interaction must occur. If an interaction is not on a message with this channel ID, it won't be received.");
     impl_guild_id!("Sets the guild in which the interaction must occur. If an interaction is not on a message with this guild ID, it won't be received.");
     impl_message_id!("Sets the message on which the interaction must occur. If an interaction is not on a message with this ID, it won't be received.");
-    impl_custom_ids!("Sets acceptable custom IDs for the interaction. If an interaction does not contain one of the custom IDs, it won't be recieved.");
+    impl_custom_ids!("Sets acceptable custom IDs for the interaction. If an interaction does not contain one of the custom IDs, it won't be received.");
     impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received.");
 }
 

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -17,6 +17,11 @@ impl FilterTrait<MessageComponentInteraction> for Filter<MessageComponentInterac
         interaction: &mut LazyArc<'_, MessageComponentInteraction>,
     ) -> bool {
         self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id)
+            && self
+                .options
+                .custom_ids
+                .as_ref()
+                .map_or(true, |id| id.contains(&interaction.data.custom_id))
             && self.options.message_id.map_or(true, |id| interaction.message.id == id)
             && self.options.channel_id.map_or(true, |id| id == interaction.channel_id)
             && self.options.author_id.map_or(true, |id| id == interaction.user.id)
@@ -30,13 +35,15 @@ pub struct FilterOptions {
     guild_id: Option<GuildId>,
     author_id: Option<UserId>,
     message_id: Option<MessageId>,
+    custom_ids: Option<Vec<String>>,
 }
 
 impl super::CollectorBuilder<'_, MessageComponentInteraction> {
     impl_channel_id!("Sets the channel on which the interaction must occur. If an interaction is not on a message with this channel ID, it won't be received.");
     impl_guild_id!("Sets the guild in which the interaction must occur. If an interaction is not on a message with this guild ID, it won't be received.");
     impl_message_id!("Sets the message on which the interaction must occur. If an interaction is not on a message with this ID, it won't be received.");
-    impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received");
+    impl_custom_ids!("Sets acceptable custom IDs for the interaction. If an interaction does not contain one of the custom IDs, it won't be recieved.");
+    impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received.");
 }
 
 #[nougat::gat]

--- a/src/collector/macros.rs
+++ b/src/collector/macros.rs
@@ -1,48 +1,22 @@
 macro_rules! gen_macro {
-    ($name:ident, $function:item) => {
+    ($name:ident, $function_name:ident, $type_name:ty) => {
         macro_rules! $name {
             ($doc:literal) => {
                 #[doc=$doc]
-                $function
+                pub fn $function_name(mut self, $function_name: $type_name) -> Self {
+                    self.filter_options.$function_name = Some($function_name);
+
+                    self
+                }
             };
         }
     };
 }
 
-gen_macro!(
-    impl_author_id,
-    pub fn author_id(mut self, author_id: UserId) -> Self {
-        self.filter_options.author_id = Some(author_id);
+gen_macro!(impl_guild_id, guild_id, GuildId);
+gen_macro!(impl_author_id, author_id, UserId);
+gen_macro!(impl_message_id, message_id, MessageId);
+gen_macro!(impl_channel_id, channel_id, ChannelId);
+gen_macro!(impl_custom_ids, custom_ids, Vec<String>);
 
-        self
-    }
-);
-
-gen_macro!(
-    impl_channel_id,
-    pub fn channel_id(mut self, channel_id: ChannelId) -> Self {
-        self.filter_options.channel_id = Some(channel_id);
-
-        self
-    }
-);
-
-gen_macro!(
-    impl_guild_id,
-    pub fn guild_id(mut self, guild_id: GuildId) -> Self {
-        self.filter_options.guild_id = Some(guild_id);
-
-        self
-    }
-);
-
-gen_macro!(
-    impl_message_id,
-    pub fn message_id(mut self, message_id: MessageId) -> Self {
-        self.filter_options.message_id = Some(message_id);
-
-        self
-    }
-);
-
-pub(super) use {impl_author_id, impl_channel_id, impl_guild_id, impl_message_id};
+pub(super) use {impl_author_id, impl_channel_id, impl_custom_ids, impl_guild_id, impl_message_id};

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -42,7 +42,7 @@ impl super::CollectorBuilder<'_, ModalSubmitInteraction> {
     impl_channel_id!("Sets the channel on which the interaction must occur. If an interaction is not on a message with this channel ID, it won't be received.");
     impl_guild_id!("Sets the guild in which the interaction must occur. If an interaction is not on a message with this guild ID, it won't be received.");
     impl_message_id!("Sets the message on which the interaction must occur. If an interaction is not on a message with this ID, it won't be received.");
-    impl_custom_ids!("Sets acceptable custom IDs for the interaction. If an interaction does not contain one of the custom IDs, it won't be recieved.");
+    impl_custom_ids!("Sets acceptable custom IDs for the interaction. If an interaction does not contain one of the custom IDs, it won't be received.");
     impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received.");
 }
 

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -16,6 +16,11 @@ impl super::FilterTrait<ModalSubmitInteraction> for Filter<ModalSubmitInteractio
         self.options.guild_id.map_or(true, |id| Some(id) == interaction.guild_id)
             && self
                 .options
+                .custom_ids
+                .as_ref()
+                .map_or(true, |id| id.contains(&interaction.data.custom_id))
+            && self
+                .options
                 .message_id
                 .map_or(true, |id| Some(id) == interaction.message.as_ref().map(|m| m.id))
             && self.options.channel_id.map_or(true, |id| id == interaction.channel_id)
@@ -30,13 +35,15 @@ pub struct FilterOptions {
     guild_id: Option<GuildId>,
     author_id: Option<UserId>,
     message_id: Option<MessageId>,
+    custom_ids: Option<Vec<String>>,
 }
 
 impl super::CollectorBuilder<'_, ModalSubmitInteraction> {
     impl_channel_id!("Sets the channel on which the interaction must occur. If an interaction is not on a message with this channel ID, it won't be received.");
     impl_guild_id!("Sets the guild in which the interaction must occur. If an interaction is not on a message with this guild ID, it won't be received.");
     impl_message_id!("Sets the message on which the interaction must occur. If an interaction is not on a message with this ID, it won't be received.");
-    impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received");
+    impl_custom_ids!("Sets acceptable custom IDs for the interaction. If an interaction does not contain one of the custom IDs, it won't be recieved.");
+    impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received.");
 }
 
 #[nougat::gat]


### PR DESCRIPTION
Implements a built-in filter to avoid having to use the filter function for the common use of just checking custom IDs.
This also deduplicates calls of macro that generates the setter macros. 

Thanks jepcd#0837 for the idea on the serenity server.