### PR TITLE
Add back lost special deserialization behavior

### DIFF
--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -61,6 +61,7 @@ pub struct CommandInteraction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<Box<Member>>,
     /// The `user` object for the invoking user.
+    #[serde(default)]
     pub user: User,
     /// A continuation token for responding to the interaction.
     pub token: String,

--- a/src/model/application/interaction/application_command.rs
+++ b/src/model/application/interaction/application_command.rs
@@ -242,6 +242,11 @@ impl<'de> Deserialize<'de> for CommandInteraction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut interaction = Self::deserialize(deserializer)?; // calls #[serde(remote)]-generated inherent method
         if let Some(guild_id) = interaction.guild_id {
+            if let Some(member) = &mut interaction.member {
+                member.guild_id = guild_id;
+                // If `member` is present, `user` wasn't sent and is still filled with default data
+                interaction.user = member.user.clone();
+            }
             interaction.data.resolved.roles.values_mut().for_each(|r| r.guild_id = guild_id);
         }
         Ok(interaction)

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -55,6 +55,7 @@ pub struct ComponentInteraction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<Member>,
     /// The `user` object for the invoking user.
+    #[serde(default)]
     pub user: User,
     /// A continuation token for responding to the interaction.
     pub token: String,

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -43,6 +43,7 @@ pub struct ModalInteraction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<Member>,
     /// The `user` object for the invoking user.
+    #[serde(default)]
     pub user: User,
     /// A continuation token for responding to the interaction.
     pub token: String,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -111,6 +111,7 @@ pub struct PartialGuild {
     #[serde(default)]
     pub premium_tier: PremiumTier,
     /// The total number of users currently boosting this server.
+    #[serde(default)]
     pub premium_subscription_count: u64,
     /// The guild's banner, if it has one.
     pub banner: Option<String>,


### PR DESCRIPTION
https://discord.com/channels/381880193251409931/381912587505500160/1043283742254448820

> i forgot to port some of the derive-deviating behavior to the new Deserialize impls in https://github.com/serenity-rs/serenity/pull/2287
> namely, the fact that `user` is actually not a required field and is provided by serenity in guilds by cloning `member.user`