### PR TITLE
Fix clippy lints

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,1 @@
 cognitive-complexity-threshold = 20
-doc-valid-idents = [
-    "UserAgent",
-    "WebSocket",
-]
-enum-variant-name-threshold = 1
-single-char-binding-names-threshold = 3

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -24,10 +24,11 @@ use syn::{
 use crate::consts::CHECK;
 use crate::util::{self, Argument, AsOption, IdentExt2, Parenthesised};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub enum OnlyIn {
     Dm,
     Guild,
+    #[default]
     None,
 }
 
@@ -50,13 +51,6 @@ impl ToTokens for OnlyIn {
             Self::Guild => stream.extend(quote!(#only_in_path::Guild)),
             Self::None => stream.extend(quote!(#only_in_path::None)),
         }
-    }
-}
-
-impl Default for OnlyIn {
-    #[inline]
-    fn default() -> Self {
-        OnlyIn::None
     }
 }
 

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -98,7 +98,7 @@ use crate::client::{Client, FullEvent};
 pub trait Framework: Send + Sync {
     /// Called directly after the `Client` is created.
     async fn init(&mut self, client: &Client) {
-        let _ = client;
+        let _: &Client = client;
     }
     /// Called on every incoming event.
     async fn dispatch(&self, event: FullEvent);


### PR DESCRIPTION
The default value of `enum-variant-name-threshold` is 3, which seems sane. The additional removed clippy config options are no longer relevant.