### PR TITLE
Deny broken intra-doc links in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,8 @@ jobs:
         run: |
           cargo doc --no-deps --features collector,voice,unstable_discord_api
           cargo doc --no-deps -p command_attr
+        env:
+          RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
 
   examples:
     name: Examples


### PR DESCRIPTION
So we ensure that docs are always up-to-date