### PR TITLE
Use #[serde(remote = "Self")] to simplify serde impls

### DIFF
--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -19,7 +19,6 @@ use crate::client::Context;
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::application::command::{CommandOptionType, CommandType};
-use crate::model::application::interaction::add_guild_id_to_resolved;
 use crate::model::channel::{Attachment, Message, PartialChannel};
 use crate::model::guild::{Member, PartialMember, Role};
 use crate::model::id::{
@@ -36,13 +35,13 @@ use crate::model::id::{
     UserId,
 };
 use crate::model::user::User;
-use crate::model::utils::{remove_from_map, remove_from_map_opt};
 use crate::model::Permissions;
 
 /// An interaction when a user invokes a slash command.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object).
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(remote = "Self")]
 #[non_exhaustive]
 pub struct CommandInteraction {
     /// Id of the interaction.
@@ -238,35 +237,20 @@ impl CommandInteraction {
     }
 }
 
+// Manual impl needed to insert guild_id into resolved Role's
 impl<'de> Deserialize<'de> for CommandInteraction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
-
-        let guild_id = remove_from_map_opt::<GuildId, _>(&mut map, "guild_id")?;
-
-        if let Some(guild_id) = guild_id {
-            add_guild_id_to_resolved(&mut map, guild_id);
+        let mut interaction = Self::deserialize(deserializer)?; // calls #[serde(remote)]-generated inherent method
+        if let Some(guild_id) = interaction.guild_id {
+            interaction.data.resolved.roles.values_mut().for_each(|r| r.guild_id = guild_id);
         }
+        Ok(interaction)
+    }
+}
 
-        let member = remove_from_map_opt::<Box<Member>, _>(&mut map, "member")?;
-        let user = remove_from_map_opt(&mut map, "user")?
-            .or_else(|| member.as_ref().map(|m| m.user.clone()))
-            .ok_or_else(|| DeError::custom("expected user or member"))?;
-
-        Ok(Self {
-            guild_id,
-            member,
-            user,
-            id: remove_from_map(&mut map, "id")?,
-            application_id: remove_from_map(&mut map, "application_id")?,
-            data: remove_from_map(&mut map, "data")?,
-            channel_id: remove_from_map(&mut map, "channel_id")?,
-            token: remove_from_map(&mut map, "token")?,
-            version: remove_from_map(&mut map, "version")?,
-            app_permissions: remove_from_map_opt(&mut map, "app_permissions")?,
-            locale: remove_from_map(&mut map, "locale")?,
-            guild_locale: remove_from_map_opt(&mut map, "guild_locale")?,
-        })
+impl Serialize for CommandInteraction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
+        Self::serialize(self, serializer) // calls #[serde(remote)]-generated inherent method
     }
 }
 
@@ -622,6 +606,7 @@ fn option_to_raw(option: &CommandDataOption) -> StdResult<RawCommandDataOption, 
     Ok(raw)
 }
 
+// Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for CommandDataOption {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         option_from_raw(RawCommandDataOption::deserialize(deserializer)?)

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -15,7 +15,6 @@ use crate::client::Context;
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::application::component::ComponentType;
-use crate::model::application::interaction::add_guild_id_to_resolved;
 use crate::model::channel::Message;
 use crate::model::guild::Member;
 #[cfg(feature = "model")]
@@ -30,13 +29,13 @@ use crate::model::id::{
     UserId,
 };
 use crate::model::user::User;
-use crate::model::utils::{remove_from_map, remove_from_map_opt};
 use crate::model::Permissions;
 
 /// An interaction triggered by a message component.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure).
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(remote = "Self")]
 #[non_exhaustive]
 pub struct ComponentInteraction {
     /// Id of the interaction.
@@ -217,36 +216,22 @@ impl ComponentInteraction {
     }
 }
 
+// Manual impl needed to insert guild_id into model data
 impl<'de> Deserialize<'de> for ComponentInteraction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
