### PR TITLE
Add experimental typesize support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ mime_guess = { version = "2.0.4", optional = true }
 dashmap = { version = "5.5.3", features = ["serde"], optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 ed25519-dalek = { version = "2.0.0", optional = true }
+typesize = { version = "0.1.2", optional = true, features = ["url", "time", "serde_json", "secrecy", "dashmap", "parking_lot", "details"] }
 # serde feature only allows for serialisation,
 # Serenity workspace crates
 command_attr = { version = "0.5.0", path = "./command_attr", optional = true }
@@ -110,16 +111,18 @@ voice = ["client", "model"]
 # Enables unstable tokio features to give explicit names to internally spawned tokio tasks
 tokio_task_builder = ["tokio/tracing"]
 interactions_endpoint = ["ed25519-dalek"]
+# Uses chrono for Timestamp, instead of time
+chrono = ["dep:chrono", "typesize?/chrono"]
 
 # This enables all parts of the serenity codebase
 # (Note: all feature-gated APIs to be documented should have their features listed here!)
 full = ["default", "collector", "unstable_discord_api", "voice", "voice_model", "interactions_endpoint"]
 
 # Enables simd accelerated parsing.
-simd_json = ["simd-json"]
+simd_json = ["simd-json", "typesize?/simd_json"]
 
 # Enables temporary caching in functions that retrieve data via the HTTP API.
-temp_cache = ["cache", "mini-moka"]
+temp_cache = ["cache", "mini-moka", "typesize?/mini_moka"]
 
 # Removed feature (https://github.com/serenity-rs/serenity/pull/2246)
 absolute_ratelimits = []

--- a/src/cache/settings.rs
+++ b/src/cache/settings.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 /// let mut settings = CacheSettings::default();
 /// settings.max_messages = 10;
 /// ```
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Settings {

--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -1,10 +1,14 @@
 //! Wrappers around library types for easier use.
 
 use std::hash::Hash;
+#[cfg(feature = "temp_cache")]
+use std::sync::Arc;
 
 use dashmap::mapref::multiple::RefMulti;
 use dashmap::mapref::one::{Ref, RefMut};
 use dashmap::DashMap;
+#[cfg(feature = "typesize")]
+use typesize::TypeSize;
 
 #[derive(Debug)]
 /// A wrapper around Option<DashMap<K, V>> to ease disabling specific cache fields.
@@ -49,6 +53,17 @@ impl<K: Eq + Hash, V> MaybeMap<K, V> {
     }
 }
 
+#[cfg(feature = "typesize")]
+impl<K: Eq + Hash + TypeSize, V: TypeSize> TypeSize for MaybeMap<K, V> {
+    fn extra_size(&self) -> usize {
+        self.0.as_ref().map(DashMap::extra_size).unwrap_or_default()
+    }
+
+    fn get_collection_item_count(&self) -> Option<usize> {
+        self.0.as_ref().and_then(DashMap::get_collection_item_count)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 /// A wrapper around a reference to a MaybeMap, allowing for public inspection of the underlying
 /// map without allowing mutation of internal cache fields, which could cause issues.
@@ -66,7 +81,6 @@ impl<'a, K: Eq + Hash, V> ReadOnlyMapRef<'a, K, V> {
         self.0.map_or(0, DashMap::len)
     }
 }
-
 pub struct Hasher(fxhash::FxHasher);
 impl std::hash::Hasher for Hasher {
     fn finish(&self) -> u64 {
@@ -84,5 +98,58 @@ impl std::hash::BuildHasher for BuildHasher {
 
     fn build_hasher(&self) -> Self::Hasher {
         Hasher(self.0.build_hasher())
+    }
+}
+
+/// Wrapper around `SizableArc<T, Owned>`` with support for disabling typesize.
+///
+/// This denotes an Arc where T's size should be considered when calling `TypeSize::get_size`
+#[derive(Debug)]
+#[cfg(feature = "temp_cache")]
+pub(crate) struct MaybeOwnedArc<T>(
+    #[cfg(feature = "typesize")] typesize::ptr::SizableArc<T, typesize::ptr::Owned>,
+    #[cfg(not(feature = "typesize"))] Arc<T>,
+);
+
+#[cfg(feature = "temp_cache")]
+impl<T> MaybeOwnedArc<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self(Arc::new(inner).into())
+    }
+
+    pub(crate) fn get_inner(self) -> Arc<T> {
+        #[cfg(feature = "typesize")]
+        let inner = self.0 .0;
+        #[cfg(not(feature = "typesize"))]
+        let inner = self.0;
+
+        inner
+    }
+}
+
+#[cfg(all(feature = "typesize", feature = "temp_cache"))]
+impl<T: typesize::TypeSize> typesize::TypeSize for MaybeOwnedArc<T> {
+    fn extra_size(&self) -> usize {
+        self.0.extra_size()
+    }
+
+    fn get_collection_item_count(&self) -> Option<usize> {
+        self.0.get_collection_item_count()
+    }
+}
+
+#[cfg(feature = "temp_cache")]
+impl<T> std::ops::Deref for MaybeOwnedArc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "temp_cache")]
+impl<T> Clone for MaybeOwnedArc<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone().into())
     }
 }

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -157,10 +157,11 @@ macro_rules! bitflags {
             )*
         }
     ) => {
+        $(#[$outer])*
+        $vis struct $BitFlags($T);
+
         bitflags::bitflags! {
-            #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-            $(#[$outer])*
-            $vis struct $BitFlags: $T {
+            impl $BitFlags: $T {
                 $(
                     $(#[$inner $($args)*])*
                     const $Flag = $value;

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -24,6 +24,7 @@ use crate::model::Permissions;
 /// The base command model that belongs to an application.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Command {
@@ -222,6 +223,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum CommandType {
@@ -235,6 +237,7 @@ enum_number! {
 /// The parameters for an [`Command`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandOption {
@@ -296,6 +299,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum CommandOptionType {
@@ -317,6 +321,7 @@ enum_number! {
 /// The only valid values a user can pick in an [`CommandOption`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-choice-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandOptionChoice {
@@ -332,6 +337,7 @@ pub struct CommandOptionChoice {
 /// An [`Command`] permission.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandPermissions {
@@ -348,6 +354,7 @@ pub struct CommandPermissions {
 /// The [`CommandPermission`] data.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandPermission {
@@ -365,6 +372,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum CommandPermissionType {

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -42,6 +42,7 @@ use crate::utils::{CreateQuickModal, QuickModalResponse};
 /// An interaction when a user invokes a slash command.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
 #[non_exhaustive]
@@ -265,6 +266,7 @@ impl Serialize for CommandInteraction {
 /// The command data payload.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandData {
@@ -476,6 +478,7 @@ pub enum ResolvedTarget<'a> {
 /// [`CommandDataOption`]s.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandDataResolved {
@@ -508,6 +511,7 @@ pub struct CommandDataResolved {
 /// Their resolved objects can be found on [`CommandData::resolved`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-interaction-data-option-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct CommandDataOption {
@@ -632,6 +636,7 @@ impl Serialize for CommandDataOption {
 /// The value of an [`CommandDataOption`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum CommandDataOptionValue {

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -9,6 +9,7 @@ use crate::model::utils::{default_true, deserialize_val};
 enum_number! {
     /// The type of a component
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ComponentType {
@@ -27,6 +28,7 @@ enum_number! {
 /// An action row.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#action-rows).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActionRow {
@@ -41,6 +43,7 @@ pub struct ActionRow {
 /// A component which can be inside of an [`ActionRow`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#component-object-component-types).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum ActionRowComponent {
@@ -97,6 +100,7 @@ impl From<SelectMenu> for ActionRowComponent {
     }
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum ButtonKind {
@@ -142,6 +146,7 @@ impl Serialize for ButtonKind {
 /// A button component.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Button {
@@ -165,6 +170,7 @@ pub struct Button {
 enum_number! {
     /// The style of a button.
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ButtonStyle {
@@ -180,6 +186,7 @@ enum_number! {
 /// A select menu component.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SelectMenu {
@@ -212,6 +219,7 @@ pub struct SelectMenu {
 /// A select menu component options.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SelectMenuOption {
@@ -231,6 +239,7 @@ pub struct SelectMenuOption {
 /// An input text component for modal interactions
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InputText {
@@ -275,6 +284,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-styles).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum InputTextStyle {

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -22,6 +22,7 @@ use crate::utils::{CreateQuickModal, QuickModalResponse};
 /// An interaction triggered by a message component.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
 #[non_exhaustive]
@@ -240,6 +241,7 @@ impl Serialize for ComponentInteraction {
     }
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 pub enum ComponentInteractionDataKind {
     Button,
@@ -323,6 +325,7 @@ impl Serialize for ComponentInteractionDataKind {
 /// A message component interaction data, provided by [`ComponentInteraction::data`]
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-message-component-data-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ComponentInteractionData {

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -11,6 +11,7 @@ use crate::model::utils::deserialize_val;
 use crate::model::Permissions;
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Interaction {
@@ -246,6 +247,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum InteractionType {
@@ -263,7 +265,7 @@ bitflags! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-flags)
     /// ([only some are valid in this context](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-messages))
-    #[derive(Default)]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct InteractionResponseFlags: u64 {
         /// Do not include any embeds when serializing this message.
         const SUPPRESS_EMBEDS = 1 << 2;
@@ -278,6 +280,7 @@ bitflags! {
 /// [`Message`]: crate::model::channel::Message
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#message-interaction-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageInteraction {

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -25,6 +25,7 @@ use super::Permissions;
 /// Partial information about the given application.
 ///
 /// Discord docs: [application field of Ready](https://discord.com/developers/docs/topics/gateway-events#ready-ready-event-fields)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PartialCurrentApplicationInfo {
@@ -129,7 +130,8 @@ bitflags! {
     /// The flags of the application.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/application#application-object-application-flags).
-    #[derive(Default)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ApplicationFlags: u64 {
         /// Indicates if an app uses the Auto Moderation API
         const APPLICATION_AUTO_MODERATION_RULE_CREATE_BADGE = 1 << 6;

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -17,6 +17,7 @@ use crate::model::prelude::*;
 /// An interaction triggered by a modal submit.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
 #[non_exhaustive]
@@ -212,6 +213,7 @@ impl Serialize for ModalInteraction {
 /// A modal submit interaction data, provided by [`ModalInteraction::data`]
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ModalInteractionData {

--- a/src/model/application/oauth.rs
+++ b/src/model/application/oauth.rs
@@ -5,8 +5,9 @@ use serde::{Deserialize, Serialize};
 /// The available OAuth2 Scopes.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[non_exhaustive]
 pub enum Scope {
     /// For oauth2 bots, this puts the bot in the user's selected guild by default.
     #[serde(rename = "bot")]

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -5,6 +5,7 @@ use crate::model::id::{ApplicationId, InteractionId};
 /// A ping interaction, which can only be received through an endpoint url.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PingInteraction {

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -28,6 +28,7 @@ where
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#attachment-object).
 ///
 /// [`Embed`]: super::Embed
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Attachment {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -407,7 +407,10 @@ impl ChannelId {
         {
             if let Some(cache) = cache_http.cache() {
                 if let Channel::Guild(guild_channel) = &channel {
-                    cache.temp_channels.insert(guild_channel.id, Arc::new(guild_channel.clone()));
+                    use crate::cache::MaybeOwnedArc;
+
+                    let cached_channel = MaybeOwnedArc::new(guild_channel.clone());
+                    cache.temp_channels.insert(cached_channel.id, cached_channel);
                 }
             }
         }

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -11,6 +11,7 @@ use crate::model::{Colour, Timestamp};
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object).
 ///
 /// [slack's attachments]: https://api.slack.com/docs/message-attachments
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Embed {
@@ -71,6 +72,7 @@ pub struct Embed {
 /// An author object in an embed.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedAuthor {
@@ -92,6 +94,7 @@ pub struct EmbedAuthor {
 /// A field object in an embed.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedField {
@@ -133,6 +136,7 @@ impl EmbedField {
 /// Footer information for an embed.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedFooter {
@@ -151,6 +155,7 @@ pub struct EmbedFooter {
 /// An image object in an embed.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-image-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedImage {
@@ -169,6 +174,7 @@ pub struct EmbedImage {
 /// The provider of an embed.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedProvider {
@@ -181,6 +187,7 @@ pub struct EmbedProvider {
 /// The dimensions and URL of an embed thumbnail.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedThumbnail {
@@ -199,6 +206,7 @@ pub struct EmbedThumbnail {
 /// Video information for an embed.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedVideo {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -37,6 +37,7 @@ use crate::model::Timestamp;
 /// channels and lack slow mode hence [`Self::rate_limit_per_user`] will be [`None`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildChannel {
@@ -179,6 +180,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-forum-layout-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ForumLayoutType {
@@ -1235,6 +1237,7 @@ impl fmt::Display for GuildChannel {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object),
 /// [subset description](https://discord.com/developers/docs/topics/gateway#thread-delete)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PartialGuildChannel {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -30,6 +30,7 @@ use crate::utils;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object) with some
 /// [extra fields](https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Message {
@@ -846,6 +847,7 @@ impl<'a> From<&'a Message> for MessageId {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#reaction-object).
 ///
 /// [reaction type]: ReactionType
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageReaction {
@@ -863,6 +865,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MessageType {
@@ -929,6 +932,7 @@ enum_number! {
 enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-activity-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MessageActivityKind {
@@ -944,6 +948,7 @@ enum_number! {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/application#application-object),
 /// [subset undocumented](https://discord.com/developers/docs/resources/channel#message-object-message-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageApplication {
@@ -962,6 +967,7 @@ pub struct MessageApplication {
 /// Rich Presence activity information.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-activity-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageActivity {
@@ -975,6 +981,7 @@ pub struct MessageActivity {
 /// Reference data sent with crossposted messages.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageReference {
@@ -1012,6 +1019,7 @@ impl From<(ChannelId, MessageId)> for MessageReference {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-mention-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ChannelMention {
@@ -1030,7 +1038,8 @@ bitflags! {
     /// Describes extra features of the message.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-flags).
-    #[derive(Default)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct MessageFlags: u64 {
         /// This message has been published to subscribed channels (via Channel Following).
         const CROSSPOSTED = 1 << 0;
@@ -1102,6 +1111,7 @@ impl MessageId {
     }
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Nonce {
@@ -1110,6 +1120,7 @@ pub enum Nonce {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#role-subscription-data-object)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RoleSubscriptionData {
     /// The id of the sku and listing that the user is subscribed to.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -33,6 +33,7 @@ use crate::model::Timestamp;
 pub type AttachmentType<'a> = crate::builder::CreateAttachment;
 
 /// A container for any channel.
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 #[non_exhaustive]
@@ -217,6 +218,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ChannelType {
@@ -330,6 +332,7 @@ impl From<PermissionOverwrite> for PermissionOverwriteData {
 /// A channel-specific permission overwrite for a member or role.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(try_from = "PermissionOverwriteData", into = "PermissionOverwriteData")]
 pub struct PermissionOverwrite {
@@ -346,6 +349,7 @@ pub struct PermissionOverwrite {
 /// from [`GuildId::everyone_role`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object-overwrite-structure) (field `type`).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PermissionOverwriteType {
@@ -360,6 +364,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-video-quality-modes).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum VideoQualityMode {
@@ -377,6 +382,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level).
     #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum StageInstancePrivacyLevel {
@@ -394,6 +400,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object)
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u16", into = "u16")]
     #[non_exhaustive]
     pub enum AutoArchiveDuration {
@@ -407,6 +414,7 @@ enum_number! {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct StageInstance {
@@ -429,6 +437,7 @@ pub struct StageInstance {
 /// A thread data.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadMetadata {
@@ -460,6 +469,7 @@ pub struct ThreadMetadata {
 /// [2](https://discord.com/developers/docs/resources/channel#list-private-archived-threads-response-body),
 /// [3](https://discord.com/developers/docs/resources/channel#list-public-archived-threads-response-body),
 /// [4](https://discord.com/developers/docs/resources/channel#list-private-archived-threads-response-body)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadsData {
@@ -514,6 +524,7 @@ mod test {
 ///
 /// See [Discord](https://discord.com/developers/docs/resources/channel#default-reaction-object)
 /// [docs]()
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum ForumEmoji {
@@ -564,6 +575,7 @@ impl<'de> serde::Deserialize<'de> for ForumEmoji {
 /// An object that represents a tag able to be applied to a thread in a `GUILD_FORUM` channel.
 ///
 /// See [Discord docs](https://discord.com/developers/docs/resources/channel#forum-tag-object)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ForumTag {
@@ -583,6 +595,7 @@ enum_number! {
     /// The sort order for threads in a forum.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-sort-order-types).
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
@@ -599,7 +612,8 @@ bitflags! {
     /// Describes extra features of the channel.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-flags).
-    #[derive(Default)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ChannelFlags: u64 {
         /// This thread is pinned to the top of its parent GUILD_FORUM channel
         const PINNED = 1 << 1;

--- a/src/model/channel/partial_channel.rs
+++ b/src/model/channel/partial_channel.rs
@@ -6,6 +6,7 @@ use crate::model::Permissions;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object),
 /// [subset specification](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PartialChannel {

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -15,6 +15,7 @@ use crate::model::Timestamp;
 /// A Direct Message text channel with another user.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PrivateChannel {

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -20,6 +20,7 @@ use crate::model::prelude::*;
 /// An emoji reaction to a message.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-reaction-add-message-reaction-add-event-fields).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
 #[non_exhaustive]
@@ -253,6 +254,7 @@ impl Reaction {
 }
 
 /// The type of a [`Reaction`] sent.
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]
 pub enum ReactionType {

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -67,6 +67,7 @@
 ///
 /// [`Role`]: crate::model::guild::Role
 #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 pub struct Colour(pub u32);
 
 pub type Color = Colour;

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -29,6 +29,7 @@ use crate::model::guild::automod::{ActionExecution, Rule};
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#application-command-permissions-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -39,6 +40,7 @@ pub struct CommandPermissionsUpdateEvent {
 /// Requires [`GatewayIntents::AUTO_MODERATION_CONFIGURATION`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -49,6 +51,7 @@ pub struct AutoModRuleCreateEvent {
 /// Requires [`GatewayIntents::AUTO_MODERATION_CONFIGURATION`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -59,6 +62,7 @@ pub struct AutoModRuleUpdateEvent {
 /// Requires [`GatewayIntents::AUTO_MODERATION_CONFIGURATION`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -69,6 +73,7 @@ pub struct AutoModRuleDeleteEvent {
 /// Requires [`GatewayIntents::AUTO_MODERATION_EXECUTION`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -84,6 +89,7 @@ pub struct AutoModActionExecutionEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -95,6 +101,7 @@ pub struct ChannelCreateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -105,6 +112,7 @@ pub struct ChannelDeleteEvent {
 /// Requires [`GatewayIntents::GUILDS`] or [`GatewayIntents::DIRECT_MESSAGES`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-pins-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ChannelPinsUpdateEvent {
@@ -116,6 +124,7 @@ pub struct ChannelPinsUpdateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -126,6 +135,7 @@ pub struct ChannelUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_MODERATION`] and [`Permissions::VIEW_AUDIT_LOG`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildAuditLogEntryCreateEvent {
@@ -137,6 +147,7 @@ pub struct GuildAuditLogEntryCreateEvent {
 /// Requires [`GatewayIntents::GUILD_MODERATION`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-ban-add).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildBanAddEvent {
@@ -147,6 +158,7 @@ pub struct GuildBanAddEvent {
 /// Requires [`GatewayIntents::GUILD_MODERATION`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildBanRemoveEvent {
@@ -157,6 +169,7 @@ pub struct GuildBanRemoveEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -180,6 +193,7 @@ impl<'de> Deserialize<'de> for GuildCreateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -190,6 +204,7 @@ pub struct GuildDeleteEvent {
 /// Requires [`GatewayIntents::GUILD_EMOJIS_AND_STICKERS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildEmojisUpdateEvent {
@@ -201,6 +216,7 @@ pub struct GuildEmojisUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_INTEGRATIONS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildIntegrationsUpdateEvent {
@@ -210,6 +226,7 @@ pub struct GuildIntegrationsUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-add).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -220,6 +237,7 @@ pub struct GuildMemberAddEvent {
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-remove).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildMemberRemoveEvent {
@@ -230,6 +248,7 @@ pub struct GuildMemberRemoveEvent {
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildMemberUpdateEvent {
@@ -252,6 +271,7 @@ pub struct GuildMemberUpdateEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
 #[non_exhaustive]
@@ -291,6 +311,7 @@ impl Serialize for GuildMembersChunkEvent {
 }
 
 /// Helper to deserialize `GuildRoleCreateEvent` and `GuildRoleUpdateEvent`.
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Deserialize)]
 struct RoleEventHelper {
     guild_id: GuildId,
@@ -300,6 +321,7 @@ struct RoleEventHelper {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleCreateEvent {
@@ -320,6 +342,7 @@ impl<'de> Deserialize<'de> for GuildRoleCreateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleDeleteEvent {
@@ -330,6 +353,7 @@ pub struct GuildRoleDeleteEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 pub struct GuildRoleUpdateEvent {
@@ -350,6 +374,7 @@ impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_EMOJIS_AND_STICKERS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildStickersUpdateEvent {
@@ -361,6 +386,7 @@ pub struct GuildStickersUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_INVITES`] and [`Permissions::MANAGE_CHANNELS´] permission.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#invite-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteCreateEvent {
@@ -394,6 +420,7 @@ pub struct InviteCreateEvent {
 /// Requires [`GatewayIntents::GUILD_INVITES`] and [`Permissions::MANAGE_CHANNELS´] permission.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#invite-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteDeleteEvent {
@@ -405,6 +432,7 @@ pub struct InviteDeleteEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -416,6 +444,7 @@ pub struct GuildUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_MESSAGES`] or [`GatewayIntents::DIRECT_MESSAGES`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -426,6 +455,7 @@ pub struct MessageCreateEvent {
 /// Requires [`GatewayIntents::GUILD_MESSAGES`] or [`GatewayIntents::DIRECT_MESSAGES`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-delete-bulk).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageDeleteBulkEvent {
@@ -437,6 +467,7 @@ pub struct MessageDeleteBulkEvent {
 /// Requires [`GatewayIntents::GUILD_MESSAGES`] or [`GatewayIntents::DIRECT_MESSAGES`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageDeleteEvent {
@@ -464,6 +495,7 @@ where
 /// [`Self::guild_id`])
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct MessageUpdateEvent {
@@ -592,6 +624,7 @@ impl MessageUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_PRESENCES`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#presence-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -600,6 +633,7 @@ pub struct PresenceUpdateEvent {
 }
 
 /// Not officially documented.
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -611,6 +645,7 @@ pub struct PresencesReplaceEvent {
 /// [`GatewayIntents::DIRECT_MESSAGE_REACTIONS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-add).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -622,6 +657,7 @@ pub struct ReactionAddEvent {
 /// [`GatewayIntents::DIRECT_MESSAGE_REACTIONS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -636,6 +672,7 @@ pub struct ReactionRemoveEvent {
 /// [`GatewayIntents::DIRECT_MESSAGE_REACTIONS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-all).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ReactionRemoveAllEvent {
@@ -648,6 +685,7 @@ pub struct ReactionRemoveAllEvent {
 /// [`GatewayIntents::DIRECT_MESSAGE_REACTIONS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-emoji-message-reaction-remove-emoji-event-fields).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -660,6 +698,7 @@ pub struct ReactionRemoveEmojiEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#ready).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -670,6 +709,7 @@ pub struct ReadyEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#resumed).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ResumedEvent {}
@@ -677,6 +717,7 @@ pub struct ResumedEvent {}
 /// Requires [`GatewayIntents::GUILD_MESSAGE_TYPING`] or [`GatewayIntents::DIRECT_MESSAGE_TYPING`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#typing-start).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct TypingStartEvent {
@@ -692,6 +733,7 @@ pub struct TypingStartEvent {
     pub member: Option<Member>,
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct UnknownEvent {
@@ -704,6 +746,7 @@ pub struct UnknownEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#user-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -714,6 +757,7 @@ pub struct UserUpdateEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#voice-server-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct VoiceServerUpdateEvent {
@@ -725,6 +769,7 @@ pub struct VoiceServerUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_VOICE_STATES`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#voice-state-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -735,6 +780,7 @@ pub struct VoiceStateUpdateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Incomplete documentation](https://github.com/discord/discord-api-docs/pull/6398)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct VoiceChannelStatusUpdateEvent {
@@ -746,6 +792,7 @@ pub struct VoiceChannelStatusUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_WEBHOOKS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#webhooks-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct WebhookUpdateEvent {
@@ -756,6 +803,7 @@ pub struct WebhookUpdateEvent {
 /// Requires no gateway intents.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#interaction-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -766,6 +814,7 @@ pub struct InteractionCreateEvent {
 /// Requires [`GatewayIntents::GUILD_INTEGRATIONS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#integration-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -776,6 +825,7 @@ pub struct IntegrationCreateEvent {
 /// Requires [`GatewayIntents::GUILD_INTEGRATIONS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#integration-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -786,6 +836,7 @@ pub struct IntegrationUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_INTEGRATIONS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#integration-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct IntegrationDeleteEvent {
@@ -797,6 +848,7 @@ pub struct IntegrationDeleteEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#stage-instance-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -807,6 +859,7 @@ pub struct StageInstanceCreateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#stage-instance-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -817,6 +870,7 @@ pub struct StageInstanceUpdateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#stage-instance-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -827,6 +881,7 @@ pub struct StageInstanceDeleteEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -837,6 +892,7 @@ pub struct ThreadCreateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -847,6 +903,7 @@ pub struct ThreadUpdateEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -857,6 +914,7 @@ pub struct ThreadDeleteEvent {
 /// Requires [`GatewayIntents::GUILDS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-list-sync).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadListSyncEvent {
@@ -877,6 +935,7 @@ pub struct ThreadListSyncEvent {
 /// [`GatewayIntents::GUILD_MEMBERS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-member-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -887,6 +946,7 @@ pub struct ThreadMemberUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-members-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadMembersUpdateEvent {
@@ -910,6 +970,7 @@ pub struct ThreadMembersUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -920,6 +981,7 @@ pub struct GuildScheduledEventCreateEvent {
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -930,6 +992,7 @@ pub struct GuildScheduledEventUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-delete).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
@@ -940,6 +1003,7 @@ pub struct GuildScheduledEventDeleteEvent {
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildScheduledEventUserAddEvent {
@@ -952,6 +1016,7 @@ pub struct GuildScheduledEventUserAddEvent {
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildScheduledEventUserRemoveEvent {
@@ -962,6 +1027,7 @@ pub struct GuildScheduledEventUserRemoveEvent {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#payload-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
@@ -1013,6 +1079,7 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#receive-events).
 #[allow(clippy::large_enum_variant)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[serde(tag = "t", content = "d")]

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -31,6 +31,7 @@ pub struct BotGateway {
 /// Representation of an activity that a [`User`] is performing.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Activity {
@@ -79,6 +80,7 @@ pub struct Activity {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-buttons).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ActivityButton {
@@ -94,6 +96,7 @@ pub struct ActivityButton {
 /// The assets for an activity.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-assets).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivityAssets {
@@ -111,7 +114,8 @@ bitflags! {
     /// A set of flags defining what is in an activity's payload.
     ///
     /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-flags).
-    #[derive(Default)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ActivityFlags: u64 {
         /// Whether the activity is an instance activity.
         const INSTANCE = 1 << 0;
@@ -137,6 +141,7 @@ bitflags! {
 /// Information about an activity's party.
 ///
 /// [Discord docs](https://discord.com/developers/docs/game-sdk/activities#data-models-activityparty-struct).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivityParty {
@@ -149,6 +154,7 @@ pub struct ActivityParty {
 /// Secrets for an activity.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-secrets).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivitySecrets {
@@ -164,6 +170,7 @@ pub struct ActivitySecrets {
 /// Representation of an emoji used in a custom status
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-emoji).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivityEmoji {
@@ -178,6 +185,7 @@ pub struct ActivityEmoji {
 enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ActivityType {
@@ -213,6 +221,7 @@ pub struct Gateway {
 /// Information detailing the current active status of a [`User`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#client-status-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ClientStatus {
@@ -228,6 +237,7 @@ pub struct ClientStatus {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object),
 /// [modification description](https://discord.com/developers/docs/topics/gateway-events#presence-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PresenceUser {
@@ -299,6 +309,7 @@ impl PresenceUser {
 /// Information detailing the current online status of a [`User`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#presence-update-presence-update-event-fields).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Presence {
@@ -318,6 +329,7 @@ pub struct Presence {
 /// An initial set of information given after IDENTIFYing to the gateway.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#ready-ready-event-fields).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Ready {
@@ -354,6 +366,7 @@ pub struct SessionStartLimit {
     pub max_concurrency: u64,
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 pub struct ShardInfo {
     pub id: ShardId,
@@ -392,6 +405,7 @@ impl serde::Serialize for ShardInfo {
 /// Timestamps of when a user started and/or is ending their activity.
 ///
 /// [Discord docs](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytimestamps-struct).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActivityTimestamps {
@@ -424,6 +438,8 @@ bitflags! {
     /// [Gateway Intents]: https://discord.com/developers/docs/topics/gateway#gateway-intents
     /// [Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
     /// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
     pub struct GatewayIntents: u64 {
         /// Enables the following gateway events:
         ///  - GUILD_CREATE

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -13,6 +13,7 @@ use crate::model::misc::ImageHash;
 use crate::model::sticker::StickerFormatType;
 use crate::model::{Permissions, Timestamp};
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
 #[non_exhaustive]
 pub struct AffectedRole {
@@ -20,6 +21,7 @@ pub struct AffectedRole {
     pub name: String,
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
 #[non_exhaustive]
@@ -34,6 +36,7 @@ macro_rules! generate_change {
         $key:literal => $name:ident ($type:ty),
     )* ) => {
         #[cfg_attr(not(simd_json), allow(clippy::derive_partial_eq_without_eq))]
+        #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
         #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
         // serde_json's Value impls Eq, simd-json's Value doesn't
         #[cfg_attr(not(feature = "simd_json"), derive(Eq))]

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -17,6 +17,7 @@ use crate::model::prelude::*;
 /// Determines the action that was done on a target.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum Action {
@@ -105,6 +106,7 @@ impl Serialize for Action {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -115,6 +117,7 @@ pub enum ChannelAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -125,6 +128,7 @@ pub enum ChannelOverwriteAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -141,6 +145,7 @@ pub enum MemberAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -151,6 +156,7 @@ pub enum RoleAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -161,6 +167,7 @@ pub enum InviteAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -171,6 +178,7 @@ pub enum WebhookAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -181,6 +189,7 @@ pub enum EmojiAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -192,6 +201,7 @@ pub enum MessageAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -202,6 +212,7 @@ pub enum IntegrationAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -212,6 +223,7 @@ pub enum StageInstanceAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -222,6 +234,7 @@ pub enum StickerAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -232,6 +245,7 @@ pub enum ScheduledEventAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -242,6 +256,7 @@ pub enum ThreadAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -255,6 +270,7 @@ pub enum AutoModAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -264,6 +280,7 @@ pub enum CreatorMonetizationAction {
 }
 
 /// [Incomplete documentation](https://github.com/discord/discord-api-docs/pull/6398)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -273,6 +290,7 @@ pub enum VoiceChannelStatusAction {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct AuditLogs {
@@ -303,6 +321,7 @@ pub struct AuditLogs {
 /// Partial version of [`Integration`], used in [`AuditLogs::integrations`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-object-example-partial-integration-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PartialIntegration {
@@ -315,6 +334,7 @@ pub struct PartialIntegration {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[non_exhaustive]
 pub struct AuditLogEntry {
@@ -337,6 +357,7 @@ pub struct AuditLogEntry {
 
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info).
 // TODO: should be renamed to a less ambiguous name
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[non_exhaustive]
 pub struct Options {

--- a/src/model/guild/automod.rs
+++ b/src/model/guild/automod.rs
@@ -14,6 +14,7 @@ use crate::model::id::*;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object).
 // TODO: should be renamed to a less ambiguous name
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Rule {
@@ -48,6 +49,7 @@ pub struct Rule {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
 #[non_exhaustive]
 pub enum EventType {
@@ -78,6 +80,7 @@ impl From<EventType> for u8 {
 /// Discord docs:
 /// [type](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types),
 /// [metadata](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Trigger {
@@ -217,6 +220,7 @@ impl Trigger {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
 #[non_exhaustive]
 pub enum TriggerType {
@@ -259,6 +263,7 @@ impl From<TriggerType> for u8 {
 /// [`Change::TriggerMetadata`]: crate::model::guild::audit_log::Change::TriggerMetadata
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct TriggerMetadata {
@@ -278,6 +283,7 @@ pub struct TriggerMetadata {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
 #[non_exhaustive]
 pub enum KeywordPresetType {
@@ -315,6 +321,7 @@ impl From<KeywordPresetType> for u8 {
 /// An action which will execute whenever a rule is triggered.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Action {
@@ -344,6 +351,7 @@ pub enum Action {
 /// blocked).
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ActionExecution {

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -20,6 +20,7 @@ use crate::model::ModelError;
 /// integration. Emojis created using the API only work within the guild it was created in.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/emoji#emoji-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Emoji {

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -6,6 +6,7 @@ use crate::model::Timestamp;
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-object),
 /// [extra fields 1](https://discord.com/developers/docs/topics/gateway-events#integration-create),
 /// [extra fields 2](https://discord.com/developers/docs/topics/gateway-events#integration-update),
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Integration {
@@ -36,6 +37,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum IntegrationExpireBehaviour {
@@ -55,6 +57,7 @@ impl From<Integration> for IntegrationId {
 /// Integration account object.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-account-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct IntegrationAccount {
@@ -65,6 +68,7 @@ pub struct IntegrationAccount {
 /// Integration application object.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-application-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct IntegrationApplication {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -20,6 +20,7 @@ use crate::model::Timestamp;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-member-object),
 /// [extra fields](https://discord.com/developers/docs/topics/gateway-events#guild-member-add-guild-member-add-extra-fields).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Member {
@@ -66,7 +67,8 @@ bitflags! {
     /// Flags for a guild member.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags).
-    #[derive(Default)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct GuildMemberFlags: u32 {
         /// Member has left and rejoined the guild. Not editable
         const DID_REJOIN = 1 << 0;
@@ -571,6 +573,7 @@ impl fmt::Display for Member {
 /// [link](https://discord.com/developers/docs/topics/gateway-events#message-create),
 /// [link](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure),
 /// [link](https://discord.com/developers/docs/interactions/receiving-and-responding#message-interaction-object))
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PartialMember {
@@ -646,6 +649,7 @@ impl From<Member> for PartialMember {
 
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-member-object),
 /// [extra fields](https://discord.com/developers/docs/topics/gateway-events#thread-member-update-thread-member-update-event-extra-fields).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadMember {
@@ -683,7 +687,8 @@ bitflags! {
     /// Describes extra features of the message.
     ///
     /// Discord docs: flags field on [Thread Member](https://discord.com/developers/docs/resources/channel#thread-member-object).
-    #[derive(Default)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ThreadMemberFlags: u64 {
         // Not documented.
         const NOTIFICATIONS = 1 << 0;

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -80,6 +80,7 @@ pub struct Ban {
     pub user: User,
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct AfkMetadata {
     /// Id of a voice channel that's considered the AFK channel.
@@ -93,6 +94,7 @@ pub struct AfkMetadata {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object) plus
 /// [extension](https://discord.com/developers/docs/topics/gateway-events#guild-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Guild {
@@ -2594,6 +2596,7 @@ pub struct GuildWidget {
 /// Representation of the number of members that would be pruned by a guild prune operation.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#get-guild-prune-count).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildPrune {
@@ -2605,6 +2608,7 @@ pub struct GuildPrune {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object),
 /// [subset example](https://discord.com/developers/docs/resources/user#get-current-user-guilds-example-partial-guild).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildInfo {
@@ -2649,6 +2653,7 @@ impl InviteGuild {
 /// Data for an unavailable guild.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#unavailable-guild-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct UnavailableGuild {
@@ -2664,6 +2669,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum DefaultMessageNotificationLevel {
@@ -2681,6 +2687,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ExplicitContentFilter {
@@ -2700,6 +2707,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-mfa-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MfaLevel {
@@ -2718,6 +2726,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-verification-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum VerificationLevel {
@@ -2741,6 +2750,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum NsfwLevel {
@@ -2762,6 +2772,7 @@ enum_number! {
     ///
     /// See [AfkMetadata::afk_timeout].
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u16", into = "u16")]
     #[non_exhaustive]
     pub enum AfkTimeout {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -34,6 +34,7 @@ use crate::model::utils::{emojis, roles, stickers};
 /// Partial information about a [`Guild`]. This does not include information like member data.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
 #[non_exhaustive]

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -3,6 +3,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-premium-tier).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum PremiumTier {

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -19,6 +19,7 @@ use crate::model::utils::is_false;
 /// permissions.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Role {
@@ -198,6 +199,7 @@ impl<'a> From<&'a Role> for RoleId {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure).
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[non_exhaustive]
 pub struct RoleTags {
     /// The Id of the bot the [`Role`] belongs to.

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -3,6 +3,7 @@ use crate::model::prelude::*;
 /// Information about a guild scheduled event.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ScheduledEvent {
@@ -55,6 +56,7 @@ pub struct ScheduledEvent {
 enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ScheduledEventStatus {
@@ -69,6 +71,7 @@ enum_number! {
 enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ScheduledEventType {
@@ -80,6 +83,7 @@ enum_number! {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ScheduledEventMetadata {
@@ -88,6 +92,7 @@ pub struct ScheduledEventMetadata {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-user-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ScheduledEventUser {
@@ -102,6 +107,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ScheduledEventPrivacyLevel {

--- a/src/model/guild/system_channel.rs
+++ b/src/model/guild/system_channel.rs
@@ -2,7 +2,8 @@ bitflags! {
     /// Describes a system channel flags.
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags).
-    #[derive(Default)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct SystemChannelFlags: u64 {
         /// Suppress member join notifications.
         const SUPPRESS_JOIN_NOTIFICATIONS = 1 << 0;

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -5,6 +5,7 @@ use crate::model::id::{ChannelId, EmojiId};
 /// Information relating to a guild's welcome screen.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildWelcomeScreen {
@@ -19,6 +20,7 @@ pub struct GuildWelcomeScreen {
 /// A channel shown in the [`GuildWelcomeScreen`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct GuildWelcomeChannel {
@@ -88,6 +90,7 @@ impl Serialize for GuildWelcomeChannel {
 /// A [`GuildWelcomeScreen`] emoji.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]
 pub enum GuildWelcomeChannelEmoji {

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -118,6 +118,9 @@ macro_rules! id_u64 {
                     Ok(Self(s.parse()?))
                 }
             }
+
+            #[cfg(feature = "typesize")]
+            impl typesize::TypeSize for $name {}
         )*
     }
 }
@@ -280,6 +283,7 @@ id_u64! {
 ///
 /// This identifier is special, it simply models internal IDs for type safety,
 /// and therefore cannot be [`Serialize`]d or [`Deserialize`]d.
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct ShardId(pub u32);
 

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -406,6 +406,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum InviteTargetType {

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -12,6 +12,7 @@ use super::prelude::*;
 use crate::utils;
 
 /// Hides the implementation detail of ImageHash as an enum.
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ImageHashInner {
     Normal { hash: [u8; 16], is_animated: bool },
@@ -31,6 +32,7 @@ enum ImageHashInner {
 /// assert_eq!(image_hash.to_string(), String::from("f1eff024d9c85339c877985229ed8fec"));
 /// ```
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ImageHash(ImageHashInner);
 

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -208,19 +208,22 @@ pub const PRESET_VOICE: Permissions = Permissions::from_bits_truncate(
     Permissions::CONNECT.bits() | Permissions::SPEAK.bits() | Permissions::USE_VAD.bits(),
 );
 
+/// A set of permissions that can be assigned to [`User`]s and [`Role`]s via
+/// [`PermissionOverwrite`]s, roles globally in a [`Guild`], and to [`GuildChannel`]s.
+///
+/// [Discord docs](https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags).
+///
+/// [`Guild`]: super::guild::Guild
+/// [`GuildChannel`]: super::channel::GuildChannel
+/// [`PermissionOverwrite`]: super::channel::PermissionOverwrite
+/// [`Role`]: super::guild::Role
+/// [`User`]: super::user::User
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
+pub struct Permissions(u64);
+
 bitflags::bitflags! {
-    /// A set of permissions that can be assigned to [`User`]s and [`Role`]s via
-    /// [`PermissionOverwrite`]s, roles globally in a [`Guild`], and to [`GuildChannel`]s.
-    ///
-    /// [Discord docs](https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags).
-    ///
-    /// [`Guild`]: super::guild::Guild
-    /// [`GuildChannel`]: super::channel::GuildChannel
-    /// [`PermissionOverwrite`]: super::channel::PermissionOverwrite
-    /// [`Role`]: super::guild::Role
-    /// [`User`]: super::user::User
-    #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-    pub struct Permissions: u64 {
+    impl Permissions: u64 {
         /// Allows for the creation of [`RichInvite`]s.
         ///
         /// [`RichInvite`]: super::invite::RichInvite

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -62,6 +62,7 @@ impl StickerId {
 /// The smallest amount of data required to render a sticker.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-item-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct StickerItem {
@@ -144,6 +145,7 @@ fn banner_url(banner_asset_id: StickerPackBannerId) -> String {
 /// Bots cannot send stickers.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Sticker {
@@ -262,6 +264,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum StickerType {
@@ -278,6 +281,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum StickerFormatType {

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -46,6 +46,7 @@ use serde::{Deserialize, Serialize};
 const DISCORD_EPOCH: u64 = 1_420_070_400_000;
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(transparent)]
 pub struct Timestamp(
     #[cfg(feature = "chrono")] DateTime<Utc>,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -5,8 +5,6 @@ use std::fmt;
 use std::fmt::Write;
 use std::num::NonZeroU16;
 use std::ops::{Deref, DerefMut};
-#[cfg(feature = "temp_cache")]
-use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -128,6 +126,7 @@ pub(crate) mod discriminator {
 /// Information about the current user.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct CurrentUser(User);
@@ -191,6 +190,7 @@ impl CurrentUser {
 /// The representation of a user's status.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#update-presence-status-types).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(
     Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
 )]
@@ -226,6 +226,7 @@ impl OnlineStatus {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object), existence of
 /// additional partial member field documented [here](https://discord.com/developers/docs/topics/gateway-events#message-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct User {
@@ -298,6 +299,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-premium-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum PremiumType {
@@ -314,7 +316,8 @@ bitflags! {
     /// User's public flags
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-user-flags).
-    #[derive(Default)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct UserPublicFlags: u32 {
         /// User's flag as discord employee
         const DISCORD_EMPLOYEE = 1 << 0;
@@ -749,7 +752,10 @@ impl UserId {
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
         {
             if let Some(cache) = cache_http.cache() {
-                cache.temp_users.insert(user.id, Arc::new(user.clone()));
+                use crate::cache::MaybeOwnedArc;
+
+                let cached_user = MaybeOwnedArc::new(user.clone());
+                cache.temp_users.insert(cached_user.id, cached_user);
             }
         }
 

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -28,6 +28,7 @@ pub struct VoiceRegion {
 /// A user's state within a voice channel.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/voice#voice-state-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
 #[non_exhaustive]

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -1,8 +1,5 @@
 //! Webhook model and implementations.
 
-#[cfg(all(feature = "model", feature = "temp_cache"))]
-use std::sync::Arc;
-
 #[cfg(feature = "model")]
 use secrecy::ExposeSecret;
 use secrecy::SecretString;
@@ -29,6 +26,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum WebhookType {
@@ -60,6 +58,7 @@ impl WebhookType {
 /// not necessarily require a bot user or authentication to use.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/webhook#webhook-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Webhook {
@@ -103,6 +102,7 @@ pub struct Webhook {
 }
 
 /// The guild object returned by a [`Webhook`], of type [`WebhookType::ChannelFollower`].
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct WebhookGuild {
@@ -164,6 +164,7 @@ impl WebhookGuild {
     }
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct WebhookChannel {
@@ -210,7 +211,10 @@ impl WebhookChannel {
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
         {
             if let Some(cache) = cache_http.cache() {
-                cache.temp_channels.insert(guild_channel.id, Arc::new(guild_channel.clone()));
+                use crate::cache::MaybeOwnedArc;
+
+                let cached_channel = MaybeOwnedArc::new(guild_channel.clone());
+                cache.temp_channels.insert(cached_channel.id, cached_channel);
             }
         }
 


### PR DESCRIPTION
Adds a simple integration with my new [`typesize`](https://docs.rs/typesize) library to help users find which caches are using up the most ram. This is highly experimental, hence the lack of documentation, but could be seriously useful. 