### PR TITLE
Rename `utils::parse_{username,role,channel}` methods

### DIFF
--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -136,11 +136,11 @@ impl FromStr for Mention {
     type Err = MentionParseError;
 
     fn from_str(s: &str) -> StdResult<Self, Self::Err> {
-        let m = if let Some(id) = utils::parse_channel(s) {
+        let m = if let Some(id) = utils::parse_channel_mention(s) {
             id.mention()
-        } else if let Some(id) = utils::parse_role(s) {
+        } else if let Some(id) = utils::parse_role_mention(s) {
             id.mention()
-        } else if let Some(id) = utils::parse_username(s) {
+        } else if let Some(id) = utils::parse_user_mention(s) {
             id.mention()
         } else {
             return Err(MentionParseError::InvalidMention);

--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -45,7 +45,7 @@ async fn lookup_channel_global(
     guild_id: Option<GuildId>,
     s: &str,
 ) -> Result<Channel, ChannelParseError> {
-    if let Some(channel_id) = s.parse().ok().or_else(|| crate::utils::parse_channel(s)) {
+    if let Some(channel_id) = s.parse().ok().or_else(|| crate::utils::parse_channel_mention(s)) {
         return channel_id.to_channel(&ctx).await.map_err(ChannelParseError::Http);
     }
 

--- a/src/utils/argument_convert/member.rs
+++ b/src/utils/argument_convert/member.rs
@@ -54,7 +54,7 @@ impl ArgumentConvert for Member {
         // DON'T use guild.members: it's only populated when guild presences intent is enabled!
 
         // If string is a raw user ID or a mention
-        if let Some(user_id) = s.parse().ok().or_else(|| crate::utils::parse_username(s)) {
+        if let Some(user_id) = s.parse().ok().or_else(|| crate::utils::parse_user_mention(s)) {
             if let Ok(member) = guild_id.member(&ctx, user_id).await {
                 return Ok(member);
             }

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -65,7 +65,7 @@ impl ArgumentConvert for Role {
         #[cfg(not(feature = "cache"))]
         let roles = ctx.http().get_guild_roles(guild_id).await.map_err(RoleParseError::Http)?;
 
-        if let Some(role_id) = s.parse().ok().or_else(|| crate::utils::parse_role(s)) {
+        if let Some(role_id) = s.parse().ok().or_else(|| crate::utils::parse_role_mention(s)) {
             #[cfg(feature = "cache")]
             if let Some(role) = roles.get(&role_id) {
                 return Ok(role.clone());

--- a/src/utils/argument_convert/user.rs
+++ b/src/utils/argument_convert/user.rs
@@ -29,7 +29,7 @@ fn lookup_by_global_cache(ctx: impl CacheHttp, s: &str) -> Option<User> {
 
     let lookup_by_id = || users.get(&s.parse().ok()?).map(|u| u.clone());
 
-    let lookup_by_mention = || users.get(&crate::utils::parse_username(s)?).map(|u| u.clone());
+    let lookup_by_mention = || users.get(&crate::utils::parse_user_mention(s)?).map(|u| u.clone());
 
     let lookup_by_name_and_discrim = || {
         let (name, discrim) = crate::utils::parse_user_tag(s)?;
@@ -84,7 +84,7 @@ impl ArgumentConvert for User {
         }
 
         // If string is a raw user ID or a mention
-        if let Some(user_id) = s.parse().ok().or_else(|| crate::utils::parse_username(s)) {
+        if let Some(user_id) = s.parse().ok().or_else(|| crate::utils::parse_user_mention(s)) {
             // Now, we can still try UserId::to_user because it works for all users from all guilds
             // the bot is joined
             if let Ok(user) = user_id.to_user(&ctx).await {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -130,6 +130,7 @@ pub fn parse_user_tag(s: &str) -> Option<(&str, Option<NonZeroU16>)> {
 /// ```
 ///
 /// [`User`]: crate::model::user::User
+#[must_use]
 pub fn parse_user_mention(mention: &str) -> Option<UserId> {
     if mention.len() < 4 {
         return None;
@@ -174,6 +175,7 @@ pub fn parse_username(mention: impl AsRef<str>) -> Option<UserId> {
 /// ```
 ///
 /// [`Role`]: crate::model::guild::Role
+#[must_use]
 pub fn parse_role_mention(mention: &str) -> Option<RoleId> {
     if mention.len() < 4 {
         return None;
@@ -217,6 +219,7 @@ pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
 /// ```
 ///
 /// [`Channel`]: crate::model::channel::Channel
+#[must_use]
 pub fn parse_channel_mention(mention: &str) -> Option<ChannelId> {
     if mention.len() < 4 {
         return None;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -130,9 +130,7 @@ pub fn parse_user_tag(s: &str) -> Option<(&str, Option<NonZeroU16>)> {
 /// ```
 ///
 /// [`User`]: crate::model::user::User
-pub fn parse_username(mention: impl AsRef<str>) -> Option<UserId> {
-    let mention = mention.as_ref();
-
+pub fn parse_user_mention(mention: &str) -> Option<UserId> {
     if mention.len() < 4 {
         return None;
     }
@@ -145,6 +143,11 @@ pub fn parse_username(mention: impl AsRef<str>) -> Option<UserId> {
     } else {
         None
     }
+}
+
+#[deprecated = "use `utils::parse_user_mention` instead"]
+pub fn parse_username(mention: impl AsRef<str>) -> Option<UserId> {
+    parse_user_mention(mention.as_ref())
 }
 
 /// Retrieves an Id from a role mention.
@@ -171,9 +174,7 @@ pub fn parse_username(mention: impl AsRef<str>) -> Option<UserId> {
 /// ```
 ///
 /// [`Role`]: crate::model::guild::Role
-pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
-    let mention = mention.as_ref();
-
+pub fn parse_role_mention(mention: &str) -> Option<RoleId> {
     if mention.len() < 4 {
         return None;
     }
@@ -184,6 +185,11 @@ pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
     } else {
         None
     }
+}
+
+#[deprecated = "use `utils::parse_role_mention` instead"]
+pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
+    parse_role_mention(mention.as_ref())
 }
 
 /// Retrieves an Id from a channel mention.
@@ -211,9 +217,7 @@ pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
 /// ```
 ///
 /// [`Channel`]: crate::model::channel::Channel
-pub fn parse_channel(mention: impl AsRef<str>) -> Option<ChannelId> {
-    let mention = mention.as_ref();
-
+pub fn parse_channel_mention(mention: &str) -> Option<ChannelId> {
     if mention.len() < 4 {
         return None;
     }
@@ -224,6 +228,11 @@ pub fn parse_channel(mention: impl AsRef<str>) -> Option<ChannelId> {
     } else {
         None
     }
+}
+
+#[deprecated = "use `utils::parse_channel_mention` instead"]
+pub fn parse_channel(mention: impl AsRef<str>) -> Option<ChannelId> {
+    parse_channel_mention(mention.as_ref())
 }
 
 /// Retrieves the animated state, name and Id from an emoji mention, in the form of an
@@ -525,18 +534,18 @@ mod test {
 
     #[test]
     fn test_username_parser() {
-        assert_eq!(parse_username("<@12345>").unwrap(), 12_345);
-        assert_eq!(parse_username("<@!12345>").unwrap(), 12_345);
+        assert_eq!(parse_user_mention("<@12345>").unwrap(), 12_345);
+        assert_eq!(parse_user_mention("<@!12345>").unwrap(), 12_345);
     }
 
     #[test]
     fn role_parser() {
-        assert_eq!(parse_role("<@&12345>").unwrap(), 12_345);
+        assert_eq!(parse_role_mention("<@&12345>").unwrap(), 12_345);
     }
 
     #[test]
     fn test_channel_parser() {
-        assert_eq!(parse_channel("<#12345>").unwrap(), 12_345);
+        assert_eq!(parse_channel_mention("<#12345>").unwrap(), 12_345);
     }
 
     #[test]


### PR DESCRIPTION
Renames the methods to `parse_{user,role,channel}_mention` while leaving the old names as deprecated aliases.