### PR TITLE
Add support for `default_values` on select menus

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -328,11 +328,22 @@ async fn interaction(
                                 CreateSelectMenuOption::new("bar", "bar"),
                             ],
                         }))
-                        .select_menu(CreateSelectMenu::new("1", CreateSelectMenuKind::Mentionable))
-                        .select_menu(CreateSelectMenu::new("2", CreateSelectMenuKind::Role))
-                        .select_menu(CreateSelectMenu::new("3", CreateSelectMenuKind::User))
+                        .select_menu(CreateSelectMenu::new(
+                            "1",
+                            CreateSelectMenuKind::Mentionable {
+                                default_users: None,
+                                default_roles: None,
+                            },
+                        ))
+                        .select_menu(CreateSelectMenu::new("2", CreateSelectMenuKind::Role {
+                            default_roles: None,
+                        }))
+                        .select_menu(CreateSelectMenu::new("3", CreateSelectMenuKind::User {
+                            default_users: None,
+                        }))
                         .select_menu(CreateSelectMenu::new("4", CreateSelectMenuKind::Channel {
                             channel_types: None,
+                            default_channels: None,
                         })),
                 ),
             )


### PR DESCRIPTION
For select menus not of type `String`, the `default_values` json field allows for autofilled values to be populated. Therefore, fields have been added to the corresponding `CreateSelectMenuKind` enum variants to support this.

I'd like feedback, specifically for `Mentionable`. Should there be separate arrays for default UserIds and RoleIds, or should there just be a single array of GenericIds? This would allow for more controlled ordering e.g. interleaving users and roles in the list.

I've tested that this works, but for some reason if `default_values` is populated, the client has a 5 second delay to render the select menu. Can anyone else confirm this? Unsure what could be causing it, as the time to response from the API remains normal with the field populated.