### PR TITLE
Remove nougat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 dep_time = { version = "0.3.6", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
-nougat = { version = "0.2.0", optional = true }
 derivative = { version = "2.2.0", optional = true }
 simd-json = { version = "0.6", optional = true }
 uwl = { version = "0.6.0", optional = true }
@@ -83,7 +82,7 @@ builder = ["base64"]
 cache = ["fxhash", "dashmap", "parking_lot"]
 # Enables collectors, a utility feature that lets you await interaction events in code with
 # zero setup, without needing to setup an InteractionCreate event listener.
-collector = ["gateway", "model", "derivative", "nougat"]
+collector = ["gateway", "model", "derivative"]
 # Wraps the gateway and http functionality into a single interface
 # TODO: should this require "gateway"?
 client = ["http", "typemap_rev"]

--- a/src/collector/base_filter.rs
+++ b/src/collector/base_filter.rs
@@ -6,12 +6,12 @@ use tokio::sync::mpsc::{
     UnboundedSender as Sender,
 };
 
-use super::{Collectable, CommonFilterOptions, LazyItem, LazyItemGat};
+use super::{Collectable, CommonFilterOptions, LazyItem};
 use crate::client::bridge::gateway::ShardMessenger;
 
 pub trait FilterTrait<Item: Collectable> {
     fn register(self, messenger: &ShardMessenger);
-    fn is_passing_constraints(&self, item: &mut LazyItemGat<'_, Item>) -> bool;
+    fn is_passing_constraints(&self, item: &mut Item::LazyItem<'_>) -> bool;
 }
 
 #[derive(Clone, Debug)]
@@ -54,7 +54,7 @@ where
 {
     /// Sends an item to the consuming collector if the item conforms
     /// to the constraints and the limits are not reached yet.
-    pub(crate) fn process_item(&mut self, item: &mut LazyItemGat<'_, Item>) -> bool {
+    pub(crate) fn process_item(&mut self, item: &mut Item::LazyItem<'_>) -> bool {
         if self.is_passing_constraints(item) {
             self.collected += 1;
 

--- a/src/collector/base_filter.rs
+++ b/src/collector/base_filter.rs
@@ -11,7 +11,7 @@ use crate::client::bridge::gateway::ShardMessenger;
 
 pub trait FilterTrait<Item: Collectable> {
     fn register(self, messenger: &ShardMessenger);
-    fn is_passing_constraints(&self, item: &mut Item::LazyItem<'_>) -> bool;
+    fn is_passing_constraints(&self, item: &mut Item::Lazy<'_>) -> bool;
 }
 
 #[derive(Clone, Debug)]
@@ -54,7 +54,7 @@ where
 {
     /// Sends an item to the consuming collector if the item conforms
     /// to the constraints and the limits are not reached yet.
-    pub(crate) fn process_item(&mut self, item: &mut Item::LazyItem<'_>) -> bool {
+    pub(crate) fn process_item(&mut self, item: &mut Item::Lazy<'_>) -> bool {
         if self.is_passing_constraints(item) {
             self.collected += 1;
 

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -43,7 +43,6 @@ impl super::CollectorBuilder<'_, ComponentInteraction> {
     impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received.");
 }
 
-#[nougat::gat]
 impl super::Collectable for ComponentInteraction {
     type FilterOptions = FilterOptions;
     type FilterItem = ComponentInteraction;

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -46,7 +46,7 @@ impl super::CollectorBuilder<'_, ComponentInteraction> {
 impl super::Collectable for ComponentInteraction {
     type FilterOptions = FilterOptions;
     type FilterItem = ComponentInteraction;
-    type LazyItem<'a> = LazyArc<'a, ComponentInteraction>;
+    type Lazy<'a> = LazyArc<'a, ComponentInteraction>;
 }
 
 /// A component interaction collector receives interactions matching a the given filter for a set duration.

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -123,7 +123,6 @@ pub type EventFilter = super::Filter<Event>;
 
 // No deprecated CollectSingle alias as EventCollector never had a CollectSingle version.
 
-#[nougat::gat]
 impl super::Collectable for Event {
     type FilterItem = Event;
     type FilterOptions = FilterOptions;

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -126,7 +126,7 @@ pub type EventFilter = super::Filter<Event>;
 impl super::Collectable for Event {
     type FilterItem = Event;
     type FilterOptions = FilterOptions;
-    type LazyItem<'a> = LazyArc<'a, Event>;
+    type Lazy<'a> = LazyArc<'a, Event>;
 }
 
 #[cfg(test)]

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -34,7 +34,6 @@ impl super::CollectorBuilder<'_, Message> {
     impl_guild_id!("Sets the required guild ID of a message. If a message does not meet this ID, it won't be received.");
 }
 
-#[nougat::gat]
 impl super::Collectable for Message {
     type FilterItem = Message;
     type FilterOptions = FilterOptions;

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -37,7 +37,7 @@ impl super::CollectorBuilder<'_, Message> {
 impl super::Collectable for Message {
     type FilterItem = Message;
     type FilterOptions = FilterOptions;
-    type LazyItem<'a> = LazyArc<'a, Message>;
+    type Lazy<'a> = LazyArc<'a, Message>;
 }
 
 /// A message collector receives messages matching the given filter for a set duration.

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -103,14 +103,11 @@ pub trait LazyItem<Item: ?Sized> {
     fn as_arc(&mut self) -> &mut Arc<Item>;
 }
 
-#[nougat::gat]
 pub trait Collectable: sealed::Sealed + Sized {
     type LazyItem<'a>: LazyItem<Self>;
     type FilterOptions: Default;
     type FilterItem;
 }
-
-type LazyItemGat<'a, Item> = nougat::Gat!(<Item as Collectable>::LazyItem<'a>);
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = ""), Debug(bound = ""), Default(bound = ""))]

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -104,7 +104,7 @@ pub trait LazyItem<Item: ?Sized> {
 }
 
 pub trait Collectable: sealed::Sealed + Sized {
-    type LazyItem<'a>: LazyItem<Self>;
+    type Lazy<'a>: LazyItem<Self>;
     type FilterOptions: Default;
     type FilterItem;
 }

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -43,7 +43,6 @@ impl super::CollectorBuilder<'_, ModalInteraction> {
     impl_author_id!("Sets the required author ID of an interaction. If an interaction is not triggered by a user with this ID, it won't be received.");
 }
 
-#[nougat::gat]
 impl super::Collectable for ModalInteraction {
     type FilterOptions = FilterOptions;
     type FilterItem = ModalInteraction;

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -46,7 +46,7 @@ impl super::CollectorBuilder<'_, ModalInteraction> {
 impl super::Collectable for ModalInteraction {
     type FilterOptions = FilterOptions;
     type FilterItem = ModalInteraction;
-    type LazyItem<'a> = LazyArc<'a, ModalInteraction>;
+    type Lazy<'a> = LazyArc<'a, ModalInteraction>;
 }
 
 /// A modal interaction collector receives interactions matching a the given filter for a set duration.

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -149,7 +149,7 @@ impl super::CollectorBuilder<'_, ReactionAction> {
 impl super::Collectable for ReactionAction {
     type FilterItem = Reaction;
     type FilterOptions = FilterOptions;
-    type LazyItem<'a> = LazyReactionAction<'a>;
+    type Lazy<'a> = LazyReactionAction<'a>;
 }
 
 /// A reaction collector receives reactions matching a the given filter for a set duration.

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -146,7 +146,6 @@ impl super::CollectorBuilder<'_, ReactionAction> {
     impl_author_id!("Sets the required author ID of a reaction. If a reaction is not issued by a user with this ID, it won't be received.");
 }
 
-#[nougat::gat]
 impl super::Collectable for ReactionAction {
     type FilterItem = Reaction;
     type FilterOptions = FilterOptions;


### PR DESCRIPTION
GATs are stable now, so we can just use them without nougat.