### PR TITLE
Added AsRef on Context for Context

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -426,6 +426,12 @@ impl Context {
     }
 }
 
+impl AsRef<Context> for Context {
+    fn as_ref(&self) -> &Context {
+        &self
+    }
+}
+
 impl AsRef<Http> for Context {
     fn as_ref(&self) -> &Http {
         &self.http


### PR DESCRIPTION
This fixes an issue with poise's `execute_modal_on_component_interaction` which takes in a impl AsRef<Context> however, this does not actually accept context so this fixes it