### PR TITLE
Make start_typing infallible

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4259,19 +4259,17 @@ impl Http {
     /// # use serenity::model::prelude::*;
     /// #
     /// # fn long_process() {}
-    /// # fn main() -> Result<()> {
+    /// # fn main() {
     /// # let http: Arc<Http> = unimplemented!();
     /// // Initiate typing (assuming http is `Arc<Http>`)
     /// let channel_id = ChannelId::new(7);
-    /// let typing = http.start_typing(channel_id)?;
+    /// let typing = http.start_typing(channel_id);
     ///
     /// // Run some long-running process
     /// long_process();
     ///
     /// // Stop typing
     /// typing.stop();
-    /// #
-    /// # Ok(())
     /// # }
     /// ```
     pub fn start_typing(self: &Arc<Self>, channel_id: ChannelId) -> Typing {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4274,7 +4274,7 @@ impl Http {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn start_typing(self: &Arc<Self>, channel_id: ChannelId) -> Result<Typing> {
+    pub fn start_typing(self: &Arc<Self>, channel_id: ChannelId) -> Typing {
         Typing::start(self.clone(), channel_id)
     }
 

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -30,18 +30,17 @@ use crate::model::id::ChannelId;
 /// # use std::sync::Arc;
 /// #
 /// # fn long_process() {}
-/// # fn main() -> Result<()> {
+/// # fn main() {
 /// # let http: Http = unimplemented!();
 /// let channel_id = ChannelId::new(7);
 /// // Initiate typing (assuming `http` is bound)
-/// let typing = Typing::start(Arc::new(http), channel_id)?;
+/// let typing = Typing::start(Arc::new(http), channel_id);
 ///
 /// // Run some long-running process
 /// long_process();
 ///
 /// // Stop typing
 /// typing.stop();
-/// # Ok(())
 /// # }
 /// ```
 ///

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -61,7 +61,7 @@ impl Typing {
     /// Returns an  [`Error::Http`] if there is an error.
     ///
     /// [`Channel`]: crate::model::channel::Channel
-    pub fn start(http: Arc<Http>, channel_id: ChannelId) -> Result<Self> {
+    pub fn start(http: Arc<Http>, channel_id: ChannelId) -> Self {
         let (sx, mut rx) = oneshot::channel();
 
         spawn_named::<_, Result<_>>("typing::start", async move {
@@ -78,10 +78,10 @@ impl Typing {
                 sleep(Duration::from_secs(7)).await;
             }
 
-            Result::Ok(())
+            Ok(())
         });
 
-        Ok(Self(sx))
+        Self(sx)
     }
 
     /// Stops typing in [`Channel`].

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -754,22 +754,20 @@ impl ChannelId {
     /// ## Examples
     ///
     /// ```rust,no_run
-    /// # use serenity::{http::{Http, Typing}, Result, model::id::ChannelId};
+    /// # use serenity::{http::Http, Result, model::id::ChannelId};
     /// # use std::sync::Arc;
     /// #
     /// # fn long_process() {}
-    /// # fn main() -> Result<()> {
+    /// # fn main() {
     /// # let http: Arc<Http> = unimplemented!();
     /// // Initiate typing (assuming http is `Arc<Http>`)
-    /// let typing = ChannelId::new(7).start_typing(&http)?;
+    /// let typing = ChannelId::new(7).start_typing(&http);
     ///
     /// // Run some long-running process
     /// long_process();
     ///
     /// // Stop typing
     /// typing.stop();
-    /// #
-    /// # Ok(())
     /// # }
     /// ```
     ///

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -777,7 +777,7 @@ impl ChannelId {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission
     /// to send messages in this channel.
-    pub fn start_typing(self, http: &Arc<Http>) -> Result<Typing> {
+    pub fn start_typing(self, http: &Arc<Http>) -> Typing {
         http.start_typing(self)
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -980,7 +980,7 @@ impl GuildChannel {
     /// # }
     /// ```
     #[allow(clippy::missing_errors_doc)]
-    pub fn start_typing(&self, http: &Arc<Http>) -> Result<Typing> {
+    pub fn start_typing(&self, http: &Arc<Http>) -> Typing {
         http.start_typing(self.id)
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -955,13 +955,8 @@ impl GuildChannel {
     ///
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # use serenity::{
-    /// #    cache::Cache,
-    /// #    http::{Http, Typing},
-    /// #    model::{ModelError, channel::GuildChannel, id::ChannelId},
-    /// #    Result,
-    /// # };
+    /// # async fn run() {
+    /// # use serenity::{cache::Cache, http::Http, model::channel::GuildChannel, Result};
     /// # use std::sync::Arc;
     /// #
     /// # fn long_process() {}
@@ -969,14 +964,13 @@ impl GuildChannel {
     /// # let cache = Cache::default();
     /// # let channel: GuildChannel = unimplemented!();
     /// // Initiate typing (assuming http is `Arc<Http>` and `channel` is bound)
-    /// let typing = channel.start_typing(&http)?;
+    /// let typing = channel.start_typing(&http);
     ///
     /// // Run some long-running process
     /// long_process();
     ///
     /// // Stop typing
     /// typing.stop();
-    /// # Ok(())
     /// # }
     /// ```
     #[allow(clippy::missing_errors_doc)]

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -351,7 +351,7 @@ impl PrivateChannel {
     /// # Errors
     ///
     /// May return [`Error::Http`] if the current user cannot send a direct message to this user.
-    pub fn start_typing(self, http: &Arc<Http>) -> Result<Typing> {
+    pub fn start_typing(self, http: &Arc<Http>) -> Typing {
         http.start_typing(self.id)
     }
 

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -323,13 +323,8 @@ impl PrivateChannel {
     ///
     /// ```rust,no_run
     /// # #[cfg(feature = "cache")]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// # use serenity::{
-    /// #    cache::Cache,
-    /// #    http::{Http, Typing},
-    /// #    model::{ModelError, channel::PrivateChannel, id::ChannelId},
-    /// #    Result,
-    /// # };
+    /// # async fn run() {
+    /// # use serenity::{cache::Cache, http::Http, model::channel::PrivateChannel, Result};
     /// # use std::sync::Arc;
     /// #
     /// # fn long_process() {}
@@ -337,14 +332,13 @@ impl PrivateChannel {
     /// # let cache = Cache::default();
     /// # let channel: PrivateChannel = unimplemented!();
     /// // Initiate typing (assuming http is `Arc<Http>` and `channel` is bound)
-    /// let typing = channel.start_typing(&http)?;
+    /// let typing = channel.start_typing(&http);
     ///
     /// // Run some long-running process
     /// long_process();
     ///
     /// // Stop typing
     /// typing.stop();
-    /// # Ok(())
     /// # }
     /// ```
     ///


### PR DESCRIPTION
Since `Typing::start` spawns a separate task to perform anything that's fallible, the method itself can be be unfallible, as well as any methods that call it.