### PR TITLE
Remove PrivateChannel from caching and events

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -29,7 +29,7 @@ use serenity::framework::standard::{
 };
 use serenity::gateway::ShardManager;
 use serenity::http::Http;
-use serenity::model::channel::{Channel, Message};
+use serenity::model::channel::Message;
 use serenity::model::gateway::{GatewayIntents, Ready};
 use serenity::model::id::UserId;
 use serenity::model::permissions::Permissions;
@@ -557,7 +557,7 @@ async fn slow_mode(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
         } else {
             format!("Successfully set slow mode rate to `{slow_mode_rate_seconds}` seconds.")
         }
-    } else if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(&ctx.cache) {
+    } else if let Some(channel) = msg.channel_id.to_channel_cached(&ctx.cache) {
         let slow_mode_rate = channel.rate_limit_per_user.unwrap_or(0);
         format!("Current slow mode rate is `{slow_mode_rate}` seconds.")
     } else {

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -28,7 +28,7 @@ use crate::model::prelude::*;
 /// impl EventHandler for Handler {
 ///     async fn message(&self, context: Context, msg: Message) {
 ///         if msg.content == "!createinvite" {
-///             let channel_opt = context.cache.guild_channel(msg.channel_id).as_deref().cloned();
+///             let channel_opt = context.cache.channel(msg.channel_id).as_deref().cloned();
 ///             let channel = match channel_opt {
 ///                 Some(channel) => channel,
 ///                 None => {
@@ -118,7 +118,7 @@ impl<'a> CreateInvite<'a> {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// # let channel = context.cache.guild_channel(81384788765712384).unwrap().clone();
+    /// # let channel = context.cache.channel(81384788765712384).unwrap().clone();
     /// let builder = CreateInvite::new().max_age(3600);
     /// let invite = channel.create_invite(context, builder).await?;
     /// # Ok(())
@@ -150,7 +150,7 @@ impl<'a> CreateInvite<'a> {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// # let channel = context.cache.guild_channel(81384788765712384).unwrap().clone();
+    /// # let channel = context.cache.channel(81384788765712384).unwrap().clone();
     /// let builder = CreateInvite::new().max_uses(5);
     /// let invite = channel.create_invite(context, builder).await?;
     /// # Ok(())
@@ -180,7 +180,7 @@ impl<'a> CreateInvite<'a> {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// # let channel = context.cache.guild_channel(81384788765712384).unwrap().clone();
+    /// # let channel = context.cache.channel(81384788765712384).unwrap().clone();
     /// let builder = CreateInvite::new().temporary(true);
     /// let invite = channel.create_invite(context, builder).await?;
     /// # Ok(())
@@ -210,7 +210,7 @@ impl<'a> CreateInvite<'a> {
     /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
     /// # #[command]
     /// # async fn example(context: &Context) -> CommandResult {
-    /// # let channel = context.cache.guild_channel(81384788765712384).unwrap().clone();
+    /// # let channel = context.cache.channel(81384788765712384).unwrap().clone();
     /// let builder = CreateInvite::new().unique(true);
     /// let invite = channel.create_invite(context, builder).await?;
     /// # Ok(())
@@ -265,10 +265,7 @@ impl<'a> CreateInvite<'a> {
 #[cfg(feature = "http")]
 #[async_trait::async_trait]
 impl<'a> Builder for CreateInvite<'a> {
-    #[cfg(feature = "cache")]
-    type Context<'ctx> = (ChannelId, Option<GuildId>);
-    #[cfg(not(feature = "cache"))]
-    type Context<'ctx> = (ChannelId,);
+    type Context<'ctx> = ChannelId;
     type Built = RichInvite;
 
     /// Creates an invite for the given channel.
@@ -289,15 +286,10 @@ impl<'a> Builder for CreateInvite<'a> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    ctx.0,
-                    ctx.1,
-                    Permissions::CREATE_INSTANT_INVITE,
-                )?;
+                crate::utils::user_has_perms_cache(cache, ctx, Permissions::CREATE_INSTANT_INVITE)?;
             }
         }
 
-        cache_http.http().create_invite(ctx.0, &self, self.audit_log_reason).await
+        cache_http.http().create_invite(ctx, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -321,7 +321,7 @@ impl Builder for CreateMessage {
                 req |= Permissions::ATTACH_FILES;
             }
             if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(cache, channel_id, guild_id, req)?;
+                crate::utils::user_has_perms_cache(cache, channel_id, req)?;
             }
         }
 
@@ -344,7 +344,7 @@ impl Builder for CreateMessage {
             // Use either the passed in guild ID (e.g. if we were called from GuildChannel directly
             // we already know our guild ID), and otherwise find the guild ID in cache
             message.guild_id = guild_id
-                .or_else(|| Some(cache_http.cache()?.guild_channel(message.channel_id)?.guild_id));
+                .or_else(|| Some(cache_http.cache()?.channel(message.channel_id)?.guild_id));
         }
 
         Ok(message)

--- a/src/builder/create_stage_instance.rs
+++ b/src/builder/create_stage_instance.rs
@@ -75,7 +75,7 @@ impl<'a> Builder for CreateStageInstance<'a> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.guild_channel(ctx) {
+                if let Some(channel) = cache.channel(ctx) {
                     if channel.kind != ChannelType::Stage {
                         return Err(Error::Model(ModelError::InvalidChannelType));
                     }

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -80,7 +80,7 @@ impl<'a> Builder for CreateWebhook<'a> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.guild_channel(ctx) {
+                if let Some(channel) = cache.channel(ctx) {
                     // forum channels are not text-based, but webhooks can be created in them
                     // and used to send messages in their posts
                     if !channel.is_text_based() && channel.kind != ChannelType::Forum {

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -294,10 +294,7 @@ impl<'a> EditChannel<'a> {
 #[cfg(feature = "http")]
 #[async_trait::async_trait]
 impl<'a> Builder for EditChannel<'a> {
-    #[cfg(feature = "cache")]
-    type Context<'ctx> = (ChannelId, Option<GuildId>);
-    #[cfg(not(feature = "cache"))]
-    type Context<'ctx> = (ChannelId,);
+    type Context<'ctx> = ChannelId;
     type Built = GuildChannel;
 
     /// Edits the channel's settings.
@@ -320,23 +317,13 @@ impl<'a> Builder for EditChannel<'a> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    ctx.0,
-                    ctx.1,
-                    Permissions::MANAGE_CHANNELS,
-                )?;
+                crate::utils::user_has_perms_cache(cache, ctx, Permissions::MANAGE_CHANNELS)?;
                 if self.permission_overwrites.is_some() {
-                    crate::utils::user_has_perms_cache(
-                        cache,
-                        ctx.0,
-                        ctx.1,
-                        Permissions::MANAGE_ROLES,
-                    )?;
+                    crate::utils::user_has_perms_cache(cache, ctx, Permissions::MANAGE_ROLES)?;
                 }
             }
         }
 
-        cache_http.http().edit_channel(ctx.0, &self, self.audit_log_reason).await
+        cache_http.http().edit_channel(ctx, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -68,7 +68,7 @@ impl<'a> Builder for EditStageInstance<'a> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.guild_channel(ctx) {
+                if let Some(channel) = cache.channel(ctx) {
                     if channel.kind != ChannelType::Stage {
                         return Err(Error::Model(ModelError::InvalidChannelType));
                     }

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -93,7 +93,7 @@ impl Builder for EditVoiceState {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.guild_channel(channel_id) {
+                if let Some(channel) = cache.channel(channel_id) {
                     if channel.kind != ChannelType::Stage {
                         return Err(Error::from(ModelError::InvalidChannelType));
                     }

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -82,16 +82,8 @@ impl CacheUpdate for ChannelPinsUpdateEvent {
     type Output = ();
 
     fn update(&mut self, cache: &Cache) -> Option<()> {
-        if let Some(mut channel) = cache.guild_channel_mut(self.channel_id) {
+        if let Some(mut channel) = cache.channel_mut(self.channel_id) {
             channel.last_pin_timestamp = self.last_pin_timestamp;
-
-            return None;
-        }
-
-        if let Some(mut channel) = cache.private_channels.get_mut(&self.channel_id) {
-            channel.last_pin_timestamp = self.last_pin_timestamp;
-
-            return None;
         }
 
         None
@@ -573,7 +565,7 @@ impl CacheUpdate for VoiceChannelStatusUpdateEvent {
     type Output = String;
 
     fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
-        if let Some(mut channel) = cache.guild_channel_mut(self.id) {
+        if let Some(mut channel) = cache.channel_mut(self.id) {
             let old = channel.status.clone();
             channel.status = self.status.clone();
             // Discord updates topic but doesn't fire ChannelUpdate.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -995,10 +995,10 @@ mod test {
         // Add a channel delete event to the cache, the cached messages for that channel should now
         // be gone.
         let mut delete = ChannelDeleteEvent {
-            channel: Channel::Guild(channel.clone()),
+            channel: channel.clone(),
         };
         assert!(cache.update(&mut delete).is_some());
-        assert!(!cache.messages.contains_key(&delete.channel.id()));
+        assert!(!cache.messages.contains_key(&delete.channel.id));
 
         // Test deletion of a guild channel's message cache when a GuildDeleteEvent is received.
         let mut guild_create = GuildCreateEvent {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -112,7 +112,6 @@ impl<K: Eq + Hash, V, T> std::ops::Deref for CacheRef<'_, K, V, T> {
 pub type UserRef<'a> = CacheRef<'a, UserId, User>;
 pub type GuildRef<'a> = CacheRef<'a, GuildId, Guild>;
 pub type CurrentUserRef<'a> = CacheRef<'a, (), CurrentUser>;
-pub type PrivateChannelRef<'a> = CacheRef<'a, ChannelId, PrivateChannel>;
 pub type GuildChannelRef<'a> = CacheRef<'a, GuildId, GuildChannel, Guild>;
 pub type ChannelMessagesRef<'a> = CacheRef<'a, ChannelId, HashMap<MessageId, Message>>;
 
@@ -130,7 +129,6 @@ pub(crate) struct CachedShardData {
 ///
 /// This is the list of cached resources and the events that populate them:
 /// - channels: [`ChannelCreateEvent`], [`ChannelUpdateEvent`], [`GuildCreateEvent`]
-/// - private_channels: [`ChannelCreateEvent`]
 /// - guilds: [`GuildCreateEvent`]
 /// - unavailable_guilds: [`ReadyEvent`], [`GuildDeleteEvent`]
 /// - users: [`GuildMemberAddEvent`], [`GuildMemberRemoveEvent`], [`GuildMembersChunkEvent`],
@@ -151,7 +149,7 @@ pub struct Cache {
     ///
     /// The TTL for each value is configured in CacheSettings.
     #[cfg(feature = "temp_cache")]
-    pub(crate) temp_channels: MokaCache<ChannelId, GuildChannel, BuildHasher>,
+    pub(crate) temp_channels: MokaCache<ChannelId, Arc<GuildChannel>, BuildHasher>,
     /// Cache of users who have been fetched from `to_user`.
     ///
     /// The TTL for each value is configured in CacheSettings.
@@ -161,8 +159,6 @@ pub struct Cache {
     // Channels cache:
     /// A map of channel ids to the guilds in which the channel data is stored.
     pub(crate) channels: MaybeMap<ChannelId, GuildId>,
-    /// A map of direct message channels that the current user has open with other users.
-    pub(crate) private_channels: MaybeMap<ChannelId, PrivateChannel>,
 
     // Guilds cache:
     // ---
@@ -258,7 +254,6 @@ impl Cache {
             temp_users: temp_cache(settings.time_to_live),
 
             channels: MaybeMap(settings.cache_channels.then(DashMap::default)),
-            private_channels: MaybeMap(settings.cache_channels.then(DashMap::default)),
 
             guilds: MaybeMap(settings.cache_guilds.then(DashMap::default)),
             unavailable_guilds: MaybeMap(settings.cache_guilds.then(DashMap::default)),
@@ -331,26 +326,6 @@ impl Cache {
         total
     }
 
-    /// Fetches a vector of all [`PrivateChannel`] Ids that are stored in the cache.
-    ///
-    /// # Examples
-    ///
-    /// If there are 6 private channels and 2 groups in the cache, then `8` Ids will be returned.
-    ///
-    /// Printing the count of all private channels and groups:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::cache::Cache;
-    /// #
-    /// # let cache = Cache::default();
-    /// let amount = cache.private_channels().len();
-    ///
-    /// println!("There are {} private channels", amount);
-    /// ```
-    pub fn private_channels(&self) -> ReadOnlyMapRef<'_, ChannelId, PrivateChannel> {
-        self.private_channels.as_read_only()
-    }
-
     /// Fetches a vector of all [`Guild`]s' Ids that are stored in the cache.
     ///
     /// Note that if you are utilizing multiple [`Shard`]s, then the guilds retrieved over all
@@ -387,37 +362,37 @@ impl Cache {
         self.guilds.iter().map(|i| *i.key()).chain(unavailable_guild_ids).collect()
     }
 
-    /// Retrieves a [`Channel`] from the cache based on the given Id.
-    ///
-    /// This will search the `channels` map, then the [`Self::private_channels`] map.
-    ///
-    /// If you know what type of channel you're looking for, you should instead manually retrieve
-    /// from one of the respective methods:
-    ///
-    /// - [`GuildChannel`]: [`Self::guild_channel`] or [`Self::guild_channels`]
-    /// - [`PrivateChannel`]: [`Self::private_channel`] or [`Self::private_channels`]
+    /// Retrieves a [`GuildChannel`] from the cache based on the given Id.
     #[inline]
-    pub fn channel<C: Into<ChannelId>>(&self, id: C) -> Option<Channel> {
+    pub fn channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannelRef<'_>> {
         self._channel(id.into())
     }
 
-    fn _channel(&self, id: ChannelId) -> Option<Channel> {
-        if let Some(channel) = self.guild_channel(id) {
-            return Some(Channel::Guild(channel.clone()));
+    fn _channel(&self, id: ChannelId) -> Option<GuildChannelRef<'_>> {
+        let guild_id = *self.channels.get(&id)?;
+        let guild_ref = self.guilds.get(&guild_id)?;
+        let channel = guild_ref.try_map(|g| g.channels.get(&id)).ok();
+        if let Some(channel) = channel {
+            return Some(CacheRef::from_mapped_ref(channel));
         }
 
         #[cfg(feature = "temp_cache")]
         {
             if let Some(channel) = self.temp_channels.get(&id) {
-                return Some(Channel::Guild(channel));
+                return Some(CacheRef::from_arc(channel));
             }
         }
 
-        if let Some(private_channel) = self.private_channels.get(&id) {
-            return Some(Channel::Private(private_channel.clone()));
-        }
-
         None
+    }
+
+    pub(super) fn channel_mut(
+        &self,
+        id: ChannelId,
+    ) -> Option<MappedRefMut<'_, GuildId, Guild, GuildChannel, BuildHasher>> {
+        let guild_id = *self.channels.get(&id)?;
+        let guild_ref = self.guilds.get_mut(&guild_id)?;
+        guild_ref.try_map(|g| g.channels.get_mut(&id)).ok()
     }
 
     /// Get a reference to the cached messages for a channel based on the given `Id`.
@@ -469,75 +444,6 @@ impl Cache {
         self.guilds.len()
     }
 
-    /// Retrieves a reference to a [`Guild`]'s channel. Unlike [`Self::channel`], this will only
-    /// search guilds for the given channel.
-    ///
-    /// The only advantage of this method is that you can pass in anything that is indirectly a
-    /// [`ChannelId`].
-    ///
-    /// # Examples
-    ///
-    /// Getting a guild's channel via the Id of the message received through a
-    /// [`EventHandler::message`] event dispatch:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::model::prelude::*;
-    /// # use serenity::prelude::*;
-    /// #
-    /// struct Handler;
-    ///
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn message(&self, context: Context, message: Message) {
-    ///         let channel_opt = context.cache.guild_channel(message.channel_id).as_deref().cloned();
-    ///         let channel = match channel_opt {
-    ///             Some(channel) => channel,
-    ///             None => {
-    ///                 let result = message
-    ///                     .channel_id
-    ///                     .say(&context, "Could not find guild's channel data")
-    ///                     .await;
-    ///                 if let Err(why) = result {
-    ///                     println!("Error sending message: {:?}", why);
-    ///                 }
-    ///
-    ///                 return;
-    ///             },
-    ///         };
-    ///     }
-    /// }
-    ///
-    /// # #[cfg(feature = "client")]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// [`EventHandler::message`]: crate::client::EventHandler::message
-    #[inline]
-    pub fn guild_channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannelRef<'_>> {
-        self._guild_channel(id.into())
-    }
-
-    fn _guild_channel(&self, id: ChannelId) -> Option<GuildChannelRef<'_>> {
-        let guild_id = *self.channels.get(&id)?;
-        let guild_ref = self.guilds.get(&guild_id)?;
-        guild_ref.try_map(|g| g.channels.get(&id)).ok().map(CacheRef::from_mapped_ref)
-    }
-
-    pub(super) fn guild_channel_mut(
-        &self,
-        id: ChannelId,
-    ) -> Option<MappedRefMut<'_, GuildId, Guild, GuildChannel, BuildHasher>> {
-        let guild_id = *self.channels.get(&id)?;
-        let guild_ref = self.guilds.get_mut(&guild_id)?;
-        guild_ref.try_map(|g| g.channels.get_mut(&id)).ok()
-    }
-
     /// Retrieves a [`Guild`]'s member from the cache based on the guild's and user's given Ids.
     ///
     /// **Note**: This will clone the entire member. Instead, retrieve the guild and retrieve from
@@ -556,7 +462,7 @@ impl Cache {
     /// # async fn run(http: Http, cache: Cache, message: Message) {
     /// #
     /// let member = {
-    ///     let channel = match cache.guild_channel(message.channel_id) {
+    ///     let channel = match cache.channel(message.channel_id) {
     ///         Some(channel) => channel,
     ///         None => {
     ///             if let Err(why) = message.channel_id.say(http, "Error finding channel data").await {
@@ -724,38 +630,6 @@ impl Cache {
         self.messages.get(&channel_id).and_then(|messages| messages.get(&message_id).cloned())
     }
 
-    /// Retrieves a [`PrivateChannel`] from the cache's [`Self::private_channels`] map, if it
-    /// exists.
-    ///
-    /// The only advantage of this method is that you can pass in anything that is indirectly a
-    /// [`ChannelId`].
-    ///
-    /// # Examples
-    ///
-    /// Retrieve a private channel from the cache and print its recipient's name:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::cache::Cache;
-    /// #
-    /// # let cache = Cache::default();
-    /// // assuming the cache has been unlocked
-    ///
-    /// if let Some(channel) = cache.private_channel(7) {
-    ///     println!("The recipient is {}", channel.recipient);
-    /// };
-    /// ```
-    #[inline]
-    pub fn private_channel(
-        &self,
-        channel_id: impl Into<ChannelId>,
-    ) -> Option<PrivateChannelRef<'_>> {
-        self._private_channel(channel_id.into())
-    }
-
-    fn _private_channel(&self, channel_id: ChannelId) -> Option<PrivateChannelRef<'_>> {
-        self.private_channels.get(&channel_id).map(CacheRef::from_ref)
-    }
-
     /// Retrieves a [`Guild`]'s role by their Ids.
     ///
     /// **Note**: This will clone the entire role. Instead, retrieve the guild and retrieve from
@@ -875,7 +749,7 @@ impl Cache {
 
     /// Returns a channel category matching the given ID
     pub fn category(&self, channel_id: ChannelId) -> Option<GuildChannelRef<'_>> {
-        let channel = self.guild_channel(channel_id)?;
+        let channel = self.channel(channel_id)?;
         if channel.kind == ChannelType::Category {
             Some(channel)
         } else {
@@ -885,7 +759,7 @@ impl Cache {
 
     /// Returns the parent category of the given channel ID.
     pub fn channel_category_id(&self, channel_id: ChannelId) -> Option<ChannelId> {
-        self.guild_channel(channel_id)?.parent_id
+        self.channel(channel_id)?.parent_id
     }
 
     /// Clones all channel categories in the given guild and returns them.

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -138,7 +138,7 @@ event_handler! {
     /// Dispatched when a channel is updated.
     ///
     /// The old channel data is only provided when the cache feature is enabled.
-    async fn channel_update(&self, ChannelUpdate { ctx: Context, old: Option<Channel>, new: Channel });
+    async fn channel_update(&self, ChannelUpdate { ctx: Context, old: Option<GuildChannel>, new: GuildChannel });
 
     /// Dispatched when a new audit log entry is created.
     ///

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -30,8 +30,6 @@ use super::Framework;
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
 use crate::client::{Context, FullEvent};
-#[cfg(feature = "cache")]
-use crate::model::channel::Channel;
 use crate::model::channel::Message;
 #[cfg(feature = "cache")]
 use crate::model::guild::Member;
@@ -250,7 +248,7 @@ impl StandardFramework {
 
             #[cfg(feature = "cache")]
             {
-                if let Some(Channel::Guild(channel)) = msg.channel_id.to_channel_cached(ctx) {
+                if let Some(channel) = msg.channel_id.to_channel_cached(&ctx.cache) {
                     let guild_id = channel.guild_id;
 
                     if config.blocked_guilds.contains(&guild_id) {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -167,7 +167,6 @@ impl Message {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
-                        self.guild_id,
                         Permissions::MANAGE_MESSAGES,
                     )?;
                 }
@@ -226,7 +225,6 @@ impl Message {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
-                        self.guild_id,
                         Permissions::MANAGE_MESSAGES,
                     )?;
                 }
@@ -250,12 +248,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                utils::user_has_perms_cache(
-                    cache,
-                    self.channel_id,
-                    self.guild_id,
-                    Permissions::MANAGE_MESSAGES,
-                )?;
+                utils::user_has_perms_cache(cache, self.channel_id, Permissions::MANAGE_MESSAGES)?;
             }
         }
 
@@ -301,12 +294,7 @@ impl Message {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                utils::user_has_perms_cache(
-                    cache,
-                    self.channel_id,
-                    self.guild_id,
-                    Permissions::MANAGE_MESSAGES,
-                )?;
+                utils::user_has_perms_cache(cache, self.channel_id, Permissions::MANAGE_MESSAGES)?;
             }
         }
 
@@ -512,7 +500,6 @@ impl Message {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
-                        self.guild_id,
                         Permissions::MANAGE_MESSAGES,
                     )?;
                 }
@@ -557,7 +544,6 @@ impl Message {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
-                        self.guild_id,
                         Permissions::ADD_REACTIONS,
                     )?;
                 }
@@ -669,7 +655,6 @@ impl Message {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
-                        self.guild_id,
                         Permissions::SEND_MESSAGES,
                     )?;
                 }
@@ -740,7 +725,6 @@ impl Message {
                     utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
-                        self.guild_id,
                         Permissions::MANAGE_MESSAGES,
                     )?;
                 }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -34,7 +34,6 @@ pub type AttachmentType<'a> = crate::builder::CreateAttachment;
 
 /// A container for any channel.
 #[derive(Clone, Debug, Serialize)]
-#[serde(untagged)]
 #[non_exhaustive]
 #[allow(clippy::large_enum_variant)] // https://github.com/rust-lang/rust-clippy/issues/9798
 pub enum Channel {

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -34,6 +34,7 @@ pub type AttachmentType<'a> = crate::builder::CreateAttachment;
 
 /// A container for any channel.
 #[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
 #[non_exhaustive]
 #[allow(clippy::large_enum_variant)] // https://github.com/rust-lang/rust-clippy/issues/9798
 pub enum Channel {

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -69,8 +69,8 @@ impl PrivateChannel {
     /// closing a private channel on the client, which can be re-opened.
     #[allow(clippy::missing_errors_doc)]
     #[inline]
-    pub async fn delete(&self, http: impl AsRef<Http>) -> Result<Channel> {
-        self.id.delete(http).await
+    pub async fn delete(&self, http: impl AsRef<Http>) -> Result<PrivateChannel> {
+        self.id.delete(http).await?.private().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 
     /// Deletes all messages by Ids from the given vector in the channel.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -108,7 +108,6 @@ impl Reaction {
                     crate::utils::user_has_perms_cache(
                         cache,
                         self.channel_id,
-                        self.guild_id,
                         Permissions::MANAGE_MESSAGES,
                     )?;
                 }
@@ -140,7 +139,6 @@ impl Reaction {
                 crate::utils::user_has_perms_cache(
                     cache,
                     self.channel_id,
-                    self.guild_id,
                     Permissions::MANAGE_MESSAGES,
                 )?;
             }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -80,7 +80,6 @@ pub struct AutoModActionExecutionEvent {
 ///
 /// This is fired when:
 /// - A [`Channel`] is created in a [`Guild`]
-/// - A [`PrivateChannel`] is created
 ///
 /// Requires [`GatewayIntents::GUILDS`].
 ///
@@ -90,7 +89,7 @@ pub struct AutoModActionExecutionEvent {
 #[non_exhaustive]
 pub struct ChannelCreateEvent {
     /// The channel that was created.
-    pub channel: Channel,
+    pub channel: GuildChannel,
 }
 
 /// Requires [`GatewayIntents::GUILDS`].
@@ -100,7 +99,7 @@ pub struct ChannelCreateEvent {
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct ChannelDeleteEvent {
-    pub channel: Channel,
+    pub channel: GuildChannel,
 }
 
 /// Requires [`GatewayIntents::GUILDS`] or [`GatewayIntents::DIRECT_MESSAGES`].
@@ -121,7 +120,7 @@ pub struct ChannelPinsUpdateEvent {
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct ChannelUpdateEvent {
-    pub channel: Channel,
+    pub channel: GuildChannel,
 }
 
 /// Requires [`GatewayIntents::GUILD_MODERATION`] and [`Permissions::VIEW_AUDIT_LOG`].

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -100,11 +100,9 @@ impl Invite {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let guild_id = self.guild.as_ref().map(|g| g.id);
                 crate::utils::user_has_perms_cache(
                     cache,
                     self.channel.id,
-                    guild_id,
                     Permissions::MANAGE_GUILD,
                 )?;
             }
@@ -325,11 +323,9 @@ impl RichInvite {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                let guild_id = self.guild.as_ref().map(|g| g.id);
                 crate::utils::user_has_perms_cache(
                     cache,
                     self.channel.id,
-                    guild_id,
                     Permissions::MANAGE_GUILD,
                 )?;
             }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -705,19 +705,6 @@ impl UserId {
     ///
     /// [current user]: CurrentUser
     pub async fn create_dm_channel(self, cache_http: impl CacheHttp) -> Result<PrivateChannel> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                for channel_entry in cache.private_channels().iter() {
-                    let channel = channel_entry.value();
-
-                    if channel.recipient.id == self {
-                        return Ok(channel.clone());
-                    }
-                }
-            }
-        }
-
         let map = json!({
             "recipient_id": self,
         });

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use crate::cache::Cache;
-use crate::model::channel::Channel;
 use crate::model::id::GuildId;
 use crate::model::mention::Mention;
 use crate::model::user::User;
@@ -223,7 +222,7 @@ fn clean_mention(
     let cache = cache.as_ref();
     match mention {
         Mention::Channel(id) => {
-            if let Some(Channel::Guild(channel)) = id.to_channel_cached(cache) {
+            if let Some(channel) = id.to_channel_cached(cache) {
                 format!("#{}", channel.name).into()
             } else {
                 "#deleted-channel".into()


### PR DESCRIPTION
The entire `PrivateChannel` dashmap was never used, discord hasn't supplied events for it since API v8, and all the methods handling it were just unneeded. This allows for removal of `Channel` from a lot of the API surface, replacing it with the specific `GuildChannel` or specifically using `PrivateChannel`.

This was motivated by the `allow(clippy::large_enum_variant)` on `Channel` making me reconsider if it is strictly needed, which it is for a few endpoints (http get channel can return private channels), but was able to be removed from a lot of endpoints. 