-
-        let guild_id = remove_from_map_opt(&mut map, "guild_id")?;
-
-        if let Some(guild_id) = guild_id {
-            add_guild_id_to_resolved(&mut map, guild_id);
+        let mut interaction = Self::deserialize(deserializer)?; // calls #[serde(remote)]-generated inherent method
+        if let (Some(guild_id), Some(member)) = (interaction.guild_id, &mut interaction.member) {
+            member.guild_id = guild_id;
+            // If `member` is present, `user` wasn't sent and is still filled with default data
+            interaction.user = member.user.clone();
         }
+        Ok(interaction)
+    }
+}
 
-        let member = remove_from_map_opt::<Member, _>(&mut map, "member")?;
-        let user = remove_from_map_opt(&mut map, "user")?
-            .or_else(|| member.as_ref().map(|m| m.user.clone()))
-            .ok_or_else(|| DeError::custom("expected user or member"))?;
-
-        Ok(Self {
-            guild_id,
-            member,
-            user,
-            id: remove_from_map(&mut map, "id")?,
-            application_id: remove_from_map(&mut map, "application_id")?,
-            data: remove_from_map(&mut map, "data")?,
-            channel_id: remove_from_map(&mut map, "channel_id")?,
-            token: remove_from_map(&mut map, "token")?,
-            version: remove_from_map(&mut map, "version")?,
-            message: remove_from_map(&mut map, "message")?,
-            app_permissions: remove_from_map_opt(&mut map, "app_permissions")?,
-            locale: remove_from_map(&mut map, "locale")?,
-            guild_locale: remove_from_map_opt(&mut map, "guild_locale")?,
-        })
+impl Serialize for ComponentInteraction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
+        Self::serialize(self, serializer) // calls #[serde(remote)]-generated inherent method
     }
 }
 
@@ -261,6 +246,7 @@ pub enum ComponentInteractionDataKind {
     Unknown(u8),
 }
 
+// Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for ComponentInteractionDataKind {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         #[derive(Deserialize)]

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -13,7 +13,7 @@ use self::ping::PingInteraction;
 use crate::internal::prelude::*;
 use crate::json::from_value;
 use crate::model::guild::PartialMember;
-use crate::model::id::{ApplicationId, GuildId, InteractionId};
+use crate::model::id::{ApplicationId, InteractionId};
 use crate::model::user::User;
 use crate::model::utils::deserialize_val;
 use crate::model::Permissions;
@@ -217,6 +217,7 @@ impl Interaction {
     }
 }
 
+// Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for Interaction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
         let map = JsonMap::deserialize(deserializer)?;
@@ -301,24 +302,4 @@ pub struct MessageInteraction {
     /// The member who invoked the interaction in the guild.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<PartialMember>,
-}
-
-fn add_guild_id_to_resolved(map: &mut JsonMap, guild_id: GuildId) {
-    if let Some(member) = map.get_mut("member").and_then(Value::as_object_mut) {
-        member.insert("guild_id".to_string(), guild_id.get().into());
-    }
-
-    if let Some(data) = map.get_mut("data") {
-        if let Some(resolved) = data.get_mut("resolved") {
-            if let Some(roles) = resolved.get_mut("roles") {
-                if let Some(values) = roles.as_object_mut() {
-                    for value in values.values_mut() {
-                        if let Some(role) = value.as_object_mut() {
-                            role.insert("guild_id".to_string(), guild_id.get().into());
-                        };
-                    }
-                }
-            }
-        }
-    }
 }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -55,6 +55,7 @@ pub struct GuildChannel {
     ///
     /// The original voice channel has an Id equal to the guild's Id,
     /// incremented by one.
+    #[serde(default)]
     pub guild_id: GuildId,
     /// The type of the channel.
     #[serde(rename = "type")]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -175,6 +175,7 @@ impl Channel {
     }
 }
 
+// Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for Channel {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let map = JsonMap::deserialize(deserializer)?;

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -84,6 +84,7 @@ impl Action {
     }
 }
 
+// Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for Action {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let value = u8::deserialize(deserializer)?;

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -25,6 +25,7 @@ pub struct Member {
     /// Indicator of whether the member can hear in voice channels.
     pub deaf: bool,
     /// The unique Id of the guild that the member is a part of.
+    #[serde(default)]
     pub guild_id: GuildId,
     /// Timestamp representing the date when the member joined.
     pub joined_at: Option<Timestamp>,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,4 +1,4 @@
-use serde::de::Error as DeError;
+use serde::Serialize;
 #[cfg(feature = "cache")]
 use tracing::{error, warn};
 
@@ -24,26 +24,19 @@ use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::{MessageCollector, ReactionCollector};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-use crate::json::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::application::command::{Command, CommandPermission};
 #[cfg(feature = "model")]
 use crate::model::guild::automod::Rule;
 use crate::model::prelude::*;
-use crate::model::utils::{
-    add_guild_id_to_map,
-    emojis,
-    remove_from_map,
-    remove_from_map_opt,
-    roles,
-    stickers,
-};
+use crate::model::utils::{emojis, roles, stickers};
 
 /// Partial information about a [`Guild`]. This does not include information
 /// like member data.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object).
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(remote = "Self")]
 #[non_exhaustive]
 pub struct PartialGuild {
     /// Application ID of the guild creator if it is bot-created.
@@ -1561,94 +1554,23 @@ impl PartialGuild {
     }
 }
 
+// Manual impl needed to insert guild_id into Role's
 impl<'de> Deserialize<'de> for PartialGuild {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut map = JsonMap::deserialize(deserializer)?;
+        let mut guild = Self::deserialize(deserializer)?; // calls #[serde(remote)]-generated inherent method
+        guild.roles.values_mut().for_each(|r| r.guild_id = guild.id);
+        Ok(guild)
+    }
+}
 
