### PR TITLE
Replace `once_cell::sync::OnceCell` with `std::sync::OnceLock`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ mime_guess = { version = "2.0", optional = true }
 dashmap = { version = "5.1.0", features = ["serde"], optional = true }
 parking_lot = { version = "0.12", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
-once_cell = { version = "1.16.0", optional = true }
 # Serenity workspace crates
 command_attr = { version = "0.4.1", path = "./command_attr", optional = true }
 serenity-voice-model = { version = "0.1.1", path = "./voice-model", optional = true }
@@ -87,7 +86,7 @@ collector = ["gateway", "model"]
 # TODO: should this require "gateway"?
 client = ["http", "typemap_rev"]
 # Enables the Framework trait which is an abstraction for old-style text commands.
-framework = ["client", "model", "utils", "once_cell"]
+framework = ["client", "model", "utils"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["flate2"]
 # Enables HTTP, which enables bots to execute actions on Discord.

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -1,11 +1,11 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+#[cfg(feature = "framework")]
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use futures::SinkExt;
-#[cfg(feature = "framework")]
-use once_cell::sync::OnceCell;
 use tokio::sync::{Mutex, RwLock};
 use tracing::{info, instrument, warn};
 use typemap_rev::TypeMap;
@@ -47,9 +47,8 @@ use crate::model::gateway::GatewayIntents;
 /// # async fn run() -> Result<(), Box<dyn Error>> {
 /// #
 /// use std::env;
-/// use std::sync::Arc;
+/// use std::sync::{Arc, OnceLock};
 ///
-/// use once_cell::sync::OnceCell;
 /// use serenity::client::{EventHandler, RawEventHandler};
 /// use serenity::framework::{Framework, StandardFramework};
 /// use serenity::gateway::{ShardManager, ShardManagerOptions};
@@ -73,7 +72,7 @@ use crate::model::gateway::GatewayIntents;
 ///     data,
 ///     event_handlers: vec![event_handler],
 ///     raw_event_handlers: vec![],
-///     framework: Arc::new(OnceCell::with_value(framework)),
+///     framework: Arc::new(OnceLock::with_value(framework)),
 ///     // the shard index to start initiating from
 ///     shard_index: 0,
 ///     // the number of shards to initiate (this initiates 0, 1, and 2)
@@ -354,7 +353,7 @@ pub struct ShardManagerOptions {
     pub event_handlers: Vec<Arc<dyn EventHandler>>,
     pub raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
-    pub framework: Arc<OnceCell<Arc<dyn Framework>>>,
+    pub framework: Arc<OnceLock<Arc<dyn Framework>>>,
     pub shard_index: u32,
     pub shard_init: u32,
     pub shard_total: u32,

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -72,7 +72,7 @@ use crate::model::gateway::GatewayIntents;
 ///     data,
 ///     event_handlers: vec![event_handler],
 ///     raw_event_handlers: vec![],
-///     framework: Arc::new(OnceLock::with_value(framework)),
+///     framework: Arc::new(OnceLock::from(framework)),
 ///     // the shard index to start initiating from
 ///     shard_index: 0,
 ///     // the number of shards to initiate (this initiates 0, 1, and 2)

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+#[cfg(feature = "framework")]
+use std::sync::OnceLock;
 
 use futures::channel::mpsc::UnboundedReceiver as Receiver;
 use futures::StreamExt;
-#[cfg(feature = "framework")]
-use once_cell::sync::OnceCell;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{sleep, timeout, Duration, Instant};
 use tracing::{debug, info, instrument, warn};
@@ -53,7 +53,7 @@ pub struct ShardQueuer {
     pub raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
-    pub framework: Arc<OnceCell<Arc<dyn Framework>>>,
+    pub framework: Arc<OnceLock<Arc<dyn Framework>>>,
     /// The instant that a shard was last started.
     ///
     /// This is used to determine how long to wait between shard IDENTIFYs.


### PR DESCRIPTION
Newly stabilized in 1.70. Allows us to remove `once_cell` as a dependency.