### PR TITLE
Fix CI on `next`

### DIFF
--- a/command_attr/Cargo.toml
+++ b/command_attr/Cargo.toml
@@ -12,4 +12,4 @@ proc-macro = true
 [dependencies]
 quote = "^1.0"
 syn = { version = "^1.0", features = ["full", "derive", "extra-traits"] }
-proc-macro2 = "1.0"
+proc-macro2 = "^1.0.60"

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -559,7 +559,7 @@ mod test {
     #[test]
     fn test_webhook_parser() {
         for domain in DOMAINS {
-            let url = format!("https://{}/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV", domain).parse().unwrap();
+            let url = format!("https://{domain}/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV").parse().unwrap();
             let (id, token) = parse_webhook(&url).unwrap();
             assert_eq!(id, 245037420704169985);
             assert_eq!(


### PR DESCRIPTION
Fix clippy failure introduced after #2544. Also, fixes the `minimal-versions` check by setting the lower bound on proc-macro2 to be v1.0.60.