### PR TITLE
Don't claim that the default text channel's ID equals the guild ID

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -71,8 +71,6 @@ pub struct GuildChannel {
     pub parent_id: Option<ChannelId>,
     /// The Id of the guild the channel is located in.
     ///
-    /// If this matches with the [`id`], then this is the default text channel.
-    ///
     /// The original voice channel has an Id equal to the guild's Id,
     /// incremented by one.
     pub guild_id: GuildId,


### PR DESCRIPTION
Follow up to #2148, which missed this line.