### PR TITLE
fix faulty checks in `suppress_embeds`

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -796,16 +796,18 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                utils::user_has_perms_cache(
-                    cache,
-                    self.channel_id,
-                    self.guild_id,
-                    Permissions::MANAGE_MESSAGES,
-                )?;
-
-                if self.author.id != cache.current_user_id() {
-                    return Err(Error::Model(ModelError::NotAuthor));
-                }
+                if let Err(Error::Model(ModelError::InvalidPermissions(..))) =
+                    utils::user_has_perms_cache(
+                        cache,
+                        self.channel_id,
+                        self.guild_id,
+                        Permissions::MANAGE_MESSAGES,
+                    )
+                {
+                    if self.author.id != cache.current_user_id() {
+                        return Err(Error::Model(ModelError::NotAuthor));
+                    }
+                };
             }
         }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -796,18 +796,14 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Err(Error::Model(ModelError::InvalidPermissions(..))) =
+                if self.author.id != cache.current_user_id() {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
                         self.guild_id,
                         Permissions::MANAGE_MESSAGES,
-                    )
-                {
-                    if self.author.id != cache.current_user_id() {
-                        return Err(Error::Model(ModelError::NotAuthor));
-                    }
-                };
+                    )?;
+                }
             }
         }
 


### PR DESCRIPTION
the previous implementation would return a `NotAuthor` error after trying to use `suppress_embeds` on a message sent by a different user, even if the current user has Manage Messages perm.