### PR TITLE
Fix channel type in CreateChannel

### DIFF
--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -10,6 +10,7 @@ use crate::model::prelude::*;
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateChannel<'a> {
+    #[serde(rename = "type")]
     kind: ChannelType,
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This PR fixes a small typo in `CreateChannel` which make the creation of channel of other type impossible.  (https://discord.com/developers/docs/resources/channel#channels-resource)