### PR TITLE
Turn generic params with `IntoIterator` bounds into `impl IntoIterator`

### DIFF
--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -151,9 +151,9 @@ impl CreateMessage {
 
     /// Adds a list of reactions to create after the message's sent.
     #[inline]
-    pub fn reactions<R: Into<ReactionType>, It: IntoIterator<Item = R>>(
+    pub fn reactions<R: Into<ReactionType>>(
         mut self,
-        reactions: It,
+        reactions: impl IntoIterator<Item = R>,
     ) -> Self {
         self.reactions = reactions.into_iter().map(Into::into).collect();
         self
@@ -232,9 +232,9 @@ impl CreateMessage {
     ///
     /// **Note**: This will replace all existing stickers. Use [`Self::add_sticker_id()`] or
     /// [`Self::add_sticker_ids()`] to keep existing stickers.
-    pub fn sticker_ids<T: Into<StickerId>, It: IntoIterator<Item = T>>(
+    pub fn sticker_ids<T: Into<StickerId>>(
         mut self,
-        sticker_ids: It,
+        sticker_ids: impl IntoIterator<Item = T>,
     ) -> Self {
         self.sticker_ids = sticker_ids.into_iter().map(Into::into).collect();
         self
@@ -257,9 +257,9 @@ impl CreateMessage {
     ///
     /// **Note**: This will keep all existing stickers. Use [`Self::sticker_ids()`] to replace
     /// existing stickers.
-    pub fn add_sticker_ids<T: Into<StickerId>, It: IntoIterator<Item = T>>(
+    pub fn add_sticker_ids<T: Into<StickerId>>(
         mut self,
-        sticker_ids: It,
+        sticker_ids: impl IntoIterator<Item = T>,
     ) -> Self {
         for sticker_id in sticker_ids {
             self = self.add_sticker_id(sticker_id);

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -217,10 +217,7 @@ impl<'a> EditChannel<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn permissions<I>(mut self, perms: I) -> Self
-    where
-        I: IntoIterator<Item = PermissionOverwrite>,
-    {
+    pub fn permissions(mut self, perms: impl IntoIterator<Item = PermissionOverwrite>) -> Self {
         let overwrites = perms.into_iter().map(Into::into).collect::<Vec<_>>();
 
         self.permission_overwrites = Some(overwrites);

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -484,11 +484,7 @@ impl Configuration {
     /// framework.configure(|c| c.prefixes(vec!["!", ">", "+"]));
     /// ```
     #[inline]
-    pub fn prefixes<T, It>(&mut self, prefixes: It) -> &mut Self
-    where
-        T: ToString,
-        It: IntoIterator<Item = T>,
-    {
+    pub fn prefixes<T: ToString>(&mut self, prefixes: impl IntoIterator<Item = T>) -> &mut Self {
         self.prefixes =
             prefixes.into_iter().map(|p| p.to_string()).filter(|p| !p.is_empty()).collect();
 
@@ -545,11 +541,10 @@ impl Configuration {
     /// let framework = StandardFramework::new();
     /// framework.configure(|c| c.delimiters(vec![", ", " "]));
     /// ```
-    pub fn delimiters<T, It>(&mut self, delimiters: It) -> &mut Self
-    where
-        T: Into<Delimiter>,
-        It: IntoIterator<Item = T>,
-    {
+    pub fn delimiters<T: Into<Delimiter>>(
+        &mut self,
+        delimiters: impl IntoIterator<Item = T>,
+    ) -> &mut Self {
         self.delimiters.clear();
         self.delimiters.extend(delimiters.into_iter().map(Into::into));
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -183,11 +183,11 @@ impl ChannelId {
     /// Also will return [`Error::Http`] if the current user lacks permission to delete messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_messages<T, It>(self, http: impl AsRef<Http>, message_ids: It) -> Result<()>
-    where
-        T: AsRef<MessageId>,
-        It: IntoIterator<Item = T>,
-    {
+    pub async fn delete_messages<T: AsRef<MessageId>>(
+        self,
+        http: impl AsRef<Http>,
+        message_ids: impl IntoIterator<Item = T>,
+    ) -> Result<()> {
         let ids =
             message_ids.into_iter().map(|message_id| message_id.as_ref().0).collect::<Vec<_>>();
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -380,15 +380,11 @@ impl GuildChannel {
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
-    pub async fn delete_messages<T, It>(
+    pub async fn delete_messages<T: AsRef<MessageId>>(
         &self,
         http: impl AsRef<Http>,
-        message_ids: It,
-    ) -> Result<()>
-    where
-        T: AsRef<MessageId>,
-        It: IntoIterator<Item = T>,
-    {
+        message_ids: impl IntoIterator<Item = T>,
+    ) -> Result<()> {
         self.id.delete_messages(http, message_ids).await
     }
 

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -88,15 +88,11 @@ impl PrivateChannel {
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
-    pub async fn delete_messages<T, It>(
+    pub async fn delete_messages<T: AsRef<MessageId>>(
         &self,
         http: impl AsRef<Http>,
-        message_ids: It,
-    ) -> Result<()>
-    where
-        T: AsRef<MessageId>,
-        It: IntoIterator<Item = T>,
-    {
+        message_ids: impl IntoIterator<Item = T>,
+    ) -> Result<()> {
         self.id.delete_messages(http, message_ids).await
     }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1173,10 +1173,11 @@ impl GuildId {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
-    pub async fn reorder_channels<It>(self, http: impl AsRef<Http>, channels: It) -> Result<()>
-    where
-        It: IntoIterator<Item = (ChannelId, u64)>,
-    {
+    pub async fn reorder_channels(
+        self,
+        http: impl AsRef<Http>,
+        channels: impl IntoIterator<Item = (ChannelId, u64)>,
+    ) -> Result<()> {
         let items = channels
             .into_iter()
             .map(|(id, pos)| {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2084,10 +2084,11 @@ impl Guild {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
-    pub async fn reorder_channels<It>(&self, http: impl AsRef<Http>, channels: It) -> Result<()>
-    where
-        It: IntoIterator<Item = (ChannelId, u64)>,
-    {
+    pub async fn reorder_channels(
+        &self,
+        http: impl AsRef<Http>,
+        channels: impl IntoIterator<Item = (ChannelId, u64)>,
+    ) -> Result<()> {
         self.id.reorder_channels(http, channels).await
     }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1112,10 +1112,11 @@ impl PartialGuild {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[inline]
-    pub async fn reorder_channels<It>(&self, http: impl AsRef<Http>, channels: It) -> Result<()>
-    where
-        It: IntoIterator<Item = (ChannelId, u64)>,
-    {
+    pub async fn reorder_channels(
+        &self,
+        http: impl AsRef<Http>,
+        channels: impl IntoIterator<Item = (ChannelId, u64)>,
+    ) -> Result<()> {
         self.id.reorder_channels(http, channels).await
     }
 

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -35,10 +35,7 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn attachments<It>(&mut self, attachments: It) -> &mut Self
-    where
-        It: IntoIterator<Item = Attachment>,
-    {
+    pub fn attachments(&mut self, attachments: impl IntoIterator<Item = Attachment>) -> &mut Self {
         self.msg.attachments = attachments.into_iter().collect();
 
         self
@@ -88,10 +85,7 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn embeds<It>(&mut self, embeds: It) -> &mut Self
-    where
-        It: IntoIterator<Item = Embed>,
-    {
+    pub fn embeds(&mut self, embeds: impl IntoIterator<Item = Embed>) -> &mut Self {
         self.msg.embeds = embeds.into_iter().collect();
 
         self
@@ -143,10 +137,7 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn mention_roles<It>(&mut self, roles: It) -> &mut Self
-    where
-        It: IntoIterator<Item = RoleId>,
-    {
+    pub fn mention_roles(&mut self, roles: impl IntoIterator<Item = RoleId>) -> &mut Self {
         self.msg.mention_roles = roles.into_iter().collect();
 
         self
@@ -156,10 +147,7 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn mentions<It>(&mut self, mentions: It) -> &mut Self
-    where
-        It: IntoIterator<Item = User>,
-    {
+    pub fn mentions(&mut self, mentions: impl IntoIterator<Item = User>) -> &mut Self {
         self.msg.mentions = mentions.into_iter().collect();
 
         self
@@ -179,10 +167,7 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn reactions<It>(&mut self, reactions: It) -> &mut Self
-    where
-        It: IntoIterator<Item = MessageReaction>,
-    {
+    pub fn reactions(&mut self, reactions: impl IntoIterator<Item = MessageReaction>) -> &mut Self {
         self.msg.reactions = reactions.into_iter().collect();
 
         self


### PR DESCRIPTION
Users should never need to specify the concrete type on an `IntoIterator` bound. I think this technically isn't a breaking change, but targeting `current` would mean dealing with a nightmare of merge conflicts on `next`, so I picked some low hanging fruit instead.