### PR TITLE
Add CreateAttachment.description and EditAttachment

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -59,7 +59,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             )
             .await?;
         // Pre-PR, this falsely triggered a MODEL_TYPE_CONVERT Discord error
-        msg.edit(&ctx, EditMessage::new().add_existing_attachment(msg.attachments[0].id)).await?;
+        msg.edit(&ctx, EditMessage::new().attachments(EditAttachments::new_keep_all(&msg))).await?;
     } else if msg.content == "unifiedattachments" {
         let mut msg = channel_id.send_message(ctx, CreateMessage::new().content("works")).await?;
         msg.edit(ctx, EditMessage::new().content("works still")).await?;
@@ -72,9 +72,10 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             .await?;
         msg.edit(
             ctx,
-            EditMessage::new()
-                .attachment(CreateAttachment::url(ctx, IMAGE_URL_2).await?)
-                .add_existing_attachment(msg.attachments[0].id),
+            EditMessage::new().attachments(
+                EditAttachments::new_keep_all(&msg)
+                    .add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
+            ),
         )
         .await?;
     } else if msg.content == "ranking" {
@@ -240,9 +241,10 @@ async fn interaction(
         let msg = interaction
             .edit_response(
                 &ctx,
-                EditInteractionResponse::new()
-                    .new_attachment(CreateAttachment::url(ctx, IMAGE_URL_2).await?)
-                    .keep_existing_attachment(msg.attachments[0].id),
+                EditInteractionResponse::new().attachments(
+                    EditAttachments::new_keep_all(&msg)
+                        .add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
+                ),
             )
             .await?;
 
@@ -253,8 +255,7 @@ async fn interaction(
             .edit_response(
                 &ctx,
                 EditInteractionResponse::new()
-                    .clear_existing_attachments()
-                    .keep_existing_attachment(msg.attachments[1].id),
+                    .attachments(EditAttachments::new().keep(msg.attachments[1].id)),
             )
             .await?;
     } else if interaction.data.name == "unifiedattachments1" {
@@ -291,8 +292,9 @@ async fn interaction(
         interaction
             .edit_response(
                 ctx,
-                EditInteractionResponse::new()
-                    .new_attachment(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
+                EditInteractionResponse::new().attachments(
+                    EditAttachments::new().add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
+                ),
             )
             .await?;
 

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -59,7 +59,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             )
             .await?;
         // Pre-PR, this falsely triggered a MODEL_TYPE_CONVERT Discord error
-        msg.edit(&ctx, EditMessage::new().attachments(EditAttachments::new_keep_all(&msg))).await?;
+        msg.edit(&ctx, EditMessage::new().attachments(EditAttachments::keep_all(&msg))).await?;
     } else if msg.content == "unifiedattachments" {
         let mut msg = channel_id.send_message(ctx, CreateMessage::new().content("works")).await?;
         msg.edit(ctx, EditMessage::new().content("works still")).await?;
@@ -73,8 +73,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         msg.edit(
             ctx,
             EditMessage::new().attachments(
-                EditAttachments::new_keep_all(&msg)
-                    .add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
+                EditAttachments::keep_all(&msg).add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
             ),
         )
         .await?;
@@ -242,7 +241,7 @@ async fn interaction(
             .edit_response(
                 &ctx,
                 EditInteractionResponse::new().attachments(
-                    EditAttachments::new_keep_all(&msg)
+                    EditAttachments::keep_all(&msg)
                         .add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
                 ),
             )

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -291,9 +291,8 @@ async fn interaction(
         interaction
             .edit_response(
                 ctx,
-                EditInteractionResponse::new().attachments(
-                    EditAttachments::new().add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
-                ),
+                EditInteractionResponse::new()
+                    .new_attachment(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
             )
             .await?;
 

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -5,6 +5,7 @@ use tokio::io::AsyncReadExt;
 #[cfg(feature = "http")]
 use url::Url;
 
+use crate::all::Message;
 #[cfg(feature = "http")]
 use crate::error::Error;
 use crate::error::Result;
@@ -12,61 +13,21 @@ use crate::error::Result;
 use crate::http::Http;
 use crate::model::id::AttachmentId;
 
-/// Enum that allows to add existing attachments and new attachments to the payload.
-#[derive(Clone, Debug, Serialize)]
-#[serde(untagged)]
-pub(crate) enum MessageAttachment {
-    Existing(ExistingAttachment),
-    New(NewAttachment),
-}
-
-/// [Discord docs] with the caveat at the top "For the attachments array in Message Create/Edit
-/// requests, only the id is required."
-///
-/// [Discord docs]: https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure
-#[derive(Clone, Debug, Serialize)]
-pub(crate) struct ExistingAttachment {
-    pub id: AttachmentId,
-    // TODO: add the other non-required attachment fields? Like content_type, description,
-    // ephemeral (ephemeral in particular seems pretty interesting)
-}
-
-/// Represents a new attachment in the payload, and allows for passing a description.
-#[derive(Clone, Debug, Serialize)]
-pub(crate) struct NewAttachment {
-    #[serde(rename = "id")]
-    pub index: u64,
-    pub filename: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-}
-
-impl MessageAttachment {
-    pub(crate) fn from_files(files: &[CreateAttachment]) -> Vec<Self> {
-        files
-            .iter()
-            .enumerate()
-            .map(|(i, file)| {
-                Self::New(NewAttachment {
-                    index: i as u64,
-                    filename: file.filename.clone(),
-                    description: file.description.clone(),
-                })
-            })
-            .collect()
-    }
-}
-
 /// Enum that allows a user to pass a [`Path`] or a [`File`] type to [`send_files`]
 ///
+/// [Discord docs](https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure).
+///
 /// [`send_files`]: crate::model::id::ChannelId::send_files
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 #[must_use]
 pub struct CreateAttachment {
-    pub data: Vec<u8>,
+    pub(crate) id: u64, // Placeholder ID will be filled in when sending the request
     pub filename: String,
     pub description: Option<String>,
+
+    #[serde(skip)]
+    pub data: Vec<u8>,
 }
 
 impl CreateAttachment {
@@ -76,6 +37,7 @@ impl CreateAttachment {
             data: data.into(),
             filename: filename.into(),
             description: None,
+            id: 0,
         }
     }
 
@@ -96,11 +58,7 @@ impl CreateAttachment {
             )
         })?;
 
-        Ok(CreateAttachment {
-            data,
-            filename: filename.to_string_lossy().to_string(),
-            description: None,
-        })
+        Ok(CreateAttachment::bytes(data, filename.to_string_lossy().to_string()))
     }
 
     /// Builds an [`CreateAttachment`] by reading from a file handler.
@@ -112,11 +70,7 @@ impl CreateAttachment {
         let mut data = Vec::new();
         file.try_clone().await?.read_to_end(&mut data).await?;
 
-        Ok(CreateAttachment {
-            data,
-            filename: filename.into(),
-            description: None,
-        })
+        Ok(CreateAttachment::bytes(data, filename))
     }
 
     /// Builds an [`CreateAttachment`] by downloading attachment data from a URL.
@@ -136,11 +90,7 @@ impl CreateAttachment {
             .and_then(Iterator::last)
             .ok_or_else(|| Error::Url(url.to_string()))?;
 
-        Ok(CreateAttachment {
-            data,
-            filename: filename.to_string(),
-            description: None,
-        })
+        Ok(CreateAttachment::bytes(data, filename))
     }
 
     /// Converts the stored data to the base64 representation.
@@ -157,8 +107,173 @@ impl CreateAttachment {
         encoded
     }
 
-    pub fn description(mut self, description: Option<String>) -> Self {
-        self.description = description;
+    /// Sets a description for the file (max 1024 characters).
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
         self
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct ExistingAttachment {
+    id: AttachmentId,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(untagged)]
+enum NewOrExisting {
+    New(CreateAttachment),
+    Existing(ExistingAttachment),
+}
+
+/// You can add new attachments and edit existing ones using this builder.
+///
+/// When this builder is _not_ supplied in a message edit, Discord keeps the attachments intact.
+/// However, as soon as a builder is supplied, Discord removes all attachments from the message.
+/// If you want to keep old attachments, you have to specify this for each attachment using
+/// [`Self.keep()`].
+///
+/// # Examples
+///
+/// ## Removing all attachments
+///
+/// ```rust,no_run
+/// # use serenity::all::*;
+/// # async fn _foo(ctx: Context, mut msg: Message) -> Result<(), Error> {
+/// msg.edit(ctx, EditMessage::new().attachments(EditAttachments::new())).await?;
+/// # Ok(()) }
+/// ```
+///
+/// ## Adding a new attachment without deleting existing attachments
+///
+/// ```rust,no_run
+/// # use serenity::all::*;
+/// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
+/// msg.edit(ctx, EditMessage::new().attachments(
+///     EditAttachments::new_keep_all(&msg).add(my_attachment)
+/// )).await?;
+/// # Ok(()) }
+/// ```
+///
+/// ## Delete all but the first attachment
+///
+/// ```rust,no_run
+/// # use serenity::all::*;
+/// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
+/// msg.edit(ctx, EditMessage::new().attachments(
+///     EditAttachments::new().keep(msg.attachments[0].id)
+/// )).await?;
+/// # Ok(()) }
+/// ```
+///
+/// ## Delete only the first attachment
+///
+/// ```rust,no_run
+/// # use serenity::all::*;
+/// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
+/// msg.edit(ctx, EditMessage::new().attachments(
+///     EditAttachments::new_keep_all(&msg).dont_keep(msg.attachments[0].id)
+/// )).await?;
+/// # Ok(()) }
+/// ```
+///
+/// # Notes
+///
+/// Internally, this type is used not just for message editing endpoints, but also for message
+/// creation endpoints.
+#[derive(Default, Debug, Clone, serde::Serialize)]
+#[serde(transparent)]
+#[must_use]
+pub struct EditAttachments {
+    new_and_existing_attachments: Vec<NewOrExisting>,
+}
+
+impl EditAttachments {
+    /// An empty attachments builder.
+    ///
+    /// Existing attachments are not kept by default, either. See [`Self::new_keep_all()`] or
+    /// [`Self::keep()`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new attachments builder that keeps all existing attachments.
+    ///
+    /// Shorthand for [`Self::new()`] and calling [`Self::keep()`] for every
+    /// [`AttachmentId`] in [`Message::attachments`].
+    ///
+    /// If you only want to keep a subset of attachments from the message, either implement this
+    /// method manually, or use [`Self::dont_keep()`].
+    ///
+    /// **Note: this EditAttachments must be run on the same message as is supplied here, or else
+    /// Discord will throw an error!**
+    pub fn new_keep_all(msg: &Message) -> Self {
+        Self {
+            new_and_existing_attachments: msg
+                .attachments
+                .iter()
+                .map(|a| {
+                    NewOrExisting::Existing(ExistingAttachment {
+                        id: a.id,
+                    })
+                })
+                .collect(),
+        }
+    }
+
+    /// This method adds an existing attachment to the list of attachments that are kept after
+    /// editing.
+    pub fn keep(mut self, id: AttachmentId) -> Self {
+        self.new_and_existing_attachments.push(NewOrExisting::Existing(ExistingAttachment {
+            id,
+        }));
+        self
+    }
+
+    /// This method removes an existing attachment from the list of attachments that are kept after
+    /// editing.
+    pub fn dont_keep(mut self, id: AttachmentId) -> Self {
+        #[allow(clippy::match_like_matches_macro)] // `matches!` is less clear here
+        self.new_and_existing_attachments.retain(|a| match a {
+            NewOrExisting::Existing(a) if a.id == id => false,
+            _ => true,
+        });
+        self
+    }
+
+    /// Adds a new attachment to the attachment list.
+    #[allow(clippy::should_implement_trait)] // Clippy thinks add == std::ops::Add::add
+    pub fn add(mut self, attachment: CreateAttachment) -> Self {
+        self.new_and_existing_attachments.push(NewOrExisting::New(attachment));
+        self
+    }
+
+    /// Clones all new attachments into a new Vec, keeping only data and filename, because those
+    /// are needed for the multipart form data. The data is taken out of `self` in the process, so
+    /// this method can only be called once.
+    pub(crate) fn take_files(&mut self) -> Vec<CreateAttachment> {
+        let mut id_placeholder = 0;
+
+        let mut files = Vec::new();
+        for attachment in &mut self.new_and_existing_attachments {
+            if let NewOrExisting::New(attachment) = attachment {
+                let mut cloned_attachment = CreateAttachment::bytes(
+                    std::mem::take(&mut attachment.data),
+                    attachment.filename.clone(),
+                );
+
+                // Assign placeholder IDs so Discord can match metadata to file contents
+                attachment.id = id_placeholder;
+                cloned_attachment.id = id_placeholder;
+                files.push(cloned_attachment);
+
+                id_placeholder += 1;
+            }
+        }
+        files
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.new_and_existing_attachments.is_empty()
     }
 }

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -199,8 +199,8 @@ impl EditAttachments {
 
     /// Creates a new attachments builder that keeps all existing attachments.
     ///
-    /// Shorthand for [`Self::new()`] and calling [`Self::keep()`] for every
-    /// [`AttachmentId`] in [`Message::attachments`].
+    /// Shorthand for [`Self::new()`] and calling [`Self::keep()`] for every [`AttachmentId`] in
+    /// [`Message::attachments`].
     ///
     /// If you only want to keep a subset of attachments from the message, either implement this
     /// method manually, or use [`Self::dont_keep()`].

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -139,7 +139,7 @@ enum NewOrExisting {
 ///
 /// ```rust,no_run
 /// # use serenity::all::*;
-/// # async fn _foo(ctx: Context, mut msg: Message) -> Result<(), Error> {
+/// # async fn _foo(ctx: Http, mut msg: Message) -> Result<(), Error> {
 /// msg.edit(ctx, EditMessage::new().attachments(EditAttachments::new())).await?;
 /// # Ok(()) }
 /// ```

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -148,7 +148,7 @@ enum NewOrExisting {
 ///
 /// ```rust,no_run
 /// # use serenity::all::*;
-/// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
+/// # async fn _foo(ctx: Http, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
 /// msg.edit(ctx, EditMessage::new().attachments(
 ///     EditAttachments::keep_all(&msg).add(my_attachment)
 /// )).await?;
@@ -159,7 +159,7 @@ enum NewOrExisting {
 ///
 /// ```rust,no_run
 /// # use serenity::all::*;
-/// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
+/// # async fn _foo(ctx: Http, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
 /// msg.edit(ctx, EditMessage::new().attachments(
 ///     EditAttachments::new().keep(msg.attachments[0].id)
 /// )).await?;
@@ -170,7 +170,7 @@ enum NewOrExisting {
 ///
 /// ```rust,no_run
 /// # use serenity::all::*;
-/// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
+/// # async fn _foo(ctx: Http, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
 /// msg.edit(ctx, EditMessage::new().attachments(
 ///     EditAttachments::keep_all(&msg).remove(msg.attachments[0].id)
 /// )).await?;

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -129,9 +129,9 @@ enum NewOrExisting {
 /// You can add new attachments and edit existing ones using this builder.
 ///
 /// When this builder is _not_ supplied in a message edit, Discord keeps the attachments intact.
-/// However, as soon as a builder is supplied, Discord removes all attachments from the message.
-/// If you want to keep old attachments, you have to specify this for each attachment using
-/// [`Self.keep()`].
+/// However, as soon as a builder is supplied, Discord removes all attachments from the message. If
+/// you want to keep old attachments, you must specify this either using [`Self::keep_all`], or
+/// individually for each attachment using [`Self::keep`].
 ///
 /// # Examples
 ///

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -172,7 +172,7 @@ enum NewOrExisting {
 /// # use serenity::all::*;
 /// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
 /// msg.edit(ctx, EditMessage::new().attachments(
-///     EditAttachments::keep_all(&msg).dont_keep(msg.attachments[0].id)
+///     EditAttachments::keep_all(&msg).remove(msg.attachments[0].id)
 /// )).await?;
 /// # Ok(()) }
 /// ```
@@ -203,7 +203,7 @@ impl EditAttachments {
     /// [`Message::attachments`].
     ///
     /// If you only want to keep a subset of attachments from the message, either implement this
-    /// method manually, or use [`Self::dont_keep()`].
+    /// method manually, or use [`Self::remove()`].
     ///
     /// **Note: this EditAttachments must be run on the same message as is supplied here, or else
     /// Discord will throw an error!**
@@ -223,6 +223,8 @@ impl EditAttachments {
 
     /// This method adds an existing attachment to the list of attachments that are kept after
     /// editing.
+    ///
+    /// Opposite of [`Self::remove`].
     pub fn keep(mut self, id: AttachmentId) -> Self {
         self.new_and_existing_attachments.push(NewOrExisting::Existing(ExistingAttachment {
             id,
@@ -232,7 +234,9 @@ impl EditAttachments {
 
     /// This method removes an existing attachment from the list of attachments that are kept after
     /// editing.
-    pub fn dont_keep(mut self, id: AttachmentId) -> Self {
+    ///
+    /// Opposite of [`Self::keep`].
+    pub fn remove(mut self, id: AttachmentId) -> Self {
         #[allow(clippy::match_like_matches_macro)] // `matches!` is less clear here
         self.new_and_existing_attachments.retain(|a| match a {
             NewOrExisting::Existing(a) if a.id == id => false,

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -150,7 +150,7 @@ enum NewOrExisting {
 /// # use serenity::all::*;
 /// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
 /// msg.edit(ctx, EditMessage::new().attachments(
-///     EditAttachments::new_keep_all(&msg).add(my_attachment)
+///     EditAttachments::keep_all(&msg).add(my_attachment)
 /// )).await?;
 /// # Ok(()) }
 /// ```
@@ -172,7 +172,7 @@ enum NewOrExisting {
 /// # use serenity::all::*;
 /// # async fn _foo(ctx: Context, mut msg: Message, my_attachment: CreateAttachment) -> Result<(), Error> {
 /// msg.edit(ctx, EditMessage::new().attachments(
-///     EditAttachments::new_keep_all(&msg).dont_keep(msg.attachments[0].id)
+///     EditAttachments::keep_all(&msg).dont_keep(msg.attachments[0].id)
 /// )).await?;
 /// # Ok(()) }
 /// ```
@@ -191,7 +191,7 @@ pub struct EditAttachments {
 impl EditAttachments {
     /// An empty attachments builder.
     ///
-    /// Existing attachments are not kept by default, either. See [`Self::new_keep_all()`] or
+    /// Existing attachments are not kept by default, either. See [`Self::keep_all()`] or
     /// [`Self::keep()`].
     pub fn new() -> Self {
         Self::default()
@@ -207,7 +207,7 @@ impl EditAttachments {
     ///
     /// **Note: this EditAttachments must be run on the same message as is supplied here, or else
     /// Discord will throw an error!**
-    pub fn new_keep_all(msg: &Message) -> Self {
+    pub fn keep_all(msg: &Message) -> Self {
         Self {
             new_and_existing_attachments: msg
                 .attachments

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -277,6 +277,7 @@ impl EditAttachments {
         files
     }
 
+    #[cfg(feature = "cache")]
     pub(crate) fn is_empty(&self) -> bool {
         self.new_and_existing_attachments.is_empty()
     }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -140,7 +140,7 @@ impl Builder for CreateInteractionResponse {
             | CreateInteractionResponse::Defer(msg)
             | CreateInteractionResponse::UpdateMessage(msg) => {
                 let files = std::mem::take(&mut msg.files);
-                msg.attachments.extend(ExistingAttachment::from_files(&files));
+                msg.attachments.extend(MessageAttachment::from_files(&files));
                 files
             },
             _ => Vec::new(),
@@ -167,7 +167,7 @@ pub struct CreateInteractionResponseMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<ExistingAttachment>,
+    attachments: Vec<MessageAttachment>,
 
     #[serde(skip)]
     files: Vec<CreateAttachment>,

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -33,7 +33,7 @@ pub struct CreateInteractionResponseFollowup {
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<ExistingAttachment>,
+    attachments: Vec<MessageAttachment>,
 
     #[serde(skip)]
     files: Vec<CreateAttachment>,
@@ -188,7 +188,7 @@ impl Builder for CreateInteractionResponseFollowup {
         self.check_length()?;
 
         let files = std::mem::take(&mut self.files);
-        self.attachments.extend(ExistingAttachment::from_files(&files));
+        self.attachments.extend(MessageAttachment::from_files(&files));
 
         let http = cache_http.http();
         match ctx.0 {

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "http")]
 use super::{check_overflow, Builder};
-use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
+use super::{
+    CreateActionRow,
+    CreateAllowedMentions,
+    CreateAttachment,
+    CreateEmbed,
+    ExistingAttachment,
+};
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
@@ -26,6 +32,8 @@ pub struct CreateInteractionResponseFollowup {
     components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attachments: Vec<ExistingAttachment>,
 
     #[serde(skip)]
     files: Vec<CreateAttachment>,
@@ -178,7 +186,9 @@ impl Builder for CreateInteractionResponseFollowup {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         self.check_length()?;
+
         let files = std::mem::take(&mut self.files);
+        self.attachments.extend(ExistingAttachment::from_files(&files));
 
         let http = cache_http.http();
         match ctx.0 {

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    MessageAttachment,
+    EditAttachments,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -32,11 +32,7 @@ pub struct CreateInteractionResponseFollowup {
     components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<MessageAttachment>,
-
-    #[serde(skip)]
-    files: Vec<CreateAttachment>,
+    attachments: EditAttachments,
 }
 
 impl CreateInteractionResponseFollowup {
@@ -81,13 +77,16 @@ impl CreateInteractionResponseFollowup {
     }
 
     /// Appends a file to the message.
-    pub fn add_file(self, file: CreateAttachment) -> Self {
-        self.add_files(vec![file])
+    pub fn add_file(mut self, file: CreateAttachment) -> Self {
+        self.attachments = self.attachments.add(file);
+        self
     }
 
     /// Appends a list of files to the message.
     pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
-        self.files.extend(files);
+        for file in files {
+            self.attachments = self.attachments.add(file);
+        }
         self
     }
 
@@ -96,8 +95,8 @@ impl CreateInteractionResponseFollowup {
     /// Calling this multiple times will overwrite the file list. To append files, call
     /// [`Self::add_file`] or [`Self::add_files`] instead.
     pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
-        self.files = files.into_iter().collect();
-        self
+        self.attachments = EditAttachments::new();
+        self.add_files(files)
     }
 
     /// Adds an embed to the message.
@@ -187,8 +186,7 @@ impl Builder for CreateInteractionResponseFollowup {
     ) -> Result<Self::Built> {
         self.check_length()?;
 
-        let files = std::mem::take(&mut self.files);
-        self.attachments.extend(MessageAttachment::from_files(&files));
+        let files = self.attachments.take_files();
 
         let http = cache_http.http();
         match ctx.0 {

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "http")]
 use super::{check_overflow, Builder};
-use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
+use super::{
+    CreateActionRow,
+    CreateAllowedMentions,
+    CreateAttachment,
+    CreateEmbed,
+    ExistingAttachment,
+};
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
@@ -61,6 +67,8 @@ pub struct CreateMessage {
     sticker_ids: Vec<StickerId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attachments: Vec<ExistingAttachment>,
 
     // The following fields are handled separately.
     #[serde(skip)]
@@ -322,7 +330,9 @@ impl Builder for CreateMessage {
         self.check_length()?;
 
         let http = cache_http.http();
+
         let files = std::mem::take(&mut self.files);
+        self.attachments.extend(ExistingAttachment::from_files(&files));
 
         #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut message = http.send_message(channel_id, files, &self).await?;

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -68,7 +68,7 @@ pub struct CreateMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<ExistingAttachment>,
+    attachments: Vec<MessageAttachment>,
 
     // The following fields are handled separately.
     #[serde(skip)]
@@ -332,7 +332,7 @@ impl Builder for CreateMessage {
         let http = cache_http.http();
 
         let files = std::mem::take(&mut self.files);
-        self.attachments.extend(ExistingAttachment::from_files(&files));
+        self.attachments.extend(MessageAttachment::from_files(&files));
 
         #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut message = http.send_message(channel_id, files, &self).await?;

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    MessageAttachment,
+    EditAttachments,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -67,12 +67,9 @@ pub struct CreateMessage {
     sticker_ids: Vec<StickerId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<MessageAttachment>,
+    attachments: EditAttachments,
 
     // The following fields are handled separately.
-    #[serde(skip)]
-    files: Vec<CreateAttachment>,
     #[serde(skip)]
     reactions: Vec<ReactionType>,
 }
@@ -171,7 +168,7 @@ impl CreateMessage {
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
     pub fn add_file(mut self, file: CreateAttachment) -> Self {
-        self.files.push(file);
+        self.attachments = self.attachments.add(file);
         self
     }
 
@@ -181,7 +178,9 @@ impl CreateMessage {
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
     pub fn add_files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
-        self.files.extend(files);
+        for file in files {
+            self.attachments = self.attachments.add(file);
+        }
         self
     }
 
@@ -194,8 +193,8 @@ impl CreateMessage {
     ///
     /// [Attach Files]: Permissions::ATTACH_FILES
     pub fn files(mut self, files: impl IntoIterator<Item = CreateAttachment>) -> Self {
-        self.files = files.into_iter().collect();
-        self
+        self.attachments = EditAttachments::new();
+        self.add_files(files)
     }
 
     /// Set the allowed mentions for the message.
@@ -319,7 +318,7 @@ impl Builder for CreateMessage {
         #[cfg(feature = "cache")]
         {
             let mut req = Permissions::SEND_MESSAGES;
-            if !self.files.is_empty() {
+            if !self.attachments.is_empty() {
                 req |= Permissions::ATTACH_FILES;
             }
             if let Some(cache) = cache_http.cache() {
@@ -331,8 +330,7 @@ impl Builder for CreateMessage {
 
         let http = cache_http.http();
 
-        let files = std::mem::take(&mut self.files);
-        self.attachments.extend(MessageAttachment::from_files(&files));
+        let files = self.attachments.take_files();
 
         #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut message = http.send_message(channel_id, files, &self).await?;

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -94,9 +94,8 @@ impl EditInteractionResponse {
         Self(self.0.keep_existing_attachment(id))
     }
 
-    /// Shorthand for [`Self::attachments`] with [`EditAttachments::new`]
+    /// Shorthand for calling [`Self::attachments`] with [`EditAttachments::new`].
     pub fn clear_attachments(self) -> Self {
-        #[allow(deprecated)]
         Self(self.0.clear_attachments())
     }
 }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -83,10 +83,8 @@ impl EditInteractionResponse {
 
     /// Adds a new attachment to the message.
     ///
-    /// Resets existing attachments. See [`Self::keep_existing_attachment`] or read
-    /// [`EditAttachments`] for explanation.
+    /// Resets existing attachments. See the documentation for [`EditAttachments`] for details.
     pub fn new_attachment(self, attachment: CreateAttachment) -> Self {
-        #[allow(deprecated)]
         Self(self.0.new_attachment(attachment))
     }
 

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -6,6 +6,7 @@ use super::{
     CreateAttachment,
     CreateEmbed,
     EditWebhookMessage,
+    ExistingAttachment,
 };
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -126,7 +127,15 @@ impl Builder for EditInteractionResponse {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         self.0.check_length()?;
+
         let files = std::mem::take(&mut self.0.files);
+        if !files.is_empty() {
+            self.0
+                .attachments
+                .get_or_insert(Vec::new())
+                .extend(ExistingAttachment::from_files(&files));
+        }
+
         cache_http.http().edit_original_interaction_response(ctx, &self, files).await
     }
 }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -88,9 +88,8 @@ impl EditInteractionResponse {
         Self(self.0.new_attachment(attachment))
     }
 
-    /// Shorthand for [`EditAttachments::keep`]
+    /// Shorthand for [`EditAttachments::keep`].
     pub fn keep_existing_attachment(self, id: AttachmentId) -> Self {
-        #[allow(deprecated)]
         Self(self.0.keep_existing_attachment(id))
     }
 

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -6,7 +6,7 @@ use super::{
     CreateAttachment,
     CreateEmbed,
     EditWebhookMessage,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -133,7 +133,7 @@ impl Builder for EditInteractionResponse {
             self.0
                 .attachments
                 .get_or_insert(Vec::new())
-                .extend(ExistingAttachment::from_files(&files));
+                .extend(MessageAttachment::from_files(&files));
         }
 
         cache_http.http().edit_original_interaction_response(ctx, &self, files).await

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -81,22 +81,25 @@ impl EditInteractionResponse {
         Self(self.0.attachments(attachments))
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
+    /// Adds a new attachment to the message.
+    ///
+    /// Resets existing attachments. See [`Self::keep_existing_attachment`] or read
+    /// [`EditAttachments`] for explanation.
     pub fn new_attachment(self, attachment: CreateAttachment) -> Self {
         #[allow(deprecated)]
         Self(self.0.new_attachment(attachment))
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
+    /// Shorthand for [`EditAttachments::keep`]
     pub fn keep_existing_attachment(self, id: AttachmentId) -> Self {
         #[allow(deprecated)]
         Self(self.0.keep_existing_attachment(id))
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
-    pub fn clear_existing_attachments(self) -> Self {
+    /// Shorthand for [`Self::attachments`] with [`EditAttachments::new`]
+    pub fn clear_attachments(self) -> Self {
         #[allow(deprecated)]
-        Self(self.0.clear_existing_attachments())
+        Self(self.0.clear_attachments())
     }
 }
 

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -241,7 +241,7 @@ impl Builder for EditMessage {
     ///
     /// **Note**: If any embeds or attachments are set, they will overwrite the existing contents
     /// of the message, deleting existing embeds and attachments. Preserving them requires calling
-    /// [`Self::add_existing_attachment`] in the case of attachments. In the case of embeds,
+    /// [`Self::keep_existing_attachment`] in the case of attachments. In the case of embeds,
     /// duplicate copies of the existing embeds must be sent. Luckily, [`CreateEmbed`] implements
     /// [`From<Embed>`], so one can simply call `embed.into()`.
     ///

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -210,7 +210,7 @@ impl EditMessage {
     #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
     pub fn remove_existing_attachment(mut self, id: AttachmentId) -> Self {
         if let Some(attachments) = self.attachments {
-            self.attachments = Some(attachments.dont_keep(id));
+            self.attachments = Some(attachments.remove(id));
         }
         self
     }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -193,21 +193,24 @@ impl EditMessage {
         self
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
+    /// Adds a new attachment to the message.
+    ///
+    /// Resets existing attachments. See [`Self::keep_existing_attachment`] or read
+    /// [`EditAttachments`] for explanation.
     pub fn attachment(mut self, attachment: CreateAttachment) -> Self {
         let attachments = self.attachments.get_or_insert_with(Default::default);
         self.attachments = Some(std::mem::take(attachments).add(attachment));
         self
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
+    /// Shorthand for [`EditAttachments::keep`]
     pub fn add_existing_attachment(mut self, id: AttachmentId) -> Self {
         let attachments = self.attachments.get_or_insert_with(Default::default);
         self.attachments = Some(std::mem::take(attachments).keep(id));
         self
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
+    /// Shorthand for [`EditAttachments::remove`]
     pub fn remove_existing_attachment(mut self, id: AttachmentId) -> Self {
         if let Some(attachments) = self.attachments {
             self.attachments = Some(attachments.remove(id));
@@ -215,7 +218,7 @@ impl EditMessage {
         self
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
+    /// Shorthand for [`Self::attachments`] with [`EditAttachments::new`]
     pub fn remove_all_attachments(mut self) -> Self {
         self.attachments = Some(EditAttachments::new());
         self

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -195,22 +195,21 @@ impl EditMessage {
 
     /// Adds a new attachment to the message.
     ///
-    /// Resets existing attachments. See [`Self::keep_existing_attachment`] or read
-    /// [`EditAttachments`] for explanation.
-    pub fn attachment(mut self, attachment: CreateAttachment) -> Self {
+    /// Resets existing attachments. See the documentation for [`EditAttachments`] for details.
+    pub fn new_attachment(mut self, attachment: CreateAttachment) -> Self {
         let attachments = self.attachments.get_or_insert_with(Default::default);
         self.attachments = Some(std::mem::take(attachments).add(attachment));
         self
     }
 
-    /// Shorthand for [`EditAttachments::keep`]
-    pub fn add_existing_attachment(mut self, id: AttachmentId) -> Self {
+    /// Shorthand for [`EditAttachments::keep`].
+    pub fn keep_existing_attachment(mut self, id: AttachmentId) -> Self {
         let attachments = self.attachments.get_or_insert_with(Default::default);
         self.attachments = Some(std::mem::take(attachments).keep(id));
         self
     }
 
-    /// Shorthand for [`EditAttachments::remove`]
+    /// Shorthand for [`EditAttachments::remove`].
     pub fn remove_existing_attachment(mut self, id: AttachmentId) -> Self {
         if let Some(attachments) = self.attachments {
             self.attachments = Some(attachments.remove(id));
@@ -218,7 +217,7 @@ impl EditMessage {
         self
     }
 
-    /// Shorthand for [`Self::attachments`] with [`EditAttachments::new`]
+    /// Shorthand for calling [`Self::attachments`] with [`EditAttachments::new`].
     pub fn remove_all_attachments(mut self) -> Self {
         self.attachments = Some(EditAttachments::new());
         self

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -139,22 +139,21 @@ impl EditWebhookMessage {
 
     /// Adds a new attachment to the message.
     ///
-    /// Resets existing attachments. See [`Self::keep_existing_attachment`] or read
-    /// [`EditAttachments`] for explanation.
+    /// Resets existing attachments. See the documentation for [`EditAttachments`] for details.
     pub fn new_attachment(mut self, attachment: CreateAttachment) -> Self {
         let attachments = self.attachments.get_or_insert_with(Default::default);
         self.attachments = Some(std::mem::take(attachments).add(attachment));
         self
     }
 
-    /// Shorthand for [`EditAttachments::keep`]
+    /// Shorthand for [`EditAttachments::keep`].
     pub fn keep_existing_attachment(mut self, id: AttachmentId) -> Self {
         let attachments = self.attachments.get_or_insert_with(Default::default);
         self.attachments = Some(std::mem::take(attachments).keep(id));
         self
     }
 
-    /// Shorthand for [`Self::attachments`] with [`EditAttachments::new`]
+    /// Shorthand for calling [`Self::attachments`] with [`EditAttachments::new`].
     pub fn clear_attachments(mut self) -> Self {
         self.attachments = Some(EditAttachments::new());
         self

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -5,8 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
-    MessageAttachment,
+    EditAttachments,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -31,12 +30,10 @@ pub struct EditWebhookMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) attachments: Option<Vec<MessageAttachment>>,
+    pub(crate) attachments: Option<EditAttachments>,
 
     #[serde(skip)]
     thread_id: Option<ChannelId>,
-    #[serde(skip)]
-    pub(crate) files: Vec<CreateAttachment>,
 }
 
 impl EditWebhookMessage {
@@ -134,35 +131,29 @@ impl EditWebhookMessage {
     }
     super::button_and_select_menu_convenience_methods!(self.components);
 
-    /// Add a new attachment for the message.
-    ///
-    /// This can be called multiple times.
-    ///
-    /// If this is called one or more times, existing attachments will reset. To keep them, provide
-    /// their IDs to [`Self::keep_existing_attachment`].
+    /// Sets attachments, see [`EditAttachments`] for more details.
+    pub fn attachments(mut self, attachments: EditAttachments) -> Self {
+        self.attachments = Some(attachments);
+        self
+    }
+
+    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
     pub fn new_attachment(mut self, attachment: CreateAttachment) -> Self {
-        self.files.push(attachment);
+        let attachments = self.attachments.get_or_insert_with(Default::default);
+        self.attachments = Some(std::mem::take(attachments).add(attachment));
         self
     }
 
-    /// Keeps an existing attachment by id.
-    ///
-    /// To be used after [`Self::new_attachment`] or [`Self::clear_existing_attachments`].
+    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
     pub fn keep_existing_attachment(mut self, id: AttachmentId) -> Self {
-        self.attachments.get_or_insert_with(Vec::new).push(MessageAttachment::Existing(
-            ExistingAttachment {
-                id,
-            },
-        ));
+        let attachments = self.attachments.get_or_insert_with(Default::default);
+        self.attachments = Some(std::mem::take(attachments).keep(id));
         self
     }
 
-    /// Clears existing attachments.
-    ///
-    /// In combination with [`Self::keep_existing_attachment`], this can be used to selectively
-    /// keep only some existing attachments.
+    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
     pub fn clear_existing_attachments(mut self) -> Self {
-        self.attachments = Some(Vec::new());
+        self.attachments = Some(EditAttachments::new());
         self
     }
 }
@@ -193,12 +184,7 @@ impl Builder for EditWebhookMessage {
     ) -> Result<Self::Built> {
         self.check_length()?;
 
-        let files = std::mem::take(&mut self.files);
-        if !files.is_empty() {
-            self.attachments
-                .get_or_insert(Vec::new())
-                .extend(MessageAttachment::from_files(&files));
-        }
+        let files = self.attachments.as_mut().map_or(Vec::new(), |a| a.take_files());
 
         cache_http
             .http()

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -137,22 +137,25 @@ impl EditWebhookMessage {
         self
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
+    /// Adds a new attachment to the message.
+    ///
+    /// Resets existing attachments. See [`Self::keep_existing_attachment`] or read
+    /// [`EditAttachments`] for explanation.
     pub fn new_attachment(mut self, attachment: CreateAttachment) -> Self {
         let attachments = self.attachments.get_or_insert_with(Default::default);
         self.attachments = Some(std::mem::take(attachments).add(attachment));
         self
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
+    /// Shorthand for [`EditAttachments::keep`]
     pub fn keep_existing_attachment(mut self, id: AttachmentId) -> Self {
         let attachments = self.attachments.get_or_insert_with(Default::default);
         self.attachments = Some(std::mem::take(attachments).keep(id));
         self
     }
 
-    #[deprecated(since = "0.12.0", note = "use `.attachments(...)` for new code")]
-    pub fn clear_existing_attachments(mut self) -> Self {
+    /// Shorthand for [`Self::attachments`] with [`EditAttachments::new`]
+    pub fn clear_attachments(mut self) -> Self {
         self.attachments = Some(EditAttachments::new());
         self
     }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -6,6 +6,7 @@ use super::{
     CreateAttachment,
     CreateEmbed,
     ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -30,7 +31,7 @@ pub struct EditWebhookMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) attachments: Option<Vec<ExistingAttachment>>,
+    pub(crate) attachments: Option<Vec<MessageAttachment>>,
 
     #[serde(skip)]
     thread_id: Option<ChannelId>,
@@ -148,12 +149,11 @@ impl EditWebhookMessage {
     ///
     /// To be used after [`Self::new_attachment`] or [`Self::clear_existing_attachments`].
     pub fn keep_existing_attachment(mut self, id: AttachmentId) -> Self {
-        self.attachments.get_or_insert_with(Vec::new).push(ExistingAttachment {
-            id: id.get(),
-            // TODO: can this be edited? if so, users should be able to set these fields.
-            filename: None,
-            description: None,
-        });
+        self.attachments.get_or_insert_with(Vec::new).push(MessageAttachment::Existing(
+            ExistingAttachment {
+                id,
+            },
+        ));
         self
     }
 
@@ -197,7 +197,7 @@ impl Builder for EditWebhookMessage {
         if !files.is_empty() {
             self.attachments
                 .get_or_insert(Vec::new())
-                .extend(ExistingAttachment::from_files(&files));
+                .extend(MessageAttachment::from_files(&files));
         }
 
         cache_http

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -5,7 +5,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
-    ExistingAttachment,
+    MessageAttachment,
 };
 #[cfg(feature = "http")]
 use crate::constants;
@@ -76,7 +76,7 @@ pub struct ExecuteWebhook {
     #[serde(skip_serializing_if = "Option::is_none")]
     thread_name: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<ExistingAttachment>,
+    attachments: Vec<MessageAttachment>,
 
     #[serde(skip)]
     thread_id: Option<ChannelId>,
@@ -362,7 +362,7 @@ impl Builder for ExecuteWebhook {
         self.check_length()?;
 
         let files = std::mem::take(&mut self.files);
-        self.attachments.extend(ExistingAttachment::from_files(&files));
+        self.attachments.extend(MessageAttachment::from_files(&files));
 
         cache_http.http().execute_webhook(ctx.0, self.thread_id, ctx.1, ctx.2, files, &self).await
     }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "http")]
 use super::{check_overflow, Builder};
-use super::{CreateActionRow, CreateAllowedMentions, CreateAttachment, CreateEmbed};
+use super::{
+    CreateActionRow,
+    CreateAllowedMentions,
+    CreateAttachment,
+    CreateEmbed,
+    ExistingAttachment,
+};
 #[cfg(feature = "http")]
 use crate::constants;
 #[cfg(feature = "http")]
@@ -69,6 +75,8 @@ pub struct ExecuteWebhook {
     flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     thread_name: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attachments: Vec<ExistingAttachment>,
 
     #[serde(skip)]
     thread_id: Option<ChannelId>,
@@ -352,7 +360,10 @@ impl Builder for ExecuteWebhook {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         self.check_length()?;
+
         let files = std::mem::take(&mut self.files);
+        self.attachments.extend(ExistingAttachment::from_files(&files));
+
         cache_http.http().execute_webhook(ctx.0, self.thread_id, ctx.1, ctx.2, files, &self).await
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -26,6 +26,7 @@ use super::{
     HttpError,
     LightMethod,
     MessagePagination,
+    MultipartUpload,
     UserPagination,
 };
 use crate::builder::CreateAttachment;
@@ -489,8 +490,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                attachment_files: Some(files.into_iter().map(Into::into).collect()),
-                upload_file: None,
+                upload: MultipartUpload::Attachments(files.into_iter().map(Into::into).collect()),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -690,8 +690,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                attachment_files: Some(files.into_iter().map(Into::into).collect()),
-                upload_file: None,
+                upload: MultipartUpload::Attachments(files.into_iter().map(Into::into).collect()),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -861,8 +860,7 @@ impl Http {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
-                attachment_files: None,
-                upload_file: Some(file),
+                upload: MultipartUpload::File(file),
                 fields: map.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
                 payload_json: None,
             }),
@@ -1525,8 +1523,9 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                attachment_files: Some(new_attachments.into_iter().map(Into::into).collect()),
-                upload_file: None,
+                upload: MultipartUpload::Attachments(
+                    new_attachments.into_iter().map(Into::into).collect(),
+                ),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -1814,8 +1813,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                attachment_files: Some(new_attachments),
-                upload_file: None,
+                upload: MultipartUpload::Attachments(new_attachments),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -1961,8 +1959,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                attachment_files: Some(new_attachments.into_iter().collect()),
-                upload_file: None,
+                upload: MultipartUpload::Attachments(new_attachments.into_iter().collect()),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -2415,8 +2412,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                attachment_files: Some(files.into_iter().collect()),
-                upload_file: None,
+                upload: MultipartUpload::Attachments(files.into_iter().collect()),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -2481,8 +2477,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                attachment_files: Some(new_attachments),
-                upload_file: None,
+                upload: MultipartUpload::Attachments(new_attachments),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -4224,8 +4219,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                attachment_files: Some(files.into_iter().collect()),
-                upload_file: None,
+                upload: MultipartUpload::Attachments(files.into_iter().collect()),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -15,7 +15,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::de::DeserializeOwned;
 use tracing::{debug, instrument, trace};
 
-use super::multipart::Multipart;
+use super::multipart::{Multipart, MultipartUpload};
 use super::ratelimiting::Ratelimiter;
 use super::request::Request;
 use super::routing::Route;
@@ -26,7 +26,6 @@ use super::{
     HttpError,
     LightMethod,
     MessagePagination,
-    MultipartUpload,
     UserPagination,
 };
 use crate::builder::CreateAttachment;
@@ -490,7 +489,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                upload: MultipartUpload::Attachments(files.into_iter().map(Into::into).collect()),
+                upload: MultipartUpload::Attachments(files),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -690,7 +689,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                upload: MultipartUpload::Attachments(files.into_iter().map(Into::into).collect()),
+                upload: MultipartUpload::Attachments(files),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -1523,9 +1522,7 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                upload: MultipartUpload::Attachments(
-                    new_attachments.into_iter().map(Into::into).collect(),
-                ),
+                upload: MultipartUpload::Attachments(new_attachments),
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -489,7 +489,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: files.into_iter().map(Into::into).collect(),
+                attachment_files: Some(files.into_iter().map(Into::into).collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -689,7 +690,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: files.into_iter().map(Into::into).collect(),
+                attachment_files: Some(files.into_iter().map(Into::into).collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -859,7 +861,8 @@ impl Http {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
-                files: vec![file],
+                attachment_files: None,
+                upload_file: Some(file),
                 fields: map.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
                 payload_json: None,
             }),
@@ -1522,7 +1525,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: new_attachments.into_iter().map(Into::into).collect(),
+                attachment_files: Some(new_attachments.into_iter().map(Into::into).collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -1810,7 +1814,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: new_attachments,
+                attachment_files: Some(new_attachments),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -1956,7 +1961,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: new_attachments.into_iter().collect(),
+                attachment_files: Some(new_attachments.into_iter().collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -2409,7 +2415,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: files.into_iter().collect(),
+                attachment_files: Some(files.into_iter().collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -2474,7 +2481,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: new_attachments,
+                attachment_files: Some(new_attachments),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });
@@ -4216,7 +4224,8 @@ impl Http {
             request.body = Some(to_vec(map)?);
         } else {
             request.multipart = Some(Multipart {
-                files: files.into_iter().collect(),
+                attachment_files: Some(files.into_iter().collect()),
+                upload_file: None,
                 payload_json: Some(to_string(map)?),
                 fields: vec![],
             });

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -22,8 +22,8 @@ pub enum MultipartUpload {
     Attachments(Vec<CreateAttachment>),
 }
 
-/// Holder for multipart body. Contains upload data, multipart fields, and payload_json for creating
-/// requests with attachments.
+/// Holder for multipart body. Contains upload data, multipart fields, and payload_json for
+/// creating requests with attachments.
 #[derive(Clone, Debug)]
 pub struct Multipart {
     pub upload: MultipartUpload,

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -22,7 +22,7 @@ pub enum MultipartUpload {
     Attachments(Vec<CreateAttachment>),
 }
 
-/// Holder for multipart body. Contains files, multipart fields, and payload_json for creating
+/// Holder for multipart body. Contains upload data, multipart fields, and payload_json for creating
 /// requests with attachments.
 #[derive(Clone, Debug)]
 pub struct Multipart {


### PR DESCRIPTION
Summary: support attachment description, replace ad-hoc attachment edit methods with designated EditAttachments builder

Based on #2570

CreateAttachment is now Serialize and can be used for the `attachments` field directly, eliminating the extra `files` fields.

Attachment handling is now centralized in EditAttachments. This removes redundancy in serenity code and makes it more maintainable. Also, by modifying attachments through EditAttachments instead of ad-hoc methods on the builder itself, the side effects of adding attachments can now be documented much more clearly, as well as mirroring those side effects in the builder syntax (also see https://github.com/serenity-rs/serenity/pull/2570#discussion_r1373236965). The old ad-hoc methods are kept for backwards-compatibility, but marked deprecated
