### PR TITLE
don't use non-zero integers on model/channel/embed

### DIFF
--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU32;
-
 #[cfg(feature = "model")]
 use reqwest::Client as ReqwestClient;
 
@@ -41,15 +39,15 @@ pub struct Attachment {
     /// Sescription for the file (max 1024 characters).
     pub description: Option<String>,
     /// If the attachment is an image, then the height of the image is provided.
-    pub height: Option<NonZeroU32>,
+    pub height: Option<u32>,
     /// The proxy URL.
     pub proxy_url: String,
     /// The size of the file in bytes.
-    pub size: NonZeroU32,
+    pub size: u32,
     /// The URL of the uploaded attachment.
     pub url: String,
     /// If the attachment is an image, then the width of the image is provided.
-    pub width: Option<NonZeroU32>,
+    pub width: Option<u32>,
     /// The attachment's [media type].
     ///
     /// [media type]: https://en.wikipedia.org/wiki/Media_type
@@ -82,7 +80,7 @@ impl Attachment {
     /// If this attachment is an image, then a tuple of the width and height in pixels is returned.
     #[must_use]
     pub fn dimensions(&self) -> Option<(u32, u32)> {
-        self.width.and_then(|width| self.height.map(|height| (width.get(), height.get())))
+        self.width.and_then(|width| self.height.map(|height| (width, height)))
     }
 
     /// Downloads the attachment, returning back a vector of bytes.

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU32;
-
 use crate::model::{Colour, Timestamp};
 
 /// Represents a rich embed which allows using richer markdown, multiple fields and more. This was
@@ -163,9 +161,9 @@ pub struct EmbedImage {
     /// A proxied URL of the image.
     pub proxy_url: Option<String>,
     /// The height of the image.
-    pub height: Option<NonZeroU32>,
+    pub height: Option<u32>,
     /// The width of the image.
-    pub width: Option<NonZeroU32>,
+    pub width: Option<u32>,
 }
 
 /// The provider of an embed.
@@ -193,9 +191,9 @@ pub struct EmbedThumbnail {
     /// A proxied URL of the thumbnail.
     pub proxy_url: Option<String>,
     /// The height of the thumbnail in pixels.
-    pub height: Option<NonZeroU32>,
+    pub height: Option<u32>,
     /// The width of the thumbnail in pixels.
-    pub width: Option<NonZeroU32>,
+    pub width: Option<u32>,
 }
 
 /// Video information for an embed.
@@ -209,7 +207,7 @@ pub struct EmbedVideo {
     /// A proxied URL of the thumbnail.
     pub proxy_url: Option<String>,
     /// The height of the video in pixels.
-    pub height: Option<NonZeroU32>,
+    pub height: Option<u32>,
     /// The width of the video in pixels.
-    pub width: Option<NonZeroU32>,
+    pub width: Option<u32>,
 }


### PR DESCRIPTION
fixing rustime errors

https://discord.com/channels/381880193251409931/381912587505500160/1121738497460547694
https://discord.com/channels/381880193251409931/381912587505500160/1121248649125576735

(not clearly sure what field exactly was causing error)