### PR TITLE
Move `#[must_use]` to struct definition for CreateGuildWelcomeChannel

### DIFF
--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -78,6 +78,7 @@ impl<'a> EditGuildWelcomeScreen<'a> {
 ///
 /// [`GuildWelcomeChannel`]: crate::model::guild::GuildWelcomeChannel
 #[derive(Clone, Debug, Default, Serialize)]
+#[must_use]
 pub struct CreateGuildWelcomeChannel {
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<ChannelId>,
@@ -91,21 +92,18 @@ pub struct CreateGuildWelcomeChannel {
 
 impl CreateGuildWelcomeChannel {
     /// The Id of the channel to show. It is required.
-    #[must_use]
     pub fn id(mut self, id: impl Into<ChannelId>) -> Self {
         self.channel_id = Some(id.into());
         self
     }
 
     /// The description shown for the channel. It is required.
-    #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }
 
     /// The emoji shown for the channel.
-    #[must_use]
     pub fn emoji(mut self, emoji: GuildWelcomeChannelEmoji) -> Self {
         match emoji {
             GuildWelcomeChannelEmoji::Unicode(name) => {


### PR DESCRIPTION
This was a nit I had with #2225 that I didn't get the chance to voice before it was merged.