### PR TITLE
Fix AutoModActionExecution

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1043,6 +1043,7 @@ pub enum Event {
     ///
     /// [`EventHandler::auto_moderation_action_execution`]:
     /// crate::client::EventHandler::auto_moderation_action_execution
+    #[serde(rename = "AUTO_MODERATION_ACTION_EXECUTION")]
     AutoModActionExecution(AutoModActionExecutionEvent),
     /// A [`Channel`] was created.
     ///


### PR DESCRIPTION
Fixes #2561 

Just needed to be renamed to the actual event name.

![image](https://github.com/serenity-rs/serenity/assets/22662856/1e5848b3-afe7-4c88-bd2c-8c50957c5c30)

This is probably fine to be backported to current right? It wouldn't be a "breaking change" because it fixes something that either never worked or discord changed somewhere.