### PR TITLE
Implement Get Current User Guild Member endpoint

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3667,6 +3667,56 @@ impl Http {
         .await
     }
 
+    /// Returns a guild [`Member`] object for the current user.
+    ///
+    /// # Authorization
+    ///
+    /// This method only works for user tokens with the [`GuildsMembersRead`] OAuth2 scope.
+    ///
+    /// [`GuildsMembersRead`]: crate::model::application::Scope::GuildsMembersRead
+    ///
+    /// # Examples
+    ///
+    /// Get the member object for the current user within the specified guild.
+    ///
+    /// ```rust,no_run
+    /// # use serenity::http::Http;
+    /// #
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let http: Http = unimplemented!();
+    /// use serenity::model::id::GuildId;
+    ///
+    /// let guild_id = GuildId::new(81384788765712384);
+    ///
+    /// let member = http.get_current_user_guild_member(guild_id).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// See the [Discord Developer Portal documentation][docs] for more.
+    ///
+    /// [docs]: https://discord.com/developers/docs/resources/user#get-current-user-guild-member
+    pub async fn get_current_user_guild_member(&self, guild_id: GuildId) -> Result<Member> {
+        let mut value: Value = self
+            .fire(Request {
+                body: None,
+                multipart: None,
+                headers: None,
+                method: LightMethod::Get,
+                route: Route::UserMeGuildMember {
+                    guild_id,
+                },
+                params: None,
+            })
+            .await?;
+
+        if let Some(map) = value.as_object_mut() {
+            map.insert("guild_id".to_string(), guild_id.get().into());
+        }
+
+        from_value(value).map_err(From::from)
+    }
+
     /// Gets information about a specific invite.
     ///
     /// # Arguments

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -386,6 +386,10 @@ routes! ('a, {
     api!("/users/@me/guilds/{}", guild_id),
     Some(RatelimitingKind::Path);
 
+    UserMeGuildMember { guild_id: GuildId },
+    api!("/users/@me/guilds/{}/member", guild_id),
+    Some(RatelimitingKind::Path);
+
     UserMeGuilds,
     api!("/users/@me/guilds"),
     Some(RatelimitingKind::Path);

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1005,6 +1005,19 @@ impl GuildId {
         http.as_ref().kick_member(self, user_id.into(), Some(reason)).await
     }
 
+    /// Returns a guild [`Member`] object for the current user.
+    ///
+    /// See [`Http::get_current_user_guild_member`] for more.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the current user is not in the guild or the access token
+    /// lacks the necessary scope.
+    #[inline]
+    pub async fn current_user_member(self, http: impl AsRef<Http>) -> Result<Member> {
+        http.as_ref().get_current_user_guild_member(self).await
+    }
+
     /// Leaves the guild.
     ///
     /// # Errors

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1519,6 +1519,19 @@ impl Guild {
         self.id.kick_with_reason(http, user_id, reason).await
     }
 
+    /// Returns a guild [`Member`] object for the current user.
+    ///
+    /// See [`Http::get_current_user_guild_member`] for more.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the current user is not in the guild or the access token
+    /// lacks the necessary scope.
+    #[inline]
+    pub async fn current_user_member(&self, http: impl AsRef<Http>) -> Result<Member> {
+        self.id.current_user_member(http).await
+    }
+
     /// Leaves the guild.
     ///
     /// # Errors

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1250,6 +1250,19 @@ impl PartialGuild {
         self.id.invites(http).await
     }
 
+    /// Returns a guild [`Member`] object for the current user.
+    ///
+    /// See [`Http::get_current_user_guild_member`] for more.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the current user is not in the guild or the access token
+    /// lacks the necessary scope.
+    #[inline]
+    pub async fn current_user_member(&self, http: impl AsRef<Http>) -> Result<Member> {
+        self.id.current_user_member(http).await
+    }
+
     /// Leaves the guild.
     ///
     /// # Errors


### PR DESCRIPTION
This change adds the missing [Get Current User Guild Member](https://discord.com/developers/docs/resources/user#get-current-user-guild-member) endpoint.

Replaces #2485.