### PR TITLE
Add deserialize trait for all builder types

### DIFF
--- a/examples/e14_slash_commands/src/commands/modal.rs
+++ b/examples/e14_slash_commands/src/commands/modal.rs
@@ -1,6 +1,7 @@
 use serenity::builder::*;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
+use serenity::utils::CreateQuickModal;
 
 pub async fn run(ctx: &Context, interaction: &CommandInteraction) -> Result<(), serenity::Error> {
     let modal = CreateQuickModal::new("About you")

--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -9,7 +9,7 @@ use crate::model::prelude::*;
 /// A builder to add parameters when using [`GuildId::add_member`].
 ///
 /// [`GuildId::add_member`]: crate::model::id::GuildId::add_member
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct AddMember {
     access_token: String,

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -8,7 +8,7 @@ use crate::model::application::Scope;
 use crate::model::prelude::*;
 
 /// A builder for constructing an invite link with custom OAuth2 scopes.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateBotAuthParameters {
     client_id: Option<ApplicationId>,

--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::id::{RoleId, UserId};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum ParseValue {
     Everyone,
@@ -56,7 +56,7 @@ enum ParseValue {
 ///
 /// [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
 /// [`ChannelId::edit_message`]: crate::model::id::ChannelId::edit_message
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateAllowedMentions {
     parse: HashSet<ParseValue>,

--- a/src/builder/create_application_command.rs
+++ b/src/builder/create_application_command.rs
@@ -14,7 +14,7 @@ use crate::model::prelude::*;
 /// [`CommandOption`]: crate::model::application::CommandOption
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateCommandOption(CommandOption);
 
@@ -281,7 +281,7 @@ impl CreateCommandOption {
 /// Discord docs:
 /// - [global command](https://discord.com/developers/docs/interactions/application-commands#create-global-application-command-json-params)
 /// - [guild command](https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command-json-params)
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateCommand {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/create_application_command_permission.rs
+++ b/src/builder/create_application_command_permission.rs
@@ -14,7 +14,7 @@ use crate::model::id::{CommandId, GuildId};
 /// A builder for creating several [`CommandPermissionData`].
 ///
 /// [`CommandPermissionData`]: crate::model::application::CommandPermissionData
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateCommandPermissionsData {
     permissions: Vec<CreateCommandPermissionData>,
@@ -72,7 +72,7 @@ impl Builder for CreateCommandPermissionsData {
 /// All fields are required.
 ///
 /// [`CommandPermissionData`]: crate::model::application::CommandPermissionData
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateCommandPermissionData {
     #[serde(rename = "type")]

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -16,7 +16,7 @@ use crate::model::id::AttachmentId;
 /// requests, only the id is required."
 ///
 /// [Discord docs]: https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ExistingAttachment {
     pub id: AttachmentId,
     // TODO: add the other non-required attachment fields? Like content_type, description,

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -26,7 +26,7 @@ pub(crate) struct ExistingAttachment {
 /// Enum that allows a user to pass a [`Path`] or a [`File`] type to [`send_files`]
 ///
 /// [`send_files`]: crate::model::id::ChannelId::send_files
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 #[must_use]
 pub struct CreateAttachment {

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -9,7 +9,7 @@ use crate::model::prelude::*;
 /// A builder for creating a new [`GuildChannel`] in a [`Guild`].
 ///
 /// Except [`Self::name`], all fields are optional.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateChannel<'a> {
     #[serde(rename = "type")]

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -62,7 +62,7 @@ pub struct CreateEmbed {
     colour: Option<Colour>,
 
     #[serde(rename = "type")]
-    kind: &'static str,
+    kind: String,
 }
 
 impl CreateEmbed {
@@ -285,7 +285,7 @@ impl Default for CreateEmbed {
             description: None,
             thumbnail: None,
             timestamp: None,
-            kind: "rich",
+            kind: "rich".to_string(),
             author: None,
             colour: None,
             footer: None,

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -18,7 +18,7 @@
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct HoldsUrl {
     url: String,
 }
@@ -37,7 +37,7 @@ impl HoldsUrl {
 /// [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
 /// [`Embed`]: crate::model::channel::Embed
 /// [`ExecuteWebhook::embeds`]: crate::builder::ExecuteWebhook::embeds
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateEmbed {
     fields: Vec<EmbedField>,
@@ -339,7 +339,7 @@ impl From<Embed> for CreateEmbed {
 
 /// A builder to create a fake [`Embed`] object's author, for use with the [`CreateEmbed::author`]
 /// method.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateEmbedAuthor {
     name: String,
@@ -392,7 +392,7 @@ impl From<EmbedAuthor> for CreateEmbedAuthor {
 /// method.
 ///
 /// This does not have any required fields.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateEmbedFooter {
     text: String,

--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -7,7 +7,7 @@ use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateForumPost<'a> {
     name: String,

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -274,13 +274,13 @@ impl CreateInteractionResponseMessage {
     super::button_and_select_menu_convenience_methods!();
 }
 
-#[derive(Clone, Default, Debug, Serialize)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct AutocompleteChoice {
     pub name: String,
     pub value: Value,
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateAutocompleteResponse {
     choices: Vec<AutocompleteChoice>,

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -141,7 +141,7 @@ impl Builder for CreateInteractionResponse {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateInteractionResponseMessage {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -361,7 +361,7 @@ impl Builder for CreateAutocompleteResponse {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 #[non_exhaustive]
 pub struct CreateModal {

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -11,7 +11,7 @@ use crate::model::prelude::*;
 #[cfg(feature = "http")]
 use crate::utils::check_overflow;
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateInteractionResponseFollowup {
     embeds: Vec<CreateEmbed>,

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -67,7 +67,7 @@ use crate::model::prelude::*;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateInvite<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -47,7 +47,7 @@ use crate::utils::check_overflow;
 /// [`ChannelId::say`]: crate::model::id::ChannelId::say
 /// [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
 /// [`Http::send_message`]: crate::http::Http::send_message
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateMessage {
     tts: bool,

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -7,7 +7,7 @@ use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateScheduledEvent<'a> {
     name: String,

--- a/src/builder/create_stage_instance.rs
+++ b/src/builder/create_stage_instance.rs
@@ -7,7 +7,7 @@ use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Builder for creating a [`StageInstance`].
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateStageInstance<'a> {
     channel_id: Option<ChannelId>,

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -21,7 +21,7 @@ pub struct CreateSticker<'a> {
     name: String,
     tags: String,
     description: String,
-    
+
     #[serde(skip)]
     file: CreateAttachment,
     #[serde(skip)]

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -15,7 +15,7 @@ use crate::model::prelude::*;
 /// - [`PartialGuild::create_sticker`]
 /// - [`Guild::create_sticker`]
 /// - [`GuildId::create_sticker`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateSticker<'a> {
     name: String,

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -21,6 +21,8 @@ pub struct CreateSticker<'a> {
     name: String,
     tags: String,
     description: String,
+    
+    #[serde(skip)]
     file: CreateAttachment,
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -22,6 +22,7 @@ pub struct CreateSticker<'a> {
     tags: String,
     description: String,
     file: CreateAttachment,
+    #[serde(skip)]
     audit_log_reason: Option<&'a str>,
 }
 

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -6,7 +6,7 @@ use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateThread<'a> {
     name: String,

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -8,7 +8,7 @@ use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateWebhook<'a> {
     name: String,

--- a/src/builder/edit_automod_rule.rs
+++ b/src/builder/edit_automod_rule.rs
@@ -9,7 +9,7 @@ use crate::model::guild::automod::Rule;
 use crate::model::guild::automod::{Action, EventType, Trigger};
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[must_use]
 /// A builder for creating or editing guild AutoMod rules.
 ///

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -27,7 +27,7 @@ use crate::model::prelude::*;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditChannel<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -7,7 +7,7 @@ use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to optionally edit certain fields of a [`Guild`].
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditGuild<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -9,7 +9,7 @@ use crate::model::prelude::*;
 /// A builder to specify the fields to edit in a [`GuildWelcomeScreen`].
 ///
 /// [`GuildWelcomeScreen`]: crate::model::guild::GuildWelcomeScreen
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditGuildWelcomeScreen<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -85,7 +85,7 @@ impl<'a> Builder for EditGuildWelcomeScreen<'a> {
 /// A builder for creating a [`GuildWelcomeChannel`].
 ///
 /// [`GuildWelcomeChannel`]: crate::model::guild::GuildWelcomeChannel
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct CreateGuildWelcomeChannel {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -9,7 +9,7 @@ use crate::model::prelude::*;
 /// A builder to specify the fields to edit in a [`GuildWidget`].
 ///
 /// [`GuildWidget`]: crate::model::guild::GuildWidget
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditGuildWidget<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -17,7 +17,7 @@ use crate::model::prelude::*;
 #[cfg(feature = "http")]
 use crate::utils::check_overflow;
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditInteractionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 
 /// A builder which edits the properties of a [`Member`], to be used in conjunction with
 /// [`Member::edit`].
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditMember<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -43,7 +43,7 @@ use crate::utils::check_overflow;
 /// ```
 ///
 /// [`Message`]: crate::model::channel::Message
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditMessage {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -10,7 +10,7 @@ use crate::model::user::CurrentUser;
 
 /// A builder to edit the current user's settings, to be used in conjunction with
 /// [`CurrentUser::edit`].
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditProfile {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -41,7 +41,7 @@ use crate::model::prelude::*;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditRole<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -7,7 +7,7 @@ use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditScheduledEvent<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -8,7 +8,7 @@ use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Edits a [`StageInstance`].
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditStageInstance<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_sticker.rs
+++ b/src/builder/edit_sticker.rs
@@ -21,7 +21,7 @@ use crate::model::prelude::*;
 /// [`Guild::edit_sticker`]: crate::model::guild::Guild::edit_sticker
 /// [`GuildId::edit_sticker`]: crate::model::id::GuildId::edit_sticker
 /// [`Sticker::edit`]: crate::model::sticker::Sticker::edit
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditSticker<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -7,7 +7,7 @@ use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditThread<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 
 /// A builder which edits a user's voice state, to be used in conjunction with
 /// [`GuildChannel::edit_voice_state`].
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditVoiceState {
     channel_id: Option<ChannelId>,

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -7,7 +7,7 @@ use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[must_use]
 pub struct EditWebhook<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -15,7 +15,7 @@ use crate::utils::check_overflow;
 /// A builder to specify the fields to edit in an existing [`Webhook`]'s message.
 ///
 /// [`Webhook`]: crate::model::webhook::Webhook
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct EditWebhookMessage {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -50,7 +50,7 @@ use crate::utils::check_overflow;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct ExecuteWebhook {
     tts: bool,

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -44,7 +44,7 @@ use crate::model::prelude::*;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 #[must_use]
 pub struct GetMessages {
     search_filter: Option<SearchFilter>,
@@ -113,7 +113,7 @@ impl Builder for GetMessages {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 enum SearchFilter {
     After(MessageId),
     Around(MessageId),

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -19,7 +19,7 @@ use crate::internal::prelude::*;
 /// [`serde::Deserialize`] is useful to be able to store builders locally.
 #[cfg(feature = "http")]
 #[async_trait::async_trait]
-pub trait Builder {
+pub trait Builder: serde::Serialize + serde::de::DeserializeOwned {
     /// Further context that's not stored in the builder itself, like which channel to execute the
     /// request in.
     type Context<'ctx>;

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -63,8 +63,6 @@ mod edit_webhook;
 mod edit_webhook_message;
 mod execute_webhook;
 mod get_messages;
-#[cfg(feature = "collector")]
-mod quick_modal;
 
 pub use add_member::*;
 pub use bot_auth_parameters::*;
@@ -104,8 +102,6 @@ pub use edit_webhook::*;
 pub use edit_webhook_message::*;
 pub use execute_webhook::*;
 pub use get_messages::*;
-#[cfg(feature = "collector")]
-pub use quick_modal::*;
 
 macro_rules! button_and_select_menu_convenience_methods {
     () => {

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -12,9 +12,16 @@ use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 
+/// Common trait for all HTTP request builders in this module.
+///
+/// Will have a [`serde::Serialize`]` + `[`serde::Deserialize`] bound in the future, because
+/// builders need to be serializable in order to send them to the Discord API and
+/// [`serde::Deserialize`] is useful to be able to store builders locally.
 #[cfg(feature = "http")]
 #[async_trait::async_trait]
 pub trait Builder {
+    /// Further context that's not stored in the builder itself, like which channel to execute the
+    /// request in.
     type Context<'ctx>;
     type Built;
 

--- a/src/builder/quick_modal.rs
+++ b/src/builder/quick_modal.rs
@@ -1,8 +1,6 @@
 use super::{Builder, CreateActionRow, CreateInputText, CreateInteractionResponse, CreateModal};
-use crate::client::bridge::gateway::ShardMessenger;
+use crate::client::Context;
 use crate::collector::ModalInteractionCollector;
-use crate::http::CacheHttp;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 #[cfg(feature = "collector")]
@@ -76,22 +74,16 @@ impl CreateQuickModal {
     pub fn paragraph_field(self, label: impl Into<String>) -> Self {
         self.field(CreateInputText::new(InputTextStyle::Paragraph, label, ""))
     }
-}
-
-#[async_trait::async_trait]
-impl Builder for CreateQuickModal {
-    type Context<'ctx> = (InteractionId, &'ctx str, &'ctx ShardMessenger);
-    type Built = Option<QuickModalResponse>;
 
     /// # Errors
     ///
     /// See [`CreateInteractionResponse::execute()`].
-    async fn execute(
+    pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        let (interaction_id, token, shard) = ctx;
+        ctx: &Context,
+        interaction_id: InteractionId,
+        token: &str,
+    ) -> Result<Option<QuickModalResponse>, crate::Error> {
         let modal_custom_id = interaction_id.get().to_string();
         let builder = CreateInteractionResponse::Modal(
             CreateModal::new(&modal_custom_id, self.title).components(
@@ -104,10 +96,12 @@ impl Builder for CreateQuickModal {
                     .collect(),
             ),
         );
-        builder.execute(cache_http, (interaction_id, token)).await?;
+        builder.execute(ctx, (interaction_id, token)).await?;
 
-        let modal_interaction =
-            ModalInteractionCollector::new(shard).custom_ids(vec![modal_custom_id]).next().await;
+        let modal_interaction = ModalInteractionCollector::new(&ctx.shard)
+            .custom_ids(vec![modal_custom_id])
+            .next()
+            .await;
 
         let Some(modal_interaction) = modal_interaction else {return Ok(None)};
 

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -13,8 +13,6 @@ use crate::builder::{
     EditInteractionResponse,
 };
 #[cfg(feature = "collector")]
-use crate::builder::{CreateQuickModal, QuickModalResponse};
-#[cfg(feature = "collector")]
 use crate::client::Context;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
@@ -37,6 +35,8 @@ use crate::model::id::{
 };
 use crate::model::user::User;
 use crate::model::Permissions;
+#[cfg(all(feature = "collector", feature = "utils"))]
+use crate::utils::{CreateQuickModal, QuickModalResponse};
 
 /// An interaction when a user invokes a slash command.
 ///
@@ -225,7 +225,7 @@ impl CommandInteraction {
     /// # Errors
     ///
     /// See [`CreateQuickModal::execute()`].
-    #[cfg(feature = "collector")]
+    #[cfg(all(feature = "collector", feature = "utils"))]
     pub async fn quick_modal(
         &self,
         ctx: &Context,

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -231,7 +231,7 @@ impl CommandInteraction {
         ctx: &Context,
         builder: CreateQuickModal,
     ) -> Result<Option<QuickModalResponse>> {
-        builder.execute(ctx, (self.id, &self.token, &ctx.shard)).await
+        builder.execute(ctx, self.id, &self.token).await
     }
 }
 

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -10,8 +10,6 @@ use crate::builder::{
     EditInteractionResponse,
 };
 #[cfg(feature = "collector")]
-use crate::builder::{CreateQuickModal, QuickModalResponse};
-#[cfg(feature = "collector")]
 use crate::client::Context;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
@@ -32,6 +30,8 @@ use crate::model::id::{
 };
 use crate::model::user::User;
 use crate::model::Permissions;
+#[cfg(all(feature = "collector", feature = "utils"))]
+use crate::utils::{CreateQuickModal, QuickModalResponse};
 
 /// An interaction triggered by a message component.
 ///
@@ -221,7 +221,7 @@ impl ComponentInteraction {
     /// # Errors
     ///
     /// See [`CreateQuickModal::execute()`].
-    #[cfg(feature = "collector")]
+    #[cfg(all(feature = "collector", feature = "utils"))]
     pub async fn quick_modal(
         &self,
         ctx: &Context,

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -227,7 +227,7 @@ impl ComponentInteraction {
         ctx: &Context,
         builder: CreateQuickModal,
     ) -> Result<Option<QuickModalResponse>> {
-        builder.execute(ctx, (self.id, &self.token, &ctx.shard)).await
+        builder.execute(ctx, self.id, &self.token).await
     }
 }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -224,7 +224,7 @@ enum_number! {
     /// A representation of a type of channel.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).
-    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ChannelType {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,8 @@ mod argument_convert;
 mod content_safe;
 mod custom_message;
 mod message_builder;
+#[cfg(feature = "collector")]
+mod quick_modal;
 
 pub mod token;
 
@@ -16,6 +18,8 @@ use std::num::NonZeroU64;
 pub use argument_convert::*;
 #[cfg(feature = "cache")]
 pub use content_safe::*;
+#[cfg(feature = "collector")]
+pub use quick_modal::*;
 use url::Url;
 
 pub use self::custom_message::CustomMessage;

--- a/src/utils/quick_modal.rs
+++ b/src/utils/quick_modal.rs
@@ -1,4 +1,10 @@
-use super::{Builder, CreateActionRow, CreateInputText, CreateInteractionResponse, CreateModal};
+use crate::builder::{
+    Builder as _,
+    CreateActionRow,
+    CreateInputText,
+    CreateInteractionResponse,
+    CreateModal,
+};
 use crate::client::Context;
 use crate::collector::ModalInteractionCollector;
 use crate::model::prelude::*;

--- a/src/utils/quick_modal.rs
+++ b/src/utils/quick_modal.rs
@@ -18,7 +18,7 @@ pub struct QuickModalResponse {
 /// Convenience builder to create a modal, wait for the user to submit and parse the response.
 ///
 /// ```rust
-/// # use serenity::{builder::*, model::prelude::*, prelude::*, Result};
+/// # use serenity::{builder::*, model::prelude::*, prelude::*, utils::CreateQuickModal, Result};
 /// # async fn _foo(ctx: &Context, interaction: &CommandInteraction) -> Result<()> {
 /// let modal = CreateQuickModal::new("About you")
 ///     .timeout(std::time::Duration::from_secs(600))


### PR DESCRIPTION
## This PR

This PR adds the `Deserialize` trait (and sometimes `Serialize`) to all types [found here](https://docs.rs/serenity/0.11.5/serenity/builder/index.html), barring several that don't seem to benefit from it.

## Notes

- #2335 should be merged first (I'll keep this a draft until that has been completed)

## Issues

This will close #2324 