### PR TITLE
Add `reply_builder` function

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -5,6 +5,7 @@ use std::fmt::Display;
 #[cfg(all(feature = "cache", feature = "model"))]
 use std::fmt::Write;
 
+#[cfg(feature = "model")]
 use crate::builder::CreateMessage;
 #[cfg(all(feature = "model", feature = "utils"))]
 use crate::builder::{CreateEmbed, EditMessage};


### PR DESCRIPTION
I added a `reply_builder` function, that acts in a similar way to [`send_message`](https://github.com/serenity-rs/serenity/blob/current/src/model/channel/guild_channel.rs#L1040).
It is meant to make replying with embeds, files & other things that you would need a builder for, easier.

Please don't mind the 3 commits! My terminal/installation of git didn't properly accept the backtick character, so I had to do some fixing.