### PR TITLE
Use `pub use X::*` in builder/mod.rs

### DIFF
--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use application::command::CommandOptionChoice;
+
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::*;
@@ -7,13 +9,6 @@ use crate::internal::prelude::*;
 use crate::model::application::command::Command;
 use crate::model::application::command::{CommandOptionType, CommandType};
 use crate::model::prelude::*;
-
-#[derive(Clone, Debug, Serialize)]
-pub struct CommandOptionChoice {
-    name: String,
-    value: Value,
-    name_localizations: HashMap<String, String>,
-}
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
@@ -163,7 +158,7 @@ impl CreateApplicationCommandOption {
         self.add_choice(CommandOptionChoice {
             name: name.into(),
             value: Value::from(value),
-            name_localizations: HashMap::new(),
+            name_localizations: None,
         })
     }
 
@@ -177,7 +172,9 @@ impl CreateApplicationCommandOption {
         self.add_choice(CommandOptionChoice {
             name: name.into(),
             value: Value::from(value),
-            name_localizations: locales.into_iter().map(|(l, n)| (l.into(), n.into())).collect(),
+            name_localizations: Some(
+                locales.into_iter().map(|(l, n)| (l.into(), n.into())).collect(),
+            ),
         })
     }
 
@@ -189,7 +186,7 @@ impl CreateApplicationCommandOption {
         self.add_choice(CommandOptionChoice {
             name: name.into(),
             value: Value::String(value.into()),
-            name_localizations: HashMap::new(),
+            name_localizations: None,
         })
     }
 
@@ -203,7 +200,9 @@ impl CreateApplicationCommandOption {
         self.add_choice(CommandOptionChoice {
             name: name.into(),
             value: Value::String(value.into()),
-            name_localizations: locales.into_iter().map(|(l, n)| (l.into(), n.into())).collect(),
+            name_localizations: Some(
+                locales.into_iter().map(|(l, n)| (l.into(), n.into())).collect(),
+            ),
         })
     }
 
@@ -215,7 +214,7 @@ impl CreateApplicationCommandOption {
         self.add_choice(CommandOptionChoice {
             name: name.into(),
             value: Value::from(value),
-            name_localizations: HashMap::new(),
+            name_localizations: None,
         })
     }
 
