### PR TITLE
Make AutocompleteChoice constructable again

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -278,8 +278,8 @@ impl CreateInteractionResponseMessage {
 // Same as CommandOptionChoice according to Discord, see
 // [Autocomplete docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete).
 #[must_use]
-#[serde(transparent)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
 pub struct AutocompleteChoice(CommandOptionChoice);
 impl AutocompleteChoice {
     pub fn new(name: impl Into<String>, value: impl Into<Value>) -> Self {

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -278,6 +278,26 @@ impl CreateInteractionResponseMessage {
 /// They're same according to Discord, see
 /// [Autocomplete docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete).
 pub type AutocompleteChoice = CommandOptionChoice;
+impl AutocompleteChoice {
+    pub fn new(name: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
+        Self {
+            name: name.into(),
+            name_localizations: None,
+            value: value.into(),
+        }
+    }
+
+    pub fn add_localized_name(
+        mut self,
+        locale: impl Into<String>,
+        localized_name: impl Into<String>,
+    ) -> Self {
+        self.name_localizations
+            .get_or_insert_with(Default::default)
+            .insert(locale.into(), localized_name.into());
+        self
+    }
+}
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete)
 #[derive(Clone, Debug, Default, Serialize)]

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -275,17 +275,18 @@ impl CreateInteractionResponseMessage {
     super::button_and_select_menu_convenience_methods!(self.components);
 }
 
-/// They're same according to Discord, see
-/// [Autocomplete docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete).
+// Same as CommandOptionChoice according to Discord, see
+// [Autocomplete docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete).
 #[must_use]
-pub type AutocompleteChoice = CommandOptionChoice;
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AutocompleteChoice(CommandOptionChoice);
 impl AutocompleteChoice {
     pub fn new(name: impl Into<String>, value: impl Into<Value>) -> Self {
-        Self {
+        Self(CommandOptionChoice {
             name: name.into(),
             name_localizations: None,
             value: value.into(),
-        }
+        })
     }
 
     pub fn add_localized_name(
@@ -293,7 +294,8 @@ impl AutocompleteChoice {
         locale: impl Into<String>,
         localized_name: impl Into<String>,
     ) -> Self {
-        self.name_localizations
+        self.0
+            .name_localizations
             .get_or_insert_with(Default::default)
             .insert(locale.into(), localized_name.into());
         self
@@ -328,11 +330,7 @@ impl CreateAutocompleteResponse {
     /// **Note**: There can be no more than 25 choices set. Name must be between 1 and 100
     /// characters. Value must be between -2^53 and 2^53.
     pub fn add_int_choice(self, name: impl Into<String>, value: i64) -> Self {
-        self.add_choice(AutocompleteChoice {
-            name: name.into(),
-            value: Value::from(value),
-            name_localizations: None,
-        })
+        self.add_choice(AutocompleteChoice::new(name, value))
     }
 
     /// Adds a string autocomplete choice.
@@ -340,11 +338,7 @@ impl CreateAutocompleteResponse {
     /// **Note**: There can be no more than 25 choices set. Name must be between 1 and 100
     /// characters. Value must be up to 100 characters.
     pub fn add_string_choice(self, name: impl Into<String>, value: impl Into<String>) -> Self {
-        self.add_choice(AutocompleteChoice {
-            name: name.into(),
-            value: Value::String(value.into()),
-            name_localizations: None,
-        })
+        self.add_choice(AutocompleteChoice::new(name, value.into()))
     }
 
     /// Adds a number autocomplete choice.
@@ -352,11 +346,7 @@ impl CreateAutocompleteResponse {
     /// **Note**: There can be no more than 25 choices set. Name must be between 1 and 100
     /// characters. Value must be between -2^53 and 2^53.
     pub fn add_number_choice(self, name: impl Into<String>, value: f64) -> Self {
-        self.add_choice(AutocompleteChoice {
-            name: name.into(),
-            value: Value::from(value),
-            name_localizations: None,
-        })
+        self.add_choice(AutocompleteChoice::new(name, value))
     }
 
     fn add_choice(mut self, value: AutocompleteChoice) -> Self {

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -278,6 +278,7 @@ impl CreateInteractionResponseMessage {
 // Same as CommandOptionChoice according to Discord, see
 // [Autocomplete docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete).
 #[must_use]
+#[serde(transparent)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AutocompleteChoice(CommandOptionChoice);
 impl AutocompleteChoice {

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -279,7 +279,7 @@ impl CreateInteractionResponseMessage {
 /// [Autocomplete docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete).
 pub type AutocompleteChoice = CommandOptionChoice;
 impl AutocompleteChoice {
-    pub fn new(name: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
+    pub fn new(name: impl Into<String>, value: impl Into<Value>) -> Self {
         Self {
             name: name.into(),
             name_localizations: None,

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -277,6 +277,7 @@ impl CreateInteractionResponseMessage {
 
 /// They're same according to Discord, see
 /// [Autocomplete docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete).
+#[must_use]
 pub type AutocompleteChoice = CommandOptionChoice;
 impl AutocompleteChoice {
     pub fn new(name: impl Into<String>, value: impl Into<Value>) -> Self {


### PR DESCRIPTION
Noticed this because poise's serenity-next branch failed to build