### PR TITLE
Fix function signatures for `ChannelId::delete_reactions` and `Message::delete_reaction`

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -292,7 +292,7 @@ impl ChannelId {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
     pub async fn delete_reactions(
-        &self,
+        self,
         http: impl AsRef<Http>,
         message_id: impl Into<MessageId>,
     ) -> Result<()> {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -277,7 +277,7 @@ impl Message {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
     pub async fn delete_reaction(
-        self,
+        &self,
         http: impl AsRef<Http>,
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,


### PR DESCRIPTION
This slipped through during review of #2533. See https://github.com/serenity-rs/serenity/pull/2533#issuecomment-1712899950. It's still soon enough that I don't think this should count as a breaking change.