### PR TITLE
Add deserialize for create_components

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -574,7 +574,7 @@ mod test {
         let serialized_action_row: String = serde_json::to_string(&action_row).unwrap();
 
         let deserized_action_row: Result<CreateActionRow, _> =
-            serde_json::from_str(&serialized_action_row.replace("1", "2"));
+            serde_json::from_str(&serialized_action_row.replace('1', "2"));
 
         assert!(deserized_action_row.is_err());
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -153,20 +153,6 @@ impl CreateButton {
         })
     }
 
-    /// Sets the custom id of the button, a developer-defined identifier. Replaces the current value
-    /// as set in [`Self::new`].
-    ///
-    /// Has no effect on link buttons.
-    pub fn custom_id(mut self, id: impl Into<String>) -> Self {
-        if let ButtonKind::NonLink {
-            custom_id, ..
-        } = &mut self.0.data
-        {
-            *custom_id = id.into();
-        }
-        self
-    }
-
     /// Sets the style of this button.
     ///
     /// Has no effect on link buttons.

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -71,6 +71,19 @@ impl CreateButton {
         })
     }
 
+    /// Sets the custom id of the button, a developer-defined identifier. Replaces the current value
+    /// as set in [`Self::new`].
+    pub fn custom_id(mut self, id: impl Into<String>) -> Self {
+        // Make sure we're not a link button
+        if let ButtonKind::NonLink {
+            custom_id, ..
+        } = &mut self.0.data
+        {
+            *custom_id = id.into();
+        }
+        self
+    }
+
     /// Sets the style of this button.
     ///
     /// Has no effect on link buttons.

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -26,17 +26,10 @@ impl serde::Serialize for CreateActionRow {
         use serde::ser::Error as _;
 
         let components: Vec<serde_json::Value> = match self {
-            Self::Buttons(x) => {
-                let mut buttons = Vec::new();
-
-                // This needs to be a for loop so that we can use `?` to return
-                // early on error
-                for button in x {
-                    buttons.push(serde_json::to_value(button).map_err(S::Error::custom)?);
-                }
-
-                buttons
-            },
+            Self::Buttons(x) => x
+                .iter()
+                .map(|button| serde_json::to_value(button).map_err(S::Error::custom))
+                .collect::<Result<Vec<_>, _>>()?,
             Self::SelectMenu(x) => vec![serde_json::to_value(x).map_err(S::Error::custom)?],
             Self::InputText(x) => vec![serde_json::to_value(x).map_err(S::Error::custom)?],
         };

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -33,7 +33,7 @@ impl serde::Serialize for CreateActionRow {
 /// A builder for creating a [`Button`].
 ///
 /// [`Button`]: crate::model::application::Button
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateButton(Button);
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -409,3 +409,23 @@ impl CreateInputText {
         self
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::all::{CreateButton, CreateActionRow};
+
+    #[test]
+    fn serialize_create_button() {
+        let button = CreateButton::new("create_button_test_id");
+
+        let json = serde_json::to_string(&button).unwrap();
+
+        assert_eq!(
+            json,
+            r#"{"type":2,"style":1,"custom_id":"create_button_test_id","disabled":false}"#
+        );
+
+        // Verify the button is deserializable
+        let _button: CreateButton = serde_json::from_str(&json).unwrap();
+    }
+}


### PR DESCRIPTION
## This PR

This adds the `Deserialize` trait to several types in the `create_components` builder. It also adds tests where the deserialization logic is more custom.

The following types now implement `Deserialize`:
- `CreateActionRow`
- `CreateButton`
- `CreateSelectMenu`
- `CreateSelectMenuOption`
- `CreateInputText`

## Other items to note

- The deserialize logic for `CreateActionRow` will check if no components are being deserialized, and return an error if so. This can occur by accident if the `CreateActionRow` is of type `Buttons` and the interior `Vec` is empty, and this is serialized.

## Issues

This helps towards solving #2324