### PR TITLE
Use secrecy::SecretString instead of manual debug implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = ["fs", "macros", "rt", "sync", "time", "io-u
 futures = { version = "0.3", default-features = false, features = ["std"] }
 dep_time = { version = "0.3.20", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
 base64 = { version = "0.21" }
+secrecy = { version = "0.8.0", features = ["serde"] }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
 simd-json = { version = "0.7", optional = true }
@@ -47,7 +48,6 @@ dashmap = { version = "5.1.0", features = ["serde"], optional = true }
 parking_lot = { version = "0.12", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 # serde feature only allows for serialisation,
-secrecy = { version = "0.8.0", features = ["serde"], optional = true }
 # Serenity workspace crates
 command_attr = { version = "0.4.1", path = "./command_attr", optional = true }
 serenity-voice-model = { version = "0.1.1", path = "./voice-model", optional = true }
@@ -92,7 +92,7 @@ framework = ["client", "model", "utils"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["flate2"]
 # Enables HTTP, which enables bots to execute actions on Discord.
-http = ["mime_guess", "percent-encoding", "secrecy"]
+http = ["mime_guess", "percent-encoding"]
 # Enables wrapper methods around HTTP requests on model types.
 # Requires "builder" to configure the requests and "http" to execute them.
 # Note: the model type definitions themselves are always active, regardless of this feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ mime_guess = { version = "2.0", optional = true }
 dashmap = { version = "5.1.0", features = ["serde"], optional = true }
 parking_lot = { version = "0.12", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
+# serde feature only allows for serialisation,
+secrecy = { version = "0.8.0", features = ["serde"], optional = true }
 # Serenity workspace crates
 command_attr = { version = "0.4.1", path = "./command_attr", optional = true }
 serenity-voice-model = { version = "0.1.1", path = "./voice-model", optional = true }
@@ -90,7 +92,7 @@ framework = ["client", "model", "utils"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["flate2"]
 # Enables HTTP, which enables bots to execute actions on Discord.
-http = ["mime_guess", "percent-encoding"]
+http = ["mime_guess", "percent-encoding", "secrecy"]
 # Enables wrapper methods around HTTP requests on model types.
 # Requires "builder" to configure the requests and "http" to execute them.
 # Note: the model type definitions themselves are always active, regardless of this feature.

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -215,6 +215,24 @@ pub mod single_recipient {
     }
 }
 
+pub mod secret {
+    use secrecy::{ExposeSecret, Secret, Zeroize};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn deserialize<'de, S: Deserialize<'de> + Zeroize, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Secret<S>>, D::Error> {
+        Option::<S>::deserialize(deserializer).map(|s| s.map(Secret::new))
+    }
+
+    pub fn serialize<S: Serialize + Zeroize, Sr: Serializer>(
+        secret: &Option<Secret<S>>,
+        serializer: Sr,
+    ) -> Result<Sr::Ok, Sr::Error> {
+        secret.as_ref().map(|s| s.expose_secret()).serialize(serializer)
+    }
+}
+
 pub fn deserialize_voice_states<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> StdResult<HashMap<UserId, VoiceState>, D::Error> {


### PR DESCRIPTION
This fixes some mismatches between Debug implementations and the underlying struct, which were caught by `clippy::missing_fields_in_debug`. This PR also means that webhook/bot tokens are going to be zeroed when dropped, as a security measure. 