### PR TITLE
Implement FromStr for ids

### DIFF
--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -73,6 +73,14 @@ macro_rules! id_u64 {
                     id.0 as i64
                 }
             }
+
+            impl std::str::FromStr for $name {
+                type Err = <u64 as std::str::FromStr>::Err;
+
+                fn from_str(s: &str) -> Result<Self, Self::Err> {
+                    Ok(Self(s.parse()?))
+                }
+            }
         )*
     }
 }


### PR DESCRIPTION
Useful for databasing, i.e. in Postgres, where ID's must be stored as strings because `u64::MAX` is larger than the largest BigInt type.

```rs
// before
Id::from(some_string.parse::<u64>().unwrap());

// after
Id::from_str(&some_string).unwrap();
```