### PR TITLE
Add owner_id for group dms, threads and forum posts

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -82,7 +82,7 @@ pub struct GuildChannel {
     /// The Id of the user who created this channel
     ///
     /// **Note**: This is only available for threads and forum posts
-    pub owner_id: Option<u64>,
+    pub owner_id: Option<UserId>,
     /// The Id of the last message sent in the channel.
     ///
     /// **Note**: This is only available for text channels.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -79,6 +79,10 @@ pub struct GuildChannel {
     /// The type of the channel.
     #[serde(rename = "type")]
     pub kind: ChannelType,
+    /// The Id of the user who created this channel
+    ///
+    /// **Note**: This is only available for threads and forum posts
+    pub owner_id: Option<u64>,
     /// The Id of the last message sent in the channel.
     ///
     /// **Note**: This is only available for text channels.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -24,6 +24,10 @@ pub struct PrivateChannel {
     pub id: ChannelId,
     /// The Id of the last message sent.
     pub last_message_id: Option<MessageId>,
+    /// The Id of the user who created this channel
+    ///
+    /// **Note**: This is only available for group dms
+    pub owner_id: Option<u64>,
     /// Timestamp of the last time a [`Message`] was pinned.
     pub last_pin_timestamp: Option<Timestamp>,
     /// Indicator of the type of channel this is.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -27,7 +27,7 @@ pub struct PrivateChannel {
     /// The Id of the user who created this channel
     ///
     /// **Note**: This is only available for group dms
-    pub owner_id: Option<u64>,
+    pub owner_id: Option<UserId>,
     /// Timestamp of the last time a [`Message`] was pinned.
     pub last_pin_timestamp: Option<Timestamp>,
     /// Indicator of the type of channel this is.


### PR DESCRIPTION
Allows retrieving the creator/owner of a group dm or thread.
In code it just adds the owner_id (Option<UserId>) field for deserialization upon to_channel invocation.