### PR TITLE
Hotfix proxy support

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -71,7 +71,7 @@ impl<'a> Request<'a> {
         let mut path = self.route.path().to_string();
 
         if let Some(proxy) = proxy {
-            path = path.replace("https://discord.com/", proxy);
+            path = path.replace("https://discord.com", proxy);
         }
 
         if let Some(params) = self.params {


### PR DESCRIPTION
This is a hotfix that addresses #2322. It solves the issue around slashes by leaving the existing one in. However, I'm not satisfied with this as a longterm solution, because providing a proxy url with a slash at the end will produce a malformed URL (with two slashes in a row). It will correctly parse, but the request will likely 404. In the future, the string replacement should be replaced with calls to methods on `Url`. The only pain here is that replacing the domain of a `Url` object is not easy (there are no methods directly on `Url` to do so).