### PR TITLE
Rework Framework trait 

### DIFF
--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -71,8 +71,7 @@ use crate::CacheAndHttp;
 /// let ws_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
 /// let data = Arc::new(RwLock::new(TypeMap::new()));
 /// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
-/// let framework =
-///     Arc::new(StandardFramework::new()) as Arc<dyn Framework + Send + Sync + 'static>;
+/// let framework = Arc::new(StandardFramework::new()) as Arc<dyn Framework + 'static>;
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data,
@@ -353,12 +352,12 @@ pub struct ShardManagerOptions {
     pub event_handlers: Vec<Arc<dyn EventHandler>>,
     pub raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    pub framework: Option<Arc<dyn Framework + Send + Sync>>,
+    pub framework: Option<Arc<dyn Framework>>,
     pub shard_index: u32,
     pub shard_init: u32,
     pub shard_total: u32,
     #[cfg(feature = "voice")]
-    pub voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
+    pub voice_manager: Option<Arc<dyn VoiceGatewayManager>>,
     pub ws_url: Arc<Mutex<String>>,
     pub cache_and_http: CacheAndHttp,
     pub intents: GatewayIntents,

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -55,7 +55,7 @@ pub struct ShardQueuer {
     pub raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
-    pub framework: Option<Arc<dyn Framework + Send + Sync>>,
+    pub framework: Option<Arc<dyn Framework>>,
     /// The instant that a shard was last started.
     ///
     /// This is used to determine how long to wait between shard IDENTIFYs.
@@ -75,7 +75,7 @@ pub struct ShardQueuer {
     pub rx: Receiver<ShardQueuerMessage>,
     /// A copy of the client's voice manager.
     #[cfg(feature = "voice")]
-    pub voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
+    pub voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
     /// A copy of the URL to use to connect to the gateway.
     pub ws_url: Arc<Mutex<String>>,
     pub cache_and_http: CacheAndHttp,

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -40,7 +40,7 @@ pub struct ShardRunner {
     event_handlers: Vec<Arc<dyn EventHandler>>,
     raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    framework: Option<Arc<dyn Framework + Send + Sync>>,
+    framework: Option<Arc<dyn Framework>>,
     manager_tx: Sender<ShardManagerMessage>,
     // channel to receive messages from the shard manager and dispatches
     runner_rx: Receiver<InterMessage>,
@@ -48,7 +48,7 @@ pub struct ShardRunner {
     runner_tx: Sender<InterMessage>,
     pub(crate) shard: Shard,
     #[cfg(feature = "voice")]
-    voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
+    voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
     cache_and_http: CacheAndHttp,
     #[cfg(feature = "collector")]
     event_filters: Vec<EventFilter>,
@@ -656,10 +656,10 @@ pub struct ShardRunnerOptions {
     pub event_handlers: Vec<Arc<dyn EventHandler>>,
     pub raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    pub framework: Option<Arc<dyn Framework + Send + Sync>>,
+    pub framework: Option<Arc<dyn Framework>>,
     pub manager_tx: Sender<ShardManagerMessage>,
     pub shard: Shard,
     #[cfg(feature = "voice")]
-    pub voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync>>,
+    pub voice_manager: Option<Arc<dyn VoiceGatewayManager>>,
     pub cache_and_http: CacheAndHttp,
 }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -31,7 +31,7 @@ fn update_cache<E>(_: &Context, _: &mut E) -> Option<()> {
 pub(crate) async fn dispatch_model<'rec>(
     event: Event,
     context: Context,
-    #[cfg(feature = "framework")] framework: Option<Arc<dyn Framework + Send + Sync>>,
+    #[cfg(feature = "framework")] framework: Option<Arc<dyn Framework>>,
     event_handlers: Vec<Arc<dyn EventHandler>>,
     raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
 ) {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -35,41 +35,33 @@ pub(crate) async fn dispatch_model<'rec>(
     event_handlers: Vec<Arc<dyn EventHandler>>,
     raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
 ) {
-    #[cfg(feature = "framework")]
-    let mut framework_dispatch_future = None;
-    #[cfg(feature = "framework")]
-    if let Event::MessageCreate(event) = &event {
-        if let Some(framework) = framework {
-            let (context, message) = (context.clone(), event.message.clone());
-            framework_dispatch_future =
-                Some(async move { framework.dispatch(context, message).await });
-        }
-    }
-
     for raw_handler in raw_event_handlers {
         let (context, event) = (context.clone(), event.clone());
         tokio::spawn(async move { raw_handler.raw_event(context, event).await });
     }
 
     let full_events = update_cache_with_event(context, event);
-    // Handle Event, this is done to prevent indenting twice (once to destructure DispatchEvent, then to destructure Event)
-    if let Some((event, extra_event)) = full_events {
+    if let Some(events) = full_events {
+        let iter = std::iter::once(events.0).chain(events.1);
         for handler in event_handlers {
-            let (event, extra_event) = (event.clone(), extra_event.clone());
-            if let Some(event) = extra_event {
+            for event in iter.clone() {
                 let handler = handler.clone();
                 spawn_named(
                     event.snake_case_name(),
                     async move { event.dispatch(&*handler).await },
                 );
             }
-            spawn_named(event.snake_case_name(), async move { event.dispatch(&*handler).await });
         }
-    }
 
-    #[cfg(feature = "framework")]
-    if let Some(x) = framework_dispatch_future {
-        spawn_named("dispatch::framework::message", x);
+        #[cfg(feature = "framework")]
+        if let Some(framework) = framework {
+            for event in iter {
+                let framework = framework.clone();
+                spawn_named("dispatch::framework::dispatch", async move {
+                    framework.dispatch(event).await;
+                });
+            }
+        }
     }
 }
 

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -31,7 +31,7 @@ macro_rules! event_handler {
         /// This enum stores every possible event that an [`EventHandler`] can receive.
         #[non_exhaustive]
         #[allow(clippy::large_enum_variant)] // TODO: do some boxing to fix this
-        #[derive(Clone)]
+        #[derive(Clone, Debug)]
         pub enum FullEvent { $(
             $( #[doc = $doc] )* $( #[cfg(feature = $feature)] )?
             $variant_name {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -74,9 +74,9 @@ pub struct ClientBuilder {
     #[cfg(feature = "cache")]
     cache_settings: CacheSettings,
     #[cfg(feature = "framework")]
-    framework: Option<Arc<dyn Framework + Send + Sync + 'static>>,
+    framework: Option<Arc<dyn Framework>>,
     #[cfg(feature = "voice")]
-    voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
+    voice_manager: Option<Arc<dyn VoiceGatewayManager>>,
     event_handlers: Vec<Arc<dyn EventHandler>>,
     raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
     presence: PresenceData,
@@ -202,7 +202,7 @@ impl ClientBuilder {
     #[cfg(feature = "framework")]
     pub fn framework<F>(mut self, framework: F) -> Self
     where
-        F: Framework + Send + Sync + 'static,
+        F: Framework + 'static,
     {
         self.framework = Some(Arc::new(framework));
 
@@ -214,18 +214,15 @@ impl ClientBuilder {
     /// extra control.
     /// You can provide a clone and keep the original to manually dispatch.
     #[cfg(feature = "framework")]
-    pub fn framework_arc<T: Framework + Send + Sync + 'static>(
-        mut self,
-        framework: Arc<T>,
-    ) -> Self {
-        self.framework = Some(framework as Arc<dyn Framework + Send + Sync + 'static>);
+    pub fn framework_arc<T: Framework + 'static>(mut self, framework: Arc<T>) -> Self {
+        self.framework = Some(framework as Arc<dyn Framework + 'static>);
 
         self
     }
 
     /// Gets the framework, if already initialized. See [`Self::framework`] for more info.
     #[cfg(feature = "framework")]
-    pub fn get_framework(&self) -> Option<Arc<dyn Framework + Send + Sync>> {
+    pub fn get_framework(&self) -> Option<Arc<dyn Framework>> {
         self.framework.clone()
     }
 
@@ -239,7 +236,7 @@ impl ClientBuilder {
     #[cfg(feature = "voice")]
     pub fn voice_manager<V>(mut self, voice_manager: V) -> Self
     where
-        V: VoiceGatewayManager + Send + Sync + 'static,
+        V: VoiceGatewayManager + 'static,
     {
         self.voice_manager = Some(Arc::new(voice_manager));
 
@@ -255,7 +252,7 @@ impl ClientBuilder {
     #[cfg(feature = "voice")]
     pub fn voice_manager_arc(
         mut self,
-        voice_manager: Arc<dyn VoiceGatewayManager + Send + Sync + 'static>,
+        voice_manager: Arc<dyn VoiceGatewayManager + 'static>,
     ) -> Self {
         self.voice_manager = Some(voice_manager);
 
@@ -264,7 +261,7 @@ impl ClientBuilder {
 
     /// Gets the voice manager, if already initialized. See [`Self::voice_manager`] for more info.
     #[cfg(feature = "voice")]
-    pub fn get_voice_manager(&self) -> Option<Arc<dyn VoiceGatewayManager + Send + Sync>> {
+    pub fn get_voice_manager(&self) -> Option<Arc<dyn VoiceGatewayManager>> {
         self.voice_manager.clone()
     }
 
@@ -662,7 +659,7 @@ pub struct Client {
     /// This is an ergonomic structure for interfacing over shards' voice
     /// connections.
     #[cfg(feature = "voice")]
-    pub voice_manager: Option<Arc<dyn VoiceGatewayManager + Send + Sync + 'static>>,
+    pub voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
     /// URL that the client's shards will use to connect to the gateway.
     ///
     /// This is likely not important for production usage and is, at best, used

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -29,7 +29,7 @@ use self::buckets::{RateLimitInfo, RevertBucket};
 use super::Framework;
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
-use crate::client::Context;
+use crate::client::{Context, FullEvent};
 #[cfg(feature = "cache")]
 use crate::model::channel::Channel;
 use crate::model::channel::Message;
@@ -615,8 +615,10 @@ impl StandardFramework {
 
 #[async_trait]
 impl Framework for StandardFramework {
-    #[instrument(skip(self, ctx, msg))]
-    async fn dispatch(&self, mut ctx: Context, msg: Message) {
+    #[instrument(skip(self, event))]
+    async fn dispatch(&self, event: FullEvent) {
+        let FullEvent::Message { mut ctx, new_message: msg } = event else { return };
+
         if self.should_ignore(&msg) {
             return;
         }


### PR DESCRIPTION
So it's useful for more than just the built-in text command framework. New Framework trait API:

```rust
pub trait Framework: Send + Sync {
    async fn init(&mut self, client: &Client);
    async fn dispatch(&self, event: FullEvent);
}
```

Previous:

```rust
pub trait Framework: Send + Sync {
    async fn dispatch(&self, _: Context, _: Message);
}
```

This PR was developed in tandem with porting poise to it. Here's the corresponding poise code: https://github.com/kangalioo/poise/tree/better-framework