### PR TITLE
Make icon and unicode_emoji nullable in addition to optional

### DIFF
--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -56,9 +56,10 @@ pub struct EditRole<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<String>,
+    icon: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    unicode_emoji: Option<String>,
+    unicode_emoji: Option<Option<String>>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
 
@@ -83,7 +84,7 @@ impl<'a> EditRole<'a> {
             permissions: Some(role.permissions.bits()),
             position: Some(role.position),
             colour: Some(role.colour),
-            unicode_emoji: role.unicode_emoji.clone(),
+            unicode_emoji: role.unicode_emoji.as_ref().map(|v| Some(v.clone())),
             audit_log_reason: None,
             // TODO: Do we want to download role.icon?
             icon: None,
@@ -129,16 +130,16 @@ impl<'a> EditRole<'a> {
     }
 
     /// Set the role icon to a unicode emoji.
-    pub fn unicode_emoji(mut self, unicode_emoji: impl Into<String>) -> Self {
-        self.unicode_emoji = Some(unicode_emoji.into());
-        self.icon = None;
+    pub fn unicode_emoji(mut self, unicode_emoji: Option<String>) -> Self {
+        self.unicode_emoji = Some(unicode_emoji);
+        self.icon = Some(None);
         self
     }
 
     /// Set the role icon to a custom image.
-    pub fn icon(mut self, icon: &CreateAttachment) -> Self {
-        self.icon = Some(icon.to_base64());
-        self.unicode_emoji = None;
+    pub fn icon(mut self, icon: Option<&CreateAttachment>) -> Self {
+        self.icon = Some(icon.map(CreateAttachment::to_base64));
+        self.unicode_emoji = Some(None);
         self
     }
 


### PR DESCRIPTION
With this PR it is now possible to properly clear a role's icon/unicode_emoji.

### The problem
In both `serenity/current` and `serenity/next` all `EditRole` fields are skipped when they are `None`. This does not work for `EditRole::icon` and `EditRole::unicode_emoji` because the field being `undefined` is different from the field being `null` at the API[^1]: if the field is `undefined` it will be kept unchanged, and if it is `null` it will be cleared. 

The existing code then doesn't actually clear the icon/unicode_emoji when setting the other, but simply keeps it unchanged. 

### The solution
With a double Option it is possible to distinguish `undefined` from `null` from a set value. This is the [canonical](https://github.com/serde-rs/serde/issues/984#issuecomment-314143738) solution using serde (the example shows de-serialization but it works the same in reverse).

Then, `None` is "keep field unchanged", `Some(None)` is "clear this field" and `Some(Some(value)` is "set this field to this value"

### API breaks
- `EditRole::unicode_emoji()` takes a `Option<String>` instead of `impl Into<String>`.
- `EditRole::icon()` takes a `Option<&CreateAttachment>` instead of `&CreateAttachment`

### Verified
* `EditRole::icon(Some(...))` sets the icon and clears the Unicode emoji. 
* `EditRole::icon(None)` clears both icon and Unicode emoji.
* `EditRole::unicode_emoji(Some(...))` sets the Unicode emoji and clears the icon.
* `EditRole::unicode_emoji(None)` clears both Unicode emoji and icon.
* `cargo +nightly fmt --all` and `cargo test --all` pass.

### Other stuff
For more control it would be possible now to remove the automatic clearing of the unicode_emoji/icon in `icon()`/`unicode_emoji()`, but I didn't see any real use-cases for this.

[^1]: "All parameters to this endpoint are optional and nullable." - https://discord.com/developers/docs/resources/guild#modify-guild-role