### PR TITLE
Add `defer_ephemeral` helper functions

### DIFF
--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -273,6 +273,21 @@ impl MessageComponentInteraction {
         })
         .await
     }
+
+    /// Helper function to defer an interaction ephemerally
+    ///
+    /// # Errors
+    ///
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    pub async fn defer_ephemeral(&self, http: impl AsRef<Http>) -> Result<()> {
+        self.create_interaction_response(http, |f| {
+            f.kind(InteractionResponseType::DeferredChannelMessageWithSource)
+                .interaction_response_data(|f| f.ephemeral(true))
+        })
+        .await
+    }
 }
 
 impl<'de> Deserialize<'de> for MessageComponentInteraction {

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -259,6 +259,21 @@ impl ModalSubmitInteraction {
         })
         .await
     }
+
+    /// Helper function to defer an interaction ephemerally
+    ///
+    /// # Errors
+    ///
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    pub async fn defer_ephemeral(&self, http: impl AsRef<Http>) -> Result<()> {
+        self.create_interaction_response(http, |f| {
+            f.kind(InteractionResponseType::DeferredUpdateMessage)
+                .interaction_response_data(|f| f.ephemeral(true))
+        })
+        .await
+    }
 }
 
 impl<'de> Deserialize<'de> for ModalSubmitInteraction {


### PR DESCRIPTION
This time the PR is correct.
I have forgotten to add these functions to the other interactions (that support it).

This PR adds the defer_ephemeral functions to both the ModalSubmitInteraction and MessageComponentInteraction
(similar to #2223 )