### PR TITLE
Make `Event::Unknown` wrap `UnknownEvent` again

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -390,8 +390,8 @@ fn update_cache_with_event(ctx: Context, event: Event) -> Option<(FullEvent, Opt
             ctx,
             event,
         },
-        Event::Unknown => {
-            debug!("An unknown event was received");
+        Event::Unknown(event) => {
+            debug!("An unknown event was received: {event:?}");
             return None;
         },
         Event::UserUpdate(mut event) => {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -13,14 +13,7 @@ use serde::Serialize;
 
 use super::application::ActionRow;
 use super::prelude::*;
-use super::utils::{
-    deserialize_val,
-    emojis,
-    ignore_input,
-    remove_from_map,
-    remove_from_map_opt,
-    stickers,
-};
+use super::utils::{deserialize_val, emojis, remove_from_map, remove_from_map_opt, stickers};
 use crate::constants::Opcode;
 use crate::model::application::{CommandPermissions, Interaction};
 use crate::model::guild::audit_log::AuditLogEntry;
@@ -695,7 +688,9 @@ pub struct TypingStartEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct UnknownEvent {
+    #[serde(rename = "t")]
     pub kind: String,
+    #[serde(rename = "d")]
     pub value: Value,
 }
 
@@ -1201,8 +1196,8 @@ pub enum Event {
     /// A guild member has unsubscribed from a scheduled event.
     GuildScheduledEventUserRemove(GuildScheduledEventUserRemoveEvent),
     /// An event type not covered by the above
-    #[serde(other, deserialize_with = "ignore_input")]
-    Unknown,
+    #[serde(untagged)]
+    Unknown(UnknownEvent),
 }
 
 impl Event {
@@ -1210,7 +1205,7 @@ impl Event {
     /// [`Unknown`](Event::Unknown).
     #[must_use]
     pub fn name(&self) -> Option<String> {
-        if let Self::Unknown = self {
+        if let Self::Unknown(_) = self {
             None
         } else {
             let map = serde_json::to_value(self).ok()?;

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -17,11 +17,6 @@ pub fn is_false(v: &bool) -> bool {
     !v
 }
 
-#[allow(clippy::unnecessary_wraps)]
-pub fn ignore_input<'de, D: Deserializer<'de>>(_: D) -> StdResult<(), D::Error> {
-    Ok(())
-}
-
 #[cfg(feature = "model")]
 pub(super) fn avatar_url(
     guild_id: Option<GuildId>,


### PR DESCRIPTION
Marking `Event::Unknown` with `#[serde(untagged)]` allows it to wrap an `UnknownEvent`, which lets users keep data about unsupported events if they want to debug the issue or report it upstream. This doesn't affect performance, as the generated serde code is nearly identical. Deserialization operates as normal, only now in case of failure, serde will attempt to deserialize into `Event::Unknown` before giving up and returning an error.