### PR TITLE
Skip parsing attributes from rustfmt or clippy

### DIFF
--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -105,6 +105,10 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut options = Options::new();
 
     for attribute in &fun.attributes {
+        if is_rustfmt_or_clippy_attr(&attribute.path) {
+            continue;
+        }
+
         let span = attribute.span();
         let values = propagate_err!(parse_values(attribute));
 
@@ -311,6 +315,10 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut options = HelpOptions::default();
 
     for attribute in &fun.attributes {
+        if is_rustfmt_or_clippy_attr(&attribute.path) {
+            continue;
+        }
+
         let span = attribute.span();
         let values = propagate_err!(parse_values(attribute));
 
@@ -615,6 +623,10 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut options = GroupOptions::new();
 
     for attribute in &group.attributes {
+        if is_rustfmt_or_clippy_attr(&attribute.path) {
+            continue;
+        }
+
         let span = attribute.span();
         let values = propagate_err!(parse_values(attribute));
 
@@ -741,6 +753,10 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut check_in_help = true;
 
     for attribute in &fun.attributes {
+        if is_rustfmt_or_clippy_attr(&attribute.path) {
+            continue;
+        }
+
         let span = attribute.span();
         let values = propagate_err!(parse_values(attribute));
 

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -14,6 +14,7 @@ use syn::{
     FnArg,
     Ident,
     Pat,
+    Path,
     ReturnType,
     Stmt,
     Token,
@@ -99,6 +100,10 @@ fn is_cooked(attr: &Attribute) -> bool {
     COOKED_ATTRIBUTE_NAMES.iter().any(|n| attr.path.is_ident(n))
 }
 
+pub fn is_rustfmt_or_clippy_attr(path: &Path) -> bool {
+    path.segments.first().map_or(false, |s| s.ident == "rustfmt" || s.ident == "clippy")
+}
+
 /// Removes cooked attributes from a vector of attributes. Uncooked attributes are left in the
 /// vector.
 ///
@@ -111,7 +116,7 @@ fn remove_cooked(attrs: &mut Vec<Attribute>) -> Vec<Attribute> {
     // FIXME: Replace with `Vec::drain_filter` once it is stable.
     let mut i = 0;
     while i < attrs.len() {
-        if !is_cooked(&attrs[i]) {
+        if !is_cooked(&attrs[i]) && !is_rustfmt_or_clippy_attr(&attrs[i].path) {
             i += 1;
             continue;
         }


### PR DESCRIPTION
This alters attribute parse code in `command_attr` to not parse attributes like `#[rustfmt::skip]` as its own, and instead should emit them in the output of the macros.