### PR TITLE
Add optional `description` field to `CreateAttachment`

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -140,7 +140,7 @@ impl Builder for CreateInteractionResponse {
             | CreateInteractionResponse::Defer(msg)
             | CreateInteractionResponse::UpdateMessage(msg) => {
                 let files = std::mem::take(&mut msg.files);
-                msg.attachments.extend(ExistingAttachment::from_files(&files));
+                msg.attachments.extend(MessageAttachment::from_files(&files));
                 files
             },
             _ => Vec::new(),
@@ -167,7 +167,7 @@ pub struct CreateInteractionResponseMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<ExistingAttachment>,
+    attachments: Vec<MessageAttachment>,
 
     #[serde(skip)]
     files: Vec<CreateAttachment>,

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -33,7 +33,7 @@ pub struct CreateInteractionResponseFollowup {
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<ExistingAttachment>,
+    attachments: Vec<MessageAttachment>,
 
     #[serde(skip)]
     files: Vec<CreateAttachment>,
@@ -188,7 +188,7 @@ impl Builder for CreateInteractionResponseFollowup {
         self.check_length()?;
 
         let files = std::mem::take(&mut self.files);
-        self.attachments.extend(ExistingAttachment::from_files(&files));
+        self.attachments.extend(MessageAttachment::from_files(&files));
 
         let http = cache_http.http();
         match ctx.0 {

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "http")]
 use super::{check_overflow, Builder};
-use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
+use super::{
+    CreateActionRow,
+    CreateAllowedMentions,
+    CreateAttachment,
+    CreateEmbed,
+    ExistingAttachment,
+};
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
@@ -26,6 +32,8 @@ pub struct CreateInteractionResponseFollowup {
     components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attachments: Vec<ExistingAttachment>,
 
     #[serde(skip)]
     files: Vec<CreateAttachment>,
@@ -178,7 +186,9 @@ impl Builder for CreateInteractionResponseFollowup {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         self.check_length()?;
+
         let files = std::mem::take(&mut self.files);
+        self.attachments.extend(ExistingAttachment::from_files(&files));
 
         let http = cache_http.http();
         match ctx.0 {

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "http")]
 use super::{check_overflow, Builder};
-use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
+use super::{
+    CreateActionRow,
+    CreateAllowedMentions,
+    CreateAttachment,
+    CreateEmbed,
+    ExistingAttachment,
+};
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
@@ -61,6 +67,8 @@ pub struct CreateMessage {
     sticker_ids: Vec<StickerId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attachments: Vec<ExistingAttachment>,
 
     // The following fields are handled separately.
     #[serde(skip)]
@@ -322,7 +330,9 @@ impl Builder for CreateMessage {
         self.check_length()?;
 
         let http = cache_http.http();
+
         let files = std::mem::take(&mut self.files);
+        self.attachments.extend(ExistingAttachment::from_files(&files));
 
         #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut message = http.send_message(channel_id, files, &self).await?;

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -68,7 +68,7 @@ pub struct CreateMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<ExistingAttachment>,
+    attachments: Vec<MessageAttachment>,
 
     // The following fields are handled separately.
     #[serde(skip)]
@@ -332,7 +332,7 @@ impl Builder for CreateMessage {
         let http = cache_http.http();
 
         let files = std::mem::take(&mut self.files);
-        self.attachments.extend(ExistingAttachment::from_files(&files));
+        self.attachments.extend(MessageAttachment::from_files(&files));
 
         #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut message = http.send_message(channel_id, files, &self).await?;

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -6,6 +6,7 @@ use super::{
     CreateAttachment,
     CreateEmbed,
     EditWebhookMessage,
+    ExistingAttachment,
 };
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -126,7 +127,15 @@ impl Builder for EditInteractionResponse {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         self.0.check_length()?;
+
         let files = std::mem::take(&mut self.0.files);
+        if !files.is_empty() {
+            self.0
+                .attachments
+                .get_or_insert(Vec::new())
+                .extend(ExistingAttachment::from_files(&files));
+        }
+
         cache_http.http().edit_original_interaction_response(ctx, &self, files).await
     }
 }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -6,7 +6,7 @@ use super::{
     CreateAttachment,
     CreateEmbed,
     EditWebhookMessage,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -133,7 +133,7 @@ impl Builder for EditInteractionResponse {
             self.0
                 .attachments
                 .get_or_insert(Vec::new())
-                .extend(ExistingAttachment::from_files(&files));
+                .extend(MessageAttachment::from_files(&files));
         }
 
         cache_http.http().edit_original_interaction_response(ctx, &self, files).await

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -6,6 +6,7 @@ use super::{
     CreateAttachment,
     CreateEmbed,
     ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -30,7 +31,7 @@ pub struct EditWebhookMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) attachments: Option<Vec<ExistingAttachment>>,
+    pub(crate) attachments: Option<Vec<MessageAttachment>>,
 
     #[serde(skip)]
     thread_id: Option<ChannelId>,
@@ -148,12 +149,11 @@ impl EditWebhookMessage {
     ///
     /// To be used after [`Self::new_attachment`] or [`Self::clear_existing_attachments`].
     pub fn keep_existing_attachment(mut self, id: AttachmentId) -> Self {
-        self.attachments.get_or_insert_with(Vec::new).push(ExistingAttachment {
-            id: id.get(),
-            // TODO: can this be edited? if so, users should be able to set these fields.
-            filename: None,
-            description: None,
-        });
+        self.attachments.get_or_insert_with(Vec::new).push(MessageAttachment::Existing(
+            ExistingAttachment {
+                id,
+            },
+        ));
         self
     }
 
@@ -197,7 +197,7 @@ impl Builder for EditWebhookMessage {
         if !files.is_empty() {
             self.attachments
                 .get_or_insert(Vec::new())
-                .extend(ExistingAttachment::from_files(&files));
+                .extend(MessageAttachment::from_files(&files));
         }
 
         cache_http

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -76,7 +76,7 @@ pub struct ExecuteWebhook {
     #[serde(skip_serializing_if = "Option::is_none")]
     thread_name: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<ExistingAttachment>,
+    attachments: Vec<MessageAttachment>,
 
     #[serde(skip)]
     thread_id: Option<ChannelId>,
@@ -362,7 +362,7 @@ impl Builder for ExecuteWebhook {
         self.check_length()?;
 
         let files = std::mem::take(&mut self.files);
-        self.attachments.extend(ExistingAttachment::from_files(&files));
+        self.attachments.extend(MessageAttachment::from_files(&files));
 
         cache_http.http().execute_webhook(ctx.0, self.thread_id, ctx.1, ctx.2, files, &self).await
     }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "http")]
 use super::{check_overflow, Builder};
-use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
+use super::{
+    CreateActionRow,
+    CreateAllowedMentions,
+    CreateAttachment,
+    CreateEmbed,
+    ExistingAttachment,
+};
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
@@ -69,6 +75,8 @@ pub struct ExecuteWebhook {
     flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     thread_name: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attachments: Vec<ExistingAttachment>,
 
     #[serde(skip)]
     thread_id: Option<ChannelId>,
@@ -352,7 +360,10 @@ impl Builder for ExecuteWebhook {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         self.check_length()?;
+
         let files = std::mem::take(&mut self.files);
+        self.attachments.extend(ExistingAttachment::from_files(&files));
+
         cache_http.http().execute_webhook(ctx.0, self.thread_id, ctx.1, ctx.2, files, &self).await
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -489,7 +489,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: files.into_iter().map(Into::into).collect(),
+                attachment_files: Some(files.into_iter().map(Into::into).collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -689,7 +690,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: files.into_iter().map(Into::into).collect(),
+                attachment_files: Some(files.into_iter().map(Into::into).collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -859,7 +861,8 @@ impl Http {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
-                files: vec![file],
+                attachment_files: None,
+                upload_file: Some(file),
                 fields: map.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
                 payload_json: None,
             }),
@@ -1522,7 +1525,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: new_attachments.into_iter().map(Into::into).collect(),
+                attachment_files: Some(new_attachments.into_iter().map(Into::into).collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -1810,7 +1814,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: new_attachments,
+                attachment_files: Some(new_attachments),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -1956,7 +1961,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: new_attachments.into_iter().collect(),
+                attachment_files: Some(new_attachments.into_iter().collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -2409,7 +2415,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: files.into_iter().collect(),
+                attachment_files: Some(files.into_iter().collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -2474,7 +2481,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: new_attachments,
+                attachment_files: Some(new_attachments),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -4216,7 +4224,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: files.into_iter().collect(),
+                attachment_files: Some(files.into_iter().collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });


### PR DESCRIPTION
Closes #2563.

## Description
Currently, uploading files as message attachments is done by simply appending them as multipart form parts, without creating an entry in the `attachments` field of the JSON payload.
Because the `description` is specified in the entries of that field, this PR updates all builders that are used for uploading files: during the build/execute process, entries for each file of the `files` array are added to the `attachments` field of the payload.

The PR also makes changes to the `Multipart` struct.
Currently, the part name of the 0th file is set to `file`, all other file parts are called `fileN` because they must have unique names. This is done to work around the fact that Discord expects the part name for endpoints that take in single file uploads to be `file`, e.g. when creating stickers.
I believe that using `fileN` only works because the format of part names is not actively enforced unless you use the `attachments` field like described above.

When creating entries in the `attachments` field, Discord expects their ID to be set to `N` (starting at 0), and the name of the part containing the data to be set to `files[N]` (see [example payload](https://discord.com/developers/docs/reference#editing-message-attachments-example-request-bodies-multipartformdata)). Due to these strict naming rules, this PR replaces the `files` field of the `Multipart` struct with two new fields: 
- `upload_file: Option<CreateAttachment>` for uploading a single file to endpoints like creating stickers - the part name is set to `file`.
- `attachment_files: Option<Vec<CreateAttachment>>` for uploading multiple files as message attachments - the part name is set to `files[N]`.

## Breaking changes
- Field `description: Option<String>` added to struct `CreateAttachment`.
- Field `files: Vec<CreateAttachment>` removed, fields `upload_file: Option<CreateAttachment>` and `attachment_files: Option<Vec<CreateAttachment>>` added to struct `Multipart`.

## Things to do, change and discuss
- [ ] Testing.
- [ ] Adding `attachments` entries for new `files` in the execute function of the builders is a bit weird and should probably be done in the functions that also modify the `files` array (like `new_attachment`). I'm not sure how exactly that should be done (in a clean way).
- [ ] Structs and fields might need to be renamed (e.g. `upload_file`/`attachment_files`).
- [x] `ExistingAttachment` cannot continue to use the type `AttachmentId` for its ID field ATM, because the inner type is `NonZeroU64` and the ID of new files is an index starting at zero (see above). I'm not sure how to properly handle this. Maybe there should be a new struct for this and `ExistingAttachment` should be left as-is.
- ~~If the description and/or file name of existing attachments can be edited, this should (and easily could) be exposed when editing messages.~~ This doesn't seem to be possible.
- [ ] As far as I can tell, the `filename` field of the `NewAttachment` struct is redundant and we could remove it, because the filename is already included directly in the multipart request.

Help, critique and any other comments on some of these points and the code would be much appreciated.