### PR TITLE
Add `Hash` to `Timestamp`'s derive list (0.12)

### DIFF
--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 /// Discord's epoch starts at "2015-01-01T00:00:00+00:00"
 const DISCORD_EPOCH: u64 = 1_420_070_400_000;
 
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct Timestamp(
     #[cfg(feature = "chrono")] DateTime<Utc>,


### PR DESCRIPTION
It's a simple change, and `chrono`'s `DateTime` and `time`'s `OffsetDateTime` implement `Hash` themselves, so why not?

Note: This is 0.12's version of https://github.com/serenity-rs/serenity/pull/2613