### PR TITLE
Add dedicated type for storing image hashes

### DIFF
--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -5,6 +5,7 @@ use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
+use super::CreateAttachment;
 
 /// A builder to optionally edit certain fields of a guild
 ///
@@ -91,18 +92,16 @@ impl<'a> EditGuild<'a> {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut guild = GuildId::new(1).to_partial_guild(&http).await?;
-    /// let base64_icon = CreateAttachment::path("./guild_icon.png").await?.to_base64();
+    /// let icon = CreateAttachment::path("./guild_icon.png").await?;
     ///
     /// // assuming a `guild` has already been bound
-    /// let builder = EditGuild::new().icon(Some(base64_icon));
+    /// let builder = EditGuild::new().icon(Some(&icon));
     /// guild.edit(&http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// [`CreateAttachment`]: crate::builder::CreateAttachment
-    pub fn icon(mut self, icon: Option<String>) -> Self {
-        self.icon = Some(icon);
+    pub fn icon(mut self, icon: Option<&CreateAttachment>) -> Self {
+        self.icon = Some(icon.map(CreateAttachment::to_base64));
         self
     }
 

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "http")]
 use super::Builder;
+use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-use super::CreateAttachment;
 
 /// A builder to optionally edit certain fields of a guild
 ///

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -84,8 +84,9 @@ impl<'a> EditRole<'a> {
             position: Some(role.position),
             colour: Some(role.colour),
             unicode_emoji: role.unicode_emoji.clone(),
-            icon: role.icon.clone(),
             audit_log_reason: None,
+            // TODO: Do we want to download role.icon?
+            icon: None,
         }
     }
 

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -286,7 +286,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     pending: self.pending,
                     premium_since: self.premium_since,
                     permissions: None,
-                    avatar: self.avatar.clone(),
+                    avatar: self.avatar,
                     communication_disabled_until: self.communication_disabled_until,
                     flags: GuildMemberFlags::default(),
                 });

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -18,8 +18,8 @@ mod ping_interaction;
 pub use ping_interaction::*;
 
 use super::id::{ApplicationId, GenericId, GuildId, SkuId, UserId};
-use super::user::User;
 use super::misc::ImageHash;
+use super::user::User;
 use super::Permissions;
 
 /// Partial information about the given application.

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -19,6 +19,7 @@ pub use ping_interaction::*;
 
 use super::id::{ApplicationId, GenericId, GuildId, SkuId, UserId};
 use super::user::User;
+use super::misc::ImageHash;
 use super::Permissions;
 
 /// Partial information about the given application.
