### PR TITLE
Make discriminator optional and non-zero in preparation for new usernames

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -365,8 +365,10 @@ impl Message {
             let mut at_distinct = String::with_capacity(38);
             at_distinct.push('@');
             at_distinct.push_str(&u.name);
-            at_distinct.push('#');
-            write!(at_distinct, "{:04}", u.discriminator).unwrap();
+            if let Some(discriminator) = u.discriminator {
+                at_distinct.push('#');
+                write!(at_distinct, "{:04}", discriminator.get()).unwrap();
+            }
 
             let mut m = u.mention().to_string();
             // Check whether we're replacing a nickname mention or a normal mention.

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -28,11 +28,6 @@ use super::Permissions;
 /// #[serenity::async_trait]
 /// impl EventHandler for Handler {
 ///     async fn guild_ban_removal(&self, context: Context, guild_id: GuildId, user: User) {
-///         // If the user has an even discriminator, don't re-ban them.
-///         if user.discriminator % 2 == 0 {
-///             return;
-///         }
-///
 ///         match guild_id.ban(&context, user, 8).await {
 ///             Ok(()) => {
 ///                 // Ban successful.

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,5 +1,7 @@
 //! Models pertaining to the gateway.
 
+use std::num::NonZeroU16;
+
 use serde::ser::SerializeSeq;
 use url::Url;
 
@@ -232,8 +234,8 @@ pub struct PresenceUser {
     pub id: UserId,
     pub avatar: Option<String>,
     pub bot: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator::option")]
-    pub discriminator: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator")]
+    pub discriminator: Option<NonZeroU16>,
     pub email: Option<String>,
     pub mfa_enabled: Option<bool>,
     #[serde(rename = "username")]
@@ -251,7 +253,7 @@ impl PresenceUser {
         Some(User {
             avatar: self.avatar,
             bot: self.bot?,
-            discriminator: self.discriminator?,
+            discriminator: self.discriminator,
             id: self.id,
             name: self.name?,
             public_flags: self.public_flags,
@@ -285,7 +287,7 @@ impl PresenceUser {
             self.avatar = Some(avatar.clone());
         }
         self.bot = Some(user.bot);
-        self.discriminator = Some(user.discriminator);
+        self.discriminator = user.discriminator;
         self.name = Some(user.name.clone());
         if let Some(public_flags) = user.public_flags {
             self.public_flags = Some(public_flags);

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -233,7 +233,11 @@ impl Member {
     #[inline]
     #[must_use]
     pub fn distinct(&self) -> String {
-        format!("{}#{:04}", self.display_name(), self.user.discriminator)
+        if let Some(discriminator) = self.user.discriminator {
+            format!("{}#{:04}", self.display_name(), discriminator.get())
+        } else {
+            self.display_name().to_string()
+        }
     }
 
     /// Edits the member in place with the given data.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2728,6 +2728,7 @@ mod test {
     #[cfg(feature = "model")]
     mod model {
         use std::collections::*;
+        use std::num::NonZeroU16;
 
         use crate::model::prelude::*;
 
@@ -2736,7 +2737,7 @@ mod test {
                 nick: Some("aaaa".to_string()),
                 user: User {
                     name: "test".into(),
-                    discriminator: 1432,
+                    discriminator: NonZeroU16::new(1432),
                     ..User::default()
                 },
                 ..Default::default()

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -55,6 +55,9 @@ impl ContentSafeOptions {
 
     /// If set to true, if [`content_safe`] replaces a user mention it will add their four digit
     /// discriminator with a preceding `#`, turning `@username` to `@username#discriminator`.
+    ///
+    /// This option is ignored if the username is a next-gen username, and
+    /// therefore does not have a discriminator.
     #[must_use]
     pub fn show_discriminator(mut self, b: bool) -> Self {
         self.show_discriminator = b;
@@ -322,8 +325,7 @@ mod tests {
         <@!i)/==(<<>z/9080)> <@!1231invalid> <@invalid123> \
         <@123invalid> <@> <@ ";
 
-        let without_user_mentions =
-            "@Crab#0000 <@!000000000000000000> @invalid-user @invalid-user \
+        let without_user_mentions = "@Crab <@!000000000000000000> @invalid-user @invalid-user \
         <@!123123123123123123123> @invalid-user @invalid-user <@!invalid> \
         <@invalid> <@日本語 한국어$§)[/__#\\(/&2032$§#> \
         <@!i)/==(<<>z/9080)> <@!1231invalid> <@invalid123> \
@@ -335,13 +337,13 @@ mod tests {
 
         let options = ContentSafeOptions::default();
         assert_eq!(
-            format!("@{}#{:04}", user.name, user.discriminator),
+            format!("@{}", user.name),
             content_safe(&cache, "<@!100000000000000000>", &options, &[])
         );
 
         let options = ContentSafeOptions::default();
         assert_eq!(
-            format!("@{}#{:04}", user.name, user.discriminator),
+            format!("@{}", user.name),
             content_safe(&cache, "<@100000000000000000>", &options, &[])
         );
 
@@ -350,7 +352,7 @@ mod tests {
 
         let options = ContentSafeOptions::default();
         assert_eq!(
-            format!("@{}#{:04}", outside_cache_user.name, outside_cache_user.discriminator),
+            format!("@{}", outside_cache_user.name),
             content_safe(&cache, "<@100000000000000001>", &options, &[outside_cache_user])
         );
 


### PR DESCRIPTION
This PR requires a major version bump!

Per https://discord.com/blog/usernames the discriminator field is about to become optional. This will proceed in two phases. It's not clear when phase 1 will start. It may have started already.

Phase 0 (Prior behavior): All users have discriminators. 

Phase 1: Users with discriminators co-exist among users without discriminators. Users without discriminators have `"discriminator": 0` in their JSON during this phase.

Phase 2: Once all users are migrated, discriminators are eliminated entirely and won't be returned in the JSON.

This PR is designed such that it can continue working correctly regardless of which phase we are currently in.