### PR TITLE
Move sending shard shutdown messages into the global shutdown lock

### DIFF
--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -277,10 +277,12 @@ impl ShardManager {
 
         info!("Shutting down shard {}", shard_id);
 
-        drop(self.shard_queuer.unbounded_send(ShardQueuerMessage::ShutdownShard(shard_id, code)));
-
         {
             let mut shard_shutdown = self.shard_shutdown.lock().await;
+
+            drop(
+                self.shard_queuer.unbounded_send(ShardQueuerMessage::ShutdownShard(shard_id, code)),
+            );
             match timeout(TIMEOUT, shard_shutdown.next()).await {
                 Ok(Some(shutdown_shard_id)) => {
                     if shutdown_shard_id != shard_id {


### PR DESCRIPTION
Should fix a race condition that shows something like "Failed to cleanly shutdown shard N: Shutdown channel sent incorrect ID"

@GnomedDev 