### PR TITLE
Replace `serenity::json::prelude` with public wrapper functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ secrecy = { version = "0.8.0", features = ["serde"] }
 arrayvec = { version = "0.7.3", features = ["serde"] }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
-simd-json = { version = "0.10", optional = true }
+simd-json = { version = "0.12", optional = true }
 uwl = { version = "0.6.0", optional = true }
 levenshtein = { version = "1.0.5", optional = true }
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"], optional = true }

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ the HTTP functions.
 instead of `rustls_backend`.
 - **tokio_task_builder**: Enables tokio's `tracing` feature and uses `tokio::task::Builder` to spawn tasks with names if `RUSTFLAGS="--cfg tokio_unstable"` is set.
 - **unstable_discord_api**: Enables features of the Discord API that do not have a stable interface. The features might not have official documentation or are subject to change.
-- **simd_json**: Enables SIMD accelerated JSON parsing and rendering for API calls, use with `RUSTFLAGS="-C target-cpu=native"`
+- **simd_json**: Enables SIMD accelerated JSON parsing and rendering for API calls, if supported on the target CPU architecture.
 - **temp_cache**: Enables temporary caching in functions that retrieve data via the HTTP API.
 - **chrono**: Uses the `chrono` crate to represent timestamps. If disabled, the `time` crate is used instead.
 - **interactions_endpoint**: Enables tools related to Discord's Interactions Endpoint URL feature

--- a/examples/e19_interactions_endpoint/Cargo.toml
+++ b/examples/e19_interactions_endpoint/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2018"
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["builder", "interactions_endpoint"] }
 tiny_http = "0.12.0"
-serde_json = "1.0"

--- a/examples/e19_interactions_endpoint/src/main.rs
+++ b/examples/e19_interactions_endpoint/src/main.rs
@@ -1,5 +1,6 @@
 use serenity::builder::*;
 use serenity::interactions_endpoint::Verifier;
+use serenity::json;
 use serenity::model::application::*;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -36,7 +37,7 @@ fn handle_request(
     }
 
     // Build Discord response
