### PR TITLE
Split ThreadMember into PartialThreadMember and ThreadMember

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -124,7 +124,7 @@ pub struct GuildChannel {
     pub thread_metadata: Option<ThreadMetadata>,
     /// Thread member object for the current user, if they have joined the thread, only included on
     /// certain API endpoints.
-    pub member: Option<ThreadMember>,
+    pub member: Option<PartialThreadMember>,
     /// Default duration for newly created threads, in minutes, to automatically archive the thread
     /// after recent activity.
     pub default_auto_archive_duration: Option<AutoArchiveDuration>,

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -644,30 +644,31 @@ impl From<Member> for PartialMember {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct PartialThreadMember {
+    /// The time the current user last joined the thread.
+    pub join_timestamp: Timestamp,
+    /// Any user-thread settings, currently only used for notifications
+    pub flags: ThreadMemberFlags,
+}
+
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-member-object),
 /// [extra fields](https://discord.com/developers/docs/topics/gateway-events#thread-member-update-thread-member-update-event-extra-fields).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ThreadMember {
+    #[serde(flatten)]
+    pub inner: PartialThreadMember,
     /// The id of the thread.
-    ///
-    /// This field is omitted on the member sent within each thread in the GUILD_CREATE event.
-    pub id: Option<ChannelId>,
+    pub id: ChannelId,
     /// The id of the user.
-    ///
-    /// This field is omitted on the member sent within each thread in the GUILD_CREATE event.
-    pub user_id: Option<UserId>,
-    /// The time the current user last joined the thread.
-    pub join_timestamp: Timestamp,
-    /// Any user-thread settings, currently only used for notifications
-    pub flags: ThreadMemberFlags,
+    pub user_id: UserId,
     /// Additional information about the user.
-    ///
-    /// This field is omitted on the member sent within each thread in the GUILD_CREATE event.
     ///
     /// This field is only present when `with_member` is set to `true` when calling
     /// List Thread Members or Get Thread Member, or inside [`ThreadMembersUpdateEvent`].
-    pub member: Option<Box<Member>>,
+    pub member: Option<Member>,
     /// ID of the guild.
     ///
     /// Always present in [`ThreadMemberUpdateEvent`], otherwise `None`.


### PR DESCRIPTION
This reduces GuildChannel size from 456 to 424 while getting rid of the Box.