### PR TITLE
Remove `CacheAndHttp`

### DIFF
--- a/src/client/bridge/gateway/shard_queuer.rs
+++ b/src/client/bridge/gateway/shard_queuer.rs
@@ -20,16 +20,18 @@ use super::{
     ShardRunnerInfo,
     ShardRunnerOptions,
 };
+#[cfg(feature = "cache")]
+use crate::cache::Cache;
 #[cfg(feature = "voice")]
 use crate::client::bridge::voice::VoiceGatewayManager;
 use crate::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
 use crate::gateway::{ConnectionStage, InterMessage, PresenceData, Shard};
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
 use crate::model::gateway::{GatewayIntents, ShardInfo};
-use crate::CacheAndHttp;
 
 const WAIT_BETWEEN_BOOTS_IN_SECONDS: u64 = 5;
 
@@ -80,7 +82,9 @@ pub struct ShardQueuer {
     pub voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
     /// A copy of the URL to use to connect to the gateway.
     pub ws_url: Arc<Mutex<String>>,
-    pub cache_and_http: CacheAndHttp,
+    #[cfg(feature = "cache")]
+    pub cache: Arc<Cache>,
+    pub http: Arc<Http>,
     pub intents: GatewayIntents,
     pub presence: Option<PresenceData>,
 }
