### PR TITLE
Make create_thread doc alias

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1043,6 +1043,7 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
+    #[doc(alias = "create_thread")]
     pub async fn create_public_thread<F>(
         &self,
         http: impl AsRef<Http>,
@@ -1065,6 +1066,7 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
+    #[doc(alias = "create_thread")]
     pub async fn create_private_thread<F>(
         &self,
         http: impl AsRef<Http>,


### PR DESCRIPTION
Makes the methods more discoverable

![Screenshot_20221115_141727](https://user-images.githubusercontent.com/21220820/201929276-51155d9a-c6fd-40e1-b02f-250272fea627.png)

https://discord.com/channels/381880193251409931/381912587505500160/1042027849214865509