### PR TITLE
Avoid cloning entire cache fields by adding ReadOnlyMapRef

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -31,7 +31,7 @@
 //! [`http`]: crate::http
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::hash::{BuildHasher, Hash};
+use std::hash::Hash;
 use std::str::FromStr;
 #[cfg(feature = "temp_cache")]
 use std::sync::Arc;
@@ -39,8 +39,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::mapref::entry::Entry;
-use dashmap::mapref::multiple::RefMulti;
-use dashmap::mapref::one::{Ref, RefMut};
+use dashmap::mapref::one::Ref;
 use dashmap::DashMap;
 use fxhash::FxBuildHasher;
 #[cfg(feature = "temp_cache")]
@@ -55,6 +54,9 @@ use crate::model::prelude::*;
 mod cache_update;
 mod event;
 mod settings;
+mod wrappers;
+
+use wrappers::{MaybeMap, ReadOnlyMapRef};
 
 type MessageCache = DashMap<ChannelId, HashMap<MessageId, Message>, FxBuildHasher>;
 
@@ -157,34 +159,6 @@ pub(crate) struct CachedShardData {
     pub total: u32,
     pub connected: HashSet<u32>,
     pub has_sent_shards_ready: bool,
-}
-
-#[derive(Debug)]
-pub(crate) struct MaybeMap<K: Eq + Hash, V>(Option<DashMap<K, V, FxBuildHasher>>);
-impl<K: Eq + Hash, V> MaybeMap<K, V> {
-    pub fn iter(&self) -> impl Iterator<Item = RefMulti<'_, K, V, FxBuildHasher>> {
-        Option::iter(&self.0).flat_map(DashMap::iter)
-    }
-
-    pub fn get(&self, k: &K) -> Option<Ref<'_, K, V, FxBuildHasher>> {
-        self.0.as_ref()?.get(k)
-    }
-
-    pub fn get_mut(&self, k: &K) -> Option<RefMut<'_, K, V, FxBuildHasher>> {
-        self.0.as_ref()?.get_mut(k)
-    }
-
-    pub fn insert(&self, k: K, v: V) -> Option<V> {
-        self.0.as_ref()?.insert(k, v)
-    }
-
-    pub fn remove(&self, k: &K) -> Option<(K, V)> {
-        self.0.as_ref()?.remove(k)
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.as_ref().map_or(0, |map| map.len())
-    }
 }
 
 /// A cache containing data received from [`Shard`]s.