@@ -41,7 +42,7 @@ pub struct PartialCurrentApplicationInfo {
 pub struct CurrentApplicationInfo {
     pub id: ApplicationId,
     pub name: String,
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     pub description: String,
     #[serde(default)]
     pub rpc_origins: Vec<String>,
@@ -83,7 +84,7 @@ pub struct CurrentApplicationInfo {
 #[non_exhaustive]
 pub struct Team {
     /// The icon of the team.
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     /// The snowflake ID of the team.
     pub id: GenericId,
     /// The name of the team.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -945,11 +945,11 @@ pub struct MessageApplication {
     /// ID of the application.
     pub id: ApplicationId,
     /// ID of the embed's image asset.
-    pub cover_image: Option<String>,
+    pub cover_image: Option<ImageHash>,
     /// Application's description.
     pub description: String,
     /// ID of the application's icon.
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     /// Name of the application.
     pub name: String,
 }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -247,7 +247,7 @@ pub struct GuildMemberUpdateEvent {
     pub deaf: bool,
     #[serde(default)]
     pub mute: bool,
-    pub avatar: Option<String>,
+    pub avatar: Option<ImageHash>,
     pub communication_disabled_until: Option<Timestamp>,
 }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -232,7 +232,7 @@ pub struct ClientStatus {
 #[non_exhaustive]
 pub struct PresenceUser {
     pub id: UserId,
-    pub avatar: Option<String>,
+    pub avatar: Option<ImageHash>,
     pub bot: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator")]
     pub discriminator: Option<NonZeroU16>,
@@ -283,8 +283,8 @@ impl PresenceUser {
     #[cfg(feature = "cache")] // method is only used with the cache feature enabled
     pub(crate) fn update_with_user(&mut self, user: &User) {
         self.id = user.id;
-        if let Some(avatar) = &user.avatar {
-            self.avatar = Some(avatar.clone());
+        if let Some(avatar) = user.avatar {
+            self.avatar = Some(avatar);
         }
         self.bot = Some(user.bot);
         self.discriminator = user.discriminator;

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -8,6 +8,7 @@ use crate::model::guild::{
     VerificationLevel,
 };
 use crate::model::id::{ApplicationId, ChannelId, GenericId, GuildId, RoleId, UserId};
+use crate::model::misc::ImageHash;
 use crate::model::sticker::StickerFormatType;
 use crate::model::{Permissions, Timestamp};
 
@@ -98,9 +99,9 @@ generate_change! {
     /// Availability of a sticker was changed.
     "available" => Available(bool),
     /// User avatar was changed.
-    "avatar_hash" => AvatarHash(String),
+    "avatar_hash" => AvatarHash(ImageHash),
     /// Guild banner was changed.
-    "banner_hash" => BannerHash(String),
+    "banner_hash" => BannerHash(ImageHash),
     /// Voice channel bitrate was changed.
     "bitrate" => Bitrate(u32),
     /// Channel for invite code or guild scheduled event was changed.
@@ -122,7 +123,7 @@ generate_change! {
     /// Description for guild, sticker, or guild scheduled event was changed.
     "description" => Description(String),
     /// Guild's discovery splash was changed.
-    "discovery_splash_hash" => DiscoverySplashHash(String),
+    "discovery_splash_hash" => DiscoverySplashHash(ImageHash),
     "enabled" => Enabled(bool),
     /// Integration emoticons was enabled/disabled.
     "enable_emoticons" => EnableEmoticons(bool),
@@ -146,11 +147,11 @@ generate_change! {
     /// Role is now displayed/no longer displayed separate from online users.
     "hoist" => Hoist(bool),
     /// Guild icon was changed.
-    "icon_hash" => IconHash(String),
+    "icon_hash" => IconHash(ImageHash),
     /// Guild scheduled event cover image was changed.
     "id" => Id(GenericId),
     /// ID of the changed entity.
-    "image_hash" => ImageHash(String),
+    "image_hash" => ImageHash(ImageHash),
     /// Private thread's invitable state was changed.
     "invitable" => Invitable(bool),
     /// ID of the user who created the invite.
@@ -202,7 +203,7 @@ generate_change! {
     /// ID of the rules channel was changed.
     "rules_channel_id" => RulesChannelId(ChannelId),
     /// Invite splash page artwork was changed.
-    "splash_hash" => SplashHash(String),
+    "splash_hash" => SplashHash(ImageHash),
     /// Status of guild scheduled event was changed.
     "status" => Status(u64),
     /// ID of the system channel was changed.

--- a/src/model/guild/guild_preview.rs
+++ b/src/model/guild/guild_preview.rs
@@ -1,7 +1,7 @@
 use crate::model::guild::Emoji;
 use crate::model::id::GuildId;
-use crate::model::sticker::Sticker;
 use crate::model::misc::ImageHash;
+use crate::model::sticker::Sticker;
 
 /// Preview [`Guild`] information.
 ///

--- a/src/model/guild/guild_preview.rs
+++ b/src/model/guild/guild_preview.rs
@@ -1,6 +1,7 @@
 use crate::model::guild::Emoji;
 use crate::model::id::GuildId;
 use crate::model::sticker::Sticker;
+use crate::model::misc::ImageHash;
 
 /// Preview [`Guild`] information.
 ///
@@ -15,11 +16,11 @@ pub struct GuildPreview {
     /// The guild name.
     pub name: String,
     /// The guild icon hash if it has one.
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     /// The guild splash hash if it has one.
-    pub splash: Option<String>,
+    pub splash: Option<ImageHash>,
     /// The guild discovery splash hash it it has one.
-    pub discovery_splash: Option<String>,
+    pub discovery_splash: Option<ImageHash>,
     /// The custom guild emojis.
     pub emojis: Vec<Emoji>,
     /// The guild features. See [`Guild::features`]

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -70,7 +70,7 @@ pub struct IntegrationAccount {
 pub struct IntegrationApplication {
     pub id: ApplicationId,
     pub name: String,
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     pub description: String,
     pub bot: Option<User>,
 }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -14,6 +14,7 @@ use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 use crate::model::permissions::Permissions;
 use crate::model::prelude::*;
+#[cfg(feature = "model")]
 use crate::model::utils::avatar_url;
 use crate::model::Timestamp;
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -14,6 +14,7 @@ use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 use crate::model::permissions::Permissions;
 use crate::model::prelude::*;
+use crate::model::utils::avatar_url;
 use crate::model::Timestamp;
 
 /// Information about a member of a guild.
@@ -30,7 +31,7 @@ pub struct Member {
     /// Can't be longer than 32 characters.
     pub nick: Option<String>,
     /// The guild avatar hash
-    pub avatar: Option<String>,
+    pub avatar: Option<ImageHash>,
     /// Vector of Ids of [`Role`]s given to the member.
     pub roles: Vec<RoleId>,
     /// Timestamp representing the date when the member joined.
@@ -528,7 +529,7 @@ impl Member {
     #[inline]
     #[must_use]
     pub fn avatar_url(&self) -> Option<String> {
-        avatar_url(self.guild_id, self.user.id, self.avatar.as_ref())
+        avatar_url(Some(self.guild_id), self.user.id, self.avatar.as_ref())
     }
 
     /// Retrieves the URL to the current member's avatar, falling back to the user's avatar, then
@@ -641,15 +642,6 @@ impl From<Member> for PartialMember {
             permissions: member.permissions,
         }
     }
-}
-
-#[cfg(feature = "model")]
-fn avatar_url(guild_id: GuildId, user_id: UserId, hash: Option<&String>) -> Option<String> {
-    hash.map(|hash| {
-        let ext = if hash.starts_with("a_") { "gif" } else { "webp" };
-
-        cdn!("/guilds/{}/users/{}/avatars/{}.{}?size=1024", guild_id.0, user_id.0, hash, ext)
-    })
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-member-object),

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -626,7 +626,7 @@ impl Guild {
     pub async fn create(
         http: impl AsRef<Http>,
         name: &str,
-        icon: ImageHash,
+        icon: Option<ImageHash>,
     ) -> Result<PartialGuild> {
         let map = json!({
             "icon": icon,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -96,18 +96,18 @@ pub struct Guild {
     /// The hash of the icon used by the guild.
     ///
     /// In the client, this appears on the guild list on the left-hand side.
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     /// Icon hash, returned when in the template object
-    pub icon_hash: Option<String>,
+    pub icon_hash: Option<ImageHash>,
     /// An identifying hash of the guild's splash icon.
     ///
     /// If the `InviteSplash` feature is enabled, this can be used to generate a URL to a splash
     /// image.
-    pub splash: Option<String>,
+    pub splash: Option<ImageHash>,
     /// An identifying hash of the guild discovery's splash icon.
     ///
     /// **Note**: Only present for guilds with the `DISCOVERABLE` feature.
-    pub discovery_splash: Option<String>,
+    pub discovery_splash: Option<ImageHash>,
     // Omitted `owner` field because only Http::get_guilds uses it, which returns GuildInfo
     /// The Id of the [`User`] who owns the guild.
     pub owner_id: UserId,
@@ -626,7 +626,7 @@ impl Guild {
     pub async fn create(
         http: impl AsRef<Http>,
         name: &str,
-        icon: Option<&str>,
+        icon: ImageHash,
     ) -> Result<PartialGuild> {
         let map = json!({
             "icon": icon,
@@ -1053,10 +1053,10 @@ impl Guild {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut guild: Guild = unimplemented!();
-    /// let base64_icon = CreateAttachment::path("./icon.png").await?.to_base64();
+    /// let icon = CreateAttachment::path("./icon.png").await?;
     ///
     /// // assuming a `guild` has already been bound
-    /// let builder = EditGuild::new().icon(Some(base64_icon));
+    /// let builder = EditGuild::new().icon(Some(&icon));
     /// guild.edit(&http, builder).await?;
     /// # Ok(())
     /// # }
@@ -1412,11 +1412,7 @@ impl Guild {
     /// This will produce a WEBP image URL, or GIF if the guild has a GIF icon.
     #[must_use]
     pub fn icon_url(&self) -> Option<String> {
-        self.icon.as_ref().map(|icon| {
-            let ext = if icon.starts_with("a_") { "gif" } else { "webp" };
-
-            cdn!("/icons/{}/{}.{}", self.id, icon, ext)
-        })
+        icon_url(self.id, self.icon.as_ref())
     }
 
     /// Gets all [`Emoji`]s of this guild via HTTP.
@@ -2579,7 +2575,7 @@ pub struct GuildInfo {
     /// The hash of the icon of the guild.
     ///
     /// This can be used to generate a URL to the guild's icon image.
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     /// Indicator of whether the current user is the owner.
     pub owner: bool,
     /// The permissions that the current user has.
@@ -2595,11 +2591,7 @@ impl GuildInfo {
     /// This will produce a WEBP image URL, or GIF if the guild has a GIF icon.
     #[must_use]
     pub fn icon_url(&self) -> Option<String> {
-        self.icon.as_ref().map(|icon| {
-            let ext = if icon.starts_with("a_") { "gif" } else { "webp" };
-
-            cdn!("/icons/{}/{}.{}", self.id, icon, ext)
-        })
+        icon_url(self.id, self.icon.as_ref())
     }
 }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -26,9 +26,9 @@ use crate::http::{CacheHttp, Http};
 use crate::model::application::{Command, CommandPermissions};
 #[cfg(feature = "model")]
 use crate::model::guild::automod::Rule;
+use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::icon_url;
-use crate::model::prelude::*;
 use crate::model::utils::{emojis, roles, stickers};
 
 /// Partial information about a [`Guild`]. This does not include information like member data.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -26,6 +26,8 @@ use crate::http::{CacheHttp, Http};
 use crate::model::application::{Command, CommandPermissions};
 #[cfg(feature = "model")]
 use crate::model::guild::automod::Rule;
+#[cfg(feature = "model")]
+use crate::model::utils::icon_url;
 use crate::model::prelude::*;
 use crate::model::utils::{emojis, roles, stickers};
 
@@ -48,18 +50,18 @@ pub struct PartialGuild {
     /// The hash of the icon used by the guild.
     ///
     /// In the client, this appears on the guild list on the left-hand side.
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     /// Icon hash, returned when in the template object
-    pub icon_hash: Option<String>,
+    pub icon_hash: Option<ImageHash>,
     /// An identifying hash of the guild's splash icon.
     ///
     /// If the `InviteSplash` feature is enabled, this can be used to generate a URL to a splash
     /// image.
-    pub splash: Option<String>,
+    pub splash: Option<ImageHash>,
     /// An identifying hash of the guild discovery's splash icon.
     ///
     /// **Note**: Only present for guilds with the `DISCOVERABLE` feature.
-    pub discovery_splash: Option<String>,
+    pub discovery_splash: Option<ImageHash>,
     // Omitted `owner` field because only Http::get_guilds uses it, which returns GuildInfo
     /// The Id of the [`User`] who owns the guild.
     pub owner_id: UserId,
@@ -1194,7 +1196,7 @@ impl PartialGuild {
     /// Returns a formatted URL of the guild's icon, if the guild has an icon.
     #[must_use]
     pub fn icon_url(&self) -> Option<String> {
-        self.icon.as_ref().map(|icon| cdn!("/icons/{}/{}.webp", self.id, icon))
+        icon_url(self.id, self.icon.as_ref())
     }
 
     /// Returns a formatted URL of the guild's banner, if the guild has a banner.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -64,10 +64,7 @@ pub struct Role {
     #[serde(default)]
     pub tags: RoleTags,
     /// Role icon image hash.
-    ///
-    /// `role-icons/<role_id>/<hash>.png` - PNG, JPEG, WEBP
-    /// `role-icons/<role_id>/a_<hash>.gif` - GIF, Animated WEBP
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     /// Role unicoded image.
     pub unicode_emoji: Option<String>,
 }

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -49,7 +49,7 @@ pub struct ScheduledEvent {
     /// [`GuildId::scheduled_event`] or [`GuildId::scheduled_events`].
     pub user_count: Option<u64>,
     /// The hash of the event's cover image, if present.
-    pub image: Option<String>,
+    pub image: Option<ImageHash>,
 }
 
 enum_number! {

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -181,7 +181,7 @@ impl Invite {
     /// #         "id": UserId::new(3),
     /// #         "username": "foo",
     /// #         "discriminator": "1234",
-    /// #         "avatar": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    /// #         "avatar": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     /// #     },
     /// # })).unwrap();
     /// #
@@ -214,10 +214,10 @@ pub struct InviteChannel {
 pub struct InviteGuild {
     pub id: GuildId,
     pub name: String,
-    pub splash: Option<String>,
-    pub banner: Option<String>,
+    pub splash: Option<ImageHash>,
+    pub banner: Option<ImageHash>,
     pub description: Option<String>,
-    pub icon: Option<String>,
+    pub icon: Option<ImageHash>,
     pub features: Vec<String>,
     pub verification_level: VerificationLevel,
     pub vanity_url_code: Option<String>,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -55,21 +55,41 @@ impl_from_str! {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ImageHashInner {
     Normal { hash: [u8; 16], is_animated: bool },
-    Clyde
+    Clyde,
 }
 
 /// An image hash returned from the Discord API.
 ///
-/// Note: This is parsed into a compact form when constructed, then turned back
-/// into the cannonical hex representation used by the API when needed.
+/// This type can be constructed via it's [`FromStr`] implementation, and can be turned into it's
+/// cannonical representation via [`std::fmt::Display`] or [`serde::Serialize`].
+///
+/// # Example
+/// ```rust
+/// use serenity::model::misc::ImageHash;
+///
+/// let image_hash: ImageHash = "f1eff024d9c85339c877985229ed8fec".parse().unwrap();
+/// assert_eq!(image_hash.to_string(), String::from("f1eff024d9c85339c877985229ed8fec"));
+/// ```
+
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct ImageHash (ImageHashInner);
+pub struct ImageHash(ImageHashInner);
 
 impl ImageHash {
+    /// Returns if the linked image is animated, which means the hash starts with `a_`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use serenity::model::misc::ImageHash;
+    ///
+    /// let animated_hash: ImageHash = "a_e3c0db7f38777778fb43081f8746ebc9".parse().unwrap();
+    /// assert!(animated_hash.is_animated());
+    /// ```
     #[must_use]
     pub fn is_animated(&self) -> bool {
         match &self.0 {
-            ImageHashInner::Normal { is_animated, .. } => *is_animated,
+            ImageHashInner::Normal {
+                is_animated, ..
+            } => *is_animated,
             ImageHashInner::Clyde => true,
         }
     }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -172,8 +172,7 @@ impl std::str::FromStr for ImageHash {
         let mut hash = [0u8; 16];
         for i in (0..hex.len()).step_by(2) {
             let hex_byte = &hex[i..i + 2];
-            hash[i / 2] =
-                u8::from_str_radix(hex_byte, 16).map_err(ImageHashParseError::UnparsableBytes)?;
+            hash[i / 2] = u8::from_str_radix(hex_byte, 16).map_err(Self::Err::UnparsableBytes)?;
         }
 
         Ok(Self(ImageHashInner::Normal {

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -145,7 +145,7 @@ pub enum ImageHashParseError {
 }
 
 impl std::error::Error for ImageHashParseError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         if let Self::UnparsableBytes(source) = self {
             Some(source)
         } else {

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -138,7 +138,6 @@ impl std::fmt::Display for ImageHash {
 #[derive(Debug, Clone)]
 pub enum ImageHashParseError {
     InvalidLength(usize),
-    MissingAnimatedMark,
     UnparsableBytes(std::num::ParseIntError),
 }
 
@@ -148,7 +147,6 @@ impl std::fmt::Display for ImageHashParseError {
             Self::InvalidLength(length) => {
                 write!(f, "Invalid length {length}, expected 32 or 34 characters")
             },
-            Self::MissingAnimatedMark => f.write_str("Input is 34 characters long, but missing a_"),
             Self::UnparsableBytes(bytes) => write!(f, "Could not parse to hex: {bytes}"),
         }
     }
@@ -158,11 +156,7 @@ impl std::str::FromStr for ImageHash {
     type Err = ImageHashParseError;
 
     fn from_str(s: &str) -> StdResult<Self, Self::Err> {
-        let (hex, is_animated) = if s.len() == 34 {
-            if &s.as_bytes()[0..2] != b"a_" {
-                return Err(ImageHashParseError::MissingAnimatedMark);
-            }
-
+        let (hex, is_animated) = if s.len() == 34 && s.starts_with("a_") {
             (&s[2..], true)
         } else if s.len() == 32 {
             (s, false)

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -2,11 +2,9 @@
 
 #[cfg(all(feature = "model", feature = "utils"))]
 use std::error::Error as StdError;
-#[cfg(all(feature = "model", feature = "utils"))]
 use std::fmt;
 #[cfg(all(feature = "model", feature = "utils"))]
 use std::result::Result as StdResult;
-#[cfg(all(feature = "model", feature = "utils"))]
 use std::str::FromStr;
 
 use super::prelude::*;

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -128,7 +128,6 @@ impl std::str::FromStr for ImageHash {
 
     fn from_str(s: &str) -> StdResult<Self, Self::Err> {
         let (hex, is_animated) = if s.len() == 34 {
-            println!("{:?}", &s.as_bytes()[0..1]);
             if &s.as_bytes()[0..2] != b"a_" {
                 return Err(ImageHashParseError::MissingAnimatedMark);
             }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -135,9 +135,12 @@ impl std::fmt::Display for ImageHash {
     }
 }
 
+/// An error returned when [`ImageHash`] is passed an erronous value.
 #[derive(Debug, Clone)]
 pub enum ImageHashParseError {
+    /// The given hash was not a valid [`ImageHash`] length, containing the invalid length.
     InvalidLength(usize),
+    /// The given hash was a valid length, but was not entirely parsable hex values.
     UnparsableBytes(std::num::ParseIntError),
 }
 

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -144,13 +144,23 @@ pub enum ImageHashParseError {
     UnparsableBytes(std::num::ParseIntError),
 }
 
+impl std::error::Error for ImageHashParseError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        if let Self::UnparsableBytes(source) = self {
+            Some(source)
+        } else {
+            None
+        }
+    }
+}
+
 impl std::fmt::Display for ImageHashParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidLength(length) => {
                 write!(f, "Invalid length {length}, expected 32 or 34 characters")
             },
-            Self::UnparsableBytes(bytes) => write!(f, "Could not parse to hex: {bytes}"),
+            Self::UnparsableBytes(_) => write!(f, "Could not parse hex to ImageHash"),
         }
     }
 }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -26,6 +26,9 @@ use crate::internal::prelude::*;
 use crate::json::json;
 use crate::json::to_string;
 use crate::model::mention::Mentionable;
+#[cfg(feature = "model")]
+use crate::model::utils::avatar_url;
+
 /// Used with `#[serde(with|deserialize_with|serialize_with)]`
 ///
 /// # Examples
@@ -276,7 +279,7 @@ pub struct User {
     #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator")]
     pub discriminator: Option<NonZeroU16>,
     /// Optional avatar hash.
-    pub avatar: Option<String>,
+    pub avatar: Option<ImageHash>,
     /// Indicator of whether the user is a bot.
     #[serde(default)]
     pub bot: bool,
@@ -290,7 +293,7 @@ pub struct User {
     ///
     /// **Note**: This will only be present if the user is fetched via Rest API, e.g. with
     /// [`crate::http::Http::get_user`].
-    pub banner: Option<String>,
+    pub banner: Option<ImageHash>,
     /// The user's banner colour encoded as an integer representation of hexadecimal colour code
     ///
     /// **Note**: This will only be present if the user is fetched via Rest API, e.g. with
@@ -405,7 +408,7 @@ impl User {
     #[inline]
     #[must_use]
     pub fn avatar_url(&self) -> Option<String> {
-        avatar_url(self.id, self.avatar.as_ref())
+        avatar_url(None, self.id, self.avatar.as_ref())
     }
 
     /// Returns the formatted URL of the user's banner, if one exists.
@@ -819,15 +822,6 @@ impl<'a> From<&'a User> for UserId {
 }
 
 #[cfg(feature = "model")]
-fn avatar_url(user_id: UserId, hash: Option<&String>) -> Option<String> {
-    hash.map(|hash| {
-        let ext = if hash.starts_with("a_") { "gif" } else { "webp" };
-
-        cdn!("/avatars/{}/{}.{}?size=1024", user_id.0, hash, ext)
-    })
-}
-
-#[cfg(feature = "model")]
 fn default_avatar_url(discriminator: Option<NonZeroU16>) -> String {
     if let Some(discriminator) = discriminator {
         cdn!("/embed/avatars/{}.png", discriminator.get() % 5u16)
@@ -839,14 +833,14 @@ fn default_avatar_url(discriminator: Option<NonZeroU16>) -> String {
 }
 
 #[cfg(feature = "model")]
-fn static_avatar_url(user_id: UserId, hash: Option<&String>) -> Option<String> {
+fn static_avatar_url(user_id: UserId, hash: Option<&ImageHash>) -> Option<String> {
     hash.map(|hash| cdn!("/avatars/{}/{}.webp?size=1024", user_id, hash))
 }
 
 #[cfg(feature = "model")]
-fn banner_url(user_id: UserId, hash: Option<&String>) -> Option<String> {
+fn banner_url(user_id: UserId, hash: Option<&ImageHash>) -> Option<String> {
     hash.map(|hash| {
-        let ext = if hash.starts_with("a_") { "gif" } else { "webp" };
+        let ext = if hash.is_animated() { "gif" } else { "webp" };
 
         cdn!("/banners/{}/{}.{}?size=1024", user_id.0, hash, ext)
     })
@@ -897,29 +891,31 @@ mod test {
     #[cfg(feature = "model")]
     mod model {
         use std::num::NonZeroU16;
+        use std::str::FromStr;
 
         use crate::model::id::UserId;
+        use crate::model::misc::ImageHash;
         use crate::model::user::User;
 
         #[test]
         fn test_core() {
             let mut user = User {
                 id: UserId::new(210),
-                avatar: Some("abc".to_string()),
+                avatar: Some(ImageHash::from_str("fb211703bcc04ee612c88d494df0272f").unwrap()),
                 discriminator: NonZeroU16::new(1432),
                 name: "test".to_string(),
                 ..Default::default()
             };
 
-            assert!(user.avatar_url().unwrap().ends_with("/avatars/210/abc.webp?size=1024"));
-            assert!(user.static_avatar_url().unwrap().ends_with("/avatars/210/abc.webp?size=1024"));
+            let expected = "/avatars/210/fb211703bcc04ee612c88d494df0272f.webp?size=1024";
+            assert!(user.avatar_url().unwrap().ends_with(expected));
+            assert!(user.static_avatar_url().unwrap().ends_with(expected));
 
-            user.avatar = Some("a_aaa".to_string());
-            assert!(user.avatar_url().unwrap().ends_with("/avatars/210/a_aaa.gif?size=1024"));
-            assert!(user
-                .static_avatar_url()
-                .unwrap()
-                .ends_with("/avatars/210/a_aaa.webp?size=1024"));
+            user.avatar = Some(ImageHash::from_str("a_fb211703bcc04ee612c88d494df0272f").unwrap());
+            let expected = "/avatars/210/a_fb211703bcc04ee612c88d494df0272f.gif?size=1024";
+            assert!(user.avatar_url().unwrap().ends_with(expected));
+            let expected = "/avatars/210/a_fb211703bcc04ee612c88d494df0272f.webp?size=1024";
+            assert!(user.static_avatar_url().unwrap().ends_with(expected));
 
             user.avatar = None;
             assert!(user.avatar_url().is_none());

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -22,6 +22,32 @@ pub fn ignore_input<'de, D: Deserializer<'de>>(_: D) -> StdResult<(), D::Error> 
     Ok(())
 }
 
+#[cfg(feature = "model")]
+pub(super) fn avatar_url(
+    guild_id: Option<GuildId>,
+    user_id: UserId,
+    hash: Option<&ImageHash>,
+) -> Option<String> {
+    hash.map(|hash| {
+        let ext = if hash.is_animated() { "gif" } else { "webp" };
+
+        if let Some(guild_id) = guild_id {
+            cdn!("/guilds/{}/users/{}/avatars/{}.{}?size=1024", guild_id.0, user_id.0, hash, ext)
+        } else {
+            cdn!("/avatars/{}/{}.{}?size=1024", user_id.0, hash, ext)
+        }
+    })
+}
+
+#[cfg(feature = "model")]
+pub(super) fn icon_url(id: GuildId, icon: Option<&ImageHash>) -> Option<String> {
+    icon.map(|icon| {
+        let ext = if icon.is_animated() { "gif" } else { "webp" };
+
+        cdn!("/icons/{}/{}.{}", id, icon, ext)
+    })
+}
+
 pub fn deserialize_val<T, E>(val: Value) -> StdResult<T, E>
 where
     T: serde::de::DeserializeOwned,

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -77,7 +77,7 @@ pub struct Webhook {
     /// The default avatar.
     ///
     /// This can be temporarily overridden via [`ExecuteWebhook::avatar_url`].
-    pub avatar: Option<String>,
+    pub avatar: Option<ImageHash>,
     /// The webhook's secure token.
     pub token: Option<String>,
     /// The bot/OAuth2 application that created this webhook.


### PR DESCRIPTION
This converts the hex representation that is used across the API into a much smaller (56 vs 17) type which improves type safety, saves space, and reduces heap allocations (only during a clone, but deserialization could be made work without an allocation if we pull in an ArrayString dependency).