### PR TITLE
Prevent double slashes with HTTP proxy

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -71,7 +71,8 @@ impl<'a> Request<'a> {
         let mut path = self.route.path().to_string();
 
         if let Some(proxy) = proxy {
-            path = path.replace("https://discord.com", proxy);
+            // trim_end_matches to prevent double slashes after the domain
+            path = path.replace("https://discord.com", proxy.trim_end_matches('/'));
         }
 
         if let Some(params) = self.params {


### PR DESCRIPTION
Fixes #2322

Probably wouldn't have caused because double slashes are treated by HTTP servers as single slashes in my experience.

After a bit of back and forth I opted not to use reqwest methods. Parsing the given proxy in HttpBuilder into an Url directly means the builder method returns Result (or panics) which is both ugly. Also, Url's methods yield the scheme and domain both as &str, so we would still just have a string in the internal proxy field instead of a type-safe value. So I kept the current simple solution that gets the job done and just added the fix