### PR TITLE
Actually call ChannelUpdate's CacheUpdate implementation and clean up permission calculation a bit

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -202,6 +202,13 @@ async fn message(
             .await?;
     } else if msg.content == "shutdown" {
         shard_manager.lock().await.shutdown_all().await;
+    } else if msg.content == "channelperms" {
+        let guild = guild_id.to_guild_cached(ctx).unwrap().clone();
+        let perms = guild.user_permissions_in(
+            &channel_id.to_channel(ctx).await?.guild().unwrap(),
+            &*guild.member(ctx, msg.author.id).await?,
+        );
+        channel_id.say(ctx, format!("{:?}", perms)).await?;
     } else {
         return Ok(());
     }

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -105,9 +105,11 @@ impl CacheUpdate for ChannelDeleteEvent {
 }
 
 impl CacheUpdate for ChannelUpdateEvent {
-    type Output = ();
+    type Output = Channel;
 
-    fn update(&mut self, cache: &Cache) -> Option<()> {
+    fn update(&mut self, cache: &Cache) -> Option<Channel> {
+        let old_channel = cache.channel(self.channel.id());
+
         match &self.channel {
             Channel::Guild(channel) => {
                 let (guild_id, channel_id) = (channel.guild_id, channel.id);
@@ -126,7 +128,7 @@ impl CacheUpdate for ChannelUpdateEvent {
             },
         }
 
-        None
+        old_channel
     }
 }
 

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -141,8 +141,8 @@ fn update_cache_with_event(ctx: Context, event: Event) -> Option<(FullEvent, Opt
             ctx,
             pin: event,
         },
-        Event::ChannelUpdate(event) => {
-            let old_channel = if_cache!(ctx.cache.channel(event.channel.id()));
+        Event::ChannelUpdate(mut event) => {
+            let old_channel = if_cache!(event.update(&ctx.cache));
 
             FullEvent::ChannelUpdate {
                 ctx,

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -860,19 +860,7 @@ pub(crate) fn has_correct_permissions(
             let Some(channel) = guild.channels.get(&message.channel_id) else {return false};
             let Some(member) = guild.members.get(&message.author.id) else {return false};
 
-            match guild.user_permissions_in(channel, member) {
-                Ok(perms) => perms.contains(*options.required_permissions()),
-                Err(e) => {
-                    tracing::error!(
-                        "Error getting permissions for user {} in channel {}: {}",
-                        member.user.id,
-                        channel.id,
-                        e
-                    );
-
-                    false
-                },
-            }
+            guild.user_permissions_in(channel, member).contains(*options.required_permissions())
         })
     }
 }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -802,7 +802,7 @@ impl GuildChannel {
         let guild = self.guild(&cache).ok_or(Error::Model(ModelError::GuildNotFound))?;
         let member =
             guild.members.get(&user_id.into()).ok_or(Error::Model(ModelError::MemberNotFound))?;
-        guild.user_permissions_in(self, member)
+        Ok(guild.user_permissions_in(self, member))
     }
 
     /// Calculates the permissions of a role.
@@ -818,6 +818,8 @@ impl GuildChannel {
     /// [`Cache`].
     #[cfg(feature = "cache")]
     #[inline]
+    #[deprecated = "this function ignores other roles the user may have as well as user-specific permissions; use Guild::user_permissions_in instead"]
+    #[allow(deprecated)]
     pub fn permissions_for_role(
         &self,
         cache: impl AsRef<Cache>,

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -110,9 +110,12 @@ pub enum Error {
     /// role, then the role can not be edited.
     Hierarchy,
     /// Indicates that you do not have the required permissions to perform an operation.
-    ///
-    /// The provided [`Permissions`] is the set of required permissions required.
-    InvalidPermissions(Permissions),
+    InvalidPermissions {
+        /// Which permissions were required for the operation
+        required: Permissions,
+        /// Which permissions the bot had
+        present: Permissions,
+    },
     /// An indicator that the [current user] cannot perform an action.
     ///
     /// [current user]: super::user::CurrentUser
@@ -187,7 +190,9 @@ impl fmt::Display for Error {
             Self::ChannelNotFound => f.write_str("Channel not found in the cache."),
             Self::Hierarchy => f.write_str("Role hierarchy prevents this action."),
             Self::InvalidChannelType => f.write_str("The channel cannot perform the action."),
-            Self::InvalidPermissions(_) => f.write_str("Invalid permissions."),
+            Self::InvalidPermissions {
+                ..
+            } => f.write_str("Invalid permissions."),
             Self::InvalidUser => f.write_str("The current user cannot perform the action."),
             Self::ItemMissing => f.write_str("The required item is missing from the cache."),
             Self::WrongGuild => f.write_str("Provided member or channel is from the wrong guild."),

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -17,10 +17,7 @@ mod welcome_screen;
 #[cfg(feature = "model")]
 use std::borrow::Cow;
 
-#[cfg(feature = "model")]
-use tracing::error;
-#[cfg(all(feature = "model", feature = "cache"))]
-use tracing::warn;
+use tracing::{error, warn};
 
 pub use self::emoji::*;
 pub use self::guild_id::*;
@@ -2438,6 +2435,7 @@ struct CalculatePermissions {
     pub member_deny_overwrites: Permissions,
 }
 
+#[cfg(feature = "model")]
 impl Default for CalculatePermissions {
     fn default() -> Self {
         Self {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -368,7 +368,7 @@ impl Guild {
     }
 
     #[cfg(feature = "cache")]
-    fn check_hierarchy(&self, cache: impl AsRef<Cache>, other_user: UserId) -> Result<()> {
+    fn check_hierarchy(&self, cache: &Cache, other_user: UserId) -> Result<()> {
         let current_id = cache.as_ref().current_user().id;
 
         if let Some(higher) = self.greater_member_hierarchy(&cache, other_user, current_id) {
@@ -387,9 +387,7 @@ impl Guild {
         let member = self.members.get(&uid)?;
         self.channels.values().find(|&channel| {
             channel.kind != ChannelType::Category
-                && self
-                    .user_permissions_in(channel, member)
-                    .map_or(false, Permissions::view_channel)
+                && self.user_permissions_in(channel, member).view_channel()
         })
     }
 
@@ -404,30 +402,28 @@ impl Guild {
                 && self
                     .members
                     .values()
-                    .filter_map(|member| self.user_permissions_in(channel, member).ok())
+                    .map(|member| self.user_permissions_in(channel, member))
                     .all(Permissions::view_channel)
         })
     }
 
+    /// Intentionally not async. Retrieving anything from HTTP here is overkill/undesired
     #[cfg(feature = "cache")]
-    pub(crate) async fn has_perms(
+    pub(crate) fn require_perms(
         &self,
-        cache_http: impl CacheHttp,
-        mut permissions: Permissions,
-    ) -> bool {
-        if let Some(cache) = cache_http.cache() {
-            let user_id = cache.current_user().id;
-
-            if let Ok(perms) = self.member_permissions(cache_http, user_id).await {
-                permissions.remove(perms);
-
-                permissions.is_empty()
-            } else {
-                false
+        cache: &Cache,
+        required_permissions: Permissions,
+    ) -> Result<(), Error> {
+        if let Some(member) = self.members.get(&cache.current_user().id) {
+            let bot_permissions = self.member_permissions(member);
+            if !bot_permissions.contains(required_permissions) {
+                return Err(Error::Model(ModelError::InvalidPermissions {
+                    required: required_permissions,
+                    present: bot_permissions,
+                }));
             }
-        } else {
-            false
         }
+        Ok(())
     }
 
     #[cfg(feature = "cache")]
@@ -516,11 +512,7 @@ impl Guild {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let req = Permissions::BAN_MEMBERS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+                self.require_perms(cache, Permissions::BAN_MEMBERS)?;
 
                 self.check_hierarchy(cache, user)?;
             }
@@ -548,12 +540,8 @@ impl Guild {
     pub async fn bans(&self, cache_http: impl CacheHttp) -> Result<Vec<Ban>> {
         #[cfg(feature = "cache")]
         {
-            if cache_http.cache().is_some() {
-                let req = Permissions::BAN_MEMBERS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+            if let Some(cache) = cache_http.cache() {
+                self.require_perms(cache, Permissions::BAN_MEMBERS)?;
             }
         }
 
@@ -939,9 +927,7 @@ impl Guild {
         {
             if let Some(cache) = cache_http.cache() {
                 if self.owner_id != cache.current_user().id {
-                    let req = Permissions::MANAGE_GUILD;
-
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                    return Err(Error::Model(ModelError::InvalidUser));
                 }
             }
         }
@@ -1173,12 +1159,8 @@ impl Guild {
     ) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            if cache_http.cache().is_some() {
-                let req = Permissions::CHANGE_NICKNAME;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+            if let Some(cache) = cache_http.cache() {
+                self.require_perms(cache, Permissions::CHANGE_NICKNAME)?;
             }
         }
 
@@ -1482,12 +1464,8 @@ impl Guild {
     pub async fn invites(&self, cache_http: impl CacheHttp) -> Result<Vec<RichInvite>> {
         #[cfg(feature = "cache")]
         {
-            if cache_http.cache().is_some() {
-                let req = Permissions::MANAGE_GUILD;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+            if let Some(cache) = cache_http.cache() {
+                self.require_perms(cache, Permissions::MANAGE_GUILD)?;
             }
         }
 
@@ -1866,57 +1844,8 @@ impl Guild {
     /// See [`Guild::member`].
     #[inline]
     #[cfg(feature = "cache")]
-    pub async fn member_permissions(
-        &self,
-        cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
-    ) -> Result<Permissions> {
-        self._member_permissions(cache_http, user_id.into()).await
-    }
-
-    #[cfg(feature = "cache")]
-    async fn _member_permissions(
-        &self,
-        cache_http: impl CacheHttp,
-        user_id: UserId,
-    ) -> Result<Permissions> {
-        if user_id == self.owner_id {
-            return Ok(Permissions::all());
-        }
-
-        let member = self.member(cache_http, &user_id).await?;
-
-        Ok(self._member_permission_from_member(&member))
-    }
-
-    /// Helper function that's used for getting a [`Member`]'s permissions.
-    #[cfg(feature = "cache")]
-    pub(crate) fn _member_permission_from_member(&self, member: &Member) -> Permissions {
-        if member.user.id == self.owner_id {
-            return Permissions::all();
-        }
-
-        let Some(everyone) = self.roles.get(&RoleId(self.id.0)) else {
-            error!("@everyone role ({}) missing in '{}'", self.id, self.name);
-
-            return Permissions::empty();
-        };
-
-        let mut permissions = everyone.permissions;
-
-        for role in &member.roles {
-            if let Some(role) = self.roles.get(role) {
-                if role.permissions.contains(Permissions::ADMINISTRATOR) {
-                    return Permissions::all();
-                }
-
-                permissions |= role.permissions;
-            } else {
-                warn!("{} on {} has non-existent role {:?}", member.user.id, self.id, role,);
-            }
-        }
-
-        permissions
+    pub fn member_permissions(&self, member: &Member) -> Permissions {
+        Self::_user_permissions_in(None, member, &self.roles, self.owner_id, self.id)
     }
 
     /// Moves a member to a specific voice channel.
@@ -1945,93 +1874,77 @@ impl Guild {
     ///
     /// Returns [`Error::Model`] if the [`Member`] has a non-existent role for some reason.
     #[inline]
-    pub fn user_permissions_in(
-        &self,
-        channel: &GuildChannel,
-        member: &Member,
-    ) -> Result<Permissions> {
-        Self::_user_permissions_in(channel, member, &self.roles, self.owner_id, self.id)
+    pub fn user_permissions_in(&self, channel: &GuildChannel, member: &Member) -> Permissions {
+        Self::_user_permissions_in(Some(channel), member, &self.roles, self.owner_id, self.id)
     }
 
     /// Helper function that can also be used from [`PartialGuild`].
     pub(crate) fn _user_permissions_in(
-        channel: &GuildChannel,
+        channel: Option<&GuildChannel>,
         member: &Member,
-        roles: &HashMap<RoleId, Role>,
-        owner_id: UserId,
+        guild_roles: &HashMap<RoleId, Role>,
+        guild_owner_id: UserId,
         guild_id: GuildId,
-    ) -> Result<Permissions> {
-        // The owner has all permissions in all cases.
-        if member.user.id == owner_id {
-            return Ok(Self::remove_unnecessary_voice_permissions(channel, Permissions::all()));
-        }
+    ) -> Permissions {
+        let mut everyone_allow_overwrites = Permissions::empty();
+        let mut everyone_deny_overwrites = Permissions::empty();
+        let mut roles_allow_overwrites = Vec::new();
+        let mut roles_deny_overwrites = Vec::new();
+        let mut member_allow_overwrites = Permissions::empty();
+        let mut member_deny_overwrites = Permissions::empty();
 
-        // Start by retrieving the @everyone role's permissions.
-        let Some(everyone) = roles.get(&RoleId(guild_id.0)) else {
-            error!("@everyone role missing in {}", guild_id,);
-            return Err(Error::Model(ModelError::RoleNotFound));
-        };
-
-        // Create a base set of permissions, starting with `@everyone`s.
-        let mut permissions = everyone.permissions;
-
-        for &role in &member.roles {
-            if let Some(role) = roles.get(&role) {
-                permissions |= role.permissions;
-            } else {
-                error!("{} on {} has non-existent role {:?}", member.user.id, guild_id, role);
-                return Err(Error::Model(ModelError::RoleNotFound));
-            }
-        }
-
-        // Administrators have all permissions in any channel.
-        if permissions.contains(Permissions::ADMINISTRATOR) {
-            return Ok(Self::remove_unnecessary_voice_permissions(channel, Permissions::all()));
-        }
-
-        // Apply the permission overwrites for the channel for each of the overwrites that, first,
-        // applies to the member's roles, and then the member itself.
-        //
-        // First apply the denied permission overwrites for each, then apply the allowed.
-
-        let mut data = Vec::with_capacity(member.roles.len());
-
-        // Roles
-        for overwrite in &channel.permission_overwrites {
-            if let PermissionOverwriteType::Role(role) = overwrite.kind {
-                if role.0 != guild_id.0 && !member.roles.contains(&role) {
-                    continue;
-                }
-
-                if let Some(role) = roles.get(&role) {
-                    data.push((role.position, overwrite.deny, overwrite.allow));
+        if let Some(channel) = channel {
+            for overwrite in &channel.permission_overwrites {
+                match overwrite.kind {
+                    PermissionOverwriteType::Member(user_id) => {
+                        if member.user.id == user_id {
+                            member_allow_overwrites = overwrite.allow;
+                            member_deny_overwrites = overwrite.deny;
+                        }
+                    },
+                    PermissionOverwriteType::Role(role_id) => {
+                        if role_id.0 == guild_id.0 {
+                            everyone_allow_overwrites = overwrite.allow;
+                            everyone_deny_overwrites = overwrite.deny;
+                        } else if member.roles.contains(&role_id) {
+                            roles_allow_overwrites.push(overwrite.allow);
+                            roles_deny_overwrites.push(overwrite.deny);
+                        }
+                    },
                 }
             }
         }
 
-        data.sort_by(|a, b| a.0.cmp(&b.0));
-
-        for overwrite in data {
-            permissions = (permissions & !overwrite.1) | overwrite.2;
-        }
-
-        // Member
-        for overwrite in &channel.permission_overwrites {
-            if PermissionOverwriteType::Member(member.user.id) != overwrite.kind {
-                continue;
-            }
-
-            permissions = (permissions & !overwrite.deny) | overwrite.allow;
-        }
-
-        // The default channel is always readable.
-        if channel.id.0 == guild_id.0 {
-            permissions |= Permissions::VIEW_CHANNEL;
-        }
-
-        Self::remove_unusable_permissions(&mut permissions);
-
-        Ok(permissions)
+        calculate_permissions(CalculatePermissions {
+            is_guild_owner: member.user.id == guild_owner_id,
+            everyone_permissions: match guild_roles.get(&RoleId(guild_id.0)) {
+                Some(role) => role.permissions,
+                None => {
+                    error!("@everyone role missing in {}", guild_id);
+                    Permissions::empty()
+                },
+            },
+            user_roles_permissions: member
+                .roles
+                .iter()
+                .map(|role_id| match guild_roles.get(role_id) {
+                    Some(role) => role.permissions,
+                    None => {
+                        warn!(
+                            "{} on {} has non-existent role {:?}",
+                            member.user.id, guild_id, role_id
+                        );
+                        Permissions::empty()
+                    },
+                })
+                .collect(),
+            everyone_allow_overwrites,
+            everyone_deny_overwrites,
+            roles_allow_overwrites,
+            roles_deny_overwrites,
+            member_allow_overwrites,
+            member_deny_overwrites,
+        })
     }
 
     /// Calculate a [`Role`]'s permissions in a given channel in the guild.
@@ -2040,6 +1953,7 @@ impl Guild {
     ///
     /// Will return an [`Error::Model`] if the [`Role`] or [`Channel`] is not from this [`Guild`].
     #[inline]
+    #[deprecated = "this function ignores other roles the user may have as well as user-specific permissions; use user_permissions_in instead"]
     pub fn role_permissions_in(&self, channel: &GuildChannel, role: &Role) -> Result<Permissions> {
         Self::_role_permissions_in(channel, role, self.id)
     }
@@ -2097,12 +2011,8 @@ impl Guild {
     pub async fn prune_count(&self, cache_http: impl CacheHttp, days: u8) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
-            if cache_http.cache().is_some() {
-                let req = Permissions::KICK_MEMBERS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+            if let Some(cache) = cache_http.cache() {
+                self.require_perms(cache, Permissions::KICK_MEMBERS)?;
             }
         }
 
@@ -2358,12 +2268,8 @@ impl Guild {
     pub async fn start_prune(&self, cache_http: impl CacheHttp, days: u8) -> Result<GuildPrune> {
         #[cfg(feature = "cache")]
         {
-            if cache_http.cache().is_some() {
-                let req = Permissions::KICK_MEMBERS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+            if let Some(cache) = cache_http.cache() {
+                self.require_perms(cache, Permissions::KICK_MEMBERS)?;
             }
         }
 
@@ -2389,12 +2295,8 @@ impl Guild {
     ) -> Result<()> {
         #[cfg(feature = "cache")]
         {
-            if cache_http.cache().is_some() {
-                let req = Permissions::BAN_MEMBERS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
+            if let Some(cache) = cache_http.cache() {
+                self.require_perms(cache, Permissions::BAN_MEMBERS)?;
             }
         }
 
@@ -2510,6 +2412,91 @@ impl Guild {
     pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
         self.id.get_active_threads(http).await
     }
+}
+
+#[cfg(feature = "model")]
+struct CalculatePermissions {
+    /// Whether the guild member is the guild owner
+    pub is_guild_owner: bool,
+    /// Base permissions given to @everyone (guild level)
+    pub everyone_permissions: Permissions,
+    /// Permissions allowed to a user by their roles (guild level)
+    pub user_roles_permissions: Vec<Permissions>,
+    /// Overwrites that deny permissions for @everyone (channel level)
+    pub everyone_allow_overwrites: Permissions,
+    /// Overwrites that allow permissions for @everyone (channel level)
+    pub everyone_deny_overwrites: Permissions,
+    /// Overwrites that deny permissions for specific roles (channel level)
+    pub roles_allow_overwrites: Vec<Permissions>,
+    /// Overwrites that allow permissions for specific roles (channel level)
+    pub roles_deny_overwrites: Vec<Permissions>,
+    /// Member-specific overwrites that deny permissions (channel level)
+    pub member_allow_overwrites: Permissions,
+    /// Member-specific overwrites that allow permissions (channel level)
+    pub member_deny_overwrites: Permissions,
+}
+
+impl Default for CalculatePermissions {
+    fn default() -> Self {
+        Self {
+            is_guild_owner: false,
+            everyone_permissions: Permissions::empty(),
+            user_roles_permissions: Vec::new(),
+            everyone_allow_overwrites: Permissions::empty(),
+            everyone_deny_overwrites: Permissions::empty(),
+            roles_allow_overwrites: Vec::new(),
+            roles_deny_overwrites: Vec::new(),
+            member_allow_overwrites: Permissions::empty(),
+            member_deny_overwrites: Permissions::empty(),
+        }
+    }
+}
+
+/// Translated from the pseudo code at https://discord.com/developers/docs/topics/permissions#permission-overwrites
+///
+/// The comments within this file refer to the above link
+#[cfg(feature = "model")]
+fn calculate_permissions(data: CalculatePermissions) -> Permissions {
+    if data.is_guild_owner {
+        return Permissions::all();
+    }
+
+    // 1. Base permissions given to @everyone are applied at a guild level
+    let mut permissions = data.everyone_permissions;
+    // 2. Permissions allowed to a user by their roles are applied at a guild level
+    for role_permission in data.user_roles_permissions {
+        permissions |= role_permission;
+    }
+
+    if permissions.contains(Permissions::ADMINISTRATOR) {
+        return Permissions::all();
+    }
+
+    // 3. Overwrites that deny permissions for @everyone are applied at a channel level
+    permissions &= !data.everyone_deny_overwrites;
+    // 4. Overwrites that allow permissions for @everyone are applied at a channel level
+    permissions |= data.everyone_allow_overwrites;
+
+    // 5. Overwrites that deny permissions for specific roles are applied at a channel level
+    let mut role_deny_permissions = Permissions::empty();
+    for p in data.roles_deny_overwrites {
+        role_deny_permissions |= p;
+    }
+    permissions &= !role_deny_permissions;
+
+    // 6. Overwrites that allow permissions for specific roles are applied at a channel level
+    let mut role_allow_permissions = Permissions::empty();
+    for p in data.roles_allow_overwrites {
+        role_allow_permissions |= p;
+    }
+    permissions |= role_allow_permissions;
+
+    // 7. Member-specific overwrites that deny permissions are applied at a channel level
+    permissions &= !data.member_deny_overwrites;
+    // 8. Member-specific overwrites that allow permissions are applied at a channel level
+    permissions |= data.member_allow_overwrites;
+
+    permissions
 }
 
 /// Checks if a `&str` contains another `&str`.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1082,6 +1082,7 @@ impl PartialGuild {
     /// See [`Guild::member`].
     #[inline]
     #[cfg(feature = "cache")]
+    #[must_use]
     pub fn member_permissions(&self, member: &Member) -> Permissions {
         Guild::_user_permissions_in(None, member, &self.roles, self.owner_id, self.id)
     }
@@ -1312,6 +1313,7 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Model`] if the Member has a non-existent [`Role`] for some reason.
     #[inline]
+    #[must_use]
     pub fn user_permissions_in(&self, channel: &GuildChannel, member: &Member) -> Permissions {
         Guild::_user_permissions_in(Some(channel), member, &self.roles, self.owner_id, self.id)
     }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,6 +1,4 @@
 use serde::Serialize;
-#[cfg(feature = "cache")]
-use tracing::{error, warn};
 
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -1084,46 +1082,8 @@ impl PartialGuild {
     /// See [`Guild::member`].
     #[inline]
     #[cfg(feature = "cache")]
-    pub async fn member_permissions(
-        &self,
-        cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
-    ) -> Result<Permissions> {
-        self._member_permissions(cache_http, user_id.into()).await
-    }
-
-    #[cfg(feature = "cache")]
-    async fn _member_permissions(
-        &self,
-        cache_http: impl CacheHttp,
-        user_id: UserId,
-    ) -> Result<Permissions> {
-        if user_id == self.owner_id {
-            return Ok(Permissions::all());
-        }
-
-        let Some(everyone) = self.roles.get(&RoleId(self.id.0)) else {
-            error!("@everyone role ({}) missing in '{}'", self.id, self.name,);
-            return Ok(Permissions::empty());
-        };
-
-        let member = self.member(cache_http, &user_id).await?;
-
-        let mut permissions = everyone.permissions;
-
-        for role in &member.roles {
-            if let Some(role) = self.roles.get(role) {
-                if role.permissions.contains(Permissions::ADMINISTRATOR) {
-                    return Ok(Permissions::all());
-                }
-
-                permissions |= role.permissions;
-            } else {
-                warn!("{} on {} has non-existent role {:?}", member.user.id, self.id, role,);
-            }
-        }
-
-        Ok(permissions)
+    pub fn member_permissions(&self, member: &Member) -> Permissions {
+        Guild::_user_permissions_in(None, member, &self.roles, self.owner_id, self.id)
     }
 
     /// Re-orders the channels of the guild.
@@ -1186,35 +1146,7 @@ impl PartialGuild {
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
     pub async fn start_prune(&self, cache_http: impl CacheHttp, days: u8) -> Result<GuildPrune> {
-        #[cfg(feature = "cache")]
-        {
-            if cache_http.cache().is_some() {
-                let req = Permissions::KICK_MEMBERS;
-
-                if !self.has_perms(&cache_http, req).await {
-                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                }
-            }
-        }
-
         self.id.start_prune(cache_http.http(), days).await
-    }
-
-    #[cfg(feature = "cache")]
-    async fn has_perms(&self, cache_http: impl CacheHttp, mut permissions: Permissions) -> bool {
-        if let Some(cache) = cache_http.cache() {
-            let user_id = cache.current_user().id;
-
-            if let Ok(perms) = self.member_permissions(cache_http, user_id).await {
-                permissions.remove(perms);
-
-                permissions.is_empty()
-            } else {
-                false
-            }
-        } else {
-            false
-        }
     }
 
     /// Kicks a [`Member`] from the guild.
@@ -1380,12 +1312,8 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Model`] if the Member has a non-existent [`Role`] for some reason.
     #[inline]
-    pub fn user_permissions_in(
-        &self,
-        channel: &GuildChannel,
-        member: &Member,
-    ) -> Result<Permissions> {
-        Guild::_user_permissions_in(channel, member, &self.roles, self.owner_id, self.id)
+    pub fn user_permissions_in(&self, channel: &GuildChannel, member: &Member) -> Permissions {
+        Guild::_user_permissions_in(Some(channel), member, &self.roles, self.owner_id, self.id)
     }
 
     /// Calculate a [`Role`]'s permissions in a given channel in the guild.
@@ -1394,6 +1322,7 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Model`] if the [`Role`] or [`Channel`] is not from this [`Guild`].
     #[inline]
+    #[deprecated = "this function ignores other roles the user may have as well as user-specific permissions; use user_permissions_in instead"]
     pub fn role_permissions_in(&self, channel: &GuildChannel, role: &Role) -> Result<Permissions> {
         Guild::_role_permissions_in(channel, role, self.id)
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -411,6 +411,7 @@ pub fn parse_webhook(url: &Url) -> Option<(WebhookId, &str)> {
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
+#[allow(clippy::unused_async)] // don't wanna change the bazillion internal invocations
 pub(crate) async fn user_has_guild_perms(
     cache_http: impl CacheHttp,
     guild_id: GuildId,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -421,9 +421,7 @@ pub(crate) async fn user_has_guild_perms(
         // `Guild::has_perms` is an async fn, but we want the returned Future to be `Send`.
         let lookup = cache.guild(guild_id).as_deref().cloned();
         if let Some(guild) = lookup {
-            if !guild.has_perms(cache_http, permissions).await {
-                return Err(Error::Model(ModelError::InvalidPermissions(permissions)));
-            }
+            guild.require_perms(cache, permissions)?;
         }
     }
     Ok(())
@@ -437,25 +435,30 @@ pub(crate) fn user_has_perms_cache(
     cache: impl AsRef<Cache>,
     channel_id: ChannelId,
     guild_id: Option<GuildId>,
-    permissions: Permissions,
+    required_permissions: Permissions,
 ) -> Result<()> {
-    if match user_has_perms(cache, channel_id, guild_id, permissions) {
-        Err(Error::Model(err)) => err.is_cache_err(),
-        result => result?,
-    } {
-        Ok(())
-    } else {
-        Err(Error::Model(ModelError::InvalidPermissions(permissions)))
+    match user_perms(cache, channel_id, guild_id) {
+        Ok(perms) => {
+            if perms.contains(required_permissions) {
+                Ok(())
+            } else {
+                Err(Error::Model(ModelError::InvalidPermissions {
+                    required: required_permissions,
+                    present: perms,
+                }))
+            }
+        },
+        Err(Error::Model(err)) if err.is_cache_err() => Ok(()),
+        Err(other) => Err(other),
     }
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
-pub(crate) fn user_has_perms(
+pub(crate) fn user_perms(
     cache: impl AsRef<Cache>,
     channel_id: ChannelId,
     guild_id: Option<GuildId>,
-    mut permissions: Permissions,
-) -> Result<bool> {
+) -> Result<Permissions> {
     let cache = cache.as_ref();
 
     let Some(channel) = cache.channel(channel_id) else {
@@ -474,7 +477,7 @@ pub(crate) fn user_has_perms(
         Channel::Guild(channel) => (channel.guild_id, channel),
         Channel::Private(_) => match guild_id {
             Some(_) => return Err(Error::Model(ModelError::InvalidChannelType)),
-            None => return Ok(true),
+            None => return Ok(Permissions::all()),
         },
     };
 
@@ -486,11 +489,7 @@ pub(crate) fn user_has_perms(
         return Err(Error::Model(ModelError::MemberNotFound))
     };
 
-    let perms = guild.user_permissions_in(&guild_channel, member)?;
-
-    permissions.remove(perms);
-
-    Ok(permissions.is_empty())
+    Ok(guild.user_permissions_in(&guild_channel, member))
 }
 
 /// Calculates the Id of the shard responsible for a guild, given its Id and total number of shards


### PR DESCRIPTION
In the first commit, I cleaned up permissions a bit to duplicate less code and be closer to the Discord API. Copy pasting the commit message:

- Rewrite user_permissions_in
- Change ModelError::InvalidPermissions fields from (Permissions) to { required: Permissions, present: Permissions }
- Deprecate role_permissions_in/permissions_for_role
- Change has_perms to require_perms and reduce boilerplate
- Implement member_permissions in terms of _user_permissions_in (de-duplicate permission calculation code)

The second commit fixes #2378 by invoking the CacheUpdate implementation of ChannelUpdate that it has had the entire time, but no one called it (lol)

