### PR TITLE
Revert #2400

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["examples/*"]
 bitflags = "1.3"
 serde_json = "1.0.75"
 async-trait = "0.1.54"
-tracing = { version = "0.1.34", features = ["log"] }
+tracing = { version = "0.1.23", features = ["log"] }
 serde = { version = "1.0.130", features = ["derive"] }
 url = { version = "^2.1", features = ["serde"] }
 tokio = { version = "1", features = ["fs", "macros", "rt", "sync", "time", "io-util"] }

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,5 +1,4 @@
 use serenity::builder::*;
-use serenity::gateway::*;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 
@@ -8,11 +7,7 @@ mod model_type_sizes;
 const IMAGE_URL: &str = "https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png";
 const IMAGE_URL_2: &str = "https://rustacean.net/assets/rustlogo.png";
 
-async fn message(
-    ctx: &Context,
-    msg: Message,
-    shard_manager: &tokio::sync::Mutex<ShardManager>,
-) -> Result<(), serenity::Error> {
+async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
     let channel_id = msg.channel_id;
     let guild_id = msg.guild_id.unwrap();
     if let Some(_args) = msg.content.strip_prefix("testmessage ") {
@@ -200,8 +195,6 @@ async fn message(
                     .add_file(CreateAttachment::url(ctx, audio_url).await?),
             )
             .await?;
-    } else if msg.content == "shutdown" {
-        shard_manager.lock().await.shutdown_all().await;
     } else if let Some(channel) = msg.content.strip_prefix("movetorootandback") {
         let mut channel =
             channel.trim().parse::<ChannelId>().unwrap().to_channel(ctx).await?.guild().unwrap();
@@ -349,16 +342,11 @@ async fn interaction(
     Ok(())
 }
 
-struct Handler {
-    shard_manager: std::sync::Arc<
-        tokio::sync::Mutex<Option<std::sync::Arc<tokio::sync::Mutex<ShardManager>>>>,
-    >,
-}
+struct Handler;
 #[serenity::async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
-        let shard_manager = self.shard_manager.lock().await.clone().unwrap();
-        message(&ctx, msg, &shard_manager).await.unwrap();
+        message(&ctx, msg).await.unwrap();
     }
 
     async fn interaction_create(&self, ctx: Context, i: Interaction) {
@@ -390,11 +378,5 @@ async fn main() -> Result<(), serenity::Error> {
     env_logger::init();
     let token = std::env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
     let intents = GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT;
-    let shard_manager = std::sync::Arc::new(tokio::sync::Mutex::new(None));
-    let handler = Handler {
-        shard_manager: shard_manager.clone(),
-    };
-    let mut client = Client::builder(token, intents).event_handler(handler).await?;
-    *shard_manager.lock().await = Some(client.shard_manager.clone());
-    client.start().await
+    Client::builder(token, intents).event_handler(Handler).await?.start().await
 }

--- a/src/gateway/bridge/mod.rs
+++ b/src/gateway/bridge/mod.rs
@@ -50,10 +50,7 @@ mod shard_runner_message;
 mod voice;
 
 use std::fmt;
-use std::sync::Arc;
 use std::time::Duration as StdDuration;
-
-use tokio::sync::Mutex;
 
 pub use self::event::ShardStageUpdateEvent;
 pub use self::shard_manager::{ShardManager, ShardManagerOptions};
@@ -63,7 +60,7 @@ pub use self::shard_runner::{ShardRunner, ShardRunnerOptions};
 pub use self::shard_runner_message::ShardRunnerMessage;
 #[cfg(feature = "voice")]
 pub use self::voice::VoiceGatewayManager;
-use super::{ChunkGuildFilter, Shard};
+use super::ChunkGuildFilter;
 use crate::gateway::ConnectionStage;
 use crate::model::event::Event;
 use crate::model::id::ShardId;
@@ -76,6 +73,8 @@ pub enum ShardQueuerMessage {
     Start(ShardId, ShardId),
     /// Message to shutdown the shard queuer.
     Shutdown,
+    /// Message to dequeue/shutdown a shard.
+    ShutdownShard(ShardId, u16),
 }
 
 /// Information about a [`ShardRunner`].
@@ -91,8 +90,6 @@ pub struct ShardRunnerInfo {
     pub runner_tx: ShardMessenger,
     /// The current connection stage of the shard.
     pub stage: ConnectionStage,
-    /// The Shard instance this runner communicates with
-    pub shard: Arc<Mutex<Shard>>,
 }
 
 impl AsRef<ShardMessenger> for ShardRunnerInfo {

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -5,8 +5,9 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
-use futures::SinkExt;
+use futures::{SinkExt, StreamExt};
 use tokio::sync::{Mutex, RwLock};
+use tokio::time::timeout;
 use tracing::{info, instrument, warn};
 use typemap_rev::TypeMap;
 
@@ -108,6 +109,8 @@ pub struct ShardManager {
     /// The total shards in use, 1-indexed.
     shard_total: u32,
     shard_queuer: Sender<ShardQueuerMessage>,
+    shard_shutdown: Receiver<ShardId>,
+    shard_shutdown_send: Sender<ShardId>,
     gateway_intents: GatewayIntents,
 }
 
@@ -120,6 +123,7 @@ impl ShardManager {
         let (shard_queue_tx, shard_queue_rx) = mpsc::unbounded();
 
         let runners = Arc::new(Mutex::new(HashMap::new()));
+        let (shutdown_send, shutdown_recv) = mpsc::unbounded();
 
         let manager = Arc::new(Mutex::new(Self {
             return_value_tx,
@@ -127,6 +131,8 @@ impl ShardManager {
             shard_init: opt.shard_init,
             shard_queuer: shard_queue_tx,
             shard_total: opt.shard_total,
+            shard_shutdown: shutdown_recv,
+            shard_shutdown_send: shutdown_send,
             runners: Arc::clone(&runners),
             gateway_intents: opt.intents,
         }));
@@ -191,11 +197,7 @@ impl ShardManager {
     /// This will _not_ instantiate the new shards.
     #[instrument(skip(self))]
     pub async fn set_shards(&mut self, index: u32, init: u32, total: u32) {
-        // Don't use shutdown_all here because shutdown_all also returns from Client::start
-        let shard_ids = self.runners.lock().await.keys().copied().collect::<Vec<_>>();
-        for shard_id in shard_ids {
-            self.shutdown(shard_id, 1000).await;
-        }
+        self.shutdown_all().await;
 
         self.shard_index = index;
         self.shard_init = init;
@@ -265,31 +267,54 @@ impl ShardManager {
     /// never happen_. It may already be stopped.
     #[instrument(skip(self))]
     pub async fn shutdown(&mut self, shard_id: ShardId, code: u16) {
+        const TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(5);
+
         info!("Shutting down shard {}", shard_id);
 
-        let Some(shard) = self.runners.lock().await.get(&shard_id).map(|r| Arc::clone(&r.shard)) else {
-            warn!("Shard ID {} doesn't exist", shard_id);
-            return;
-        };
-        shard.lock().await.shutdown(code).await;
+        drop(self.shard_queuer.unbounded_send(ShardQueuerMessage::ShutdownShard(shard_id, code)));
+
+        match timeout(TIMEOUT, self.shard_shutdown.next()).await {
+            Ok(Some(shutdown_shard_id)) => {
+                if shutdown_shard_id != shard_id {
+                    warn!(
+                        "Failed to cleanly shutdown shard {}: Shutdown channel sent incorrect ID",
+                        shard_id,
+                    );
+                }
+            },
+            Ok(None) => (),
+            Err(why) => {
+                warn!("Failed to cleanly shutdown shard {}, reached timeout: {:?}", shard_id, why);
+            },
+        }
+
         self.runners.lock().await.remove(&shard_id);
     }
 
-    /// Shuts down all shards and returns from [`crate::client::Client::start`].
+    /// Sends a shutdown message for all shards that the manager is responsible for that are still
+    /// known to be running.
     ///
     /// If you only need to shutdown a select number of shards, prefer looping over the
     /// [`Self::shutdown`] method.
     #[instrument(skip(self))]
     pub async fn shutdown_all(&mut self) {
+        let keys = {
+            let runners = self.runners.lock().await;
+
+            if runners.is_empty() {
+                return;
+            }
+
+            runners.keys().copied().collect::<Vec<_>>()
+        };
+
         info!("Shutting down all shards");
 
-        let shard_ids = self.runners.lock().await.keys().copied().collect::<Vec<_>>();
-        for shard_id in shard_ids {
+        for shard_id in keys {
             self.shutdown(shard_id, 1000).await;
         }
 
         drop(self.shard_queuer.unbounded_send(ShardQueuerMessage::Shutdown));
-        self.return_with_value(Ok(())).await;
     }
 
     #[instrument(skip(self))]
@@ -313,8 +338,17 @@ impl ShardManager {
         }
     }
 
+    pub fn shutdown_finished(&self, id: ShardId) {
+        if let Err(e) = self.shard_shutdown_send.unbounded_send(id) {
+            tracing::warn!("failed to notify about finished shutdown: {}", e);
+        }
+    }
+
     pub async fn restart_shard(&mut self, id: ShardId) {
         self.restart(id).await;
+        if let Err(e) = self.shard_shutdown_send.unbounded_send(id) {
+            tracing::warn!("failed to notify about finished shutdown: {}", e);
+        }
     }
 
     pub async fn update_shard_latency_and_stage(
@@ -339,12 +373,6 @@ impl Drop for ShardManager {
     /// [`ShardRunner`]: super::ShardRunner
     fn drop(&mut self) {
         drop(self.shard_queuer.unbounded_send(ShardQueuerMessage::Shutdown));
-        let runners = Arc::clone(&self.runners);
-        tokio::spawn(async move {
-            for runner in runners.lock().await.values_mut() {
-                runner.shard.lock().await.shutdown(1000).await;
-            }
-        });
     }
 }
 

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -26,7 +26,7 @@ use crate::cache::Cache;
 use crate::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
-use crate::gateway::{ConnectionStage, PresenceData, Shard};
+use crate::gateway::{ConnectionStage, PresenceData, Shard, ShardRunnerMessage};
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
@@ -108,7 +108,13 @@ impl ShardQueuer {
             match timeout(TIMEOUT, self.rx.next()).await {
                 Ok(Some(ShardQueuerMessage::Shutdown)) => {
                     debug!("[Shard Queuer] Received to shutdown.");
+                    self.shutdown_runners().await;
+
                     break;
+                },
+                Ok(Some(ShardQueuerMessage::ShutdownShard(shard, code))) => {
+                    debug!("[Shard Queuer] Received to shutdown shard {} with {}.", shard.0, code);
+                    self.shutdown(shard, code).await;
                 },
                 Ok(Some(ShardQueuerMessage::Start(id, total))) => {
                     debug!("[Shard Queuer] Received to start shard {} of {}.", id.0, total.0);
@@ -181,6 +187,7 @@ impl ShardQueuer {
             manager: Arc::clone(&self.manager),
             #[cfg(feature = "voice")]
             voice_manager: self.voice_manager.clone(),
+            shard,
             #[cfg(feature = "cache")]
             cache: Arc::clone(&self.cache),
             http: Arc::clone(&self.http),
@@ -190,17 +197,56 @@ impl ShardQueuer {
             latency: None,
             runner_tx: ShardMessenger::new(&runner),
             stage: ConnectionStage::Disconnected,
-            shard: Arc::new(Mutex::new(shard)),
         };
 
-        let shard2 = Arc::clone(&runner_info.shard);
         spawn_named("shard_queuer::stop", async move {
-            drop(runner.run(&shard2).await);
-            debug!("[ShardRunner {:?}] Stopping", shard2.lock().await.shard_info());
+            drop(runner.run().await);
+            debug!("[ShardRunner {:?}] Stopping", runner.shard.shard_info());
         });
 
         self.runners.lock().await.insert(id, runner_info);
 
         Ok(())
+    }
+
+    #[instrument(skip(self))]
+    async fn shutdown_runners(&mut self) {
+        let keys = {
+            let runners = self.runners.lock().await;
+
+            if runners.is_empty() {
+                return;
+            }
+
+            runners.keys().copied().collect::<Vec<_>>()
+        };
+
+        info!("Shutting down all shards");
+
+        for shard_id in keys {
+            self.shutdown(shard_id, 1000).await;
+        }
+    }
+
+    /// Attempts to shut down the shard runner by Id.
+    ///
+    /// **Note**: If the receiving end of an mpsc channel - theoretically owned by the shard runner
+    /// - no longer exists, then the shard runner will not know it should shut down. This _should
+    /// never happen_. It may already be stopped.
+    #[instrument(skip(self))]
+    pub async fn shutdown(&mut self, shard_id: ShardId, code: u16) {
+        info!("Shutting down shard {}", shard_id);
+
+        if let Some(runner) = self.runners.lock().await.get(&shard_id) {
+            let msg = ShardRunnerMessage::Shutdown(shard_id, code);
+
+            if let Err(why) = runner.runner_tx.tx.unbounded_send(msg) {
+                warn!(
+                    "Failed to cleanly shutdown shard {} when sending message to shard runner: {:?}",
+                    shard_id,
+                    why,
+                );
+            }
+        }
     }
 }

--- a/src/gateway/bridge/shard_runner_message.rs
+++ b/src/gateway/bridge/shard_runner_message.rs
@@ -1,5 +1,6 @@
 use tokio_tungstenite::tungstenite::Message;
 
+use super::ShardId;
 use crate::gateway::{ActivityData, ChunkGuildFilter};
 use crate::model::id::GuildId;
 use crate::model::user::OnlineStatus;
@@ -8,7 +9,10 @@ use crate::model::user::OnlineStatus;
 #[derive(Debug)]
 pub enum ShardRunnerMessage {
     /// Indicator that a shard should be restarted.
-    Restart,
+    Restart(ShardId),
+    /// Indicator that a shard should be fully shutdown without bringing it
+    /// back up.
+    Shutdown(ShardId, u16),
     /// Indicates that the client is to send a member chunk message.
     ChunkGuild {
         /// The IDs of the [`Guild`] to chunk.


### PR DESCRIPTION
It was determined that #2400 broke shard restarts and caused them to not be initiated when a network error occurred, leading to crashes because of uncaught errors. As a hotfix, this reverts that PR.