### PR TITLE
Make CreateActionRow an enum

### DIFF
--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -23,7 +23,7 @@ fn sound_button(name: &str, emoji: ReactionType) -> CreateButton {
     // To add an emoji to buttons, use .emoji(). The method accepts anything ReactionType or
     // anything that can be converted to it. For a list of that, search Trait Implementations in the
     // docs for From<...>.
-    CreateButton::new(ButtonStyle::Primary, name).emoji(emoji).label(name)
+    CreateButton::new(name, ButtonStyle::Primary, name).emoji(emoji)
 }
 
 struct Handler;
@@ -43,7 +43,7 @@ impl EventHandler for Handler {
                 CreateMessage::new().content("Please select your favorite animal").components(
                     CreateComponents::new().set_action_row(
                         // An action row can only contain one select menu!
-                        CreateActionRow::new().add_select_menu(
+                        CreateActionRow::SelectMenu(
                             CreateSelectMenu::new("animal_select", vec![
                                 CreateSelectMenuOption::new("🐈 meow", "Cat"),
                                 CreateSelectMenuOption::new("🐕 woof", "Dog"),
@@ -89,30 +89,26 @@ impl EventHandler for Handler {
                     .interaction_response_data(
                         CreateInteractionResponseData::default()
                             .content(format!("You chose: **{}**\nNow choose a sound!", animal))
-                            .components(
-                                CreateComponents::default().set_action_row(
-                                    CreateActionRow::default()
-                                        // add_XXX methods are an alternative to create_XXX methods
-                                        .add_button(sound_button("meow", "🐈".parse().unwrap()))
-                                        .add_button(sound_button("woof", "🐕".parse().unwrap()))
-                                        .add_button(sound_button("neigh", "🐎".parse().unwrap()))
-                                        .add_button(sound_button(
-                                            "hoooooooonk",
-                                            "🦙".parse().unwrap(),
-                                        ))
-                                        .add_button(sound_button(
-                                            "crab rave",
-                                            // Custom emojis in Discord are represented with
-                                            // `<:EMOJI_NAME:EMOJI_ID>`. You can see this by
-                                            // posting an emoji in your server and putting a backslash
-                                            // before the emoji.
-                                            //
-                                            // Because ReactionType implements FromStr, we can use .parse()
-                                            // to convert the textual emoji representation to ReactionType
-                                            "<:ferris:381919740114763787>".parse().unwrap(),
-                                        )),
-                                ),
-                            ),
+                            .components(CreateComponents::default().set_action_row(
+                                CreateActionRow::Buttons(vec![
+                                    // add_XXX methods are an alternative to create_XXX methods
+                                    sound_button("meow", "🐈".parse().unwrap()),
+                                    sound_button("woof", "🐕".parse().unwrap()),
+                                    sound_button("neigh", "🐎".parse().unwrap()),
+                                    sound_button("hoooooooonk", "🦙".parse().unwrap()),
+                                    sound_button(
+                                        "crab rave",
+                                        // Custom emojis in Discord are represented with
+                                        // `<:EMOJI_NAME:EMOJI_ID>`. You can see this by
+                                        // posting an emoji in your server and putting a backslash
+                                        // before the emoji.
+                                        //
+                                        // Because ReactionType implements FromStr, we can use .parse()
+                                        // to convert the textual emoji representation to ReactionType
+                                        "<:ferris:381919740114763787>".parse().unwrap(),
+                                    ),
+                                ]),
+                            )),
                     ),
             )
             .await

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,4 +1,5 @@
 use serenity::builder::*;
+use serenity::model::prelude::component::ButtonStyle;
 use serenity::model::prelude::interaction::application_command::*;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
@@ -70,6 +71,33 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             .edit(
                 ctx,
                 EditChannel::new().name("new-channel-name").audit_log_reason("hello\nworld\n🙂"),
+            )
+            .await?;
+    } else if msg.content == "actionrow" {
+        channel_id
+            .send_message(
+                ctx,
+                CreateMessage::new().components(
+                    CreateComponents::new()
+                        .add_action_row(CreateActionRow::Buttons(vec![
+                            CreateButton::new("foo", ButtonStyle::Primary, "0"),
+                            CreateButton::new("bar", ButtonStyle::Secondary, "1"),
+                            CreateButton::new_link("baz", "https://google.com"),
+                        ]))
+                        // ONLY VALID IN MODALS
+                        // .add_action_row(CreateActionRow::InputText(CreateInputText::new(
+                        //     InputTextStyle::Short,
+                        //     "hi",
+                        //     "2",
+                        // )))
+                        .add_action_row(CreateActionRow::SelectMenu(CreateSelectMenu::new(
+                            "3",
+                            vec![
+                                CreateSelectMenuOption::new("foo", "foo"),
+                                CreateSelectMenuOption::new("bar", "bar"),
+                            ],
+                        ))),
+                ),
             )
             .await?;
     } else {

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -39,56 +39,31 @@ impl CreateComponents {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-#[serde(untagged)]
-enum ComponentBuilder {
-    Button(CreateButton),
-    SelectMenu(CreateSelectMenu),
-    InputText(CreateInputText),
-}
-
 /// A builder for creating an [`ActionRow`].
 ///
 /// [`ActionRow`]: crate::model::application::component::ActionRow
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 #[must_use]
-pub struct CreateActionRow {
-    components: Vec<ComponentBuilder>,
-    #[serde(rename = "type")]
-    kind: u8,
+pub enum CreateActionRow {
+    Buttons(Vec<CreateButton>),
+    SelectMenu(CreateSelectMenu),
+    /// Only valid in modals!
+    InputText(CreateInputText),
 }
 
-impl Default for CreateActionRow {
-    fn default() -> Self {
-        CreateActionRow {
-            components: Vec::new(),
-            kind: 1,
-        }
-    }
-}
+impl serde::Serialize for CreateActionRow {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::Error as _;
 
-impl CreateActionRow {
-    /// Equivalent to [`Self::default`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Adds a button.
-    pub fn add_button(mut self, button: CreateButton) -> Self {
-        self.components.push(ComponentBuilder::Button(button));
-        self
-    }
-
-    /// Adds a select menu.
-    pub fn add_select_menu(mut self, menu: CreateSelectMenu) -> Self {
-        self.components.push(ComponentBuilder::SelectMenu(menu));
-        self
-    }
-
-    /// Adds an input text.
-    pub fn add_input_text(mut self, input_text: CreateInputText) -> Self {
-        self.components.push(ComponentBuilder::InputText(input_text));
-        self
+        serde_json::json!({
+            "type": 1,
+            "components": match self {
+                Self::Buttons(x) => serde_json::to_value(x).map_err(S::Error::custom)?,
+                Self::SelectMenu(x) => serde_json::to_value(vec![x]).map_err(S::Error::custom)?,
+                Self::InputText(x) => serde_json::to_value(vec![x]).map_err(S::Error::custom)?,
+            }
+        })
+        .serialize(serializer)
     }
 }
 
@@ -101,27 +76,27 @@ pub struct CreateButton(Button);
 
 impl CreateButton {
     /// Creates a link button to the given URL.
-    pub fn new_link(url: impl Into<String>) -> Self {
+    pub fn new_link(label: impl Into<String>, url: impl Into<String>) -> Self {
         Self(Button {
             kind: ComponentType::Button,
             data: ButtonKind::Link {
                 url: url.into(),
             },
-            label: None,
+            label: label.into(),
             emoji: None,
             disabled: false,
         })
     }
 
     /// Creates a normal button with the given custom ID
-    pub fn new(style: ButtonStyle, custom_id: impl Into<String>) -> Self {
+    pub fn new(label: impl Into<String>, style: ButtonStyle, custom_id: impl Into<String>) -> Self {
         Self(Button {
             kind: ComponentType::Button,
             data: ButtonKind::NonLink {
                 style,
                 custom_id: custom_id.into(),
             },
-            label: None,
+            label: label.into(),
             emoji: None,
             disabled: false,
         })
@@ -129,7 +104,7 @@ impl CreateButton {
 
     /// The label of the button.
     pub fn label(mut self, label: impl Into<String>) -> Self {
-        self.0.label = Some(label.into());
+        self.0.label = label.into();
         self
     }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -117,7 +117,7 @@ where
     // test deserialization
     let deserialized = from_value::<T>(json).unwrap();
     assert!(
-        &deserialized != data,
+        &deserialized == data,
         "JSON->data deserialization failed\nexpected: {data:?}\n     got: {deserialized:?}"
     );
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -109,15 +109,17 @@ where
 {
     // test serialization
     let serialized = to_value(data).unwrap();
-    if serialized != json {
-        panic!("data->JSON serialization failed\nexpected: {json:?}\n     got: {serialized:?}");
-    }
+    assert!(
+        serialized == json,
+        "data->JSON serialization failed\nexpected: {json:?}\n     got: {serialized:?}"
+    );
 
     // test deserialization
     let deserialized = from_value::<T>(json).unwrap();
-    if &deserialized != data {
-        panic!("JSON->data deserialization failed\nexpected: {data:?}\n     got: {deserialized:?}");
-    }
+    assert!(
+        &deserialized != data,
+        "JSON->data deserialization failed\nexpected: {data:?}\n     got: {deserialized:?}"
+    );
 }
 
 pub mod prelude {

--- a/src/json.rs
+++ b/src/json.rs
@@ -102,12 +102,22 @@ where
 }
 
 #[cfg(test)]
+#[track_caller]
 pub(crate) fn assert_json<T>(data: &T, json: crate::json::Value)
 where
     T: serde::Serialize + for<'de> serde::Deserialize<'de> + PartialEq + std::fmt::Debug,
 {
-    assert_eq!(to_value(data).unwrap(), json); // test deserialization
-    assert_eq!(&from_value::<T>(json).unwrap(), data); // test deserialization
+    // test serialization
+    let serialized = to_value(data).unwrap();
+    if serialized != json {
+        panic!("data->JSON serialization failed\nexpected: {json:?}\n     got: {serialized:?}");
+    }
+
+    // test deserialization
+    let deserialized = from_value::<T>(json).unwrap();
+    if &deserialized != data {
+        panic!("JSON->data deserialization failed\nexpected: {data:?}\n     got: {deserialized:?}");
+    }
 }
 
 pub mod prelude {

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_non_link_button_serde() {
-        let json = r#"{"type":2,"style":4,"custom_id":"hello","disabled":false}"#;
+        let json = r#"{"type":2,"style":4,"custom_id":"hello","label":"a","disabled":false}"#;
 
         let button = crate::json::from_str::<Button>(&mut json.to_string()).unwrap();
         assert!(matches!(
@@ -243,7 +243,8 @@ mod tests {
 
     #[test]
     fn test_link_button_serde() {
-        let json = r#"{"type":2,"style":5,"url":"https://google.com","disabled":false}"#;
+        let json =
+            r#"{"type":2,"style":5,"url":"https://google.com","label":"a","disabled":false}"#;
 
         let button = crate::json::from_str::<Button>(&mut json.to_string()).unwrap();
         assert!(matches!(&button.data, ButtonKind::Link {

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -79,7 +79,7 @@ impl From<SelectMenu> for ActionRowComponent {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum ButtonKind {
     Link { url: String },
@@ -124,7 +124,7 @@ impl Serialize for ButtonKind {
 /// A button component.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure).
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Button {
     /// The component type, it will always be [`ComponentType::Button`].
     #[serde(rename = "type")]

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -122,6 +122,8 @@ impl Serialize for ButtonKind {
 }
 
 /// A button component.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Button {
     /// The component type, it will always be [`ComponentType::Button`].
@@ -131,8 +133,7 @@ pub struct Button {
     #[serde(flatten)]
     pub data: ButtonKind,
     /// The text which appears on the button.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
+    pub label: String,
     /// The emoji of this button, if there is one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub emoji: Option<ReactionType>,


### PR DESCRIPTION
Now, the constraint that an action row can't contain multiple select menu or input texts, is statically enforced.

I also noticed that the label field on buttons is apparently now unconditionally required (despite what [the docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure) say). Sending any button without label, no matter if normal or link, results in `message: "This field is required", path: "components.0.components.0.label"`. See the full error:

```rust
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: Http(UnsuccessfulRequest(ErrorResponse { status_code: 400, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("discord.com")), port: None, path: "/api/v10/channels/703332075914264609/messages", query: None, fragment: None }, error: DiscordJsonError { code: 50035, message: "Invalid Form Body", errors: [DiscordJsonSingleError { code: "BASE_TYPE_REQUIRED", message: "This field is required", path: "components.0.components.0.label" }, DiscordJsonSingleError { code: "BASE_TYPE_REQUIRED", message: "This field is required", path: "components.0.components.1.label" }, DiscordJsonSingleError { code: "BASE_TYPE_REQUIRED", message: "This field is required", path: "components.0.components.2.label" }] } }))', examples/testing/src/main.rs:225:34
```

So I changed the label field from `Option<String>` to `String` and added label as a parameter to the CreateButton constructors