### PR TITLE
Add support for new monetization APIs

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -57,6 +57,13 @@ pub enum CreateInteractionResponse {
     ///
     /// Corresponds to Discord's `MODAL`.
     Modal(CreateModal),
+    /// Not valid for autocomplete and Ping interactions. Only available for applications with
+    /// monetization enabled.
+    ///
+    /// Responds to the interaction with an upgrade button.
+    ///
+    /// Corresponds to Discord's `PREMIUM_REQUIRED'.
+    PremiumRequired,
 }
 
 impl serde::Serialize for CreateInteractionResponse {
@@ -66,13 +73,14 @@ impl serde::Serialize for CreateInteractionResponse {
         #[allow(clippy::match_same_arms)] // hurts readability
         json!({
             "type": match self {
-                Self::Pong { .. } => 1,
-                Self::Message { .. } => 4,
-                Self::Defer { .. } => 5,
-                Self::Acknowledge { .. } => 6,
-                Self::UpdateMessage { .. } => 7,
-                Self::Autocomplete { .. } => 8,
-                Self::Modal { .. } => 9,
+                Self::Pong => 1,
+                Self::Message(_) => 4,
+                Self::Defer(_) => 5,
+                Self::Acknowledge => 6,
+                Self::UpdateMessage(_) => 7,
+                Self::Autocomplete(_) => 8,
+                Self::Modal(_) => 9,
+                Self::PremiumRequired => 10,
             },
             "data": match self {
                 Self::Pong => json::NULL,
@@ -82,6 +90,7 @@ impl serde::Serialize for CreateInteractionResponse {
                 Self::UpdateMessage(x) => json::to_value(x).map_err(S::Error::custom)?,
                 Self::Autocomplete(x) => json::to_value(x).map_err(S::Error::custom)?,
                 Self::Modal(x) => json::to_value(x).map_err(S::Error::custom)?,
+                Self::PremiumRequired => json::NULL,
             }
         })
         .serialize(serializer)

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -478,15 +478,12 @@ fn update_cache_with_event(
             unsubscribed: event,
         },
         Event::EntitlementCreate(event) => FullEvent::EntitlementCreate {
-            ctx,
             entitlement: event.entitlement,
         },
         Event::EntitlementUpdate(event) => FullEvent::EntitlementUpdate {
-            ctx,
             entitlement: event.entitlement,
         },
         Event::EntitlementDelete(event) => FullEvent::EntitlementDelete {
-            ctx,
             entitlement: event.entitlement,
         },
     };

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -477,6 +477,18 @@ fn update_cache_with_event(
         Event::GuildScheduledEventUserRemove(event) => FullEvent::GuildScheduledEventUserRemove {
             unsubscribed: event,
         },
+        Event::EntitlementCreate(event) => FullEvent::EntitlementCreate {
+            ctx,
+            entitlement: event.entitlement,
+        },
+        Event::EntitlementUpdate(event) => FullEvent::EntitlementUpdate {
+            ctx,
+            entitlement: event.entitlement,
+        },
+        Event::EntitlementDelete(event) => FullEvent::EntitlementDelete {
+            ctx,
+            entitlement: event.entitlement,
+        },
     };
 
     Some((event, extra_event))

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -450,20 +450,19 @@ event_handler! {
     /// Provides data about the subscription.
     async fn entitlement_create(&self, EntitlementCreate { ctx: Context, entitlement: Entitlement });
 
-    /// Dispatched when a user's subscription to a SKU renews for the next billing period.
+    /// Dispatched when a user's entitlement has been updated, such as when a subscription is
+    /// renewed for the next billing period.
     ///
-    /// Provides data abut the updated subscription. Specifically, the [`Entitlement::ends_at`]
-    /// field will have changed.
+    /// Provides data abut the updated subscription. If the entitlement is renewed, the
+    /// [`Entitlement::ends_at`] field will have changed.
     async fn entitlement_update(&self, EntitlementUpdate { ctx: Context, entitlement: Entitlement });
 
     /// Dispatched when a user's entitlement has been deleted. This happens rarely, but can occur
-    /// if a subscription is refunded or otherwise deleted by Discord.
+    /// if a subscription is refunded or otherwise deleted by Discord. Entitlements are not deleted
+    /// when they expire.
     ///
     /// Provides data about the subscription. Specifically, the [`Entitlement::deleted`] field will
     /// be set.
-    ///
-    /// Note that expired subscriptions do not result in deletion of their corresponding
-    /// [`Entitlement`] and will not trigger this event upon expiring.
     async fn entitlement_delete(&self, EntitlementDelete { ctx: Context, entitlement: Entitlement });
 
     /// Dispatched when an HTTP rate limit is hit

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -445,6 +445,27 @@ event_handler! {
     /// Provides data about the cancelled subscription.
     async fn guild_scheduled_event_user_remove(&self, ctx: Context, | GuildScheduledEventUserRemove {  unsubscribed: GuildScheduledEventUserRemoveEvent });
 
+    /// Dispatched when a user subscribes to a SKU.
+    ///
+    /// Provides data about the subscription.
+    async fn entitlement_create(&self, EntitlementCreate { ctx: Context, entitlement: Entitlement });
+
+    /// Dispatched when a user's subscription to a SKU renews for the next billing period.
+    ///
+    /// Provides data abut the updated subscription. Specifically, the [`Entitlement::ends_at`]
+    /// field will have changed.
+    async fn entitlement_update(&self, EntitlementUpdate { ctx: Context, entitlement: Entitlement });
+
+    /// Dispatched when a user's entitlement has been deleted. This happens rarely, but can occur
+    /// if a subscription is refunded or otherwise deleted by Discord.
+    ///
+    /// Provides data about the subscription. Specifically, the [`Entitlement::deleted`] field will
+    /// be set.
+    ///
+    /// Note that expired subscriptions do not result in deletion of their corresponding
+    /// [`Entitlement`] and will not trigger this event upon expiring.
+    async fn entitlement_delete(&self, EntitlementDelete { ctx: Context, entitlement: Entitlement });
+
     /// Dispatched when an HTTP rate limit is hit
     async fn ratelimit(&self, | Ratelimit { data: RatelimitInfo });
 }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -448,14 +448,14 @@ event_handler! {
     /// Dispatched when a user subscribes to a SKU.
     ///
     /// Provides data about the subscription.
-    async fn entitlement_create(&self, EntitlementCreate { ctx: Context, entitlement: Entitlement });
+    async fn entitlement_create(&self, ctx: Context, | EntitlementCreate { entitlement: Entitlement });
 
     /// Dispatched when a user's entitlement has been updated, such as when a subscription is
     /// renewed for the next billing period.
     ///
     /// Provides data abut the updated subscription. If the entitlement is renewed, the
     /// [`Entitlement::ends_at`] field will have changed.
-    async fn entitlement_update(&self, EntitlementUpdate { ctx: Context, entitlement: Entitlement });
+    async fn entitlement_update(&self, ctx: Context, | EntitlementUpdate { entitlement: Entitlement });
 
     /// Dispatched when a user's entitlement has been deleted. This happens rarely, but can occur
     /// if a subscription is refunded or otherwise deleted by Discord. Entitlements are not deleted
@@ -463,7 +463,7 @@ event_handler! {
     ///
     /// Provides data about the subscription. Specifically, the [`Entitlement::deleted`] field will
     /// be set.
-    async fn entitlement_delete(&self, EntitlementDelete { ctx: Context, entitlement: Entitlement });
+    async fn entitlement_delete(&self, ctx: Context, | EntitlementDelete { entitlement: Entitlement });
 
     /// Dispatched when an HTTP rate limit is hit
     async fn ratelimit(&self, | Ratelimit { data: RatelimitInfo });

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3116,6 +3116,7 @@ impl Http {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     /// Gets all entitlements for the current app, active and expired.
     pub async fn get_entitlements(
         &self,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -873,6 +873,36 @@ impl Http {
         .await
     }
 
+    /// Creates a test entitlement to a given SKU for a given guild or user. Discord will act as
+    /// though that user/guild has entitlement in perpetuity to the SKU. As a result, the returned
+    /// entitlement will have `starts_at` and `ends_at` both be `None`.
+    pub async fn create_test_entitlement(
+        &self,
+        sku_id: SkuId,
+        owner: EntitlementOwner,
+    ) -> Result<Entitlement> {
+        let (owner_id, owner_type) = match owner {
+            EntitlementOwner::Guild(id) => (id.get(), 1),
+            EntitlementOwner::User(id) => (id.get(), 2),
+        };
+        let map = json!({
+            "sku_id": sku_id,
+            "owner_id": owner_id,
+            "owner_type": owner_type
+        });
+        self.fire(Request {
+            body: Some(to_vec(&map)?),
+            multipart: None,
+            headers: None,
+            method: LightMethod::Post,
+            route: Route::Entitlements {
+                application_id: self.try_application_id()?,
+            },
+            params: None,
+        })
+        .await
+    }
+
     /// Creates a webhook for the given [channel][`GuildChannel`]'s Id, passing in the given data.
     ///
     /// This method requires authentication.
@@ -1343,6 +1373,23 @@ impl Http {
             route: Route::GuildSticker {
                 guild_id,
                 sticker_id,
+            },
+            params: None,
+        })
+        .await
+    }
+
+    /// Deletes a currently active test entitlement. Discord will act as though the corresponding
+    /// user/guild *no longer has* an entitlement to the corresponding SKU.
+    pub async fn delete_test_entitlement(&self, entitlement_id: EntitlementId) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Delete,
+            route: Route::Entitlement {
+                application_id: self.try_application_id()?,
+                entitlement_id,
             },
             params: None,
         })
@@ -3069,6 +3116,56 @@ impl Http {
         .await
     }
 
+    /// Gets all entitlements for the current app, active and expired.
+    pub async fn get_entitlements(
+        &self,
+        user_id: Option<UserId>,
+        sku_ids: Option<Vec<SkuId>>,
+        before: Option<EntitlementId>,
+        after: Option<EntitlementId>,
+        limit: Option<u8>,
+        guild_id: Option<GuildId>,
+        exclude_ended: Option<bool>,
+    ) -> Result<Vec<Entitlement>> {
+        let mut params = vec![];
+        if let Some(user_id) = user_id {
+            params.push(("user_id", user_id.to_string()));
+        }
+        if let Some(sku_ids) = sku_ids {
+            params.push((
+                "sku_ids",
+                sku_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(","),
+            ));
+        }
+        if let Some(before) = before {
+            params.push(("before", before.to_string()));
+        }
+        if let Some(after) = after {
+            params.push(("after", after.to_string()));
+        }
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+        if let Some(guild_id) = guild_id {
+            params.push(("guild_id", guild_id.to_string()));
+        }
+        if let Some(exclude_ended) = exclude_ended {
+            params.push(("exclude_ended", exclude_ended.to_string()));
+        }
+
+        self.fire(Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Get,
+            route: Route::Entitlements {
+                application_id: self.try_application_id()?,
+            },
+            params: Some(params),
+        })
+        .await
+    }
+
     /// Gets current gateway.
     pub async fn get_gateway(&self) -> Result<Gateway> {
         self.fire(Request {
@@ -3919,6 +4016,21 @@ impl Http {
                 reaction: &reaction_type.as_data(),
             },
             params: Some(params),
+        })
+        .await
+    }
+
+    /// Gets all SKUs for the current application.
+    pub async fn get_skus(&self) -> Result<Vec<Sku>> {
+        self.fire(Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Get,
+            route: Route::Skus {
+                application_id: self.try_application_id()?,
+            },
+            params: None,
         })
         .await
     }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -450,6 +450,18 @@ routes! ('a, {
     api!("/applications/{}/guilds/{}/commands/permissions", application_id, guild_id),
     Some(RatelimitingKind::PathAndId(application_id.into()));
 
+    Skus { application_id: ApplicationId },
+    api!("/applications/{}/skus", application_id),
+    Some(RatelimitingKind::PathAndId(application_id.into()));
+
+    Entitlement { application_id: ApplicationId, entitlement_id: EntitlementId },
+    api!("/applications/{}/entitlements/{}", application_id, entitlement_id),
+    Some(RatelimitingKind::PathAndId(application_id.into()));
+
+    Entitlements { application_id: ApplicationId },
+    api!("/applications/{}/entitlements", application_id),
+    Some(RatelimitingKind::PathAndId(application_id.into()));
+
     StageInstances,
     api!("/stage-instances"),
     Some(RatelimitingKind::Path);

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -80,7 +80,7 @@ pub struct CommandInteraction {
     /// The guild's preferred locale.
     pub guild_locale: Option<String>,
     /// For monetized applications, any entitlements of the invoking user.
-    pub entitlements: Option<Vec<Entitlement>>,
+    pub entitlements: Vec<Entitlement>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -34,6 +34,7 @@ use crate::model::id::{
     TargetId,
     UserId,
 };
+use crate::model::monetization::Entitlement;
 use crate::model::user::User;
 use crate::model::Permissions;
 #[cfg(all(feature = "collector", feature = "utils"))]
@@ -78,6 +79,8 @@ pub struct CommandInteraction {
     pub locale: String,
     /// The guild's preferred locale.
     pub guild_locale: Option<String>,
+    /// For monetized applications, any entitlements of the invoking user.
+    pub entitlements: Option<Vec<Entitlement>>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -60,6 +60,8 @@ pub struct ComponentInteraction {
     pub locale: String,
     /// The guild's preferred locale.
     pub guild_locale: Option<String>,
+    /// For monetized applications, any entitlements of the invoking user.
+    pub entitlements: Option<Vec<Entitlement>>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -61,7 +61,7 @@ pub struct ComponentInteraction {
     /// The guild's preferred locale.
     pub guild_locale: Option<String>,
     /// For monetized applications, any entitlements of the invoking user.
-    pub entitlements: Option<Vec<Entitlement>>,
+    pub entitlements: Vec<Entitlement>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -95,10 +95,10 @@ impl Interaction {
     #[must_use]
     pub fn entitlements(&self) -> Option<&[Entitlement]> {
         match self {
-            Self::Ping(i) => i.entitlements.as_deref(),
-            Self::Command(i) | Self::Autocomplete(i) => i.entitlements.as_deref(),
-            Self::Component(i) => i.entitlements.as_deref(),
-            Self::Modal(i) => i.entitlements.as_deref(),
+            Self::Ping(_) => None,
+            Self::Command(i) | Self::Autocomplete(i) => Some(&i.entitlements),
+            Self::Component(i) => Some(&i.entitlements),
+            Self::Modal(i) => Some(&i.entitlements),
         }
     }
 

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -6,6 +6,7 @@ use crate::internal::prelude::*;
 use crate::json::from_value;
 use crate::model::guild::PartialMember;
 use crate::model::id::{ApplicationId, InteractionId};
+use crate::model::monetization::Entitlement;
 use crate::model::user::User;
 use crate::model::utils::deserialize_val;
 use crate::model::Permissions;
@@ -87,6 +88,17 @@ impl Interaction {
             Self::Command(i) | Self::Autocomplete(i) => i.guild_locale.as_deref(),
             Self::Component(i) => i.guild_locale.as_deref(),
             Self::Modal(i) => i.guild_locale.as_deref(),
+        }
+    }
+
+    /// For monetized applications, gets the invoking user's granted entitlements.
+    #[must_use]
+    pub fn entitlements(&self) -> Option<&[Entitlement]> {
+        match self {
+            Self::Ping(i) => i.entitlements.as_deref(),
+            Self::Command(i) | Self::Autocomplete(i) => i.entitlements.as_deref(),
+            Self::Component(i) => i.entitlements.as_deref(),
+            Self::Modal(i) => i.entitlements.as_deref(),
         }
     }
 

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -59,6 +59,8 @@ pub struct ModalInteraction {
     pub locale: String,
     /// The guild's preferred locale.
     pub guild_locale: Option<String>,
+    /// For monetized applications, any entitlements of the invoking user.
+    pub entitlements: Option<Vec<Entitlement>>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -60,7 +60,7 @@ pub struct ModalInteraction {
     /// The guild's preferred locale.
     pub guild_locale: Option<String>,
     /// For monetized applications, any entitlements of the invoking user.
-    pub entitlements: Option<Vec<Entitlement>>,
+    pub entitlements: Vec<Entitlement>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -18,6 +18,4 @@ pub struct PingInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
-    /// For monetized applications, any entitlements of the invoking user.
-    pub entitlements: Option<Vec<Entitlement>>,
 }

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 use crate::model::id::{ApplicationId, InteractionId};
-use crate::model::monetization::Entitlement;
 
 /// A ping interaction, which can only be received through an endpoint url.
 ///

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::model::id::{ApplicationId, InteractionId};
+use crate::model::monetization::Entitlement;
 
 /// A ping interaction, which can only be received through an endpoint url.
 ///
@@ -17,4 +18,6 @@ pub struct PingInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
+    /// For monetized applications, any entitlements of the invoking user.
+    pub entitlements: Option<Vec<Entitlement>>,
 }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1024,6 +1024,7 @@ pub struct GuildScheduledEventUserRemoveEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -1034,6 +1035,7 @@ pub struct EntitlementCreateEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -1044,6 +1046,7 @@ pub struct EntitlementUpdateEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1021,6 +1021,36 @@ pub struct GuildScheduledEventUserRemoveEvent {
     pub guild_id: GuildId,
 }
 
+/// Requires no gateway intents.
+///
+/// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+#[non_exhaustive]
+pub struct EntitlementCreateEvent {
+    pub entitlement: Entitlement,
+}
+
+/// Requires no gateway intents.
+///
+/// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+#[non_exhaustive]
+pub struct EntitlementUpdateEvent {
+    pub entitlement: Entitlement,
+}
+
+/// Requires no gateway intents.
+///
+/// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+#[non_exhaustive]
+pub struct EntitlementDeleteEvent {
+    pub entitlement: Entitlement,
+}
+
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#payload-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[allow(clippy::large_enum_variant)]
@@ -1262,6 +1292,12 @@ pub enum Event {
     GuildScheduledEventUserAdd(GuildScheduledEventUserAddEvent),
     /// A guild member has unsubscribed from a scheduled event.
     GuildScheduledEventUserRemove(GuildScheduledEventUserRemoveEvent),
+    /// A user subscribed to a SKU.
+    EntitlementCreate(EntitlementCreateEvent),
+    /// A user's subscription to a SKU renewed for the next billing period.
+    EntitlementUpdate(EntitlementUpdateEvent),
+    /// A user's entitlement was deleted by Discord, or refunded.
+    EntitlementDelete(EntitlementDeleteEvent),
     /// An event type not covered by the above
     #[serde(untagged)]
     Unknown(UnknownEvent),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1294,7 +1294,7 @@ pub enum Event {
     GuildScheduledEventUserRemove(GuildScheduledEventUserRemoveEvent),
     /// A user subscribed to a SKU.
     EntitlementCreate(EntitlementCreateEvent),
-    /// A user's subscription to a SKU renewed for the next billing period.
+    /// A user's entitlement was updated or renewed.
     EntitlementUpdate(EntitlementUpdateEvent),
     /// A user's entitlement was deleted by Discord, or refunded.
     EntitlementDelete(EntitlementDeleteEvent),

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -251,6 +251,10 @@ pub struct StageInstanceId(#[serde(with = "snowflake")] NonZeroU64);
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct ForumTagId(#[serde(with = "snowflake")] NonZeroU64);
 
+/// An identifier for an entitlement.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+pub struct EntitlementId(#[serde(with = "snowflake")] pub NonZeroU64);
+
 id_u64! {
     AttachmentId;
     ApplicationId;
@@ -277,6 +281,7 @@ id_u64! {
     StageInstanceId;
     RuleId;
     ForumTagId;
+    EntitlementId;
 }
 
 /// An identifier for a Shard.

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -32,6 +32,7 @@ pub mod id;
 pub mod invite;
 pub mod mention;
 pub mod misc;
+pub mod monetization;
 pub mod permissions;
 pub mod sticker;
 pub mod timestamp;
@@ -90,6 +91,7 @@ pub mod prelude {
         invite::*,
         mention::*,
         misc::*,
+        monetization::*,
         permissions::*,
         sticker::*,
         user::*,

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -56,6 +56,7 @@ bitflags! {
 /// Represents that a user or guild has access to a premium offering in the application.
 ///
 /// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Entitlement {
     /// The ID of the entitlement.
@@ -85,6 +86,7 @@ enum_number! {
     /// Differentiates between Entitlement types.
     ///
     /// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-types).
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -68,7 +68,8 @@ pub struct Entitlement {
     /// The type of the entitlement.
     #[serde(rename = "type")]
     pub kind: EntitlementKind,
-    /// Whether the entitlement has been deleted or not.
+    /// Whether the entitlement has been deleted or not. Entitlements are not deleted when they
+    /// expire.
     pub deleted: bool,
     /// Start date after which the entitlement is valid. Not present when using test entitlements.
     pub starts_at: Option<Timestamp>,

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -40,6 +40,7 @@ bitflags! {
     /// Differentates between user and server subscriptions.
     ///
     /// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags).
+    #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
     pub struct SkuFlags: u64 {
         /// SKU is available for purchase.
         const AVAILABLE = 1 << 2;

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -1,0 +1,99 @@
+use crate::model::prelude::*;
+
+/// A premium offering that can be made available to an application's users and guilds.
+///
+/// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Sku {
+    /// The unique ID of the SKU.
+    pub id: SkuId,
+    /// The class of the SKU.
+    #[serde(rename = "type")]
+    pub kind: SkuKind,
+    /// Id of the SKU's parent application.
+    pub application_id: ApplicationId,
+    /// The customer-facing name of the premium offering.
+    pub name: String,
+    /// A system-generated URL slug based on the SKU.
+    pub slug: String,
+    /// Flags indicating the type of subscription the SKU represents.
+    pub flags: SkuFlags,
+}
+
+enum_number! {
+    /// Differentiates between SKU classes.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object-sku-types).
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum SkuKind {
+        /// Represents a recurring subscription.
+        Subscription = 5,
+        /// A system-generated group for each SKU created of type [`SkuKind::Subscription`].
+        SubscriptionGroup = 6,
+        _ => Unknown(u8),
+    }
+}
+
+bitflags! {
+    /// Differentates between user and server subscriptions.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags).
+    pub struct SkuFlags: u64 {
+        /// SKU is available for purchase.
+        const AVAILABLE = 1 << 2;
+        /// Recurring SKU that can be purchased by a user and applied to a single server. Grants
+        /// access to every user in that server.
+        const GUILD_SUBSCRIPTION = 1 << 7;
+        /// Recurring SKU purchased by a user for themselves. Grants access to the purchasing user
+        /// in every server.
+        const USER_SUBSCRIPTION = 1 << 8;
+    }
+}
+
+/// Represents that a user or guild has access to a premium offering in the application.
+///
+/// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-structure).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Entitlement {
+    /// The ID of the entitlement.
+    pub id: EntitlementId,
+    /// The ID of the corresponding SKU.
+    pub sku_id: SkuId,
+    /// The ID of the parent application.
+    pub application_id: ApplicationId,
+    /// The ID of the user that is granted access to the SKU.
+    pub user_id: Option<UserId>,
+    /// The type of the entitlement.
+    #[serde(rename = "type")]
+    pub kind: EntitlementKind,
+    /// Whether the entitlement has been deleted or not.
+    pub deleted: bool,
+    /// Start date after which the entitlement is valid. Not present when using test entitlements.
+    pub starts_at: Option<Timestamp>,
+    /// End date after which the entitlement is no longer valid. Not present when using test
+    /// entitlements.
+    pub ends_at: Option<Timestamp>,
+    /// The ID of the guild that is granted access to the SKU.
+    pub guild_id: Option<GuildId>,
+}
+
+enum_number! {
+    /// Differentiates between Entitlement types.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-types).
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum EntitlementKind {
+        /// Entitlement was purchased as an app subscription.
+        ApplicationSubscription = 8,
+        _ => Unknown(u8),
+    }
+}
+
+pub enum EntitlementOwner {
+    Guild(GuildId),
+    User(UserId),
+}


### PR DESCRIPTION
This PR adds support for the new monetization support added to Discord. Namely, the following endpoints:
* List SKUs
* List Entitlements
* Create Test Entitlement
* Delete Test Entitlement

As well, added via the `PREMIUM_REQUIRED` interaction response type and the `entitlements` field in interaction data. Also, added the `ENTITLEMENT_CREATE`, `ENTITLEMENT_UPDATE`, and `ENTITLEMENT_DELETE` gateway events.

Note: This PR is untested and there are some things I'd like verified before this gets merged. In particular:
- [x] The `PREMIUM_REQUIRED` response type is not valid for `PING` and `APPLICATION_COMMAND_AUTOCOMPLETE` interactions. I'm not sure if this means that the payloads received from those interactions don't contain an `entitlements` field or not. I've elected to keep the `entitlements` field for all interaction types, but I'd like this verified as well.
    - **ANSWER**: Turns out the field is present for `AUTOCOMPLETE` and not for `PING`.
- [x] Are the `before` and `after` parameters to the [List Entitlements](https://github.com/discord/discord-api-docs/pull/6477) endpoint mutually exclusive in any way, like they are for some other endpoints?
    - **ANSWER**: No, they aren't.
