### PR TITLE
Properly escape all reactions

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -792,8 +792,7 @@ impl Http {
             multipart: None,
             headers: None,
             route: RouteInfo::CreateReaction {
-                // Escape emojis like '#️⃣' that contain a hash
-                reaction: &reaction_type.as_data().replace('#', "%23"),
+                reaction: &reaction_type.as_data(),
                 channel_id,
                 message_id,
             },
@@ -1199,8 +1198,7 @@ impl Http {
             multipart: None,
             headers: None,
             route: RouteInfo::DeleteReaction {
-                // Escape emojis like '#️⃣' that contain a hash
-                reaction: &reaction_type.as_data().replace('#', "%23"),
+                reaction: &reaction_type.as_data(),
                 user: &user,
                 channel_id,
                 message_id,

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -439,7 +439,7 @@ impl ReactionType {
             } => {
                 format!("{}:{}", name.as_ref().map_or("", String::as_str), id)
             },
-            ReactionType::Unicode(ref unicode) => unicode.clone(),
+            ReactionType::Unicode(ref unicode) => unicode.replace('#', "%23"),
         }
     }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -6,6 +6,8 @@ use std::fmt::Display as _;
 use std::fmt::{self, Write as _};
 use std::str::FromStr;
 
+#[cfg(feature = "model")]
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::de::{Deserialize, Error as DeError, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeMap, Serializer};
 #[cfg(feature = "model")]
@@ -431,15 +433,17 @@ impl ReactionType {
     #[inline]
     #[must_use]
     pub fn as_data(&self) -> String {
-        match *self {
+        match self {
             ReactionType::Custom {
                 id,
-                ref name,
+                name,
                 ..
             } => {
-                format!("{}:{}", name.as_ref().map_or("", String::as_str), id)
+                format!("{}:{}", name.as_deref().unwrap_or_default(), id)
             },
-            ReactionType::Unicode(ref unicode) => unicode.replace('#', "%23"),
+            ReactionType::Unicode(unicode) => {
+                utf8_percent_encode(unicode, NON_ALPHANUMERIC).to_string()
+            },
         }
     }
 


### PR DESCRIPTION
Previously, `DeleteReactionMessageEmoji` and `GetReactionUsers` endpoints would fail with the #️⃣ emoji because they forgot to escape it. This unifies the escaping to always happen.