### PR TITLE
Introduce a `Builder` trait

### DIFF
--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "http")]
-use crate::http::Http;
+use super::Builder;
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -25,24 +27,6 @@ impl<'a> EditGuildWelcomeScreen<'a> {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Edits the guild's welcome screen.
-    ///
-    /// **Note**: Requires the [Manage Guild] permission.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
-    ///
-    /// [Manage Guild]: Permissions::MANAGE_GUILD
-    #[cfg(feature = "http")]
-    pub async fn execute(
-        self,
-        http: impl AsRef<Http>,
-        guild_id: GuildId,
-    ) -> Result<GuildWelcomeScreen> {
-        http.as_ref().edit_guild_welcome_screen(guild_id, &self, self.audit_log_reason).await
     }
 
     /// Whether the welcome screen is enabled or not.
@@ -71,6 +55,30 @@ impl<'a> EditGuildWelcomeScreen<'a> {
     pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
         self.audit_log_reason = Some(reason);
         self
+    }
+}
+
+#[cfg(feature = "http")]
+#[async_trait::async_trait]
+impl<'a> Builder for EditGuildWelcomeScreen<'a> {
+    type Context<'ctx> = GuildId;
+    type Built = GuildWelcomeScreen;
+
+    /// Edits the guild's welcome screen.
+    ///
+    /// **Note**: Requires the [Manage Guild] permission.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    ///
+    /// [Manage Guild]: Permissions::MANAGE_GUILD
+    async fn execute(
+        self,
+        cache_http: impl CacheHttp,
+        ctx: Self::Context<'_>,
+    ) -> Result<Self::Built> {
+        cache_http.http().edit_guild_welcome_screen(ctx, &self, self.audit_log_reason).await
     }
 }
 

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "http")]
-use crate::http::{CacheHttp, Http};
+use super::Builder;
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
@@ -22,40 +24,6 @@ impl<'a> EditStageInstance<'a> {
         Self::default()
     }
 
