### PR TITLE
Fix `missing field "waveform"` error

### DIFF
--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -69,7 +69,7 @@ pub struct Attachment {
     ///
     /// The waveform details are a Discord implementation detail and may change without warning or
     /// documentation.
-    #[serde(deserialize_with = "base64_bytes")]
+    #[serde(default, deserialize_with = "base64_bytes")]
     pub waveform: Option<Vec<u8>>,
 }
 


### PR DESCRIPTION
Introduced by #2392 

Due to an annoying serde-derive footgun https://github.com/serde-rs/serde/issues/2249#issuecomment-1214136680