### PR TITLE
Reduce extra clones in the http module

### DIFF
--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -119,7 +119,7 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
         // We could also pattern-match the reaction in case we want
         // to handle added or removed reactions.
         // In this case we will just get the inner reaction.
-        let _ = if reaction.as_inner_ref().emoji.as_data() == "1" {
+        let _ = if reaction.as_inner_ref().emoji.as_data() == "1️⃣" {
             score += 1;
             msg.reply(ctx, "That's correct!").await
         } else {

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -119,14 +119,11 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
         // We could also pattern-match the reaction in case we want
         // to handle added or removed reactions.
         // In this case we will just get the inner reaction.
-        let emoji = &reaction.as_inner_ref().emoji;
-
-        let _ = match emoji.as_data().as_str() {
-            "1️⃣" => {
-                score += 1;
-                msg.reply(ctx, "That's correct!").await
-            },
-            _ => msg.reply(ctx, "Wrong!").await,
+        let _ = if reaction.as_inner_ref().emoji.as_data() == "1" {
+            score += 1;
+            msg.reply(ctx, "That's correct!").await
+        } else {
+            msg.reply(ctx, "Wrong!").await
         };
     } else {
         let _ = msg.reply(ctx, "No reaction within 10 seconds.").await;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3427,7 +3427,7 @@ impl Http {
             multipart: None,
             headers: None,
             route: RouteInfo::GetMessages {
-                query: query.to_owned(),
+                query,
                 channel_id,
             },
         })
@@ -3473,8 +3473,6 @@ impl Http {
         limit: u8,
         after: Option<u64>,
     ) -> Result<Vec<User>> {
-        let reaction = reaction_type.as_data();
-
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3484,7 +3482,7 @@ impl Http {
                 channel_id,
                 limit,
                 message_id,
-                reaction,
+                reaction: &reaction_type.as_data(),
             },
         })
         .await

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -26,18 +26,20 @@ impl Multipart {
             // For endpoints that require a single file (e.g. create sticker),
             // it will error if the part name is not `file`.
             // https://github.com/discord/discord-api-docs/issues/2064#issuecomment-691650970
-            let part_name =
-                if file_num == 0 { "file".to_string() } else { format!("file{file_num}") };
+            let part_name = if file_num == 0 {
+                Cow::Borrowed("file")
+            } else {
+                Cow::Owned(format!("file{file_num}"))
+            };
 
             let mut part = Part::bytes(file.data);
-            let filename = file.filename;
-            part = guess_mime_str(part, &filename)?;
-            part = part.file_name(filename);
+            part = guess_mime_str(part, &file.filename)?;
+            part = part.file_name(file.filename);
             multipart = multipart.part(part_name, part);
         }
 
-        for (name, value) in &self.fields {
-            multipart = multipart.text(name.clone(), value.clone());
+        for (name, value) in self.fields {
+            multipart = multipart.text(name, value);
         }
 
         if let Some(payload_json) = self.payload_json {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -937,7 +937,7 @@ impl Route {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum RouteInfo<'a> {
     AddGuildMember {
@@ -1435,7 +1435,7 @@ pub enum RouteInfo<'a> {
     },
     GetMessages {
         channel_id: ChannelId,
-        query: String,
+        query: &'a str,
     },
     GetPins {
         channel_id: ChannelId,
@@ -1445,7 +1445,7 @@ pub enum RouteInfo<'a> {
         channel_id: ChannelId,
         limit: u8,
         message_id: MessageId,
-        reaction: String,
+        reaction: &'a str,
     },
     GetSticker {
         sticker_id: StickerId,
@@ -1519,8 +1519,8 @@ pub enum RouteInfo<'a> {
 
 impl<'a> RouteInfo<'a> {
     #[must_use]
-    pub fn deconstruct(&self) -> (LightMethod, Route, Cow<'_, str>) {
-        match *self {
+    pub fn deconstruct(self) -> (LightMethod, Route, Cow<'static, str>) {
+        match self {
             RouteInfo::AddGuildMember {
                 guild_id,
                 user_id,
@@ -2545,7 +2545,7 @@ impl<'a> RouteInfo<'a> {
             ),
             RouteInfo::GetMessages {
                 channel_id,
-                ref query,
+                query,
             } => (
                 LightMethod::Get,
                 Route::ChannelsIdMessages(channel_id),
@@ -2563,7 +2563,7 @@ impl<'a> RouteInfo<'a> {
                 channel_id,
                 limit,
                 message_id,
-                ref reaction,
+                reaction,
             } => (
                 LightMethod::Get,
                 Route::ChannelsIdMessagesIdReactions(channel_id),

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "model")]
+use std::borrow::Cow;
+#[cfg(feature = "model")]
 use std::cmp::Ordering;
 use std::convert::TryFrom;
 #[cfg(doc)]
@@ -393,16 +395,14 @@ impl ReactionType {
     /// likely little use for it.
     #[inline]
     #[must_use]
-    pub fn as_data(&self) -> String {
+    pub fn as_data(&self) -> Cow<'_, str> {
         match self {
             ReactionType::Custom {
                 id,
                 name,
                 ..
-            } => {
-                format!("{}:{id}", name.as_deref().unwrap_or(""))
-            },
-            ReactionType::Unicode(unicode) => unicode.clone(),
+            } => format!("{}:{id}", name.as_deref().unwrap_or("")).into(),
+            ReactionType::Unicode(unicode) => unicode.into(),
         }
     }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "model")]
 use std::borrow::Cow;
 #[cfg(feature = "model")]
 use std::cmp::Ordering;


### PR DESCRIPTION
This is a revamp of #2071 based on top of the new changes to next, as the old PR had gotten stale. We pass around owned data to reduce clones. Also, removing any last uses of `String` in `RouteInfo` lets us mark it `Copy`, improving ergonomics.