### PR TITLE
Update renamed lint name in voice-model

### DIFF
--- a/voice-model/src/lib.rs
+++ b/voice-model/src/lib.rs
@@ -1,6 +1,6 @@
 //! Mappings of objects received from Discord's voice gateway API, with implementations for
 //! (de)serialisation.
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 mod close_code;
 pub mod constants;


### PR DESCRIPTION
I saw the warning about it all the time while testing and decided to finally PR this tiny fix 