### PR TITLE
Fix compilation with just the `http` and `builder` features enabled

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -240,7 +240,7 @@ impl CreateEmbed {
             length += title.chars().count();
         }
 
-        crate::utils::check_overflow(length, crate::constants::EMBED_MAX_LENGTH)
+        super::check_overflow(length, crate::constants::EMBED_MAX_LENGTH)
             .map_err(|overflow| Error::Model(ModelError::EmbedTooLarge(overflow)))
     }
 }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "http")]
-use super::Builder;
+use super::{check_overflow, Builder};
 use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
 #[cfg(feature = "http")]
 use crate::constants;
@@ -7,8 +7,6 @@ use crate::constants;
 use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-#[cfg(feature = "http")]
-use crate::utils::check_overflow;
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object).
 #[derive(Clone, Debug)]

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "http")]
-use super::Builder;
+use super::{check_overflow, Builder};
 use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
 #[cfg(feature = "http")]
 use crate::constants;
@@ -8,8 +8,6 @@ use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-#[cfg(feature = "http")]
-use crate::utils::check_overflow;
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#create-followup-message)
 #[derive(Clone, Debug, Default, Serialize)]

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "http")]
-use super::Builder;
+use super::{check_overflow, Builder};
 use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
 #[cfg(feature = "http")]
 use crate::constants;
@@ -8,8 +8,6 @@ use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-#[cfg(feature = "http")]
-use crate::utils::check_overflow;
 
 /// A builder to specify the contents of an send message request, primarily meant for use
 /// through [`ChannelId::send_message`].
@@ -330,7 +328,7 @@ impl Builder for CreateMessage {
         let mut message = http.send_message(channel_id, files, &self).await?;
 
         for reaction in self.reactions {
-            channel_id.create_reaction(http, message.id, reaction).await?;
+            http.create_reaction(channel_id, message.id, &reaction).await?;
         }
 
         // HTTP sent Messages don't have guild_id set, so we fill it in ourselves by best effort

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "http")]
-use super::Builder;
+use super::{check_overflow, Builder};
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -14,8 +14,6 @@ use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-#[cfg(feature = "http")]
-use crate::utils::check_overflow;
 
 /// A builder to specify the fields to edit in an existing message.
 ///

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -185,7 +185,7 @@ impl<'a> Builder for EditRole<'a> {
         };
 
         if let Some(position) = self.position {
-            guild_id.edit_role_position(http, role.id, position).await?;
+            http.edit_role_position(guild_id, role.id, position, self.audit_log_reason).await?;
         }
         Ok(role)
     }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "http")]
-use super::Builder;
+use super::{check_overflow, Builder};
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -14,8 +14,6 @@ use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-#[cfg(feature = "http")]
-use crate::utils::check_overflow;
 
 /// A builder to specify the fields to edit in an existing [`Webhook`]'s message.
 ///

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "http")]
-use super::Builder;
+use super::{check_overflow, Builder};
 use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
 #[cfg(feature = "http")]
 use crate::constants;
@@ -8,8 +8,6 @@ use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-#[cfg(feature = "http")]
-use crate::utils::check_overflow;
 
 /// A builder to create the content for a [`Webhook`]'s execution.
 ///

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -27,6 +27,15 @@ pub trait Builder {
     ) -> Result<Self::Built>;
 }
 
+#[cfg(feature = "http")]
+pub(crate) fn check_overflow(len: usize, max: usize) -> StdResult<(), usize> {
+    if len > max {
+        Err(len - max)
+    } else {
+        Ok(())
+    }
+}
+
 mod add_member;
 mod bot_auth_parameters;
 mod create_allowed_mentions;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::{HeaderMap as Headers, HeaderValue};
-use reqwest::{Client, ClientBuilder, Response as ReqwestResponse, StatusCode, Url};
+#[cfg(feature = "utils")]
+use reqwest::Url;
+use reqwest::{Client, ClientBuilder, Response as ReqwestResponse, StatusCode};
 use secrecy::{ExposeSecret, SecretString};
 use serde::de::DeserializeOwned;
 use tracing::{debug, instrument, trace};

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -23,7 +23,7 @@ use crate::gateway::ShardMessenger;
 use crate::http::{CacheHttp, Http};
 use crate::model::application::{ActionRow, MessageInteraction};
 use crate::model::prelude::*;
-#[cfg(feature = "model")]
+#[cfg(all(feature = "model", feature = "cache"))]
 use crate::utils;
 
 /// A representation of a message over a guild's text channel, a group, or a private channel.
