### PR TITLE
Add CreateButton custom_id method

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -71,6 +71,20 @@ impl CreateButton {
         })
     }
 
+    /// Sets the custom id of the button, a developer-defined identifier. Replaces the current value
+    /// as set in [`Self::new`].
+    ///
+    /// Has no effect on link buttons.
+    pub fn custom_id(mut self, id: impl Into<String>) -> Self {
+        if let ButtonKind::NonLink {
+            custom_id, ..
+        } = &mut self.0.data
+        {
+            *custom_id = id.into();
+        }
+        self
+    }
+
     /// Sets the style of this button.
     ///
     /// Has no effect on link buttons.


### PR DESCRIPTION
This adds a `custom_id` method that can update the custom id of a `CreateButton` builder. It makes the same assumption as the existing `style` method on this type, where it won't affect any link buttons:

```rust
    /// Has no effect on link buttons.
    pub fn custom_id(mut self, id: impl Into<String>) -> Self {
        if let ButtonKind::NonLink {
            ...
        }
        ...
    }
```

This will close #2325.