### PR TITLE
Change `CurrentUser` to a newtype around `User`.

### DIFF
--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -186,11 +186,11 @@ impl Reaction {
             #[cfg(feature = "cache")]
             {
                 if let Some(cache) = cache_http.cache() {
-                    return Ok(cache.current_user().clone());
+                    return Ok(cache.current_user().clone().into());
                 }
             }
 
-            Ok(cache_http.http().get_current_user().await?)
+            Ok(cache_http.http().get_current_user().await?.into())
         }
     }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -626,7 +626,7 @@ pub struct UnknownEvent {
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct UserUpdateEvent {
-    pub current_user: User,
+    pub current_user: CurrentUser,
 }
 
 /// Requires no gateway intents.

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -177,6 +177,7 @@ mentionable!(value: Channel, value.id());
 mentionable!(value: GuildChannel, value.id);
 mentionable!(value: PrivateChannel, value.id);
 mentionable!(value: Member, value.user.id);
+mentionable!(value: CurrentUser, value.id);
 mentionable!(value: User, value.id);
 mentionable!(value: Role, value.id);
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -4,6 +4,7 @@ use std::fmt;
 #[cfg(feature = "model")]
 use std::fmt::Write;
 use std::num::NonZeroU16;
+use std::ops::{Deref, DerefMut};
 #[cfg(feature = "temp_cache")]
 use std::sync::Arc;
 
@@ -124,7 +125,29 @@ pub(crate) mod discriminator {
 /// Information about the current user.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object).
-pub type CurrentUser = User;
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct CurrentUser(User);
+
+impl Deref for CurrentUser {
+    type Target = User;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for CurrentUser {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<CurrentUser> for User {
+    fn from(user: CurrentUser) -> Self {
+        user.0
+    }
+}
 
 #[cfg(feature = "model")]
 impl CurrentUser {


### PR DESCRIPTION
Changes `CurrentUser` from a type-alias to `User`, to a newtype around `User`, and implements `Deref` and `DerefMut` so that all methods on `User` are still accessible. This change is done to remove `User::edit`, which was accidentally exposed in #2393.  Calling the method would edit the current user's profile, regardless of the id of the `User` it was called on, which was confusing. Now, the `edit` function can only be called on `CurrentUser`, which upholds the requirement that a user can only edit their own profile.