### PR TITLE
Add files in the edit original interaction response

### DIFF
--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -4,11 +4,42 @@ use super::{CreateAllowedMentions, CreateEmbed};
 use crate::builder::CreateComponents;
 use crate::json;
 use crate::json::prelude::*;
+use crate::model::channel::AttachmentType;
 
 #[derive(Clone, Debug, Default)]
-pub struct EditInteractionResponse(pub HashMap<&'static str, Value>);
+pub struct EditInteractionResponse<'a>(
+    pub HashMap<&'static str, Value>,
+    pub Vec<AttachmentType<'a>>,
+);
 
-impl EditInteractionResponse {
+impl<'a> EditInteractionResponse<'a> {
+    /// Appends a file to the message.
+    pub fn add_file<T: Into<AttachmentType<'a>>>(&mut self, file: T) -> &mut Self {
+        self.1.push(file.into());
+        self
+    }
+
+    /// Appends a list of files to the message.
+    pub fn add_files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
+        &mut self,
+        files: It,
+    ) -> &mut Self {
+        self.1.extend(files.into_iter().map(Into::into));
+        self
+    }
+
+    /// Sets a list of files to include in the message.
+    ///
+    /// Calling this multiple times will overwrite the file list.
+    /// To append files, call [`Self::add_file`] or [`Self::add_files`] instead.
+    pub fn files<T: Into<AttachmentType<'a>>, It: IntoIterator<Item = T>>(
+        &mut self,
+        files: It,
+    ) -> &mut Self {
+        self.1 = files.into_iter().map(Into::into).collect();
+        self
+    }
+
     /// Sets the `InteractionApplicationCommandCallbackData` for the message.
 
     /// Set the content of the message.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1797,9 +1797,9 @@ impl Http {
 
     /// Edits the initial interaction response.
     ///
-    /// Refer to Discord's [docs] for Edit Webhook Message for field information.
+    /// Refer to Discord's [docs] for Edit Original Interaction Response for field information.
     ///
-    /// [docs]: https://discord.com/developers/docs/resources/webhook#edit-webhook-message
+    /// [docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response
     pub async fn edit_original_interaction_response(
         &self,
         interaction_token: &str,
@@ -1808,6 +1808,33 @@ impl Http {
         self.fire(Request {
             body: Some(to_string(map)?.as_bytes()),
             multipart: None,
+            headers: None,
+            route: RouteInfo::EditOriginalInteractionResponse {
+                application_id: self.try_application_id()?,
+                interaction_token,
+            },
+        })
+        .await
+    }
+
+    /// Edits the initial interaction response with files.
+    ///
+    /// Refer to Discord's [docs] for Edit Original Interaction Response for field information.
+    ///
+    /// [docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response
+    pub async fn edit_original_interaction_response_with_files(
+        &self,
+        interaction_token: &str,
+        map: &Value,
+        files: impl IntoIterator<Item = AttachmentType<'_>>,
+    ) -> Result<Message> {
+        self.fire(Request {
+            body: None,
+            multipart: Some(Multipart {
+                files: files.into_iter().map(Into::into).collect(),
+                payload_json: Some(to_value(map)?),
+                fields: vec![],
+            }),
             headers: None,
             route: RouteInfo::EditOriginalInteractionResponse {
                 application_id: self.try_application_id()?,

--- a/src/model/application/interaction/message_component.rs
+++ b/src/model/application/interaction/message_component.rs
@@ -125,7 +125,7 @@ impl MessageComponentInteraction {
     ///
     /// `application_id` will usually be the bot's [`UserId`], except in cases of bots being very old.
     ///
-    /// Refer to Discord's docs for Edit Webhook Message for field information.
+    /// [Edit Original Interaction Response]: https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
     ///
@@ -136,13 +136,14 @@ impl MessageComponentInteraction {
     /// Returns [`Error::Model`] if the edited content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error deserializing the response.
-    pub async fn edit_original_interaction_response<F>(
+    pub async fn edit_original_interaction_response<'a, F>(
         &self,
         http: impl AsRef<Http>,
         f: F,
     ) -> Result<Message>
     where
-        F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse,
+        for<'b> F:
+            FnOnce(&'b mut EditInteractionResponse<'a>) -> &'b mut EditInteractionResponse<'a>,
     {
         let mut interaction_response = EditInteractionResponse::default();
         f(&mut interaction_response);

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -128,7 +128,9 @@ impl ModalSubmitInteraction {
     ///
     /// `application_id` will usually be the bot's [`UserId`], except in cases of bots being very old.
     ///
-    /// Refer to Discord's docs for Edit Webhook Message for field information.
+    /// Refer to Discord's docs for [Edit Original Interaction Response] for field information.
+    ///
+    /// [Edit Original Interaction Response]: https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
     ///
@@ -139,13 +141,14 @@ impl ModalSubmitInteraction {
     /// Returns [`Error::Model`] if the edited content is too long.
     /// May also return [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error deserializing the response.
-    pub async fn edit_original_interaction_response<F>(
+    pub async fn edit_original_interaction_response<'a, F>(
         &self,
         http: impl AsRef<Http>,
         f: F,
     ) -> Result<Message>
     where
-        F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse,
+        for<'b> F:
+            FnOnce(&'b mut EditInteractionResponse<'a>) -> &'b mut EditInteractionResponse<'a>,
     {
         let mut interaction_response = EditInteractionResponse::default();
         f(&mut interaction_response);


### PR DESCRIPTION
I have implemented methods for working with files in the edit original interaction response.
Example:
```rust
interaction.edit_original_interaction_response(http, |response|
    response
        .add_file("image.png")
).await.unwrap();
```