### PR TITLE
Routing overhaul

### DIFF
--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -1,8 +1,5 @@
 #[cfg(feature = "http")]
-use std::fmt::Write;
-
-#[cfg(feature = "http")]
-use crate::http::Http;
+use crate::http::{Http, MessagePagination};
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -48,7 +45,7 @@ use crate::model::prelude::*;
 #[derive(Clone, Copy, Debug, Default)]
 #[must_use]
 pub struct GetMessages {
-    pub search_filter: Option<SearchFilter>,
+    pub search_filter: Option<MessagePagination>,
     pub limit: Option<u8>,
 }
 
@@ -74,38 +71,25 @@ impl GetMessages {
         http: impl AsRef<Http>,
         channel_id: ChannelId,
     ) -> Result<Vec<Message>> {
-        let mut query = "?".to_string();
-        if let Some(limit) = self.limit {
-            write!(query, "limit={limit}")?;
-        }
-
-        if let Some(filter) = self.search_filter {
-            match filter {
-                SearchFilter::After(after) => write!(query, "&after={after}")?,
-                SearchFilter::Around(around) => write!(query, "&around={around}")?,
-                SearchFilter::Before(before) => write!(query, "&before={before}")?,
-            }
-        }
-
-        http.as_ref().get_messages(channel_id, &query).await
+        http.as_ref().get_messages(channel_id, self.search_filter, self.limit).await
     }
 
     /// Indicates to retrieve the messages after a specific message, given its Id.
     pub fn after(mut self, message_id: impl Into<MessageId>) -> Self {
-        self.search_filter = Some(SearchFilter::After(message_id.into()));
+        self.search_filter = Some(MessagePagination::After(message_id.into()));
         self
     }
 
     /// Indicates to retrieve the messages _around_ a specific message, in other words in either
     /// direction from the message in time.
     pub fn around(mut self, message_id: impl Into<MessageId>) -> Self {
-        self.search_filter = Some(SearchFilter::Around(message_id.into()));
+        self.search_filter = Some(MessagePagination::Around(message_id.into()));
         self
     }
 
     /// Indicates to retrieve the messages before a specific message, given its Id.
     pub fn before(mut self, message_id: impl Into<MessageId>) -> Self {
-        self.search_filter = Some(SearchFilter::Before(message_id.into()));
+        self.search_filter = Some(MessagePagination::Before(message_id.into()));
         self
     }
 
@@ -119,11 +103,4 @@ impl GetMessages {
         self.limit = Some(limit.min(100));
         self
     }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum SearchFilter {
-    After(MessageId),
-    Around(MessageId),
-    Before(MessageId),
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3800,7 +3800,7 @@ impl Http {
             multipart: None,
             headers: None,
             method: LightMethod::Get,
-            route: Route::ChannelMessageReactionsList {
+            route: Route::ChannelMessageReactionEmoji {
                 channel_id,
                 message_id,
                 reaction: &reaction_type.as_data(),
@@ -4055,7 +4055,7 @@ impl Http {
             multipart: None,
             headers: reason.map(reason_into_header),
             method: LightMethod::Delete,
-            route: Route::GuildKick {
+            route: Route::GuildMember {
                 guild_id,
                 user_id,
             },

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -16,9 +16,16 @@ use tracing::{debug, instrument, trace};
 use super::multipart::Multipart;
 use super::ratelimiting::Ratelimiter;
 use super::request::Request;
-use super::routing::RouteInfo;
+use super::routing::Route;
 use super::typing::Typing;
-use super::{ErrorResponse, GuildPagination, HttpError, UserPagination};
+use super::{
+    ErrorResponse,
+    GuildPagination,
+    HttpError,
+    LightMethod,
+    MessagePagination,
+    UserPagination,
+};
 use crate::builder::CreateAttachment;
 use crate::constants;
 use crate::internal::prelude::*;
@@ -29,8 +36,7 @@ use crate::model::prelude::*;
 
 /// A builder for the underlying [`Http`] client that performs requests
 /// to Discord's HTTP API. If you do not need to use a proxy or do not
-/// need to disable the rate limiter, you can use [`Http::new`] or
-/// [`Http::new_with_application_id`] instead.
+/// need to disable the rate limiter, you can use [`Http::new`] instead.
 ///
 /// ## Example
 ///
@@ -239,10 +245,12 @@ impl Http {
                 body: Some(body),
                 multipart: None,
                 headers: None,
-                route: RouteInfo::AddGuildMember {
+                method: LightMethod::Put,
+                route: Route::GuildMember {
                     guild_id,
                     user_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -270,11 +278,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::AddMemberRole {
+            method: LightMethod::Put,
+            route: Route::GuildMemberRole {
                 guild_id,
                 role_id,
                 user_id,
             },
+            params: None,
         })
         .await
     }
@@ -299,11 +309,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: reason.map(reason_into_header),
-            route: RouteInfo::GuildBanUser {
-                delete_message_days: Some(delete_message_days),
+            method: LightMethod::Put,
+            route: Route::GuildBan {
                 guild_id,
                 user_id,
             },
+            params: Some(vec![("delete_message_days", delete_message_days.to_string())]),
         })
         .await
     }
@@ -320,9 +331,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::BroadcastTyping {
+            method: LightMethod::Post,
+            route: Route::ChannelTyping {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -347,9 +360,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateChannel {
+            method: LightMethod::Post,
+            route: Route::GuildChannels {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -364,7 +379,9 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateStageInstance,
+            method: LightMethod::Post,
+            route: Route::StageInstances,
+            params: None,
         })
         .await
     }
@@ -384,10 +401,12 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreatePublicThread {
+            method: LightMethod::Post,
+            route: Route::ChannelPublicThreads {
                 channel_id,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -405,9 +424,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreatePrivateThread {
+            method: LightMethod::Post,
+            route: Route::ChannelPrivateThreads {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -430,9 +451,11 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateEmoji {
+            method: LightMethod::Post,
+            route: Route::GuildEmojis {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -450,10 +473,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateFollowupMessage {
+            method: LightMethod::Post,
+            route: Route::WebhookFollowupMessages {
                 application_id: self.try_application_id()?,
-                interaction_token,
+                token: interaction_token,
             },
+            params: None,
         };
 
         if files.is_empty() {
@@ -488,9 +513,11 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateGlobalCommand {
+            method: LightMethod::Post,
+            route: Route::ApplicationCommands {
                 application_id: self.try_application_id()?,
             },
+            params: None,
         })
         .await
     }
@@ -504,9 +531,11 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateGlobalCommands {
+            method: LightMethod::Put,
+            route: Route::ApplicationCommands {
                 application_id: self.try_application_id()?,
             },
+            params: None,
         })
         .await
     }
@@ -521,10 +550,12 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateGuildCommands {
+            method: LightMethod::Put,
+            route: Route::ApplicationGuildCommands {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -567,7 +598,9 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateGuild,
+            method: LightMethod::Post,
+            route: Route::Guilds,
+            params: None,
         })
         .await
     }
@@ -588,10 +621,12 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateGuildCommand {
+            method: LightMethod::Post,
+            route: Route::ApplicationGuildCommands {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -615,10 +650,12 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateGuildIntegration {
+            method: LightMethod::Post,
+            route: Route::GuildIntegration {
                 guild_id,
                 integration_id,
             },
+            params: None,
         })
         .await
     }
@@ -640,10 +677,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateInteractionResponse {
+            method: LightMethod::Post,
+            route: Route::InteractionResponse {
                 interaction_id,
-                interaction_token,
+                token: interaction_token,
             },
+            params: None,
         };
 
         if files.is_empty() {
@@ -681,9 +720,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateInvite {
+            method: LightMethod::Post,
+            route: Route::ChannelInvites {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -702,10 +743,12 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreatePermission {
+            method: LightMethod::Put,
+            route: Route::ChannelPermission {
                 channel_id,
                 target_id,
             },
+            params: None,
         })
         .await
     }
@@ -718,7 +761,9 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: None,
-            route: RouteInfo::CreatePrivateChannel,
+            method: LightMethod::Post,
+            route: Route::UserMeDmChannels,
+            params: None,
         })
         .await
     }
@@ -734,11 +779,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateReaction {
-                reaction: &reaction_type.as_data(),
+            method: LightMethod::Put,
+            route: Route::ChannelMessageReactionMe {
                 channel_id,
                 message_id,
+                reaction: &reaction_type.as_data(),
             },
+            params: None,
         })
         .await
     }
@@ -755,9 +802,11 @@ impl Http {
                 body: Some(to_vec(body)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
-                route: RouteInfo::CreateRole {
+                method: LightMethod::Post,
+                route: Route::GuildRoles {
                     guild_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -786,9 +835,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateScheduledEvent {
+            method: LightMethod::Post,
+            route: Route::GuildScheduledEvents {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -813,9 +864,11 @@ impl Http {
                 payload_json: None,
             }),
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateSticker {
+            method: LightMethod::Post,
+            route: Route::GuildStickers {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -862,9 +915,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateWebhook {
+            method: LightMethod::Post,
+            route: Route::ChannelWebhooks {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -879,9 +934,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteChannel {
+            method: LightMethod::Delete,
+            route: Route::Channel {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -896,9 +953,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteStageInstance {
+            method: LightMethod::Delete,
+            route: Route::StageInstance {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -914,10 +973,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteEmoji {
+            method: LightMethod::Delete,
+            route: Route::GuildEmoji {
                 guild_id,
                 emoji_id,
             },
+            params: None,
         })
         .await
     }
@@ -932,11 +993,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteFollowupMessage {
+            method: LightMethod::Delete,
+            route: Route::WebhookFollowupMessage {
                 application_id: self.try_application_id()?,
-                interaction_token,
+                token: interaction_token,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -947,10 +1010,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteGlobalCommand {
+            method: LightMethod::Delete,
+            route: Route::ApplicationCommand {
                 application_id: self.try_application_id()?,
                 command_id,
             },
+            params: None,
         })
         .await
     }
@@ -961,9 +1026,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteGuild {
+            method: LightMethod::Delete,
+            route: Route::Guild {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -978,11 +1045,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteGuildCommand {
+            method: LightMethod::Delete,
+            route: Route::ApplicationGuildCommand {
                 application_id: self.try_application_id()?,
                 guild_id,
                 command_id,
             },
+            params: None,
         })
         .await
     }
@@ -998,10 +1067,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteGuildIntegration {
+            method: LightMethod::Delete,
+            route: Route::GuildIntegration {
                 guild_id,
                 integration_id,
             },
+            params: None,
         })
         .await
     }
@@ -1016,9 +1087,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteInvite {
+            method: LightMethod::Delete,
+            route: Route::Invite {
                 code,
             },
+            params: None,
         })
         .await
     }
@@ -1034,10 +1107,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteMessage {
+            method: LightMethod::Delete,
+            route: Route::ChannelMessage {
                 channel_id,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -1053,9 +1128,11 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteMessages {
+            method: LightMethod::Post,
+            route: Route::ChannelMessagesBulkDelete {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -1087,10 +1164,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteMessageReactions {
+            method: LightMethod::Delete,
+            route: Route::ChannelMessageReactions {
                 channel_id,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -1106,11 +1185,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteMessageReactionEmoji {
-                reaction: &reaction_type.as_data(),
+            method: LightMethod::Delete,
+            route: Route::ChannelMessageReactionEmoji {
                 channel_id,
                 message_id,
+                reaction: &reaction_type.as_data(),
             },
+            params: None,
         })
         .await
     }
@@ -1124,10 +1205,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteOriginalInteractionResponse {
+            method: LightMethod::Delete,
+            route: Route::WebhookOriginalInteractionResponse {
                 application_id: self.try_application_id()?,
-                interaction_token,
+                token: interaction_token,
             },
+            params: None,
         })
         .await
     }
@@ -1143,35 +1226,58 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeletePermission {
+            method: LightMethod::Delete,
+            route: Route::ChannelPermission {
                 channel_id,
                 target_id,
             },
+            params: None,
         })
         .await
     }
 
-    /// Deletes a reaction from a message if owned by us or
-    /// we have specific permissions.
+    /// Deletes a user's reaction from a message.
     pub async fn delete_reaction(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
-        user_id: Option<UserId>,
+        user_id: UserId,
         reaction_type: &ReactionType,
     ) -> Result<()> {
-        let user = user_id.map_or_else(|| "@me".to_string(), |uid| uid.to_string());
-
         self.wind(204, Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteReaction {
-                reaction: &reaction_type.as_data(),
-                user: &user,
+            method: LightMethod::Delete,
+            route: Route::ChannelMessageReaction {
                 channel_id,
                 message_id,
+                user_id,
+                reaction: &reaction_type.as_data(),
             },
+            params: None,
+        })
+        .await
+    }
+
+    /// Deletes a reaction by the current user from a message.
+    pub async fn delete_reaction_me(
+        &self,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        reaction_type: &ReactionType,
+    ) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Delete,
+            route: Route::ChannelMessageReactionMe {
+                channel_id,
+                message_id,
+                reaction: &reaction_type.as_data(),
+            },
+            params: None,
         })
         .await
     }
@@ -1187,10 +1293,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteRole {
+            method: LightMethod::Delete,
+            route: Route::GuildRole {
                 guild_id,
                 role_id,
             },
+            params: None,
         })
         .await
     }
@@ -1210,10 +1318,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteScheduledEvent {
+            method: LightMethod::Delete,
+            route: Route::GuildScheduledEvent {
                 guild_id,
                 event_id,
             },
+            params: None,
         })
         .await
     }
@@ -1233,10 +1343,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteSticker {
+            method: LightMethod::Delete,
+            route: Route::GuildSticker {
                 guild_id,
                 sticker_id,
             },
+            params: None,
         })
         .await
     }
@@ -1272,9 +1384,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteWebhook {
+            method: LightMethod::Delete,
+            route: Route::Webhook {
                 webhook_id,
             },
+            params: None,
         })
         .await
     }
@@ -1310,10 +1424,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteWebhookWithToken {
-                token,
+            method: LightMethod::Delete,
+            route: Route::WebhookWithToken {
                 webhook_id,
+                token,
             },
+            params: None,
         })
         .await
     }
