### PR TITLE
Change `ThreadMembersUpdateEvent::member_count` to i16

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -731,7 +731,10 @@ pub struct ThreadMembersUpdateEvent {
     /// The id of the Guild.
     pub guild_id: GuildId,
     /// The approximate number of members in the thread, capped at 50.
-    pub member_count: u8,
+    ///
+    /// NOTE: This count has been observed to be above 50, or below 0.
+    /// See: <https://github.com/discord/discord-api-docs/issues/5139>
+    pub member_count: i16,
     /// The users who were added to the thread.
     #[serde(default)]
     pub added_members: Vec<ThreadMember>,


### PR DESCRIPTION
As added to the documentation in this PR, the member_count value is buggy and has been observed to exceed 50 or even be negative. This PR changes the value to `i16` as I have not observed the value be outside the bounds of that.

See: https://github.com/discord/discord-api-docs/issues/5139