### PR TITLE
Fix `defer_ephemeral` for modals

### DIFF
--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -269,7 +269,7 @@ impl ModalSubmitInteraction {
     /// API response.
     pub async fn defer_ephemeral(&self, http: impl AsRef<Http>) -> Result<()> {
         self.create_interaction_response(http, |f| {
-            f.kind(InteractionResponseType::DeferredUpdateMessage)
+            f.kind(InteractionResponseType::DeferredChannelMessageWithSource)
                 .interaction_response_data(|f| f.ephemeral(true))
         })
         .await


### PR DESCRIPTION
Deferring an interaction ephemerally should be done using `DeferredChannelMessageWithSource`. Apparently modals support also using `DeferredUpdateMessage`, but this is undocumented.