@@ -178,14 +182,14 @@ impl ShardQueuer {
 
         let mut shard = Shard::new(
             Arc::clone(&self.ws_url),
-            self.cache_and_http.http.token(),
+            self.http.token(),
             shard_info,
             self.intents,
             self.presence.clone(),
         )
         .await?;
 
-        let cloned_http = self.cache_and_http.http.clone();
+        let cloned_http = Arc::clone(&self.http);
         shard.set_application_id_callback(move |id| cloned_http.set_application_id(id));
 
         let mut runner = ShardRunner::new(ShardRunnerOptions {
@@ -198,7 +202,9 @@ impl ShardQueuer {
             #[cfg(feature = "voice")]
             voice_manager: self.voice_manager.clone(),
             shard,
-            cache_and_http: self.cache_and_http.clone(),
+            #[cfg(feature = "cache")]
+            cache: Arc::clone(&self.cache),
+            http: Arc::clone(&self.http),
         });
 
         let runner_info = ShardRunnerInfo {

--- a/src/client/bridge/gateway/shard_runner.rs
+++ b/src/client/bridge/gateway/shard_runner.rs
@@ -13,6 +13,8 @@ use super::event::{ClientEvent, ShardStageUpdateEvent};
 #[cfg(feature = "collector")]
 use super::CollectorCallback;
 use super::{ShardClientMessage, ShardId, ShardManagerMessage, ShardRunnerMessage};
+#[cfg(feature = "cache")]
+use crate::cache::Cache;
 #[cfg(feature = "voice")]
 use crate::client::bridge::voice::VoiceGatewayManager;
 use crate::client::dispatch::{dispatch_client, dispatch_model};
@@ -20,9 +22,9 @@ use crate::client::{Context, EventHandler, RawEventHandler};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
 use crate::gateway::{GatewayError, InterMessage, ReconnectType, Shard, ShardAction};
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::event::{Event, GatewayEvent};
-use crate::CacheAndHttp;
 
 /// A runner for managing a [`Shard`] and its respective WebSocket client.
 pub struct ShardRunner {
@@ -39,7 +41,9 @@ pub struct ShardRunner {
     pub(crate) shard: Shard,
     #[cfg(feature = "voice")]
     voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
-    cache_and_http: CacheAndHttp,
+    #[cfg(feature = "cache")]
+    pub cache: Arc<Cache>,
+    pub http: Arc<Http>,
     #[cfg(feature = "collector")]
     collectors: Vec<CollectorCallback>,
 }
@@ -61,7 +65,9 @@ impl ShardRunner {
             shard: opt.shard,
             #[cfg(feature = "voice")]
             voice_manager: opt.voice_manager,
-            cache_and_http: opt.cache_and_http,
+            #[cfg(feature = "cache")]
+            cache: opt.cache,
+            http: opt.http,
             #[cfg(feature = "collector")]
             collectors: vec![],
         }
@@ -261,9 +267,9 @@ impl ShardRunner {
             Arc::clone(&self.data),
             self.runner_tx.clone(),
             self.shard.shard_info().id,
-            Arc::clone(&self.cache_and_http.http),
+            Arc::clone(&self.http),
             #[cfg(feature = "cache")]
-            Arc::clone(&self.cache_and_http.cache),
+            Arc::clone(&self.cache),
         )
     }
 
@@ -564,5 +570,7 @@ pub struct ShardRunnerOptions {
     pub shard: Shard,
     #[cfg(feature = "voice")]
     pub voice_manager: Option<Arc<dyn VoiceGatewayManager>>,
-    pub cache_and_http: CacheAndHttp,
+    #[cfg(feature = "cache")]
+    pub cache: Arc<Cache>,
+    pub http: Arc<Http>,
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -64,7 +64,6 @@ use crate::internal::prelude::*;
 use crate::model::gateway::GatewayIntents;
 use crate::model::id::ApplicationId;
 use crate::model::user::OnlineStatus;
-pub use crate::CacheAndHttp;
 
 /// A builder implementing [`IntoFuture`] building a [`Client`] to interact with Discord.
 #[cfg(feature = "gateway")]
@@ -380,11 +379,8 @@ impl IntoFuture for ClientBuilder {
         #[cfg(feature = "voice")]
         let voice_manager = self.voice_manager;
 
-        let cache_and_http = CacheAndHttp {
-            #[cfg(feature = "cache")]
-            cache: Arc::new(Cache::new_with_settings(self.cache_settings)),
-            http: Arc::clone(&http),
-        };
+        #[cfg(feature = "cache")]
+        let cache = Arc::new(Cache::new_with_settings(self.cache_settings));
 
         Box::pin(async move {
             let ws_url = Arc::new(Mutex::new(match http.get_gateway().await {
@@ -409,7 +405,9 @@ impl IntoFuture for ClientBuilder {
                 #[cfg(feature = "voice")]
                 voice_manager: voice_manager.as_ref().map(Arc::clone),
                 ws_url: Arc::clone(&ws_url),
-                cache_and_http: cache_and_http.clone(),
+                #[cfg(feature = "cache")]
+                cache: Arc::clone(&cache),
+                http: Arc::clone(&http),
                 intents,
                 presence: Some(presence),
             });
@@ -421,7 +419,9 @@ impl IntoFuture for ClientBuilder {
                 #[cfg(feature = "voice")]
                 voice_manager,
                 ws_url,
-                cache_and_http,
+                #[cfg(feature = "cache")]
+                cache,
+                http,
             };
             #[cfg(feature = "framework")]
             if let Some(mut framework) = framework {
@@ -671,8 +671,11 @@ pub struct Client {
     /// This is wrapped in an `Arc<Mutex<T>>` so all shards will have an updated
     /// value available.
     pub ws_url: Arc<Mutex<String>>,
-    /// A container for an optional cache and HTTP client.
-    pub cache_and_http: CacheAndHttp,
+    /// The cache for the client.
+    #[cfg(feature = "cache")]
+    pub cache: Arc<Cache>,
+    /// An HTTP client.
+    pub http: Arc<Http>,
 }
 
 impl Client {
@@ -769,7 +772,7 @@ impl Client {
     #[instrument(skip(self))]
     pub async fn start_autosharded(&mut self) -> Result<()> {
         let (end, total) = {
-            let res = self.cache_and_http.http.get_bot_gateway().await?;
+            let res = self.http.get_bot_gateway().await?;
 
             (res.shards - 1, res.shards)
         };
@@ -966,7 +969,7 @@ impl Client {
     ) -> Result<()> {
         #[cfg(feature = "voice")]
         if let Some(voice_manager) = &self.voice_manager {
-            let user = self.cache_and_http.http.get_current_user().await?;
+            let user = self.http.get_current_user().await?;
 
             voice_manager.initialise(total_shards, user.id).await;
         }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -48,8 +48,6 @@ use crate::cache::Cache;
 #[cfg(feature = "client")]
 use crate::client::Context;
 use crate::model::prelude::*;
-#[cfg(feature = "client")]
-use crate::CacheAndHttp;
 
 /// This trait will be required by functions that need [`Http`] and can
 /// optionally use a [`Cache`] to potentially avoid REST-requests.
@@ -103,17 +101,6 @@ where
 
 #[cfg(feature = "client")]
 impl CacheHttp for Context {
-    fn http(&self) -> &Http {
-        &self.http
-    }
-    #[cfg(feature = "cache")]
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        Some(&self.cache)
-    }
-}
-
-#[cfg(feature = "client")]
-impl CacheHttp for CacheAndHttp {
     fn http(&self) -> &Http {
         &self.http
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! serenity = "0.11"
 //! ```
 //!
-//! [`Cache`]: crate::caceh::Cache
+//! [`Cache`]: crate::cache::Cache
 //! [`Context`]: crate::client::Context
 //! [`EventHandler::message`]: crate::client::EventHandler::message
 //! [`Event`]: crate::model::event::Event

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //! serenity = "0.11"
 //! ```
 //!
+//! [`Cache`]: crate::caceh::Cache
 //! [`Context`]: crate::client::Context
 //! [`EventHandler::message`]: crate::client::EventHandler::message
 //! [`Event`]: crate::model::event::Event
@@ -114,39 +115,6 @@ pub mod utils;
 
 mod error;
 
-#[cfg(feature = "client")]
-use std::sync::Arc;
-
-#[cfg(all(feature = "client", feature = "cache"))]
-use crate::cache::Cache;
-#[cfg(all(feature = "client", feature = "gateway"))]
-pub use crate::client::Client;
-pub use crate::error::{Error, Result};
-#[cfg(feature = "client")]
-use crate::http::Http;
-
-#[cfg(feature = "client")]
-#[derive(Clone)]
-pub struct CacheAndHttp {
-    #[cfg(feature = "cache")]
-    pub cache: Arc<Cache>,
-    pub http: Arc<Http>,
-}
-
-#[cfg(all(feature = "client", feature = "cache"))]
-impl AsRef<Cache> for CacheAndHttp {
-    fn as_ref(&self) -> &Cache {
-        &self.cache
-    }
-}
-
-#[cfg(feature = "client")]
-impl AsRef<Http> for CacheAndHttp {
-    fn as_ref(&self) -> &Http {
-        &self.http
-    }
-}
-
 // For the procedural macros in `command_attr`.
 pub use async_trait::async_trait;
 pub use futures;
@@ -154,6 +122,10 @@ pub use futures::future::FutureExt;
 #[cfg(feature = "standard_framework")]
 #[doc(hidden)]
 pub use static_assertions;
+
+#[cfg(all(feature = "client", feature = "gateway"))]
+pub use crate::client::Client;
+pub use crate::error::{Error, Result};
 
 #[cfg(feature = "absolute_ratelimits")]
 compile_error!(

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,5 +32,3 @@ pub use crate::http::HttpError;
 pub use crate::model::mention::Mentionable;
 #[cfg(feature = "model")]
 pub use crate::model::{gateway::GatewayIntents, ModelError};
-#[cfg(feature = "client")]
-pub use crate::CacheAndHttp;


### PR DESCRIPTION
Supersedes #2118. As far as I can tell, any concerns around removing this have been addressed by this point. Therefore, removing this and inlining its fields is a net positive, mainly serving to avoid confusion with the `CacheHttp` trait.