### PR TITLE
Add MaybeMap::shrink_to_fit and use on unavailable_guilds

### DIFF
--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -38,6 +38,12 @@ impl<K: Eq + Hash, V> MaybeMap<K, V> {
         self.0.as_ref().map_or(0, |map| map.len())
     }
 
+    pub fn shrink_to_fit(&self) {
+        if let Some(map) = self.0.as_ref() {
+            map.shrink_to_fit();
+        }
+    }
+
     pub(crate) fn as_read_only(&self) -> ReadOnlyMapRef<'_, K, V> {
         ReadOnlyMapRef(self.0.as_ref())
     }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -175,6 +175,8 @@ fn update_cache_with_event(ctx: Context, event: Event) -> Option<(FullEvent, Opt
                 let context = ctx.clone();
 
                 if context.cache.unavailable_guilds.len() == 0 {
+                    context.cache.unavailable_guilds.shrink_to_fit();
+
                     let guild_amount =
                         context.cache.guilds.iter().map(|i| *i.key()).collect::<Vec<GuildId>>();
 


### PR DESCRIPTION
This resets the unavailable_guilds cache before cache_ready is fired, as it has been filled up to the number of guilds and is very unlikely to get to that size again.