### PR TITLE
Make InputText::{label, style} optional

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -301,8 +301,8 @@ impl CreateInputText {
         custom_id: impl Into<String>,
     ) -> Self {
         Self(InputText {
-            style,
-            label: label.into(),
+            style: Some(style),
+            label: Some(label.into()),
             custom_id: custom_id.into(),
 
             placeholder: None,
@@ -317,13 +317,13 @@ impl CreateInputText {
 
     /// Sets the style of this input text. Replaces the current value as set in [`Self::new`].
     pub fn style(mut self, kind: InputTextStyle) -> Self {
-        self.0.style = kind;
+        self.0.style = Some(kind);
         self
     }
 
     /// Sets the label of this input text. Replaces the current value as set in [`Self::new`].
     pub fn label(mut self, label: impl Into<String>) -> Self {
-        self.0.label = label.into();
+        self.0.label = Some(label.into());
         self
     }
 

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -239,10 +239,18 @@ pub struct InputText {
     pub kind: ComponentType,
     /// Developer-defined identifier for the input; max 100 characters
     pub custom_id: String,
-    /// The [`InputTextStyle`]
-    pub style: InputTextStyle,
-    /// Label for this component; max 45 characters
-    pub label: String,
+    /// The [`InputTextStyle`]. Required when sending modal data.
+    ///
+    /// Discord docs are wrong here; it says the field is always sent in modal submit interactions
+    /// but it's not. It's only required when _sending_ modal data to Discord.
+    /// <https://github.com/discord/discord-api-docs/issues/6141>
+    pub style: Option<InputTextStyle>,
+    /// Label for this component; max 45 characters. Required when sending modal data.
+    ///
+    /// Discord docs are wrong here; it says the field is always sent in modal submit interactions
+    /// but it's not. It's only required when _sending_ modal data to Discord.
+    /// <https://github.com/discord/discord-api-docs/issues/6141>
+    pub label: Option<String>,
     /// Minimum input length for a text input; min 0, max 4000
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_length: Option<u64>,


### PR DESCRIPTION
Discord says they are required, implied for both send and receive direction, but they're only required for sending. When receiving, they are apparently missing.

Fixes https://github.com/serenity-rs/serenity/issues/2421

https://github.com/discord/discord-api-docs/issues/6141