### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,14 @@ secrecy = { version = "0.8.0", features = ["serde"] }
 arrayvec = { version = "0.7.3", features = ["serde"] }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
-simd-json = { version = "0.7", optional = true }
+simd-json = { version = "0.10", optional = true }
 uwl = { version = "0.6.0", optional = true }
 levenshtein = { version = "1.0.5", optional = true }
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.13", optional = true }
 reqwest = { version = "0.11.7", default-features = false, features = ["multipart", "stream"], optional = true }
 static_assertions = { version = "1.1", optional = true }
-tokio-tungstenite = { version = "0.19", optional = true }
+tokio-tungstenite = { version = "0.20", optional = true }
 typemap_rev = { version = "0.3.0", optional = true }
 bytes = { version = "1.0", optional = true }
 percent-encoding = { version = "2.1", optional = true }
@@ -47,7 +47,7 @@ mini-moka = { version = "0.10", optional = true }
 mime_guess = { version = "2.0", optional = true }
 dashmap = { version = "5.1.0", features = ["serde"], optional = true }
 parking_lot = { version = "0.12", optional = true }
-ed25519-dalek = { version = "1.0.1", optional = true }
+ed25519-dalek = { version = "2", optional = true }
 # serde feature only allows for serialisation,
 # Serenity workspace crates
 command_attr = { version = "0.4.1", path = "./command_attr", optional = true }

--- a/examples/e15_simple_dashboard/Cargo.toml
+++ b/examples/e15_simple_dashboard/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 rillrate = "0.41"
-notify = "6.1.1"
+notify = "=5.0.0-pre.14"
 
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/examples/e15_simple_dashboard/Cargo.toml
+++ b/examples/e15_simple_dashboard/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 rillrate = "0.41"
-notify = "=5.0.0-pre.14"
+notify = "6.1.1"
 
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -105,8 +105,7 @@ impl WsClient {
         let config = WebSocketConfig {
             max_message_size: None,
             max_frame_size: None,
-            max_send_queue: None,
-            accept_unmasked_frames: false,
+            ..Default::default()
         };
         let (stream, _) = connect_async_with_config(url, Some(config), false).await?;
 

--- a/src/interactions_endpoint.rs
+++ b/src/interactions_endpoint.rs
@@ -54,7 +54,7 @@ impl std::error::Error for InvalidKey {
 /// }
 /// ```
 pub struct Verifier {
-    public_key: ed25519_dalek::PublicKey,
+    public_key: ed25519_dalek::VerifyingKey,
 }
 
 impl Verifier {
@@ -75,7 +75,7 @@ impl Verifier {
     /// [`InvalidKey`] if the key isn't cryptographically valid.
     pub fn try_new(public_key: [u8; 32]) -> Result<Self, InvalidKey> {
         Ok(Self {
-            public_key: ed25519_dalek::PublicKey::from_bytes(&public_key).map_err(InvalidKey)?,
+            public_key: ed25519_dalek::VerifyingKey::from_bytes(&public_key).map_err(InvalidKey)?,
         })
     }
 
@@ -87,8 +87,8 @@ impl Verifier {
         use ed25519_dalek::Verifier as _;
 
         // Extract and parse signature
-        let signature = parse_hex::<64>(signature).ok_or(())?;
-        let signature = ed25519_dalek::Signature::from_bytes(&signature).map_err(|_| ())?;
+        let signature_bytes = parse_hex(signature).ok_or(())?;
+        let signature = ed25519_dalek::Signature::from_bytes(&signature_bytes);
 
         // Verify
         let message_to_verify = [timestamp.as_bytes(), body].concat();

--- a/voice-model/Cargo.toml
+++ b/voice-model/Cargo.toml
@@ -26,7 +26,7 @@ features = ["raw_value"]
 version = "1"
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 serde_test = "1"
 
 [[bench]]


### PR DESCRIPTION
* simd-json 0.7 -> 0.10
* tokio-tungstenite 0.19 -> 0.20
* ed25519-dalek 1.0 -> 2.0
* criterion 0.4 -> 0.5
* notify 5.0.0-pre.14 -> 6.1

In tungstenite 0.20, the `WebSocketConfig::max_send_queue` is deprecated for `max_write_buffer_length`. The default value corresponds to an unlimited length, same as before. However, there's a new `write_buffer_length` field which controls how much buffering is done before a flush occurs and the buffer gets written to the underlying system. It defaults to 128KiB (so 128 * 1024) - is this a fine value for us to use?