-    let response = match serde_json::from_slice::<Interaction>(body)? {
+    let response = match json::from_slice::<Interaction>(body)? {
         // Discord rejects the interaction endpoints URL if pings are not acknowledged
         Interaction::Ping(_) => CreateInteractionResponse::Pong,
         Interaction::Command(interaction) => handle_command(interaction),
@@ -45,7 +46,7 @@ fn handle_request(
 
     // Send the Discord response back via HTTP
     request.respond(
-        tiny_http::Response::from_data(serde_json::to_vec(&response)?)
+        tiny_http::Response::from_data(json::to_vec(&response)?)
             .with_header("Content-Type: application/json".parse::<tiny_http::Header>().unwrap()),
     )?;
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::json::json;
+use crate::json::{self, json};
 use crate::model::prelude::*;
 
 /// A builder for creating a components action row in a message.
@@ -19,12 +19,12 @@ impl serde::Serialize for CreateActionRow {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::Error as _;
 
-        serde_json::json!({
+        json!({
             "type": 1,
             "components": match self {
-                Self::Buttons(x) => serde_json::to_value(x).map_err(S::Error::custom)?,
-                Self::SelectMenu(x) => serde_json::to_value(vec![x]).map_err(S::Error::custom)?,
-                Self::InputText(x) => serde_json::to_value(vec![x]).map_err(S::Error::custom)?,
+                Self::Buttons(x) => json::to_value(x).map_err(S::Error::custom)?,
+                Self::SelectMenu(x) => json::to_value(vec![x]).map_err(S::Error::custom)?,
+                Self::InputText(x) => json::to_value(vec![x]).map_err(S::Error::custom)?,
             }
         })
         .serialize(serializer)

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -6,6 +6,7 @@ use crate::constants;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
 use crate::internal::prelude::*;
+use crate::json::{self, json};
 use crate::model::prelude::*;
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object).
@@ -57,7 +58,7 @@ impl serde::Serialize for CreateInteractionResponse {
         use serde::ser::Error as _;
 
         #[allow(clippy::match_same_arms)] // hurts readability
-        serde_json::json!({
+        json!({
             "type": match self {
                 Self::Pong { .. } => 1,
                 Self::Message { .. } => 4,
@@ -68,13 +69,13 @@ impl serde::Serialize for CreateInteractionResponse {
                 Self::Modal { .. } => 9,
             },
             "data": match self {
-                Self::Pong => serde_json::Value::Null,
-                Self::Message(x) => serde_json::to_value(x).map_err(S::Error::custom)?,
-                Self::Defer(x) => serde_json::to_value(x).map_err(S::Error::custom)?,
-                Self::Acknowledge => serde_json::Value::Null,
-                Self::UpdateMessage(x) => serde_json::to_value(x).map_err(S::Error::custom)?,
-                Self::Autocomplete(x) => serde_json::to_value(x).map_err(S::Error::custom)?,
-                Self::Modal(x) => serde_json::to_value(x).map_err(S::Error::custom)?,
+                Self::Pong => json::NULL,
+                Self::Message(x) => json::to_value(x).map_err(S::Error::custom)?,
+                Self::Defer(x) => json::to_value(x).map_err(S::Error::custom)?,
+                Self::Acknowledge => json::NULL,
+                Self::UpdateMessage(x) => json::to_value(x).map_err(S::Error::custom)?,
+                Self::Autocomplete(x) => json::to_value(x).map_err(S::Error::custom)?,
+                Self::Modal(x) => json::to_value(x).map_err(S::Error::custom)?,
             }
         })
         .serialize(serializer)

--- a/src/cache/cache_update.rs
+++ b/src/cache/cache_update.rs
@@ -56,7 +56,7 @@ use super::Cache;
 ///                 Some(old_user)
 ///             },
 ///             Entry::Vacant(entry) => {
-///                 // We can convert a [`serde_json::Value`] to a User for test
+///                 // We can convert a [`json::Value`] to a User for test
 ///                 // purposes.
 ///                 let user = from_value::<User>(json!({
 ///                     "id": self.user_id,

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -132,14 +132,14 @@ impl WsClient {
                     why
                 })?;
 
-                from_str(decompressed).map_err(|why| {
+                from_str(&decompressed).map_err(|why| {
                     warn!("Err deserializing bytes: {why:?}");
                     debug!("Failing bytes: {bytes:?}");
 
                     why
                 })?
             },
-            Message::Text(payload) => from_str(payload.clone()).map_err(|why| {
+            Message::Text(payload) => from_str(&payload).map_err(|why| {
                 warn!("Err deserializing text: {why:?}; text: {payload}");
 
                 why

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2142,7 +2142,7 @@ impl Http {
     ///
     /// ```rust,no_run
     /// use serenity::http::Http;
-    /// use serenity::json::{json, prelude::*};
+    /// use serenity::json::json;
     /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -2195,7 +2195,7 @@ impl Http {
     ///
     /// ```rust,no_run
     /// use serenity::http::Http;
-    /// use serenity::json::{json, prelude::*};
+    /// use serenity::json::json;
     /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -2293,7 +2293,7 @@ impl Http {
     ///
     /// ```rust,no_run
     /// use serenity::http::Http;
-    /// use serenity::json::prelude::*;
+    /// use serenity::json::json;
     /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -2364,7 +2364,7 @@ impl Http {
     ///
     /// ```rust,no_run
     /// use serenity::http::Http;
-    /// use serenity::json::prelude::*;
+    /// use serenity::json::json;
     /// use serenity::model::prelude::*;
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2300,10 +2300,9 @@ impl Http {
     /// # let http: Http = unimplemented!();
     /// let id = WebhookId::new(245037420704169985);
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-    /// let value = json!({"name": "new name"});
-    /// let map = value.as_object().unwrap();
+    /// let map = json!({"name": "new name"});
     ///
-    /// let edited = http.edit_webhook_with_token(id, token, map, None).await?;
+    /// let edited = http.edit_webhook_with_token(id, token, &map, None).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -2371,11 +2370,10 @@ impl Http {
     /// # let http: Http = unimplemented!();
     /// let id = WebhookId::new(245037420704169985);
     /// let token = "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
-    /// let value = json!({"content": "test"});
-    /// let map = value.as_object().unwrap();
+    /// let map = json!({"content": "test"});
     /// let files = vec![];
     ///
-    /// let message = http.execute_webhook(id, None, token, true, files, map).await?;
+    /// let message = http.execute_webhook(id, None, token, true, files, &map).await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -31,7 +31,7 @@ use super::{
 use crate::builder::CreateAttachment;
 use crate::constants;
 use crate::internal::prelude::*;
-use crate::json::prelude::*;
+use crate::json::*;
 use crate::model::application::{Command, CommandPermissions};
 use crate::model::guild::automod::Rule;
 use crate::model::prelude::*;

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -7,7 +7,7 @@ use serde::de::{Deserialize, Deserializer, Error as _};
 use url::ParseError as UrlError;
 
 use crate::internal::prelude::*;
-use crate::json::decode_resp;
+use crate::json::*;
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/internal/prelude.rs
+++ b/src/internal/prelude.rs
@@ -4,9 +4,6 @@
 
 pub use std::result::Result as StdResult;
 
-#[cfg(feature = "simd_json")]
-pub use simd_json::{Mutable, Value as ValueTrait, ValueAccess};
-
 #[cfg(feature = "client")]
 pub use crate::client::ClientError;
 pub use crate::error::{Error, Result};

--- a/src/json.rs
+++ b/src/json.rs
@@ -60,8 +60,7 @@ where
 }
 
 /// Deserialize an instance of type `T` from a string of JSON text.
-#[cfg_attr(not(feature = "simd_json"), allow(unused_mut))]
-#[allow(clippy::missing_errors_doc)] // It's obvious
+#[allow(clippy::missing_errors_doc)]
 pub fn from_str<T>(s: &str) -> Result<T>
 where
     T: DeserializeOwned,
@@ -74,6 +73,7 @@ where
 }
 
 /// Deserialize an instance of type `T` from bytes of JSON text.
+#[allow(clippy::missing_errors_doc)]
 pub fn from_slice<T>(v: &[u8]) -> Result<T>
 where
     T: DeserializeOwned,
@@ -88,6 +88,7 @@ where
 }
 
 /// Interpret a [`Value`] as an instance of type `T`.
+#[allow(clippy::missing_errors_doc)]
 pub fn from_value<T>(value: Value) -> Result<T>
 where
     T: DeserializeOwned,
@@ -100,6 +101,7 @@ where
 }
 
 /// Deserialize an instance of type `T` from bytes of JSON text.
+#[allow(clippy::missing_errors_doc)]
 pub fn from_reader<R, T>(rdr: R) -> Result<T>
 where
     R: std::io::Read,
@@ -113,6 +115,7 @@ where
 }
 
 /// Serialize the given data structure as a String of JSON.
+#[allow(clippy::missing_errors_doc)]
 pub fn to_string<T>(value: &T) -> Result<String>
 where
     T: ?Sized + Serialize,
@@ -125,6 +128,7 @@ where
 }
 
 /// Serialize the given data structure as a pretty-printed String of JSON.
+#[allow(clippy::missing_errors_doc)]
 pub fn to_string_pretty<T>(value: &T) -> Result<String>
 where
     T: ?Sized + Serialize,
@@ -137,6 +141,7 @@ where
 }
 
 /// Serialize the given data structure as a JSON byte vector.
+#[allow(clippy::missing_errors_doc)]
 pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
 where
     T: ?Sized + Serialize,
@@ -149,6 +154,7 @@ where
 }
 
 /// Serialize the given data structure as a pretty-printed JSON byte vector.
+#[allow(clippy::missing_errors_doc)]
 pub fn to_vec_pretty<T>(value: &T) -> Result<Vec<u8>>
 where
     T: ?Sized + Serialize,
@@ -161,6 +167,7 @@ where
 }
 
 /// Convert a `T` into a [`Value`] which is an enum that can represent any valid JSON data.
+#[allow(clippy::missing_errors_doc)]
 pub fn to_value<T>(value: T) -> Result<Value>
 where
     T: Serialize,

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -14,6 +14,7 @@ use crate::client::Context;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
+use crate::json::{self, json};
 use crate::model::prelude::*;
 #[cfg(all(feature = "collector", feature = "utils"))]
 use crate::utils::{CreateQuickModal, QuickModalResponse};
@@ -256,16 +257,14 @@ impl<'de> Deserialize<'de> for ComponentInteractionDataKind {
         #[derive(Deserialize)]
         struct Json {
             component_type: ComponentType,
-            values: Option<serde_json::Value>,
+            values: Option<json::Value>,
         }
         let json = Json::deserialize(deserializer)?;
 
         macro_rules! parse_values {
             () => {
-                serde_json::from_value(
-                    json.values.ok_or_else(|| D::Error::missing_field("values"))?,
-                )
-                .map_err(D::Error::custom)?
+                json::from_value(json.values.ok_or_else(|| D::Error::missing_field("values"))?)
+                    .map_err(D::Error::custom)?
             };
         }
 
@@ -298,7 +297,7 @@ impl<'de> Deserialize<'de> for ComponentInteractionDataKind {
 
 impl Serialize for ComponentInteractionDataKind {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
-        serde_json::json!({
+        json!({
             "component_type": match self {
                 Self::Button { .. } => 2,
                 Self::StringSelect { .. } => 3,
@@ -309,12 +308,12 @@ impl Serialize for ComponentInteractionDataKind {
                 Self::Unknown(x) => *x,
             },
             "values": match self {
-                Self::StringSelect { values } => serde_json::to_value(values).map_err(S::Error::custom)?,
-                Self::UserSelect { values } => serde_json::to_value(values).map_err(S::Error::custom)?,
-                Self::RoleSelect { values } => serde_json::to_value(values).map_err(S::Error::custom)?,
-                Self::MentionableSelect { values } => serde_json::to_value(values).map_err(S::Error::custom)?,
-                Self::ChannelSelect { values } => serde_json::to_value(values).map_err(S::Error::custom)?,
-                Self::Button | Self::Unknown(_) => serde_json::Value::Null,
+                Self::StringSelect { values } => json::to_value(values).map_err(S::Error::custom)?,
+                Self::UserSelect { values } => json::to_value(values).map_err(S::Error::custom)?,
+                Self::RoleSelect { values } => json::to_value(values).map_err(S::Error::custom)?,
+                Self::MentionableSelect { values } => json::to_value(values).map_err(S::Error::custom)?,
+                Self::ChannelSelect { values } => json::to_value(values).map_err(S::Error::custom)?,
+                Self::Button | Self::Unknown(_) => json::NULL,
             },
         })
         .serialize(serializer)

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -23,7 +23,7 @@ pub use self::private_channel::*;
 pub use self::reaction::*;
 #[cfg(feature = "model")]
 use crate::http::CacheHttp;
-use crate::json::prelude::*;
+use crate::json::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
 use crate::model::Timestamp;

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -13,7 +13,7 @@
 /// Passing in a role's colour, and then retrieving its green component via [`Self::g`]:
 ///
 /// ```rust
-/// # use serde_json::{json, from_value};
+/// # use serenity::json::{json, from_value};
 /// # use serenity::model::guild::Role;
 /// # use serenity::model::id::RoleId;
 /// # use serenity::model::id::GuildId;

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -22,7 +22,6 @@ use super::utils::{
     stickers,
 };
 use crate::constants::Opcode;
-use crate::internal::prelude::*;
 use crate::model::application::{CommandPermissions, Interaction};
 use crate::model::guild::audit_log::AuditLogEntry;
 use crate::model::guild::automod::{ActionExecution, Rule};
@@ -386,7 +385,7 @@ pub struct InviteCreateEvent {
     /// User whose stream to display for this voice channel stream invite.
     pub target_user: Option<User>,
     /// Embedded application to open for this voice channel embedded application invite.
-    pub target_application: Option<serde_json::Value>,
+    pub target_application: Option<Value>,
     /// they're assigned a role).
     pub temporary: bool,
     /// How many times the invite has been used (always will be 0).

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn action_serde() {
-        use serde_json::json;
+        use crate::json::{self, json};
 
         #[derive(Debug, Deserialize, Serialize)]
         struct T {
@@ -429,7 +429,7 @@ mod tests {
             "action": 234,
         });
 
-        let value = serde_json::from_value::<T>(value).unwrap();
+        let value = json::from_value::<T>(value).unwrap();
         assert_eq!(value.action.num(), 234);
 
         assert!(matches!(value.action, Action::Unknown(234)));

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -65,7 +65,7 @@ impl Emoji {
     /// Delete a given emoji:
     ///
     /// ```rust,no_run
-    /// # use serde_json::{json, from_value};
+    /// # use serenity::json::{json, from_value};
     /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// # use serenity::client::Context;
     /// # use serenity::model::prelude::{EmojiId, Emoji};

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1205,9 +1205,10 @@ impl GuildId {
                     "position": pos,
                 })
             })
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+            .into();
 
-        http.as_ref().edit_guild_channel_positions(self, &Value::from(items)).await
+        http.as_ref().edit_guild_channel_positions(self, &items).await
     }
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname starts with a

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -59,7 +59,7 @@ use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, UserPagination};
 #[cfg(feature = "model")]
-use crate::json::prelude::json;
+use crate::json::json;
 #[cfg(feature = "model")]
 use crate::model::application::{Command, CommandPermissions};
 #[cfg(feature = "model")]

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -371,7 +371,7 @@ impl RichInvite {
     /// #     "inviter": {
     /// #         "avatar": None::<String>,
     /// #         "bot": false,
-    /// #         "discriminator": 3,
+    /// #         "discriminator": "1234",
     /// #         "id": UserId::new(4),
     /// #         "username": "qux",
     /// #         "public_flags": None::<UserPublicFlags>,

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -153,7 +153,7 @@ impl Invite {
     /// Retrieve the URL for an invite with the code `WxZumR`:
     ///
     /// ```rust
-    /// # use serde_json::{json, from_value};
+    /// # use serenity::json::{json, from_value};
     /// # use serenity::model::prelude::*;
     /// #
     /// # fn main() {
@@ -345,7 +345,7 @@ impl RichInvite {
     /// Retrieve the URL for an invite with the code `WxZumR`:
     ///
     /// ```rust
-    /// # use serde_json::{json, from_value};
+    /// # use serenity::json::{json, from_value};
     /// # use serenity::model::prelude::*;
     /// #
     /// # fn main() {

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -132,7 +132,7 @@ impl MessageBuilder {
     /// Mention an emoji in a message's content:
     ///
     /// ```rust
-    /// # use serde_json::{json, from_value};
+    /// # use serenity::json::{json, from_value};
     /// # use serenity::model::guild::Emoji;
     /// # use serenity::model::id::EmojiId;
     /// # use serenity::utils::MessageBuilder;


### PR DESCRIPTION
To avoid future breakage, we shouldn't re-export functions from dependency libs in case a function signature changes, which would pass on breaking changes to serenity's users. Providing wrapper functions solves this issue.

Note: changed `from_str`to take `&str` instead of `String`, and simply clone it for the `simd_json` case. This means the more common `serde_json` use case no longer requires ownership (or an extra clone before passing the string in).