### PR TITLE
Remove create_autocomplete_response

### DIFF
--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "model")]
 use crate::builder::{
-    CreateAutocompleteResponse,
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     CreateInteractionResponseMessage,
@@ -96,19 +95,6 @@ impl CommandInteraction {
         &self,
         http: impl AsRef<Http>,
         builder: CreateInteractionResponse,
-    ) -> Result<()> {
-        builder.execute(http, self.id, &self.token).await
-    }
-
-    /// Creates a response to an autocomplete interaction.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Http`] if the API returns an error.
-    pub async fn create_autocomplete_response(
-        &self,
-        http: impl AsRef<Http>,
-        builder: CreateAutocompleteResponse,
     ) -> Result<()> {
         builder.execute(http, self.id, &self.token).await
     }


### PR DESCRIPTION
#2228 changed CreateAutocompleteResponse to be a stand-alone response struct into just the representation of the `data` response struct field. That's because you're supposed to embed it in the `CreateInteractionResponse` enum now. But I forgot that there exists `create_autocomplete_response`, a convenience function for `create_response`, which took CreateAutocompleteResponse directly. After #2228, create_autocomplete_response still compiled, but now didn't send a proper response to discord but just its `data` field.

This PR removes create_autocomplete_response as a temporary fix. For now, you should use create_response as for any other interaction response.

Later, there should be a PR that re-adds convenience interaction response methods, but do it proper this time, i.e. not just for autocomplete, but also for the other response types. This undertaking should happen after #2229 is merged (which itself is currently waiting on #2240), because otherwise we'd have to duplicate the convenience methods for CommandInteraction, ComponentInteraction, and ModalInteraction.