### PR TITLE
Added static_face as variation of face

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -516,6 +516,16 @@ impl User {
         self.avatar_url().unwrap_or_else(|| self.default_avatar_url())
     }
 
+    /// Retrieves the URL to the static version of the user's avatar, falling back to the default
+    /// avatar if needed.
+    ///
+    /// This will call [`Self::static_avatar_url`] first, and if that returns [`None`], it then
+    /// falls back to [`Self::default_avatar_url`].
+    #[must_use]
+    pub fn static_face(&self) -> String {
+        self.static_avatar_url().unwrap_or_else(|| self.default_avatar_url())
+    }
+
     /// Check if a user has a [`Role`]. This will retrieve the [`Guild`] from the [`Cache`] if it
     /// is available, and then check if that guild has the given [`Role`].
     ///


### PR DESCRIPTION
This copies the `face()` function in `user.rs`, but uses `static_avatar_url` instead of `avatar_url`.

I am not sure if the `#[must_use]` is needed, since I don't exactly know what it does. If not, I will remove it in a follow up commit.