-    /// Edits the stage instance
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
-    ///
-    /// Returns [`Error::Http`] if the channel is not a stage channel, or there is no stage
-    /// instance currently.
-    #[cfg(feature = "http")]
-    #[inline]
-    pub async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        channel_id: ChannelId,
-    ) -> Result<StageInstance> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.guild_channel(channel_id) {
-                    if channel.kind != ChannelType::Stage {
-                        return Err(Error::Model(ModelError::InvalidChannelType));
-                    }
-                }
-            }
-        }
-
-        self._execute(cache_http.http(), channel_id).await
-    }
-
-    #[cfg(feature = "http")]
-    async fn _execute(self, http: &Http, channel_id: ChannelId) -> Result<StageInstance> {
-        http.edit_stage_instance(channel_id, &self, self.audit_log_reason).await
-    }
-
     /// Sets the topic of the stage channel instance.
     pub fn topic(mut self, topic: impl Into<String>) -> Self {
         self.topic = Some(topic.into());
@@ -66,5 +34,39 @@ impl<'a> EditStageInstance<'a> {
     pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
         self.audit_log_reason = Some(reason);
         self
+    }
+}
+
+#[cfg(feature = "http")]
+#[async_trait::async_trait]
+impl<'a> Builder for EditStageInstance<'a> {
+    type Context<'ctx> = ChannelId;
+    type Built = StageInstance;
+
+    /// Edits the stage instance
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
+    ///
+    /// Returns [`Error::Http`] if the channel is not a stage channel, or there is no stage
+    /// instance currently.
+    async fn execute(
+        self,
+        cache_http: impl CacheHttp,
+        ctx: Self::Context<'_>,
+    ) -> Result<Self::Built> {
+        #[cfg(feature = "cache")]
+        {
+            if let Some(cache) = cache_http.cache() {
+                if let Some(channel) = cache.guild_channel(ctx) {
+                    if channel.kind != ChannelType::Stage {
+                        return Err(Error::Model(ModelError::InvalidChannelType));
+                    }
+                }
+            }
+        }
+
+        cache_http.http().edit_stage_instance(ctx, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "http")]
-use crate::http::{CacheHttp, Http};
+use super::Builder;
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -20,54 +22,6 @@ impl EditVoiceState {
     /// Equivalent to [`Self::default`].
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Edits the given user's voice state in a stage channel. Pass [`None`] for `user_id` to edit
-    /// the current user's voice state.
-    ///
-    /// **Note**: Requires the [Request to Speak] permission. Also requires the [Mute Members]
-    /// permission to suppress another user or unsuppress the current user. This is not required if
-    /// suppressing the current user.
-    ///
-    /// # Errors
-    ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidChannelType`] if the channel is
-    /// not a stage channel.
-    ///
-    /// Returns [`Error::Http`] if the user lacks permission, or if invalid data is given.
-    ///
-    /// [Request to Speak]: Permissions::REQUEST_TO_SPEAK
-    /// [Mute Members]: Permissions::MUTE_MEMBERS
-    #[cfg(feature = "http")]
-    pub async fn execute(
-        mut self,
-        cache_http: impl CacheHttp,
-        guild_id: GuildId,
-        channel_id: ChannelId,
-        user_id: Option<UserId>,
-    ) -> Result<()> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.guild_channel(channel_id) {
-                    if channel.kind != ChannelType::Stage {
-                        return Err(Error::from(ModelError::InvalidChannelType));
-                    }
-                }
-            }
-        }
-
-        self.channel_id = Some(channel_id);
-        self._execute(cache_http.http(), guild_id, user_id).await
-    }
-
-    #[cfg(feature = "http")]
-    async fn _execute(self, http: &Http, guild_id: GuildId, user_id: Option<UserId>) -> Result<()> {
-        if let Some(user_id) = user_id {
-            http.edit_voice_state(guild_id, user_id, &self).await
-        } else {
-            http.edit_voice_state_me(guild_id, &self).await
-        }
     }
 
     /// Whether to suppress the user. Setting this to false will invite a user to speak.
@@ -101,5 +55,53 @@ impl EditVoiceState {
     pub fn request_to_speak_timestamp(mut self, timestamp: impl Into<Timestamp>) -> Self {
         self.request_to_speak_timestamp = Some(Some(timestamp.into()));
         self
+    }
+}
+
+#[cfg(feature = "http")]
+#[async_trait::async_trait]
+impl Builder for EditVoiceState {
+    type Context<'ctx> = (GuildId, ChannelId, Option<UserId>);
+    type Built = ();
+
+    /// Edits the given user's voice state in a stage channel. Providing a [`UserId`] will edit
+    /// that user's voice state, otherwise the current user's voice state will be edited.
+    ///
+    /// **Note**: Requires the [Request to Speak] permission. Also requires the [Mute Members]
+    /// permission to suppress another user or unsuppress the current user. This is not required if
+    /// suppressing the current user.
+    ///
+    /// # Errors
+    ///
+    /// If the `cache` is enabled, returns a [`ModelError::InvalidChannelType`] if the channel is
+    /// not a stage channel.
+    ///
+    /// Returns [`Error::Http`] if the user lacks permission, or if invalid data is given.
+    ///
+    /// [Request to Speak]: Permissions::REQUEST_TO_SPEAK
+    /// [Mute Members]: Permissions::MUTE_MEMBERS
+    async fn execute(
+        mut self,
+        cache_http: impl CacheHttp,
+        ctx: Self::Context<'_>,
+    ) -> Result<Self::Built> {
+        let (guild_id, channel_id, user_id) = ctx;
+        #[cfg(feature = "cache")]
+        {
+            if let Some(cache) = cache_http.cache() {
+                if let Some(channel) = cache.guild_channel(channel_id) {
+                    if channel.kind != ChannelType::Stage {
+                        return Err(Error::from(ModelError::InvalidChannelType));
+                    }
+                }
+            }
+        }
+
+        self.channel_id = Some(channel_id);
+        if let Some(user_id) = user_id {
+            cache_http.http().edit_voice_state(guild_id, user_id, &self).await
+        } else {
+            cache_http.http().edit_voice_state_me(guild_id, &self).await
+        }
     }
 }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -7,6 +7,24 @@
 // #[serde(skip_serializing_if = "Option::is_none")]
 #![allow(clippy::option_option)]
 
+#[cfg(feature = "http")]
+use crate::http::CacheHttp;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+
+#[cfg(feature = "http")]
+#[async_trait::async_trait]
+pub trait Builder {
+    type Context<'ctx>;
+    type Built;
+
+    async fn execute(
+        self,
+        cache_http: impl CacheHttp,
+        ctx: Self::Context<'_>,
+    ) -> Result<Self::Built>;
+}
+
 mod add_member;
 mod bot_auth_parameters;
 mod create_allowed_mentions;
@@ -119,4 +137,5 @@ macro_rules! button_and_select_menu_convenience_methods {
         }
     };
 }
+
 use button_and_select_menu_convenience_methods;

--- a/src/builder/quick_modal.rs
+++ b/src/builder/quick_modal.rs
@@ -1,6 +1,8 @@
-use super::{CreateActionRow, CreateInputText, CreateInteractionResponse, CreateModal};
-use crate::client::Context;
+use super::{Builder, CreateActionRow, CreateInputText, CreateInteractionResponse, CreateModal};
+use crate::client::bridge::gateway::ShardMessenger;
 use crate::collector::ModalInteractionCollector;
+use crate::http::CacheHttp;
+use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 #[cfg(feature = "collector")]
@@ -74,16 +76,22 @@ impl CreateQuickModal {
     pub fn paragraph_field(self, label: impl Into<String>) -> Self {
         self.field(CreateInputText::new(InputTextStyle::Paragraph, label, ""))
     }
+}
+
+#[async_trait::async_trait]
+impl Builder for CreateQuickModal {
+    type Context<'ctx> = (InteractionId, &'ctx str, &'ctx ShardMessenger);
+    type Built = Option<QuickModalResponse>;
 
     /// # Errors
     ///
     /// See [`CreateInteractionResponse::execute()`].
-    pub async fn execute(
+    async fn execute(
         self,
-        ctx: &Context,
-        interaction_id: InteractionId,
-        token: &str,
-    ) -> Result<Option<QuickModalResponse>, crate::Error> {
+        cache_http: impl CacheHttp,
+        ctx: Self::Context<'_>,
+    ) -> Result<Self::Built> {
+        let (interaction_id, token, shard) = ctx;
         let modal_custom_id = interaction_id.get().to_string();
         let builder = CreateInteractionResponse::Modal(
             CreateModal::new(&modal_custom_id, self.title).components(
@@ -96,12 +104,10 @@ impl CreateQuickModal {
                     .collect(),
             ),
         );
-        builder.execute(ctx, interaction_id, token).await?;
+        builder.execute(cache_http, (interaction_id, token)).await?;
 
-        let modal_interaction = ModalInteractionCollector::new(&ctx.shard)
-            .custom_ids(vec![modal_custom_id])
-            .next()
-            .await;
+        let modal_interaction =
+            ModalInteractionCollector::new(shard).custom_ids(vec![modal_custom_id]).next().await;
 
         let Some(modal_interaction) = modal_interaction else {return Ok(None)};
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2348,8 +2348,9 @@ impl Http {
     /// If `thread_id` is not `None`, then the message will be sent to the thread in the webhook's
     /// associated [`Channel`] with the corresponding Id, which will be automatically unarchived.
     ///
-    /// Pass `true` to `wait` to wait for server confirmation of the message sending before
-    /// receiving a response. From the [Discord docs]:
+    /// If `wait` is `false`, this function will return `Ok(None)` on success. Otherwise, it will
+    /// wait for server confirmation of the message having been sent, and return `Ok(Some(msg))`.
+    /// From the [Discord docs]:
     ///
     /// > waits for server confirmation of message send before response, and returns the created
     /// > message body (defaults to false; when false a message that is not saved does not return

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "model")]
-use crate::builder::CreateCommand;
+use crate::builder::{Builder, CreateCommand};
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 use crate::json::Value;
@@ -137,10 +137,10 @@ impl Command {
     ///
     /// [`InteractionCreate`]: crate::client::EventHandler::interaction_create
     pub async fn create_global_application_command(
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: CreateCommand,
     ) -> Result<Command> {
-        builder.execute(http, None, None).await
+        builder.execute(cache_http, (None, None)).await
     }
 
     /// Override all global application commands.
@@ -161,11 +161,11 @@ impl Command {
     ///
     /// See [`CreateCommand::execute`] for a list of possible errors.
     pub async fn edit_global_application_command(
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         command_id: CommandId,
         builder: CreateCommand,
     ) -> Result<Command> {
-        builder.execute(http, None, Some(command_id)).await
+        builder.execute(cache_http, (None, Some(command_id))).await
     }
 
     /// Gets all global commands.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "model")]
 use crate::builder::{
+    Builder,
     CreateAttachment,
     CreateForumPost,
     CreateInvite,
@@ -212,14 +213,11 @@ impl GuildChannel {
         cache_http: impl CacheHttp,
         builder: CreateInvite<'_>,
     ) -> Result<RichInvite> {
-        builder
-            .execute(
-                cache_http,
-                self.id,
-                #[cfg(feature = "cache")]
-                Some(self.guild_id),
-            )
-            .await
+        #[cfg(feature = "cache")]
+        let invite = builder.execute(cache_http, (self.id, Some(self.guild_id))).await;
+        #[cfg(not(feature = "cache"))]
+        let invite = builder.execute(cache_http, (self.id,)).await;
+        invite
     }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a single [`Member`] or
@@ -439,14 +437,11 @@ impl GuildChannel {
         cache_http: impl CacheHttp,
         builder: EditChannel<'_>,
     ) -> Result<()> {
-        *self = builder
-            .execute(
-                cache_http,
-                self.id,
-                #[cfg(feature = "cache")]
-                Some(self.guild_id),
-            )
-            .await?;
+        #[cfg(feature = "cache")]
+        let channel = builder.execute(cache_http, (self.id, Some(self.guild_id))).await?;
+        #[cfg(not(feature = "cache"))]
+        let channel = builder.execute(cache_http, (self.id,)).await?;
+        *self = channel;
         Ok(())
     }
 
@@ -467,11 +462,11 @@ impl GuildChannel {
     #[inline]
     pub async fn edit_message(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
         builder: EditMessage,
     ) -> Result<Message> {
-        self.id.edit_message(http, message_id, builder).await
+        self.id.edit_message(cache_http, message_id, builder).await
     }
 
     /// Edits a thread.
@@ -481,10 +476,10 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission.
     pub async fn edit_thread(
         &mut self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditThread<'_>,
     ) -> Result<()> {
-        *self = self.id.edit_thread(http, builder).await?;
+        *self = self.id.edit_thread(cache_http, builder).await?;
         Ok(())
     }
 
@@ -534,7 +529,7 @@ impl GuildChannel {
         user_id: impl Into<UserId>,
         builder: EditVoiceState,
     ) -> Result<()> {
-        builder.execute(cache_http, self.guild_id, self.id, Some(user_id.into())).await
+        builder.execute(cache_http, (self.guild_id, self.id, Some(user_id.into()))).await
     }
 
     /// Edits the current user's voice state in a stage channel.
@@ -586,7 +581,7 @@ impl GuildChannel {
         cache_http: impl CacheHttp,
         builder: EditVoiceState,
     ) -> Result<()> {
-        builder.execute(cache_http, self.guild_id, self.id, None).await
+        builder.execute(cache_http, (self.guild_id, self.id, None)).await
     }
 
     /// Follows the News Channel
@@ -671,10 +666,10 @@ impl GuildChannel {
     #[inline]
     pub async fn messages(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: GetMessages,
     ) -> Result<Vec<Message>> {
-        self.id.messages(http, builder).await
+        self.id.messages(cache_http, builder).await
     }
 
     /// Returns the name of the guild channel.
@@ -903,15 +898,7 @@ impl GuildChannel {
         files: impl IntoIterator<Item = CreateAttachment>,
         builder: CreateMessage,
     ) -> Result<Message> {
-        builder
-            .files(files)
-            .execute(
-                cache_http,
-                self.id,
-                #[cfg(feature = "cache")]
-                Some(self.guild_id),
-            )
-            .await
+        self.send_message(cache_http, builder.files(files)).await
     }
 
     /// Sends a message to the channel.
@@ -928,14 +915,11 @@ impl GuildChannel {
         cache_http: impl CacheHttp,
         builder: CreateMessage,
     ) -> Result<Message> {
-        builder
-            .execute(
-                cache_http,
-                self.id,
-                #[cfg(feature = "cache")]
-                Some(self.guild_id),
-            )
-            .await
+        #[cfg(feature = "cache")]
+        let msg = builder.execute(cache_http, (self.id, Some(self.guild_id))).await;
+        #[cfg(not(feature = "cache"))]
+        let msg = builder.execute(cache_http, (self.id,)).await;
+        msg
     }
 
     /// Starts typing in the channel for an indefinite period of time.
@@ -1166,11 +1150,11 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn create_public_thread(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_public_thread(http, message_id, builder).await
+        self.id.create_public_thread(cache_http, message_id, builder).await
     }
 
     /// Creates a private thread.
@@ -1180,10 +1164,10 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn create_private_thread(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_private_thread(http, builder).await
+        self.id.create_private_thread(cache_http, builder).await
     }
 
     /// Creates a post in a forum channel.
@@ -1193,10 +1177,10 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn create_forum_post(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: CreateForumPost<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_forum_post(http, builder).await
+        self.id.create_forum_post(cache_http, builder).await
     }
 }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 use std::fmt::Write;
 
 #[cfg(all(feature = "model", feature = "utils"))]
-use crate::builder::{CreateAllowedMentions, CreateMessage, EditMessage};
+use crate::builder::{Builder, CreateAllowedMentions, CreateMessage, EditMessage};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "collector")]
@@ -337,7 +337,7 @@ impl Message {
             }
         }
 
-        *self = builder.execute(cache_http.http(), self.channel_id, self.id).await?;
+        *self = builder.execute(cache_http, (self.channel_id, self.id)).await?;
         Ok(())
     }
 

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -147,14 +147,16 @@ impl PrivateChannel {
     ///
     /// See [`EditMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
+    ///
+    /// [`EditMessage::execute`]: ../../builder/struct.EditMessage.html#method.execute
     #[inline]
     pub async fn edit_message(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
         builder: EditMessage,
     ) -> Result<Message> {
-        self.id.edit_message(http, message_id, builder).await
+        self.id.edit_message(cache_http, message_id, builder).await
     }
 
     /// Determines if the channel is NSFW.
@@ -195,10 +197,10 @@ impl PrivateChannel {
     #[inline]
     pub async fn messages(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: GetMessages,
     ) -> Result<Vec<Message>> {
-        self.id.messages(http, builder).await
+        self.id.messages(cache_http, builder).await
     }
 
     /// Returns "DM with $username#discriminator".
@@ -260,6 +262,8 @@ impl PrivateChannel {
     ///
     /// Returns a [`ModelError::MessageTooLong`] if the content length is over the above limit. See
     /// [`CreateMessage::execute`] for more details.
+    ///
+    /// [`CreateMessage::execute`]: ../../builder/struct.CreateMessage.html#method.execute
     #[inline]
     pub async fn say(
         &self,
@@ -277,6 +281,8 @@ impl PrivateChannel {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
+    ///
+    /// [`CreateMessage::execute`]: ../../builder/struct.CreateMessage.html#method.execute
     #[inline]
     pub async fn send_files(
         self,
@@ -296,6 +302,8 @@ impl PrivateChannel {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
+    ///
+    /// [`CreateMessage::execute`]: ../../builder/struct.CreateMessage.html#method.execute
     #[inline]
     pub async fn send_message(
         &self,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -6,6 +6,7 @@ use futures::stream::Stream;
 #[cfg(feature = "model")]
 use crate::builder::{
     AddMember,
+    Builder,
     CreateChannel,
     CreateCommand,
     CreateCommandPermissionsData,
@@ -109,10 +110,10 @@ impl GuildId {
     #[inline]
     pub async fn create_automod_rule(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        builder.execute(http, self, None).await
+        builder.execute(cache_http, (self, None)).await
     }
 
     /// Edit an auto moderation [`Rule`], given its Id.
@@ -127,11 +128,11 @@ impl GuildId {
     #[inline]
     pub async fn edit_automod_rule(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         rule_id: impl Into<RuleId>,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        builder.execute(http, self, Some(rule_id.into())).await
+        builder.execute(cache_http, (self, Some(rule_id.into()))).await
     }
 
     /// Deletes an auto moderation [`Rule`] from the guild.
@@ -164,11 +165,11 @@ impl GuildId {
     #[inline]
     pub async fn add_member(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
         builder: AddMember,
     ) -> Result<Option<Member>> {
-        builder.execute(http, self, user_id.into()).await
+        builder.execute(cache_http, (self, user_id.into())).await
     }
 
     /// Ban a [`User`] from the guild, deleting a number of days' worth of messages (`dmd`) between
@@ -414,7 +415,7 @@ impl GuildId {
         cache_http: impl CacheHttp,
         builder: EditRole<'_>,
     ) -> Result<Role> {
-        builder.execute(cache_http, self, None).await
+        builder.execute(cache_http, (self, None)).await
     }
 
     /// Creates a new scheduled event in the guild with the data set, if any.
@@ -640,11 +641,11 @@ impl GuildId {
     #[inline]
     pub async fn edit_member(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
         builder: EditMember<'_>,
     ) -> Result<Member> {
-        builder.execute(http, self, user_id.into()).await
+        builder.execute(cache_http, (self, user_id.into())).await
     }
 
     /// Edits the current user's nickname for the guild.
@@ -706,7 +707,7 @@ impl GuildId {
         role_id: impl Into<RoleId>,
         builder: EditRole<'_>,
     ) -> Result<Role> {
-        builder.execute(cache_http, self, Some(role_id.into())).await
+        builder.execute(cache_http, (self, Some(role_id.into()))).await
     }
 
     /// Modifies a scheduled event in the guild with the data set, if any.
@@ -725,7 +726,7 @@ impl GuildId {
         event_id: impl Into<ScheduledEventId>,
         builder: EditScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
-        builder.execute(cache_http, self, event_id.into()).await
+        builder.execute(cache_http, (self, event_id.into())).await
     }
 
     /// Edits a sticker.
@@ -757,11 +758,11 @@ impl GuildId {
     #[inline]
     pub async fn edit_sticker(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         sticker_id: impl Into<StickerId>,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
-        builder.execute(http, self, sticker_id.into()).await
+        builder.execute(cache_http, (self, sticker_id.into())).await
     }
 
     /// Edit the position of a [`Role`] relative to all others in the [`Guild`].
@@ -801,10 +802,10 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_welcome_screen(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
-        builder.execute(http, self).await
+        builder.execute(cache_http, self).await
     }
 
     /// Edits the guild's widget.
@@ -818,10 +819,10 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_widget(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
-        builder.execute(http, self).await
+        builder.execute(cache_http, self).await
     }
 
     /// Gets all of the guild's roles over the REST API.
@@ -1084,12 +1085,12 @@ impl GuildId {
     #[inline]
     pub async fn move_member(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
         channel_id: impl Into<ChannelId>,
     ) -> Result<Member> {
         let builder = EditMember::new().voice_channel(channel_id.into());
-        self.edit_member(http, user_id, builder).await
+        self.edit_member(cache_http, user_id, builder).await
     }
 
     /// Returns the name of whatever guild this id holds.
@@ -1112,10 +1113,10 @@ impl GuildId {
     #[inline]
     pub async fn disconnect_member(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
     ) -> Result<Member> {
-        self.edit_member(http, user_id, EditMember::new().disconnect_member()).await
+        self.edit_member(cache_http, user_id, EditMember::new().disconnect_member()).await
     }
 
     /// Gets the number of [`Member`]s that would be pruned with the given number of days.
@@ -1424,10 +1425,10 @@ impl GuildId {
     /// See [`CreateCommand::execute`] for a list of possible errors.
     pub async fn create_application_command(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: CreateCommand,
     ) -> Result<Command> {
-        builder.execute(http, Some(self), None).await
+        builder.execute(cache_http, (Some(self), None)).await
     }
 
     /// Override all guild application commands.
@@ -1452,11 +1453,11 @@ impl GuildId {
     /// See [`CreateCommandPermissionsData::execute`] for a list of possible errors.
     pub async fn create_application_command_permission(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         command_id: CommandId,
         builder: CreateCommandPermissionsData,
     ) -> Result<CommandPermission> {
-        builder.execute(http, self, command_id).await
+        builder.execute(cache_http, (self, command_id)).await
     }
 
     /// Get all guild application commands.
@@ -1488,11 +1489,11 @@ impl GuildId {
     /// See [`CreateCommand::execute`] for a list of possible errors.
     pub async fn edit_application_command(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         command_id: CommandId,
         builder: CreateCommand,
     ) -> Result<Command> {
-        builder.execute(http, Some(self), Some(command_id)).await
+        builder.execute(cache_http, (Some(self), Some(command_id))).await
     }
 
     /// Delete guild application command by its Id.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -307,10 +307,10 @@ impl Guild {
     #[inline]
     pub async fn create_automod_rule(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        self.id.create_automod_rule(http, builder).await
+        self.id.create_automod_rule(cache_http, builder).await
     }
 
     /// Edit an auto moderation [`Rule`], given its Id.
@@ -325,11 +325,11 @@ impl Guild {
     #[inline]
     pub async fn edit_automod_rule(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         rule_id: impl Into<RuleId>,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        self.id.edit_automod_rule(http, rule_id, builder).await
+        self.id.edit_automod_rule(cache_http, rule_id, builder).await
     }
 
     /// Deletes an auto moderation [`Rule`] from the guild.
@@ -555,11 +555,11 @@ impl Guild {
     #[inline]
     pub async fn add_member(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
         builder: AddMember,
     ) -> Result<Option<Member>> {
-        self.id.add_member(http, user_id, builder).await
+        self.id.add_member(cache_http, user_id, builder).await
     }
 
     /// Retrieves a list of [`AuditLogs`] for the guild.
@@ -731,13 +731,15 @@ impl Guild {
     /// # Errors
     ///
     /// See [`CreateCommand::execute`] for a list of possible errors.
+    ///
+    /// [`CreateCommand::execute`]: ../../builder/struct.CreateCommand.html#method.execute
     #[inline]
     pub async fn create_application_command(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: CreateCommand,
     ) -> Result<Command> {
-        self.id.create_application_command(http, builder).await
+        self.id.create_application_command(cache_http, builder).await
     }
 
     /// Override all guild application commands.
@@ -760,13 +762,15 @@ impl Guild {
     /// # Errors
     ///
     /// See [`CreateCommandPermissionsData::execute`] for a list of possible errors.
+    ///
+    /// [`CreateCommandPermissionsData::execute`]: ../../builder/struct.CreateCommandPermissionsData.html#method.execute
     pub async fn create_application_command_permission(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         command_id: CommandId,
         builder: CreateCommandPermissionsData,
     ) -> Result<CommandPermission> {
-        self.id.create_application_command_permission(http, command_id, builder).await
+        self.id.create_application_command_permission(cache_http, command_id, builder).await
     }
 
     /// Get all guild application commands.
@@ -796,13 +800,15 @@ impl Guild {
     /// # Errors
     ///
     /// See [`CreateCommand::execute`] for a list of possible errors.
+    ///
+    /// [`CreateCommand::execute`]: ../../builder/struct.CreateCommand.html#method.execute
     pub async fn edit_application_command(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         command_id: CommandId,
         builder: CreateCommand,
     ) -> Result<Command> {
-        self.id.edit_application_command(http, command_id, builder).await
+        self.id.edit_application_command(cache_http, command_id, builder).await
     }
 
     /// Delete guild application command by its Id.
@@ -1107,11 +1113,11 @@ impl Guild {
     #[inline]
     pub async fn edit_member(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
         builder: EditMember<'_>,
     ) -> Result<Member> {
-        self.id.edit_member(http, user_id, builder).await
+        self.id.edit_member(cache_http, user_id, builder).await
     }
 
     /// Edits the current user's nickname for the guild.
@@ -1248,11 +1254,11 @@ impl Guild {
     #[inline]
     pub async fn edit_sticker(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         sticker_id: impl Into<StickerId>,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
-        self.id.edit_sticker(http, sticker_id, builder).await
+        self.id.edit_sticker(cache_http, sticker_id, builder).await
     }
 
     /// Edits the guild's welcome screen.
@@ -1266,10 +1272,10 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_welcome_screen(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
-        self.id.edit_welcome_screen(http, builder).await
+        self.id.edit_welcome_screen(cache_http, builder).await
     }
 
     /// Edits the guild's widget.
@@ -1283,10 +1289,10 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_widget(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
-        self.id.edit_widget(http, builder).await
+        self.id.edit_widget(cache_http, builder).await
     }
 
     /// Gets a partial amount of guild data by its Id.
@@ -1894,11 +1900,11 @@ impl Guild {
     #[inline]
     pub async fn move_member(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
         channel_id: impl Into<ChannelId>,
     ) -> Result<Member> {
-        self.id.move_member(http, user_id, channel_id).await
+        self.id.move_member(cache_http, user_id, channel_id).await
     }
 
     /// Calculate a [`Member`]'s permissions in a given channel in the guild.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -193,10 +193,10 @@ impl PartialGuild {
     #[inline]
     pub async fn create_automod_rule(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        self.id.create_automod_rule(http, builder).await
+        self.id.create_automod_rule(cache_http, builder).await
     }
 
     /// Edit an auto moderation [`Rule`], given its Id.
@@ -211,11 +211,11 @@ impl PartialGuild {
     #[inline]
     pub async fn edit_automod_rule(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         rule_id: impl Into<RuleId>,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        self.id.edit_automod_rule(http, rule_id, builder).await
+        self.id.edit_automod_rule(cache_http, rule_id, builder).await
     }
 
     /// Deletes an auto moderation [`Rule`] from the guild.
@@ -455,13 +455,15 @@ impl PartialGuild {
     /// # Errors
     ///
     /// See [`CreateCommand::execute`] for a list of possible errors.
+    ///
+    /// [`CreateCommand::execute`]: ../../builder/struct.CreateCommand.html#method.execute
     #[inline]
     pub async fn create_application_command(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: CreateCommand,
     ) -> Result<Command> {
-        self.id.create_application_command(http, builder).await
+        self.id.create_application_command(cache_http, builder).await
     }
 
     /// Override all guild application commands.
@@ -484,13 +486,15 @@ impl PartialGuild {
     /// # Errors
     ///
     /// See [`CreateCommandPermissionsData::execute`] for a list of possible errors.
+    ///
+    /// [`CreateCommandPermissionsData::execute`]: ../../builder/struct.CreateCommandPermissionsData.html#method.execute
     pub async fn create_application_command_permission(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         command_id: CommandId,
         builder: CreateCommandPermissionsData,
     ) -> Result<CommandPermission> {
-        self.id.create_application_command_permission(http, command_id, builder).await
+        self.id.create_application_command_permission(cache_http, command_id, builder).await
     }
 
     /// Get all guild application commands.
@@ -520,13 +524,15 @@ impl PartialGuild {
     /// # Errors
     ///
     /// See [`CreateCommand::execute`] for a list of possible errors.
+    ///
+    /// [`CreateCommand::execute`]: ../../builder/struct.CreateCommand.html#method.execute
     pub async fn edit_application_command(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         command_id: CommandId,
         builder: CreateCommand,
     ) -> Result<Command> {
-        self.id.edit_application_command(http, command_id, builder).await
+        self.id.edit_application_command(cache_http, command_id, builder).await
     }
 
     /// Delete guild application command by its Id.
@@ -764,11 +770,11 @@ impl PartialGuild {
     #[inline]
     pub async fn edit_member(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
         builder: EditMember<'_>,
     ) -> Result<Member> {
-        self.id.edit_member(http, user_id, builder).await
+        self.id.edit_member(cache_http, user_id, builder).await
     }
 
     /// Edits the current user's nickname for the guild.
@@ -873,11 +879,11 @@ impl PartialGuild {
     #[inline]
     pub async fn edit_sticker(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         sticker_id: impl Into<StickerId>,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
-        self.id.edit_sticker(http, sticker_id, builder).await
+        self.id.edit_sticker(cache_http, sticker_id, builder).await
     }
 
     /// Edits the guild's welcome screen.
@@ -891,10 +897,10 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_welcome_screen(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
-        self.id.edit_welcome_screen(http, builder).await
+        self.id.edit_welcome_screen(cache_http, builder).await
     }
 
     /// Edits the guild's widget.
@@ -908,10 +914,10 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_widget(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
-        self.id.edit_widget(http, builder).await
+        self.id.edit_widget(cache_http, builder).await
     }
 
     /// Gets a partial amount of guild data by its Id.
@@ -1307,11 +1313,11 @@ impl PartialGuild {
     #[inline]
     pub async fn move_member(
         &self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
         channel_id: impl Into<ChannelId>,
     ) -> Result<Member> {
-        self.id.move_member(http, user_id, channel_id).await
+        self.id.move_member(cache_http, user_id, channel_id).await
     }
 
     /// Calculate a [`Member`]'s permissions in a given channel in the guild.

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "model")]
 use crate::builder::EditSticker;
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -43,11 +43,11 @@ impl StickerId {
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
     pub async fn edit(
         self,
-        http: impl AsRef<Http>,
+        cache_http: impl CacheHttp,
         guild_id: impl Into<GuildId>,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
-        guild_id.into().edit_sticker(http, self, builder).await
+        guild_id.into().edit_sticker(cache_http, self, builder).await
     }
 }
 
@@ -219,9 +219,13 @@ impl Sticker {
     ///
     /// [Manage Emojis and Stickers]: Permissions::MANAGE_EMOJIS_AND_STICKERS
     #[inline]
-    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditSticker<'_>) -> Result<()> {
+    pub async fn edit(
+        &mut self,
+        cache_http: impl CacheHttp,
+        builder: EditSticker<'_>,
+    ) -> Result<()> {
         if let Some(guild_id) = self.guild_id {
-            *self = self.id.edit(http, guild_id, builder).await?;
+            *self = self.id.edit(cache_http, guild_id, builder).await?;
             Ok(())
         } else {
             Err(Error::Model(ModelError::DeleteNitroSticker))

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::prelude::*;
 #[cfg(feature = "model")]
-use crate::builder::{CreateBotAuthParameters, CreateMessage, EditProfile};
+use crate::builder::{Builder, CreateBotAuthParameters, CreateMessage, EditProfile};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, UserRef};
 #[cfg(feature = "collector")]
@@ -252,8 +252,8 @@ impl CurrentUser {
     ///
     /// Returns an [`Error::Http`] if an invalid value is set. May also return an [`Error::Json`]
     /// if there is an error in deserializing the API response.
-    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditProfile) -> Result<()> {
-        *self = builder.execute(http).await?;
+    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditProfile) -> Result<()> {
+        *self = builder.execute(cache_http, ()).await?;
         Ok(())
     }
 


### PR DESCRIPTION
Since every builder has a `fn execute()` method, it makes sense to factor it out into a trait. One benefit of doing this is that, in the docs, the method no longer appears in the list of inherent methods for the struct, instead appearing below them in the list of implemented traits. This helps declutter the docs.

However, a unified function signature does require changing some builders to take a tuple of parameters, instead of multiple inline parameters. While technically a breaking change, this is more or less an implementation detail because most users will interface with builders through the model methods. Also, some model methods now take `impl CacheHttp` instead of `AsRef<Http>`, but the former is compatible with the latter, so this is not a breaking change.

Breaking change:
 \- All builders now take 3 arguments for their `execute` method.