### PR TITLE
Fix simd_json serialization

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,3 +1,4 @@
+use serenity::model::prelude::command::*;
 use serenity::model::prelude::interaction::application_command::*;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
@@ -5,6 +6,13 @@ use serenity::prelude::*;
 async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
     if let Some(_args) = msg.content.strip_prefix("testmessage ") {
         println!("command message: {:#?}", msg);
+    } else if msg.content == "globalcommand" {
+        // Tests https://github.com/serenity-rs/serenity/issues/2259
+        // Activate simd_json feature for this
+        Command::create_global_application_command(&ctx, |b| {
+            b.name("ping").description("A simple ping command")
+        })
+        .await?;
     } else {
         return Ok(());
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -397,7 +397,7 @@ impl Http {
     /// Creates a stage instance.
     pub async fn create_stage_instance(&self, map: &Value) -> Result<StageInstance> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateStageInstance,
@@ -461,7 +461,7 @@ impl Http {
         audit_log_reason: Option<&str>,
     ) -> Result<Emoji> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateEmoji {
@@ -480,7 +480,7 @@ impl Http {
         map: &Value,
     ) -> Result<Message> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateFollowupMessage {
@@ -529,7 +529,7 @@ impl Http {
     /// [docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
     pub async fn create_global_application_command(&self, map: &Value) -> Result<Command> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGlobalApplicationCommand {
@@ -542,7 +542,7 @@ impl Http {
     /// Creates new global application commands.
     pub async fn create_global_application_commands(&self, map: &Value) -> Result<Vec<Command>> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGlobalApplicationCommands {
@@ -559,7 +559,7 @@ impl Http {
         map: &Value,
     ) -> Result<Vec<Command>> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGuildApplicationCommands {
@@ -605,7 +605,7 @@ impl Http {
     /// [whitelist]: https://discord.com/developers/docs/resources/guild#create-guild
     pub async fn create_guild(&self, map: &Value) -> Result<PartialGuild> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGuild,
@@ -626,7 +626,7 @@ impl Http {
         map: &Value,
     ) -> Result<Command> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateGuildApplicationCommand {
@@ -653,7 +653,7 @@ impl Http {
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(204, Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::CreateGuildIntegration {
@@ -677,7 +677,7 @@ impl Http {
         map: &Value,
     ) -> Result<()> {
         self.wind(204, Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::CreateInteractionResponse {
@@ -1091,7 +1091,7 @@ impl Http {
     /// Deletes a bunch of messages, only works for bots.
     pub async fn delete_messages(&self, channel_id: u64, map: &Value) -> Result<()> {
         self.wind(204, Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::DeleteMessages {
@@ -1354,7 +1354,7 @@ impl Http {
     /// Edits a stage instance.
     pub async fn edit_stage_instance(&self, channel_id: u64, map: &Value) -> Result<StageInstance> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::EditStageInstance {
@@ -1398,7 +1398,7 @@ impl Http {
         map: &Value,
     ) -> Result<Message> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::EditFollowupMessage {
@@ -1475,7 +1475,7 @@ impl Http {
         map: &Value,
     ) -> Result<Command> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGlobalApplicationCommand {
@@ -1520,7 +1520,7 @@ impl Http {
         map: &Value,
     ) -> Result<Command> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommand {
@@ -1546,7 +1546,7 @@ impl Http {
         map: &Value,
     ) -> Result<CommandPermission> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommandPermission {
@@ -1571,7 +1571,7 @@ impl Http {
         map: &Value,
     ) -> Result<Vec<CommandPermission>> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::EditGuildApplicationCommandsPermissions {
@@ -1808,7 +1808,7 @@ impl Http {
         map: &Value,
     ) -> Result<Message> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: None,
             route: RouteInfo::EditOriginalInteractionResponse {
@@ -2114,7 +2114,7 @@ impl Http {
         audit_log_reason: Option<&str>,
     ) -> Result<Webhook> {
         self.fire(Request {
-            body: Some(map.to_string().as_bytes()),
+            body: Some(to_string(map)?.as_bytes()),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             route: RouteInfo::EditWebhook {


### PR DESCRIPTION
Fixes #2259

Problem: many Http methods have a `Value` argument for arbitrary JSON data and call `.to_string()` on it to convert it to textual JSON. This works in serde_json, because it defines `Value::to_string()` to output JSON:
![Screenshot_20221106_085250](https://user-images.githubusercontent.com/21220820/200160060-06358ab0-b92e-47a1-8597-9a7274944ed2.png)

However, simd_json spits out the raw Rust Debug representation:
![Screenshot_20221106_085305](https://user-images.githubusercontent.com/21220820/200160068-8d2c3dd7-d7cc-44df-8e9d-a1c93a6c59f1.png)

This PR fixes those lines to use `to_string(map)?` instead of  `map.to_string()`. to_string is a method from our json module that calls the correct JSON serialization function depending on backend