### PR TITLE
Bump bitflags to 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["examples/*"]
 
 [dependencies]
 # Required dependencies
-bitflags = "1.3"
+bitflags = "2.4"
 serde_json = "1.0.75"
 async-trait = "0.1.54"
 tracing = { version = "0.1.23", features = ["log"] }

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -156,10 +156,9 @@ macro_rules! bitflags {
                 const $Flag:ident = $value:expr;
             )*
         }
-
-        $($t:tt)*
     ) => {
         bitflags::bitflags! {
+            #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
             $(#[$outer])*
             $vis struct $BitFlags: $T {
                 $(
@@ -170,10 +169,6 @@ macro_rules! bitflags {
         }
 
         bitflags!(__impl_serde $BitFlags: $T);
-
-        bitflags! {
-            $($t)*
-        }
     };
     (__impl_serde $BitFlags:ident: $T:tt) => {
         impl<'de> serde::de::Deserialize<'de> for $BitFlags {
@@ -188,7 +183,6 @@ macro_rules! bitflags {
             }
         }
     };
-    () => {};
 }
 
 #[cfg(test)]

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -158,7 +158,7 @@ macro_rules! bitflags {
         }
     ) => {
         bitflags::bitflags! {
-            #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+            #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
             $(#[$outer])*
             $vis struct $BitFlags: $T {
                 $(

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -137,22 +137,22 @@ macro_rules! generate_get_permission_names {
 /// [Speak]: Permissions::SPEAK
 /// [Use External Emojis]: Permissions::USE_EXTERNAL_EMOJIS
 /// [Use VAD]: Permissions::USE_VAD
-pub const PRESET_GENERAL: Permissions = Permissions {
-    bits: Permissions::ADD_REACTIONS.bits
-        | Permissions::ATTACH_FILES.bits
-        | Permissions::CHANGE_NICKNAME.bits
-        | Permissions::CONNECT.bits
-        | Permissions::CREATE_INSTANT_INVITE.bits
-        | Permissions::EMBED_LINKS.bits
-        | Permissions::MENTION_EVERYONE.bits
-        | Permissions::READ_MESSAGE_HISTORY.bits
-        | Permissions::VIEW_CHANNEL.bits
-        | Permissions::SEND_MESSAGES.bits
-        | Permissions::SEND_TTS_MESSAGES.bits
-        | Permissions::SPEAK.bits
-        | Permissions::USE_EXTERNAL_EMOJIS.bits
-        | Permissions::USE_VAD.bits,
-};
+pub const PRESET_GENERAL: Permissions = Permissions::from_bits_truncate(
+    Permissions::ADD_REACTIONS.bits()
+        | Permissions::ATTACH_FILES.bits()
+        | Permissions::CHANGE_NICKNAME.bits()
+        | Permissions::CONNECT.bits()
+        | Permissions::CREATE_INSTANT_INVITE.bits()
+        | Permissions::EMBED_LINKS.bits()
+        | Permissions::MENTION_EVERYONE.bits()
+        | Permissions::READ_MESSAGE_HISTORY.bits()
+        | Permissions::VIEW_CHANNEL.bits()
+        | Permissions::SEND_MESSAGES.bits()
+        | Permissions::SEND_TTS_MESSAGES.bits()
+        | Permissions::SPEAK.bits()
+        | Permissions::USE_EXTERNAL_EMOJIS.bits()
+        | Permissions::USE_VAD.bits(),
+);
 
 /// Returns a set of text-only permissions with the original `@everyone` permissions set to true.
 ///
@@ -180,19 +180,19 @@ pub const PRESET_GENERAL: Permissions = Permissions {
 /// [Send Messages]: Permissions::SEND_MESSAGES
 /// [Send TTS Messages]: Permissions::SEND_TTS_MESSAGES
 /// [Use External Emojis]: Permissions::USE_EXTERNAL_EMOJIS
-pub const PRESET_TEXT: Permissions = Permissions {
-    bits: Permissions::ADD_REACTIONS.bits
-        | Permissions::ATTACH_FILES.bits
-        | Permissions::CHANGE_NICKNAME.bits
-        | Permissions::CREATE_INSTANT_INVITE.bits
-        | Permissions::EMBED_LINKS.bits
-        | Permissions::MENTION_EVERYONE.bits
-        | Permissions::READ_MESSAGE_HISTORY.bits
-        | Permissions::VIEW_CHANNEL.bits
-        | Permissions::SEND_MESSAGES.bits
-        | Permissions::SEND_TTS_MESSAGES.bits
-        | Permissions::USE_EXTERNAL_EMOJIS.bits,
-};
+pub const PRESET_TEXT: Permissions = Permissions::from_bits_truncate(
+    Permissions::ADD_REACTIONS.bits()
+        | Permissions::ATTACH_FILES.bits()
+        | Permissions::CHANGE_NICKNAME.bits()
+        | Permissions::CREATE_INSTANT_INVITE.bits()
+        | Permissions::EMBED_LINKS.bits()
+        | Permissions::MENTION_EVERYONE.bits()
+        | Permissions::READ_MESSAGE_HISTORY.bits()
+        | Permissions::VIEW_CHANNEL.bits()
+        | Permissions::SEND_MESSAGES.bits()
+        | Permissions::SEND_TTS_MESSAGES.bits()
+        | Permissions::USE_EXTERNAL_EMOJIS.bits(),
+);
 
 /// Returns a set of voice-only permissions with the original `@everyone` permissions set to true.
 ///
@@ -204,9 +204,9 @@ pub const PRESET_TEXT: Permissions = Permissions {
 /// [Connect]: Permissions::CONNECT
 /// [Speak]: Permissions::SPEAK
 /// [Use VAD]: Permissions::USE_VAD
-pub const PRESET_VOICE: Permissions = Permissions {
-    bits: Permissions::CONNECT.bits | Permissions::SPEAK.bits | Permissions::USE_VAD.bits,
-};
+pub const PRESET_VOICE: Permissions = Permissions::from_bits_truncate(
+    Permissions::CONNECT.bits() | Permissions::SPEAK.bits() | Permissions::USE_VAD.bits(),
+);
 
 bitflags::bitflags! {
     /// A set of permissions that can be assigned to [`User`]s and [`Role`]s via
@@ -219,7 +219,7 @@ bitflags::bitflags! {
     /// [`PermissionOverwrite`]: super::channel::PermissionOverwrite
     /// [`Role`]: super::guild::Role
     /// [`User`]: super::user::User
-    #[derive(Default)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
     pub struct Permissions: u64 {
         /// Allows for the creation of [`RichInvite`]s.
         ///

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -219,7 +219,7 @@ bitflags::bitflags! {
     /// [`PermissionOverwrite`]: super::channel::PermissionOverwrite
     /// [`Role`]: super::guild::Role
     /// [`User`]: super::user::User
-    #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
     pub struct Permissions: u64 {
         /// Allows for the creation of [`RichInvite`]s.
         ///

--- a/voice-model/Cargo.toml
+++ b/voice-model/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.1"
 edition = "2018"
 
 [dependencies]
-bitflags = "1"
+bitflags = "2.4"
 enum_primitive = "0.1.1"
 serde_repr = "0.1.5"
 

--- a/voice-model/src/speaking_state.rs
+++ b/voice-model/src/speaking_state.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 bitflags! {
     /// Flag set describing how a speaker is sending audio.
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct SpeakingState: u8 {
         /// Normal transmission of voice audio.
         const MICROPHONE = 1;

--- a/voice-model/src/speaking_state.rs
+++ b/voice-model/src/speaking_state.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 bitflags! {
     /// Flag set describing how a speaker is sending audio.
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
     pub struct SpeakingState: u8 {
         /// Normal transmission of voice audio.
         const MICROPHONE = 1;


### PR DESCRIPTION
In bitflags 2.x, bitflag structs changed to tuple structs and can't be instantiated the same way as before. Unfortunately, performing bitops on them isn't possible in `const` contexts, so a workaround is to perform them on the raw `.bits()` and pass the result to `from_bits_truncate`.

Also, bitflag structs no longer automatically derive the following traits: `Clone`, `Copy`, `Debug`, `Default`, `Hash`, `PartialEq`, `Eq`, `PartialOrd`, and `Ord`. To avoid breaking backcompat, I added them back, but serenity does not rely on all of them. Nothing relies on `PartialOrd`/`Ord`, and only the `Permissions` and `SpeakingState` types rely on `Hash`/`PartialEq`/`Eq`. The common required traits are just `Copy`/`Clone` and `Debug`. It's worth considering if we should remove extra impls for types which we expect won't ever make use of them in user code.