### PR TITLE
Include all Message fields in MessageUpdateEvent

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -556,8 +556,8 @@ impl MessageUpdateEvent {
         // Discord won't send a MessageUpdateEvent with a different MessageId and ChannelId than we
         // already have. But let's set the fields anyways, in case the user calls this method with
         // a self-constructed MessageUpdateEvent that does change these fields.
-        message.id = id;
-        message.channel_id = channel_id;
+        message.id = *id;
+        message.channel_id = *channel_id;
 
         if let Some(x) = author { message.author = x.clone() }
         if let Some(x) = content { message.content = x.clone() }


### PR DESCRIPTION
I previously had commented some out in https://github.com/serenity-rs/serenity/pull/2393/files#diff-ae030146ad938ad8598138dec5f70cd4a4d3df75907295fc933f3d281a54430dL423-L448 because they cannot change in message update events. But unbeknownst to me, Discord doesn't send only the changed fields, but it sends some fields even when they didn't change.

The safer thing is to have just every single field of Message's fields also in MessageUpdateEvent