### PR TITLE
Remove duplicate channels map

### DIFF
--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -313,11 +313,12 @@ mod tests {
 
         let cache = Arc::new(Cache::default());
 
+        guild.channels.insert(channel.id, channel.clone());
         guild.members.insert(user.id, member.clone());
         guild.roles.insert(role.id, role);
         cache.users.insert(user.id, user.clone());
         cache.guilds.insert(guild.id, guild.clone());
-        cache.channels.insert(channel.id, channel);
+        cache.channels.insert(channel.id, guild.id);
 
         let with_user_mentions = "<@!100000000000000000> <@!000000000000000000> <@123> <@!123> \
         <@!123123123123123123123> <@123> <@123123123123123123> <@!invalid> \


### PR DESCRIPTION
When a channel was received from the gateway it was cloned to be inserted into `cache.channels` and the `cache.guild.id.channels` maps, and since channels are the most cached model (around 7.3m channel models cached in my 230k server bot) this lead to a massive waste of memory (11.8gb of wasted ram in my extreme case).

This PR changes that map to only store the guild id that the channel originated from, which reduces ram usage by around half on my bot.

To accomplish this, I added in `CacheRefInner::MappedDashRef`, which stores a mapped dashmap ref, which in future can be used to remove the remaining `_field` methods.

I also took the liberty to remove the `category` methods that were cloning tons of channels and to implement using this method would cause massive cache contention for no real world use?