### PR TITLE
Add `GuildMfa` endpoint

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1727,6 +1727,11 @@ impl Http {
         value: &Value,
         audit_log_reason: Option<&str>,
     ) -> Result<MfaLevel> {
+        #[derive(Deserialize)]
+        struct GuildMfaLevel {
+            level: MfaLevel,
+        }
+
         let body = to_vec(value)?;
 
         self.fire(Request {
@@ -1740,6 +1745,7 @@ impl Http {
             params: None,
         })
         .await
+        .map(|mfa: GuildMfaLevel| mfa.level)
     }
 
     /// Edits a [`Guild`]'s widget.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1720,6 +1720,28 @@ impl Http {
         .await
     }
 
+    /// Edits the MFA level of a guild. Requires guild ownership.
+    pub async fn edit_guild_mfa_level(
+        &self,
+        guild_id: GuildId,
+        value: &Value,
+        audit_log_reason: Option<&str>,
+    ) -> Result<MfaLevel> {
+        let body = to_vec(value)?;
+
+        self.fire(Request {
+            body: Some(body),
+            multipart: None,
+            headers: audit_log_reason.map(reason_into_header),
+            method: LightMethod::Post,
+            route: Route::GuildMfa {
+                guild_id,
+            },
+            params: None,
+        })
+        .await
+    }
+
     /// Edits a [`Guild`]'s widget.
     pub async fn edit_guild_widget(
         &self,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -273,6 +273,10 @@ routes! ('a, {
     api!("/guilds/{}/members/@me", guild_id),
     RatelimitingKind::PathAndId(guild_id.0);
 
+    GuildMfa { guild_id: GuildId },
+    api!("/guilds/{}/mfa", guild_id),
+    RatelimitingKind::PathAndId(guild_id.0);
+
     GuildPrune { guild_id: GuildId },
     api!("/guilds/{}/prune", guild_id),
     RatelimitingKind::PathAndId(guild_id.0);

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -648,6 +648,25 @@ impl GuildId {
         builder.execute(cache_http, (self, user_id.into())).await
     }
 
+    /// Edits the guild's MFA level. Returns the new level on success.
+    ///
+    /// Requires guild ownership.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn edit_mfa_level(
+        self,
+        http: impl AsRef<Http>,
+        mfa_level: MfaLevel,
+        audit_log_reason: Option<&str>,
+    ) -> Result<MfaLevel> {
+        let value = json!({
+            "level": mfa_level,
+        });
+        http.as_ref().edit_guild_mfa_level(self, &value, audit_log_reason).await
+    }
+
     /// Edits the current user's nickname for the guild.
     ///
     /// Pass [`None`] to reset the nickname.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1128,7 +1128,7 @@ impl Guild {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     pub async fn edit_mfa_level(
-        self,
+        &self,
         http: impl AsRef<Http>,
         mfa_level: MfaLevel,
         audit_log_reason: Option<&str>,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1120,6 +1120,22 @@ impl Guild {
         self.id.edit_member(cache_http, user_id, builder).await
     }
 
+    /// Edits the guild's MFA level. Returns the new level on success.
+    ///
+    /// Requires guild ownership.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn edit_mfa_level(
+        self,
+        http: impl AsRef<Http>,
+        mfa_level: MfaLevel,
+        audit_log_reason: Option<&str>,
+    ) -> Result<MfaLevel> {
+        self.id.edit_mfa_level(http, mfa_level, audit_log_reason).await
+    }
+
     /// Edits the current user's nickname for the guild.
     ///
     /// Pass [`None`] to reset the nickname.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -785,7 +785,7 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     pub async fn edit_mfa_level(
-        self,
+        &self,
         http: impl AsRef<Http>,
         mfa_level: MfaLevel,
         audit_log_reason: Option<&str>,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -777,6 +777,22 @@ impl PartialGuild {
         self.id.edit_member(cache_http, user_id, builder).await
     }
 
+    /// Edits the guild's MFA level. Returns the new level on success.
+    ///
+    /// Requires guild ownership.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn edit_mfa_level(
+        self,
+        http: impl AsRef<Http>,
+        mfa_level: MfaLevel,
+        audit_log_reason: Option<&str>,
+    ) -> Result<MfaLevel> {
+        self.id.edit_mfa_level(http, mfa_level, audit_log_reason).await
+    }
+
     /// Edits the current user's nickname for the guild.
     ///
     /// Pass [`None`] to reset the nickname.


### PR DESCRIPTION
Adds a new `GuildMfa` endpoint and corresponding `Http::edit_guild_mfa_level` plus `{GuildId,Guild,PartialGuild}::edit_mfa_level` methods.

Thanks @cheesycod for providing testing