### PR TITLE
Add missing `set_components()` methods

### DIFF
--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -98,7 +98,7 @@ impl EditInteractionResponse {
         self
     }
 
-    /// Sets the components of this message.
+    /// Creates components for this message.
     pub fn components<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut CreateComponents) -> &mut CreateComponents,
@@ -107,6 +107,12 @@ impl EditInteractionResponse {
         f(&mut components);
 
         self.0.insert("components", Value::from(components.0));
+        self
+    }
+
+    /// Sets the components of this message.
+    pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
+        self.0.insert("components", Value::Array(components.0));
         self
     }
 }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -69,4 +69,13 @@ impl EditWebhookMessage {
         self.0.insert("components", Value::from(components.0));
         self
     }
+
+    /// Sets the components of this message. Requires an application-owned webhook. See
+    /// [`components`] for details.
+    ///
+    /// [`components`]: crate::builder::EditWebhookMessage::components
+    pub fn set_components(&mut self, components: CreateComponents) -> &mut Self {
+        self.0.insert("components", Value::Array(components.0));
+        self
+    }
 }


### PR DESCRIPTION
Adds `set_components()` to `EditInteractionResponse` and `EditWebhookMessage` builders.