### PR TITLE
Miscellaneous http refactoring

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -11,6 +11,7 @@ const IMAGE_URL: &str = "https://raw.githubusercontent.com/serenity-rs/serenity/
 const IMAGE_URL_2: &str = "https://rustacean.net/assets/rustlogo.png";
 
 async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
+    let guild_id = msg.guild_id.unwrap();
     let channel_id = msg.channel_id;
     let guild_id = msg.guild_id.unwrap();
     if let Some(_args) = msg.content.strip_prefix("testmessage ") {
@@ -154,6 +155,9 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             )
             .await?;
         println!("new automod rules: {:?}", guild_id.automod_rules(ctx).await?);
+    } else if let Some(user_id) = msg.content.strip_prefix("ban ") {
+        // Test if banning without a reason actually works
+        guild_id.ban(ctx, UserId(user_id.trim().parse().unwrap()), 0).await?;
     } else {
         return Ok(());
     }

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -11,7 +11,6 @@ const IMAGE_URL: &str = "https://raw.githubusercontent.com/serenity-rs/serenity/
 const IMAGE_URL_2: &str = "https://rustacean.net/assets/rustlogo.png";
 
 async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
-    let guild_id = msg.guild_id.unwrap();
     let channel_id = msg.channel_id;
     let guild_id = msg.guild_id.unwrap();
     if let Some(_args) = msg.content.strip_prefix("testmessage ") {

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -176,7 +176,7 @@ impl ShardQueuer {
 
         let mut shard = Shard::new(
             Arc::clone(&self.ws_url),
-            &self.cache_and_http.http.token,
+            self.cache_and_http.http.token(),
             shard_info,
             self.intents,
             self.presence.clone(),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -133,7 +133,7 @@ impl ClientBuilder {
 
     /// Gets the current token used for the [`Http`] client.
     pub fn get_token(&self) -> &str {
-        &self.http.token
+        self.http.token()
     }
 
     /// Sets the application id.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -373,14 +373,16 @@ impl IntoFuture for ClientBuilder {
 
         let mut http = self.http;
 
-        let event_handlers_clone = event_handlers.clone();
-        http.ratelimiter.set_ratelimit_callback(Box::new(move |info| {
-            for event_handler in &event_handlers_clone {
-                let event_handler = event_handler.clone();
-                let info = info.clone();
-                tokio::spawn(async move { event_handler.ratelimit(info).await });
-            }
-        }));
+        if let Some(ratelimiter) = &mut http.ratelimiter {
+            let event_handlers_clone = event_handlers.clone();
+            ratelimiter.set_ratelimit_callback(Box::new(move |info| {
+                for event_handler in &event_handlers_clone {
+                    let event_handler = event_handler.clone();
+                    let info = info.clone();
+                    tokio::spawn(async move { event_handler.ratelimit(info).await });
+                }
+            }));
+        }
 
         let http = Arc::new(http);
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -219,29 +219,7 @@ impl fmt::Debug for Http {
 impl Http {
     #[must_use]
     pub fn new(token: &str) -> Self {
-        let builder = configure_client_backend(Client::builder());
-
-        let client = builder.build().expect("Cannot build reqwest::Client");
-        let client2 = client.clone();
-
-        let token = parse_token(token);
-
-        Http {
-            client,
-            ratelimiter: Some(Ratelimiter::new(client2, token.to_string())),
-            proxy: None,
-            token,
-            application_id: AtomicU64::new(0),
-        }
-    }
-
-    #[must_use]
-    pub fn new_with_application_id(token: &str, application_id: ApplicationId) -> Self {
-        let http = Self::new(token);
-
-        http.set_application_id(application_id);
-
-        http
+        HttpBuilder::new(token).build()
     }
 
     pub fn application_id(&self) -> Option<ApplicationId> {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -39,11 +39,8 @@ use crate::model::prelude::*;
 /// ```rust
 /// # use serenity::http::HttpBuilder;
 /// # fn run() {
-/// let http = HttpBuilder::new("token")
-///     .proxy("http://127.0.0.1:3000")
-///     .expect("Invalid proxy URL")
-///     .ratelimiter_disabled(true)
-///     .build();
+/// let http =
+///     HttpBuilder::new("token").proxy("http://127.0.0.1:3000").ratelimiter_disabled(true).build();
 /// # }
 /// ```
 #[must_use]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -305,12 +305,12 @@ impl Http {
         guild_id: GuildId,
         user_id: UserId,
         delete_message_days: u8,
-        reason: &str,
+        reason: Option<&str>,
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: Some(reason_into_header(reason)),
+            headers: reason.map(reason_into_header),
             route: RouteInfo::GuildBanUser {
                 delete_message_days: Some(delete_message_days),
                 guild_id,
@@ -3673,22 +3673,17 @@ impl Http {
         .await
     }
 
-    /// Kicks a member from a guild.
-    pub async fn kick_member(&self, guild_id: GuildId, user_id: UserId) -> Result<()> {
-        self.kick_member_with_reason(guild_id, user_id, "").await
-    }
-
     /// Kicks a member from a guild with a provided reason.
-    pub async fn kick_member_with_reason(
+    pub async fn kick_member(
         &self,
         guild_id: GuildId,
         user_id: UserId,
-        reason: &str,
+        reason: Option<&str>,
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
             multipart: None,
-            headers: Some(reason_into_header(reason)),
+            headers: reason.map(reason_into_header),
             route: RouteInfo::KickMember {
                 guild_id,
                 user_id,

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -180,11 +180,7 @@ impl Ratelimiter {
     ///
     /// Only error kind that may be returned is [`Error::Http`].
     #[instrument]
-    pub async fn perform(&self, req: RatelimitedRequest<'_>) -> Result<Response> {
-        let RatelimitedRequest {
-            req,
-        } = req;
-
+    pub async fn perform(&self, req: Request<'_>) -> Result<Response> {
         loop {
             // This will block if another thread hit the global ratelimit.
             drop(self.global.lock().await);
@@ -438,25 +434,6 @@ impl Default for Ratelimit {
             remaining: i64::MAX,
             reset: None,
             reset_after: None,
-        }
-    }
-}
-
-/// Information about a request for the ratelimiter to perform.
-///
-/// This only contains the basic information needed by the ratelimiter to
-/// perform a full cycle of making the request and returning the response.
-///
-/// Use the [`From`] implementations for making one of these.
-#[derive(Debug)]
-pub struct RatelimitedRequest<'a> {
-    req: Request<'a>,
-}
-
-impl<'a> From<Request<'a>> for RatelimitedRequest<'a> {
-    fn from(req: Request<'a>) -> Self {
-        Self {
-            req,
         }
     }
 }

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -159,7 +159,7 @@ impl Ratelimiter {
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// let routes = http.ratelimiter.routes();
+    /// let routes = http.ratelimiter.unwrap().routes();
     /// let reader = routes.read().await;
     ///
     /// let channel_id = ChannelId::new(7);

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -69,7 +69,7 @@ impl<'a> Request<'a> {
         self,
         client: &Client,
         token: &str,
-        proxy: Option<&Url>,
+        proxy: Option<&str>,
     ) -> Result<ReqwestRequestBuilder> {
         let Request {
             body,
@@ -81,7 +81,7 @@ impl<'a> Request<'a> {
         let (method, _, mut path) = route_info.deconstruct();
 
         if let Some(proxy) = proxy {
-            path = Cow::Owned(path.to_mut().replace("https://discord.com/", proxy.as_str()));
+            path = Cow::Owned(path.to_mut().replace("https://discord.com/", proxy));
         }
 
         let mut builder =

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -205,7 +205,7 @@ impl GuildId {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn ban(self, http: impl AsRef<Http>, user: impl Into<UserId>, dmd: u8) -> Result<()> {
-        self._ban_with_reason(http, user.into(), dmd, "").await
+        self._ban(http, user.into(), dmd, None).await
     }
 
     /// Ban a [`User`] from the guild with a reason. Refer to [`Self::ban`] to further documentation.
@@ -222,22 +222,24 @@ impl GuildId {
         dmd: u8,
         reason: impl AsRef<str>,
     ) -> Result<()> {
-        self._ban_with_reason(http, user.into(), dmd, reason.as_ref()).await
+        self._ban(http, user.into(), dmd, Some(reason.as_ref())).await
     }
 
-    async fn _ban_with_reason(
+    async fn _ban(
         self,
         http: impl AsRef<Http>,
         user: UserId,
         dmd: u8,
-        reason: &str,
+        reason: Option<&str>,
     ) -> Result<()> {
         if dmd > 7 {
             return Err(Error::Model(ModelError::DeleteMessageDaysAmount(dmd)));
         }
 
-        if reason.len() > 512 {
-            return Err(Error::ExceededLimit(reason.to_string(), 512));
+        if let Some(reason) = reason {
+            if reason.len() > 512 {
+                return Err(Error::ExceededLimit(reason.to_string(), 512));
+            }
         }
 
         http.as_ref().ban_user(self, user, dmd, reason).await
@@ -966,7 +968,7 @@ impl GuildId {
     /// [Kick Members]: Permissions::KICK_MEMBERS
     #[inline]
     pub async fn kick(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        http.as_ref().kick_member(self, user_id.into()).await
+        http.as_ref().kick_member(self, user_id.into(), None).await
     }
 
     /// # Errors
@@ -980,7 +982,7 @@ impl GuildId {
         user_id: impl Into<UserId>,
         reason: &str,
     ) -> Result<()> {
-        http.as_ref().kick_member_with_reason(self, user_id.into(), reason).await
+        http.as_ref().kick_member(self, user_id.into(), Some(reason)).await
     }
 
     /// Leaves the guild.


### PR DESCRIPTION
Some small http refactors, mainly getting rid of cruft and moving some things around:

 1. Instead of having a `ratelimiter_disabled` flag, simply wrap `Http::ratelimiter` in `Option`.
 2. Use `HttpBuilder` in `Http::new` instead of duplicating construction logic
 3. Unify `ban` and `ban_with_reason`, and likewise with the kick methods. The model methods API remains unchanged.
 4. Introduce a `SecretString` type to prevent leaking the token, e.g. via `Debug`.
 5. Change `Http::proxy` to `Option<String>`, because url parsing is already done before a request is sent out. This changes the error to happen at request execution-time rather than when the `Http` is built, which may or may not be desirable. Thoughts?

This contains work adapted from #2241.