### PR TITLE
Use ShardId everywhere

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -27,7 +27,7 @@ use serenity::framework::standard::{
     Reason,
     StandardFramework,
 };
-use serenity::gateway::{ShardId, ShardManager};
+use serenity::gateway::ShardManager;
 use serenity::http::Http;
 use serenity::model::channel::{Channel, Message};
 use serenity::model::gateway::{GatewayIntents, Ready};
@@ -465,7 +465,7 @@ async fn latency(ctx: &Context, msg: &Message) -> CommandResult {
 
     // Shards are backed by a "shard runner" responsible for processing events over the shard, so
     // we'll get the information about the shard runner for the shard this command was sent over.
-    let runner = match runners.get(&ShardId(ctx.shard_id)) {
+    let runner = match runners.get(&ctx.shard_id) {
         Some(runner) => runner,
         None => {
             msg.reply(ctx, "No shard found").await?;

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -23,7 +23,7 @@ use serenity::async_trait;
 use serenity::client::{Client, Context, EventHandler};
 use serenity::framework::standard::macros::{command, group, hook};
 use serenity::framework::standard::{CommandResult, StandardFramework};
-use serenity::gateway::{ShardId, ShardManager};
+use serenity::gateway::ShardManager;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 use tokio::sync::Mutex;
@@ -269,7 +269,7 @@ impl EventHandler for Handler {
                     let manager = shard_manager.lock().await;
                     let runners = manager.runners.lock().await;
 
-                    let runner = runners.get(&ShardId(ctx.shard_id)).unwrap();
+                    let runner = runners.get(&ctx.shard_id).unwrap();
 
                     if let Some(duration) = runner.latency {
                         duration.as_millis() as f64
@@ -299,7 +299,7 @@ async fn before_hook(ctx: &Context, _: &Message, cmd_name: &str) -> bool {
 
     let command_count_value = {
         let mut count_write = elements.command_usage_values.lock().await;
-        let mut command_count_value = count_write.get_mut(cmd_name).unwrap();
+        let command_count_value = count_write.get_mut(cmd_name).unwrap();
         command_count_value.use_count += 1;
         command_count_value.clone()
     };
@@ -464,7 +464,7 @@ async fn ping(ctx: &Context, msg: &Message) -> CommandResult {
         let manager = shard_manager.lock().await;
         let runners = manager.runners.lock().await;
 
-        let runner = runners.get(&ShardId(ctx.shard_id)).unwrap();
+        let runner = runners.get(&ctx.shard_id).unwrap();
 
         if let Some(duration) = runner.latency {
             format!("{:.2}ms", duration.as_millis())

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use super::{Cache, CacheUpdate};
+use crate::gateway::ShardId;
 use crate::model::channel::{Channel, GuildChannel, Message};
 use crate::model::event::{
     ChannelCreateEvent,
@@ -518,12 +519,12 @@ impl CacheUpdate for ReadyEvent {
         let mut guilds_to_remove = vec![];
         let ready_guilds_hashset =
             self.ready.guilds.iter().map(|status| status.id).collect::<HashSet<_>>();
-        let shard_data = self.ready.shard.unwrap_or_else(|| ShardInfo::new(1, 1));
+        let shard_data = self.ready.shard.unwrap_or_else(|| ShardInfo::new(ShardId(1), 1));
 
         for guild_entry in cache.guilds.iter() {
             let guild = guild_entry.key();
             // Only handle data for our shard.
-            if crate::utils::shard_id(*guild, shard_data.total) == shard_data.id
+            if crate::utils::shard_id(*guild, shard_data.total) == shard_data.id.0
                 && !ready_guilds_hashset.contains(guild)
             {
                 guilds_to_remove.push(*guild);

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use super::{Cache, CacheUpdate};
-use crate::gateway::ShardId;
 use crate::model::channel::{Channel, GuildChannel, Message};
 use crate::model::event::{
     ChannelCreateEvent,
@@ -33,6 +32,7 @@ use crate::model::event::{
 };
 use crate::model::gateway::ShardInfo;
 use crate::model::guild::{Guild, GuildMemberFlags, Member, Role};
+use crate::model::id::ShardId;
 use crate::model::user::{CurrentUser, OnlineStatus};
 use crate::model::voice::VoiceState;
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -43,7 +43,6 @@ use tracing::instrument;
 
 pub use self::cache_update::CacheUpdate;
 pub use self::settings::Settings;
-use crate::gateway::ShardId;
 use crate::model::prelude::*;
 
 mod cache_update;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -43,6 +43,7 @@ use tracing::instrument;
 
 pub use self::cache_update::CacheUpdate;
 pub use self::settings::Settings;
+use crate::gateway::ShardId;
 use crate::model::prelude::*;
 
 mod cache_update;
@@ -113,7 +114,7 @@ pub type ChannelMessagesRef<'a> = CacheRef<'a, ChannelId, HashMap<MessageId, Mes
 #[derive(Debug)]
 pub(crate) struct CachedShardData {
     pub total: u32,
-    pub connected: HashSet<u32>,
+    pub connected: HashSet<ShardId>,
     pub has_sent_shards_ready: bool,
 }
 

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -8,7 +8,7 @@ use typemap_rev::TypeMap;
 pub use crate::cache::Cache;
 use crate::gateway::ActivityData;
 #[cfg(feature = "gateway")]
-use crate::gateway::{ShardMessenger, ShardRunner};
+use crate::gateway::{ShardId, ShardMessenger, ShardRunner};
 use crate::http::Http;
 use crate::model::prelude::*;
 
@@ -35,7 +35,7 @@ pub struct Context {
     /// The messenger to communicate with the shard runner.
     pub shard: ShardMessenger,
     /// The ID of the shard this context is related to.
-    pub shard_id: u32,
+    pub shard_id: ShardId,
     pub http: Arc<Http>,
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,
@@ -57,7 +57,7 @@ impl Context {
     pub(crate) fn new(
         data: Arc<RwLock<TypeMap>>,
         runner: &ShardRunner,
-        shard_id: u32,
+        shard_id: ShardId,
         http: Arc<Http>,
         #[cfg(feature = "cache")] cache: Arc<Cache>,
     ) -> Context {

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -8,7 +8,7 @@ use typemap_rev::TypeMap;
 pub use crate::cache::Cache;
 use crate::gateway::ActivityData;
 #[cfg(feature = "gateway")]
-use crate::gateway::{ShardId, ShardMessenger, ShardRunner};
+use crate::gateway::{ShardMessenger, ShardRunner};
 use crate::http::Http;
 use crate::model::prelude::*;
 

--- a/src/gateway/bridge/event.rs
+++ b/src/gateway/bridge/event.rs
@@ -1,7 +1,7 @@
 //! A collection of events created by the client, not a part of the Discord API itself.
 
-use super::ShardId;
 use crate::gateway::ConnectionStage;
+use crate::model::id::ShardId;
 
 /// An event denoting that a shard's connection stage was changed.
 ///

--- a/src/gateway/bridge/mod.rs
+++ b/src/gateway/bridge/mod.rs
@@ -66,6 +66,7 @@ pub use self::voice::VoiceGatewayManager;
 use super::{ChunkGuildFilter, Shard};
 use crate::gateway::ConnectionStage;
 use crate::model::event::Event;
+use crate::model::id::ShardId;
 
 /// A message to be sent to the [`ShardQueuer`].
 #[derive(Clone, Debug)]
@@ -75,17 +76,6 @@ pub enum ShardQueuerMessage {
     Start(ShardId, ShardId),
     /// Message to shutdown the shard queuer.
     Shutdown,
-}
-
-/// A light tuplestruct wrapper around a u32 to verify type correctness when working with the IDs
-/// of shards.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct ShardId(pub u32);
-
-impl fmt::Display for ShardId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
 }
 
 /// Information about a [`ShardRunner`].

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -217,7 +217,7 @@ impl ShardManager {
     /// ```rust,no_run
     /// use std::env;
     ///
-    /// use serenity::gateway::ShardId;
+    /// use serenity::model::id::ShardId;
     /// use serenity::prelude::*;
     ///
     /// struct Handler;

--- a/src/gateway/bridge/shard_messenger.rs
+++ b/src/gateway/bridge/shard_messenger.rs
@@ -60,7 +60,8 @@ impl ShardMessenger {
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::gateway::{ChunkGuildFilter, Shard, ShardId};
+    /// # use serenity::model::id::ShardId;
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard};
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -85,7 +86,8 @@ impl ShardMessenger {
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::gateway::{ChunkGuildFilter, Shard, ShardId};
+    /// # use serenity::model::id::ShardId;
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard};
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -137,7 +139,8 @@ impl ShardMessenger {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
-    /// # use serenity::gateway::{Shard, ShardId};
+    /// # use serenity::gateway::{Shard};
+    /// # use serenity::model::id::ShardId;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
     /// # use std::sync::Arc;
     /// #
@@ -212,7 +215,8 @@ impl ShardMessenger {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
-    /// # use serenity::gateway::{Shard, ShardId};
+    /// # use serenity::gateway::{Shard};
+    /// # use serenity::model::id::ShardId;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
     /// # use std::sync::Arc;
     /// #

--- a/src/gateway/bridge/shard_messenger.rs
+++ b/src/gateway/bridge/shard_messenger.rs
@@ -60,15 +60,14 @@ impl ShardMessenger {
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::gateway::ChunkGuildFilter;
-    /// # use serenity::gateway::Shard;
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard, ShardId};
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
     /// #     let shard_info = ShardInfo {
-    /// #         id: 0,
+    /// #         id: ShardId(0),
     /// #         total: 1,
     /// #     };
     /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
@@ -86,15 +85,14 @@ impl ShardMessenger {
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::gateway::ChunkGuildFilter;
-    /// # use serenity::gateway::Shard;
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard, ShardId};
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
     /// #     let shard_info = ShardInfo {
-    /// #         id: 0,
+    /// #         id: ShardId(0),
     /// #         total: 1,
     /// #     };
     /// #
@@ -139,7 +137,7 @@ impl ShardMessenger {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
-    /// # use serenity::gateway::Shard;
+    /// # use serenity::gateway::{Shard, ShardId};
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
     /// # use std::sync::Arc;
     /// #
@@ -147,7 +145,7 @@ impl ShardMessenger {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
     /// #     let shard_info = ShardInfo {
-    /// #         id: 0,
+    /// #         id: ShardId(0),
     /// #         total: 1,
     /// #     };
     /// #
@@ -214,14 +212,14 @@ impl ShardMessenger {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
-    /// # use serenity::gateway::Shard;
+    /// # use serenity::gateway::{Shard, ShardId};
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #     let shard_info = ShardInfo {
-    /// #         id: 0,
+    /// #         id: ShardId(0),
     /// #         total: 1,
     /// #     };
     /// #

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -112,7 +112,7 @@ impl ShardQueuer {
                 },
                 Ok(Some(ShardQueuerMessage::Start(id, total))) => {
                     debug!("[Shard Queuer] Received to start shard {} of {}.", id.0, total.0);
-                    self.checked_start(id.0, total.0).await;
+                    self.checked_start(id, total.0).await;
                 },
                 Ok(None) => break,
                 Err(_) => {
@@ -142,7 +142,7 @@ impl ShardQueuer {
     }
 
     #[instrument(skip(self))]
-    async fn checked_start(&mut self, id: u32, total: u32) {
+    async fn checked_start(&mut self, id: ShardId, total: u32) {
         debug!("[Shard Queuer] Checked start for shard {} out of {}", id, total);
         self.check_last_start().await;
 
@@ -157,7 +157,7 @@ impl ShardQueuer {
     }
 
     #[instrument(skip(self))]
-    async fn start(&mut self, id: u32, total: u32) -> Result<()> {
+    async fn start(&mut self, id: ShardId, total: u32) -> Result<()> {
         let shard_info = ShardInfo::new(id, total);
 
         let mut shard = Shard::new(
@@ -199,7 +199,7 @@ impl ShardQueuer {
             debug!("[ShardRunner {:?}] Stopping", shard2.lock().await.shard_info());
         });
 
-        self.runners.lock().await.insert(ShardId(id), runner_info);
+        self.runners.lock().await.insert(id, runner_info);
 
         Ok(())
     }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -89,17 +89,17 @@ impl Shard {
     /// ```rust,no_run
     /// use std::sync::Arc;
     ///
-    /// use serenity::gateway::Shard;
+    /// use serenity::gateway::{Shard, ShardId};
+    /// use serenity::model::gateway::{GatewayIntents, ShardInfo};
     /// use tokio::sync::Mutex;
     /// #
     /// # use serenity::http::Http;
-    /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Arc<Http> = unimplemented!();
     /// let token = std::env::var("DISCORD_BOT_TOKEN")?;
     /// let shard_info = ShardInfo {
-    ///     id: 0,
+    ///     id: ShardId(0),
     ///     total: 1,
     /// };
     ///
@@ -596,14 +596,13 @@ impl Shard {
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::gateway::ChunkGuildFilter;
-    /// # use serenity::gateway::Shard;
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard, ShardId};
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #     let shard_info = ShardInfo {
-    /// #          id: 0,
+    /// #          id: ShardId(0),
     /// #          total: 1,
     /// #     };
     /// #
@@ -621,9 +620,8 @@ impl Shard {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
-    /// # use serenity::gateway::Shard;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::gateway::ChunkGuildFilter;
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard, ShardId};
     /// # use std::error::Error;
     /// # use std::sync::Arc;
     /// #
@@ -631,7 +629,7 @@ impl Shard {
     /// #     let mutex = Arc::new(Mutex::new("".to_string()));
     /// #
     /// #     let shard_info = ShardInfo {
-    /// #          id: 0,
+    /// #          id: ShardId(0),
     /// #          total: 1,
     /// #     };
     /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -89,8 +89,9 @@ impl Shard {
     /// ```rust,no_run
     /// use std::sync::Arc;
     ///
-    /// use serenity::gateway::{Shard, ShardId};
+    /// use serenity::gateway::Shard;
     /// use serenity::model::gateway::{GatewayIntents, ShardInfo};
+    /// use serenity::model::id::ShardId;
     /// use tokio::sync::Mutex;
     /// #
     /// # use serenity::http::Http;
@@ -595,8 +596,9 @@ impl Shard {
     ///
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard};
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::gateway::{ChunkGuildFilter, Shard, ShardId};
+    /// # use serenity::model::id::ShardId;
     /// # use std::sync::Arc;
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -621,7 +623,8 @@ impl Shard {
     /// ```rust,no_run
     /// # use tokio::sync::Mutex;
     /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::gateway::{ChunkGuildFilter, Shard, ShardId};
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard};
+    /// # use serenity::model::id::ShardId;
     /// # use std::error::Error;
     /// # use std::sync::Arc;
     /// #

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -7,7 +7,6 @@ use url::Url;
 
 use super::prelude::*;
 use super::utils::*;
-use crate::gateway::ShardId;
 
 /// A representation of the data retrieved from the bot gateway endpoint.
 ///

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use super::prelude::*;
 use super::utils::*;
+use crate::gateway::ShardId;
 
 /// A representation of the data retrieved from the bot gateway endpoint.
 ///
@@ -355,14 +356,14 @@ pub struct SessionStartLimit {
 
 #[derive(Clone, Copy, Debug)]
 pub struct ShardInfo {
-    pub id: u32,
+    pub id: ShardId,
     pub total: u32,
 }
 
 impl ShardInfo {
     #[cfg(feature = "client")]
     #[must_use]
-    pub(crate) fn new(id: u32, total: u32) -> Self {
+    pub(crate) fn new(id: ShardId, total: u32) -> Self {
         Self {
             id,
             total,
@@ -373,7 +374,7 @@ impl ShardInfo {
 impl<'de> serde::Deserialize<'de> for ShardInfo {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         <(u32, u32)>::deserialize(deserializer).map(|(id, total)| ShardInfo {
-            id,
+            id: ShardId(id),
             total,
         })
     }
@@ -382,7 +383,7 @@ impl<'de> serde::Deserialize<'de> for ShardInfo {
 impl serde::Serialize for ShardInfo {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
         let mut seq = serializer.serialize_seq(Some(2))?;
-        seq.serialize_element(&self.id)?;
+        seq.serialize_element(&self.id.0)?;
         seq.serialize_element(&self.total)?;
         seq.end()
     }

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -252,6 +252,19 @@ id_u64! {
     ForumTagId;
 }
 
+/// An identifier for a Shard.
+///
+/// This identifier is special, it simply models internal IDs for type safety,
+/// and therefore cannot be [`Serialize`]d or [`Deserialize`]d.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct ShardId(pub u32);
+
+impl fmt::Display for ShardId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Used with `#[serde(with|deserialize_with|serialize_with)]`
 ///
 /// # Examples


### PR DESCRIPTION
Fixes the type mismatch causing a load of manual ShardId constructions, which go against the point of type safety.