### PR TITLE
Remove `PingInteraction::guild_locale` field

### DIFF
--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -82,7 +82,7 @@ impl Interaction {
     #[must_use]
     pub fn guild_locale(&self) -> Option<&str> {
         match self {
-            Self::Ping(i) => i.guild_locale.as_deref(),
+            Self::Ping(_) => None,
             Self::Command(i) | Self::Autocomplete(i) => i.guild_locale.as_deref(),
             Self::Component(i) => i.guild_locale.as_deref(),
             Self::Modal(i) => i.guild_locale.as_deref(),

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -16,6 +16,4 @@ pub struct PingInteraction {
     pub token: String,
     /// Always `1`.
     pub version: u8,
-    /// The guild's preferred locale.
-    pub guild_locale: Option<String>,
 }


### PR DESCRIPTION
All `PING` interactions only happen when verifying an interaction endpoint (see [docs](https://discord.com/developers/docs/tutorials/upgrading-to-application-commands#adding-an-interactions-endpoint-url)). Since `PING` interactions don't happen in a guild, they don't have an associated `guild_id` field. Therefore, it makes no sense to also include a `guild_locale` field. Most likely, this field has always been `None`.