### PR TITLE
 Replace `moka` cache crate with `mini-moka` for fewer dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio-tungstenite = { version = "0.17", optional = true }
 typemap_rev = { version = "0.1.3", optional = true }
 bytes = { version = "1.0", optional = true }
 percent-encoding = { version = "2.1", optional = true }
-moka = { version = "0.9", default-features = false, features = ["dash"], optional = true }
+mini-moka = { version = "0.10", optional = true }
 mime_guess = { version = "2.0", optional = true }
 dashmap = { version = "5.1.0", features = ["serde"], optional = true }
 parking_lot = { version = "0.12", optional = true }
@@ -118,7 +118,7 @@ full = ["default", "collector", "unstable_discord_api", "voice", "voice_model", 
 simd_json = ["simd-json"]
 
 # Enables temporary caching in functions that retrieve data via the HTTP API.
-temp_cache = ["cache", "moka"]
+temp_cache = ["cache", "mini-moka"]
 
 # Removed feature (https://github.com/serenity-rs/serenity/pull/2246)
 absolute_ratelimits = []

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -42,7 +42,7 @@ use dashmap::mapref::entry::Entry;
 use dashmap::mapref::one::Ref;
 use dashmap::DashMap;
 #[cfg(feature = "temp_cache")]
-use moka::dash::Cache as DashCache;
+use mini_moka::sync::Cache as MokaCache;
 use parking_lot::RwLock;
 use tracing::instrument;
 
@@ -187,12 +187,12 @@ pub struct Cache {
     ///
     /// The TTL for each value is configured in CacheSettings.
     #[cfg(feature = "temp_cache")]
-    pub(crate) temp_channels: DashCache<ChannelId, GuildChannel, BuildHasher>,
+    pub(crate) temp_channels: MokaCache<ChannelId, GuildChannel, BuildHasher>,
     /// Cache of users who have been fetched from `to_user`.
     ///
     /// The TTL for each value is configured in CacheSettings.
     #[cfg(feature = "temp_cache")]
-    pub(crate) temp_users: DashCache<UserId, Arc<User>, BuildHasher>,
+    pub(crate) temp_users: MokaCache<UserId, Arc<User>, BuildHasher>,
 
     // Channels cache:
     // ---
@@ -289,12 +289,12 @@ impl Cache {
     #[instrument]
     pub fn new_with_settings(settings: Settings) -> Self {
         #[cfg(feature = "temp_cache")]
-        fn temp_cache<K, V>(ttl: Duration) -> DashCache<K, V, BuildHasher>
+        fn temp_cache<K, V>(ttl: Duration) -> MokaCache<K, V, BuildHasher>
         where
             K: Hash + Eq + Send + Sync + 'static,
             V: Clone + Send + Sync + 'static,
         {
-            DashCache::builder().time_to_live(ttl).build_with_hasher(BuildHasher::default())
+            MokaCache::builder().time_to_live(ttl).build_with_hasher(BuildHasher::default())
         }
 
         Self {


### PR DESCRIPTION
CC: @Milo123459

This PR replaces [`moka` cache crate](https://crates.io/crates/moka) with [`mini-moka` crate](https://crates.io/crates/mini-moka). `mini-moka` provides a cache implementation `mini_moka::sync::Cache`, which is a successor of `moka::dash::Cache`. Currently Serenity uses `moka::dash::Cache` when `temp_cache` feature is enabled.

`mini_moka::sync::Cache` has the same API and functionality as `moka::dash::Cache`, but has fewer external crate dependencies.

**Before**:

```console
$ cargo tree -F temp_cache

├── moka v0.9.6
│   ├── crossbeam-channel v0.5.6
│   │   ├── cfg-if v1.0.0
│   │   └── crossbeam-utils v0.8.12
│   │       └── cfg-if v1.0.0
│   ├── crossbeam-utils v0.8.12 (*)
│   ├── dashmap v5.4.0 (*)
│   ├── num_cpus v1.14.0
│   │   └── libc v0.2.137
│   ├── once_cell v1.16.0
│   ├── parking_lot v0.12.1
│   │   ├── lock_api v0.4.9 (*)
│   │   └── parking_lot_core v0.9.4 (*)
│   ├── scheduled-thread-pool v0.2.6
│   │   └── parking_lot v0.12.1 (*)
│   ├── smallvec v1.10.0
│   ├── tagptr v0.2.0
│   └── triomphe v0.1.8
```

**After**:

```console
├── mini-moka v0.10.0
│   ├── crossbeam-channel v0.5.6
│   │   ├── cfg-if v1.0.0
│   │   └── crossbeam-utils v0.8.12
│   │       └── cfg-if v1.0.0
│   ├── crossbeam-utils v0.8.12 (*)
│   ├── dashmap v5.4.0 (*)
│   ├── smallvec v1.10.0
│   ├── tagptr v0.2.0
│   └── triomphe v0.1.8
```

In `mini-moka` v0.10.0, 

* The locks from `parking_lot` were replaced with the ones from `std::sync`.
* The thread pool from `scheduled-thread-pool` was removed:
    * The thread pool was doing housekeeping tasks such as evicting expired cache entries.
    * Now these housekeeping tasks will be executed by client thread when necessary.
        * (It will be done in `insert` and `get` calls when necessary)

(I am the creator of `moka` and `mini-moka` crates)