@@ -1331,9 +1447,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditChannel {
+            method: LightMethod::Patch,
+            route: Route::Channel {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -1349,9 +1467,11 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditStageInstance {
+            method: LightMethod::Patch,
+            route: Route::StageInstance {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -1370,10 +1490,12 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditEmoji {
+            method: LightMethod::Patch,
+            route: Route::GuildEmoji {
                 guild_id,
                 emoji_id,
             },
+            params: None,
         })
         .await
     }
@@ -1394,11 +1516,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::EditFollowupMessage {
+            method: LightMethod::Patch,
+            route: Route::WebhookFollowupMessage {
                 application_id: self.try_application_id()?,
-                interaction_token,
+                token: interaction_token,
                 message_id,
             },
+            params: None,
         };
 
         if new_attachments.is_empty() {
@@ -1428,11 +1552,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetFollowupMessage {
+            method: LightMethod::Get,
+            route: Route::WebhookFollowupMessage {
                 application_id: self.try_application_id()?,
-                interaction_token,
+                token: interaction_token,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -1453,10 +1579,12 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditGlobalCommand {
+            method: LightMethod::Patch,
+            route: Route::ApplicationCommand {
                 application_id: self.try_application_id()?,
                 command_id,
             },
+            params: None,
         })
         .await
     }
@@ -1474,9 +1602,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditGuild {
+            method: LightMethod::Patch,
+            route: Route::Guild {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -1498,11 +1628,13 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditGuildCommand {
+            method: LightMethod::Patch,
+            route: Route::ApplicationGuildCommand {
                 application_id: self.try_application_id()?,
                 guild_id,
                 command_id,
             },
+            params: None,
         })
         .await
     }
@@ -1524,11 +1656,13 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditGuildCommandPermission {
+            method: LightMethod::Put,
+            route: Route::ApplicationGuildCommandPermissions {
                 application_id: self.try_application_id()?,
                 guild_id,
                 command_id,
             },
+            params: None,
         })
         .await
     }
@@ -1549,10 +1683,12 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditGuildCommandsPermissions {
+            method: LightMethod::Put,
+            route: Route::ApplicationGuildCommandsPermissions {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -1569,9 +1705,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditGuildChannels {
+            method: LightMethod::Patch,
+            route: Route::GuildChannels {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -1589,9 +1727,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditGuildWidget {
+            method: LightMethod::Patch,
+            route: Route::GuildWidget {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -1609,9 +1749,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditGuildWelcomeScreen {
+            method: LightMethod::Patch,
+            route: Route::GuildWelcomeScreen {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -1631,10 +1773,12 @@ impl Http {
                 body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
-                route: RouteInfo::EditMember {
+                method: LightMethod::Patch,
+                route: Route::GuildMember {
                     guild_id,
                     user_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -1659,10 +1803,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::EditMessage {
+            method: LightMethod::Patch,
+            route: Route::ChannelMessage {
                 channel_id,
                 message_id,
             },
+            params: None,
         };
 
         if new_attachments.is_empty() {
@@ -1690,10 +1836,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::CrosspostMessage {
+            method: LightMethod::Post,
+            route: Route::ChannelMessageCrosspost {
                 channel_id,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -1711,9 +1859,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditMemberMe {
+            method: LightMethod::Patch,
+            route: Route::GuildMemberMe {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -1734,9 +1884,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditMemberMe {
+            method: LightMethod::Patch,
+            route: Route::GuildMemberMe {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -1754,9 +1906,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: None,
-            route: RouteInfo::FollowNewsChannel {
+            method: LightMethod::Post,
+            route: Route::ChannelFollowNews {
                 channel_id: news_channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -1770,10 +1924,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetOriginalInteractionResponse {
+            method: LightMethod::Get,
+            route: Route::WebhookOriginalInteractionResponse {
                 application_id: self.try_application_id()?,
-                interaction_token,
+                token: interaction_token,
             },
+            params: None,
         })
         .await
     }
@@ -1793,10 +1949,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::EditOriginalInteractionResponse {
+            method: LightMethod::Patch,
+            route: Route::WebhookOriginalInteractionResponse {
                 application_id: self.try_application_id()?,
-                interaction_token,
+                token: interaction_token,
             },
+            params: None,
         };
 
         if new_attachments.is_empty() {
@@ -1820,7 +1978,9 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditProfile,
+            method: LightMethod::Patch,
+            route: Route::UserMe,
+            params: None,
         })
         .await
     }
@@ -1838,10 +1998,12 @@ impl Http {
                 body: Some(to_vec(map)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
-                route: RouteInfo::EditRole {
+                method: LightMethod::Patch,
+                route: Route::GuildRole {
                     guild_id,
                     role_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -1871,9 +2033,11 @@ impl Http {
                 body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
-                route: RouteInfo::EditRolePosition {
+                method: LightMethod::Patch,
+                route: Route::GuildRoles {
                     guild_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -1905,10 +2069,12 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditScheduledEvent {
+            method: LightMethod::Patch,
+            route: Route::GuildScheduledEvent {
                 guild_id,
                 event_id,
             },
+            params: None,
         })
         .await
     }
@@ -1932,10 +2098,12 @@ impl Http {
                 body: Some(body),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
-                route: RouteInfo::EditSticker {
+                method: LightMethod::Patch,
+                route: Route::GuildSticker {
                     guild_id,
                     sticker_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -1957,9 +2125,11 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditThread {
+            method: LightMethod::Patch,
+            route: Route::Channel {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -2006,10 +2176,12 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditVoiceState {
+            method: LightMethod::Patch,
+            route: Route::GuildVoiceStates {
                 guild_id,
                 user_id,
             },
+            params: None,
         })
         .await
     }
@@ -2057,9 +2229,11 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditVoiceStateMe {
+            method: LightMethod::Patch,
+            route: Route::GuildVoiceStateMe {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2107,9 +2281,11 @@ impl Http {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditWebhook {
+            method: LightMethod::Patch,
+            route: Route::Webhook {
                 webhook_id,
             },
+            params: None,
         })
         .await
     }
@@ -2153,10 +2329,12 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditWebhookWithToken {
-                token,
+            method: LightMethod::Patch,
+            route: Route::WebhookWithToken {
                 webhook_id,
+                token,
             },
+            params: None,
         })
         .await
     }
@@ -2222,16 +2400,21 @@ impl Http {
         files: Vec<CreateAttachment>,
         map: &impl serde::Serialize,
     ) -> Result<Option<Message>> {
+        let mut params = vec![("wait", wait.to_string())];
+        if let Some(thread_id) = thread_id {
+            params.push(("thread_id", thread_id.to_string()));
+        }
+
         let mut request = Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::ExecuteWebhook {
-                token,
-                wait,
+            method: LightMethod::Post,
+            route: Route::WebhookWithToken {
                 webhook_id,
-                thread_id,
+                token,
             },
+            params: Some(params),
         };
 
         if files.is_empty() {
@@ -2264,11 +2447,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetWebhookMessage {
-                token,
+            method: LightMethod::Get,
+            route: Route::WebhookMessage {
                 webhook_id,
+                token,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -2287,11 +2472,13 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: None,
-            route: RouteInfo::EditWebhookMessage {
-                token,
+            method: LightMethod::Patch,
+            route: Route::WebhookMessage {
                 webhook_id,
+                token,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -2307,11 +2494,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::DeleteWebhookMessage {
-                token,
+            method: LightMethod::Delete,
+            route: Route::WebhookMessage {
                 webhook_id,
+                token,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -2331,7 +2520,9 @@ impl Http {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::GetActiveMaintenance,
+                method: LightMethod::Get,
+                route: Route::StatusMaintenancesActive,
+                params: None,
             })
             .await?;
 
@@ -2344,9 +2535,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetBans {
+            method: LightMethod::Get,
+            route: Route::GuildBans {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2360,17 +2553,29 @@ impl Http {
         before: Option<u64>,
         limit: Option<u8>,
     ) -> Result<AuditLogs> {
+        let mut params = vec![];
+        if let Some(action_type) = action_type {
+            params.push(("action_type", action_type.to_string()));
+        }
+        if let Some(before) = before {
+            params.push(("before", before.to_string()));
+        }
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+        if let Some(user_id) = user_id {
+            params.push(("user_id", user_id.to_string()));
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetAuditLogs {
-                action_type,
-                before,
+            method: LightMethod::Get,
+            route: Route::GuildAuditLogs {
                 guild_id,
-                limit,
-                user_id,
             },
+            params: Some(params),
         })
         .await
     }
@@ -2383,9 +2588,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetAutoModRules {
+            method: LightMethod::Get,
+            route: Route::GuildAutomodRules {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2398,10 +2605,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetAutoModRule {
+            method: LightMethod::Get,
+            route: Route::GuildAutomodRule {
                 guild_id,
                 rule_id,
             },
+            params: None,
         })
         .await
     }
@@ -2421,9 +2630,11 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::CreateAutoModRule {
+            method: LightMethod::Post,
+            route: Route::GuildAutomodRules {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2444,10 +2655,12 @@ impl Http {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::EditAutoModRule {
+            method: LightMethod::Patch,
+            route: Route::GuildAutomodRule {
                 guild_id,
                 rule_id,
             },
+            params: None,
         })
         .await
     }
@@ -2465,10 +2678,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::DeleteAutoModRule {
+            method: LightMethod::Delete,
+            route: Route::GuildAutomodRule {
                 guild_id,
                 rule_id,
             },
+            params: None,
         })
         .await
     }
@@ -2479,7 +2694,9 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetBotGateway,
+            method: LightMethod::Get,
+            route: Route::GatewayBot,
+            params: None,
         })
         .await
     }
@@ -2490,9 +2707,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetChannelInvites {
+            method: LightMethod::Get,
+            route: Route::ChannelInvites {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -2506,9 +2725,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetChannelThreadMembers {
+            method: LightMethod::Get,
+            route: Route::ChannelThreadMembers {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -2519,9 +2740,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildActiveThreads {
+            method: LightMethod::Get,
+            route: Route::GuildThreadsActive {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2533,15 +2756,23 @@ impl Http {
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
+        let mut params = vec![];
+        if let Some(before) = before {
+            params.push(("before", before.to_string()));
+        }
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
+            method: LightMethod::Get,
             headers: None,
-            route: RouteInfo::GetChannelArchivedPublicThreads {
+            route: Route::ChannelArchivedPublicThreads {
                 channel_id,
-                before,
-                limit,
             },
+            params: Some(params),
         })
         .await
     }
@@ -2553,15 +2784,23 @@ impl Http {
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
+        let mut params = vec![];
+        if let Some(before) = before {
+            params.push(("before", before.to_string()));
+        }
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetChannelArchivedPrivateThreads {
+            method: LightMethod::Get,
+            route: Route::ChannelArchivedPrivateThreads {
                 channel_id,
-                before,
-                limit,
             },
+            params: Some(params),
         })
         .await
     }
@@ -2573,15 +2812,23 @@ impl Http {
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
+        let mut params = vec![];
+        if let Some(before) = before {
+            params.push(("before", before.to_string()));
+        }
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetChannelJoinedPrivateArchivedThreads {
+            method: LightMethod::Get,
+            route: Route::ChannelJoinedPrivateThreads {
                 channel_id,
-                before,
-                limit,
             },
+            params: Some(params),
         })
         .await
     }
@@ -2592,9 +2839,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::JoinThread {
+            method: LightMethod::Put,
+            route: Route::ChannelThreadMemberMe {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -2605,9 +2854,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::LeaveThread {
+            method: LightMethod::Delete,
+            route: Route::ChannelThreadMemberMe {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -2622,10 +2873,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::AddThreadMember {
+            method: LightMethod::Put,
+            route: Route::ChannelThreadMember {
                 channel_id,
                 user_id,
             },
+            params: None,
         })
         .await
     }
@@ -2640,10 +2893,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::RemoveThreadMember {
+            method: LightMethod::Delete,
+            route: Route::ChannelThreadMember {
                 channel_id,
                 user_id,
             },
+            params: None,
         })
         .await
     }
@@ -2673,9 +2928,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetChannelWebhooks {
+            method: LightMethod::Get,
+            route: Route::ChannelWebhooks {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -2686,9 +2943,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetChannel {
+            method: LightMethod::Get,
+            route: Route::Channel {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -2699,9 +2958,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetChannels {
+            method: LightMethod::Get,
+            route: Route::GuildChannels {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2712,9 +2973,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetStageInstance {
+            method: LightMethod::Get,
+            route: Route::StageInstance {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -2727,7 +2990,9 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetCurrentApplicationInfo,
+            method: LightMethod::Get,
+            route: Route::Oauth2ApplicationCurrent,
+            params: None,
         })
         .await
     }
@@ -2738,7 +3003,9 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetCurrentUser,
+            method: LightMethod::Get,
+            route: Route::UserMe,
+            params: None,
         })
         .await
     }
@@ -2749,9 +3016,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetEmojis {
+            method: LightMethod::Get,
+            route: Route::GuildEmojis {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2762,10 +3031,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetEmoji {
+            method: LightMethod::Get,
+            route: Route::GuildEmoji {
                 guild_id,
                 emoji_id,
             },
+            params: None,
         })
         .await
     }
@@ -2776,7 +3047,9 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGateway,
+            method: LightMethod::Get,
+            route: Route::Gateway,
+            params: None,
         })
         .await
     }
@@ -2787,9 +3060,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGlobalCommands {
+            method: LightMethod::Get,
+            route: Route::ApplicationCommands {
                 application_id: self.try_application_id()?,
             },
+            params: None,
         })
         .await
     }
@@ -2800,10 +3075,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGlobalCommand {
+            method: LightMethod::Get,
+            route: Route::ApplicationCommand {
                 application_id: self.try_application_id()?,
                 command_id,
             },
+            params: None,
         })
         .await
     }
@@ -2814,9 +3091,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuild {
+            method: LightMethod::Get,
+            route: Route::Guild {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2827,9 +3106,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildWithCounts {
+            method: LightMethod::Get,
+            route: Route::Guild {
                 guild_id,
             },
+            params: Some(vec![("with_counts", true.to_string())]),
         })
         .await
     }
@@ -2840,10 +3121,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildCommands {
+            method: LightMethod::Get,
+            route: Route::ApplicationGuildCommands {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2858,11 +3141,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildCommand {
+            method: LightMethod::Get,
+            route: Route::ApplicationGuildCommand {
                 application_id: self.try_application_id()?,
                 guild_id,
                 command_id,
             },
+            params: None,
         })
         .await
     }
@@ -2876,10 +3161,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildCommandsPermissions {
+            method: LightMethod::Get,
+            route: Route::ApplicationGuildCommandsPermissions {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2894,11 +3181,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildCommandPermissions {
+            method: LightMethod::Get,
+            route: Route::ApplicationGuildCommandPermissions {
                 application_id: self.try_application_id()?,
                 guild_id,
                 command_id,
             },
+            params: None,
         })
         .await
     }
@@ -2911,9 +3200,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildWidget {
+            method: LightMethod::Get,
+            route: Route::GuildWidget {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2924,9 +3215,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildPreview {
+            method: LightMethod::Get,
+            route: Route::GuildPreview {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2937,9 +3230,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildWelcomeScreen {
+            method: LightMethod::Get,
+            route: Route::GuildWelcomeScreen {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2950,9 +3245,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildIntegrations {
+            method: LightMethod::Get,
+            route: Route::GuildIntegrations {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2963,9 +3260,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildInvites {
+            method: LightMethod::Get,
+            route: Route::GuildInvites {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -2981,9 +3280,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildVanityUrl {
+            method: LightMethod::Get,
+            route: Route::GuildVanityUrl {
                 guild_id,
             },
+            params: None,
         })
         .await
         .map(|x| x.code)
@@ -3003,16 +3304,22 @@ impl Http {
             }
         }
 
+        let mut params =
+            vec![("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string())];
+        if let Some(after) = after {
+            params.push(("after", after.to_string()));
+        }
+
         let mut value: Value = self
             .fire(Request {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::GetGuildMembers {
-                    after,
+                method: LightMethod::Get,
+                route: Route::GuildMembers {
                     guild_id,
-                    limit,
                 },
+                params: Some(params),
             })
             .await?;
 
@@ -3033,10 +3340,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildPruneCount {
-                days,
+            method: LightMethod::Get,
+            route: Route::GuildPrune {
                 guild_id,
             },
+            params: Some(vec![("days", days.to_string())]),
         })
         .await
     }
@@ -3048,9 +3356,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildRegions {
+            method: LightMethod::Get,
+            route: Route::GuildRegions {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -3062,9 +3372,11 @@ impl Http {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::GetGuildRoles {
+                method: LightMethod::Get,
+                route: Route::GuildRoles {
                     guild_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -3094,11 +3406,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetScheduledEvent {
+            method: LightMethod::Get,
+            route: Route::GuildScheduledEvent {
                 guild_id,
                 event_id,
-                with_user_count,
             },
+            params: Some(vec![("with_user_count", with_user_count.to_string())]),
         })
         .await
     }
@@ -3117,10 +3430,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetScheduledEvents {
+            method: LightMethod::Get,
+            route: Route::GuildScheduledEvents {
                 guild_id,
-                with_user_count,
             },
+            params: Some(vec![("with_user_count", with_user_count.to_string())]),
         })
         .await
     }
@@ -3148,26 +3462,30 @@ impl Http {
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        let (after, before) = match target {
-            None => (None, None),
-            Some(p) => match p {
-                UserPagination::After(id) => (Some(id.get()), None),
-                UserPagination::Before(id) => (None, Some(id.get())),
-            },
-        };
+        let mut params = vec![];
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+        if let Some(with_member) = with_member {
+            params.push(("with_member", with_member.to_string()));
+        }
+        if let Some(target) = target {
+            match target {
+                UserPagination::After(id) => params.push(("after", id.to_string())),
+                UserPagination::Before(id) => params.push(("before", id.to_string())),
+            }
+        }
 
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetScheduledEventUsers {
+            method: LightMethod::Get,
+            route: Route::GuildScheduledEventUsers {
                 guild_id,
                 event_id,
-                after,
-                before,
-                limit,
-                with_member,
             },
+            params: Some(params),
         })
         .await
     }
@@ -3179,9 +3497,11 @@ impl Http {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::GetGuildStickers {
+                method: LightMethod::Get,
+                route: Route::GuildStickers {
                     guild_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -3207,10 +3527,12 @@ impl Http {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::GetGuildSticker {
+                method: LightMethod::Get,
+                route: Route::GuildSticker {
                     guild_id,
                     sticker_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -3246,9 +3568,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuildWebhooks {
+            method: LightMethod::Get,
+            route: Route::GuildWebhooks {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -3273,7 +3597,7 @@ impl Http {
     ///
     /// let guild_id = GuildId::new(81384788765712384);
     ///
-    /// let guilds = http.get_guilds(Some(&GuildPagination::After(guild_id)), Some(10)).await?;
+    /// let guilds = http.get_guilds(Some(GuildPagination::After(guild_id)), Some(10)).await?;
     /// #     Ok(())
     /// # }
     /// ```
@@ -3281,26 +3605,27 @@ impl Http {
     /// [docs]: https://discord.com/developers/docs/resources/user#get-current-user-guilds
     pub async fn get_guilds(
         &self,
-        target: Option<&GuildPagination>,
+        target: Option<GuildPagination>,
         limit: Option<u64>,
     ) -> Result<Vec<GuildInfo>> {
-        let (after, before) = match target {
-            None => (None, None),
-            Some(gp) => match gp {
-                GuildPagination::After(id) => (Some(id.get()), None),
-                GuildPagination::Before(id) => (None, Some(id.get())),
-            },
-        };
+        let mut params = vec![];
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+        if let Some(target) = target {
+            match target {
+                GuildPagination::After(id) => params.push(("after", id.to_string())),
+                GuildPagination::Before(id) => params.push(("before", id.to_string())),
+            }
+        }
 
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetGuilds {
-                after,
-                before,
-                limit,
-            },
+            method: LightMethod::Get,
+            route: Route::UserMeGuilds,
+            params: Some(params),
         })
         .await
     }
@@ -3327,16 +3652,23 @@ impl Http {
         #[cfg(feature = "utils")]
         let code = crate::utils::parse_invite(code);
 
+        let mut params = vec![
+            ("member_counts", member_counts.to_string()),
+            ("expiration", expiration.to_string()),
+        ];
+        if let Some(event_id) = event_id {
+            params.push(("event_id", event_id.to_string()));
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetInvite {
+            method: LightMethod::Get,
+            route: Route::Invite {
                 code,
-                member_counts,
-                expiration,
-                event_id,
             },
+            params: Some(params),
         })
         .await
     }
@@ -3348,10 +3680,12 @@ impl Http {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::GetMember {
+                method: LightMethod::Get,
+                route: Route::GuildMember {
                     guild_id,
                     user_id,
                 },
+                params: None,
             })
             .await?;
 
@@ -3372,24 +3706,44 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetMessage {
+            method: LightMethod::Get,
+            route: Route::ChannelMessage {
                 channel_id,
                 message_id,
             },
+            params: None,
         })
         .await
     }
 
     /// Gets X messages from a channel.
-    pub async fn get_messages(&self, channel_id: ChannelId, query: &str) -> Result<Vec<Message>> {
+    pub async fn get_messages(
+        &self,
+        channel_id: ChannelId,
+        target: Option<MessagePagination>,
+        limit: Option<u8>,
+    ) -> Result<Vec<Message>> {
+        let mut params = vec![];
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+        if let Some(target) = target {
+            match target {
+                MessagePagination::After(id) => params.push(("after", id.to_string())),
+                MessagePagination::Around(id) => params.push(("around", id.to_string())),
+                MessagePagination::Before(id) => params.push(("before", id.to_string())),
+            }
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetMessages {
-                query,
+            method: LightMethod::Get,
+            route: Route::ChannelMessages {
                 channel_id,
             },
+            params: Some(params),
         })
         .await
     }
@@ -3405,7 +3759,9 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetStickerPacks,
+            method: LightMethod::Get,
+            route: Route::StickerPacks,
+            params: None,
         })
         .await
         .map(|s| s.sticker_packs)
@@ -3417,9 +3773,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetPins {
+            method: LightMethod::Get,
+            route: Route::ChannelPins {
                 channel_id,
             },
+            params: None,
         })
         .await
     }
@@ -3433,17 +3791,21 @@ impl Http {
         limit: u8,
         after: Option<u64>,
     ) -> Result<Vec<User>> {
+        let mut params = vec![("limit", limit.to_string())];
+        if let Some(after) = after {
+            params.push(("after", after.to_string()));
+        }
         self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetReactionUsers {
-                after,
+            method: LightMethod::Get,
+            route: Route::ChannelMessageReactionsList {
                 channel_id,
-                limit,
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
+            params: Some(params),
         })
         .await
     }
@@ -3454,9 +3816,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetSticker {
+            method: LightMethod::Get,
+            route: Route::Sticker {
                 sticker_id,
             },
+            params: None,
         })
         .await
     }
@@ -3476,7 +3840,9 @@ impl Http {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::GetUnresolvedIncidents,
+                method: LightMethod::Get,
+                route: Route::StatusIncidentsUnresolved,
+                params: None,
             })
             .await?;
 
@@ -3498,7 +3864,9 @@ impl Http {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::GetUpcomingMaintenances,
+                method: LightMethod::Get,
+                route: Route::StatusMaintenancesUpcoming,
+                params: None,
             })
             .await?;
 
@@ -3511,9 +3879,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetUser {
+            method: LightMethod::Get,
+            route: Route::User {
                 user_id,
             },
+            params: None,
         })
         .await
     }
@@ -3529,7 +3899,9 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetUserConnections,
+            method: LightMethod::Get,
+            route: Route::UserMeConnections,
+            params: None,
         })
         .await
     }
@@ -3540,7 +3912,9 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetUserDmChannels,
+            method: LightMethod::Get,
+            route: Route::UserMeDmChannels,
+            params: None,
         })
         .await
     }
@@ -3551,7 +3925,9 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetVoiceRegions,
+            method: LightMethod::Get,
+            route: Route::VoiceRegions,
+            params: None,
         })
         .await
     }
@@ -3581,9 +3957,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetWebhook {
+            method: LightMethod::Get,
+            route: Route::Webhook {
                 webhook_id,
             },
+            params: None,
         })
         .await
     }
@@ -3618,10 +3996,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetWebhookWithToken {
-                token,
+            method: LightMethod::Get,
+            route: Route::WebhookWithToken {
                 webhook_id,
+                token,
             },
+            params: None,
         })
         .await
     }
@@ -3653,10 +4033,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::GetWebhookWithToken {
-                token,
+            method: LightMethod::Get,
+            route: Route::WebhookWithToken {
                 webhook_id,
+                token,
             },
+            params: None,
         })
         .await
     }
@@ -3672,10 +4054,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: reason.map(reason_into_header),
-            route: RouteInfo::KickMember {
+            method: LightMethod::Delete,
+            route: Route::GuildKick {
                 guild_id,
                 user_id,
             },
+            params: None,
         })
         .await
     }
@@ -3686,9 +4070,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::LeaveGuild {
+            method: LightMethod::Delete,
+            route: Route::UserMeGuild {
                 guild_id,
             },
+            params: None,
         })
         .await
     }
@@ -3710,9 +4096,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::CreateMessage {
+            method: LightMethod::Post,
+            route: Route::ChannelMessages {
                 channel_id,
             },
+            params: None,
         };
 
         if files.is_empty() {
@@ -3739,10 +4127,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::PinMessage {
+            method: LightMethod::Put,
+            route: Route::ChannelPin {
                 channel_id,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -3758,10 +4148,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::RemoveBan {
+            method: LightMethod::Delete,
+            route: Route::GuildBan {
                 guild_id,
                 user_id,
             },
+            params: None,
         })
         .await
     }
@@ -3783,11 +4175,13 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::RemoveMemberRole {
+            method: LightMethod::Delete,
+            route: Route::GuildMemberRole {
                 guild_id,
                 user_id,
                 role_id,
             },
+            params: None,
         })
         .await
     }
@@ -3805,11 +4199,14 @@ impl Http {
                 body: None,
                 multipart: None,
                 headers: None,
-                route: RouteInfo::SearchGuildMembers {
+                method: LightMethod::Get,
+                route: Route::GuildMembersSearch {
                     guild_id,
-                    query,
-                    limit,
                 },
+                params: Some(vec![
+                    ("query", query.to_string()),
+                    ("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string()),
+                ]),
             })
             .await?;
 
@@ -3835,10 +4232,11 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::StartGuildPrune {
-                days,
+            method: LightMethod::Post,
+            route: Route::GuildPrune {
                 guild_id,
             },
+            params: Some(vec![("days", days.to_string())]),
         })
         .await
     }
@@ -3853,10 +4251,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: None,
-            route: RouteInfo::StartIntegrationSync {
+            method: LightMethod::Post,
+            route: Route::GuildIntegrationSync {
                 guild_id,
                 integration_id,
             },
+            params: None,
         })
         .await
     }
@@ -3913,10 +4313,12 @@ impl Http {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
-            route: RouteInfo::UnpinMessage {
+            method: LightMethod::Delete,
+            route: Route::ChannelPin {
                 channel_id,
                 message_id,
             },
+            params: None,
         })
         .await
     }
@@ -3929,8 +4331,7 @@ impl Http {
     ///
     /// # Examples
     ///
-    /// Create a new message via the [`RouteInfo::CreateMessage`] endpoint and
-    /// deserialize the response into a [`Message`]:
+    /// Create a new message and deserialize the response into a [`Message`]:
     ///
     /// ```rust,no_run
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -3938,7 +4339,7 @@ impl Http {
     /// #
     /// # let http = Http::new("token");
     /// use serenity::{
-    ///     http::{RouteInfo, Request},
+    ///     http::{LightMethod, Request, Route},
     ///     model::prelude::*,
     /// };
     ///
@@ -3946,10 +4347,9 @@ impl Http {
     ///     // payload bytes here
     /// ];
     /// let channel_id = ChannelId::new(381880193700069377);
-    /// let route_info = RouteInfo::CreateMessage { channel_id };
+    /// let route = Route::ChannelMessages { channel_id };
     ///
-    /// let mut request = Request::new(route_info);
-    /// request.body(Some(bytes));
+    /// let mut request = Request::new(route, LightMethod::Post).body(Some(bytes));
     ///
     /// let message = http.fire::<Message>(request).await?;
     ///
@@ -3974,7 +4374,7 @@ impl Http {
     ///
     /// # Examples
     ///
-    /// Send a body of bytes over the [`RouteInfo::CreateMessage`] endpoint:
+    /// Send a body of bytes over the create message endpoint:
     ///
     /// ```rust,no_run
     /// # use serenity::http::Http;
@@ -3982,16 +4382,15 @@ impl Http {
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let http = Http::new("token");
-    /// use serenity::http::{Request, RouteInfo};
+    /// use serenity::http::{LightMethod, Request, Route};
     ///
     /// let bytes = vec![
     ///     // payload bytes here
     /// ];
     /// let channel_id = ChannelId::new(381880193700069377);
-    /// let route_info = RouteInfo::CreateMessage { channel_id };
+    /// let route = Route::ChannelMessages { channel_id };
     ///
-    /// let mut request = Request::new(route_info);
-    /// request.body(Some(bytes));
+    /// let mut request = Request::new(route, LightMethod::Post).body(Some(bytes));
     ///
     /// let response = http.request(request).await?;
     ///
@@ -4002,7 +4401,7 @@ impl Http {
     /// ```
     #[instrument]
     pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
-        let method = req.route.deconstruct().0;
+        let method = req.method.reqwest_method();
         let response = if let Some(ratelimiter) = &self.ratelimiter {
             ratelimiter.perform(req).await?
         } else {
@@ -4014,7 +4413,7 @@ impl Http {
             Ok(response)
         } else {
             Err(Error::Http(HttpError::UnsuccessfulRequest(
-                ErrorResponse::from_response(response, method.reqwest_method()).await,
+                ErrorResponse::from_response(response, method).await,
             )))
         }
     }
@@ -4025,7 +4424,7 @@ impl Http {
     /// This is a function that performs a light amount of work and returns an
     /// empty tuple, so it's called "self.wind" to denote that it's lightweight.
     pub(super) async fn wind(&self, expected: u16, req: Request<'_>) -> Result<()> {
-        let method = req.route.deconstruct().0;
+        let method = req.method.reqwest_method();
         let response = self.request(req).await?;
 
         if response.status().as_u16() == expected {
@@ -4036,7 +4435,7 @@ impl Http {
         trace!("Unsuccessful response: {:?}", response);
 
         Err(Error::Http(HttpError::UnsuccessfulRequest(
-            ErrorResponse::from_response(response, method.reqwest_method()).await,
+            ErrorResponse::from_response(response, method).await,
         )))
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -205,3 +205,11 @@ pub enum UserPagination {
     /// The Id to get the users before.
     Before(UserId),
 }
+
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum MessagePagination {
+    After(MessageId),
+    Around(MessageId),
+    Before(MessageId),
+}

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -51,8 +51,7 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::time::{sleep, Duration};
 use tracing::{debug, instrument};
 
-pub use super::routing::Route;
-use super::routing::RouteInfo;
+pub use super::routing::RatelimitingBucket;
 use super::{HttpError, LightMethod, Request};
 use crate::internal::prelude::*;
 
@@ -92,7 +91,7 @@ pub struct Ratelimiter {
     global: Arc<Mutex<()>>,
     // When futures is implemented, make tasks clear out their respective entry
     // when the 'reset' passes.
-    routes: Arc<RwLock<HashMap<Route, Arc<Mutex<Ratelimit>>>>>,
+    routes: Arc<RwLock<HashMap<RatelimitingBucket, Arc<Mutex<Ratelimit>>>>>,
     token: String,
     ratelimit_callback: Box<dyn Fn(RatelimitInfo) + Send + Sync>,
     absolute_ratelimits: bool,
@@ -142,7 +141,7 @@ impl Ratelimiter {
         self.absolute_ratelimits = absolute_ratelimits;
     }
 
-    /// The routes mutex is a HashMap of each [`Route`] and their respective
+    /// The routes mutex is a HashMap of each [`RatelimitingBucket`] and their respective
     /// ratelimit information.
     ///
     /// See the documentation for [`Ratelimit`] for more information on how the
@@ -163,7 +162,10 @@ impl Ratelimiter {
     /// let reader = routes.read().await;
     ///
     /// let channel_id = ChannelId::new(7);
-    /// if let Some(route) = reader.get(&Route::ChannelsId(channel_id)) {
+    /// let route = Route::Channel {
+    ///     channel_id,
+    /// };
+    /// if let Some(route) = reader.get(&route.ratelimiting_bucket()) {
     ///     if let Some(reset) = route.lock().await.reset() {
     ///         println!("Reset time at: {:?}", reset);
     ///     }
@@ -172,7 +174,7 @@ impl Ratelimiter {
     /// # }
     /// ```
     #[must_use]
-    pub fn routes(&self) -> Arc<RwLock<HashMap<Route, Arc<Mutex<Ratelimit>>>>> {
+    pub fn routes(&self) -> Arc<RwLock<HashMap<RatelimitingBucket, Arc<Mutex<Ratelimit>>>>> {
         Arc::clone(&self.routes)
     }
 
@@ -185,18 +187,6 @@ impl Ratelimiter {
             // This will block if another thread hit the global ratelimit.
             drop(self.global.lock().await);
 
-            // Destructure the tuple instead of retrieving the third value to
-            // take advantage of the type system. If `RouteInfo::deconstruct`
-            // returns a different number of tuple elements in the future,
-            // directly accessing a certain index
-            // (e.g. `req.route.deconstruct().1`) would mean this code would not
-            // indicate it might need to be updated for the new tuple element
-            // amount.
-            //
-            // This isn't normally important, but might be for ratelimiting.
-            let (method, route, path) = req.route.deconstruct();
-            let path = path.to_string();
-
             // Perform pre-checking here:
             //
             // - get the route's relevant rate
@@ -205,9 +195,11 @@ impl Ratelimiter {
             // - get the global rate;
             // - sleep if there is 0 remaining
             // - then, perform the request
-            let bucket = Arc::clone(self.routes.write().await.entry(route).or_default());
+            let ratelimiting_bucket = req.route.ratelimiting_bucket();
+            let bucket =
+                Arc::clone(self.routes.write().await.entry(ratelimiting_bucket).or_default());
 
-            bucket.lock().await.pre_hook(&req.route, &self.ratelimit_callback).await;
+            bucket.lock().await.pre_hook(&req, &self.ratelimit_callback).await;
 
             let request = req.clone().build(&self.client, &self.token, None)?.build()?;
 
@@ -226,7 +218,7 @@ impl Ratelimiter {
             // It _may_ be possible for the limit to be raised at any time,
             // so check if it did from the value of the 'x-ratelimit-limit'
             // header. If the limit was 5 and is now 7, add 2 to the 'remaining'
-            if route == Route::None {
+            if ratelimiting_bucket.is_none() {
                 return Ok(response);
             }
 
@@ -237,12 +229,15 @@ impl Ratelimiter {
                     if let Some(retry_after) =
                         parse_header::<f64>(response.headers(), "retry-after")?
                     {
-                        debug!("Ratelimited on route {:?} for {:?}s", route, retry_after);
+                        debug!(
+                            "Ratelimited on route {:?} for {:?}s",
+                            ratelimiting_bucket, retry_after
+                        );
                         (self.ratelimit_callback)(RatelimitInfo {
                             timeout: Duration::from_secs_f64(retry_after),
                             limit: 50,
-                            method,
-                            path,
+                            method: req.method,
+                            path: req.route.path().to_string(),
                             global: true,
                         });
                         sleep(Duration::from_secs_f64(retry_after)).await;
@@ -256,12 +251,7 @@ impl Ratelimiter {
                 bucket
                     .lock()
                     .await
-                    .post_hook(
-                        &response,
-                        &req.route,
-                        &self.ratelimit_callback,
-                        self.absolute_ratelimits,
-                    )
+                    .post_hook(&response, &req, &self.ratelimit_callback, self.absolute_ratelimits)
                     .await
             };
 
@@ -273,7 +263,7 @@ impl Ratelimiter {
 }
 
 /// A set of data containing information about the ratelimits for a particular
-/// [`Route`], which is stored in [`Http`].
+/// [`RatelimitingBucket`], which is stored in [`Http`].
 ///
 /// See the [Discord docs] on ratelimits for more information.
 ///
@@ -298,7 +288,7 @@ impl Ratelimit {
     #[instrument(skip(ratelimit_callback))]
     pub async fn pre_hook(
         &mut self,
-        route: &RouteInfo<'_>,
+        req: &Request<'_>,
         ratelimit_callback: &(dyn Fn(RatelimitInfo) + Send + Sync),
     ) {
         if self.limit() == 0 {
@@ -325,14 +315,16 @@ impl Ratelimit {
         };
 
         if self.remaining() == 0 {
-            let (method, route, path) = route.deconstruct();
-
-            debug!("Pre-emptive ratelimit on route {:?} for {}ms", route, delay.as_millis(),);
+            debug!(
+                "Pre-emptive ratelimit on route {:?} for {}ms",
+                req.route.ratelimiting_bucket(),
+                delay.as_millis(),
+            );
             ratelimit_callback(RatelimitInfo {
                 timeout: delay,
                 limit: self.limit,
-                method,
-                path: path.to_string(),
+                method: req.method,
+                path: req.route.path().to_string(),
                 global: false,
             });
 
@@ -348,7 +340,7 @@ impl Ratelimit {
     pub async fn post_hook(
         &mut self,
         response: &Response,
-        route: &RouteInfo<'_>,
+        req: &Request<'_>,
         ratelimit_callback: &(dyn Fn(RatelimitInfo) + Send + Sync),
         absolute_ratelimits: bool,
     ) -> Result<bool> {
@@ -379,14 +371,16 @@ impl Ratelimit {
         Ok(if response.status() != StatusCode::TOO_MANY_REQUESTS {
             false
         } else if let Some(retry_after) = parse_header::<f64>(response.headers(), "retry-after")? {
-            let (method, route, path) = route.deconstruct();
-
-            debug!("Ratelimited on route {:?} for {:?}ms", route, retry_after);
+            debug!(
+                "Ratelimited on route {:?} for {:?}ms",
+                req.route.ratelimiting_bucket(),
+                retry_after
+            );
             ratelimit_callback(RatelimitInfo {
                 timeout: Duration::from_secs_f64(retry_after),
                 limit: self.limit,
-                method,
-                path: path.to_string(),
+                method: req.method,
+                path: req.route.path().to_string(),
                 global: false,
             });
 

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1,2731 +1,480 @@
 use std::borrow::Cow;
-use std::fmt::{Display, Write};
+use std::num::NonZeroU64;
 
-use super::LightMethod;
-use crate::constants;
 use crate::model::id::*;
 
-/// A representation of all routes registered within the library. These are safe
-/// and memory-efficient representations of each path that functions exist for
-/// in the [`http`] module.
-///
-/// Used as ratelimit buckets.
-///
-/// [`http`]: crate::http
+/// Used to group requests together for ratelimiting.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[non_exhaustive]
-pub enum Route {
-    /// Route for the `/channels/:channel_id` path.
-    ChannelsId(ChannelId),
-    /// Route for the `/channels/:channel_id/invites` path.
-    ChannelsIdInvites(ChannelId),
-    /// Route for the `/channels/:channel_id/messages` path.
-    ChannelsIdMessages(ChannelId),
-    /// Route for the `/channels/:channel_id/messages/bulk-delete` path.
-    ChannelsIdMessagesBulkDelete(ChannelId),
-    /// Route for the `/channels/:channel_id/messages/:message_id` path.
-    ///
-    /// This route is a unique case. The ratelimit for message _deletions_ is
-    /// different than the overall route ratelimit.
-    ///
-    /// Refer to the docs on [Rate Limits] in the yellow warning section.
-    /// [Rate Limits]: <https://discord.com/developers/docs/topics/rate-limits>
-    ChannelsIdMessagesId(LightMethod, ChannelId),
-    /// Route for the `/channels/:channel_id/messages/:message_id/ack` path.
-    ChannelsIdMessagesIdAck(ChannelId),
-    /// Route for the `/channels/:channel_id/messages/:message_id/reactions`
-    /// path.
-    ChannelsIdMessagesIdReactions(ChannelId),
-    /// Route for the
-    /// `/channels/:channel_id/messages/:message_id/reactions/:reaction/@me`
-    /// path.
-    ChannelsIdMessagesIdReactionsUserIdType(ChannelId),
-    /// Route for the `/channels/:channel_id/permissions/:target_id` path.
-    ChannelsIdPermissionsOverwriteId(ChannelId),
-    /// Route for the `/channels/:channel_id/pins` path.
-    ChannelsIdPins(ChannelId),
-    /// Route for the `/channels/:channel_id/pins/:message_id` path.
-    ChannelsIdPinsMessageId(ChannelId),
-    /// Route for the `/channels/:channel_id/message/:message_id/crosspost` path.
-    ChannelsIdCrosspostsMessageId(ChannelId),
-    /// Route for the `/channels/:channel_id/typing` path.
-    ChannelsIdTyping(ChannelId),
-    /// Route for the `/channels/:channel_id/webhooks` path.
-    ChannelsIdWebhooks(ChannelId),
-    /// Route for the `/channels/:channel_id/messages/:message_id/threads` path.
-    ChannelsIdMessagesIdThreads(ChannelId),
-    /// Route for the `/channels/:channel_id/threads` path.
-    ChannelsIdThreads(ChannelId),
-    /// Route for the `/channels/:channel_id/thread-members/@me` path.
-    ChannelsIdThreadMembersMe(ChannelId),
-    /// Route for the `/channels/:channel_id/thread-members/:user_id` path.
-    ChannelsIdThreadMembersUserId(ChannelId),
-    /// Route for the `/channels/channel_id/thread-members` path.
-    ChannelsIdThreadMembers(ChannelId),
-    /// Route for the `/channels/:channel_id/threads/archived/public` path.
-    ChannelsIdArchivedPublicThreads(ChannelId),
-    /// Route for the `/channels/:channel_id/threads/archived/private` path.
-    ChannelsIdArchivedPrivateThreads(ChannelId),
-    /// Route for the `/channels/:channel_id/users/@me/threads/archived/private` path.
-    ChannelsIdMeJoindedArchivedPrivateThreads(ChannelId),
-    /// Route for the `/channels/{channel.id}/followers` path.
-    FollowNewsChannel(ChannelId),
-    /// Route for the `/gateway` path.
-    Gateway,
-    /// Route for the `/gateway/bot` path.
-    GatewayBot,
-    /// Route for the `/guilds` path.
-    Guilds,
-    /// Route for the `/guilds/:guild_id` path.
-    GuildsId(GuildId),
-    /// Route for the `/guilds/:guild_id/auto-moderation/rules` path.
-    GuildsIdAutoModRules(GuildId),
-    /// Route for the `/guilds/:guild_id/auto-moderation/rules/:rule_id` path.
-    GuildsIdAutoModRulesId(GuildId),
-    /// Route for the `/guilds/:guild_id/bans` path.
-    GuildsIdBans(GuildId),
-    GuildsIdAuditLogs(GuildId),
-    /// Route for the `/guilds/:guild_id/bans/:user_id` path.
-    GuildsIdBansUserId(GuildId),
-    /// Route for the `/guilds/:guild_id/channels/:channel_id` path.
-    GuildsIdChannels(GuildId),
-    /// Route for the `/guilds/:guild_id/widget` path.
-    GuildsIdWidget(GuildId),
-    /// Route for the `/guilds/:guild_id/preview` path.
-    ///
-    /// [`GuildPreview`]: crate::model::guild::GuildPreview
-    GuildsIdPreview(GuildId),
-    /// Route for the `/guilds/:guild_id/emojis` path.
-    GuildsIdEmojis(GuildId),
-    /// Route for the `/guilds/:guild_id/emojis/:emoji_id` path.
-    GuildsIdEmojisId(GuildId),
-    /// Route for the `/guilds/:guild_id/integrations` path.
-    GuildsIdIntegrations(GuildId),
-    /// Route for the `/guilds/:guild_id/integrations/:integration_id` path.
-    GuildsIdIntegrationsId(GuildId),
-    /// Route for the `/guilds/:guild_id/integrations/:integration_id/sync`
-    /// path.
-    GuildsIdIntegrationsIdSync(GuildId),
-    /// Route for the `/guilds/:guild_id/invites` path.
-    GuildsIdInvites(GuildId),
-    /// Route for the `/guilds/:guild_id/members` path.
-    GuildsIdMembers(GuildId),
-    /// Route for the `/guilds/:guild_id/members/:user_id` path.
-    GuildsIdMembersId(GuildId),
-    /// Route for the `/guilds/:guild_id/members/:user_id/roles/:role_id` path.
-    GuildsIdMembersIdRolesId(GuildId),
-    /// Route for the `/guilds/:guild_id/members/@me` path.
-    GuildsIdMembersMe(GuildId),
-    /// Route for the `/guilds/:guild_id/members/@me/nick` path.
-    GuildsIdMembersMeNick(GuildId),
-    /// Route for the `/guilds/:guild_id/members/search` path.
-    GuildsIdMembersSearch(GuildId),
-    /// Route for the `/guilds/:guild_id/prune` path.
-    GuildsIdPrune(GuildId),
-    /// Route for the `/guilds/:guild_id/regions` path.
-    GuildsIdRegions(GuildId),
-    /// Route for the `/guilds/:guild_id/roles` path.
-    GuildsIdRoles(GuildId),
-    /// Route for the `/guilds/:guild_id/roles/:role_id` path.
-    GuildsIdRolesId(GuildId),
-    /// Route for the `/guilds/:guild_id/scheduled-events` path.
-    GuildsIdScheduledEvents(GuildId),
-    /// Route for the `/guilds/:guild_id/scheduled-events/:event_id` path.
-    GuildsIdScheduledEventsId(GuildId),
-    /// Route for the `/guilds/:guild_id/scheduled-events/:event_id/users` path.
-    GuildsIdScheduledEventsIdUsers(GuildId),
-    /// Route for the `/guilds/:guild_id/stickers` path.
-    GuildsIdStickers(GuildId),
-    /// Route for the `/guilds/:guild_id/stickers/:sticker_id` path.
-    GuildsIdStickersId(GuildId),
-    /// Route for the `/guilds/:guild_id/vanity-url` path.
-    GuildsIdVanityUrl(GuildId),
-    /// Route for the `/guilds/:guild_id/voice-states/:user_id` path.
-    GuildsIdVoiceStates(GuildId),
-    /// Route for the `/guilds/:guild_id/voice-states/@me` path.
-    GuildsIdVoiceStatesMe(GuildId),
-    /// Route for the `/guilds/:guild_id/webhooks` path.
-    GuildsIdWebhooks(GuildId),
-    /// Route for the `/guilds/:guild_id/welcome-screen` path.
-    GuildsIdWelcomeScreen(GuildId),
-    /// Route for the `/guilds/:guild_id/threads/active` path.
-    GuildsIdThreadsActive,
-    /// Route for the `/invites/:code` path.
-    InvitesCode,
-    /// Route for the `/sticker-packs` path.
-    StickerPacks,
-    /// Route for the `/stickers/:sticker_id` path.
-    StickersId,
-    /// Route for the `/users/:user_id` path.
-    UsersId,
-    /// Route for the `/users/@me` path.
-    UsersMe,
-    /// Route for the `/users/@me/channels` path.
-    UsersMeChannels,
-    /// Route for the `/users/@me/connections` path.
-    UsersMeConnections,
-    /// Route for the `/users/@me/guilds` path.
-    UsersMeGuilds,
-    /// Route for the `/users/@me/guilds/:guild_id` path.
-    UsersMeGuildsId,
-    /// Route for the `/voice/regions` path.
-    VoiceRegions,
-    /// Route for the `/webhooks/:webhook_id` path.
-    WebhooksId(WebhookId),
-    /// Route for the `/webhooks/:webhook_id/:token/messages/:message_id` path.
-    WebhooksIdMessagesId(WebhookId),
-    /// Route for the `/webhooks/:application_id` path.
-    WebhooksApplicationId(ApplicationId),
-    /// Route for the `/interactions/:interaction_id` path.
-    InteractionsId(InteractionId),
-    /// Route for the `/applications/:application_id` path.
-    ApplicationsIdCommands(ApplicationId),
-    /// Route for the `/applications/:application_id/commands/:command_id` path.
-    ApplicationsIdCommandsId(ApplicationId),
-    /// Route for the `/applications/:application_id/guilds/:guild_id` path.
-    ApplicationsIdGuildsIdCommands(ApplicationId),
-    /// Route for the `/applications/:application_id/guilds/:guild_id/commands/permissions` path.
-    ApplicationsIdGuildsIdCommandsPermissions(ApplicationId),
-    /// Route for the `/applications/:application_id/guilds/:guild_id/commands/:command_id/permissions` path.
-    ApplicationsIdGuildsIdCommandIdPermissions(ApplicationId),
-    /// Route for the `/applications/:application_id/guilds/:guild_id` path.
-    ApplicationsIdGuildsIdCommandsId(ApplicationId),
-    /// Route for the `/stage-instances` path.
-    StageInstances,
-    /// Route for the `/stage-instances/:channel_id` path.
-    StageInstancesChannelId(ChannelId),
-    /// Route where no ratelimit headers are in place (i.e. user account-only
-    /// routes).
-    ///
-    /// This is a special case, in that if the route is [`None`] then pre- and
-    /// post-hooks are not executed.
+pub struct RatelimitingBucket(Option<(std::mem::Discriminant<Route<'static>>, Option<NonZeroU64>)>);
+
+impl RatelimitingBucket {
+    #[must_use]
+    pub fn is_none(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+enum RatelimitingKind {
+    /// Requests with the same path and major parameter (usually an Id) should be grouped together
+    /// for ratelimiting.
+    PathAndId(NonZeroU64),
+    /// Requests with the same path should be ratelimited together.
+    Path,
+    /// No ratelimiting should be performed.
     None,
 }
 
-impl Route {
-    #[must_use]
-    pub fn channel(channel_id: ChannelId) -> String {
-        api!("/channels/{}", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_invites(channel_id: ChannelId) -> String {
-        api!("/channels/{}/invites", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_message(channel_id: ChannelId, message_id: MessageId) -> String {
-        api!("/channels/{}/messages/{}", channel_id, message_id)
-    }
-
-    #[must_use]
-    pub fn channel_message_crosspost(channel_id: ChannelId, message_id: MessageId) -> String {
-        api!("/channels/{}/messages/{}/crosspost", channel_id, message_id)
-    }
-
-    #[must_use]
-    pub fn channel_message_reaction<D, T>(
-        channel_id: ChannelId,
-        message_id: MessageId,
-        user_id: D,
-        reaction_type: T,
-    ) -> String
-    where
-        D: Display,
-        T: Display,
-    {
-        api!(
-            "/channels/{}/messages/{}/reactions/{}/{}",
-            channel_id,
-            message_id,
-            reaction_type,
-            user_id,
-        )
-    }
-
-    #[must_use]
-    pub fn channel_message_reaction_emoji<T>(
-        channel_id: ChannelId,
-        message_id: MessageId,
-        reaction_type: T,
-    ) -> String
-    where
-        T: Display,
-    {
-        api!("/channels/{}/messages/{}/reactions/{}", channel_id, message_id, reaction_type)
-    }
-
-    #[must_use]
-    pub fn channel_message_reactions(channel_id: ChannelId, message_id: MessageId) -> String {
-        api!("/channels/{}/messages/{}/reactions", channel_id, message_id)
-    }
-
-    #[must_use]
-    pub fn channel_message_reactions_list(
-        channel_id: ChannelId,
-        message_id: MessageId,
-        reaction: &str,
-        limit: u8,
-        after: Option<u64>,
-    ) -> String {
-        let mut url = api!(
-            "/channels/{}/messages/{}/reactions/{}?limit={}",
-            channel_id,
-            message_id,
-            reaction,
-            limit,
-        );
-
-        if let Some(after) = after {
-            write!(url, "&after={after}").unwrap();
+/// A macro for defining routes as well as the type of ratelimiting they perform. Takes as input a
+/// list of route definitions, and generates a definition for the `Route` enum and implements
+/// methods on it.
+macro_rules! routes {
+    ($lt:lifetime, {
+        $(
+            $name:ident $({ $($field_name:ident: $field_type:ty),* })?,
+            $path:expr,
+            $ratelimiting_kind:expr;
+        )+
+    }) => {
+        #[derive(Clone, Copy, Debug)]
+        pub enum Route<$lt> {
+            $(
+                $name $({ $($field_name: $field_type),* })?,
+            )+
         }
 
-        url
-    }
-
-    #[must_use]
-    pub fn channel_messages(channel_id: ChannelId, query: Option<&str>) -> String {
-        api!("/channels/{}/messages{}", channel_id, query.unwrap_or(""))
-    }
-
-    #[must_use]
-    pub fn channel_messages_bulk_delete(channel_id: ChannelId) -> String {
-        api!("/channels/{}/messages/bulk-delete", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_follow_news(channel_id: ChannelId) -> String {
-        api!("/channels/{}/followers", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_permission(channel_id: ChannelId, target_id: TargetId) -> String {
-        api!("/channels/{}/permissions/{}", channel_id, target_id)
-    }
-
-    #[must_use]
-    pub fn channel_pin(channel_id: ChannelId, message_id: MessageId) -> String {
-        api!("/channels/{}/pins/{}", channel_id, message_id)
-    }
-
-    #[must_use]
-    pub fn channel_pins(channel_id: ChannelId) -> String {
-        api!("/channels/{}/pins", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_typing(channel_id: ChannelId) -> String {
-        api!("/channels/{}/typing", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_webhooks(channel_id: ChannelId) -> String {
-        api!("/channels/{}/webhooks", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_public_threads(channel_id: ChannelId, message_id: MessageId) -> String {
-        api!("/channels/{}/messages/{}/threads", channel_id, message_id)
-    }
-
-    #[must_use]
-    pub fn channel_private_threads(channel_id: ChannelId) -> String {
-        api!("/channels/{}/threads", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_thread_member(channel_id: ChannelId, user_id: UserId) -> String {
-        api!("/channels/{}/thread-members/{}", channel_id, user_id)
-    }
-
-    #[must_use]
-    pub fn channel_thread_member_me(channel_id: ChannelId) -> String {
-        api!("/channels/{}/thread-members/@me", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_thread_members(channel_id: ChannelId) -> String {
-        api!("/channels/{}/thread-members", channel_id)
-    }
-
-    #[must_use]
-    pub fn channel_archived_public_threads(
-        channel_id: ChannelId,
-        before: Option<u64>,
-        limit: Option<u64>,
-    ) -> String {
-        let mut s = api!("/channels/{}/threads/archived/public", channel_id);
-
-        if let Some(id) = before {
-            write!(s, "&before={id}").unwrap();
-        }
-
-        if let Some(limit) = limit {
-            write!(s, "&limit={limit}").unwrap();
-        }
-
-        s
-    }
-
-    #[must_use]
-    pub fn channel_archived_private_threads(
-        channel_id: ChannelId,
-        before: Option<u64>,
-        limit: Option<u64>,
-    ) -> String {
-        let mut s = api!("/channels/{}/threads/archived/private", channel_id);
-
-        if let Some(id) = before {
-            write!(s, "&before={id}").unwrap();
-        }
-
-        if let Some(limit) = limit {
-            write!(s, "&limit={limit}").unwrap();
-        }
-
-        s
-    }
-
-    #[must_use]
-    pub fn channel_joined_private_threads(
-        channel_id: ChannelId,
-        before: Option<u64>,
-        limit: Option<u64>,
-    ) -> String {
-        let mut s = api!("/channels/{}/users/@me/threads/archived/private", channel_id);
-
-        if let Some(id) = before {
-            write!(s, "&before={id}").unwrap();
-        }
-
-        if let Some(limit) = limit {
-            write!(s, "&limit={limit}").unwrap();
-        }
-
-        s
-    }
-
-    #[must_use]
-    pub fn gateway() -> &'static str {
-        api!("/gateway")
-    }
-
-    #[must_use]
-    pub fn gateway_bot() -> &'static str {
-        api!("/gateway/bot")
-    }
-
-    #[must_use]
-    pub fn guild(guild_id: GuildId) -> String {
-        api!("/guilds/{}", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_with_counts(guild_id: GuildId) -> String {
-        api!("/guilds/{}?with_counts=true", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_audit_logs(
-        guild_id: GuildId,
-        action_type: Option<u8>,
-        user_id: Option<UserId>,
-        before: Option<u64>,
-        limit: Option<u8>,
-    ) -> String {
-        let mut s = api!("/guilds/{}/audit-logs?", guild_id);
-
-        if let Some(action_type) = action_type {
-            write!(s, "&action_type={action_type}").unwrap();
-        }
-
-        if let Some(before) = before {
-            write!(s, "&before={before}").unwrap();
-        }
-
-        if let Some(limit) = limit {
-            write!(s, "&limit={limit}").unwrap();
-        }
-
-        if let Some(user_id) = user_id {
-            write!(s, "&user_id={user_id}").unwrap();
-        }
-
-        s
-    }
-
-    #[must_use]
-    pub fn guild_automod_rule(guild_id: GuildId, rule_id: RuleId) -> String {
-        api!("/guilds/{}/auto-moderation/rules/{}", guild_id, rule_id)
-    }
-
-    #[must_use]
-    pub fn guild_automod_rules(guild_id: GuildId) -> String {
-        api!("/guilds/{}/auto-moderation/rules", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_ban(guild_id: GuildId, user_id: UserId) -> String {
-        api!("/guilds/{}/bans/{}", guild_id, user_id)
-    }
-
-    #[must_use]
-    pub fn guild_ban_optioned(
-        guild_id: GuildId,
-        user_id: UserId,
-        delete_message_days: u8,
-    ) -> String {
-        api!("/guilds/{}/bans/{}?delete_message_days={}", guild_id, user_id, delete_message_days)
-    }
-
-    #[must_use]
-    pub fn guild_kick_optioned(guild_id: GuildId, user_id: UserId) -> String {
-        api!("/guilds/{}/members/{}", guild_id, user_id)
-    }
-
-    #[must_use]
-    pub fn guild_bans(guild_id: GuildId) -> String {
-        api!("/guilds/{}/bans", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_channels(guild_id: GuildId) -> String {
-        api!("/guilds/{}/channels", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_widget(guild_id: GuildId) -> String {
-        api!("/guilds/{}/widget", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_preview(guild_id: GuildId) -> String {
-        api!("/guilds/{}/preview", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_emojis(guild_id: GuildId) -> String {
-        api!("/guilds/{}/emojis", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_emoji(guild_id: GuildId, emoji_id: EmojiId) -> String {
-        api!("/guilds/{}/emojis/{}", guild_id, emoji_id)
-    }
-
-    #[must_use]
-    pub fn guild_integration(guild_id: GuildId, integration_id: IntegrationId) -> String {
-        api!("/guilds/{}/integrations/{}", guild_id, integration_id)
-    }
-
-    #[must_use]
-    pub fn guild_integration_sync(guild_id: GuildId, integration_id: IntegrationId) -> String {
-        api!("/guilds/{}/integrations/{}/sync", guild_id, integration_id)
-    }
-
-    #[must_use]
-    pub fn guild_integrations(guild_id: GuildId) -> String {
-        api!("/guilds/{}/integrations", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_invites(guild_id: GuildId) -> String {
-        api!("/guilds/{}/invites", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_member(guild_id: GuildId, user_id: UserId) -> String {
-        api!("/guilds/{}/members/{}", guild_id, user_id)
-    }
-
-    #[must_use]
-    pub fn guild_member_role(guild_id: GuildId, user_id: UserId, role_id: RoleId) -> String {
-        api!("/guilds/{}/members/{}/roles/{}", guild_id, user_id, role_id)
-    }
-
-    #[must_use]
-    pub fn guild_members(guild_id: GuildId) -> String {
-        api!("/guilds/{}/members", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_members_search(guild_id: GuildId, query: &str, limit: Option<u64>) -> String {
-        let mut s = api!("/guilds/{}/members/search?", guild_id);
-
-        write!(s, "&query={query}&limit={}", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT))
-            .unwrap();
-        s
-    }
-
-    #[must_use]
-    pub fn guild_members_optioned(
-        guild_id: GuildId,
-        after: Option<u64>,
-        limit: Option<u64>,
-    ) -> String {
-        let mut s = api!("/guilds/{}/members?", guild_id);
-
-        if let Some(after) = after {
-            write!(s, "&after={after}").unwrap();
-        }
-
-        write!(s, "&limit={}", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT)).unwrap();
-        s
-    }
-
-    #[must_use]
-    pub fn guild_member_me(guild_id: GuildId) -> String {
-        api!("/guilds/{}/members/@me", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_nickname(guild_id: GuildId) -> String {
-        api!("/guilds/{}/members/@me/nick", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_prune(guild_id: GuildId, days: u8) -> String {
-        api!("/guilds/{}/prune?days={}", guild_id, days)
-    }
-
-    #[must_use]
-    pub fn guild_regions(guild_id: GuildId) -> String {
-        api!("/guilds/{}/regions", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_role(guild_id: GuildId, role_id: RoleId) -> String {
-        api!("/guilds/{}/roles/{}", guild_id, role_id)
-    }
-
-    #[must_use]
-    pub fn guild_roles(guild_id: GuildId) -> String {
-        api!("/guilds/{}/roles", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_scheduled_event(
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
-        with_user_count: Option<bool>,
-    ) -> String {
-        let mut s = api!("/guilds/{}/scheduled-events/{}", guild_id, event_id);
-        if let Some(b) = with_user_count {
-            write!(s, "?with_user_count={b}").unwrap();
-        }
-        s
-    }
-
-    #[must_use]
-    pub fn guild_scheduled_events(guild_id: GuildId, with_user_count: Option<bool>) -> String {
-        let mut s = api!("/guilds/{}/scheduled-events", guild_id);
-        if let Some(b) = with_user_count {
-            write!(s, "?with_user_count={b}").unwrap();
-        }
-        s
-    }
-
-    #[must_use]
-    pub fn guild_scheduled_event_users(
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
-        after: Option<u64>,
-        before: Option<u64>,
-        limit: Option<u64>,
-        with_member: Option<bool>,
-    ) -> String {
-        let mut s = api!("/guilds/{}/scheduled-events/{}/users?", guild_id, event_id);
-
-        if let Some(limit) = limit {
-            write!(s, "&limit={limit}").unwrap();
-        }
-
-        if let Some(after) = after {
-            write!(s, "&after={after}").unwrap();
-        }
-
-        if let Some(before) = before {
-            write!(s, "&before={before}").unwrap();
-        }
-
-        if let Some(with_member) = with_member {
-            write!(s, "&with_member={with_member}").unwrap();
-        }
-
-        s
-    }
-
-    #[must_use]
-    pub fn guild_sticker(guild_id: GuildId, sticker_id: StickerId) -> String {
-        api!("/guilds/{}/stickers/{}", guild_id, sticker_id)
-    }
-
-    #[must_use]
-    pub fn guild_stickers(guild_id: GuildId) -> String {
-        api!("/guilds/{}/stickers", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_vanity_url(guild_id: GuildId) -> String {
-        api!("/guilds/{}/vanity-url", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_voice_states(guild_id: GuildId, user_id: UserId) -> String {
-        api!("/guilds/{}/voice-states/{}", guild_id, user_id)
-    }
-
-    #[must_use]
-    pub fn guild_voice_states_me(guild_id: GuildId) -> String {
-        api!("/guilds/{}/voice-states/@me", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_webhooks(guild_id: GuildId) -> String {
-        api!("/guilds/{}/webhooks", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_welcome_screen(guild_id: GuildId) -> String {
-        api!("/guilds/{}/welcome-screen", guild_id)
-    }
-
-    #[must_use]
-    pub fn guild_threads_active(guild_id: GuildId) -> String {
-        api!("/guilds/{}/threads/active", guild_id)
-    }
-
-    #[must_use]
-    pub fn guilds() -> &'static str {
-        api!("/guilds")
-    }
-
-    #[must_use]
-    pub fn invite(code: &str) -> String {
-        api!("/invites/{}", code)
-    }
-
-    #[must_use]
-    pub fn invite_optioned(
-        code: &str,
-        member_counts: bool,
-        expiration: bool,
-        event_id: Option<ScheduledEventId>,
-    ) -> String {
-        api!(
-            "/invites/{}?with_counts={}&with_expiration={}{}",
-            code,
-            member_counts,
-            expiration,
-            event_id.map(|id| format!("&event_id={id}")).unwrap_or_default(),
-        )
-    }
-
-    #[must_use]
-    pub fn oauth2_application_current() -> &'static str {
-        api!("/oauth2/applications/@me")
-    }
-
-    #[must_use]
-    pub fn private_channel() -> &'static str {
-        api!("/users/@me/channels")
-    }
-
-    #[must_use]
-    pub fn status_incidents_unresolved() -> &'static str {
-        status!("/incidents/unresolved.json")
-    }
-
-    #[must_use]
-    pub fn status_maintenances_active() -> &'static str {
-        status!("/scheduled-maintenances/active.json")
-    }
-
-    #[must_use]
-    pub fn status_maintenances_upcoming() -> &'static str {
-        status!("/scheduled-maintenances/upcoming.json")
-    }
-
-    #[must_use]
-    pub fn sticker(sticker_id: StickerId) -> String {
-        api!("/stickers/{}", sticker_id)
-    }
-
-    #[must_use]
-    pub fn sticker_packs() -> &'static str {
-        api!("/sticker-packs")
-    }
-
-    #[must_use]
-    pub fn user<D: Display>(target: D) -> String {
-        api!("/users/{}", target)
-    }
-
-    #[must_use]
-    pub fn user_me_connections() -> &'static str {
-        api!("/users/@me/connections")
-    }
-
-    #[must_use]
-    pub fn user_dm_channels<D: Display>(target: D) -> String {
-        api!("/users/{}/channels", target)
-    }
-
-    #[must_use]
-    pub fn user_guild<D: Display>(target: D, guild_id: GuildId) -> String {
-        api!("/users/{}/guilds/{}", target, guild_id)
-    }
-
-    #[must_use]
-    pub fn user_guilds<D: Display>(target: D) -> String {
-        api!("/users/{}/guilds", target)
-    }
-
-    #[must_use]
-    pub fn user_guilds_optioned<D: Display>(
-        target: D,
-        after: Option<u64>,
-        before: Option<u64>,
-        limit: Option<u64>,
-    ) -> String {
-        let mut s = api!("/users/{}/guilds?", target);
-
-        if let Some(limit) = limit {
-            write!(s, "&limit={limit}").unwrap();
-        }
-
-        if let Some(after) = after {
-            write!(s, "&after={after}").unwrap();
-        }
-
-        if let Some(before) = before {
-            write!(s, "&before={before}").unwrap();
-        }
-
-        s
-    }
-
-    #[must_use]
-    pub fn voice_regions() -> &'static str {
-        api!("/voice/regions")
-    }
-
-    #[must_use]
-    pub fn webhook(webhook_id: WebhookId) -> String {
-        api!("/webhooks/{}", webhook_id)
-    }
-
-    #[must_use]
-    pub fn webhook_with_token<D>(webhook_id: WebhookId, token: D) -> String
-    where
-        D: Display,
-    {
-        api!("/webhooks/{}/{}", webhook_id, token)
-    }
-
-    #[must_use]
-    pub fn webhook_with_token_optioned<D>(
-        webhook_id: WebhookId,
-        thread_id: Option<ChannelId>,
-        token: D,
-        wait: bool,
-    ) -> String
-    where
-        D: Display,
-    {
-        let mut s = api!("/webhooks/{}/{}?wait={}", webhook_id, token, wait);
-
-        if let Some(thread_id) = thread_id {
-            write!(s, "&thread_id={thread_id}").unwrap();
-        }
-
-        s
-    }
-
-    #[must_use]
-    pub fn webhook_message<D>(webhook_id: WebhookId, token: D, message_id: MessageId) -> String
-    where
-        D: Display,
-    {
-        api!("/webhooks/{}/{}/messages/{}", webhook_id, token, message_id)
-    }
-
-    #[must_use]
-    pub fn webhook_original_interaction_response<D: Display>(
-        application_id: ApplicationId,
-        token: D,
-    ) -> String {
-        api!("/webhooks/{}/{}/messages/@original", application_id, token)
-    }
-
-    #[must_use]
-    pub fn webhook_followup_message<D: Display>(
-        application_id: ApplicationId,
-        token: D,
-        message_id: MessageId,
-    ) -> String {
-        api!("/webhooks/{}/{}/messages/{}", application_id, token, message_id)
-    }
-
-    #[must_use]
-    pub fn webhook_followup_messages<D: Display>(
-        application_id: ApplicationId,
-        token: D,
-    ) -> String {
-        api!("/webhooks/{}/{}", application_id, token)
-    }
-
-    #[must_use]
-    pub fn interaction_response<D: Display>(interaction_id: InteractionId, token: D) -> String {
-        api!("/interactions/{}/{}/callback", interaction_id, token)
-    }
-
-    #[must_use]
-    pub fn application_command(application_id: ApplicationId, command_id: CommandId) -> String {
-        api!("/applications/{}/commands/{}", application_id, command_id)
-    }
-
-    #[must_use]
-    pub fn application_commands(application_id: ApplicationId) -> String {
-        api!("/applications/{}/commands", application_id)
-    }
-
-    #[must_use]
-    pub fn application_guild_command(
-        application_id: ApplicationId,
-        guild_id: GuildId,
-        command_id: CommandId,
-    ) -> String {
-        api!("/applications/{}/guilds/{}/commands/{}", application_id, guild_id, command_id)
-    }
-
-    #[must_use]
-    pub fn application_guild_command_permissions(
-        application_id: ApplicationId,
-        guild_id: GuildId,
-        command_id: CommandId,
-    ) -> String {
-        api!(
-            "/applications/{}/guilds/{}/commands/{}/permissions",
-            application_id,
-            guild_id,
-            command_id,
-        )
-    }
-
-    #[must_use]
-    pub fn application_guild_commands(application_id: ApplicationId, guild_id: GuildId) -> String {
-        api!("/applications/{}/guilds/{}/commands", application_id, guild_id)
-    }
-
-    #[must_use]
-    pub fn application_guild_commands_permissions(
-        application_id: ApplicationId,
-        guild_id: GuildId,
-    ) -> String {
-        api!("/applications/{}/guilds/{}/commands/permissions", application_id, guild_id)
-    }
-
-    #[must_use]
-    pub fn stage_instances() -> &'static str {
-        api!("/stage-instances")
-    }
-
-    #[must_use]
-    pub fn stage_instance(channel_id: ChannelId) -> String {
-        api!("/stage-instances/{}", channel_id)
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
-pub enum RouteInfo<'a> {
-    AddGuildMember {
-        guild_id: GuildId,
-        user_id: UserId,
-    },
-    AddMemberRole {
-        guild_id: GuildId,
-        role_id: RoleId,
-        user_id: UserId,
-    },
-    GuildBanUser {
-        guild_id: GuildId,
-        user_id: UserId,
-        delete_message_days: Option<u8>,
-    },
-    BroadcastTyping {
-        channel_id: ChannelId,
-    },
-    CreateAutoModRule {
-        guild_id: GuildId,
-    },
-    CreateChannel {
-        guild_id: GuildId,
-    },
-    CreateStageInstance,
-    CreatePublicThread {
-        channel_id: ChannelId,
-        message_id: MessageId,
-    },
-    CreatePrivateThread {
-        channel_id: ChannelId,
-    },
-    CreateEmoji {
-        guild_id: GuildId,
-    },
-    CreateFollowupMessage {
-        application_id: ApplicationId,
-        interaction_token: &'a str,
-    },
-    CreateGlobalCommand {
-        application_id: ApplicationId,
-    },
-    CreateGlobalCommands {
-        application_id: ApplicationId,
-    },
-    CreateGuild,
-    CreateGuildCommand {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-    },
-    CreateGuildCommands {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-    },
-    CreateGuildIntegration {
-        guild_id: GuildId,
-        integration_id: IntegrationId,
-    },
-    CreateInteractionResponse {
-        interaction_id: InteractionId,
-        interaction_token: &'a str,
-    },
-    CreateInvite {
-        channel_id: ChannelId,
-    },
-    CreateMessage {
-        channel_id: ChannelId,
-    },
-    CreatePermission {
-        channel_id: ChannelId,
-        target_id: TargetId,
-    },
-    CreatePrivateChannel,
-    CreateReaction {
-        channel_id: ChannelId,
-        message_id: MessageId,
-        reaction: &'a str,
-    },
-    CreateRole {
-        guild_id: GuildId,
-    },
-    CreateScheduledEvent {
-        guild_id: GuildId,
-    },
-    CreateSticker {
-        guild_id: GuildId,
-    },
-    CreateWebhook {
-        channel_id: ChannelId,
-    },
-    DeleteAutoModRule {
-        guild_id: GuildId,
-        rule_id: RuleId,
-    },
-    DeleteChannel {
-        channel_id: ChannelId,
-    },
-    DeleteStageInstance {
-        channel_id: ChannelId,
-    },
-    DeleteEmoji {
-        guild_id: GuildId,
-        emoji_id: EmojiId,
-    },
-    DeleteFollowupMessage {
-        application_id: ApplicationId,
-        interaction_token: &'a str,
-        message_id: MessageId,
-    },
-    DeleteGlobalCommand {
-        application_id: ApplicationId,
-        command_id: CommandId,
-    },
-    DeleteGuild {
-        guild_id: GuildId,
-    },
-    DeleteGuildCommand {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-        command_id: CommandId,
-    },
-    DeleteGuildIntegration {
-        guild_id: GuildId,
-        integration_id: IntegrationId,
-    },
-    DeleteInvite {
-        code: &'a str,
-    },
-    DeleteMessage {
-        channel_id: ChannelId,
-        message_id: MessageId,
-    },
-    DeleteMessages {
-        channel_id: ChannelId,
-    },
-    DeleteMessageReactions {
-        channel_id: ChannelId,
-        message_id: MessageId,
-    },
-    DeleteMessageReactionEmoji {
-        channel_id: ChannelId,
-        message_id: MessageId,
-        reaction: &'a str,
-    },
-    DeleteOriginalInteractionResponse {
-        application_id: ApplicationId,
-        interaction_token: &'a str,
-    },
-    DeletePermission {
-        channel_id: ChannelId,
-        target_id: TargetId,
-    },
-    DeleteReaction {
-        channel_id: ChannelId,
-        message_id: MessageId,
-        user: &'a str,
-        reaction: &'a str,
-    },
-    DeleteRole {
-        guild_id: GuildId,
-        role_id: RoleId,
-    },
-    DeleteScheduledEvent {
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
-    },
-    DeleteSticker {
-        guild_id: GuildId,
-        sticker_id: StickerId,
-    },
-    DeleteWebhook {
-        webhook_id: WebhookId,
-    },
-    DeleteWebhookWithToken {
-        token: &'a str,
-        webhook_id: WebhookId,
-    },
-    DeleteWebhookMessage {
-        token: &'a str,
-        webhook_id: WebhookId,
-        message_id: MessageId,
-    },
-    EditAutoModRule {
-        guild_id: GuildId,
-        rule_id: RuleId,
-    },
-    EditChannel {
-        channel_id: ChannelId,
-    },
-    EditStageInstance {
-        channel_id: ChannelId,
-    },
-    EditEmoji {
-        guild_id: GuildId,
-        emoji_id: EmojiId,
-    },
-    EditFollowupMessage {
-        application_id: ApplicationId,
-        interaction_token: &'a str,
-        message_id: MessageId,
-    },
-    EditGlobalCommand {
-        application_id: ApplicationId,
-        command_id: CommandId,
-    },
-    EditGuild {
-        guild_id: GuildId,
-    },
-    EditGuildCommand {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-        command_id: CommandId,
-    },
-    EditGuildCommandPermission {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-        command_id: CommandId,
-    },
-    EditGuildCommandsPermissions {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-    },
-    EditGuildChannels {
-        guild_id: GuildId,
-    },
-    EditGuildWidget {
-        guild_id: GuildId,
-    },
-    EditGuildWelcomeScreen {
-        guild_id: GuildId,
-    },
-    EditMember {
-        guild_id: GuildId,
-        user_id: UserId,
-    },
-    EditMessage {
-        channel_id: ChannelId,
-        message_id: MessageId,
-    },
-    CrosspostMessage {
-        channel_id: ChannelId,
-        message_id: MessageId,
-    },
-    EditMemberMe {
-        guild_id: GuildId,
-    },
-    EditNickname {
-        guild_id: GuildId,
-    },
-    GetOriginalInteractionResponse {
-        application_id: ApplicationId,
-        interaction_token: &'a str,
-    },
-    EditOriginalInteractionResponse {
-        application_id: ApplicationId,
-        interaction_token: &'a str,
-    },
-    EditProfile,
-    EditRole {
-        guild_id: GuildId,
-        role_id: RoleId,
-    },
-    EditRolePosition {
-        guild_id: GuildId,
-    },
-    EditScheduledEvent {
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
-    },
-    EditSticker {
-        guild_id: GuildId,
-        sticker_id: StickerId,
-    },
-    EditThread {
-        channel_id: ChannelId,
-    },
-    EditVoiceState {
-        guild_id: GuildId,
-        user_id: UserId,
-    },
-    EditVoiceStateMe {
-        guild_id: GuildId,
-    },
-    EditWebhook {
-        webhook_id: WebhookId,
-    },
-    EditWebhookWithToken {
-        token: &'a str,
-        webhook_id: WebhookId,
-    },
-    EditWebhookMessage {
-        token: &'a str,
-        webhook_id: WebhookId,
-        message_id: MessageId,
-    },
-    ExecuteWebhook {
-        token: &'a str,
-        wait: bool,
-        webhook_id: WebhookId,
-        thread_id: Option<ChannelId>,
-    },
-    FollowNewsChannel {
-        channel_id: ChannelId,
-    },
-    JoinThread {
-        channel_id: ChannelId,
-    },
-    LeaveThread {
-        channel_id: ChannelId,
-    },
-    AddThreadMember {
-        channel_id: ChannelId,
-        user_id: UserId,
-    },
-    RemoveThreadMember {
-        channel_id: ChannelId,
-        user_id: UserId,
-    },
-    GetActiveMaintenance,
-    GetAuditLogs {
-        action_type: Option<u8>,
-        before: Option<u64>,
-        guild_id: GuildId,
-        limit: Option<u8>,
-        user_id: Option<UserId>,
-    },
-    GetAutoModRules {
-        guild_id: GuildId,
-    },
-    GetAutoModRule {
-        guild_id: GuildId,
-        rule_id: RuleId,
-    },
-    GetBans {
-        guild_id: GuildId,
-    },
-    GetBotGateway,
-    GetChannel {
-        channel_id: ChannelId,
-    },
-    GetChannelInvites {
-        channel_id: ChannelId,
-    },
-    GetChannelWebhooks {
-        channel_id: ChannelId,
-    },
-    GetChannels {
-        guild_id: GuildId,
-    },
-    GetStageInstance {
-        channel_id: ChannelId,
-    },
-    GetChannelThreadMembers {
-        channel_id: ChannelId,
-    },
-    GetChannelArchivedPublicThreads {
-        channel_id: ChannelId,
-        before: Option<u64>,
-        limit: Option<u64>,
-    },
-    GetChannelArchivedPrivateThreads {
-        channel_id: ChannelId,
-        before: Option<u64>,
-        limit: Option<u64>,
-    },
-    GetChannelJoinedPrivateArchivedThreads {
-        channel_id: ChannelId,
-        before: Option<u64>,
-        limit: Option<u64>,
-    },
-    GetCurrentApplicationInfo,
-    GetCurrentUser,
-    GetEmojis {
-        guild_id: GuildId,
-    },
-    GetEmoji {
-        guild_id: GuildId,
-        emoji_id: EmojiId,
-    },
-    GetFollowupMessage {
-        application_id: ApplicationId,
-        interaction_token: &'a str,
-        message_id: MessageId,
-    },
-    GetGateway,
-    GetGlobalCommands {
-        application_id: ApplicationId,
-    },
-    GetGlobalCommand {
-        application_id: ApplicationId,
-        command_id: CommandId,
-    },
-    GetGuild {
-        guild_id: GuildId,
-    },
-    GetGuildWithCounts {
-        guild_id: GuildId,
-    },
-    GetGuildCommands {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-    },
-    GetGuildCommand {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-        command_id: CommandId,
-    },
-    GetGuildCommandsPermissions {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-    },
-    GetGuildCommandPermissions {
-        application_id: ApplicationId,
-        guild_id: GuildId,
-        command_id: CommandId,
-    },
-    GetGuildWidget {
-        guild_id: GuildId,
-    },
-    GetGuildActiveThreads {
-        guild_id: GuildId,
-    },
-    GetGuildPreview {
-        guild_id: GuildId,
-    },
-    GetGuildWelcomeScreen {
-        guild_id: GuildId,
-    },
-    GetGuildIntegrations {
-        guild_id: GuildId,
-    },
-    GetGuildInvites {
-        guild_id: GuildId,
-    },
-    GetGuildMembers {
-        after: Option<u64>,
-        limit: Option<u64>,
-        guild_id: GuildId,
-    },
-    GetGuildPruneCount {
-        days: u8,
-        guild_id: GuildId,
-    },
-    GetGuildRegions {
-        guild_id: GuildId,
-    },
-    GetGuildRoles {
-        guild_id: GuildId,
-    },
-    GetScheduledEvent {
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
-        with_user_count: bool,
-    },
-    GetScheduledEvents {
-        guild_id: GuildId,
-        with_user_count: bool,
-    },
-    GetScheduledEventUsers {
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
-        after: Option<u64>,
-        before: Option<u64>,
-        limit: Option<u64>,
-        with_member: Option<bool>,
-    },
-    GetGuildStickers {
-        guild_id: GuildId,
-    },
-    GetGuildVanityUrl {
-        guild_id: GuildId,
-    },
-    GetGuildWebhooks {
-        guild_id: GuildId,
-    },
-    GetGuilds {
-        after: Option<u64>,
-        before: Option<u64>,
-        limit: Option<u64>,
-    },
-    GetInvite {
-        code: &'a str,
-        member_counts: bool,
-        expiration: bool,
-        event_id: Option<ScheduledEventId>,
-    },
-    GetMember {
-        guild_id: GuildId,
-        user_id: UserId,
-    },
-    GetMessage {
-        channel_id: ChannelId,
-        message_id: MessageId,
-    },
-    GetMessages {
-        channel_id: ChannelId,
-        query: &'a str,
-    },
-    GetPins {
-        channel_id: ChannelId,
-    },
-    GetReactionUsers {
-        after: Option<u64>,
-        channel_id: ChannelId,
-        limit: u8,
-        message_id: MessageId,
-        reaction: &'a str,
-    },
-    GetSticker {
-        sticker_id: StickerId,
-    },
-    GetStickerPacks,
-    GetGuildSticker {
-        guild_id: GuildId,
-        sticker_id: StickerId,
-    },
-    GetUnresolvedIncidents,
-    GetUpcomingMaintenances,
-    GetUser {
-        user_id: UserId,
-    },
-    GetUserConnections,
-    GetUserDmChannels,
-    GetVoiceRegions,
-    GetWebhook {
-        webhook_id: WebhookId,
-    },
-    GetWebhookWithToken {
-        token: &'a str,
-        webhook_id: WebhookId,
-    },
-    GetWebhookMessage {
-        token: &'a str,
-        webhook_id: WebhookId,
-        message_id: MessageId,
-    },
-    KickMember {
-        guild_id: GuildId,
-        user_id: UserId,
-    },
-    LeaveGuild {
-        guild_id: GuildId,
-    },
-    PinMessage {
-        channel_id: ChannelId,
-        message_id: MessageId,
-    },
-    RemoveBan {
-        guild_id: GuildId,
-        user_id: UserId,
-    },
-    RemoveMemberRole {
-        guild_id: GuildId,
-        role_id: RoleId,
-        user_id: UserId,
-    },
-    SearchGuildMembers {
-        guild_id: GuildId,
-        query: &'a str,
-        limit: Option<u64>,
-    },
-    StartGuildPrune {
-        days: u8,
-        guild_id: GuildId,
-    },
-    StartIntegrationSync {
-        guild_id: GuildId,
-        integration_id: IntegrationId,
-    },
-    StatusIncidentsUnresolved,
-    StatusMaintenancesActive,
-    StatusMaintenancesUpcoming,
-    UnpinMessage {
-        channel_id: ChannelId,
-        message_id: MessageId,
-    },
-}
-
-impl<'a> RouteInfo<'a> {
-    #[must_use]
-    pub fn deconstruct(self) -> (LightMethod, Route, Cow<'static, str>) {
-        match self {
-            RouteInfo::AddGuildMember {
-                guild_id,
-                user_id,
-            } => (
-                LightMethod::Put,
-                Route::GuildsIdMembersId(guild_id),
-                Cow::from(Route::guild_member(guild_id, user_id)),
-            ),
-            RouteInfo::AddMemberRole {
-                guild_id,
-                role_id,
-                user_id,
-            } => (
-                LightMethod::Put,
-                Route::GuildsIdMembersIdRolesId(guild_id),
-                Cow::from(Route::guild_member_role(guild_id, user_id, role_id)),
-            ),
-            RouteInfo::GuildBanUser {
-                guild_id,
-                delete_message_days,
-                user_id,
-            } => (
-                // TODO
-                LightMethod::Put,
-                Route::GuildsIdBansUserId(guild_id),
-                Cow::from(Route::guild_ban_optioned(
-                    guild_id,
-                    user_id,
-                    delete_message_days.unwrap_or(0),
-                )),
-            ),
-            RouteInfo::BroadcastTyping {
-                channel_id,
-            } => (
-                LightMethod::Post,
-                Route::ChannelsIdTyping(channel_id),
-                Cow::from(Route::channel_typing(channel_id)),
-            ),
-            RouteInfo::CreateAutoModRule {
-                guild_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdAutoModRules(guild_id),
-                Cow::from(Route::guild_automod_rules(guild_id)),
-            ),
-            RouteInfo::CreateChannel {
-                guild_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdChannels(guild_id),
-                Cow::from(Route::guild_channels(guild_id)),
-            ),
-            RouteInfo::CreateStageInstance => {
-                (LightMethod::Post, Route::StageInstances, Cow::from(Route::stage_instances()))
-            },
-            RouteInfo::CreatePublicThread {
-                channel_id,
-                message_id,
-            } => (
-                LightMethod::Post,
-                Route::ChannelsIdMessagesIdThreads(channel_id),
-                Cow::from(Route::channel_public_threads(channel_id, message_id)),
-            ),
-            RouteInfo::CreatePrivateThread {
-                channel_id,
-            } => (
-                LightMethod::Post,
-                Route::ChannelsIdThreads(channel_id),
-                Cow::from(Route::channel_private_threads(channel_id)),
-            ),
-            RouteInfo::CreateEmoji {
-                guild_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdEmojis(guild_id),
-                Cow::from(Route::guild_emojis(guild_id)),
-            ),
-            RouteInfo::CreateFollowupMessage {
-                application_id,
-                interaction_token,
-            } => (
-                LightMethod::Post,
-                Route::WebhooksId(WebhookId(application_id.0)),
-                Cow::from(Route::webhook_followup_messages(application_id, interaction_token)),
-            ),
-            RouteInfo::CreateGlobalCommand {
-                application_id,
-            } => (
-                LightMethod::Post,
-                Route::ApplicationsIdCommands(application_id),
-                Cow::from(Route::application_commands(application_id)),
-            ),
-            RouteInfo::CreateGlobalCommands {
-                application_id,
-            } => (
-                LightMethod::Put,
-                Route::ApplicationsIdCommands(application_id),
-                Cow::from(Route::application_commands(application_id)),
-            ),
-            RouteInfo::CreateGuild => {
-                (LightMethod::Post, Route::Guilds, Cow::from(Route::guilds()))
-            },
-            RouteInfo::CreateGuildCommand {
-                application_id,
-                guild_id,
-            } => (
-                LightMethod::Post,
-                Route::ApplicationsIdGuildsIdCommands(application_id),
-                Cow::from(Route::application_guild_commands(application_id, guild_id)),
-            ),
-            RouteInfo::CreateGuildCommands {
-                application_id,
-                guild_id,
-            } => (
-                LightMethod::Put,
-                Route::ApplicationsIdGuildsIdCommands(application_id),
-                Cow::from(Route::application_guild_commands(application_id, guild_id)),
-            ),
-            RouteInfo::CreateGuildIntegration {
-                guild_id,
-                integration_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdIntegrationsId(guild_id),
-                Cow::from(Route::guild_integration(guild_id, integration_id)),
-            ),
-            RouteInfo::CreateInteractionResponse {
-                interaction_id,
-                interaction_token,
-            } => (
-                LightMethod::Post,
-                Route::InteractionsId(interaction_id),
-                Cow::from(Route::interaction_response(interaction_id, interaction_token)),
-            ),
-            RouteInfo::CreateInvite {
-                channel_id,
-            } => (
-                LightMethod::Post,
-                Route::ChannelsIdInvites(channel_id),
-                Cow::from(Route::channel_invites(channel_id)),
-            ),
-            RouteInfo::CreateMessage {
-                channel_id,
-            } => (
-                LightMethod::Post,
-                Route::ChannelsIdMessages(channel_id),
-                Cow::from(Route::channel_messages(channel_id, None)),
-            ),
-            RouteInfo::CreatePermission {
-                channel_id,
-                target_id,
-            } => (
-                LightMethod::Put,
-                Route::ChannelsIdPermissionsOverwriteId(channel_id),
-                Cow::from(Route::channel_permission(channel_id, target_id)),
-            ),
-            RouteInfo::CreatePrivateChannel => (
-                LightMethod::Post,
-                Route::UsersMeChannels,
-                Cow::from(Route::user_dm_channels("@me")),
-            ),
-            RouteInfo::CreateReaction {
-                channel_id,
-                message_id,
-                reaction,
-            } => (
-                LightMethod::Put,
-                Route::ChannelsIdMessagesIdReactionsUserIdType(channel_id),
-                Cow::from(Route::channel_message_reaction(channel_id, message_id, "@me", reaction)),
-            ),
-            RouteInfo::CreateRole {
-                guild_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdRoles(guild_id),
-                Cow::from(Route::guild_roles(guild_id)),
-            ),
-            RouteInfo::CreateScheduledEvent {
-                guild_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdScheduledEvents(guild_id),
-                Cow::from(Route::guild_scheduled_events(guild_id, None)),
-            ),
-            RouteInfo::CreateSticker {
-                guild_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdStickers(guild_id),
-                Cow::from(Route::guild_stickers(guild_id)),
-            ),
-            RouteInfo::CrosspostMessage {
-                channel_id,
-                message_id,
-            } => (
-                LightMethod::Post,
-                Route::ChannelsIdCrosspostsMessageId(channel_id),
-                Cow::from(Route::channel_message_crosspost(channel_id, message_id)),
-            ),
-            RouteInfo::CreateWebhook {
-                channel_id,
-            } => (
-                LightMethod::Post,
-                Route::ChannelsIdWebhooks(channel_id),
-                Cow::from(Route::channel_webhooks(channel_id)),
-            ),
-            RouteInfo::DeleteAutoModRule {
-                guild_id,
-                rule_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdAutoModRulesId(guild_id),
-                Cow::from(Route::guild_automod_rule(guild_id, rule_id)),
-            ),
-            RouteInfo::DeleteChannel {
-                channel_id,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsId(channel_id),
-                Cow::from(Route::channel(channel_id)),
-            ),
-            RouteInfo::DeleteStageInstance {
-                channel_id,
-            } => (
-                LightMethod::Delete,
-                Route::StageInstancesChannelId(channel_id),
-                Cow::from(Route::stage_instance(channel_id)),
-            ),
-            RouteInfo::DeleteEmoji {
-                emoji_id,
-                guild_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdEmojisId(guild_id),
-                Cow::from(Route::guild_emoji(guild_id, emoji_id)),
-            ),
-            RouteInfo::DeleteFollowupMessage {
-                application_id,
-                interaction_token,
-                message_id,
-            } => (
-                LightMethod::Delete,
-                Route::WebhooksApplicationId(application_id),
-                Cow::from(Route::webhook_followup_message(
-                    application_id,
-                    interaction_token,
-                    message_id,
-                )),
-            ),
-            RouteInfo::DeleteGlobalCommand {
-                application_id,
-                command_id,
-            } => (
-                LightMethod::Delete,
-                Route::ApplicationsIdCommandsId(application_id),
-                Cow::from(Route::application_command(application_id, command_id)),
-            ),
-            RouteInfo::DeleteGuild {
-                guild_id,
-            } => {
-                (LightMethod::Delete, Route::GuildsId(guild_id), Cow::from(Route::guild(guild_id)))
-            },
-            RouteInfo::DeleteGuildCommand {
-                application_id,
-                guild_id,
-                command_id,
-            } => (
-                LightMethod::Delete,
-                Route::ApplicationsIdGuildsIdCommandsId(application_id),
-                Cow::from(Route::application_guild_command(application_id, guild_id, command_id)),
-            ),
-            RouteInfo::DeleteGuildIntegration {
-                guild_id,
-                integration_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdIntegrationsId(guild_id),
-                Cow::from(Route::guild_integration(guild_id, integration_id)),
-            ),
-            RouteInfo::DeleteInvite {
-                code,
-            } => (LightMethod::Delete, Route::InvitesCode, Cow::from(Route::invite(code))),
-            RouteInfo::DeleteMessageReactions {
-                channel_id,
-                message_id,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsIdMessagesIdReactions(channel_id),
-                Cow::from(Route::channel_message_reactions(channel_id, message_id)),
-            ),
-            RouteInfo::DeleteMessageReactionEmoji {
-                channel_id,
-                message_id,
-                reaction,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsIdMessagesIdReactions(channel_id),
-                Cow::from(Route::channel_message_reaction_emoji(channel_id, message_id, reaction)),
-            ),
-            RouteInfo::DeleteMessage {
-                channel_id,
-                message_id,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsIdMessagesId(LightMethod::Delete, channel_id),
-                Cow::from(Route::channel_message(channel_id, message_id)),
-            ),
-            RouteInfo::DeleteMessages {
-                channel_id,
-            } => (
-                LightMethod::Post,
-                Route::ChannelsIdMessagesBulkDelete(channel_id),
-                Cow::from(Route::channel_messages_bulk_delete(channel_id)),
-            ),
-            RouteInfo::DeleteOriginalInteractionResponse {
-                application_id,
-                interaction_token,
-            } => (
-                LightMethod::Delete,
-                Route::WebhooksApplicationId(application_id),
-                Cow::from(Route::webhook_original_interaction_response(
-                    application_id,
-                    interaction_token,
-                )),
-            ),
-            RouteInfo::DeletePermission {
-                channel_id,
-                target_id,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsIdPermissionsOverwriteId(channel_id),
-                Cow::from(Route::channel_permission(channel_id, target_id)),
-            ),
-            RouteInfo::DeleteReaction {
-                channel_id,
-                message_id,
-                reaction,
-                user,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsIdMessagesIdReactionsUserIdType(channel_id),
-                Cow::from(Route::channel_message_reaction(channel_id, message_id, user, reaction)),
-            ),
-            RouteInfo::DeleteRole {
-                guild_id,
-                role_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdRolesId(guild_id),
-                Cow::from(Route::guild_role(guild_id, role_id)),
-            ),
-            RouteInfo::DeleteScheduledEvent {
-                guild_id,
-                event_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdScheduledEventsId(guild_id),
-                Cow::from(Route::guild_scheduled_event(guild_id, event_id, None)),
-            ),
-            RouteInfo::DeleteSticker {
-                guild_id,
-                sticker_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdStickersId(guild_id),
-                Cow::from(Route::guild_sticker(guild_id, sticker_id)),
-            ),
-            RouteInfo::DeleteWebhook {
-                webhook_id,
-            } => (
-                LightMethod::Delete,
-                Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook(webhook_id)),
-            ),
-            RouteInfo::DeleteWebhookWithToken {
-                token,
-                webhook_id,
-            } => (
-                LightMethod::Delete,
-                Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook_with_token(webhook_id, token)),
-            ),
-            RouteInfo::DeleteWebhookMessage {
-                token,
-                webhook_id,
-                message_id,
-            } => (
-                LightMethod::Delete,
-                Route::WebhooksIdMessagesId(webhook_id),
-                Cow::from(Route::webhook_message(webhook_id, token, message_id)),
-            ),
-            RouteInfo::EditAutoModRule {
-                guild_id,
-                rule_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdAutoModRulesId(guild_id),
-                Cow::from(Route::guild_automod_rule(guild_id, rule_id)),
-            ),
-            RouteInfo::EditChannel {
-                channel_id,
+        impl<$lt> Route<$lt> {
+            #[must_use]
+            pub fn path(&self) -> Cow<'static, str> {
+                match self {
+                    $(
+                        Self::$name $({ $($field_name),* })? => $path.into(),
+                    )+
+                }
             }
-            | RouteInfo::EditThread {
-                channel_id,
-            } => (
-                LightMethod::Patch,
-                Route::ChannelsId(channel_id),
-                Cow::from(Route::channel(channel_id)),
-            ),
-            RouteInfo::EditScheduledEvent {
-                guild_id,
-                event_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdScheduledEventsId(guild_id),
-                Cow::from(Route::guild_scheduled_event(guild_id, event_id, None)),
-            ),
-            RouteInfo::EditStageInstance {
-                channel_id,
-            } => (
-                LightMethod::Patch,
-                Route::StageInstancesChannelId(channel_id),
-                Cow::from(Route::stage_instance(channel_id)),
-            ),
-            RouteInfo::EditEmoji {
-                emoji_id,
-                guild_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdEmojisId(guild_id),
-                Cow::from(Route::guild_emoji(guild_id, emoji_id)),
-            ),
-            RouteInfo::EditFollowupMessage {
-                application_id,
-                interaction_token,
-                message_id,
-            } => (
-                LightMethod::Patch,
-                Route::WebhooksApplicationId(application_id),
-                Cow::from(Route::webhook_followup_message(
-                    application_id,
-                    interaction_token,
-                    message_id,
-                )),
-            ),
-            RouteInfo::EditGlobalCommand {
-                application_id,
-                command_id,
-            } => (
-                LightMethod::Patch,
-                Route::ApplicationsIdCommandsId(application_id),
-                Cow::from(Route::application_command(application_id, command_id)),
-            ),
-            RouteInfo::EditGuild {
-                guild_id,
-            } => (LightMethod::Patch, Route::GuildsId(guild_id), Cow::from(Route::guild(guild_id))),
-            RouteInfo::EditGuildCommand {
-                application_id,
-                guild_id,
-                command_id,
-            } => (
-                LightMethod::Patch,
-                Route::ApplicationsIdGuildsIdCommandsId(application_id),
-                Cow::from(Route::application_guild_command(application_id, guild_id, command_id)),
-            ),
-            RouteInfo::EditGuildCommandPermission {
-                application_id,
-                guild_id,
-                command_id,
-            } => (
-                LightMethod::Put,
-                Route::ApplicationsIdGuildsIdCommandIdPermissions(application_id),
-                Cow::from(Route::application_guild_command_permissions(
-                    application_id,
-                    guild_id,
-                    command_id,
-                )),
-            ),
-            RouteInfo::EditGuildCommandsPermissions {
-                application_id,
-                guild_id,
-            } => (
-                LightMethod::Put,
-                Route::ApplicationsIdGuildsIdCommandsPermissions(application_id),
-                Cow::from(Route::application_guild_commands_permissions(application_id, guild_id)),
-            ),
-            RouteInfo::EditGuildChannels {
-                guild_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdChannels(guild_id),
-                Cow::from(Route::guild_channels(guild_id)),
-            ),
-            RouteInfo::EditGuildWidget {
-                guild_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdWidget(guild_id),
-                Cow::from(Route::guild_widget(guild_id)),
-            ),
-            RouteInfo::EditGuildWelcomeScreen {
-                guild_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdWelcomeScreen(guild_id),
-                Cow::from(Route::guild_welcome_screen(guild_id)),
-            ),
-            RouteInfo::EditMember {
-                guild_id,
-                user_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdMembersId(guild_id),
-                Cow::from(Route::guild_member(guild_id, user_id)),
-            ),
-            RouteInfo::EditMessage {
-                channel_id,
-                message_id,
-            } => (
-                LightMethod::Patch,
-                Route::ChannelsIdMessagesId(LightMethod::Patch, channel_id),
-                Cow::from(Route::channel_message(channel_id, message_id)),
-            ),
-            RouteInfo::EditMemberMe {
-                guild_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdMembersMe(guild_id),
-                Cow::from(Route::guild_member_me(guild_id)),
-            ),
-            RouteInfo::EditNickname {
-                guild_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdMembersMeNick(guild_id),
-                Cow::from(Route::guild_nickname(guild_id)),
-            ),
-            RouteInfo::GetOriginalInteractionResponse {
-                application_id,
-                interaction_token,
-            } => (
-                LightMethod::Get,
-                Route::WebhooksApplicationId(application_id),
-                Cow::from(Route::webhook_original_interaction_response(
-                    application_id,
-                    interaction_token,
-                )),
-            ),
-            RouteInfo::EditOriginalInteractionResponse {
-                application_id,
-                interaction_token,
-            } => (
-                LightMethod::Patch,
-                Route::WebhooksApplicationId(application_id),
-                Cow::from(Route::webhook_original_interaction_response(
-                    application_id,
-                    interaction_token,
-                )),
-            ),
-            RouteInfo::EditProfile => {
-                (LightMethod::Patch, Route::UsersMe, Cow::from(Route::user("@me")))
-            },
-            RouteInfo::EditRole {
-                guild_id,
-                role_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdRolesId(guild_id),
-                Cow::from(Route::guild_role(guild_id, role_id)),
-            ),
-            RouteInfo::EditRolePosition {
-                guild_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdRolesId(guild_id),
-                Cow::from(Route::guild_roles(guild_id)),
-            ),
-            RouteInfo::EditSticker {
-                guild_id,
-                sticker_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdStickersId(guild_id),
-                Cow::from(Route::guild_sticker(guild_id, sticker_id)),
-            ),
-            RouteInfo::EditVoiceState {
-                guild_id,
-                user_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdVoiceStates(guild_id),
-                Cow::from(Route::guild_voice_states(guild_id, user_id)),
-            ),
-            RouteInfo::EditVoiceStateMe {
-                guild_id,
-            } => (
-                LightMethod::Patch,
-                Route::GuildsIdVoiceStatesMe(guild_id),
-                Cow::from(Route::guild_voice_states_me(guild_id)),
-            ),
-            RouteInfo::EditWebhook {
-                webhook_id,
-            } => (
-                LightMethod::Patch,
-                Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook(webhook_id)),
-            ),
-            RouteInfo::EditWebhookWithToken {
-                token,
-                webhook_id,
-            } => (
-                LightMethod::Patch,
-                Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook_with_token(webhook_id, token)),
-            ),
-            RouteInfo::GetWebhookMessage {
-                token,
-                webhook_id,
-                message_id,
-            } => (
-                LightMethod::Get,
-                Route::WebhooksIdMessagesId(webhook_id),
-                Cow::from(Route::webhook_message(webhook_id, token, message_id)),
-            ),
-            RouteInfo::EditWebhookMessage {
-                token,
-                webhook_id,
-                message_id,
-            } => (
-                LightMethod::Patch,
-                Route::WebhooksIdMessagesId(webhook_id),
-                Cow::from(Route::webhook_message(webhook_id, token, message_id)),
-            ),
-            RouteInfo::ExecuteWebhook {
-                token,
-                wait,
-                webhook_id,
-                thread_id,
-            } => (
-                LightMethod::Post,
-                Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook_with_token_optioned(webhook_id, thread_id, token, wait)),
-            ),
-            RouteInfo::FollowNewsChannel {
-                channel_id,
-            } => (
-                LightMethod::Post,
-                Route::FollowNewsChannel(channel_id),
-                Cow::from(Route::channel_follow_news(channel_id)),
-            ),
-            RouteInfo::GetAuditLogs {
-                action_type,
-                before,
-                guild_id,
-                limit,
-                user_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdAuditLogs(guild_id),
-                Cow::from(Route::guild_audit_logs(guild_id, action_type, user_id, before, limit)),
-            ),
-            RouteInfo::GetAutoModRules {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdAutoModRules(guild_id),
-                Cow::from(Route::guild_automod_rules(guild_id)),
-            ),
-            RouteInfo::GetAutoModRule {
-                guild_id,
-                rule_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdAutoModRulesId(guild_id),
-                Cow::from(Route::guild_automod_rule(guild_id, rule_id)),
-            ),
-            RouteInfo::GetBans {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdBans(guild_id),
-                Cow::from(Route::guild_bans(guild_id)),
-            ),
-            RouteInfo::GetBotGateway => {
-                (LightMethod::Get, Route::GatewayBot, Cow::from(Route::gateway_bot()))
-            },
-            RouteInfo::GetChannel {
-                channel_id,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsId(channel_id),
-                Cow::from(Route::channel(channel_id)),
-            ),
-            RouteInfo::GetStageInstance {
-                channel_id,
-            } => (
-                LightMethod::Get,
-                Route::StageInstancesChannelId(channel_id),
-                Cow::from(Route::stage_instance(channel_id)),
-            ),
-            RouteInfo::GetChannelInvites {
-                channel_id,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdInvites(channel_id),
-                Cow::from(Route::channel_invites(channel_id)),
-            ),
-            RouteInfo::GetChannelWebhooks {
-                channel_id,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdWebhooks(channel_id),
-                Cow::from(Route::channel_webhooks(channel_id)),
-            ),
-            RouteInfo::GetChannels {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdChannels(guild_id),
-                Cow::from(Route::guild_channels(guild_id)),
-            ),
-            RouteInfo::GetChannelThreadMembers {
-                channel_id,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdThreadMembers(channel_id),
-                Cow::from(Route::channel_thread_members(channel_id)),
-            ),
-            RouteInfo::GetChannelArchivedPublicThreads {
-                channel_id,
-                before,
-                limit,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdArchivedPublicThreads(channel_id),
-                Cow::from(Route::channel_archived_public_threads(channel_id, before, limit)),
-            ),
-            RouteInfo::GetChannelArchivedPrivateThreads {
-                channel_id,
-                before,
-                limit,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdArchivedPrivateThreads(channel_id),
-                Cow::from(Route::channel_archived_private_threads(channel_id, before, limit)),
-            ),
-            RouteInfo::GetChannelJoinedPrivateArchivedThreads {
-                channel_id,
-                before,
-                limit,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdMeJoindedArchivedPrivateThreads(channel_id),
-                Cow::from(Route::channel_joined_private_threads(channel_id, before, limit)),
-            ),
-            RouteInfo::GetFollowupMessage {
-                application_id,
-                interaction_token,
-                message_id,
-            } => (
-                LightMethod::Get,
-                Route::WebhooksApplicationId(application_id),
-                Cow::from(Route::webhook_followup_message(
-                    application_id,
-                    interaction_token,
-                    message_id,
-                )),
-            ),
-            RouteInfo::GetGuildActiveThreads {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdThreadsActive,
-                Cow::from(Route::guild_threads_active(guild_id)),
-            ),
-            RouteInfo::JoinThread {
-                channel_id,
-            } => (
-                LightMethod::Put,
-                Route::ChannelsIdThreadMembersMe(channel_id),
-                Cow::from(Route::channel_thread_member_me(channel_id)),
-            ),
-            RouteInfo::LeaveThread {
-                channel_id,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsIdThreadMembersMe(channel_id),
-                Cow::from(Route::channel_thread_member_me(channel_id)),
-            ),
-            RouteInfo::AddThreadMember {
-                channel_id,
-                user_id,
-            } => (
-                LightMethod::Put,
-                Route::ChannelsIdThreadMembersUserId(channel_id),
-                Cow::from(Route::channel_thread_member(channel_id, user_id)),
-            ),
-            RouteInfo::RemoveThreadMember {
-                channel_id,
-                user_id,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsIdThreadMembersUserId(channel_id),
-                Cow::from(Route::channel_thread_member(channel_id, user_id)),
-            ),
-            RouteInfo::GetCurrentApplicationInfo => {
-                (LightMethod::Get, Route::None, Cow::from(Route::oauth2_application_current()))
-            },
-            RouteInfo::GetCurrentUser => {
-                (LightMethod::Get, Route::UsersMe, Cow::from(Route::user("@me")))
-            },
-            RouteInfo::GetEmojis {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdEmojis(guild_id),
-                Cow::from(Route::guild_emojis(guild_id)),
-            ),
-            RouteInfo::GetEmoji {
-                guild_id,
-                emoji_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdEmojisId(guild_id),
-                Cow::from(Route::guild_emoji(guild_id, emoji_id)),
-            ),
-            RouteInfo::GetGateway => {
-                (LightMethod::Get, Route::Gateway, Cow::from(Route::gateway()))
-            },
-            RouteInfo::GetGlobalCommands {
-                application_id,
-            } => (
-                LightMethod::Get,
-                Route::ApplicationsIdCommands(application_id),
-                Cow::from(Route::application_commands(application_id)),
-            ),
-            RouteInfo::GetGlobalCommand {
-                application_id,
-                command_id,
-            } => (
-                LightMethod::Get,
-                Route::ApplicationsIdCommandsId(application_id),
-                Cow::from(Route::application_command(application_id, command_id)),
-            ),
-            RouteInfo::GetGuild {
-                guild_id,
-            } => (LightMethod::Get, Route::GuildsId(guild_id), Cow::from(Route::guild(guild_id))),
-            RouteInfo::GetGuildWithCounts {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsId(guild_id),
-                Cow::from(Route::guild_with_counts(guild_id)),
-            ),
-            RouteInfo::GetGuildCommands {
-                application_id,
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::ApplicationsIdGuildsIdCommands(application_id),
-                Cow::from(Route::application_guild_commands(application_id, guild_id)),
-            ),
-            RouteInfo::GetGuildCommand {
-                application_id,
-                guild_id,
-                command_id,
-            } => (
-                LightMethod::Get,
-                Route::ApplicationsIdGuildsIdCommandsId(application_id),
-                Cow::from(Route::application_guild_command(application_id, guild_id, command_id)),
-            ),
-            RouteInfo::GetGuildCommandsPermissions {
-                application_id,
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::ApplicationsIdGuildsIdCommandsPermissions(application_id),
-                Cow::from(Route::application_guild_commands_permissions(application_id, guild_id)),
-            ),
-            RouteInfo::GetGuildCommandPermissions {
-                application_id,
-                guild_id,
-                command_id,
-            } => (
-                LightMethod::Get,
-                Route::ApplicationsIdGuildsIdCommandIdPermissions(application_id),
-                Cow::from(Route::application_guild_command_permissions(
-                    application_id,
-                    guild_id,
-                    command_id,
-                )),
-            ),
-            RouteInfo::GetGuildWidget {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdWidget(guild_id),
-                Cow::from(Route::guild_widget(guild_id)),
-            ),
-            RouteInfo::GetGuildPreview {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdPreview(guild_id),
-                Cow::from(Route::guild_preview(guild_id)),
-            ),
-            RouteInfo::GetGuildWelcomeScreen {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdWelcomeScreen(guild_id),
-                Cow::from(Route::guild_welcome_screen(guild_id)),
-            ),
-            RouteInfo::GetGuildIntegrations {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdIntegrations(guild_id),
-                Cow::from(Route::guild_integrations(guild_id)),
-            ),
-            RouteInfo::GetGuildInvites {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdInvites(guild_id),
-                Cow::from(Route::guild_invites(guild_id)),
-            ),
-            RouteInfo::GetGuildMembers {
-                after,
-                guild_id,
-                limit,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdMembers(guild_id),
-                Cow::from(Route::guild_members_optioned(guild_id, after, limit)),
-            ),
-            RouteInfo::GetGuildPruneCount {
-                days,
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdPrune(guild_id),
-                Cow::from(Route::guild_prune(guild_id, days)),
-            ),
-            RouteInfo::GetGuildRegions {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdRegions(guild_id),
-                Cow::from(Route::guild_regions(guild_id)),
-            ),
-            RouteInfo::GetGuildRoles {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdRoles(guild_id),
-                Cow::from(Route::guild_roles(guild_id)),
-            ),
-            RouteInfo::GetGuildSticker {
-                guild_id,
-                sticker_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdStickersId(guild_id),
-                Cow::from(Route::guild_sticker(guild_id, sticker_id)),
-            ),
-            RouteInfo::GetGuildStickers {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdStickers(guild_id),
-                Cow::from(Route::guild_stickers(guild_id)),
-            ),
-            RouteInfo::GetGuildVanityUrl {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdVanityUrl(guild_id),
-                Cow::from(Route::guild_vanity_url(guild_id)),
-            ),
-            RouteInfo::GetGuildWebhooks {
-                guild_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdWebhooks(guild_id),
-                Cow::from(Route::guild_webhooks(guild_id)),
-            ),
-            RouteInfo::GetGuilds {
-                after,
-                before,
-                limit,
-            } => (
-                LightMethod::Get,
-                Route::UsersMeGuilds,
-                Cow::from(Route::user_guilds_optioned("@me", after, before, limit)),
-            ),
-            RouteInfo::GetInvite {
-                code,
-                member_counts,
-                expiration,
-                event_id,
-            } => (
-                LightMethod::Get,
-                Route::InvitesCode,
-                Cow::from(Route::invite_optioned(code, member_counts, expiration, event_id)),
-            ),
-            RouteInfo::GetMember {
-                guild_id,
-                user_id,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdMembersId(guild_id),
-                Cow::from(Route::guild_member(guild_id, user_id)),
-            ),
-            RouteInfo::GetMessage {
-                channel_id,
-                message_id,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdMessagesId(LightMethod::Get, channel_id),
-                Cow::from(Route::channel_message(channel_id, message_id)),
-            ),
-            RouteInfo::GetMessages {
-                channel_id,
-                query,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdMessages(channel_id),
-                Cow::from(Route::channel_messages(channel_id, Some(query))),
-            ),
-            RouteInfo::GetPins {
-                channel_id,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdPins(channel_id),
-                Cow::from(Route::channel_pins(channel_id)),
-            ),
-            RouteInfo::GetReactionUsers {
-                after,
-                channel_id,
-                limit,
-                message_id,
-                reaction,
-            } => (
-                LightMethod::Get,
-                Route::ChannelsIdMessagesIdReactions(channel_id),
-                Cow::from(Route::channel_message_reactions_list(
-                    channel_id, message_id, reaction, limit, after,
-                )),
-            ),
-            RouteInfo::GetScheduledEvent {
-                guild_id,
-                event_id,
-                with_user_count,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdScheduledEventsId(guild_id),
-                Cow::from(Route::guild_scheduled_event(guild_id, event_id, Some(with_user_count))),
-            ),
-            RouteInfo::GetScheduledEvents {
-                guild_id,
-                with_user_count,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdScheduledEvents(guild_id),
-                Cow::from(Route::guild_scheduled_events(guild_id, Some(with_user_count))),
-            ),
-            RouteInfo::GetScheduledEventUsers {
-                guild_id,
-                event_id,
-                after,
-                before,
-                limit,
-                with_member,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdScheduledEventsIdUsers(guild_id),
-                Cow::from(Route::guild_scheduled_event_users(
-                    guild_id,
-                    event_id,
-                    after,
-                    before,
-                    limit,
-                    with_member,
-                )),
-            ),
-            RouteInfo::GetSticker {
-                sticker_id,
-            } => (LightMethod::Get, Route::StickersId, Cow::from(Route::sticker(sticker_id))),
-            RouteInfo::GetStickerPacks => {
-                (LightMethod::Get, Route::StickerPacks, Cow::from(Route::sticker_packs()))
-            },
-            RouteInfo::GetUser {
-                user_id,
-            } => (LightMethod::Get, Route::UsersId, Cow::from(Route::user(user_id))),
-            RouteInfo::GetUserConnections => (
-                LightMethod::Get,
-                Route::UsersMeConnections,
-                Cow::from(Route::user_me_connections()),
-            ),
-            RouteInfo::GetUserDmChannels => (
-                LightMethod::Get,
-                Route::UsersMeChannels,
-                Cow::from(Route::user_dm_channels("@me")),
-            ),
-            RouteInfo::GetVoiceRegions => {
-                (LightMethod::Get, Route::VoiceRegions, Cow::from(Route::voice_regions()))
-            },
-            RouteInfo::GetWebhook {
-                webhook_id,
-            } => (
-                LightMethod::Get,
-                Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook(webhook_id)),
-            ),
-            RouteInfo::GetWebhookWithToken {
-                token,
-                webhook_id,
-            } => (
-                LightMethod::Get,
-                Route::WebhooksId(webhook_id),
-                Cow::from(Route::webhook_with_token(webhook_id, token)),
-            ),
-            RouteInfo::KickMember {
-                guild_id,
-                user_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdMembersId(guild_id),
-                Cow::from(Route::guild_kick_optioned(guild_id, user_id)),
-            ),
-            RouteInfo::LeaveGuild {
-                guild_id,
-            } => (
-                LightMethod::Delete,
-                Route::UsersMeGuildsId,
-                Cow::from(Route::user_guild("@me", guild_id)),
-            ),
-            RouteInfo::PinMessage {
-                channel_id,
-                message_id,
-            } => (
-                LightMethod::Put,
-                Route::ChannelsIdPins(channel_id),
-                Cow::from(Route::channel_pin(channel_id, message_id)),
-            ),
-            RouteInfo::RemoveBan {
-                guild_id,
-                user_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdBansUserId(guild_id),
-                Cow::from(Route::guild_ban(guild_id, user_id)),
-            ),
-            RouteInfo::RemoveMemberRole {
-                guild_id,
-                role_id,
-                user_id,
-            } => (
-                LightMethod::Delete,
-                Route::GuildsIdMembersIdRolesId(guild_id),
-                Cow::from(Route::guild_member_role(guild_id, user_id, role_id)),
-            ),
-            RouteInfo::SearchGuildMembers {
-                guild_id,
-                query,
-                limit,
-            } => (
-                LightMethod::Get,
-                Route::GuildsIdMembersSearch(guild_id),
-                Cow::from(Route::guild_members_search(guild_id, query, limit)),
-            ),
-            RouteInfo::StartGuildPrune {
-                days,
-                guild_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdPrune(guild_id),
-                Cow::from(Route::guild_prune(guild_id, days)),
-            ),
-            RouteInfo::StartIntegrationSync {
-                guild_id,
-                integration_id,
-            } => (
-                LightMethod::Post,
-                Route::GuildsIdIntegrationsId(guild_id),
-                Cow::from(Route::guild_integration_sync(guild_id, integration_id)),
-            ),
-            RouteInfo::GetUnresolvedIncidents | RouteInfo::StatusIncidentsUnresolved => {
-                (LightMethod::Get, Route::None, Cow::from(Route::status_incidents_unresolved()))
-            },
-            RouteInfo::GetActiveMaintenance | RouteInfo::StatusMaintenancesActive => {
-                (LightMethod::Get, Route::None, Cow::from(Route::status_maintenances_active()))
-            },
-            RouteInfo::GetUpcomingMaintenances | RouteInfo::StatusMaintenancesUpcoming => {
-                (LightMethod::Get, Route::None, Cow::from(Route::status_maintenances_upcoming()))
-            },
-            RouteInfo::UnpinMessage {
-                channel_id,
-                message_id,
-            } => (
-                LightMethod::Delete,
-                Route::ChannelsIdPinsMessageId(channel_id),
-                Cow::from(Route::channel_pin(channel_id, message_id)),
-            ),
+
+            #[must_use]
+            pub fn ratelimiting_bucket(&self) -> RatelimitingBucket {
+                #[allow(unused_variables)]
+                let ratelimiting_kind = match self {
+                    $(
+                        Self::$name $({ $($field_name),* })? => $ratelimiting_kind,
+                    )+
+                };
+
+                // To avoid adding a lifetime on RatelimitingBucket and causing lifetime infection,
+                // we transmute the Discriminant<Route<'a>> to Discriminant<Route<'static>>.
+                // SAFETY: std::mem::discriminant erases lifetimes.
+                let discriminant = unsafe { std::mem::transmute(std::mem::discriminant(self)) };
+                match ratelimiting_kind {
+                    RatelimitingKind::PathAndId(id) => {
+                        RatelimitingBucket(Some((discriminant, Some(id))))
+                    }
+                    RatelimitingKind::Path => {
+                        RatelimitingBucket(Some((discriminant, None)))
+                    }
+                    RatelimitingKind::None => RatelimitingBucket(None),
+                }
+            }
+
         }
-    }
+    };
 }
+
+// This macro takes as input a list of route definitions, represented in the following way:
+//
+// 1. The first line defines an enum variant representing an endpoint.
+// 2. The second line provides the url for that endpoint.
+// 3. The third line indicates what type of ratelimiting the endpoint employs.
+routes! ('a, {
+    Channel { channel_id: ChannelId },
+    api!("/channel/{}", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelInvites { channel_id: ChannelId },
+    api!("/channels/{}/invites", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessage { channel_id: ChannelId, message_id: MessageId },
+    api!("/channels/{}/messages/{}", channel_id, message_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessageCrosspost { channel_id: ChannelId, message_id: MessageId },
+    api!("/channels/{}/messages/{}/crosspost", channel_id, message_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessageReaction { channel_id: ChannelId, message_id: MessageId, user_id: UserId, reaction: &'a str },
+    api!("/channels/{}/messages/{}/reactions/{}/{}", channel_id, message_id, reaction, user_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessageReactionMe { channel_id: ChannelId, message_id: MessageId, reaction: &'a str },
+    api!("/channels/{}/messages/{}/reactions/{}/@me", channel_id, message_id, reaction),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessageReactionEmoji { channel_id: ChannelId, message_id: MessageId, reaction: &'a str },
+    api!("/channels/{}/messages/{}/reactions/{}", channel_id, message_id, reaction),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessageReactions { channel_id: ChannelId, message_id: MessageId },
+    api!("/channels/{}/messages/{}/reactions", channel_id, message_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessageReactionsList { channel_id: ChannelId, message_id: MessageId, reaction: &'a str },
+    api!("/channels/{}/messages/{}/reactions/{}", channel_id, message_id, reaction),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessages { channel_id: ChannelId },
+    api!("/channels/{}/messages", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelMessagesBulkDelete { channel_id: ChannelId },
+    api!("/channels/{}/messages/bulk-delete", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelFollowNews { channel_id: ChannelId },
+    api!("/channels/{}/followers", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelPermission { channel_id: ChannelId, target_id: TargetId },
+    api!("/channels/{}/permissions/{}", channel_id, target_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelPin { channel_id: ChannelId, message_id: MessageId },
+    api!("/channels/{}/pins/{}", channel_id, message_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelPins { channel_id: ChannelId },
+    api!("/channels/{}/pins", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelTyping { channel_id: ChannelId },
+    api!("/channels/{}/typing", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelWebhooks { channel_id: ChannelId },
+    api!("/channels/{}/webhooks", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelPublicThreads { channel_id: ChannelId, message_id: MessageId },
+    api!("/channels/{}/messages/{}/threads", channel_id, message_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelPrivateThreads { channel_id: ChannelId },
+    api!("/channels/{}/threads", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelThreadMember { channel_id: ChannelId, user_id: UserId },
+    api!("/channels/{}/thread-members/{}", channel_id, user_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelThreadMemberMe { channel_id: ChannelId },
+    api!("/channels/{}/thread-members/@me", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelThreadMembers { channel_id: ChannelId },
+    api!("/channels/{}/thread-members", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelArchivedPublicThreads { channel_id: ChannelId },
+    api!("/channels/{}/threads/archived/public", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelArchivedPrivateThreads { channel_id: ChannelId },
+    api!("/channels/{}/threads/archived/private", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    ChannelJoinedPrivateThreads { channel_id: ChannelId },
+    api!("/channels/{}/users/@me/threads/archived/private", channel_id),
+    RatelimitingKind::PathAndId(channel_id.0);
+
+    Gateway,
+    api!("/gateway"),
+    RatelimitingKind::Path;
+
+    GatewayBot,
+    api!("/gateway/bot"),
+    RatelimitingKind::Path;
+
+    Guild { guild_id: GuildId },
+    api!("/guilds/{}", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildAuditLogs { guild_id: GuildId },
+    api!("/guilds/{}/audit-logs", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildAutomodRule { guild_id: GuildId, rule_id: RuleId },
+    api!("/guilds/{}/auto-moderation/rules/{}", guild_id, rule_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildAutomodRules { guild_id: GuildId },
+    api!("/guilds/{}/auto-moderation/rules", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildBan { guild_id: GuildId, user_id: UserId },
+    api!("/guilds/{}/bans/{}", guild_id, user_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildKick { guild_id: GuildId, user_id: UserId },
+    api!("/guilds/{}/members/{}", guild_id, user_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildBans { guild_id: GuildId },
+    api!("/guilds/{}/bans", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildChannels { guild_id: GuildId },
+    api!("/guilds/{}/channels", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildWidget { guild_id: GuildId },
+    api!("/guilds/{}/widget", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildPreview { guild_id: GuildId },
+    api!("/guilds/{}/preview", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildEmojis { guild_id: GuildId },
+    api!("/guilds/{}/emojis", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildEmoji { guild_id: GuildId, emoji_id: EmojiId },
+    api!("/guilds/{}/emojis/{}", guild_id, emoji_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildIntegration { guild_id: GuildId, integration_id: IntegrationId },
+    api!("/guilds/{}/integrations/{}", guild_id, integration_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildIntegrationSync { guild_id: GuildId, integration_id: IntegrationId },
+    api!("/guilds/{}/integrations/{}/sync", guild_id, integration_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildIntegrations { guild_id: GuildId },
+    api!("/guilds/{}/integrations", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildInvites { guild_id: GuildId },
+    api!("/guilds/{}/invites", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildMember { guild_id: GuildId, user_id: UserId },
+    api!("/guilds/{}/members/{}", guild_id, user_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildMemberRole { guild_id: GuildId, user_id: UserId, role_id: RoleId },
+    api!("/guilds/{}/members/{}/roles/{}", guild_id, user_id, role_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildMembers { guild_id: GuildId },
+    api!("/guilds/{}/members", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildMembersSearch { guild_id: GuildId },
+    api!("/guilds/{}/members/search", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildMemberMe { guild_id: GuildId },
+    api!("/guilds/{}/members/@me", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildNickname { guild_id: GuildId },
+    api!("/guilds/{}/members/@me/nick", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildPrune { guild_id: GuildId },
+    api!("/guilds/{}/prune", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildRegions { guild_id: GuildId },
+    api!("/guilds/{}/regions", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildRole { guild_id: GuildId, role_id: RoleId },
+    api!("/guilds/{}/roles/{}", guild_id, role_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildRoles { guild_id: GuildId },
+    api!("/guilds/{}/roles", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildScheduledEvent { guild_id: GuildId, event_id: ScheduledEventId },
+    api!("/guilds/{}/scheduled-events/{}", guild_id, event_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildScheduledEvents { guild_id: GuildId },
+    api!("/guilds/{}/scheduled-events", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildScheduledEventUsers { guild_id: GuildId, event_id: ScheduledEventId },
+    api!("/guilds/{}/scheduled-events/{}/users", guild_id, event_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildSticker { guild_id: GuildId, sticker_id: StickerId },
+    api!("/guilds/{}/stickers/{}", guild_id, sticker_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildStickers { guild_id: GuildId },
+    api!("/guilds/{}/stickers", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildVanityUrl { guild_id: GuildId },
+    api!("/guilds/{}/vanity-url", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildVoiceStates { guild_id: GuildId, user_id: UserId },
+    api!("/guilds/{}/voice-states/{}", guild_id, user_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildVoiceStateMe { guild_id: GuildId },
+    api!("/guilds/{}/voice-states/@me", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildWebhooks { guild_id: GuildId },
+    api!("/guilds/{}/webhooks", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildWelcomeScreen { guild_id: GuildId },
+    api!("/guilds/{}/welcome-screen", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    GuildThreadsActive { guild_id: GuildId },
+    api!("/guilds/{}/threads/active", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
+    Guilds,
+    api!("/guilds"),
+    RatelimitingKind::Path;
+
+    Invite { code: &'a str },
+    api!("/invites/{}", code),
+    RatelimitingKind::Path;
+
+    Oauth2ApplicationCurrent,
+    api!("/oauth2/applications/@me"),
+    RatelimitingKind::None;
+
+    PrivateChannel,
+    api!("/users/@me/channels"),
+    RatelimitingKind::Path;
+
+    StatusIncidentsUnresolved,
+    status!("/incidents/unresolved.json"),
+    RatelimitingKind::None;
+
+    StatusMaintenancesActive,
+    status!("/scheduled-maintenances/active.json"),
+    RatelimitingKind::None;
+
+    StatusMaintenancesUpcoming,
+    status!("/scheduled-maintenances/upcoming.json"),
+    RatelimitingKind::None;
+
+    Sticker { sticker_id: StickerId },
+    api!("/stickers/{}", sticker_id),
+    RatelimitingKind::Path;
+
+    StickerPacks,
+    api!("/sticker-packs"),
+    RatelimitingKind::Path;
+
+    User { user_id: UserId },
+    api!("/users/{}", user_id),
+    RatelimitingKind::Path;
+
+    UserMe,
+    api!("/users/@me"),
+    RatelimitingKind::Path;
+
+    UserMeConnections,
+    api!("/users/@me/connections"),
+    RatelimitingKind::Path;
+
+    UserDmChannels { user_id: UserId },
+    api!("/users/{}/channels", user_id),
+    RatelimitingKind::Path;
+
+    UserMeDmChannels,
+    api!("/users/@me/channels"),
+    RatelimitingKind::Path;
+
+    UserGuild { user_id: UserId, guild_id: GuildId },
+    api!("/users/{}/guilds/{}", user_id, guild_id),
+    RatelimitingKind::Path;
+
+    UserMeGuild { guild_id: GuildId },
+    api!("/users/@me/guilds/{}", guild_id),
+    RatelimitingKind::Path;
+
+    UserGuilds { user_id: UserId },
+    api!("/users/{}/guilds", user_id),
+    RatelimitingKind::Path;
+
+    UserMeGuilds,
+    api!("/users/@me/guilds"),
+    RatelimitingKind::Path;
+
+    VoiceRegions,
+    api!("/voice/regions"),
+    RatelimitingKind::Path;
+
+    Webhook { webhook_id: WebhookId },
+    api!("/webhooks/{}", webhook_id),
+    RatelimitingKind::PathAndId(webhook_id.0);
+
+    WebhookWithToken { webhook_id: WebhookId, token: &'a str },
+    api!("/webhooks/{}/{}", webhook_id, token),
+    RatelimitingKind::PathAndId(webhook_id.0);
+
+    WebhookMessage { webhook_id: WebhookId, token: &'a str, message_id: MessageId },
+    api!("/webhooks/{}/{}/messages/{}", webhook_id, token, message_id),
+    RatelimitingKind::PathAndId(webhook_id.0);
+
+    WebhookOriginalInteractionResponse { application_id: ApplicationId, token: &'a str },
+    api!("/webhooks/{}/{}/messages/@original", application_id, token),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    WebhookFollowupMessage { application_id: ApplicationId, token: &'a str, message_id: MessageId },
+    api!("/webhooks/{}/{}/messages/{}", application_id, token, message_id),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    WebhookFollowupMessages { application_id: ApplicationId, token: &'a str },
+    api!("/webhooks/{}/{}", application_id, token),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    InteractionResponse { interaction_id: InteractionId, token: &'a str },
+    api!("/interactions/{}/{}/callback", interaction_id, token),
+    RatelimitingKind::PathAndId(interaction_id.0);
+
+    ApplicationCommand { application_id: ApplicationId, command_id: CommandId },
+    api!("/applications/{}/commands/{}", application_id, command_id),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    ApplicationCommands { application_id: ApplicationId },
+    api!("/applications/{}/commands", application_id),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    ApplicationGuildCommand { application_id: ApplicationId, guild_id: GuildId, command_id: CommandId },
+    api!("/applications/{}/guilds/{}/commands/{}", application_id, guild_id, command_id),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    ApplicationGuildCommandPermissions { application_id: ApplicationId, guild_id: GuildId, command_id: CommandId },
+    api!("/applications/{}/guilds/{}/commands/{}/permissions", application_id, guild_id, command_id),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    ApplicationGuildCommands { application_id: ApplicationId, guild_id: GuildId },
+    api!("/applications/{}/guilds/{}/commands", application_id, guild_id),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    ApplicationGuildCommandsPermissions { application_id: ApplicationId, guild_id: GuildId },
+    api!("/applications/{}/guilds/{}/commands/permissions", application_id, guild_id),
+    RatelimitingKind::PathAndId(application_id.0);
+
+    StageInstances,
+    api!("/stage-instances"),
+    RatelimitingKind::Path;
+
+    StageInstance { channel_id: ChannelId },
+    api!("/stage-instances/{}", channel_id),
+    RatelimitingKind::Path;
+});

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -118,10 +118,6 @@ routes! ('a, {
     api!("/channels/{}/messages/{}/reactions", channel_id, message_id),
     RatelimitingKind::PathAndId(channel_id.0);
 
-    ChannelMessageReactionsList { channel_id: ChannelId, message_id: MessageId, reaction: &'a str },
-    api!("/channels/{}/messages/{}/reactions/{}", channel_id, message_id, reaction),
-    RatelimitingKind::PathAndId(channel_id.0);
-
     ChannelMessages { channel_id: ChannelId },
     api!("/channels/{}/messages", channel_id),
     RatelimitingKind::PathAndId(channel_id.0);
@@ -214,10 +210,6 @@ routes! ('a, {
     api!("/guilds/{}/bans/{}", guild_id, user_id),
     RatelimitingKind::PathAndId(guild_id.0);
 
-    GuildKick { guild_id: GuildId, user_id: UserId },
-    api!("/guilds/{}/members/{}", guild_id, user_id),
-    RatelimitingKind::PathAndId(guild_id.0);
-
     GuildBans { guild_id: GuildId },
     api!("/guilds/{}/bans", guild_id),
     RatelimitingKind::PathAndId(guild_id.0);
@@ -276,10 +268,6 @@ routes! ('a, {
 
     GuildMemberMe { guild_id: GuildId },
     api!("/guilds/{}/members/@me", guild_id),
-    RatelimitingKind::PathAndId(guild_id.0);
-
-    GuildNickname { guild_id: GuildId },
-    api!("/guilds/{}/members/@me/nick", guild_id),
     RatelimitingKind::PathAndId(guild_id.0);
 
     GuildPrune { guild_id: GuildId },
@@ -354,10 +342,6 @@ routes! ('a, {
     api!("/oauth2/applications/@me"),
     RatelimitingKind::None;
 
-    PrivateChannel,
-    api!("/users/@me/channels"),
-    RatelimitingKind::Path;
-
     StatusIncidentsUnresolved,
     status!("/incidents/unresolved.json"),
     RatelimitingKind::None;
@@ -390,24 +374,12 @@ routes! ('a, {
     api!("/users/@me/connections"),
     RatelimitingKind::Path;
 
-    UserDmChannels { user_id: UserId },
-    api!("/users/{}/channels", user_id),
-    RatelimitingKind::Path;
-
     UserMeDmChannels,
     api!("/users/@me/channels"),
     RatelimitingKind::Path;
 
-    UserGuild { user_id: UserId, guild_id: GuildId },
-    api!("/users/{}/guilds/{}", user_id, guild_id),
-    RatelimitingKind::Path;
-
     UserMeGuild { guild_id: GuildId },
     api!("/users/@me/guilds/{}", guild_id),
-    RatelimitingKind::Path;
-
-    UserGuilds { user_id: UserId },
-    api!("/users/{}/guilds", user_id),
     RatelimitingKind::Path;
 
     UserMeGuilds,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -253,7 +253,13 @@ impl ChannelId {
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.as_ref().delete_reaction(self, message_id.into(), user_id, &reaction_type.into()).await
+        let http = http.as_ref();
+        let message_id = message_id.into();
+        let reaction_type = reaction_type.into();
+        match user_id {
+            Some(user_id) => http.delete_reaction(self, message_id, user_id, &reaction_type).await,
+            None => http.delete_reaction_me(self, message_id, &reaction_type).await,
+        }
     }
 
     /// Deletes all [`Reaction`]s of the given emoji to a message within the channel.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -117,9 +117,8 @@ impl Reaction {
             }
         }
 
-        cache_http
-            .http()
-            .delete_reaction(self.channel_id, self.message_id, user_id, &self.emoji)
+        self.channel_id
+            .delete_reaction(cache_http.http(), self.message_id, user_id, self.emoji.clone())
             .await
     }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -302,7 +302,7 @@ impl CurrentUser {
             let mut pagination = http
                 .as_ref()
                 .get_guilds(
-                    Some(&GuildPagination::After(
+                    Some(GuildPagination::After(
                         guilds.last().map_or(GuildId::new(1), |g: &GuildInfo| g.id),
                     )),
                     Some(100),


### PR DESCRIPTION
Overhaul how serenity does routing in several ways:
1. Get rid of `RouteInfo` and only use a single `Route` enum for determining a request's url as well as how to ratelimit it. This enum can be easily generated using a macro, making it easy to add new routes in the future.
2. Inline the `LightMethod` and any query parameters directly into the `Request` struct.
3. Finally, remove any duplicate or unused routes.

This PR supersedes #2241. Credit goes to @kangalioo for the original idea.

EDIT: The diff for `http/routing.rs` is quite dirty, but I basically deleted everything and replaced it all with the `routes!` macro.