### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,19 +26,19 @@ serde = { version = "1.0.130", features = ["derive"] }
 url = { version = "^2.1", features = ["serde"] }
 tokio = { version = "1", features = ["fs", "macros", "rt", "sync", "time", "io-util"] }
 futures = { version = "0.3", default-features = false, features = ["std"] }
-dep_time = { version = "0.3.6", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
+dep_time = { version = "0.3.20", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
-simd-json = { version = "0.6", optional = true }
+simd-json = { version = "0.7", optional = true }
 uwl = { version = "0.6.0", optional = true }
-base64 = { version = "0.13", optional = true }
+base64 = { version = "0.21", optional = true }
 levenshtein = { version = "1.0.5", optional = true }
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.13", optional = true }
 reqwest = { version = "0.11.7", default-features = false, features = ["multipart", "stream"], optional = true }
 static_assertions = { version = "1.1", optional = true }
-tokio-tungstenite = { version = "0.17", optional = true }
-typemap_rev = { version = "0.1.3", optional = true }
+tokio-tungstenite = { version = "0.18", optional = true }
+typemap_rev = { version = "0.3.0", optional = true }
 bytes = { version = "1.0", optional = true }
 percent-encoding = { version = "2.1", optional = true }
 mini-moka = { version = "0.10", optional = true }

--- a/examples/e06_sample_bot_structure/Cargo.toml
+++ b/examples/e06_sample_bot_structure/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 dotenv = "0.15"
 tracing = "0.1.23"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 
 [dependencies.tokio]
 version = "1.0"

--- a/examples/e07_env_logging/Cargo.toml
+++ b/examples/e07_env_logging/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tracing = "0.1.23"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [dependencies.serenity]

--- a/examples/e15_simple_dashboard/Cargo.toml
+++ b/examples/e15_simple_dashboard/Cargo.toml
@@ -10,9 +10,9 @@ rillrate = "0.41"
 notify = "=5.0.0-pre.14"
 
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 
-webbrowser = "0.5"
+webbrowser = "0.8"
 
 [dependencies.serenity]
 path = "../../"

--- a/examples/e16_sqlite_database/Cargo.toml
+++ b/examples/e16_sqlite_database/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-sqlx = { version = "0.5.7", features = ["runtime-tokio-rustls", "sqlite", "offline"] }
+sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "sqlite", "offline"] }

--- a/examples/e19_interactions_endpoint/Cargo.toml
+++ b/examples/e19_interactions_endpoint/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["builder", "interactions_endpoint"] }
-tiny_http = "0.11.0"
+tiny_http = "0.12.0"
 serde_json = "1.0"

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache", "collector"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.9.1"
+env_logger = "0.10.0"

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -110,7 +110,10 @@ impl CreateAttachment {
     /// places.
     #[must_use]
     pub fn to_base64(&self) -> String {
-        let mut encoded = base64::encode(&self.data);
+        let mut encoded = {
+            use base64::Engine;
+            base64::prelude::BASE64_STANDARD.encode(&self.data)
+        };
         encoded.insert_str(0, "data:image/png;base64,");
         encoded
     }

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -131,13 +131,13 @@ impl WsClient {
                     why
                 })?;
 
-                from_str(decompressed.as_mut_str()).map_err(|why| {
+                from_str(decompressed).map_err(|why| {
                     warn!("Err deserializing bytes: {:?}; bytes: {:?}", why, bytes);
 
                     why
                 })?
             },
-            Message::Text(mut payload) => from_str(&mut payload).map_err(|why| {
+            Message::Text(payload) => from_str(payload.clone()).map_err(|why| {
                 warn!("Err deserializing text: {:?}; text: {}", why, payload);
 
                 why

--- a/src/json.rs
+++ b/src/json.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 
-use serde::de::{Deserialize, DeserializeOwned};
+use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
 use crate::Result;
@@ -65,15 +65,18 @@ where
     Ok(result)
 }
 
+#[cfg_attr(not(feature = "simd-json"), allow(unused_mut))]
 #[allow(clippy::missing_errors_doc)] // It's obvious
-pub fn from_str<'a, T>(s: &'a mut str) -> Result<T>
+pub fn from_str<T>(mut s: String) -> Result<T>
 where
-    T: Deserialize<'a>,
+    T: DeserializeOwned,
 {
     #[cfg(not(feature = "simd-json"))]
-    let result = serde_json::from_str(s)?;
+    let result = serde_json::from_str(&s)?;
     #[cfg(feature = "simd-json")]
-    let result = simd_json::from_str(s)?;
+    // SAFETY: `simd_json::from_str` mutates the underlying string such that it might not be valid
+    // UTF-8 afterward. However, we own `s`, so it gets thrown away after it's used here.
+    let result = unsafe { simd_json::from_str(&mut s)? };
     Ok(result)
 }
 

--- a/voice-model/Cargo.toml
+++ b/voice-model/Cargo.toml
@@ -26,7 +26,7 @@ features = ["raw_value"]
 version = "1"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 serde_test = "1"
 
 [[bench]]


### PR DESCRIPTION
Update serenity's dependencies to the latest major versions. This requires a breaking change to the signature of `serenity::json::from_str`. This is to ensure the soundness of calling `simd_json::from_str`, which is unsafe, in that it might modify the underlying string such that it no longer contains valid UTF-8. So, if our wrapper function takes ownership of the buffer, it will be dropped at the end of the function, guaranteeing that invalid UTF-8 cannot be used afterward.