### PR TITLE
Add more valid domains for webhooks URL (#2491)

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -431,7 +431,7 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
 pub fn parse_webhook(url: &Url) -> Option<(u64, &str)> {
     let (webhook_id, token) = url.path().strip_prefix("/api/webhooks/")?.split_once('/')?;
     if !["http", "https"].contains(&url.scheme())
-        || !["discord.com", "discordapp.com"].contains(&url.domain()?)
+        || !["discord.com", "canary.discord.com", "discordapp.com"].contains(&url.domain()?)
         || !(17..=20).contains(&webhook_id.len())
         || !(60..=68).contains(&token.len())
     {
@@ -508,5 +508,10 @@ mod test {
         let (id, token) = parse_webhook(&url).unwrap();
         assert_eq!(id, 245037420704169985);
         assert_eq!(token, "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV");
+
+        let url_canary = "https://canary.discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV".parse().unwrap();
+        let (id_canary, token_canary) = parse_webhook(&url_canary).unwrap();
+        assert_eq!(id_canary, 245037420704169985);
+        assert_eq!(token_canary, "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV");
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -413,6 +413,16 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
     args
 }
 
+/// Discord's official domains. This is used in [`parse_webhook`] and in its corresponding test.
+const DOMAINS: &'static [&'static str] = &[
+    "discord.com",
+    "canary.discord.com",
+    "ptb.discord.com",
+    "discordapp.com",
+    "canary.discordapp.com",
+    "ptb.discordapp.com",
+];
+
 /// Parses the id and token from a webhook url. Expects a [`url::Url`] object rather than a [`&str`].
 ///
 /// # Examples
@@ -429,15 +439,6 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
 /// ```
 #[must_use]
 pub fn parse_webhook(url: &Url) -> Option<(u64, &str)> {
-    const DOMAINS: &'static [&'static str] = &[
-        "discord.com",
-        "canary.discord.com",
-        "ptb.discord.com",
-        "discordapp.com",
-        "canary.discordapp.com",
-        "ptb.discordapp.com",
-    ];
-
     let (webhook_id, token) = url.path().strip_prefix("/api/webhooks/")?.split_once('/')?;
     if !["http", "https"].contains(&url.scheme())
         || !DOMAINS.contains(&url.domain()?)
@@ -513,15 +514,6 @@ mod test {
 
     #[test]
     fn test_webhook_parser() {
-        const DOMAINS: &'static [&'static str] = &[
-            "discord.com",
-            "canary.discord.com",
-            "ptb.discord.com",
-            "discordapp.com",
-            "canary.discordapp.com",
-            "ptb.discordapp.com",
-        ];
-
         for domain in DOMAINS {
             let url = format!("https://{}/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV", domain).parse().unwrap();
             let (id, token) = parse_webhook(&url).unwrap();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -429,9 +429,18 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
 /// ```
 #[must_use]
 pub fn parse_webhook(url: &Url) -> Option<(u64, &str)> {
+    const DOMAINS: &'static [&'static str] = &[
+        "discord.com",
+        "canary.discord.com",
+        "ptb.discord.com",
+        "discordapp.com",
+        "canary.discordapp.com",
+        "ptb.discordapp.com",
+    ];
+
     let (webhook_id, token) = url.path().strip_prefix("/api/webhooks/")?.split_once('/')?;
     if !["http", "https"].contains(&url.scheme())
-        || !["discord.com", "canary.discord.com", "discordapp.com"].contains(&url.domain()?)
+        || !DOMAINS.contains(&url.domain()?)
         || !(17..=20).contains(&webhook_id.len())
         || !(60..=68).contains(&token.len())
     {
@@ -504,14 +513,23 @@ mod test {
 
     #[test]
     fn test_webhook_parser() {
-        let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV".parse().unwrap();
-        let (id, token) = parse_webhook(&url).unwrap();
-        assert_eq!(id, 245037420704169985);
-        assert_eq!(token, "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV");
+        const DOMAINS: &'static [&'static str] = &[
+            "discord.com",
+            "canary.discord.com",
+            "ptb.discord.com",
+            "discordapp.com",
+            "canary.discordapp.com",
+            "ptb.discordapp.com",
+        ];
 
-        let url_canary = "https://canary.discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV".parse().unwrap();
-        let (id_canary, token_canary) = parse_webhook(&url_canary).unwrap();
-        assert_eq!(id_canary, 245037420704169985);
-        assert_eq!(token_canary, "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV");
+        for domain in DOMAINS {
+            let url = format!("https://{}/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV", domain).parse().unwrap();
+            let (id, token) = parse_webhook(&url).unwrap();
+            assert_eq!(id, 245037420704169985);
+            assert_eq!(
+                token,
+                "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV"
+            );
+        }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -414,7 +414,7 @@ pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
 }
 
 /// Discord's official domains. This is used in [`parse_webhook`] and in its corresponding test.
-const DOMAINS: &'static [&'static str] = &[
+const DOMAINS: &[&str] = &[
     "discord.com",
     "canary.discord.com",
     "ptb.discord.com",


### PR DESCRIPTION
Add canary.discord.com to the list of valid webhook domains.

Should fix #2491