### PR TITLE
Actually call Framework::init() and add ShardManager::intents()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ mime_guess = { version = "2.0", optional = true }
 dashmap = { version = "5.1.0", features = ["serde"], optional = true }
 parking_lot = { version = "0.12", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
+once_cell = { version = "1.16.0", optional = true }
 # Serenity workspace crates
 command_attr = { version = "0.4.1", path = "./command_attr", optional = true }
 serenity-voice-model = { version = "0.1.1", path = "./voice-model", optional = true }
@@ -86,7 +87,7 @@ collector = ["gateway", "model"]
 # TODO: should this require "gateway"?
 client = ["http", "typemap_rev"]
 # Enables the Framework trait which is an abstraction for old-style text commands.
-framework = ["client", "model", "utils"]
+framework = ["client", "model", "utils", "once_cell"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["flate2"]
 # Enables HTTP, which enables bots to execute actions on Discord.

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use futures::StreamExt;
+#[cfg(feature = "framework")]
 use once_cell::sync::OnceCell;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::timeout;

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -53,6 +53,7 @@ use crate::CacheAndHttp;
 /// use std::env;
 /// use std::sync::Arc;
 ///
+/// use once_cell::sync::OnceCell;
 /// use serenity::client::bridge::gateway::{ShardManager, ShardManagerOptions};
 /// use serenity::client::{EventHandler, RawEventHandler};
 /// use serenity::framework::{Framework, StandardFramework};
@@ -78,7 +79,7 @@ use crate::CacheAndHttp;
 ///     data,
 ///     event_handlers: vec![event_handler],
 ///     raw_event_handlers: vec![],
-///     framework: Some(framework),
+///     framework: Arc::new(OnceCell::with_value(framework)),
 ///     // the shard index to start initiating from
 ///     shard_index: 0,
 ///     // the number of shards to initiate (this initiates 0, 1, and 2)
@@ -337,6 +338,7 @@ impl ShardManager {
     }
 
     /// Returns the gateway intents used for this gateway connection.
+    #[must_use]
     pub fn intents(&self) -> GatewayIntents {
         self.gateway_intents
     }

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use futures::channel::mpsc::{UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use futures::StreamExt;
+use once_cell::sync::OnceCell;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{sleep, timeout, Duration, Instant};
 use tracing::{debug, info, instrument, warn};
@@ -55,7 +56,7 @@ pub struct ShardQueuer {
     pub raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
-    pub framework: Option<Arc<dyn Framework>>,
+    pub framework: Arc<OnceCell<Arc<dyn Framework>>>,
     /// The instant that a shard was last started.
     ///
     /// This is used to determine how long to wait between shard IDENTIFYs.
@@ -191,7 +192,7 @@ impl ShardQueuer {
             event_handlers: self.event_handlers.clone(),
             raw_event_handlers: self.raw_event_handlers.clone(),
             #[cfg(feature = "framework")]
-            framework: self.framework.as_ref().map(Arc::clone),
+            framework: self.framework.get().map(Arc::clone),
             manager_tx: self.manager_tx.clone(),
             #[cfg(feature = "voice")]
             voice_manager: self.voice_manager.clone(),

--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use futures::channel::mpsc::{UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use futures::StreamExt;
+#[cfg(feature = "framework")]
 use once_cell::sync::OnceCell;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{sleep, timeout, Duration, Instant};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -30,6 +30,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
+#[cfg(feature = "framework")]
 use once_cell::sync::OnceCell;
 use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, error, info, instrument};
@@ -394,6 +395,7 @@ impl IntoFuture for ClientBuilder {
                 },
             }));
 
+            #[cfg(feature = "framework")]
             let framework_cell = Arc::new(OnceCell::new());
             let (shard_manager, shard_manager_worker) = ShardManager::new(ShardManagerOptions {
                 data: Arc::clone(&data),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -30,6 +30,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
+use once_cell::sync::OnceCell;
 use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, error, info, instrument};
 use typemap_rev::{TypeMap, TypeMapKey};
@@ -74,7 +75,7 @@ pub struct ClientBuilder {
     #[cfg(feature = "cache")]
     cache_settings: CacheSettings,
     #[cfg(feature = "framework")]
-    framework: Option<Arc<dyn Framework>>,
+    framework: Option<Box<dyn Framework>>,
     #[cfg(feature = "voice")]
     voice_manager: Option<Arc<dyn VoiceGatewayManager>>,
     event_handlers: Vec<Arc<dyn EventHandler>>,
@@ -204,26 +205,15 @@ impl ClientBuilder {
     where
         F: Framework + 'static,
     {
-        self.framework = Some(Arc::new(framework));
-
-        self
-    }
-
-    /// This method allows to pass an [`Arc`]'ed `framework` - this step is
-    /// done for you in the [`Self::framework`]-method, if you don't need the
-    /// extra control.
-    /// You can provide a clone and keep the original to manually dispatch.
-    #[cfg(feature = "framework")]
-    pub fn framework_arc<T: Framework + 'static>(mut self, framework: Arc<T>) -> Self {
-        self.framework = Some(framework as Arc<dyn Framework + 'static>);
+        self.framework = Some(Box::new(framework));
 
         self
     }
 
     /// Gets the framework, if already initialized. See [`Self::framework`] for more info.
     #[cfg(feature = "framework")]
-    pub fn get_framework(&self) -> Option<Arc<dyn Framework>> {
-        self.framework.clone()
+    pub fn get_framework(&self) -> Option<&dyn Framework> {
+        self.framework.as_deref()
     }
 
     /// Sets the voice gateway handler to be used. It will receive voice events sent
@@ -404,12 +394,13 @@ impl IntoFuture for ClientBuilder {
                 },
             }));
 
+            let framework_cell = Arc::new(OnceCell::new());
             let (shard_manager, shard_manager_worker) = ShardManager::new(ShardManagerOptions {
                 data: Arc::clone(&data),
                 event_handlers,
                 raw_event_handlers,
                 #[cfg(feature = "framework")]
-                framework,
+                framework: framework_cell.clone(),
                 shard_index: 0,
                 shard_init: 0,
                 shard_total: 0,
@@ -421,7 +412,7 @@ impl IntoFuture for ClientBuilder {
                 presence: Some(presence),
             });
 
-            Ok(Client {
+            let client = Client {
                 data,
                 shard_manager,
                 shard_manager_worker,
@@ -429,7 +420,15 @@ impl IntoFuture for ClientBuilder {
                 voice_manager,
                 ws_url,
                 cache_and_http,
-            })
+            };
+            #[cfg(feature = "framework")]
+            if let Some(mut framework) = framework {
+                framework.init(&client).await;
+                if let Err(_existing) = framework_cell.set(framework.into()) {
+                    tracing::warn!("overwrote existing contents of framework OnceCell");
+                }
+            }
+            Ok(client)
         })
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -108,7 +108,7 @@ impl ClientBuilder {
     ///
     /// **Panic**:
     /// If you have enabled the `framework`-feature (on by default), you must specify
-    /// a framework via the [`Self::framework`] or [`Self::framework_arc`] method,
+    /// a framework via the [`Self::framework`] method,
     /// otherwise awaiting the builder will cause a panic.
     pub fn new(token: impl AsRef<str>, intents: GatewayIntents) -> Self {
         Self::_new(Http::new(token.as_ref()), intents)
@@ -119,7 +119,7 @@ impl ClientBuilder {
     ///
     /// **Panic**:
     /// If you have enabled the `framework`-feature (on by default), you must specify
-    /// a framework via the [`Self::framework`] or [`Self::framework_arc`] method,
+    /// a framework via the [`Self::framework`] method,
     /// otherwise awaiting the builder will cause a panic.
     pub fn new_with_http(http: Http, intents: GatewayIntents) -> Self {
         Self::_new(http, intents)
@@ -199,8 +199,8 @@ impl ClientBuilder {
     /// dispatch a command.
     ///
     /// *Info*:
-    /// If a reference to the framework is required for manual dispatch,
-    /// use the [`Self::framework_arc`]-method instead.
+    /// If a reference to the framework is required for manual dispatch, you can implement
+    /// [`Framework`] on [`Arc<YourFrameworkType>`] instead of `YourFrameworkType`.
     #[cfg(feature = "framework")]
     pub fn framework<F>(mut self, framework: F) -> Self
     where


### PR DESCRIPTION
Follow-up PR to #2270. This should be all functionality for poise to fully use the Framework trait.

## Implementation details

`Framework::init()` takes `&Client` which contains ShardManager which contains `Option<Arc<dyn Framework>>`, so we had a circular dependency. To break this up, I changed the `Option<Arc<dyn Framework>>` in ShardManager to `Arc<OnceCell<Arc<dyn Framework>>>`.

The OnceCell type is from the once_cell crate which has been added to Cargo.toml. once_cell already was a transitive dependency anyways, via dashmap, so no dependencies are added in total.

## New poise usage

Poise port to this PR here: https://github.com/serenity-rs/poise/commit/b7bf25c4c52e11b50d32b838de5884cd7189fef4

### Comparison of poise framework setup

Old:

```rust
poise::Framework::builder()
    .token(token)
    .user_data_setup(user_data_setup)
    .options(options)
    .intents(intents)
    .run()
    .await?;
```

New:

```rust
serenity::Client::builder()
    .framework(poise::Framework::new(options, user_data_setup))
    .token(token)
    .intents(intents)
    .await?
    .start()
    .await?;
```