### PR TITLE
Add `defer_ephemeral` helper function

### DIFF
--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -309,6 +309,21 @@ impl ApplicationCommandInteraction {
         })
         .await
     }
+
+    /// Helper function to defer an interaction ephemerally
+    ///
+    /// # Errors
+    ///
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    pub async fn defer_ephemeral(&self, http: impl AsRef<Http>) -> Result<()> {
+        self.create_interaction_response(http, |f| {
+            f.kind(InteractionResponseType::DeferredChannelMessageWithSource)
+                .interaction_response_data(|f| f.ephemeral(true))
+        })
+        .await
+    }
 }
 
 impl<'de> Deserialize<'de> for ApplicationCommandInteraction {


### PR DESCRIPTION
Since it is such a small addition I decided to create a PR for #2222 .

I think this is just a neat helper function for sending deferred replys as ephemeral messages.

- fixes #2222 