@@ -422,10 +396,8 @@ impl Cache {
     ///
     /// println!("There are {} private channels", amount);
     /// ```
-    pub fn private_channels(
-        &self,
-    ) -> DashMap<ChannelId, PrivateChannel, impl BuildHasher + Send + Sync + Clone> {
-        self.private_channels.0.clone().unwrap_or_default()
+    pub fn private_channels(&self) -> ReadOnlyMapRef<'_, ChannelId, PrivateChannel> {
+        self.private_channels.as_read_only()
     }
 
     /// Fetches a vector of all [`Guild`]s' Ids that are stored in the cache.
@@ -457,8 +429,11 @@ impl Cache {
     /// [`Context`]: crate::client::Context
     /// [`Shard`]: crate::gateway::Shard
     pub fn guilds(&self) -> Vec<GuildId> {
-        let chain = self.unavailable_guilds().into_iter().map(|(k, _)| k);
-        self.guilds.iter().map(|i| *i.key()).chain(chain).collect()
+        let unavailable_guilds = self.unavailable_guilds();
+
+        let unavailable_guild_ids = unavailable_guilds.iter().map(|i| *i.key());
+
+        self.guilds.iter().map(|i| *i.key()).chain(unavailable_guild_ids).collect()
     }
 
     /// Retrieves a [`Channel`] from the cache based on the given Id.
@@ -723,10 +698,8 @@ impl Cache {
 
     /// This method clones and returns all unavailable guilds.
     #[inline]
-    pub fn unavailable_guilds(
-        &self,
-    ) -> DashMap<GuildId, (), impl BuildHasher + Send + Sync + Clone> {
-        self.unavailable_guilds.0.clone().unwrap_or_default()
+    pub fn unavailable_guilds(&self) -> ReadOnlyMapRef<'_, GuildId, ()> {
+        self.unavailable_guilds.as_read_only()
     }
 
     /// This method returns all channels from a guild of with the given `guild_id`.
@@ -927,8 +900,8 @@ impl Cache {
 
     /// Clones all users and returns them.
     #[inline]
-    pub fn users(&self) -> DashMap<UserId, User, impl BuildHasher + Send + Sync + Clone> {
-        self.users.0.clone().unwrap_or_default()
+    pub fn users(&self) -> ReadOnlyMapRef<'_, UserId, User> {
+        self.users.as_read_only()
     }
 
     /// Returns the amount of cached users.

--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -40,7 +40,7 @@ impl<K: Eq + Hash, V> MaybeMap<K, V> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 /// A wrapper around a reference to a MaybeMap, allowing for public inspection of the underlying map
 /// without allowing mutation of internal cache fields, which could cause issues.
 pub struct ReadOnlyMapRef<'a, K: Eq + Hash, V>(Option<&'a DashMap<K, V, FxBuildHasher>>);

--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -1,0 +1,59 @@
+//! Wrappers around library types for easier use.
+
+use std::hash::Hash;
+
+use dashmap::mapref::multiple::RefMulti;
+use dashmap::mapref::one::{Ref, RefMut};
+use dashmap::DashMap;
+use fxhash::FxBuildHasher;
+
+#[derive(Debug)]
+/// A wrapper around Option<DashMap<K, V>> to ease disabling specific cache fields.
+pub(crate) struct MaybeMap<K: Eq + Hash, V>(pub(super) Option<DashMap<K, V, FxBuildHasher>>);
+impl<K: Eq + Hash, V> MaybeMap<K, V> {
+    pub fn iter(&self) -> impl Iterator<Item = RefMulti<'_, K, V, FxBuildHasher>> {
+        Option::iter(&self.0).flat_map(DashMap::iter)
+    }
+
+    pub fn get(&self, k: &K) -> Option<Ref<'_, K, V, FxBuildHasher>> {
+        self.0.as_ref()?.get(k)
+    }
+
+    pub fn get_mut(&self, k: &K) -> Option<RefMut<'_, K, V, FxBuildHasher>> {
+        self.0.as_ref()?.get_mut(k)
+    }
+
+    pub fn insert(&self, k: K, v: V) -> Option<V> {
+        self.0.as_ref()?.insert(k, v)
+    }
+
+    pub fn remove(&self, k: &K) -> Option<(K, V)> {
+        self.0.as_ref()?.remove(k)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.as_ref().map_or(0, |map| map.len())
+    }
+
+    pub(crate) fn as_read_only(&self) -> ReadOnlyMapRef<'_, K, V> {
+        ReadOnlyMapRef(self.0.as_ref())
+    }
+}
+
+#[derive(Debug)]
+/// A wrapper around a reference to a MaybeMap, allowing for public inspection of the underlying map
+/// without allowing mutation of internal cache fields, which could cause issues.
+pub struct ReadOnlyMapRef<'a, K: Eq + Hash, V>(Option<&'a DashMap<K, V, FxBuildHasher>>);
+impl<'a, K: Eq + Hash, V> ReadOnlyMapRef<'a, K, V> {
+    pub fn iter(&self) -> impl Iterator<Item = RefMulti<'_, K, V, FxBuildHasher>> {
+        self.0.into_iter().flat_map(DashMap::iter)
+    }
+
+    pub fn get(&self, k: &K) -> Option<Ref<'_, K, V, FxBuildHasher>> {
+        self.0?.get(k)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.map_or(0, DashMap::len)
+    }
+}


### PR DESCRIPTION
Reimplements MaybeMap as ReadOnlyMapRef except holding a reference to the inner DashMap and not providing methods for mutation, allowing cache fields to be directly referenced (without risk of mutation) instead of entirely cloned.

Currently it is not easily possible to implement ToOwned without TAIT or other changes, so that can be implemented in a followup PR.