-        let id = remove_from_map(&mut map, "id")?;
-
-        add_guild_id_to_map(&mut map, "roles", id);
-
-        let emojis = map
-            .remove("emojis")
-            .ok_or_else(|| DeError::custom("expected guild emojis"))
-            .and_then(emojis::deserialize)
-            .map_err(DeError::custom)?;
-
-        let roles = map
-            .remove("roles")
-            .ok_or_else(|| DeError::custom("expected guild roles"))
-            .and_then(roles::deserialize)
-            .map_err(DeError::custom)?;
-
-        let premium_subscription_count = match map.remove("premium_subscription_count") {
-            #[cfg(not(feature = "simd-json"))]
-            Some(Value::Null) | None => 0,
-            #[cfg(feature = "simd-json")]
-            Some(Value::Static(StaticNode::Null)) | None => 0,
-            Some(v) => u64::deserialize(v).map_err(DeError::custom)?,
-        };
-
-        let stickers = map
-            .remove("stickers")
-            .ok_or_else(|| DeError::custom("expected guild stickers"))
-            .and_then(stickers::deserialize)
-            .map_err(DeError::custom)?;
-
-        Ok(Self {
-            id,
-            emojis,
-            roles,
-            premium_subscription_count,
-            stickers,
-            afk_channel_id: remove_from_map_opt(&mut map, "afk_channel_id")?.flatten(),
-            afk_timeout: remove_from_map(&mut map, "afk_timeout")?,
-            application_id: remove_from_map_opt(&mut map, "application_id")?.flatten(),
-            default_message_notifications: remove_from_map(
-                &mut map,
-                "default_message_notifications",
-            )?,
-            features: remove_from_map(&mut map, "features")?,
-            widget_enabled: remove_from_map_opt(&mut map, "widget_enabled")?.flatten(),
-            widget_channel_id: remove_from_map_opt(&mut map, "widget_channel_id")?.flatten(),
-            icon: remove_from_map_opt(&mut map, "icon")?.flatten(),
-            mfa_level: remove_from_map(&mut map, "mfa_level")?,
-            name: remove_from_map(&mut map, "name")?,
-            owner_id: remove_from_map(&mut map, "owner_id")?,
-            owner: remove_from_map_opt(&mut map, "owner")?.unwrap_or_default(),
-            splash: remove_from_map_opt(&mut map, "splash")?.flatten(),
-            discovery_splash: remove_from_map_opt(&mut map, "discovery_splash")?.flatten(),
-            system_channel_id: remove_from_map_opt(&mut map, "system_channel_id")?.flatten(),
-            system_channel_flags: remove_from_map(&mut map, "system_channel_flags")?,
-            rules_channel_id: remove_from_map_opt(&mut map, "rules_channel_id")?.flatten(),
-            public_updates_channel_id: remove_from_map_opt(&mut map, "public_updates_channel_id")?
-                .flatten(),
-            verification_level: remove_from_map(&mut map, "verification_level")?,
-            description: remove_from_map_opt(&mut map, "description")?.flatten(),
-            premium_tier: remove_from_map_opt(&mut map, "premium_tier")?.unwrap_or_default(),
-            banner: remove_from_map_opt(&mut map, "banner")?.flatten(),
-            vanity_url_code: remove_from_map_opt(&mut map, "vanity_url_code")?.flatten(),
-            welcome_screen: remove_from_map_opt(&mut map, "welcome_screen")?,
-            approximate_member_count: remove_from_map_opt(&mut map, "approximate_member_count")?,
-            approximate_presence_count: remove_from_map_opt(
-                &mut map,
-                "approximate_presence_count",
-            )?,
-            nsfw_level: remove_from_map(&mut map, "nsfw_level")?,
-            max_video_channel_users: remove_from_map(&mut map, "max_video_channel_users")?,
-            max_presences: remove_from_map_opt(&mut map, "max_presences")?.flatten(),
-            max_members: remove_from_map_opt(&mut map, "max_members")?.flatten(),
-            permissions: remove_from_map_opt(&mut map, "permissions")?.unwrap_or_default(),
-        })
+impl Serialize for PartialGuild {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
+        Self::serialize(self, serializer) // calls #[serde(remote)]-generated inherent method
     }
 }
 
 impl From<Guild> for PartialGuild {
     /// Converts this [`Guild`] instance into a [`PartialGuild`]
-    ///
-    /// [`PartialGuild`] is not a strict subset and contains some data specific to the current user
-    /// that [`Guild`] does not contain. Therefore, this method needs access to cache and HTTP to
-    /// generate the missing data
     fn from(guild: Guild) -> Self {
         Self {
             application_id: guild.application_id,

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -32,6 +32,7 @@ pub struct Role {
     /// The Id of the role. Can be used to calculate the role's creation date.
     pub id: RoleId,
     /// The Id of the Guild the Role is in.
+    #[serde(default)]
     pub guild_id: GuildId,
     /// The colour of the role.
     #[serde(rename = "color")]
@@ -76,46 +77,6 @@ pub struct Role {
     pub icon: Option<String>,
     /// Role unicoded image.
     pub unicode_emoji: Option<String>,
-}
-
-/// Helper for deserialization without a `GuildId` but then later updated to the correct `GuildId`.
-///
-/// The only difference to `Role` is `guild_id` is wrapped in `Option`.
-#[derive(Deserialize)]
-pub(crate) struct InterimRole {
-    pub id: RoleId,
-    #[serde(default)]
-    pub guild_id: Option<GuildId>,
-    #[serde(rename = "color")]
-    pub colour: Colour,
-    pub hoist: bool,
-    pub managed: bool,
-    #[serde(default)]
-    pub mentionable: bool,
-    pub name: String,
-    pub permissions: Permissions,
-    pub position: u32,
-    #[serde(default)]
-    pub tags: RoleTags,
-}
-
-impl From<InterimRole> for Role {
-    fn from(r: InterimRole) -> Self {
-        Self {
-            id: r.id,
-            guild_id: r.guild_id.expect("GuildID was not set on InterimRole"),
-            colour: r.colour,
-            hoist: r.hoist,
-            managed: r.managed,
-            mentionable: r.mentionable,
-            name: r.name,
-            permissions: r.permissions,
-            position: r.position,
-            tags: r.tags,
-            icon: None,
-            unicode_emoji: None,
-        }
-    }
 }
 
 #[cfg(feature = "model")]

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -29,6 +29,7 @@ pub struct GuildWelcomeChannel {
     pub emoji: Option<GuildWelcomeChannelEmoji>,
 }
 
+// Manual impl needed to deserialize emoji_id and emoji_name into a single GuildWelcomeChannelEmoji
 impl<'de> Deserialize<'de> for GuildWelcomeChannel {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -788,6 +788,7 @@ impl Permissions {
     }
 }
 
+// Manual impl needed because Permissions are sent as a stringified integer
 impl<'de> Deserialize<'de> for Permissions {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let permissions_str = String::deserialize(deserializer)?;

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -46,16 +46,6 @@ where
     remove_from_map_opt(map, key)?.ok_or_else(|| serde::de::Error::missing_field(key))
 }
 
-pub fn add_guild_id_to_map(map: &mut JsonMap, key: &str, id: GuildId) {
-    if let Some(array) = map.get_mut(key).and_then(Value::as_array_mut) {
-        for value in array {
-            if let Some(item) = value.as_object_mut() {
-                item.insert("guild_id".to_string(), id.get().into());
-            }
-        }
-    }
-}
-
 /// Used with `#[serde(with = "emojis")]`
 pub mod emojis {
     use std::collections::HashMap;
@@ -165,11 +155,11 @@ pub mod private_channels {
 pub mod roles {
     use std::collections::HashMap;
 
-    use serde::{Deserialize, Deserializer};
+    use serde::Deserializer;
 
     use super::SequenceToMapVisitor;
-    use crate::model::guild::{InterimRole, Role};
-    use crate::model::id::{GuildId, RoleId};
+    use crate::model::guild::Role;
+    use crate::model::id::RoleId;
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
@@ -178,23 +168,6 @@ pub mod roles {
     }
 
     pub use super::serialize_map_values as serialize;
-
-    /// Helper to deserialize `GuildRoleCreateEvent` and `GuildRoleUpdateEvent`.
-    pub fn deserialize_event<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Role, D::Error> {
-        #[derive(Deserialize)]
-        struct Event {
-            guild_id: GuildId,
-            role: InterimRole,
-        }
-
-        let Event {
-            guild_id,
-            mut role,
-        } = Event::deserialize(deserializer)?;
-
-        role.guild_id = Some(guild_id);
-        Ok(Role::from(role))
-    }
 }
 
 /// Used with `#[serde(with = "stickers")]`

--- a/voice-model/src/speaking_state.rs
+++ b/voice-model/src/speaking_state.rs
@@ -31,6 +31,8 @@ impl SpeakingState {
     }
 }
 
+// Manual impl needed because object is sent as a flags integer
+// (could maybe just put `#[serde(transparent)]` on the type?)
 impl<'de> Deserialize<'de> for SpeakingState {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(Self::from_bits_truncate(u8::deserialize(deserializer)?))


### PR DESCRIPTION
In multiple places, serenity used manual Deserialize implementations because it had to intervene in the deserialization process. The actual intervention is almost always small, but in turn, the entire deserialization process had to be rewritten.

This PR changes applicable places to use the Deserialize derive instead with the `#[serde(remote = "Self")]` attribute. This attribute makes serde generate the deserialize+serialize methods as private inherent methods instead of as trait implementations. Therefore, a manual deserialization implementation can easily delegate to those inherent methods and implement their special behavior on top of them.