@@ -229,7 +228,9 @@ impl CreateApplicationCommandOption {
         self.add_choice(CommandOptionChoice {
             name: name.into(),
             value: Value::from(value),
-            name_localizations: locales.into_iter().map(|(l, n)| (l.into(), n.into())).collect(),
+            name_localizations: Some(
+                locales.into_iter().map(|(l, n)| (l.into(), n.into())).collect(),
+            ),
         })
     }
 

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -91,18 +91,21 @@ pub struct CreateGuildWelcomeChannel {
 
 impl CreateGuildWelcomeChannel {
     /// The Id of the channel to show. It is required.
+    #[must_use]
     pub fn id(mut self, id: impl Into<ChannelId>) -> Self {
         self.channel_id = Some(id.into());
         self
     }
 
     /// The description shown for the channel. It is required.
+    #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }
 
     /// The emoji shown for the channel.
+    #[must_use]
     pub fn emoji(mut self, emoji: GuildWelcomeChannelEmoji) -> Self {
         match emoji {
             GuildWelcomeChannelEmoji::Unicode(name) => {

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -9,17 +9,15 @@
 // #[serde(skip_serializing_if = "Option::is_none")]
 #![allow(clippy::option_option)]
 
-mod create_channel;
-mod create_embed;
-
-mod create_application_command;
-mod create_application_command_permission;
-
 mod add_member;
 mod bot_auth_parameters;
 mod create_allowed_mentions;
+mod create_application_command;
+mod create_application_command_permission;
 mod create_attachment;
+mod create_channel;
 mod create_components;
+mod create_embed;
 mod create_interaction_response;
 mod create_interaction_response_followup;
 mod create_invite;
@@ -49,59 +47,40 @@ mod edit_webhook_message;
 mod execute_webhook;
 mod get_messages;
 
-pub use self::add_member::AddMember;
-pub use self::bot_auth_parameters::CreateBotAuthParameters;
-pub use self::create_allowed_mentions::CreateAllowedMentions;
-pub use self::create_application_command::{
-    CreateApplicationCommand,
-    CreateApplicationCommandOption,
-};
-pub use self::create_application_command_permission::{
-    CreateApplicationCommandPermissionData,
-    CreateApplicationCommandPermissionsData,
-};
-pub use self::create_attachment::CreateAttachment;
-pub(crate) use self::create_attachment::ExistingAttachment;
-pub use self::create_channel::CreateChannel;
-pub use self::create_components::{
-    CreateActionRow,
-    CreateButton,
-    CreateComponents,
-    CreateInputText,
-    CreateSelectMenu,
-    CreateSelectMenuOption,
-};
-pub use self::create_embed::{CreateEmbed, CreateEmbedAuthor, CreateEmbedFooter};
-pub use self::create_interaction_response::{
-    AutocompleteChoice,
-    CreateAutocompleteResponse,
-    CreateInteractionResponse,
-    CreateInteractionResponseData,
-};
-pub use self::create_interaction_response_followup::CreateInteractionResponseFollowup;
-pub use self::create_invite::CreateInvite;
-pub use self::create_message::CreateMessage;
-pub use self::create_scheduled_event::CreateScheduledEvent;
-pub use self::create_stage_instance::CreateStageInstance;
-pub use self::create_sticker::CreateSticker;
-pub use self::create_thread::CreateThread;
-pub use self::create_webhook::CreateWebhook;
-pub use self::edit_automod_rule::EditAutoModRule;
-pub use self::edit_channel::EditChannel;
-pub use self::edit_guild::EditGuild;
-pub use self::edit_guild_welcome_screen::EditGuildWelcomeScreen;
-pub use self::edit_guild_widget::EditGuildWidget;
-pub use self::edit_interaction_response::EditInteractionResponse;
-pub use self::edit_member::EditMember;
-pub use self::edit_message::EditMessage;
-pub use self::edit_profile::EditProfile;
-pub use self::edit_role::EditRole;
-pub use self::edit_scheduled_event::EditScheduledEvent;
-pub use self::edit_stage_instance::EditStageInstance;
-pub use self::edit_sticker::EditSticker;
-pub use self::edit_thread::EditThread;
-pub use self::edit_voice_state::EditVoiceState;
-pub use self::edit_webhook::EditWebhook;
-pub use self::edit_webhook_message::EditWebhookMessage;
-pub use self::execute_webhook::ExecuteWebhook;
-pub use self::get_messages::{GetMessages, SearchFilter};
+pub use add_member::*;
+pub use bot_auth_parameters::*;
+pub use create_allowed_mentions::*;
+pub use create_application_command::*;
+pub use create_application_command_permission::*;
+pub use create_attachment::*;
+pub use create_channel::*;
+pub use create_components::*;
+pub use create_embed::*;
+pub use create_interaction_response::*;
+pub use create_interaction_response_followup::*;
+pub use create_invite::*;
+pub use create_message::*;
+pub use create_scheduled_event::*;
+pub use create_stage_instance::*;
+pub use create_sticker::*;
+pub use create_thread::*;
+pub use create_webhook::*;
+pub use edit_automod_rule::*;
+pub use edit_channel::*;
+pub use edit_guild::*;
+pub use edit_guild_welcome_screen::*;
+pub use edit_guild_widget::*;
+pub use edit_interaction_response::*;
+pub use edit_member::*;
+pub use edit_message::*;
+pub use edit_profile::*;
+pub use edit_role::*;
+pub use edit_scheduled_event::*;
+pub use edit_stage_instance::*;
+pub use edit_sticker::*;
+pub use edit_thread::*;
+pub use edit_voice_state::*;
+pub use edit_webhook::*;
+pub use edit_webhook_message::*;
+pub use execute_webhook::*;
+pub use get_messages::*;


### PR DESCRIPTION
I compared the builder module docs before and after:

![Screenshot_20221021_154019](https://user-images.githubusercontent.com/21220820/197210478-57dd49a9-f590-4c0a-b0cd-b643b741bd2a.png)

CommandOptionChoice was a duplicate definition in create_application_command.rs; I removed it in favor of the canonical CommandOptionChoice from the model module.

CreateGuildWelcomeChannel was falsely not re-exported and meant that the welcome channels functionality of EditGuildWelcomeScreen [was unusable](https://docs.rs/serenity/0.11.5/serenity/builder/struct.EditGuildWelcomeScreen.html#method.add_welcome_channel) (see why I wanted to make this PR?)