### PR TITLE
Register collectors via shared Mutex instead of channel

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -1,15 +1,14 @@
 use std::fmt;
 use std::sync::Arc;
 
-use futures::channel::mpsc::UnboundedSender as Sender;
 use tokio::sync::RwLock;
 use typemap_rev::TypeMap;
 
 #[cfg(feature = "cache")]
 pub use crate::cache::Cache;
+use crate::gateway::ActivityData;
 #[cfg(feature = "gateway")]
-use crate::gateway::ShardMessenger;
-use crate::gateway::{ActivityData, ShardRunnerMessage};
+use crate::gateway::{ShardMessenger, ShardRunner};
 use crate::http::Http;
 use crate::model::prelude::*;
 
@@ -57,13 +56,13 @@ impl Context {
     #[cfg(all(feature = "cache", feature = "gateway"))]
     pub(crate) fn new(
         data: Arc<RwLock<TypeMap>>,
-        runner_tx: Sender<ShardRunnerMessage>,
+        runner: &ShardRunner,
         shard_id: u32,
         http: Arc<Http>,
         cache: Arc<Cache>,
     ) -> Context {
         Context {
-            shard: ShardMessenger::new(runner_tx),
+            shard: ShardMessenger::new(runner),
             shard_id,
             data,
             http,

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -59,13 +59,14 @@ impl Context {
         runner: &ShardRunner,
         shard_id: u32,
         http: Arc<Http>,
-        cache: Arc<Cache>,
+        #[cfg(feature = "cache")] cache: Arc<Cache>,
     ) -> Context {
         Context {
             shard: ShardMessenger::new(runner),
             shard_id,
             data,
             http,
+            #[cfg(feature = "cache")]
             cache,
         }
     }
@@ -73,22 +74,6 @@ impl Context {
     #[cfg(all(not(feature = "cache"), not(feature = "gateway")))]
     pub fn easy(data: Arc<RwLock<TypeMap>>, shard_id: u32, http: Arc<Http>) -> Context {
         Context {
-            shard_id,
-            data,
-            http,
-        }
-    }
-
-    /// Create a new Context to be passed to an event handler.
-    #[cfg(all(not(feature = "cache"), feature = "gateway"))]
-    pub(crate) fn new(
-        data: Arc<RwLock<TypeMap>>,
-        runner_tx: Sender<ShardRunnerMessage>,
-        shard_id: u32,
-        http: Arc<Http>,
-    ) -> Context {
-        Context {
-            shard: ShardMessenger::new(runner_tx),
             shard_id,
             data,
             http,

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -53,7 +53,7 @@ impl fmt::Debug for Context {
 
 impl Context {
     /// Create a new Context to be passed to an event handler.
-    #[cfg(all(feature = "cache", feature = "gateway"))]
+    #[cfg(feature = "gateway")]
     pub(crate) fn new(
         data: Arc<RwLock<TypeMap>>,
         runner: &ShardRunner,

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -195,7 +195,7 @@ impl ShardQueuer {
 
         let runner_info = ShardRunnerInfo {
             latency: None,
-            runner_tx: ShardMessenger::new(runner.runner_tx()),
+            runner_tx: ShardMessenger::new(&runner),
             stage: ConnectionStage::Disconnected,
         };
 

--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -46,7 +46,7 @@ pub struct ShardRunner {
     pub cache: Arc<Cache>,
     pub http: Arc<Http>,
     #[cfg(feature = "collector")]
-    collectors: Vec<CollectorCallback>,
+    pub(crate) collectors: std::sync::Arc<std::sync::Mutex<Vec<CollectorCallback>>>,
 }
 
 impl ShardRunner {
@@ -70,7 +70,7 @@ impl ShardRunner {
             cache: opt.cache,
             http: opt.http,
             #[cfg(feature = "collector")]
-            collectors: vec![],
+            collectors: std::sync::Arc::new(std::sync::Mutex::new(vec![])),
         }
     }
 
@@ -165,7 +165,7 @@ impl ShardRunner {
 
             if let Some(event) = event {
                 #[cfg(feature = "collector")]
-                self.collectors.retain_mut(|callback| (callback.0)(&event));
+                self.collectors.lock().expect("poison").retain_mut(|callback| (callback.0)(&event));
 
                 dispatch_model(
                     event,
@@ -257,7 +257,7 @@ impl ShardRunner {
     fn make_context(&self) -> Context {
         Context::new(
             Arc::clone(&self.data),
-            self.runner_tx.clone(),
+            self,
             self.shard.shard_info().id,
             Arc::clone(&self.http),
             #[cfg(feature = "cache")]
@@ -312,11 +312,6 @@ impl ShardRunner {
             ShardRunnerMessage::SetStatus(status) => {
                 self.shard.set_status(status);
                 self.shard.update_presence().await.is_ok()
-            },
-            #[cfg(feature = "collector")]
-            ShardRunnerMessage::AddCollector(collector) => {
-                self.collectors.push(collector);
-                true
             },
         }
     }

--- a/src/gateway/bridge/shard_runner_message.rs
+++ b/src/gateway/bridge/shard_runner_message.rs
@@ -1,7 +1,5 @@
 use tokio_tungstenite::tungstenite::Message;
 
-#[cfg(feature = "collector")]
-use super::CollectorCallback;
 use super::ShardId;
 use crate::gateway::{ActivityData, ChunkGuildFilter};
 use crate::model::id::GuildId;
@@ -48,6 +46,4 @@ pub enum ShardRunnerMessage {
     SetPresence(Option<ActivityData>, OnlineStatus),
     /// Indicates that the client is to update the shard's presence's status.
     SetStatus(OnlineStatus),
-    #[cfg(feature = "collector")]
-    AddCollector(CollectorCallback),
 }


### PR DESCRIPTION
That means, collector registration sidesteps the 500ms "game loop" of ShardRunner, which previously caused issues with missed events (https://discord.com/channels/381880193251409931/673965002805477386/1097264574828396646, https://github.com/serenity-rs/serenity/issues/2333#issuecomment-1510872780).

(This fix makes the workaround code in #2389 actually work)

In the future, more ShardRunnerMessage variants can be expressed as simple method calls on a Mutex-guarded resource. This would make function calls much more traceable, it's also more performant, and eliminates an extra type and a background loop