### PR TITLE
Make all model types #[non_exhaustive] where it makes sense

### DIFF
--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -26,6 +26,7 @@ enum_number! {
 
 /// An action row.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ActionRow {
     /// The type of component this ActionRow is.
     #[serde(rename = "type")]
@@ -138,6 +139,7 @@ impl Serialize for ButtonKind {
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Button {
     /// The component type, it will always be [`ComponentType::Button`].
     #[serde(rename = "type")]
@@ -173,6 +175,7 @@ enum_number! {
 
 /// A select menu component.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct SelectMenu {
     /// The component type, which may either be [`ComponentType::StringSelect`],
     /// [`ComponentType::UserSelect`], [`ComponentType::RoleSelect`],
@@ -197,6 +200,7 @@ pub struct SelectMenu {
 
 /// A select menu component options.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct SelectMenuOption {
     /// The text displayed on this option.
     pub label: String,
@@ -213,6 +217,7 @@ pub struct SelectMenuOption {
 
 /// An input text component for modal interactions
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct InputText {
     /// The component type, it will always be [`ComponentType::InputText`].
     #[serde(rename = "type")]

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -12,6 +12,7 @@ use crate::model::Permissions;
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object)
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Interaction {
     Ping(PingInteraction),
     Command(CommandInteraction),

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -23,6 +23,7 @@ use super::Permissions;
 
 /// Partial information about the given application.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct PartialCurrentApplicationInfo {
     /// The unique Id of the user.
     pub id: ApplicationId,
@@ -74,6 +75,7 @@ pub struct CurrentApplicationInfo {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-team-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Team {
     /// The icon of the team.
     pub icon: Option<String>,
@@ -91,6 +93,7 @@ pub struct Team {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-team-member-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct TeamMember {
     /// The member's membership state.
     pub membership_state: MembershipState,
@@ -137,6 +140,7 @@ bitflags! {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/application#install-params-object-install-params-structure).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct InstallParams {
     pub scopes: Vec<Scope>,
     pub permissions: Permissions,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1196,6 +1196,7 @@ impl fmt::Display for GuildChannel {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object),
 /// [subset description](https://discord.com/developers/docs/topics/gateway#thread-delete)
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct PartialGuildChannel {
     /// The channel Id.
     pub id: ChannelId,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -980,6 +980,7 @@ impl From<(ChannelId, MessageId)> for MessageReference {
 
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-mention-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ChannelMention {
     /// ID of the channel.
     pub id: ChannelId,

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -161,6 +161,7 @@ pub struct ActivitySecrets {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-emoji).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ActivityEmoji {
     /// The name of the emoji.
     pub name: String,
@@ -209,6 +210,7 @@ pub struct Gateway {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#client-status-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ClientStatus {
     pub desktop: Option<OnlineStatus>,
     pub mobile: Option<OnlineStatus>,

--- a/src/model/guild/automod.rs
+++ b/src/model/guild/automod.rs
@@ -15,6 +15,7 @@ use crate::model::id::{ChannelId, GuildId, MessageId, RoleId, RuleId, UserId};
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Rule {
     /// ID of the rule.
     pub id: RuleId,
@@ -227,6 +228,7 @@ impl From<TriggerType> for u8 {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct TriggerMetadata {
     keyword_filter: Option<Vec<String>>,
     presets: Option<Vec<KeywordPresetType>>,
@@ -271,6 +273,7 @@ impl From<KeywordPresetType> for u8 {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object).
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Action {
     /// Blocks the content of a message according to the rule.
     BlockMessage,
@@ -294,6 +297,7 @@ pub enum Action {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#auto-moderation-action-execution).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ActionExecution {
     /// ID of the guild in which the action was executed.
     pub guild_id: GuildId,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -75,6 +75,7 @@ use crate::model::Timestamp;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#ban-object).
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Ban {
     /// The reason given for this ban.
     pub reason: Option<String>,
@@ -2541,6 +2542,7 @@ pub struct GuildWidget {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#get-guild-prune-count).
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildPrune {
     /// The number of members that would be pruned by the operation.
     pub pruned: u64,
@@ -2551,6 +2553,7 @@ pub struct GuildPrune {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object), subset undocumented (closest thing is
 /// [this](https://discord.com/developers/docs/topics/rpc#getguilds-get-guilds-response-structure)).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildInfo {
     /// The unique Id of the guild.
     ///
@@ -2596,6 +2599,7 @@ impl InviteGuild {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#unavailable-guild-object).
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct UnavailableGuild {
     /// The Id of the [`Guild`] that may be unavailable.
     pub id: GuildId,

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -77,6 +77,7 @@ enum_number! {
 
 /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ScheduledEventMetadata {
     // TODO: Change to `Option<String>` in next version.
     #[serde(default)]
@@ -85,6 +86,7 @@ pub struct ScheduledEventMetadata {
 
 /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-user-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ScheduledEventUser {
     #[serde(rename = "guild_scheduled_event_id")]
     pub event_id: ScheduledEventId,

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -6,6 +6,7 @@ use crate::model::id::{ChannelId, EmojiId};
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct GuildWelcomeScreen {
     /// The server description shown in the welcome screen.
     pub description: Option<String>,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -57,6 +57,7 @@ impl_from_str! {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-emoji).
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
 pub struct EmojiIdentifier {
     /// Whether the emoji is animated
     pub animated: bool,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -240,13 +240,10 @@ pub fn parse_channel(mention: impl AsRef<str>) -> Option<ChannelId> {
 /// use serenity::model::misc::EmojiIdentifier;
 /// use serenity::utils::parse_emoji;
 ///
-/// let expected = EmojiIdentifier {
-///     animated: false,
-///     id: EmojiId::new(302516740095606785),
-///     name: "smugAnimeFace".to_string(),
-/// };
-///
-/// assert_eq!(parse_emoji("<:smugAnimeFace:302516740095606785>").unwrap(), expected);
+/// let emoji = parse_emoji("<:smugAnimeFace:302516740095606785>").unwrap();
+/// assert_eq!(emoji.animated, false);
+/// assert_eq!(emoji.id, EmojiId::new(302516740095606785));
+/// assert_eq!(emoji.name, "smugAnimeFace".to_string());
 /// ```
 ///
 /// Asserting that an invalid emoji usage returns [`None`]:


### PR DESCRIPTION
To ensure forward-compatibility - when Discord adds new fields, we don't want to have to make a breaking release