### PR TITLE
Add `Hash` to `Timestamp`'s derive list

### DIFF
--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -54,7 +54,7 @@ cfg_if::cfg_if! {
         /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
         /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
         /// ```
-        #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, Ord, PartialOrd)]
+        #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize, Serialize, Ord, PartialOrd)]
         #[serde(transparent)]
         pub struct Timestamp(DateTime<Utc>);
 
@@ -146,7 +146,7 @@ cfg_if::cfg_if! {
         /// assert_eq!(timestamp.unix_timestamp(), 1462015105);
         /// assert_eq!(timestamp.to_string(), "2016-04-30T11:18:25.796Z");
         /// ```
-        #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, Ord, PartialOrd)]
+        #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize, Serialize, Ord, PartialOrd)]
         #[serde(transparent)]
         pub struct Timestamp(#[serde(with = "rfc3339")] OffsetDateTime);
 


### PR DESCRIPTION
It's a simple change, and `chrono`'s `DateTime` and `time`'s `OffsetDateTime` implement `Hash` themselves, so why not?