### PR TITLE
Add defer ephemeral to Modal and Component interactions.

### DIFF
--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -309,6 +309,21 @@ impl ApplicationCommandInteraction {
         })
         .await
     }
+
+    /// Helper function to defer an interaction ephemerally
+    ///
+    /// # Errors
+    ///
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    pub async fn defer_ephemeral(&self, http: impl AsRef<Http>) -> Result<()> {
+        self.create_interaction_response(http, |f| {
+            f.kind(InteractionResponseType::DeferredChannelMessageWithSource)
+                .interaction_response_data(|f| f.ephemeral(true))
+        })
+        .await
+    }
 }
 
 impl<'de> Deserialize<'de> for ApplicationCommandInteraction {

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -273,6 +273,21 @@ impl MessageComponentInteraction {
         })
         .await
     }
+
+    /// Helper function to defer an interaction ephemerally
+    ///
+    /// # Errors
+    ///
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    pub async fn defer_ephemeral(&self, http: impl AsRef<Http>) -> Result<()> {
+        self.create_interaction_response(http, |f| {
+            f.kind(InteractionResponseType::DeferredUpdateMessage)
+                .interaction_response_data(|f| f.ephemeral(true))
+        })
+        .await
+    }
 }
 
 impl<'de> Deserialize<'de> for MessageComponentInteraction {

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -3,9 +3,7 @@ use serde::Serialize;
 
 #[cfg(feature = "model")]
 use crate::builder::{
-    CreateInteractionResponse,
-    CreateInteractionResponseFollowup,
-    EditInteractionResponse,
+    CreateInteractionResponse, CreateInteractionResponseFollowup, EditInteractionResponse,
 };
 #[cfg(feature = "model")]
 use crate::http::Http;
@@ -256,6 +254,21 @@ impl ModalSubmitInteraction {
     pub async fn defer(&self, http: impl AsRef<Http>) -> Result<()> {
         self.create_interaction_response(http, |f| {
             f.kind(InteractionResponseType::DeferredUpdateMessage)
+        })
+        .await
+    }
+
+    /// Helper function to defer an interaction ephemerally
+    ///
+    /// # Errors
+    ///
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    pub async fn defer_ephemeral(&self, http: impl AsRef<Http>) -> Result<()> {
+        self.create_interaction_response(http, |f| {
+            f.kind(InteractionResponseType::DeferredUpdateMessage)
+                .interaction_response_data(|f| f.ephemeral(true))
         })
         .await
     }


### PR DESCRIPTION
I have forgotten to add these functions to the other interactions (that support it).

This PR adds the `defer_ephemeral` functions to both the `ModalSubmitInteraction` and `MessageComponentInteraction`
(similar to #2223)