### PR TITLE
Remove last usages of clone in Cache that aren't absolutely needed 

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -3,16 +3,13 @@
 //! Using the cache allows to avoid REST API requests via the [`http`] module where possible.
 //! Issuing too many requests will lead to ratelimits.
 //!
-//! Following a policy to never hand out locks, the cache will clone all values when calling its
-//! methods.
-//!
 //! # Use by Models
 //!
 //! Most models of Discord objects, such as the [`Message`], [`GuildChannel`], or [`Emoji`], have
-//! methods for interacting with that single instance. This feature is only compiled if the
-//! `methods` feature is enabled. An example of this is [`Guild::edit`], which performs a check to
-//! ensure that the current user is the owner of the guild, prior to actually performing the HTTP
-//! request. The cache is involved due to the function's use of unlocking the cache and retrieving
+//! methods for interacting with that single instance. This feature is only compiled if the `model`
+//! feature is enabled. An example of this is [`Guild::edit`], which performs a check to ensure that
+//! the current user is the owner of the guild, prior to actually performing the HTTP request.
+//! The cache is involved due to the function's use of unlocking the cache and retrieving
 //! the Id of the current user, and comparing it to the Id of the user that owns the guild. This is
 //! an inexpensive method of being able to access data required by these sugary methods.
 //!

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -224,7 +224,8 @@ fn update_cache_with_event(ctx: Context, event: Event) -> Option<(FullEvent, Opt
         },
         Event::GuildMemberUpdate(mut event) => {
             let before = if_cache!(update_cache(&ctx, &mut event));
-            let after: Option<Member> = if_cache!(ctx.cache.member(event.guild_id, event.user.id));
+            let after: Option<Member> =
+                if_cache!(ctx.cache.member(event.guild_id, event.user.id).map(|m| m.clone()));
 
             FullEvent::GuildMemberUpdate {
                 ctx,

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -317,7 +317,7 @@ fn update_cache_with_event(ctx: Context, event: Event) -> Option<(FullEvent, Opt
         },
         Event::MessageUpdate(mut event) => {
             let before = if_cache!(update_cache(&ctx, &mut event));
-            let after = if_cache!(ctx.cache.message(event.channel_id, event.id));
+            let after = if_cache!(ctx.cache.message(event.channel_id, event.id).map(|m| m.clone()));
 
             FullEvent::MessageUpdate {
                 ctx,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -452,7 +452,7 @@ impl ChannelId {
         #[cfg(feature = "cache")]
         if let Some(cache) = cache_http.cache() {
             if let Some(message) = cache.message(self, message_id) {
-                return Ok(message);
+                return Ok(message.clone());
             }
         }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1080,7 +1080,7 @@ impl GuildId {
         {
             if let Some(cache) = cache_http.cache() {
                 if let Some(member) = cache.member(self, user_id) {
-                    return Ok(member);
+                    return Ok(member.clone());
                 }
             }
         }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -439,9 +439,7 @@ impl Guild {
         let name = name.as_ref();
         let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
-        for channel_entry in &guild_channels {
-            let (id, channel) = channel_entry.pair();
-
+        for (id, channel) in guild_channels.iter() {
             if channel.name == name {
                 return Some(*id);
             }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -388,9 +388,7 @@ impl PartialGuild {
         let name = name.as_ref();
         let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
-        for channel_entry in &guild_channels {
-            let (id, channel) = channel_entry.pair();
-
+        for (id, channel) in guild_channels.iter() {
             if channel.name == name {
                 return Some(*id);
             }

--- a/src/utils/argument_convert/message.rs
+++ b/src/utils/argument_convert/message.rs
@@ -71,7 +71,7 @@ impl ArgumentConvert for Message {
         #[cfg(feature = "cache")]
         if let Some(cache) = ctx.cache() {
             if let Some(msg) = cache.message(channel_id, message_id) {
-                return Ok(msg);
+                return Ok(msg.clone());
             }
         }
 


### PR DESCRIPTION
Turns out to only be useful internally for `channel_id_from_name`, but good for consistency and external usage.

## Changelog
- Removes member_field
- Changes guild_channels to return CacheRef
- Changes guild_roles to return CacheRef
- Changes message to return CacheRef
- Changes settings to return CacheRef
- Changes role to return CacheRef