@@ -470,7 +470,7 @@ impl Message {
     /// inner value of how many unicode code points the message is over.
     #[must_use]
     pub fn overflow_length(content: &str) -> Option<usize> {
-        utils::check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT).err()
+        crate::builder::check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT).err()
     }
 
     /// Pins this message to its channel.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "model")]
 use std::cmp::Ordering;
 use std::convert::TryFrom;
 #[cfg(doc)]
@@ -6,7 +5,7 @@ use std::fmt::Display as _;
 use std::fmt::{self, Write as _};
 use std::str::FromStr;
 
-#[cfg(feature = "model")]
+#[cfg(feature = "http")]
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::de::{Deserialize, Error as DeError};
 use serde::ser::{Serialize, SerializeMap, Serializer};
@@ -334,7 +333,7 @@ impl ReactionType {
     /// it.
     #[inline]
     #[must_use]
-    #[cfg(feature = "model")]
+    #[cfg(feature = "http")]
     pub fn as_data(&self) -> String {
         match self {
             ReactionType::Custom {
@@ -353,7 +352,6 @@ impl ReactionType {
     /// Helper function to allow testing equality of unicode emojis without having to perform any
     /// allocation. Will always return false if the reaction was not a unicode reaction.
     #[must_use]
-    #[cfg(feature = "model")]
     pub fn unicode_eq(&self, other: &str) -> bool {
         if let ReactionType::Unicode(unicode) = &self {
             unicode == other
@@ -366,7 +364,6 @@ impl ReactionType {
     /// Helper function to allow comparing unicode emojis without having to perform any allocation.
     /// Will return None if the reaction was not a unicode reaction.
     #[must_use]
-    #[cfg(feature = "model")]
     pub fn unicode_partial_cmp(&self, other: &str) -> Option<Ordering> {
         if let ReactionType::Unicode(unicode) = &self {
             Some(unicode.as_str().cmp(other))

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -17,6 +17,7 @@ mod welcome_screen;
 #[cfg(feature = "model")]
 use std::borrow::Cow;
 
+#[cfg(feature = "model")]
 use tracing::{error, warn};
 
 pub use self::emoji::*;
@@ -30,7 +31,6 @@ pub use self::role::*;
 pub use self::scheduled_event::*;
 pub use self::system_channel::*;
 pub use self::welcome_screen::*;
-use super::utils::*;
 #[cfg(feature = "model")]
 use crate::builder::{
     AddMember,
@@ -65,7 +65,7 @@ use crate::model::application::{Command, CommandPermissions};
 #[cfg(feature = "model")]
 use crate::model::guild::automod::Rule;
 use crate::model::prelude::*;
-use crate::model::utils::{emojis, presences, roles, stickers};
+use crate::model::utils::*;
 use crate::model::Timestamp;
 
 /// A representation of a banning of a user.
@@ -2603,7 +2603,7 @@ pub struct GuildInfo {
     pub features: Vec<String>,
 }
 
-#[cfg(any(feature = "model", feature = "utils"))]
+#[cfg(feature = "model")]
 impl GuildInfo {
     /// Returns the formatted URL of the guild's icon, if the guild has an icon.
     ///

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -21,6 +21,7 @@ use crate::collector::{MessageCollector, ReactionCollector};
 use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::CacheHttp;
+#[cfg(feature = "model")]
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::json::json;

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -1,6 +1,8 @@
 //! Webhook model and implementations.
 
-use secrecy::{ExposeSecret, SecretString};
+#[cfg(feature = "model")]
+use secrecy::ExposeSecret;
+use secrecy::SecretString;
 
 #[cfg(feature = "model")]
 use super::channel::Message;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -30,17 +30,7 @@ pub use self::token::validate as validate_token;
 use crate::cache::Cache;
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::http::CacheHttp;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
-
-#[cfg(all(feature = "builder", feature = "http"))]
-pub(crate) fn check_overflow(len: usize, max: usize) -> StdResult<(), usize> {
-    if len > max {
-        Err(len - max)
-    } else {
-        Ok(())
-    }
-}
 
 /// Retrieves the "code" part of an invite out of a URL.
 ///


### PR DESCRIPTION
Addresses https://github.com/serenity-rs/serenity/issues/2494#issuecomment-1642018417 by untangling dependencies on the `model` and `utils` feature from the `http` feature, allowing compilation without them. In particular, the following changes are made:

* Move `utils::check_overflow` into the `builder` module.
* Change the feature gate on `ReactionType::data` from `model` to `http`, and un-gate its other methods.
* Change the feature gate on `GuildInfo::icon_url` to just `model`.
* Some miscellaneous other feature gate changes to imports and the like