### PR TITLE
Make all remaining builder fields private

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -350,9 +350,9 @@ impl CreateAutocompleteResponse {
 #[must_use]
 #[non_exhaustive]
 pub struct CreateModal {
-    pub components: Vec<CreateActionRow>,
-    pub custom_id: String,
-    pub title: String,
+    components: Vec<CreateActionRow>,
+    custom_id: String,
+    title: String,
 }
 
 impl CreateModal {

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -45,8 +45,8 @@ use crate::model::prelude::*;
 #[derive(Clone, Copy, Debug, Default)]
 #[must_use]
 pub struct GetMessages {
-    pub search_filter: Option<SearchFilter>,
-    pub limit: Option<u8>,
+    search_filter: Option<SearchFilter>,
+    limit: Option<u8>,
 }
 
 impl GetMessages {
@@ -106,7 +106,7 @@ impl GetMessages {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum SearchFilter {
+enum SearchFilter {
     After(MessageId),
     Around(MessageId),
     Before(MessageId),


### PR DESCRIPTION
Some builders were left with public fields despite it not being necessary. The remaining structs in the `builder` module that have public fields are `CreateAttachment`, `QuickModalResponse`, and `AutocompleteChoice`.