### PR TITLE
Return the full data about a thread when it was deleted

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -476,11 +476,12 @@ fn update_cache_with_event(ctx: Context, event: Event) -> Option<(FullEvent, Opt
             }
         },
         Event::ThreadDelete(mut event) => {
-            update_cache(&ctx, &mut event);
+            let full_thread_data = update_cache(&ctx, &mut event);
 
             FullEvent::ThreadDelete {
                 ctx,
                 thread: event.thread,
+                full_thread_data,
             }
         },
         Event::ThreadListSync(event) => FullEvent::ThreadListSync {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -476,7 +476,7 @@ fn update_cache_with_event(ctx: Context, event: Event) -> Option<(FullEvent, Opt
             }
         },
         Event::ThreadDelete(mut event) => {
-            let full_thread_data = update_cache(&ctx, &mut event);
+            let full_thread_data = if_cache!(update_cache(&ctx, &mut event));
 
             FullEvent::ThreadDelete {
                 ctx,

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -389,7 +389,7 @@ event_handler! {
 
     /// Dispatched when a thread is deleted.
     ///
-    /// Provides the partial data about the deleted thread, and if it was present in the cache 
+    /// Provides the partial data about the deleted thread, and if it was present in the cache
     /// before its deletion, its full data.
     async fn thread_delete(&self, ThreadDelete { ctx: Context, thread: PartialGuildChannel, full_thread_data: Option<GuildChannel> });
 

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -389,8 +389,9 @@ event_handler! {
 
     /// Dispatched when a thread is deleted.
     ///
-    /// Provides the partial deleted thread.
-    async fn thread_delete(&self, ThreadDelete { ctx: Context, thread: PartialGuildChannel });
+    /// Provides the partial data about the deleted thread, and if it was present in the cache 
+    /// before its deletion, its full data.
+    async fn thread_delete(&self, ThreadDelete { ctx: Context, thread: PartialGuildChannel, full_thread_data: Option<GuildChannel> });
 
     /// Dispatched when the current user gains access to a channel.
     ///

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -389,7 +389,7 @@ event_handler! {
 
     /// Dispatched when a thread is deleted.
     ///
-    /// Provides the partial data about the deleted thread, and if it was present in the cache
+    /// Provides the partial data about the deleted thread and, if it was present in the cache
     /// before its deletion, its full data.
     async fn thread_delete(&self, ThreadDelete { ctx: Context, thread: PartialGuildChannel, full_thread_data: Option<GuildChannel> });
 


### PR DESCRIPTION
This adds a new field/parameter to the `ThreadDelete`/`thread_delete` event.

The partial thread data from Discord is lacking a lot of details about the thread, like its name. This simply passes on the `GuildChannel` instance for the deleted thread from the cache to the user.