### PR TITLE
Remove FromStrAndCache and StrExt

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -28,7 +28,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
-use std::str::FromStr;
+
 #[cfg(feature = "temp_cache")]
 use std::sync::Arc;
 #[cfg(feature = "temp_cache")]
@@ -110,44 +110,6 @@ pub type CurrentUserRef<'a> = CacheRef<'a, (), CurrentUser>;
 pub type GuildChannelRef<'a> = CacheRef<'a, ChannelId, GuildChannel>;
 pub type PrivateChannelRef<'a> = CacheRef<'a, ChannelId, PrivateChannel>;
 pub type ChannelMessagesRef<'a> = CacheRef<'a, ChannelId, HashMap<MessageId, Message>>;
-
-pub trait FromStrAndCache: Sized {
-    type Err;
-
-    #[allow(clippy::missing_errors_doc)]
-    fn from_str<CRL>(cache: CRL, s: &str) -> Result<Self, Self::Err>
-    where
-        CRL: AsRef<Cache> + Send + Sync;
-}
-
-pub trait StrExt: Sized {
-    #[allow(clippy::missing_errors_doc)]
-    fn parse_cached<CRL, F: FromStrAndCache>(&self, cache: CRL) -> Result<F, F::Err>
-    where
-        CRL: AsRef<Cache> + Send + Sync;
-}
-
-impl StrExt for &str {
-    #[allow(clippy::missing_errors_doc)]
-    fn parse_cached<CRL, F: FromStrAndCache>(&self, cache: CRL) -> Result<F, F::Err>
-    where
-        CRL: AsRef<Cache> + Send + Sync,
-    {
-        F::from_str(&cache, self)
-    }
-}
-
-impl<F: FromStr> FromStrAndCache for F {
-    type Err = F::Err;
-
-    #[allow(clippy::missing_errors_doc)]
-    fn from_str<CRL>(_cache: CRL, s: &str) -> Result<Self, Self::Err>
-    where
-        CRL: AsRef<Cache> + Send + Sync,
-    {
-        s.parse::<F>()
-    }
-}
 
 #[derive(Debug)]
 pub(crate) struct CachedShardData {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -28,7 +28,6 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
-
 #[cfg(feature = "temp_cache")]
 use std::sync::Arc;
 #[cfg(feature = "temp_cache")]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -9,7 +9,6 @@ mod partial_channel;
 mod private_channel;
 mod reaction;
 
-
 use std::fmt;
 
 use serde::de::{Error as DeError, Unexpected};
@@ -22,14 +21,12 @@ pub use self::message::*;
 pub use self::partial_channel::*;
 pub use self::private_channel::*;
 pub use self::reaction::*;
-
 #[cfg(feature = "model")]
 use crate::http::CacheHttp;
 use crate::json::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
 use crate::model::Timestamp;
-
 
 #[deprecated = "use CreateAttachment instead"]
 #[cfg(feature = "model")]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -9,8 +9,7 @@ mod partial_channel;
 mod private_channel;
 mod reaction;
 
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use std::error::Error as StdError;
+
 use std::fmt;
 
 use serde::de::{Error as DeError, Unexpected};
@@ -23,18 +22,14 @@ pub use self::message::*;
 pub use self::partial_channel::*;
 pub use self::private_channel::*;
 pub use self::reaction::*;
-#[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use crate::cache::FromStrAndCache;
+
 #[cfg(feature = "model")]
 use crate::http::CacheHttp;
 use crate::json::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
 use crate::model::Timestamp;
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use crate::utils::parse_channel;
+
 
 #[deprecated = "use CreateAttachment instead"]
 #[cfg(feature = "model")]
@@ -495,44 +490,6 @@ mod test {
 
             let private_channel = PrivateChannel::default();
             assert!(!private_channel.is_nsfw());
-        }
-    }
-}
-
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-#[derive(Debug)]
-pub enum ChannelParseError {
-    NotPresentInCache,
-    InvalidChannel,
-}
-
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-impl fmt::Display for ChannelParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotPresentInCache => f.write_str("not present in cache"),
-            Self::InvalidChannel => f.write_str("invalid channel"),
-        }
-    }
-}
-
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-impl StdError for ChannelParseError {}
-
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-impl FromStrAndCache for Channel {
-    type Err = ChannelParseError;
-
-    fn from_str<C>(cache: C, s: &str) -> StdResult<Self, Self::Err>
-    where
-        C: AsRef<Cache> + Send + Sync,
-    {
-        match parse_channel(s) {
-            Some(x) => match x.to_channel_cached(&cache) {
-                Some(channel) => Ok(channel),
-                _ => Err(ChannelParseError::NotPresentInCache),
-            },
-            _ => Err(ChannelParseError::InvalidChannel),
         }
     }
 }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -1,22 +1,18 @@
 use std::cmp::Ordering;
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use std::error::Error as StdError;
+
 use std::fmt;
 
 #[cfg(feature = "model")]
 use crate::builder::EditRole;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::Cache;
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use crate::cache::FromStrAndCache;
 #[cfg(feature = "model")]
 use crate::http::Http;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-use crate::utils::parse_role;
+
 
 /// Information about a role within a guild. A role represents a set of permissions, and can be
 /// attached to one or multiple users. A role has various miscellaneous configurations, such as
@@ -200,44 +196,6 @@ impl<'a> From<&'a Role> for RoleId {
     /// Gets the Id of a role.
     fn from(role: &Role) -> RoleId {
         role.id
-    }
-}
-
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-#[derive(Debug)]
-pub enum RoleParseError {
-    NotPresentInCache,
-    InvalidRole,
-}
-
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-impl fmt::Display for RoleParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotPresentInCache => f.write_str("not present in cache"),
-            Self::InvalidRole => f.write_str("invalid role"),
-        }
-    }
-}
-
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-impl StdError for RoleParseError {}
-
-#[cfg(all(feature = "cache", feature = "model", feature = "utils"))]
-impl FromStrAndCache for Role {
-    type Err = RoleParseError;
-
-    fn from_str<CRL>(cache: CRL, s: &str) -> StdResult<Self, Self::Err>
-    where
-        CRL: AsRef<Cache> + Send + Sync,
-    {
-        match parse_role(s) {
-            Some(x) => match x.to_role_cached(&cache) {
-                Some(role) => Ok(role),
-                None => Err(RoleParseError::NotPresentInCache),
-            },
-            None => Err(RoleParseError::InvalidRole),
-        }
     }
 }
 

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-
 use std::fmt;
 
 #[cfg(feature = "model")]
@@ -12,7 +11,6 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
-
 
 /// Information about a role within a guild. A role represents a set of permissions, and can be
 /// attached to one or multiple users. A role has various miscellaneous configurations, such as


### PR DESCRIPTION
FromStrAndCache is like ArgumentConvert but worse (was only implemented for Channel and Role, supported only cache retrieval and no on-demand async requests, and it had no access to the channel ID and guild ID it was called in)

StrExt was a simple extension trait with a single parse_cached() method that called out to FromStrAndCache

Also removes the FromStrAndCache-specific ChannelParseError and RoleParseError enums in the model module, thereby fixing #2414 