### PR TITLE
Implement Get Current User Guild Member endpoint

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3741,6 +3741,33 @@ impl Http {
         .await
     }
 
+    /// Returns a guild member object for the current user.
+    ///
+    /// This method only works for user tokens with the [`GuildsMembersRead`]
+    /// OAuth2 scope.
+    ///
+    /// [`GuildsMembersRead`]: crate::model::application::oauth::Scope::GuildsMembersRead
+    pub async fn get_current_user_guild_member(&self, guild_id: u64) -> Result<Member> {
+        let mut value = self
+            .request(Request {
+                body: None,
+                multipart: None,
+                headers: None,
+                route: RouteInfo::GetCurrentUserGuildMember {
+                    guild_id,
+                },
+            })
+            .await?
+            .json::<Value>()
+            .await?;
+
+        if let Some(map) = value.as_object_mut() {
+            map.insert("guild_id".to_string(), from_number(guild_id));
+        }
+
+        from_value::<Member>(value).map_err(From::from)
+    }
+
     /// Leaves a guild.
     pub async fn leave_guild(&self, guild_id: u64) -> Result<()> {
         self.wind(204, Request {

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -391,6 +391,8 @@ pub enum Route {
     UsersMeGuilds,
     /// Route for the `/users/@me/guilds/:guild_id` path.
     UsersMeGuildsId,
+    /// Route for the `/users/@me/guilds/:guild_id/member` path.
+    UsersMeGuildsIdMember,
     /// Route for the `/voice/regions` path.
     VoiceRegions,
     /// Route for the `/webhooks/:webhook_id` path.
@@ -1033,6 +1035,11 @@ impl Route {
     #[must_use]
     pub fn user_guild<D: Display>(target: D, guild_id: u64) -> String {
         api!("/users/{}/guilds/{}", target, guild_id)
+    }
+
+    #[must_use]
+    pub fn user_guild_member<D: Display>(target: D, guild_id: u64) -> String {
+        api!("/users/{}/guilds/{}/member", target, guild_id)
     }
 
     #[must_use]
@@ -1746,6 +1753,9 @@ pub enum RouteInfo<'a> {
     },
     LeaveGroup {
         group_id: u64,
+    },
+    GetCurrentUserGuildMember {
+        guild_id: u64,
     },
     LeaveGuild {
         guild_id: u64,
@@ -2931,6 +2941,13 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Delete,
                 Route::ChannelsId(group_id),
                 Cow::from(Route::channel(group_id)),
+            ),
+            RouteInfo::GetCurrentUserGuildMember {
+                guild_id,
+            } => (
+                LightMethod::Get,
+                Route::UsersMeGuildsIdMember,
+                Cow::from(Route::user_guild_member("@me", guild_id)),
             ),
             RouteInfo::LeaveGuild {
                 guild_id,


### PR DESCRIPTION
This change adds the missing [Get Current User Guild Member](https://discord.com/developers/docs/resources/user#get-current-user-guild-member) endpoint.