### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   rust_min: 1.53.0
-  rust_nightly: nightly-2022-08-11
+  rust_nightly: nightly-2023-01-26
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = "1.0.7"
 optional = true
 
 [dependencies.simd-json]
-version = "0.12.0"
+version = "0.10.3"
 optional = true
 
 [dependencies.tracing]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = "1.0.7"
 optional = true
 
 [dependencies.simd-json]
-version = "0.4.14"
+version = "0.12.0"
 optional = true
 
 [dependencies.tracing]

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -300,7 +300,7 @@ async fn before_hook(ctx: &Context, _: &Message, cmd_name: &str) -> bool {
 
     let command_count_value = {
         let mut count_write = elements.command_usage_values.lock().await;
-        let mut command_count_value = count_write.get_mut(cmd_name).unwrap();
+        let command_count_value = count_write.get_mut(cmd_name).unwrap();
         command_count_value.use_count += 1;
         command_count_value.clone()
     };

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -457,10 +457,8 @@ impl CacheUpdate for MessageCreateEvent {
             return None;
         }
 
-        let messages =
-            cache.messages.entry(self.message.channel_id).or_insert_with(Default::default);
-        let mut queue =
-            cache.message_queue.entry(self.message.channel_id).or_insert_with(Default::default);
+        let messages = cache.messages.entry(self.message.channel_id).or_default();
+        let mut queue = cache.message_queue.entry(self.message.channel_id).or_default();
 
         let mut removed_msg = None;
 
@@ -594,7 +592,7 @@ impl CacheUpdate for ReadyEvent {
         let ready_guilds_hashset =
             self.ready.guilds.iter().map(|status| status.id).collect::<HashSet<_>>();
         let shard_data = self.ready.shard.unwrap_or([1, 1]);
-        for guild_entry in cache.guilds.iter() {
+        for guild_entry in &cache.guilds {
             let guild = guild_entry.key();
             // Only handle data for our shard.
             if crate::utils::shard_id(guild.0, shard_data[1]) == shard_data[0]

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -276,7 +276,7 @@ impl Cache {
     pub fn unknown_members(&self) -> u64 {
         let mut total = 0;
 
-        for guild_entry in self.guilds.iter() {
+        for guild_entry in &self.guilds {
             let guild = guild_entry.value();
 
             let members = guild.members.len() as u64;

--- a/src/client/bridge/gateway/shard_manager.rs
+++ b/src/client/bridge/gateway/shard_manager.rs
@@ -117,6 +117,7 @@ pub struct ShardManager {
 impl ShardManager {
     /// Creates a new shard manager, returning both the manager and a monitor
     /// for usage in a separate thread.
+    #[allow(clippy::unused_async)]
     pub async fn new(opt: ShardManagerOptions<'_>) -> (Arc<Mutex<Self>>, ShardManagerMonitor) {
         let (thread_tx, thread_rx) = mpsc::unbounded();
         let (shard_queue_tx, shard_queue_rx) = mpsc::unbounded();

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -212,12 +212,12 @@ pub(crate) fn dispatch<'rec>(
                     #[cfg(not(feature = "framework"))]
                     {
                         // Avoid cloning if there will be no framework dispatch.
-                        dispatch_message(context, event.message, h).await;
+                        dispatch_message(context, event.message, h);
                     }
 
                     #[cfg(feature = "framework")]
                     {
-                        dispatch_message(context.clone(), event.message.clone(), h).await;
+                        dispatch_message(context.clone(), event.message.clone(), h);
 
                         let framework = Arc::clone(framework);
 
@@ -290,12 +290,12 @@ pub(crate) fn dispatch<'rec>(
                         #[cfg(not(feature = "framework"))]
                         {
                             // Avoid cloning if there will be no framework dispatch.
-                            dispatch_message(context, event.message, handler).await;
+                            dispatch_message(context, event.message, handler);
                         }
 
                         #[cfg(feature = "framework")]
                         {
-                            dispatch_message(context.clone(), event.message.clone(), handler).await;
+                            dispatch_message(context.clone(), event.message.clone(), handler);
 
                             let framework = Arc::clone(framework);
                             let message = event.message;
@@ -315,11 +315,7 @@ pub(crate) fn dispatch<'rec>(
     .boxed()
 }
 
-async fn dispatch_message(
-    context: Context,
-    mut message: Message,
-    event_handler: &Arc<dyn EventHandler>,
-) {
+fn dispatch_message(context: Context, mut message: Message, event_handler: &Arc<dyn EventHandler>) {
     #[cfg(feature = "model")]
     {
         message.transform_content();

--- a/src/collector/component_interaction_collector.rs
+++ b/src/collector/component_interaction_collector.rs
@@ -183,7 +183,7 @@ impl fmt::Debug for FilterOptions {
             .field("channel_id", &self.channel_id)
             .field("guild_id", &self.guild_id)
             .field("author_id", &self.author_id)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -294,7 +294,7 @@ impl Stream for ComponentInteractionCollector {
     fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
         if let Some(ref mut timeout) = self.timeout {
             match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
+                Poll::Ready(()) => {
                     return Poll::Ready(None);
                 },
                 Poll::Pending => (),

--- a/src/collector/event_collector.rs
+++ b/src/collector/event_collector.rs
@@ -295,7 +295,7 @@ impl Stream for EventCollector {
     fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
         if let Some(ref mut timeout) = self.timeout {
             match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
+                Poll::Ready(()) => {
                     return Poll::Ready(None);
                 },
                 Poll::Pending => (),
@@ -354,21 +354,17 @@ mod test {
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
 
-        assert!(matches!(
-            EventCollectorBuilder::new(&msg)
-                .add_event_type(EventType::GuildBanAdd)
-                .add_user_id(UserId::default())
-                .build(),
-            Ok(_)
-        ));
-        assert!(matches!(
-            EventCollectorBuilder::new(&msg)
-                .add_event_type(EventType::GuildBanAdd)
-                .add_event_type(EventType::GuildCreate)
-                .add_user_id(UserId::default())
-                .build(),
-            Ok(_)
-        ));
+        assert!(EventCollectorBuilder::new(&msg)
+            .add_event_type(EventType::GuildBanAdd)
+            .add_user_id(UserId::default())
+            .build()
+            .is_ok());
+        assert!(EventCollectorBuilder::new(&msg)
+            .add_event_type(EventType::GuildBanAdd)
+            .add_event_type(EventType::GuildCreate)
+            .add_user_id(UserId::default())
+            .build()
+            .is_ok());
     }
 
     #[test]
@@ -384,13 +380,11 @@ mod test {
                 .build(),
             Err(Error::Collector(CollectorError::InvalidEventIdFilters))
         ));
-        assert!(matches!(
-            EventCollectorBuilder::new(&msg)
-                .add_event_type(EventType::UserUpdate)
-                .add_user_id(UserId::default())
-                .build(),
-            Ok(_)
-        ));
+        assert!(EventCollectorBuilder::new(&msg)
+            .add_event_type(EventType::UserUpdate)
+            .add_user_id(UserId::default())
+            .build()
+            .is_ok());
     }
 
     #[test]
@@ -400,14 +394,12 @@ mod test {
 
         // If at least one event type has the filtered ID type(s), we go ahead and build the
         // collector, even though one or more of the event types may never be yielded.
-        assert!(matches!(
-            EventCollectorBuilder::new(&msg)
-                .add_event_type(EventType::GuildCreate)
-                .add_event_type(EventType::GuildMemberAdd)
-                .add_user_id(UserId::default())
-                .build(),
-            Ok(_)
-        ));
+        assert!(EventCollectorBuilder::new(&msg)
+            .add_event_type(EventType::GuildCreate)
+            .add_event_type(EventType::GuildMemberAdd)
+            .add_user_id(UserId::default())
+            .build()
+            .is_ok());
         // But if none of the events have that ID type, that's an error.
         assert!(matches!(
             EventCollectorBuilder::new(&msg)

--- a/src/collector/message_collector.rs
+++ b/src/collector/message_collector.rs
@@ -260,7 +260,7 @@ impl fmt::Debug for FilterOptions {
             .field("channel_id", &self.channel_id)
             .field("guild_id", &self.guild_id)
             .field("author_id", &self.author_id)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -286,7 +286,7 @@ impl Stream for MessageCollector {
     fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
         if let Some(ref mut timeout) = self.timeout {
             match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
+                Poll::Ready(()) => {
                     return Poll::Ready(None);
                 },
                 Poll::Pending => (),

--- a/src/collector/modal_interaction_collector.rs
+++ b/src/collector/modal_interaction_collector.rs
@@ -186,7 +186,7 @@ impl fmt::Debug for FilterOptions {
             .field("channel_id", &self.channel_id)
             .field("guild_id", &self.guild_id)
             .field("author_id", &self.author_id)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -297,7 +297,7 @@ impl Stream for ModalInteractionCollector {
     fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
         if let Some(ref mut timeout) = self.timeout {
             match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
+                Poll::Ready(()) => {
                     return Poll::Ready(None);
                 },
                 Poll::Pending => (),

--- a/src/collector/reaction_collector.rs
+++ b/src/collector/reaction_collector.rs
@@ -376,7 +376,7 @@ impl fmt::Debug for FilterOptions {
             .field("channel_id", &self.channel_id)
             .field("guild_id", &self.guild_id)
             .field("author_id", &self.author_id)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -402,7 +402,7 @@ impl Stream for ReactionCollector {
     fn poll_next(mut self: Pin<&mut Self>, ctx: &mut FutContext<'_>) -> Poll<Option<Self::Item>> {
         if let Some(ref mut timeout) = self.timeout {
             match timeout.as_mut().poll(ctx) {
-                Poll::Ready(_) => {
+                Poll::Ready(()) => {
                     return Poll::Ready(None);
                 },
                 Poll::Pending => (),

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -82,7 +82,7 @@ pub struct Command {
 
 impl fmt::Debug for Command {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Command").field("options", &self.options).finish()
+        f.debug_struct("Command").field("options", &self.options).finish_non_exhaustive()
     }
 }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -212,7 +212,7 @@ impl fmt::Debug for Http {
             .field("ratelimiter", &self.ratelimiter)
             .field("ratelimiter_disabled", &self.ratelimiter_disabled)
             .field("proxy", &self.proxy)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -103,7 +103,7 @@ impl fmt::Debug for Ratelimiter {
             .field("client", &self.client)
             .field("global", &self.global)
             .field("routes", &self.routes)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -67,7 +67,7 @@ impl Typing {
         spawn_named("typing::start", async move {
             loop {
                 match rx.try_recv() {
-                    Ok(_) | Err(TryRecvError::Closed) => break,
+                    Ok(()) | Err(TryRecvError::Closed) => break,
                     _ => (),
                 }
 

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -21,7 +21,7 @@ pub fn deserialize_errors<'de, D: Deserializer<'de>>(
 }
 
 fn loop_errors(value: &Value, errors: &mut Vec<DiscordJsonSingleError>, path: &[String]) {
-    for (key, looped) in value.as_object().expect("expected object").iter() {
+    for (key, looped) in value.as_object().expect("expected object") {
         let object = looped.as_object().expect("expected object");
         if object.contains_key("_errors") {
             let found_errors = object

--- a/src/internal/ws_impl.rs
+++ b/src/internal/ws_impl.rs
@@ -64,7 +64,7 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Valu
                 why
             })?
         },
-        Some(Message::Text(mut payload)) => from_str(&mut payload).map(Some).map_err(|why| {
+        Some(Message::Text(payload)) => from_str(&payload).map(Some).map_err(|why| {
             warn!("Err deserializing text: {:?}; text: {}", why, payload,);
 
             why

--- a/src/json.rs
+++ b/src/json.rs
@@ -5,8 +5,6 @@
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 
-#[cfg(feature = "gateway")]
-use serde::de::Deserialize;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
@@ -62,19 +60,19 @@ where
 }
 
 #[cfg(all(feature = "gateway", not(feature = "simd_json")))]
-pub(crate) fn from_str<'a, T>(s: &'a mut str) -> Result<T>
+pub(crate) fn from_str<'a, T>(s: &'a str) -> Result<T>
 where
-    T: Deserialize<'a>,
+    T: serde::de::Deserialize<'a>,
 {
     Ok(serde_json::from_str(s)?)
 }
 
 #[cfg(all(feature = "gateway", feature = "simd_json"))]
-pub(crate) fn from_str<'a, T>(s: &'a mut str) -> Result<T>
+pub(crate) fn from_str<T>(s: &str) -> Result<T>
 where
-    T: Deserialize<'a>,
+    T: DeserializeOwned,
 {
-    Ok(simd_json::from_str(s)?)
+    Ok(simd_json::from_slice(&mut s.to_owned().into_bytes())?)
 }
 
 #[cfg(not(feature = "simd_json"))]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -531,7 +531,7 @@ impl fmt::Debug for VoiceServerUpdateEvent {
             .field("channel_id", &self.channel_id)
             .field("endpoint", &self.endpoint)
             .field("guild_id", &self.guild_id)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -165,7 +165,7 @@ impl Emoji {
     #[cfg(feature = "cache")]
     #[must_use]
     pub fn find_guild_id(&self, cache: impl AsRef<Cache>) -> Option<GuildId> {
-        for guild_entry in cache.as_ref().guilds.iter() {
+        for guild_entry in &cache.as_ref().guilds {
             let guild = guild_entry.value();
 
             if guild.emojis.contains_key(&self.id) {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -456,7 +456,7 @@ impl Guild {
         let name = name.as_ref();
         let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
-        for channel_entry in guild_channels.iter() {
+        for channel_entry in &guild_channels {
             let (id, channel) = channel_entry.pair();
 
             if channel.name == name {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -366,7 +366,7 @@ impl PartialGuild {
         let name = name.as_ref();
         let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
-        for channel_entry in guild_channels.iter() {
+        for channel_entry in &guild_channels {
             let (id, channel) = channel_entry.pair();
 
             if channel.name == name {

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -235,7 +235,7 @@ impl RoleId {
     /// Tries to find the [`Role`] by its Id in the cache.
     #[cfg(feature = "cache")]
     pub fn to_role_cached(self, cache: impl AsRef<Cache>) -> Option<Role> {
-        for guild_entry in cache.as_ref().guilds.iter() {
+        for guild_entry in &cache.as_ref().guilds {
             let guild = guild_entry.value();
 
             if !guild.roles.contains_key(&self) {

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -39,7 +39,7 @@ const DISCORD_EPOCH: u64 = 1_420_070_400_000;
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "chrono", not(feature = "time")))] {
-        use chrono::{DateTime, NaiveDateTime, ParseError as InnerError, SecondsFormat, TimeZone, Utc};
+        use chrono::{DateTime, ParseError as InnerError, SecondsFormat, TimeZone, Utc};
 
         /// Representation of a Unix timestamp.
         ///
@@ -75,8 +75,7 @@ cfg_if::cfg_if! {
             ///
             /// Returns `Err` if the value is invalid.
             pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
-                let dt = NaiveDateTime::from_timestamp_opt(secs, 0).ok_or(InvalidTimestamp)?;
-                Ok(Self(DateTime::from_utc(dt, Utc)))
+                Ok(Self(DateTime::from_timestamp(secs, 0).ok_or(InvalidTimestamp)?))
             }
 
             /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -39,7 +39,7 @@ const DISCORD_EPOCH: u64 = 1_420_070_400_000;
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "chrono", not(feature = "time")))] {
-        use chrono::{DateTime, ParseError as InnerError, SecondsFormat, TimeZone, Utc};
+        use chrono::{DateTime, NaiveDateTime, ParseError as InnerError, SecondsFormat, TimeZone, Utc};
 
         /// Representation of a Unix timestamp.
         ///
@@ -75,7 +75,8 @@ cfg_if::cfg_if! {
             ///
             /// Returns `Err` if the value is invalid.
             pub fn from_unix_timestamp(secs: i64) -> Result<Self, InvalidTimestamp> {
-                Ok(Self(DateTime::from_timestamp(secs, 0).ok_or(InvalidTimestamp)?))
+                let dt = NaiveDateTime::from_timestamp_opt(secs, 0).ok_or(InvalidTimestamp)?;
+                Ok(Self(Utc.from_utc_datetime(&dt)))
             }
 
             /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1118,7 +1118,7 @@ impl UserId {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                for channel_entry in cache.private_channels().iter() {
+                for channel_entry in &cache.private_channels() {
                     let channel = channel_entry.value();
 
                     if channel.recipient.id == self {

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -67,7 +67,7 @@ impl fmt::Debug for VoiceState {
             .field("suppress", &self.suppress)
             .field("user_id", &self.user_id)
             .field("request_to_speak_timestamp", &self.request_to_speak_timestamp)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -103,7 +103,7 @@ impl fmt::Debug for Webhook {
             .field("guild_id", &self.guild_id)
             .field("name", &self.name)
             .field("user", &self.user)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/utils/token.rs
+++ b/src/utils/token.rs
@@ -20,7 +20,7 @@ use crate::model::id::UserId;
 /// Validate that a token is valid and that a number of malformed tokens are
 /// actually invalid:
 ///
-/// ```
+/// ```rust,no_run
 /// use serenity::utils::token::validate;
 ///
 /// // ensure a valid token is in fact a valid format:


### PR DESCRIPTION
This revives #2536 in order to fix the `simd-json` feature on the `v0.11` series and get CI to actually work again.

Initially I attempted to keep the old simd-json version exported while using a newer version internally, but unfortunately this doesn't work as types from the internal version would leak into the public API (specifically in methods on `Http` which expect a `Value` or `JsonMap`). Therefore, because the old version of `simd-json` has a soundness bug in `from_str`, and because not that many people actually use this feature, I propose we just bite the bullet and upgrade to `simd-json v0.10` on this branch. This way, we can provide a safe wrapper around `simd_json::from_str`, and while `from_str` is still exported in the prelude, it is marked unsafe.