### PR TITLE
Derive `Serialize` for `CreateSticker`

### DIFF
--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -15,14 +15,15 @@ use crate::model::prelude::*;
 /// - [`PartialGuild::create_sticker`]
 /// - [`Guild::create_sticker`]
 /// - [`GuildId::create_sticker`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateSticker<'a> {
     name: String,
     tags: String,
     description: String,
-    file: CreateAttachment,
 
+    #[serde(skip)]
+    file: CreateAttachment,
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,
 }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -22,6 +22,8 @@ pub struct CreateSticker<'a> {
     tags: String,
     description: String,
     file: CreateAttachment,
+
+    #[serde(skip)]
     audit_log_reason: Option<&'a str>,
 }
 


### PR DESCRIPTION
`CreateSticker::audit_log_reason` accidentally wasn't marked to be skipped in #2105.