### PR TITLE
Miscellaneous changes

### DIFF
--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -397,7 +397,7 @@ impl Colour {
 impl ToTokens for Colour {
     fn to_tokens(&self, stream: &mut TokenStream2) {
         let value = self.0;
-        let path = quote!(serenity::model::colour::Colour);
+        let path = quote!(serenity::model::Colour);
 
         stream.extend(quote! {
             #path(#value)

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -436,7 +436,7 @@ mod test {
     use super::CreateEmbed;
     use crate::json::{json, to_value};
     use crate::model::channel::{Embed, EmbedField, EmbedFooter, EmbedImage, EmbedVideo};
-    use crate::model::colour::Colour;
+    use crate::model::Colour;
 
     #[test]
     fn test_from_embed() {

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -24,7 +24,7 @@ use crate::utils::check_overflow;
 /// use serenity::builder::{CreateEmbed, ExecuteWebhook};
 /// use serenity::http::Http;
 /// use serenity::model::webhook::Webhook;
-/// use serenity::model::colour::Colour;
+/// use serenity::model::Colour;
 ///
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// # let http: Http = unimplemented!();

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -81,8 +81,8 @@ use crate::{
     framework::standard::CommonOptions,
     http::CacheHttp,
     model::channel::Message,
-    model::colour::Colour,
     model::id::{ChannelId, UserId},
+    model::Colour,
     Error,
 };
 

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -7,9 +7,9 @@ use futures::future::BoxFuture;
 use super::Args;
 use crate::client::Context;
 use crate::model::channel::Message;
-use crate::model::colour::Colour;
 use crate::model::id::UserId;
 use crate::model::permissions::Permissions;
+use crate::model::Colour;
 
 pub mod buckets;
 mod check;

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -32,7 +32,7 @@
 /// #     "position": 7,
 /// # })).unwrap();
 /// #
-/// use serenity::model::colour::Colour;
+/// use serenity::model::Colour;
 ///
 /// // assuming a `role` has already been bound
 ///
@@ -45,7 +45,7 @@
 /// Creating an instance with the [`Self::DARK_TEAL`] preset:
 ///
 /// ```rust
-/// use serenity::model::colour::Colour;
+/// use serenity::model::Colour;
 ///
 /// let colour = Colour::DARK_TEAL;
 ///
@@ -55,7 +55,7 @@
 /// Colours can also be directly compared for equivalence:
 ///
 /// ```rust
-/// use serenity::model::colour::Colour;
+/// use serenity::model::Colour;
 ///
 /// let blitz_blue = Colour::BLITZ_BLUE;
 /// let fooyoo = Colour::FOOYOO;
@@ -78,7 +78,7 @@ impl Colour {
     /// value, retrieved via [`Self::tuple`]:
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// let colour = Colour::new(6573123);
     ///
@@ -97,7 +97,7 @@ impl Colour {
     /// Creating a [`Colour`] via its RGB values will set its inner u32 correctly:
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert!(Colour::from_rgb(255, 0, 0).0 == 0xFF0000);
     /// assert!(Colour::from_rgb(217, 23, 211).0 == 0xD917D3);
@@ -106,7 +106,7 @@ impl Colour {
     /// And you can then retrieve those same RGB values via its methods:
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// let colour = Colour::from_rgb(217, 45, 215);
     ///
@@ -128,7 +128,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).r(), 100);
     /// ```
@@ -142,7 +142,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).g(), 76);
     /// ```
@@ -156,7 +156,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).b(), 67);
     /// ```
@@ -173,7 +173,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).tuple(), (100, 76, 67));
     /// ```
@@ -190,7 +190,7 @@ impl Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert_eq!(Colour::new(6573123).hex(), "644C43");
     /// ```
@@ -210,7 +210,7 @@ impl From<i32> for Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert_eq!(Colour::from(0xDEA584).tuple(), (222, 165, 132));
     /// ```
@@ -227,7 +227,7 @@ impl From<u32> for Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert_eq!(Colour::from(6573123u32).r(), 100);
     /// ```
@@ -244,7 +244,7 @@ impl From<u64> for Colour {
     /// # Examples
     ///
     /// ```rust
-    /// use serenity::model::colour::Colour;
+    /// use serenity::model::Colour;
     ///
     /// assert_eq!(Colour::from(6573123u64).r(), 100);
     /// ```

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -710,7 +710,7 @@ impl GatewayIntents {
     ///
     /// [AUTO_MODERATION_CONFIGURATION]: Self::AUTO_MODERATION_CONFIGURATION
     #[must_use]
-    pub fn auto_moderation_configuration(self) -> bool {
+    pub const fn auto_moderation_configuration(self) -> bool {
         self.contains(Self::AUTO_MODERATION_CONFIGURATION)
     }
 
@@ -719,7 +719,7 @@ impl GatewayIntents {
     ///
     /// [AUTO_MODERATION_EXECUTION]: Self::AUTO_MODERATION_EXECUTION
     #[must_use]
-    pub fn auto_moderation_execution(self) -> bool {
+    pub const fn auto_moderation_execution(self) -> bool {
         self.contains(Self::AUTO_MODERATION_EXECUTION)
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -43,7 +43,7 @@ pub mod webhook;
 use std::collections::HashMap;
 use std::result::Result as StdResult;
 
-use colour::Colour;
+pub use colour::Colour;
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer};
 #[cfg(feature = "voice-model")]


### PR DESCRIPTION
Re-export the `Colour` type so that both it and `Color` are accessible at the same level. Also, make `GatewayIntents::auto_moderation_{configuration, execution}` const.