### PR TITLE
Remove `EventType` enum

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1197,71 +1197,12 @@ impl Event {
     /// Return the event name of this event. Returns [`None`] if the event is
     /// [`Unknown`](Event::Unknown).
     #[must_use]
-    pub const fn name(&self) -> Option<&str> {
-        match self {
-            Self::CommandPermissionsUpdate(_) => Some("APPLICATION_COMMAND_PERMISSIONS_UPDATE"),
-            Self::AutoModRuleCreate(_) => Some("AUTO_MODERATION_RULE_CREATE"),
-            Self::AutoModRuleUpdate(_) => Some("AUTO_MODERATION_RULE_UPDATE"),
-            Self::AutoModRuleDelete(_) => Some("AUTO_MODERATION_RULE_DELETE"),
-            Self::AutoModActionExecution(_) => Some("AUTO_MODERATION_ACTION_EXECUTION"),
-            Self::ChannelCreate(_) => Some("CHANNEL_CREATE"),
-            Self::ChannelDelete(_) => Some("CHANNEL_DELETE"),
-            Self::ChannelPinsUpdate(_) => Some("CHANNEL_PINS_UPDATE"),
-            Self::ChannelUpdate(_) => Some("CHANNEL_UPDATE"),
-            Self::GuildAuditLogEntryCreate(_) => Some("GUILD_AUDIT_LOG_ENTRY_CREATE"),
-            Self::GuildBanAdd(_) => Some("GUILD_BAN_ADD"),
-            Self::GuildBanRemove(_) => Some("GUILD_BAN_REMOVE"),
-            Self::GuildCreate(_) => Some("GUILD_CREATE"),
-            Self::GuildDelete(_) => Some("GUILD_DELETE"),
-            Self::GuildEmojisUpdate(_) => Some("GUILD_EMOJIS_UPDATE"),
-            Self::GuildIntegrationsUpdate(_) => Some("GUILD_INTEGRATIONS_UPDATE"),
-            Self::GuildMemberAdd(_) => Some("GUILD_MEMBER_ADD"),
-            Self::GuildMemberRemove(_) => Some("GUILD_MEMBER_REMOVE"),
-            Self::GuildMemberUpdate(_) => Some("GUILD_MEMBER_UPDATE"),
-            Self::GuildMembersChunk(_) => Some("GUILD_MEMBERS_CHUNK"),
-            Self::GuildRoleCreate(_) => Some("GUILD_ROLE_CREATE"),
-            Self::GuildRoleDelete(_) => Some("GUILD_ROLE_DELETE"),
-            Self::GuildRoleUpdate(_) => Some("GUILD_ROLE_UPDATE"),
-            Self::GuildStickersUpdate(_) => Some("GUILD_STICKERS_UPDATE"),
-            Self::GuildUpdate(_) => Some("GUILD_UPDATE"),
-            Self::InviteCreate(_) => Some("INVITE_CREATE"),
-            Self::InviteDelete(_) => Some("INVITE_DELETE"),
-            Self::MessageCreate(_) => Some("MESSAGE_CREATE"),
-            Self::MessageDelete(_) => Some("MESSAGE_DELETE"),
-            Self::MessageDeleteBulk(_) => Some("MESSAGE_DELETE_BULK"),
-            Self::MessageUpdate(_) => Some("MESSAGE_UPDATE"),
-            Self::PresenceUpdate(_) => Some("PRESENCE_UPDATE"),
-            Self::PresencesReplace(_) => Some("PRESENCES_REPLACE"),
-            Self::ReactionAdd(_) => Some("MESSAGE_REACTION_ADD"),
-            Self::ReactionRemove(_) => Some("MESSAGE_REACTION_REMOVE"),
-            Self::ReactionRemoveAll(_) => Some("MESSAGE_REACTION_REMOVE_ALL"),
-            Self::ReactionRemoveEmoji(_) => Some("MESSAGE_REACTION_REMOVE_EMOJI"),
-            Self::Ready(_) => Some("READY"),
-            Self::Resumed(_) => Some("RESUMED"),
-            Self::TypingStart(_) => Some("TYPING_START"),
-            Self::UserUpdate(_) => Some("USER_UPDATE"),
-            Self::VoiceServerUpdate(_) => Some("VOICE_SERVER_UPDATE"),
-            Self::VoiceStateUpdate(_) => Some("VOICE_STATE_UPDATE"),
-            Self::WebhookUpdate(_) => Some("WEBHOOKS_UPDATE"),
-            Self::InteractionCreate(_) => Some("INTERACTION_CREATE"),
-            Self::IntegrationCreate(_) => Some("INTEGRATION_CREATE"),
-            Self::IntegrationUpdate(_) => Some("INTEGRATION_UPDATE"),
-            Self::IntegrationDelete(_) => Some("INTEGRATION_DELETE"),
-            Self::StageInstanceCreate(_) => Some("STAGE_INSTANCE_CREATE"),
-            Self::StageInstanceUpdate(_) => Some("STAGE_INSTANCE_UPDATE"),
-            Self::StageInstanceDelete(_) => Some("STAGE_INSTANCE_DELETE"),
-            Self::ThreadCreate(_) => Some("THREAD_CREATE"),
-            Self::ThreadUpdate(_) => Some("THREAD_UPDATE"),
-            Self::ThreadDelete(_) => Some("THREAD_DELETE"),
-            Self::ThreadListSync(_) => Some("THREAD_LIST_SYNC"),
-            Self::ThreadMemberUpdate(_) => Some("THREAD_MEMBER_UPDATE"),
-            Self::ThreadMembersUpdate(_) => Some("THREAD_MEMBERS_UPDATE"),
-            Self::GuildScheduledEventCreate(_) => Some("GUILD_SCHEDULED_EVENT_CREATE"),
-            Self::GuildScheduledEventUpdate(_) => Some("GUILD_SCHEDULED_EVENT_UPDATE"),
-            Self::GuildScheduledEventDelete(_) => Some("GUILD_SCHEDULED_EVENT_DELETE"),
-            Self::GuildScheduledEventUserAdd(_) => Some("GUILD_SCHEDULED_EVENT_USER_ADD"),
-            Self::GuildScheduledEventUserRemove(_) => Some("GUILD_SCHEDULED_EVENT_USER_REMOVE"),
-            Self::Unknown => None,
+    pub fn name(&self) -> Option<String> {
+        if let Self::Unknown = self {
+            None
+        } else {
+            let map = serde_json::to_value(self).ok()?;
+            Some(map.get("t")?.as_str()?.to_string())
         }
     }
 }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1194,417 +1194,74 @@ pub enum Event {
 }
 
 impl Event {
-    /// Return the type of this event.
-    #[must_use]
-    pub const fn event_type(&self) -> EventType {
-        match self {
-            Self::CommandPermissionsUpdate(_) => EventType::CommandPermissionsUpdate,
-            Self::AutoModRuleCreate(_) => EventType::AutoModRuleCreate,
-            Self::AutoModRuleUpdate(_) => EventType::AutoModRuleUpdate,
-            Self::AutoModRuleDelete(_) => EventType::AutoModRuleDelete,
-            Self::AutoModActionExecution(_) => EventType::AutoModActionExecution,
-            Self::ChannelCreate(_) => EventType::ChannelCreate,
-            Self::ChannelDelete(_) => EventType::ChannelDelete,
-            Self::ChannelPinsUpdate(_) => EventType::ChannelPinsUpdate,
-            Self::ChannelUpdate(_) => EventType::ChannelUpdate,
-            Self::GuildAuditLogEntryCreate(_) => EventType::GuildAuditLogEntryCreate,
-            Self::GuildBanAdd(_) => EventType::GuildBanAdd,
-            Self::GuildBanRemove(_) => EventType::GuildBanRemove,
-            Self::GuildCreate(_) => EventType::GuildCreate,
-            Self::GuildDelete(_) => EventType::GuildDelete,
-            Self::GuildEmojisUpdate(_) => EventType::GuildEmojisUpdate,
-            Self::GuildIntegrationsUpdate(_) => EventType::GuildIntegrationsUpdate,
-            Self::GuildMemberAdd(_) => EventType::GuildMemberAdd,
-            Self::GuildMemberRemove(_) => EventType::GuildMemberRemove,
-            Self::GuildMemberUpdate(_) => EventType::GuildMemberUpdate,
-            Self::GuildMembersChunk(_) => EventType::GuildMembersChunk,
-            Self::GuildRoleCreate(_) => EventType::GuildRoleCreate,
-            Self::GuildRoleDelete(_) => EventType::GuildRoleDelete,
-            Self::GuildRoleUpdate(_) => EventType::GuildRoleUpdate,
-            Self::GuildStickersUpdate(_) => EventType::GuildStickersUpdate,
-            Self::GuildUpdate(_) => EventType::GuildUpdate,
-            Self::InviteCreate(_) => EventType::InviteCreate,
-            Self::InviteDelete(_) => EventType::InviteDelete,
-            Self::MessageCreate(_) => EventType::MessageCreate,
-            Self::MessageDelete(_) => EventType::MessageDelete,
-            Self::MessageDeleteBulk(_) => EventType::MessageDeleteBulk,
-            Self::MessageUpdate(_) => EventType::MessageUpdate,
-            Self::PresenceUpdate(_) => EventType::PresenceUpdate,
-            Self::PresencesReplace(_) => EventType::PresencesReplace,
-            Self::ReactionAdd(_) => EventType::ReactionAdd,
-            Self::ReactionRemove(_) => EventType::ReactionRemove,
-            Self::ReactionRemoveAll(_) => EventType::ReactionRemoveAll,
-            Self::ReactionRemoveEmoji(_) => EventType::ReactionRemoveEmoji,
-            Self::Ready(_) => EventType::Ready,
-            Self::Resumed(_) => EventType::Resumed,
-            Self::TypingStart(_) => EventType::TypingStart,
-            Self::UserUpdate(_) => EventType::UserUpdate,
-            Self::VoiceStateUpdate(_) => EventType::VoiceStateUpdate,
-            Self::VoiceServerUpdate(_) => EventType::VoiceServerUpdate,
-            Self::WebhookUpdate(_) => EventType::WebhookUpdate,
-            Self::InteractionCreate(_) => EventType::InteractionCreate,
-            Self::IntegrationCreate(_) => EventType::IntegrationCreate,
-            Self::IntegrationUpdate(_) => EventType::IntegrationUpdate,
-            Self::IntegrationDelete(_) => EventType::IntegrationDelete,
-            Self::StageInstanceCreate(_) => EventType::StageInstanceCreate,
-            Self::StageInstanceUpdate(_) => EventType::StageInstanceUpdate,
-            Self::StageInstanceDelete(_) => EventType::StageInstanceDelete,
-            Self::ThreadCreate(_) => EventType::ThreadCreate,
-            Self::ThreadUpdate(_) => EventType::ThreadUpdate,
-            Self::ThreadDelete(_) => EventType::ThreadDelete,
-            Self::ThreadListSync(_) => EventType::ThreadListSync,
-            Self::ThreadMemberUpdate(_) => EventType::ThreadMemberUpdate,
-            Self::ThreadMembersUpdate(_) => EventType::ThreadMembersUpdate,
-            Self::GuildScheduledEventCreate(_) => EventType::GuildScheduledEventCreate,
-            Self::GuildScheduledEventUpdate(_) => EventType::GuildScheduledEventUpdate,
-            Self::GuildScheduledEventDelete(_) => EventType::GuildScheduledEventDelete,
-            Self::GuildScheduledEventUserAdd(_) => EventType::GuildScheduledEventUserAdd,
-            Self::GuildScheduledEventUserRemove(_) => EventType::GuildScheduledEventUserRemove,
-            Self::Unknown => EventType::Other,
-        }
-    }
-}
-
-/// The type of event dispatch received from the gateway.
-///
-/// This is useful for deciding how to deserialize a received payload.
-///
-/// A Deserialization implementation is provided for deserializing raw event dispatch type strings
-/// to this enum, e.g. deserializing `"CHANNEL_CREATE"` to [`EventType::ChannelCreate`].
-///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#commands-and-events-gateway-events).
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
-pub enum EventType {
-    /// Indicator that an application command permission update payload was received.
-    ///
-    /// This maps to [`CommandPermissionsUpdateEvent`].
-    CommandPermissionsUpdate,
-    /// Indicator that an auto moderation rule create payload was received.
-    ///
-    /// This maps to [`AutoModRuleCreateEvent`].
-    AutoModRuleCreate,
-    /// Indicator that an auto moderation rule update payload was received.
-    ///
-    /// This maps to [`AutoModRuleCreateEvent`].
-    AutoModRuleUpdate,
-    /// Indicator that an auto moderation rule delete payload was received.
-    ///
-    /// This maps to [`AutoModRuleDeleteEvent`].
-    AutoModRuleDelete,
-    /// Indicator that an auto moderation action execution payload was received.
-    ///
-    /// This maps to [`AutoModActionExecutionEvent`].
-    AutoModActionExecution,
-    /// Indicator that a channel create payload was received.
-    ///
-    /// This maps to [`ChannelCreateEvent`].
-    ChannelCreate,
-    /// Indicator that a channel delete payload was received.
-    ///
-    /// This maps to [`ChannelDeleteEvent`].
-    ChannelDelete,
-    /// Indicator that a channel pins update payload was received.
-    ///
-    /// This maps to [`ChannelPinsUpdateEvent`].
-    ChannelPinsUpdate,
-    /// Indicator that a channel update payload was received.
-    ///
-    /// This maps to [`ChannelUpdateEvent`].
-    ChannelUpdate,
-    /// Indicator that a new audit log entry was created.
-    ///
-    /// This maps to [`GuildAuditLogEntryCreateEvent`].
-    GuildAuditLogEntryCreate,
-    /// Indicator that a guild ban addition payload was received.
-    ///
-    /// This maps to [`GuildBanAddEvent`].
-    GuildBanAdd,
-    /// Indicator that a guild ban removal payload was received.
-    ///
-    /// This maps to [`GuildBanRemoveEvent`].
-    GuildBanRemove,
-    /// Indicator that a guild create payload was received.
-    ///
-    /// This maps to [`GuildCreateEvent`].
-    GuildCreate,
-    /// Indicator that a guild delete payload was received.
-    ///
-    /// This maps to [`GuildDeleteEvent`].
-    GuildDelete,
-    /// Indicator that a guild emojis update payload was received.
-    ///
-    /// This maps to [`GuildEmojisUpdateEvent`].
-    GuildEmojisUpdate,
-    /// Indicator that a guild integrations update payload was received.
-    ///
-    /// This maps to [`GuildIntegrationsUpdateEvent`].
-    GuildIntegrationsUpdate,
-    /// Indicator that a guild member add payload was received.
-    ///
-    /// This maps to [`GuildMemberAddEvent`].
-    GuildMemberAdd,
-    /// Indicator that a guild member remove payload was received.
-    ///
-    /// This maps to [`GuildMemberRemoveEvent`].
-    GuildMemberRemove,
-    /// Indicator that a guild member update payload was received.
-    ///
-    /// This maps to [`GuildMemberUpdateEvent`].
-    GuildMemberUpdate,
-    /// Indicator that a guild members chunk payload was received.
-    ///
-    /// This maps to [`GuildMembersChunkEvent`].
-    GuildMembersChunk,
-    /// Indicator that a guild role create payload was received.
-    ///
-    /// This maps to [`GuildRoleCreateEvent`].
-    GuildRoleCreate,
-    /// Indicator that a guild role delete payload was received.
-    ///
-    /// This maps to [`GuildRoleDeleteEvent`].
-    GuildRoleDelete,
-    /// Indicator that a guild role update payload was received.
-    ///
-    /// This maps to [`GuildRoleUpdateEvent`].
-    GuildRoleUpdate,
-    /// Indicator that a guild sticker update payload was received.
-    ///
-    /// This maps to [`GuildStickersUpdateEvent`].
-    GuildStickersUpdate,
-    /// Indicator that a guild update payload was received.
-    ///
-    /// This maps to [`GuildUpdateEvent`].
-    GuildUpdate,
-    /// Indicator that an invite was created.
-    ///
-    /// This maps to [`InviteCreateEvent`].
-    InviteCreate,
-    /// Indicator that an invite was deleted.
-    ///
-    /// This maps to [`InviteDeleteEvent`].
-    InviteDelete,
-    /// Indicator that a message create payload was received.
-    ///
-    /// This maps to [`MessageCreateEvent`].
-    MessageCreate,
-    /// Indicator that a message delete payload was received.
-    ///
-    /// This maps to [`MessageDeleteEvent`].
-    MessageDelete,
-    /// Indicator that a message delete bulk payload was received.
-    ///
-    /// This maps to [`MessageDeleteBulkEvent`].
-    MessageDeleteBulk,
-    /// Indicator that a message update payload was received.
-    ///
-    /// This maps to [`MessageUpdateEvent`].
-    MessageUpdate,
-    /// Indicator that a presence update payload was received.
-    ///
-    /// This maps to [`PresenceUpdateEvent`].
-    PresenceUpdate,
-    /// Indicator that a presences replace payload was received.
-    ///
-    /// This maps to [`PresencesReplaceEvent`].
-    PresencesReplace,
-    /// Indicator that a reaction add payload was received.
-    ///
-    /// This maps to [`ReactionAddEvent`].
-    ReactionAdd,
-    /// Indicator that a reaction remove payload was received.
-    ///
-    /// This maps to [`ReactionRemoveEvent`].
-    ReactionRemove,
-    /// Indicator that a reaction remove all payload was received.
-    ///
-    /// This maps to [`ReactionRemoveAllEvent`].
-    ReactionRemoveAll,
-    /// Indicator that a reaction remove emoji payload was received.
-    ///
-    /// This maps to [`ReactionRemoveEmojiEvent`].
-    ReactionRemoveEmoji,
-    /// Indicator that a ready payload was received.
-    ///
-    /// This maps to [`ReadyEvent`].
-    Ready,
-    /// Indicator that a resumed payload was received.
-    ///
-    /// This maps to [`ResumedEvent`].
-    Resumed,
-    /// Indicator that a typing start payload was received.
-    ///
-    /// This maps to [`TypingStartEvent`].
-    TypingStart,
-    /// Indicator that a user update payload was received.
-    ///
-    /// This maps to [`UserUpdateEvent`].
-    UserUpdate,
-    /// Indicator that a voice state payload was received.
-    ///
-    /// This maps to [`VoiceStateUpdateEvent`].
-    VoiceStateUpdate,
-    /// Indicator that a voice server update payload was received.
-    ///
-    /// This maps to [`VoiceServerUpdateEvent`].
-    VoiceServerUpdate,
-    /// Indicator that a webhook update payload was received.
-    ///
-    /// This maps to [`WebhookUpdateEvent`].
-    WebhookUpdate,
-    /// Indicator that an interaction was created.
-    ///
-    /// This maps to [`InteractionCreateEvent`].
-    InteractionCreate,
-    /// Indicator that an integration was created.
-    ///
-    /// This maps to [`IntegrationCreateEvent`].
-    IntegrationCreate,
-    /// Indicator that an integration was created.
-    ///
-    /// This maps to [`IntegrationUpdateEvent`].
-    IntegrationUpdate,
-    /// Indicator that an integration was created.
-    ///
-    /// This maps to [`IntegrationDeleteEvent`].
-    IntegrationDelete,
-    /// Indicator that a stage instance was created.
-    ///
-    /// This maps to [`StageInstanceCreateEvent`].
-    StageInstanceCreate,
-    /// Indicator that a stage instance was updated.
-    ///
-    /// This maps to [`StageInstanceUpdateEvent`].
-    StageInstanceUpdate,
-    /// Indicator that a stage instance was deleted.
-    ///
-    /// This maps to [`StageInstanceDeleteEvent`].
-    StageInstanceDelete,
-    /// Indicator that a thread was created or the current user
-    /// was added to a private thread.
-    ///
-    /// This maps to [`ThreadCreateEvent`].
-    ThreadCreate,
-    /// Indicator that a thread was updated.
-    ///
-    /// This maps to [`ThreadUpdateEvent`].
-    ThreadUpdate,
-    /// Indicator that a thread was deleted.
-    ///
-    /// This maps to [`ThreadDeleteEvent`].
-    ThreadDelete,
-    /// Indicator that the current user gains access to a channel.
-    ///
-    /// This maps to [`ThreadListSyncEvent`]
-    ThreadListSync,
-    /// Indicator that the [`ThreadMember`] object for the current user is updated.
-    ///
-    /// This maps to [`ThreadMemberUpdateEvent`]
-    ThreadMemberUpdate,
-    /// Indicator that anyone is added to or removed from a thread.
-    ///
-    /// This maps to [`ThreadMembersUpdateEvent`]
-    ThreadMembersUpdate,
-    /// Indicator that a scheduled event create payload was received.
-    ///
-    /// This maps to [`GuildScheduledEventCreateEvent`].
-    GuildScheduledEventCreate,
-    /// Indicator that a scheduled event update payload was received.
-    ///
-    /// This maps to [`GuildScheduledEventUpdateEvent`].
-    GuildScheduledEventUpdate,
-    /// Indicator that a scheduled event delete payload was received.
-    ///
-    /// This maps to [`GuildScheduledEventDeleteEvent`].
-    GuildScheduledEventDelete,
-    /// Indicator that a guild member has subscribed to a scheduled event.
-    ///
-    /// This maps to [`GuildScheduledEventUserAddEvent`].
-    GuildScheduledEventUserAdd,
-    /// Indicator that a guild member has unsubscribed from a scheduled event.
-    ///
-    /// This maps to [`GuildScheduledEventUserRemoveEvent`].
-    GuildScheduledEventUserRemove,
-    /// An unknown event was received over the gateway.
-    Other,
-}
-
-impl From<&Event> for EventType {
-    fn from(event: &Event) -> EventType {
-        event.event_type()
-    }
-}
-
-impl EventType {
-    /// Return the event name of this event. Some events are synthetic, and we lack the information
-    /// to recover the original event name for these events, in which case this method returns
-    /// [`None`].
+    /// Return the event name of this event. Returns [`None`] if the event is
+    /// [`Unknown`](Event::Unknown).
     #[must_use]
     pub const fn name(&self) -> Option<&str> {
         match self {
-            Self::CommandPermissionsUpdate => Some("APPLICATION_COMMAND_PERMISSIONS_UPDATE"),
-            Self::AutoModRuleCreate => Some("AUTO_MODERATION_RULE_CREATE"),
-            Self::AutoModRuleUpdate => Some("AUTO_MODERATION_RULE_UPDATE"),
-            Self::AutoModRuleDelete => Some("AUTO_MODERATION_RULE_DELETE"),
-            Self::AutoModActionExecution => Some("AUTO_MODERATION_ACTION_EXECUTION"),
-            Self::ChannelCreate => Some("CHANNEL_CREATE"),
-            Self::ChannelDelete => Some("CHANNEL_DELETE"),
-            Self::ChannelPinsUpdate => Some("CHANNEL_PINS_UPDATE"),
-            Self::ChannelUpdate => Some("CHANNEL_UPDATE"),
-            Self::GuildAuditLogEntryCreate => Some("GUILD_AUDIT_LOG_ENTRY_CREATE"),
-            Self::GuildBanAdd => Some("GUILD_BAN_ADD"),
-            Self::GuildBanRemove => Some("GUILD_BAN_REMOVE"),
-            Self::GuildCreate => Some("GUILD_CREATE"),
-            Self::GuildDelete => Some("GUILD_DELETE"),
-            Self::GuildEmojisUpdate => Some("GUILD_EMOJIS_UPDATE"),
-            Self::GuildIntegrationsUpdate => Some("GUILD_INTEGRATIONS_UPDATE"),
-            Self::GuildMemberAdd => Some("GUILD_MEMBER_ADD"),
-            Self::GuildMemberRemove => Some("GUILD_MEMBER_REMOVE"),
-            Self::GuildMemberUpdate => Some("GUILD_MEMBER_UPDATE"),
-            Self::GuildMembersChunk => Some("GUILD_MEMBERS_CHUNK"),
-            Self::GuildRoleCreate => Some("GUILD_ROLE_CREATE"),
-            Self::GuildRoleDelete => Some("GUILD_ROLE_DELETE"),
-            Self::GuildRoleUpdate => Some("GUILD_ROLE_UPDATE"),
-            Self::GuildStickersUpdate => Some("GUILD_STICKERS_UPDATE"),
-            Self::InviteCreate => Some("INVITE_CREATE"),
-            Self::InviteDelete => Some("INVITE_DELETE"),
-            Self::GuildUpdate => Some("GUILD_UPDATE"),
-            Self::MessageCreate => Some("MESSAGE_CREATE"),
-            Self::MessageDelete => Some("MESSAGE_DELETE"),
-            Self::MessageDeleteBulk => Some("MESSAGE_DELETE_BULK"),
-            Self::ReactionAdd => Some("MESSAGE_REACTION_ADD"),
-            Self::ReactionRemove => Some("MESSAGE_REACTION_REMOVE"),
-            Self::ReactionRemoveAll => Some("MESSAGE_REACTION_REMOVE_ALL"),
-            Self::ReactionRemoveEmoji => Some("MESSAGE_REACTION_REMOVE_ALL_EMOJI"),
-            Self::MessageUpdate => Some("MESSAGE_UPDATE"),
-            Self::PresenceUpdate => Some("PRESENCE_UPDATE"),
-            Self::PresencesReplace => Some("PRESENCES_REPLACE"),
-            Self::Ready => Some("READY"),
-            Self::Resumed => Some("RESUMED"),
-            Self::TypingStart => Some("TYPING_START"),
-            Self::UserUpdate => Some("USER_UPDATE"),
-            Self::VoiceServerUpdate => Some("VOICE_SERVER_UPDATE"),
-            Self::VoiceStateUpdate => Some("VOICE_STATE_UPDATE"),
-            Self::WebhookUpdate => Some("WEBHOOKS_UPDATE"),
-            Self::InteractionCreate => Some("INTERACTION_CREATE"),
-            Self::IntegrationCreate => Some("INTEGRATION_CREATE"),
-            Self::IntegrationUpdate => Some("INTEGRATION_UPDATE"),
-            Self::IntegrationDelete => Some("INTEGRATION_DELETE"),
-            Self::StageInstanceCreate => Some("STAGE_INSTANCE_CREATE"),
-            Self::StageInstanceUpdate => Some("STAGE_INSTANCE_UPDATE"),
-            Self::StageInstanceDelete => Some("STAGE_INSTANCE_DELETE"),
-            Self::ThreadCreate => Some("THREAD_CREATE"),
-            Self::ThreadUpdate => Some("THREAD_UPDATE"),
-            Self::ThreadDelete => Some("THREAD_DELETE"),
-            Self::ThreadListSync => Some("THREAD_LIST_SYNC"),
-            Self::ThreadMemberUpdate => Some("THREAD_MEMBER_UPDATE"),
-            Self::ThreadMembersUpdate => Some("THREAD_MEMBERS_UPDATE"),
-            Self::GuildScheduledEventCreate => Some("GUILD_SCHEDULED_EVENT_CREATE"),
-            Self::GuildScheduledEventUpdate => Some("GUILD_SCHEDULED_EVENT_UPDATE"),
-            Self::GuildScheduledEventDelete => Some("GUILD_SCHEDULED_EVENT_DELETE"),
-            Self::GuildScheduledEventUserAdd => Some("GUILD_SCHEDULED_EVENT_USER_ADD"),
-            Self::GuildScheduledEventUserRemove => Some("GUILD_SCHEDULED_EVENT_USER_REMOVE"),
-            Self::Other => None,
+            Self::CommandPermissionsUpdate(_) => Some("APPLICATION_COMMAND_PERMISSIONS_UPDATE"),
+            Self::AutoModRuleCreate(_) => Some("AUTO_MODERATION_RULE_CREATE"),
+            Self::AutoModRuleUpdate(_) => Some("AUTO_MODERATION_RULE_UPDATE"),
+            Self::AutoModRuleDelete(_) => Some("AUTO_MODERATION_RULE_DELETE"),
+            Self::AutoModActionExecution(_) => Some("AUTO_MODERATION_ACTION_EXECUTION"),
+            Self::ChannelCreate(_) => Some("CHANNEL_CREATE"),
+            Self::ChannelDelete(_) => Some("CHANNEL_DELETE"),
+            Self::ChannelPinsUpdate(_) => Some("CHANNEL_PINS_UPDATE"),
+            Self::ChannelUpdate(_) => Some("CHANNEL_UPDATE"),
+            Self::GuildAuditLogEntryCreate(_) => Some("GUILD_AUDIT_LOG_ENTRY_CREATE"),
+            Self::GuildBanAdd(_) => Some("GUILD_BAN_ADD"),
+            Self::GuildBanRemove(_) => Some("GUILD_BAN_REMOVE"),
+            Self::GuildCreate(_) => Some("GUILD_CREATE"),
+            Self::GuildDelete(_) => Some("GUILD_DELETE"),
+            Self::GuildEmojisUpdate(_) => Some("GUILD_EMOJIS_UPDATE"),
+            Self::GuildIntegrationsUpdate(_) => Some("GUILD_INTEGRATIONS_UPDATE"),
+            Self::GuildMemberAdd(_) => Some("GUILD_MEMBER_ADD"),
+            Self::GuildMemberRemove(_) => Some("GUILD_MEMBER_REMOVE"),
+            Self::GuildMemberUpdate(_) => Some("GUILD_MEMBER_UPDATE"),
+            Self::GuildMembersChunk(_) => Some("GUILD_MEMBERS_CHUNK"),
+            Self::GuildRoleCreate(_) => Some("GUILD_ROLE_CREATE"),
+            Self::GuildRoleDelete(_) => Some("GUILD_ROLE_DELETE"),
+            Self::GuildRoleUpdate(_) => Some("GUILD_ROLE_UPDATE"),
+            Self::GuildStickersUpdate(_) => Some("GUILD_STICKERS_UPDATE"),
+            Self::GuildUpdate(_) => Some("GUILD_UPDATE"),
+            Self::InviteCreate(_) => Some("INVITE_CREATE"),
+            Self::InviteDelete(_) => Some("INVITE_DELETE"),
+            Self::MessageCreate(_) => Some("MESSAGE_CREATE"),
+            Self::MessageDelete(_) => Some("MESSAGE_DELETE"),
+            Self::MessageDeleteBulk(_) => Some("MESSAGE_DELETE_BULK"),
+            Self::MessageUpdate(_) => Some("MESSAGE_UPDATE"),
+            Self::PresenceUpdate(_) => Some("PRESENCE_UPDATE"),
+            Self::PresencesReplace(_) => Some("PRESENCES_REPLACE"),
+            Self::ReactionAdd(_) => Some("MESSAGE_REACTION_ADD"),
+            Self::ReactionRemove(_) => Some("MESSAGE_REACTION_REMOVE"),
+            Self::ReactionRemoveAll(_) => Some("MESSAGE_REACTION_REMOVE_ALL"),
+            Self::ReactionRemoveEmoji(_) => Some("MESSAGE_REACTION_REMOVE_EMOJI"),
+            Self::Ready(_) => Some("READY"),
+            Self::Resumed(_) => Some("RESUMED"),
+            Self::TypingStart(_) => Some("TYPING_START"),
+            Self::UserUpdate(_) => Some("USER_UPDATE"),
+            Self::VoiceServerUpdate(_) => Some("VOICE_SERVER_UPDATE"),
+            Self::VoiceStateUpdate(_) => Some("VOICE_STATE_UPDATE"),
+            Self::WebhookUpdate(_) => Some("WEBHOOKS_UPDATE"),
+            Self::InteractionCreate(_) => Some("INTERACTION_CREATE"),
+            Self::IntegrationCreate(_) => Some("INTEGRATION_CREATE"),
+            Self::IntegrationUpdate(_) => Some("INTEGRATION_UPDATE"),
+            Self::IntegrationDelete(_) => Some("INTEGRATION_DELETE"),
+            Self::StageInstanceCreate(_) => Some("STAGE_INSTANCE_CREATE"),
+            Self::StageInstanceUpdate(_) => Some("STAGE_INSTANCE_UPDATE"),
+            Self::StageInstanceDelete(_) => Some("STAGE_INSTANCE_DELETE"),
+            Self::ThreadCreate(_) => Some("THREAD_CREATE"),
+            Self::ThreadUpdate(_) => Some("THREAD_UPDATE"),
+            Self::ThreadDelete(_) => Some("THREAD_DELETE"),
+            Self::ThreadListSync(_) => Some("THREAD_LIST_SYNC"),
+            Self::ThreadMemberUpdate(_) => Some("THREAD_MEMBER_UPDATE"),
+            Self::ThreadMembersUpdate(_) => Some("THREAD_MEMBERS_UPDATE"),
+            Self::GuildScheduledEventCreate(_) => Some("GUILD_SCHEDULED_EVENT_CREATE"),
+            Self::GuildScheduledEventUpdate(_) => Some("GUILD_SCHEDULED_EVENT_UPDATE"),
+            Self::GuildScheduledEventDelete(_) => Some("GUILD_SCHEDULED_EVENT_DELETE"),
+            Self::GuildScheduledEventUserAdd(_) => Some("GUILD_SCHEDULED_EVENT_USER_ADD"),
+            Self::GuildScheduledEventUserRemove(_) => Some("GUILD_SCHEDULED_EVENT_USER_REMOVE"),
+            Self::Unknown => None,
         }
     }
 }


### PR DESCRIPTION
The `EventType` enum is redundant and not used anywhere. This PR removes it and moves the `EventType::name` method directly onto `Event`. This method now returns `Option<String>` instead of `Option<&'static str>`, and therefore is no longer `const`.