### PR TITLE
Overhaul command permission builders

### DIFF
--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use super::context::Context;
 use crate::gateway::ShardStageUpdateEvent;
 use crate::http::RatelimitInfo;
-use crate::model::application::{CommandPermission, Interaction};
+use crate::model::application::{CommandPermissions, Interaction};
 use crate::model::guild::audit_log::AuditLogEntry;
 use crate::model::guild::automod::{ActionExecution, Rule};
 use crate::model::prelude::*;
@@ -75,7 +75,7 @@ event_handler! {
     /// Dispatched when the permissions of an application command was updated.
     ///
     /// Provides said permission's data.
-    async fn command_permissions_update(&self, CommandPermissionsUpdate { ctx: Context, permission: CommandPermission });
+    async fn command_permissions_update(&self, CommandPermissionsUpdate { ctx: Context, permission: CommandPermissions });
 
     /// Dispatched when an auto moderation rule was created.
     ///

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -30,7 +30,7 @@ use crate::builder::CreateAttachment;
 use crate::constants;
 use crate::internal::prelude::*;
 use crate::json::prelude::*;
-use crate::model::application::{Command, CommandPermission};
+use crate::model::application::{Command, CommandPermissions};
 use crate::model::guild::automod::Rule;
 use crate::model::prelude::*;
 
@@ -1648,13 +1648,13 @@ impl Http {
     ///
     /// Refer to Discord's [documentation] for field information.
     ///
-    /// [documentation]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
+    /// [documentation]: https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions
     pub async fn edit_guild_command_permissions(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
         map: &impl serde::Serialize,
-    ) -> Result<CommandPermission> {
+    ) -> Result<CommandPermissions> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1664,32 +1664,6 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
                 command_id,
-            },
-            params: None,
-        })
-        .await
-    }
-
-    /// Edits a guild commands permissions.
-    ///
-    /// Updates for guild commands will be available immediately.
-    ///
-    /// Refer to Discord's [documentation] for field information.
-    ///
-    /// [documentation]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
-    pub async fn edit_guild_commands_permissions(
-        &self,
-        guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<Vec<CommandPermission>> {
-        self.fire(Request {
-            body: Some(to_vec(map)?),
-            multipart: None,
-            headers: None,
-            method: LightMethod::Put,
-            route: Route::ApplicationGuildCommandsPermissions {
-                application_id: self.try_application_id()?,
-                guild_id,
             },
             params: None,
         })
@@ -3182,7 +3156,7 @@ impl Http {
     pub async fn get_guild_commands_permissions(
         &self,
         guild_id: GuildId,
-    ) -> Result<Vec<CommandPermission>> {
+    ) -> Result<Vec<CommandPermissions>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3202,7 +3176,7 @@ impl Http {
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-    ) -> Result<CommandPermission> {
+    ) -> Result<CommandPermissions> {
         self.fire(Request {
             body: None,
             multipart: None,

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -319,7 +319,7 @@ pub struct CommandOptionChoice {
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
-pub struct CommandPermission {
+pub struct CommandPermissions {
     /// The id of the command.
     pub id: CommandId,
     /// The id of the application the command belongs to.
@@ -327,7 +327,7 @@ pub struct CommandPermission {
     /// The id of the guild.
     pub guild_id: GuildId,
     /// The permissions for the command in the guild.
-    pub permissions: Vec<CommandPermissionData>,
+    pub permissions: Vec<CommandPermission>,
 }
 
 /// The [`CommandPermission`] data.
@@ -335,7 +335,7 @@ pub struct CommandPermission {
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
-pub struct CommandPermissionData {
+pub struct CommandPermission {
     /// The [`RoleId`] or [`UserId`], depends on `kind` value.
     pub id: CommandPermissionId,
     /// The type of data this permissions applies to.
@@ -346,7 +346,7 @@ pub struct CommandPermissionData {
 }
 
 enum_number! {
-    /// The type of an [`CommandPermissionData`].
+    /// The type of a [`CommandPermission`].
     ///
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -21,7 +21,7 @@ use super::utils::{
 };
 use crate::constants::Opcode;
 use crate::internal::prelude::*;
-use crate::model::application::{CommandPermission, Interaction};
+use crate::model::application::{CommandPermissions, Interaction};
 use crate::model::guild::audit_log::AuditLogEntry;
 use crate::model::guild::automod::{ActionExecution, Rule};
 
@@ -32,7 +32,7 @@ use crate::model::guild::automod::{ActionExecution, Rule};
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct CommandPermissionsUpdateEvent {
-    pub permission: CommandPermission,
+    pub permission: CommandPermissions,
 }
 
 /// Requires [`GatewayIntents::AUTO_MODERATION_CONFIGURATION`].

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -9,10 +9,10 @@ use crate::builder::{
     Builder,
     CreateChannel,
     CreateCommand,
-    CreateCommandPermissionsData,
     CreateScheduledEvent,
     CreateSticker,
     EditAutoModRule,
+    EditCommandPermissions,
     EditGuild,
     EditGuildWelcomeScreen,
     EditGuildWidget,
@@ -34,7 +34,7 @@ use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::json::json;
 #[cfg(feature = "model")]
-use crate::model::application::{Command, CommandPermission};
+use crate::model::application::{Command, CommandPermissions};
 #[cfg(feature = "model")]
 use crate::model::guild::automod::Rule;
 use crate::model::prelude::*;
@@ -1463,19 +1463,19 @@ impl GuildId {
         http.as_ref().create_guild_commands(self, &commands).await
     }
 
-    /// Create a guild specific [`CommandPermission`].
+    /// Overwrites permissions for a specific command.
     ///
     /// **Note**: It will update instantly.
     ///
     /// # Errors
     ///
-    /// See [`CreateCommandPermissionsData::execute`] for a list of possible errors.
-    pub async fn create_command_permission(
+    /// See [`EditCommandPermissions::execute`] for a list of possible errors.
+    pub async fn edit_command_permissions(
         self,
         cache_http: impl CacheHttp,
         command_id: CommandId,
-        builder: CreateCommandPermissionsData,
-    ) -> Result<CommandPermission> {
+        builder: EditCommandPermissions,
+    ) -> Result<CommandPermissions> {
         builder.execute(cache_http, (self, command_id)).await
     }
 
@@ -1532,7 +1532,7 @@ impl GuildId {
     pub async fn get_commands_permissions(
         self,
         http: impl AsRef<Http>,
-    ) -> Result<Vec<CommandPermission>> {
+    ) -> Result<Vec<CommandPermissions>> {
         http.as_ref().get_guild_commands_permissions(self).await
     }
 
@@ -1545,7 +1545,7 @@ impl GuildId {
         self,
         http: impl AsRef<Http>,
         command_id: CommandId,
-    ) -> Result<CommandPermission> {
+    ) -> Result<CommandPermissions> {
         http.as_ref().get_guild_command_permissions(self, command_id).await
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -39,10 +39,10 @@ use crate::builder::{
     AddMember,
     CreateChannel,
     CreateCommand,
-    CreateCommandPermissionsData,
     CreateScheduledEvent,
     CreateSticker,
     EditAutoModRule,
+    EditCommandPermissions,
     EditGuild,
     EditGuildWelcomeScreen,
     EditGuildWidget,
@@ -64,7 +64,7 @@ use crate::http::{CacheHttp, Http, UserPagination};
 #[cfg(feature = "model")]
 use crate::json::prelude::json;
 #[cfg(feature = "model")]
-use crate::model::application::{Command, CommandPermission};
+use crate::model::application::{Command, CommandPermissions};
 #[cfg(feature = "model")]
 use crate::model::guild::automod::Rule;
 use crate::model::prelude::*;
@@ -755,7 +755,7 @@ impl Guild {
         self.id.set_commands(http, commands).await
     }
 
-    /// Create a guild specific [`CommandPermission`].
+    /// Overwrites permissions for a specific command.
     ///
     /// **Note**: It will update instantly.
     ///
@@ -764,13 +764,13 @@ impl Guild {
     /// See [`CreateCommandPermissionsData::execute`] for a list of possible errors.
     ///
     /// [`CreateCommandPermissionsData::execute`]: ../../builder/struct.CreateCommandPermissionsData.html#method.execute
-    pub async fn create_command_permission(
+    pub async fn edit_command_permissions(
         &self,
         cache_http: impl CacheHttp,
         command_id: CommandId,
-        builder: CreateCommandPermissionsData,
-    ) -> Result<CommandPermission> {
-        self.id.create_command_permission(cache_http, command_id, builder).await
+        builder: EditCommandPermissions,
+    ) -> Result<CommandPermissions> {
+        self.id.edit_command_permissions(cache_http, command_id, builder).await
     }
 
     /// Get all guild application commands.
@@ -832,7 +832,7 @@ impl Guild {
     pub async fn get_commands_permissions(
         &self,
         http: impl AsRef<Http>,
-    ) -> Result<Vec<CommandPermission>> {
+    ) -> Result<Vec<CommandPermissions>> {
         self.id.get_commands_permissions(http).await
     }
 
@@ -845,7 +845,7 @@ impl Guild {
         &self,
         http: impl AsRef<Http>,
         command_id: CommandId,
-    ) -> Result<CommandPermission> {
+    ) -> Result<CommandPermissions> {
         self.id.get_command_permissions(http, command_id).await
     }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -6,9 +6,9 @@ use tracing::{error, warn};
 use crate::builder::{
     CreateChannel,
     CreateCommand,
-    CreateCommandPermissionsData,
     CreateSticker,
     EditAutoModRule,
+    EditCommandPermissions,
     EditGuild,
     EditGuildWelcomeScreen,
     EditGuildWidget,
@@ -25,7 +25,7 @@ use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
 #[cfg(feature = "model")]
-use crate::model::application::{Command, CommandPermission};
+use crate::model::application::{Command, CommandPermissions};
 #[cfg(feature = "model")]
 use crate::model::guild::automod::Rule;
 use crate::model::prelude::*;
@@ -479,7 +479,7 @@ impl PartialGuild {
         self.id.set_commands(http, commands).await
     }
 
-    /// Create a guild specific [`CommandPermission`].
+    /// Overwrites permissions for a specific command.
     ///
     /// **Note**: It will update instantly.
     ///
@@ -488,13 +488,13 @@ impl PartialGuild {
     /// See [`CreateCommandPermissionsData::execute`] for a list of possible errors.
     ///
     /// [`CreateCommandPermissionsData::execute`]: ../../builder/struct.CreateCommandPermissionsData.html#method.execute
-    pub async fn create_command_permission(
+    pub async fn edit_command_permissions(
         &self,
         cache_http: impl CacheHttp,
         command_id: CommandId,
-        builder: CreateCommandPermissionsData,
-    ) -> Result<CommandPermission> {
-        self.id.create_command_permission(cache_http, command_id, builder).await
+        builder: EditCommandPermissions,
+    ) -> Result<CommandPermissions> {
+        self.id.edit_command_permissions(cache_http, command_id, builder).await
     }
 
     /// Get all guild application commands.
@@ -556,7 +556,7 @@ impl PartialGuild {
     pub async fn get_commands_permissions(
         &self,
         http: impl AsRef<Http>,
-    ) -> Result<Vec<CommandPermission>> {
+    ) -> Result<Vec<CommandPermissions>> {
         self.id.get_commands_permissions(http).await
     }
 
@@ -569,7 +569,7 @@ impl PartialGuild {
         &self,
         http: impl AsRef<Http>,
         command_id: CommandId,
-    ) -> Result<CommandPermission> {
+    ) -> Result<CommandPermissions> {
         self.id.get_command_permissions(http, command_id).await
     }
 


### PR DESCRIPTION
- :abc: Renames `CreateCommandPermissionsData` builder to `EditCommandPermissions`
  - Name is more fitting because the builder calls the `edit_guild_command_permissions` endpoint
- :abc: Renames `CreateCommandPermissionData` builder to `CreateCommandPermission`
- :abc: Renames `CommandPermission` model type to `CommandPermissions`
  - Name is more fitting because it actually stores a Vec of all permissions for a single command
- :abc: Renames `CommandPermissionData` to `CommandPermission`
- :abc: Renames `[GuildId, Guild, PartialGuild]::create_command_permission` to `edit_command_permission`
  - Less misleading - this method overwrites all permissions of the given command
  - Matches the HTTP endpoint name
- :sparkles: Replaces `EditCommandPermissions` methods `new()`, `add_permission(CreateCommandPermission)`, `set_permissions(Vec<CreateCommandPermission>)` with just `new(Vec<CreateCommandPermission>)`
  - Not providing any `CreateCommandPermission` instances makes no sense, and `new(vec![a, b, c])` is easier for both serenity and the user than `new().add_permission(a).add_permission(b).add_permission(c)`
- :sparkles: Replaces `CreateCommandPermissionData` methods `new()`, `kind(CommandPermissionType)`, `id(CommandPermissionId)`, `permission(bool)` with `role(RoleId, bool)`, `user(UserId, bool)`, `channel(ChannelId, bool)`
  - Much shorter to invoke
  - Cannot be misused (previously your configured `kind` could mismatch the type of ID you passed in)
  - Shows everything you can do with a command permission on one glance
- :sparkles: Adds `CreateCommandPermission::everyone(GuildId, bool)` and `CreateCommandPermission::all_channels(GuildId, bool)`
  - These were previously missing
- :x: Removes `edit_guild_commands_permissions` endpoint
  - This endpoint has been disabled with Permissions V2 ([Discord docs](https://discord.com/developers/docs/interactions/application-commands#batch-edit-application-command-permissions))
  - Don't confuse with `edit_guild_command_permissions` (note the plural) - that endpoint is still active!
- :wrench: Replaces `CreateCommandPermission`'s inner private fields by making `CreateCommandPermission` a newtype around `CommandPermission`
  - They share the same schema in the Discord docs so we can also share the same type struct definition

This PR has not been runtime tested