### PR TITLE
Support creating standalone public threads

### DIFF
--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -112,8 +112,8 @@ impl<'a> Builder for CreateThread<'a> {
     ) -> Result<GuildChannel> {
         let http = cache_http.http();
         match ctx.1 {
-            Some(id) => http.create_public_thread(ctx.0, id, &self, self.audit_log_reason).await,
-            None => http.create_private_thread(ctx.0, &self, self.audit_log_reason).await,
+            Some(id) => http.create_thread_from_message(ctx.0, id, &self, self.audit_log_reason).await,
+            None => http.create_standalone_thread(ctx.0, &self, self.audit_log_reason).await,
         }
     }
 }

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -77,8 +77,9 @@ impl<'a> CreateThread<'a> {
 
     /// The thread type, either [`ChannelType::PublicThread`] or [`ChannelType::PrivateThread`].
     ///
-    /// **Note**: This defaults to [`ChannelType::PrivateThread`] in order to match the behavior
-    /// when thread documentation was first published. This is a bit of a weird default though, and
+    /// **Note**: This field is ignored for message threads, and defaults to
+    /// [`ChannelType::PrivateThread`] for standalone threads in order to match the behavior when
+    /// thread documentation was first published. This is a bit of a weird default though, and
     /// thus is highly likely to change in the future, so it is recommended to always explicitly
     /// setting it to avoid any breaking change.
     pub fn kind(mut self, kind: ChannelType) -> Self {
@@ -113,7 +114,7 @@ impl<'a> Builder for CreateThread<'a> {
         let http = cache_http.http();
         match ctx.1 {
             Some(id) => http.create_thread_from_message(ctx.0, id, &self, self.audit_log_reason).await,
-            None => http.create_standalone_thread(ctx.0, &self, self.audit_log_reason).await,
+            None => http.create_thread(ctx.0, &self, self.audit_log_reason).await,
         }
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -393,7 +393,7 @@ impl Http {
     }
 
     /// Creates a thread channel not attached to a message in the [`GuildChannel`] given its Id.
-    pub async fn create_standalone_thread(
+    pub async fn create_thread(
         &self,
         channel_id: ChannelId,
         map: &impl serde::Serialize,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -368,9 +368,8 @@ impl Http {
         .await
     }
 
-    /// Creates a public thread channel in the [`GuildChannel`] given its Id, with a base message
-    /// Id.
-    pub async fn create_public_thread(
+    /// Creates a thread channel in the [`GuildChannel`] given its Id, with a base message Id.
+    pub async fn create_thread_from_message(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
@@ -384,7 +383,7 @@ impl Http {
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
-            route: Route::ChannelPublicThreads {
+            route: Route::ChannelMessageThreads {
                 channel_id,
                 message_id,
             },
@@ -393,8 +392,8 @@ impl Http {
         .await
     }
 
-    /// Creates a private thread channel in the [`GuildChannel`] given its Id.
-    pub async fn create_private_thread(
+    /// Creates a thread channel not attached to a message in the [`GuildChannel`] given its Id.
+    pub async fn create_standalone_thread(
         &self,
         channel_id: ChannelId,
         map: &impl serde::Serialize,
@@ -407,7 +406,7 @@ impl Http {
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
-            route: Route::ChannelPrivateThreads {
+            route: Route::ChannelThreads {
                 channel_id,
             },
             params: None,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -146,11 +146,11 @@ routes! ('a, {
     api!("/channels/{}/webhooks", channel_id),
     Some(RatelimitingKind::PathAndId(channel_id.0));
 
-    ChannelPublicThreads { channel_id: ChannelId, message_id: MessageId },
+    ChannelMessageThreads { channel_id: ChannelId, message_id: MessageId },
     api!("/channels/{}/messages/{}/threads", channel_id, message_id),
     Some(RatelimitingKind::PathAndId(channel_id.0));
 
-    ChannelPrivateThreads { channel_id: ChannelId },
+    ChannelThreads { channel_id: ChannelId },
     api!("/channels/{}/threads", channel_id),
     Some(RatelimitingKind::PathAndId(channel_id.0));
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -902,12 +902,12 @@ impl ChannelId {
         http.as_ref().delete_stage_instance(self, None).await
     }
 
-    /// Creates a thread that is connected to a message.
+    /// Creates a public thread that is connected to a message.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    #[doc(alias = "create_thread", alias = "create_public_thread", alias = "create_private_thread")]
+    #[doc(alias = "create_public_thread")]
     pub async fn create_thread_from_message(
         self,
         cache_http: impl CacheHttp,
@@ -922,8 +922,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    #[doc(alias = "create_thread", alias = "create_public_thread", alias = "create_private_thread")]
-    pub async fn create_standalone_thread(
+    #[doc(alias = "create_public_thread", alias = "create_private_thread")]
+    pub async fn create_thread(
         self,
         cache_http: impl CacheHttp,
         builder: CreateThread<'_>,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -902,13 +902,13 @@ impl ChannelId {
         http.as_ref().delete_stage_instance(self, None).await
     }
 
-    /// Creates a public thread that is connected to a message.
+    /// Creates a thread that is connected to a message.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    #[doc(alias = "create_thread")]
-    pub async fn create_public_thread(
+    #[doc(alias = "create_thread", alias = "create_public_thread", alias = "create_private_thread")]
+    pub async fn create_thread_from_message(
         self,
         cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
@@ -917,18 +917,18 @@ impl ChannelId {
         builder.execute(cache_http, (self, Some(message_id.into()))).await
     }
 
-    /// Creates a private thread.
+    /// Creates a thread that is not connected to a message.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    #[doc(alias = "create_thread")]
-    pub async fn create_private_thread(
+    #[doc(alias = "create_thread", alias = "create_public_thread", alias = "create_private_thread")]
+    pub async fn create_standalone_thread(
         self,
         cache_http: impl CacheHttp,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        builder.kind(ChannelType::PrivateThread).execute(cache_http, (self, None)).await
+        builder.execute(cache_http, (self, None)).await
     }
 
     /// Creates a post in a forum channel.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1167,7 +1167,7 @@ impl GuildChannel {
         self.id.delete_stage_instance(http).await
     }
 
-    /// Creates a thread that is connected to a message.
+    /// Creates a public thread that is connected to a message.
     ///
     /// # Errors
     ///
@@ -1186,12 +1186,12 @@ impl GuildChannel {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    pub async fn create_standalone_thread(
+    pub async fn create_thread(
         &self,
         cache_http: impl CacheHttp,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_standalone_thread(cache_http, builder).await
+        self.id.create_thread(cache_http, builder).await
     }
 
     /// Creates a post in a forum channel.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1167,31 +1167,31 @@ impl GuildChannel {
         self.id.delete_stage_instance(http).await
     }
 
-    /// Creates a public thread that is connected to a message.
+    /// Creates a thread that is connected to a message.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    pub async fn create_public_thread(
+    pub async fn create_thread_from_message(
         &self,
         cache_http: impl CacheHttp,
         message_id: impl Into<MessageId>,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_public_thread(cache_http, message_id, builder).await
+        self.id.create_thread_from_message(cache_http, message_id, builder).await
     }
 
-    /// Creates a private thread.
+    /// Creates a thread that is not connected to a message.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    pub async fn create_private_thread(
+    pub async fn create_standalone_thread(
         &self,
         cache_http: impl CacheHttp,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_private_thread(cache_http, builder).await
+        self.id.create_standalone_thread(cache_http, builder).await
     }
 
     /// Creates a post in a forum channel.


### PR DESCRIPTION
Discord's API has two endpoints for creating threads: one for [creating a thread as a reply to a message](https://discord.com/developers/docs/resources/channel#start-thread-from-message) and one for [creating a thread that's not connected to any existing message](https://discord.com/developers/docs/resources/channel#start-thread-without-message). The former only supports creating public threads, but the latter supports both public and private threads. However, serenity did not allow creating public standalone threads. This PR fills that gap, and renames the methods for calling these endpoints to more accurately describe what they do.

When I brought up the missing functionality in the #serenity channel, @arqunis claimed that the “start thread without message” endpoint was only for private threads, pointing to this part of the documentation:

> \* `type` currently defaults to `PRIVATE_THREAD` in order to match the behavior when thread documentation was first published. In a future API version this will be changed to be a required field, with no default.

I believe that this is a misunderstanding of the docs. They say “defaults to `PRIVATE_THREAD`”, not “must be `PRIVATE_THREAD`”. I also tested calling the endpoint manually with `type` set to `PUBLIC_THREAD` and it works as expected.