### PR TITLE
Fix loop_errors

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,4 +1,5 @@
 use serenity::builder::*;
+use serenity::model::prelude::command::CommandOptionType;
 use serenity::model::prelude::component::ButtonStyle;
 use serenity::model::prelude::interaction::application_command::*;
 use serenity::model::prelude::*;
@@ -41,6 +42,15 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             .create_application_command(
                 &ctx,
                 CreateCommand::new("newselectmenu").description("test command"),
+            )
+            .await?;
+        guild_id
+            .create_application_command(
+                &ctx,
+                CreateCommand::new("autocomplete").description("test command").add_option(
+                    CreateCommandOption::new(CommandOptionType::String, "foo", "foo")
+                        .set_autocomplete(true),
+                ),
             )
             .await?;
     } else if msg.content == "edit" {
@@ -240,6 +250,14 @@ impl EventHandler for Handler {
         match i {
             Interaction::Command(i) => interaction(&ctx, i).await.unwrap(),
             Interaction::Component(i) => println!("{:#?}", i.data),
+            Interaction::Autocomplete(i) => {
+                i.create_autocomplete_response(
+                    &ctx,
+                    CreateAutocompleteResponse::new().add_string_choice("suggestion", "suggestion"),
+                )
+                .await
+                .unwrap();
+            },
             _ => {},
         }
     }

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -14,51 +14,48 @@ pub fn deserialize_errors<'de, D: Deserializer<'de>>(
     }
 
     let mut errors = Vec::new();
-
-    loop_errors(&map, &mut errors, &[]);
+    let mut path = Vec::new();
+    loop_errors(&map, &mut errors, &mut path);
 
     Ok(errors)
 }
 
-fn loop_errors(value: &Value, errors: &mut Vec<DiscordJsonSingleError>, path: &[String]) {
-    for (key, looped) in value.as_object().expect("expected object").iter() {
-        let object = looped.as_object().expect("expected object");
-        if object.contains_key("_errors") {
-            let found_errors = object
-                .get("_errors")
-                .expect("expected _errors")
-                .as_array()
-                .expect("expected array")
-                .clone();
+fn make_error(errors_value: &Value, errors: &mut Vec<DiscordJsonSingleError>, path: &[&str]) {
+    let found_errors = errors_value.as_array().expect("expected array").clone();
 
-            for error in found_errors {
-                let error_object = error.as_object().expect("expected object");
-                let mut object_path = path.to_owned();
+    for error in found_errors {
+        let error_object = error.as_object().expect("expected object");
 
-                object_path.push(key.to_string());
+        errors.push(DiscordJsonSingleError {
+            code: error_object
+                .get("code")
+                .expect("expected code")
+                .as_str()
+                .expect("expected string")
+                .to_owned(),
+            message: error_object
+                .get("message")
+                .expect("expected message")
+                .as_str()
+                .expect("expected string")
+                .to_owned(),
+            path: path.join("."),
+        });
+    }
+}
 
-                errors.push(DiscordJsonSingleError {
-                    code: error_object
-                        .get("code")
-                        .expect("expected code")
-                        .as_str()
-                        .expect("expected string")
-                        .to_owned(),
-                    message: error_object
-                        .get("message")
-                        .expect("expected message")
-                        .as_str()
-                        .expect("expected string")
-                        .to_owned(),
-                    path: object_path.join("."),
-                });
-            }
-            continue;
+fn loop_errors<'a>(
+    value: &'a Value,
+    errors: &mut Vec<DiscordJsonSingleError>,
+    path: &mut Vec<&'a str>,
+) {
+    for (key, value) in value.as_object().expect("expected object") {
+        if key == "_errors" {
+            make_error(value, errors, path);
+        } else {
+            path.push(key);
+            loop_errors(value, errors, path);
+            path.pop();
         }
-
-        let mut new_path = path.to_owned();
-        new_path.push(key.to_string());
-
-        loop_errors(looped, errors, &new_path);
     }
 }

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -1,4 +1,4 @@
-use serde::de::{Deserialize, Deserializer};
+use serde::de::{Deserialize, Deserializer, Error as _};
 
 use crate::http::error::DiscordJsonSingleError;
 use crate::internal::prelude::*;
@@ -15,47 +15,53 @@ pub fn deserialize_errors<'de, D: Deserializer<'de>>(
 
     let mut errors = Vec::new();
     let mut path = Vec::new();
-    loop_errors(&map, &mut errors, &mut path);
+    loop_errors(&map, &mut errors, &mut path).map_err(D::Error::custom)?;
 
     Ok(errors)
 }
 
-fn make_error(errors_value: &Value, errors: &mut Vec<DiscordJsonSingleError>, path: &[&str]) {
-    let found_errors = errors_value.as_array().expect("expected array").clone();
+fn make_error(
+    errors_value: &Value,
+    errors: &mut Vec<DiscordJsonSingleError>,
+    path: &[&str],
+) -> StdResult<(), &'static str> {
+    let found_errors = errors_value.as_array().ok_or("expected array")?;
 
     for error in found_errors {
-        let error_object = error.as_object().expect("expected object");
+        let error_object = error.as_object().ok_or("expected object")?;
 
         errors.push(DiscordJsonSingleError {
             code: error_object
                 .get("code")
-                .expect("expected code")
+                .ok_or("expected code")?
                 .as_str()
-                .expect("expected string")
+                .ok_or("expected string")?
                 .to_owned(),
             message: error_object
                 .get("message")
-                .expect("expected message")
+                .ok_or("expected message")?
                 .as_str()
-                .expect("expected string")
+                .ok_or("expected string")?
                 .to_owned(),
             path: path.join("."),
         });
     }
+    Ok(())
 }
 
 fn loop_errors<'a>(
     value: &'a Value,
     errors: &mut Vec<DiscordJsonSingleError>,
     path: &mut Vec<&'a str>,
-) {
-    for (key, value) in value.as_object().expect("expected object") {
+) -> StdResult<(), &'static str> {
+    for (key, value) in value.as_object().ok_or("expected object")? {
         if key == "_errors" {
-            make_error(value, errors, path);
+            make_error(value, errors, path)?;
         } else {
             path.push(key);
-            loop_errors(value, errors, path);
+            loop_errors(value, errors, path)?;
             path.pop();
         }
     }
+    Ok(())
 }


### PR DESCRIPTION
This function parses a Discord error response JSON https://discord.com/developers/docs/reference#error-messages

Previously, it couldn't handle a top-level `_errors` field. This was discovered by @bentuhana in https://discord.com/channels/381880193251409931/381912587505500160/1035148883501776976. (the serenity bug that caused Discord to error in the first place is fixed in #2254)

I also replaced the panic's in the code with proper Result handling