### PR TITLE
Remove unnecessary allows 

### DIFF
--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -276,7 +276,7 @@ impl<'a> Builder for CreateChannel<'a> {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::MANAGE_CHANNELS).await?;
+        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::MANAGE_CHANNELS)?;
 
         cache_http.http().create_channel(ctx, &self, self.audit_log_reason).await
     }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -204,7 +204,6 @@ impl CreateMessage {
     }
 
     /// Set the reference message this message is a reply to.
-    #[allow(clippy::unwrap_used)] // allowing unwrap here because serializing MessageReference should never error
     pub fn reference_message(mut self, reference: impl Into<MessageReference>) -> Self {
         self.message_reference = Some(reference.into());
         self

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -144,7 +144,7 @@ impl<'a> Builder for CreateScheduledEvent<'a> {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::MANAGE_EVENTS).await?;
+        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::MANAGE_EVENTS)?;
 
         cache_http.http().create_scheduled_event(ctx, &self, self.audit_log_reason).await
     }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -99,8 +99,7 @@ impl<'a> Builder for CreateSticker<'a> {
             &cache_http,
             ctx,
             Permissions::MANAGE_EMOJIS_AND_STICKERS,
-        )
-        .await?;
+        )?;
 
         let map = vec![("name", self.name), ("tags", self.tags), ("description", self.description)];
 

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -334,7 +334,7 @@ impl<'a> Builder for EditGuild<'a> {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::MANAGE_GUILD).await?;
+        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::MANAGE_GUILD)?;
 
         cache_http.http().edit_guild(ctx, &self, self.audit_log_reason).await
     }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -174,8 +174,7 @@ impl<'a> Builder for EditRole<'a> {
         let (guild_id, role_id) = ctx;
 
         #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_ROLES)
-            .await?;
+        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_ROLES)?;
 
         let http = cache_http.http();
         let role = match role_id {

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -188,7 +188,7 @@ impl<'a> Builder for EditScheduledEvent<'a> {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, ctx.0, Permissions::MANAGE_EVENTS).await?;
+        crate::utils::user_has_guild_perms(&cache_http, ctx.0, Permissions::MANAGE_EVENTS)?;
 
         cache_http.http().edit_scheduled_event(ctx.0, ctx.1, &self, self.audit_log_reason).await
     }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -7,7 +7,6 @@ use std::fmt;
 ///
 /// [`Client`]: super::Client
 /// [`Error::Client`]: crate::Error::Client
-#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Error {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -419,17 +419,13 @@ pub fn parse_webhook(url: &Url) -> Option<(WebhookId, &str)> {
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
-#[allow(clippy::unused_async)] // don't wanna change the bazillion internal invocations
-pub(crate) async fn user_has_guild_perms(
+pub(crate) fn user_has_guild_perms(
     cache_http: impl CacheHttp,
     guild_id: GuildId,
     permissions: Permissions,
 ) -> Result<()> {
     if let Some(cache) = cache_http.cache() {
-        // Unfortunately have to clone the guild because CacheRef is not `Send` and
-        // `Guild::has_perms` is an async fn, but we want the returned Future to be `Send`.
-        let lookup = cache.guild(guild_id).as_deref().cloned();
-        if let Some(guild) = lookup {
+        if let Some(guild) = cache.guild(guild_id) {
             guild.require_perms(cache, permissions)?;
         }
     }


### PR DESCRIPTION
This also turns out to save a guild clone for basically all builder executions.