### PR TITLE
fix NotAuthor error when deleting messages

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -224,9 +224,6 @@ impl Message {
         {
             if let Some(cache) = cache_http.cache() {
                 if self.author.id != cache.current_user_id() {
-                    if self.is_private() {
-                        return Err(Error::Model(ModelError::NotAuthor));
-                    }
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,


### PR DESCRIPTION
Sometimes Discord does not include `guild_id` in message objects. Because `Message::is_private` checks if `guild_id` is set `Message::delete` returns `Error::Model(ModelError::NotAuthor)` if `guild_id` is not set.
This means the function can fail when it shouldn't.

This PR removes the faulty check.