### PR TITLE
Add `WebhookGuild` struct

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1095,6 +1095,20 @@ impl<'a> From<&'a GuildChannel> for ChannelId {
     }
 }
 
+impl From<WebhookChannel> for ChannelId {
+    /// Gets the Id of a webhook channel.
+    fn from(webhook_channel: WebhookChannel) -> ChannelId {
+        webhook_channel.id
+    }
+}
+
+impl<'a> From<&'a WebhookChannel> for ChannelId {
+    /// Gets the Id of a webhook channel.
+    fn from(webhook_channel: &WebhookChannel) -> ChannelId {
+        webhook_channel.id
+    }
+}
+
 /// A helper class returned by [`ChannelId::messages_iter`]
 #[derive(Clone, Debug)]
 #[cfg(feature = "model")]

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1690,6 +1690,20 @@ impl<'a> From<&'a Guild> for GuildId {
     }
 }
 
+impl From<WebhookGuild> for GuildId {
+    /// Gets the Id of Webhook Guild struct.
+    fn from(webhook_guild: WebhookGuild) -> GuildId {
+        webhook_guild.id
+    }
+}
+
+impl<'a> From<&'a WebhookGuild> for GuildId {
+    /// Gets the Id of Webhook Guild struct.
+    fn from(webhook_guild: &WebhookGuild) -> GuildId {
+        webhook_guild.id
+    }
+}
+
 /// A helper class returned by [`GuildId::members_iter`]
 #[derive(Clone, Debug)]
 #[cfg(feature = "model")]

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -11,6 +11,7 @@ use super::user::User;
 use super::utils::secret;
 #[cfg(feature = "model")]
 use crate::builder::{Builder, EditWebhook, EditWebhookMessage, ExecuteWebhook};
+#[cfg(feature = "cache")]
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
@@ -112,6 +113,7 @@ pub struct WebhookGuild {
     pub icon: Option<ImageHash>,
 }
 
+#[cfg(feature = "model")]
 impl WebhookGuild {
     /// Tries to find the [`Guild`] by its Id in the cache.
     #[cfg(feature = "cache")]
@@ -168,6 +170,7 @@ pub struct WebhookChannel {
     pub name: String,
 }
 
+#[cfg(feature = "model")]
 impl WebhookChannel {
     /// Attempts to find a [`Channel`] by its Id in the cache.
     #[cfg(feature = "cache")]


### PR DESCRIPTION
The returned object from an API response for a webhook from a subscribed server is extremely limited, causing deserialization errors before due to missing fields. This commit fixes the errors by adding a brand-new struct for those fields.

Currently testing this on my bot, made PR to allow review.