### PR TITLE
Make collector API backwards compatible

### DIFF
--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -91,8 +91,8 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
     // There is a method implemented for some models to conveniently collect replies.
     // They return a builder that can be turned into a Stream, or here, where we can
     // await a single reply
-    let collector = msg.author.reply_collector(&ctx.shard).timeout(Duration::from_secs(10));
-    if let Some(answer) = collector.collect_single().await {
+    let collector = msg.author.await_reply(&ctx.shard).timeout(Duration::from_secs(10));
+    if let Some(answer) = collector.await {
         if answer.content.to_lowercase() == "ferris" {
             let _ = answer.reply(ctx, "That's correct!").await;
             score += 1;
@@ -110,11 +110,11 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
 
     // The message model can also be turned into a Collector to collect reactions on it.
     let collector = react_msg
-        .reaction_collector(&ctx.shard)
+        .await_reaction(&ctx.shard)
         .timeout(Duration::from_secs(10))
         .author_id(msg.author.id);
 
-    if let Some(reaction) = collector.collect_single().await {
+    if let Some(reaction) = collector.await {
         let _ = if reaction.emoji.as_data() == "1️⃣" {
             score += 1;
             msg.reply(ctx, "That's correct!").await
@@ -134,7 +134,7 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
         .channel_id(msg.channel_id)
         .timeout(Duration::from_secs(10))
         // Build the collector.
-        .collect_stream()
+        .stream()
         .take(5);
 
     // Let's acquire borrow HTTP to send a message inside the `async move`.

--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -59,9 +59,8 @@ impl EventHandler for Handler {
         // This uses a collector to wait for an incoming event without needing to listen for it
         // manually in the EventHandler.
         let interaction = match m
-            .component_interaction_collector(&ctx.shard)
+            .await_component_interaction(&ctx.shard)
             .timeout(Duration::from_secs(60 * 3))
-            .collect_single()
             .await
         {
             Some(x) => x,
@@ -108,10 +107,8 @@ impl EventHandler for Handler {
             .unwrap();
 
         // Wait for multiple interactions
-        let mut interaction_stream = m
-            .component_interaction_collector(&ctx.shard)
-            .timeout(Duration::from_secs(60 * 3))
-            .collect_stream();
+        let mut interaction_stream =
+            m.await_component_interaction(&ctx.shard).timeout(Duration::from_secs(60 * 3)).stream();
 
         while let Some(interaction) = interaction_stream.next().await {
             let sound = &interaction.data.custom_id;

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -128,9 +128,8 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
                 )
                 .await?;
             let button_press = msg
-                .component_interaction_collector(&ctx.shard)
+                .await_component_interaction(&ctx.shard)
                 .timeout(std::time::Duration::from_secs(10))
-                .collect_single()
                 .await;
             match button_press {
                 Some(x) => x.defer(ctx).await?,

--- a/src/builder/quick_modal.rs
+++ b/src/builder/quick_modal.rs
@@ -101,7 +101,7 @@ impl CreateQuickModal {
 
         let modal_interaction = ModalInteractionCollector::new(&ctx.shard)
             .custom_ids(vec![modal_custom_id])
-            .collect_single()
+            .next()
             .await;
         let modal_interaction = match modal_interaction {
             Some(x) => x,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -833,17 +833,29 @@ impl ChannelId {
 
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this channel.
     #[cfg(feature = "collector")]
-    pub fn reply_collector(self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_reply(self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
         MessageCollector::new(shard_messenger).channel_id(self)
+    }
+
+    /// Same as [`Self::await_reply`].
+    #[cfg(feature = "collector")]
+    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+        self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent in this channel.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector(
-        self,
+    pub fn await_reaction(self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+        ReactionCollector::new(shard_messenger).channel_id(self)
+    }
+
+    /// Same as [`Self::await_reaction`].
+    #[cfg(feature = "collector")]
+    pub fn await_reactions(
+        &self,
         shard_messenger: impl AsRef<ShardMessenger>,
     ) -> ReactionCollector {
-        ReactionCollector::new(shard_messenger).channel_id(self)
+        self.await_reaction(shard_messenger)
     }
 
     /// Gets a stage instance.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1051,14 +1051,29 @@ impl GuildChannel {
 
     /// Returns a builder which can be awaited to obtain a message or stream of messages sent in this guild channel.
     #[cfg(feature = "collector")]
-    pub fn reply_collector(&self, shard_messenger: &ShardMessenger) -> MessageCollector {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
         MessageCollector::new(shard_messenger).channel_id(self.id)
+    }
+
+    /// Same as [`Self::await_reply`].
+    #[cfg(feature = "collector")]
+    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+        self.await_reply(shard_messenger)
     }
 
     /// Returns a stream builder which can be awaited to obtain a reaction or stream of reactions sent by this guild channel.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector(&self, shard_messenger: &ShardMessenger) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).channel_id(self.id)
+    }
+
+    /// Same as [`Self::await_reaction`].
+    #[cfg(feature = "collector")]
+    pub fn await_reactions(
+        &self,
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollector {
+        self.await_reaction(shard_messenger)
     }
 
     /// Creates a webhook in the channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -756,26 +756,53 @@ impl Message {
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions on this message.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector(&self, shard_messenger: &ShardMessenger) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).message_id(self.id)
     }
 
-    /// Returns a builder which can be awaited to obtain a reaction or stream of component interactions on this message.
+    /// Same as [`Self::await_reaction`].
     #[cfg(feature = "collector")]
-    pub fn component_interaction_collector(
+    pub fn await_reactions(
+        &self,
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollector {
+        self.await_reaction(shard_messenger)
+    }
+
+    /// Returns a builder which can be awaited to obtain a single component interactions or a stream of component interactions on this message.
+    #[cfg(feature = "collector")]
+    pub fn await_component_interaction(
         &self,
         shard_messenger: impl AsRef<ShardMessenger>,
     ) -> ComponentInteractionCollector {
         ComponentInteractionCollector::new(shard_messenger).message_id(self.id)
     }
 
+    /// Same as [`Self::await_component_interaction`].
+    #[cfg(feature = "collector")]
+    pub fn await_component_interactions(
+        &self,
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ComponentInteractionCollector {
+        self.await_component_interaction(shard_messenger)
+    }
+
     /// Returns a builder which can be awaited to obtain a model submit interaction or stream of modal submit interactions on this message.
     #[cfg(feature = "collector")]
-    pub fn modal_interaction_collector(
+    pub fn await_modal_interaction(
         &self,
-        shard_messenger: &ShardMessenger,
+        shard_messenger: impl AsRef<ShardMessenger>,
     ) -> ModalInteractionCollector {
         ModalInteractionCollector::new(shard_messenger).message_id(self.id)
+    }
+
+    /// Same as [`Self::await_modal_interaction`].
+    #[cfg(feature = "collector")]
+    pub fn await_modal_interactions(
+        &self,
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ModalInteractionCollector {
+        self.await_modal_interaction(shard_messenger)
     }
 
     /// Retrieves the message channel's category ID if the channel has one.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1404,17 +1404,29 @@ impl GuildId {
     }
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn reply_collector(self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_reply(self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
         MessageCollector::new(shard_messenger).guild_id(self)
+    }
+
+    /// Same as [`Self::await_reply`].
+    #[cfg(feature = "collector")]
+    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+        self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector(
-        self,
+    pub fn await_reaction(self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+        ReactionCollector::new(shard_messenger).guild_id(self)
+    }
+
+    /// Same as [`Self::await_reaction`].
+    #[cfg(feature = "collector")]
+    pub fn await_reactions(
+        &self,
         shard_messenger: impl AsRef<ShardMessenger>,
     ) -> ReactionCollector {
-        ReactionCollector::new(shard_messenger).guild_id(self)
+        self.await_reaction(shard_messenger)
     }
 
     /// Create a guild specific application [`Command`].

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2492,14 +2492,29 @@ impl Guild {
 
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn reply_collector(&self, shard_messenger: &ShardMessenger) -> MessageCollector {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
         MessageCollector::new(shard_messenger).guild_id(self.id)
+    }
+
+    /// Same as [`Self::await_reply`].
+    #[cfg(feature = "collector")]
+    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+        self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector(&self, shard_messenger: &ShardMessenger) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).guild_id(self.id)
+    }
+
+    /// Same as [`Self::await_reaction`].
+    #[cfg(feature = "collector")]
+    pub fn await_reactions(
+        &self,
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollector {
+        self.await_reaction(shard_messenger)
     }
 
     /// Gets the guild active threads.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1534,14 +1534,29 @@ impl PartialGuild {
 
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this guild.
     #[cfg(feature = "collector")]
-    pub fn reply_collector(&self, shard_messenger: &ShardMessenger) -> MessageCollector {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
         MessageCollector::new(shard_messenger).guild_id(self.id)
+    }
+
+    /// Same as [`Self::await_reply`].
+    #[cfg(feature = "collector")]
+    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+        self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in this guild.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector(&self, shard_messenger: &ShardMessenger) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).guild_id(self.id)
+    }
+
+    /// Same as [`Self::await_reaction`].
+    #[cfg(feature = "collector")]
+    pub fn await_reactions(
+        &self,
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollector {
+        self.await_reaction(shard_messenger)
     }
 
     /// Gets the guild active threads.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -963,14 +963,29 @@ impl User {
 
     /// Returns a builder which can be awaited to obtain a message or stream of messages sent by this user.
     #[cfg(feature = "collector")]
-    pub fn reply_collector(&self, shard_messenger: &ShardMessenger) -> MessageCollector {
+    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
         MessageCollector::new(shard_messenger).author_id(self.id)
+    }
+
+    /// Same as [`Self::await_reply`].
+    #[cfg(feature = "collector")]
+    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+        self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent by this user.
     #[cfg(feature = "collector")]
-    pub fn reaction_collector(&self, shard_messenger: &ShardMessenger) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).author_id(self.id)
+    }
+
+    /// Same as [`Self::await_reaction`].
+    #[cfg(feature = "collector")]
+    pub fn await_reactions(
+        &self,
+        shard_messenger: impl AsRef<ShardMessenger>,
+    ) -> ReactionCollector {
+        self.await_reaction(shard_messenger)
     }
 }
 


### PR DESCRIPTION
By
- renaming foo_collector back to await_foo and await_foos
- adding IntoFuture impl on collector types
- and a deprecated `.build()` method that just redirects to `.stream()`

Part of a larger plan to make serenity 0.12 migration slightly less hell for users than it will be anyways