### PR TITLE
Change `Result` type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ use crate::model::ModelError;
 /// type, rather than the usual 2 (`Result<T, Error>`). This is because all
 /// functions that return a result return serenity's [`Error`], so this is
 /// implied, and a "simpler" result is used.
-pub type Result<T> = StdResult<T, Error>;
+pub type Result<T, E = Error> = StdResult<T, E>;
 
 /// A common error enum returned by most of the library's functionality within a
 /// custom [`Result`].

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -66,7 +66,7 @@ impl Typing {
     pub fn start(http: Arc<Http>, channel_id: ChannelId) -> Result<Self> {
         let (sx, mut rx) = oneshot::channel();
 
-        spawn_named("typing::start", async move {
+        spawn_named::<_, Result<_>>("typing::start", async move {
             loop {
                 match rx.try_recv() {
                     Ok(_) | Err(TryRecvError::Closed) => break,


### PR DESCRIPTION
Fixes conflicts when doing
```rs
use serenity::all::*;
```