### PR TITLE
Deserialize to ArrayString instead of String for ImageHash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 dep_time = { version = "0.3.20", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
 base64 = { version = "0.21" }
 secrecy = { version = "0.8.0", features = ["serde"] }
+arrayvec = { version = "0.7.3", features = ["serde"] }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
 simd-json = { version = "0.7", optional = true }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -111,8 +111,7 @@ impl serde::Serialize for ImageHash {
 
 impl<'de> serde::Deserialize<'de> for ImageHash {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        // TODO: Replace this with ArrayString<34>?
-        let helper = String::deserialize(deserializer)?;
+        let helper = arrayvec::ArrayString::<34>::deserialize(deserializer)?;
         Self::from_str(&helper).map_err(serde::de::Error::custom)
     }
 }


### PR DESCRIPTION
This saves an allocation on creation of `ImageHash`, but adds a new dependency that is not currently in the dep tree at all.

I chose the `arrayvec` crate over `smallvec`, `tinyvec`, or `heapless` as:
- `smallvec` will fall over to heap allocation if length exceeds the capacity
- `tinyvec` and `smallvec` does not include an `ArrayString`
- `heapless` contains a lot of unnecessary data structures that may bloat compile time
