### PR TITLE
Rework builders for framework

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -19,9 +19,11 @@ use serenity::framework::standard::macros::{check, command, group, help, hook};
 use serenity::framework::standard::{
     help_commands,
     Args,
+    BucketBuilder,
     CommandGroup,
     CommandOptions,
     CommandResult,
+    Configuration,
     DispatchError,
     HelpOptions,
     Reason,
@@ -256,12 +258,12 @@ async fn main() {
         // only be performed by the bot owner.
         .on_dispatch_error(dispatch_error)
         // Can't be used more than once per 5 seconds:
-        .bucket("emoji", |b| b.delay(5)).await
+        .bucket("emoji", BucketBuilder::default().delay(5)).await
         // Can't be used more than 2 times per 30 seconds, with a 5 second delay applying per
         // channel. Optionally `await_ratelimits` will delay until the command can be executed
         // instead of cancelling the command invocation.
-        .bucket("complicated", |b| {
-            b.limit(2).time_span(30).delay(5)
+        .bucket("complicated",
+            BucketBuilder::default().limit(2).time_span(30).delay(5)
                 // The target each bucket will apply to.
                 .limit_for(LimitedFor::Channel)
                 // The maximum amount of command invocations that can be delayed per target.
@@ -269,7 +271,7 @@ async fn main() {
                 .await_ratelimits(1)
                 // A function to call when a rate limit leads to a delay.
                 .delay_action(delay_action)
-        }).await
+        ).await
         // The `#[group]` macro generates `static` instances of the options set for the group.
         // They're made in the pattern: `#name_GROUP` for the group instance and `#name_GROUP_OPTIONS`.
         // #name is turned all uppercase
@@ -279,8 +281,8 @@ async fn main() {
         .group(&MATH_GROUP)
         .group(&OWNER_GROUP);
 
-    framework.configure(|c| {
-        c.with_whitespace(true)
+    framework.configure(
+        Configuration::new().with_whitespace(true)
             .on_mention(Some(bot_id))
             .prefix("~")
             // In this case, if "," would be first, a message would never be delimited at ", ",
@@ -288,8 +290,8 @@ async fn main() {
             // each.
             .delimiters(vec![", ", ","])
             // Sets the bot's owners. These will be used for commands that are owners only.
-            .owners(owners)
-    });
+            .owners(owners),
+    );
 
     // For this example to run properly, the "Presence Intent" and "Server Members Intent" options
     // need to be enabled.

--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use serenity::async_trait;
 use serenity::framework::standard::macros::group;
+use serenity::framework::standard::Configuration;
 use serenity::framework::StandardFramework;
 use serenity::gateway::ShardManager;
 use serenity::http::Http;
@@ -80,7 +81,7 @@ async fn main() {
 
     // Create the framework
     let framework = StandardFramework::new().group(&GENERAL_GROUP);
-    framework.configure(|c| c.owners(owners).prefix("~"));
+    framework.configure(Configuration::new().owners(owners).prefix("~"));
 
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES

--- a/examples/e07_env_logging/src/main.rs
+++ b/examples/e07_env_logging/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use serenity::async_trait;
 use serenity::framework::standard::macros::{command, group, hook};
-use serenity::framework::standard::{CommandResult, StandardFramework};
+use serenity::framework::standard::{CommandResult, Configuration, StandardFramework};
 use serenity::model::channel::Message;
 use serenity::model::event::ResumedEvent;
 use serenity::model::gateway::Ready;
@@ -65,7 +65,7 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
     let framework = StandardFramework::new().before(before).group(&GENERAL_GROUP);
-    framework.configure(|c| c.prefix("~"));
+    framework.configure(Configuration::new().prefix("~"));
 
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -12,6 +12,7 @@ use serenity::framework::standard::{
     Args,
     CommandGroup,
     CommandResult,
+    Configuration,
     HelpOptions,
     StandardFramework,
 };
@@ -62,9 +63,13 @@ async fn main() {
 
     let framework = StandardFramework::new().help(&MY_HELP).group(&COLLECTOR_GROUP);
 
-    framework.configure(|c| {
-        c.with_whitespace(true).on_mention(Some(bot_id)).prefix("~").delimiters(vec![", ", ","])
-    });
+    framework.configure(
+        Configuration::new()
+            .with_whitespace(true)
+            .on_mention(Some(bot_id))
+            .prefix("~")
+            .delimiters(vec![", ", ","]),
+    );
 
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use serenity::async_trait;
 use serenity::framework::standard::macros::{command, group, hook};
-use serenity::framework::standard::{Args, CommandResult, StandardFramework};
+use serenity::framework::standard::{Args, CommandResult, Configuration, StandardFramework};
 use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
 use serenity::prelude::*;
@@ -108,7 +108,7 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
     let framework = StandardFramework::new().before(before).group(&GENERAL_GROUP);
-    framework.configure(|c| c.with_whitespace(true).prefix("~"));
+    framework.configure(Configuration::new().with_whitespace(true).prefix("~"));
 
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -22,7 +22,7 @@ use rillrate::prime::*;
 use serenity::async_trait;
 use serenity::client::{Client, Context, EventHandler};
 use serenity::framework::standard::macros::{command, group, hook};
-use serenity::framework::standard::{CommandResult, StandardFramework};
+use serenity::framework::standard::{CommandResult, Configuration, StandardFramework};
 use serenity::gateway::ShardManager;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
@@ -340,8 +340,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let _ = webbrowser::open("http://localhost:6361");
 
     let framework = StandardFramework::new().before(before_hook).group(&GENERAL_GROUP);
-
-    framework.configure(|c| c.prefix("~"));
+    framework.configure(Configuration::new().prefix("~"));
 
     let token = env::var("DISCORD_TOKEN")?;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -168,12 +168,8 @@ impl ClientBuilder {
     ///
     /// [`Settings`]: CacheSettings
     #[cfg(feature = "cache")]
-    pub fn cache_settings<F>(mut self, f: F) -> Self
-    where
-        F: FnOnce(&mut CacheSettings) -> &mut CacheSettings,
-    {
-        f(&mut self.cache_settings);
-
+    pub fn cache_settings(mut self, settings: CacheSettings) -> Self {
+        self.cache_settings = settings;
         self
     }
 

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -31,7 +31,7 @@
 //!
 //! ```rust,no_run
 //! use serenity::framework::standard::macros::{command, group};
-//! use serenity::framework::standard::{CommandResult, StandardFramework};
+//! use serenity::framework::standard::{CommandResult, Configuration, StandardFramework};
 //! use serenity::model::channel::Message;
 //! use serenity::prelude::*;
 //!
@@ -67,7 +67,7 @@
 //!     // all-uppercased version of the `name` with a `_GROUP` suffix appended at the end.
 //!     .group(&GENERAL_GROUP);
 //!
-//! framework.configure(|c| c.prefix("~"));
+//! framework.configure(Configuration::new().prefix("~"));
 //!
 //! let mut client = Client::builder(&token, GatewayIntents::default())
 //!     .event_handler(Handler)

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -80,7 +80,7 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 ///
 /// impl EventHandler for Handler {}
 ///
-/// use serenity::framework::StandardFramework;
+/// use serenity::framework::standard::{Configuration, StandardFramework};
 /// use serenity::model::id::UserId;
 /// use serenity::Client;
 ///
@@ -88,7 +88,7 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 /// let token = std::env::var("DISCORD_BOT_TOKEN")?;
 ///
 /// let framework = StandardFramework::new();
-/// framework.configure(|c| c.on_mention(Some(UserId::new(5))).prefix("~"));
+/// framework.configure(Configuration::new().on_mention(Some(UserId::new(5))).prefix("~"));
 ///
 /// let mut client = Client::builder(&token, GatewayIntents::default())
 ///     .event_handler(Handler)
@@ -103,47 +103,37 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 /// [default implementation]: Self::default
 #[derive(Clone)]
 pub struct Configuration {
-    #[doc(hidden)]
-    pub allow_dm: bool,
-    #[doc(hidden)]
-    pub with_whitespace: WithWhiteSpace,
-    #[doc(hidden)]
-    pub by_space: bool,
-    #[doc(hidden)]
-    pub blocked_guilds: HashSet<GuildId>,
-    #[doc(hidden)]
-    pub blocked_users: HashSet<UserId>,
-    #[doc(hidden)]
-    pub allowed_channels: HashSet<ChannelId>,
-    #[doc(hidden)]
-    pub disabled_commands: HashSet<String>,
-    #[doc(hidden)]
-    pub dynamic_prefixes: Vec<DynamicPrefixHook>,
-    #[doc(hidden)]
-    pub ignore_bots: bool,
-    #[doc(hidden)]
-    pub ignore_webhooks: bool,
-    #[doc(hidden)]
-    pub on_mention: Option<String>,
-    #[doc(hidden)]
-    pub owners: HashSet<UserId>,
-    #[doc(hidden)]
-    pub prefixes: Vec<String>,
-    #[doc(hidden)]
-    pub no_dm_prefix: bool,
-    #[doc(hidden)]
-    pub delimiters: Vec<Delimiter>,
-    #[doc(hidden)]
-    pub case_insensitive: bool,
+    pub(crate) allow_dm: bool,
+    pub(crate) with_whitespace: WithWhiteSpace,
+    pub(crate) by_space: bool,
+    pub(crate) blocked_guilds: HashSet<GuildId>,
+    pub(crate) blocked_users: HashSet<UserId>,
+    pub(crate) allowed_channels: HashSet<ChannelId>,
+    pub(crate) disabled_commands: HashSet<String>,
+    pub(crate) dynamic_prefixes: Vec<DynamicPrefixHook>,
+    pub(crate) ignore_bots: bool,
+    pub(crate) ignore_webhooks: bool,
+    pub(crate) on_mention: Option<String>,
+    pub(crate) owners: HashSet<UserId>,
+    pub(crate) prefixes: Vec<String>,
+    pub(crate) no_dm_prefix: bool,
+    pub(crate) delimiters: Vec<Delimiter>,
+    pub(crate) case_insensitive: bool,
 }
 
 impl Configuration {
+    /// Alias for Configuration::default
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// If set to false, bot will ignore any private messages.
     ///
     /// **Note**: Defaults to `true`.
-    pub fn allow_dm(&mut self, allow_dm: bool) -> &mut Self {
+    #[must_use]
+    pub fn allow_dm(mut self, allow_dm: bool) -> Self {
         self.allow_dm = allow_dm;
-
         self
     }
 
@@ -169,9 +159,9 @@ impl Configuration {
     ///
     /// // bot processes and executes the "about" command if it exists
     /// ```
-    pub fn with_whitespace<I: Into<WithWhiteSpace>>(&mut self, with: I) -> &mut Self {
+    #[must_use]
+    pub fn with_whitespace(mut self, with: impl Into<WithWhiteSpace>) -> Self {
         self.with_whitespace = with.into();
-
         self
     }
 
@@ -180,9 +170,9 @@ impl Configuration {
     /// group's or command's names.
     ///
     /// **Note**: Defaults to `true`
-    pub fn by_space(&mut self, b: bool) -> &mut Self {
+    #[must_use]
+    pub fn by_space(mut self, b: bool) -> Self {
         self.by_space = b;
-
         self
     }
 
@@ -196,17 +186,18 @@ impl Configuration {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     /// use serenity::model::id::ChannelId;
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| {
-    ///     c.allowed_channels(vec![ChannelId::new(7), ChannelId::new(77)].into_iter().collect())
-    /// });
+    /// framework.configure(
+    ///     Configuration::new()
+    ///         .allowed_channels(vec![ChannelId::new(7), ChannelId::new(77)].into_iter().collect()),
+    /// );
     /// ```
-    pub fn allowed_channels(&mut self, channels: HashSet<ChannelId>) -> &mut Self {
+    #[must_use]
+    pub fn allowed_channels(mut self, channels: HashSet<ChannelId>) -> Self {
         self.allowed_channels = channels;
-
         self
     }
 
@@ -220,17 +211,18 @@ impl Configuration {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     /// use serenity::model::id::GuildId;
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| {
-    ///     c.blocked_guilds(vec![GuildId::new(7), GuildId::new(77)].into_iter().collect())
-    /// });
+    /// framework.configure(
+    ///     Configuration::new()
+    ///         .blocked_guilds(vec![GuildId::new(7), GuildId::new(77)].into_iter().collect()),
+    /// );
     /// ```
-    pub fn blocked_guilds(&mut self, guilds: HashSet<GuildId>) -> &mut Self {
+    #[must_use]
+    pub fn blocked_guilds(mut self, guilds: HashSet<GuildId>) -> Self {
         self.blocked_guilds = guilds;
-
         self
     }
 
@@ -246,17 +238,18 @@ impl Configuration {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     /// use serenity::model::id::UserId;
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| {
-    ///     c.blocked_users(vec![UserId::new(7), UserId::new(77)].into_iter().collect())
-    /// });
+    /// framework.configure(
+    ///     Configuration::new()
+    ///         .blocked_users(vec![UserId::new(7), UserId::new(77)].into_iter().collect()),
+    /// );
     /// ```
-    pub fn blocked_users(&mut self, users: HashSet<UserId>) -> &mut Self {
+    #[must_use]
+    pub fn blocked_users(mut self, users: HashSet<UserId>) -> Self {
         self.blocked_users = users;
-
         self
     }
 
@@ -271,7 +264,7 @@ impl Configuration {
     /// ```rust,no_run
     /// use serenity::client::Context;
     /// use serenity::framework::standard::macros::{command, group};
-    /// use serenity::framework::standard::CommandResult;
+    /// use serenity::framework::standard::{CommandResult, Configuration};
     /// use serenity::framework::StandardFramework;
     /// use serenity::model::channel::Message;
     ///
@@ -288,12 +281,12 @@ impl Configuration {
     /// let disabled = vec!["ping"].into_iter().map(|x| x.to_string()).collect();
     ///
     /// let framework = StandardFramework::new().group(&PENG_GROUP);
-    /// framework.configure(|c| c.disabled_commands(disabled));
+    /// framework.configure(Configuration::new().disabled_commands(disabled));
     /// ```
     #[inline]
-    pub fn disabled_commands(&mut self, commands: HashSet<String>) -> &mut Self {
+    #[must_use]
+    pub fn disabled_commands(mut self, commands: HashSet<String>) -> Self {
         self.disabled_commands = commands;
-
         self
     }
 
@@ -321,15 +314,14 @@ impl Configuration {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     ///
-    /// let framework = StandardFramework::new().configure(|c| {
-    ///     c.dynamic_prefix(|_, msg| {
+    /// let framework =
+    ///     StandardFramework::new().configure(Configuration::new().dynamic_prefix(|_, msg| {
     ///         Box::pin(async move {
     ///             Some(if msg.channel_id.get() % 5 == 0 { "!" } else { "*" }.to_string())
     ///         })
-    ///     })
-    /// });
+    ///     }));
     /// ```
     ///
     /// This will only use the prefix `"!"` or `"*"` depending on channel ID,
@@ -337,24 +329,25 @@ impl Configuration {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| {
-    ///     c.dynamic_prefix(|_, msg| {
-    ///         Box::pin(async move {
-    ///             Some(if msg.channel_id.get() % 5 == 0 { "!" } else { "*" }.to_string())
+    /// framework.configure(
+    ///     Configuration::new()
+    ///         .dynamic_prefix(|_, msg| {
+    ///             Box::pin(async move {
+    ///                 Some(if msg.channel_id.get() % 5 == 0 { "!" } else { "*" }.to_string())
+    ///             })
     ///         })
-    ///     })
-    ///     .prefix("") // This disables the default prefix "~"
-    /// });
+    ///         .prefix(""), // This disables the default prefix "~"
+    /// );
     /// ```
     ///
     /// [`Context::data`]: crate::client::Context::data
     #[inline]
-    pub fn dynamic_prefix(&mut self, dynamic_prefix: DynamicPrefixHook) -> &mut Self {
+    #[must_use]
+    pub fn dynamic_prefix(mut self, dynamic_prefix: DynamicPrefixHook) -> Self {
         self.dynamic_prefixes.push(dynamic_prefix);
-
         self
     }
 
@@ -364,18 +357,18 @@ impl Configuration {
     /// itself.
     ///
     /// **Note**: Defaults to `true`.
-    pub fn ignore_bots(&mut self, ignore_bots: bool) -> &mut Self {
+    #[must_use]
+    pub fn ignore_bots(mut self, ignore_bots: bool) -> Self {
         self.ignore_bots = ignore_bots;
-
         self
     }
 
     /// If set to true, bot will ignore all commands called by webhooks.
     ///
     /// **Note**: Defaults to `true`.
-    pub fn ignore_webhooks(&mut self, ignore_webhooks: bool) -> &mut Self {
+    #[must_use]
+    pub fn ignore_webhooks(mut self, ignore_webhooks: bool) -> Self {
         self.ignore_webhooks = ignore_webhooks;
-
         self
     }
 
@@ -397,9 +390,9 @@ impl Configuration {
     /// The former is a direct mention, while the latter is a nickname mention, which aids mobile
     /// devices in determining whether to display a user's nickname. It has no real meaning for
     /// your bot, and the library encourages you to ignore differentiating between the two.
-    pub fn on_mention(&mut self, id_to_mention: Option<UserId>) -> &mut Self {
+    #[must_use]
+    pub fn on_mention(mut self, id_to_mention: Option<UserId>) -> Self {
         self.on_mention = id_to_mention.map(|id| id.to_string());
-
         self
     }
 
@@ -412,11 +405,13 @@ impl Configuration {
     /// Create a HashSet in-place:
     ///
     /// ```rust,no_run
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     /// use serenity::model::id::UserId;
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| c.owners(vec![UserId::new(7), UserId::new(77)].into_iter().collect()));
+    /// framework.configure(
+    ///     Configuration::new().owners(vec![UserId::new(7), UserId::new(77)].into_iter().collect()),
+    /// );
     /// ```
     ///
     /// Create a HashSet beforehand:
@@ -424,7 +419,7 @@ impl Configuration {
     /// ```rust,no_run
     /// use std::collections::HashSet;
     ///
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     /// use serenity::model::id::UserId;
     ///
     /// let mut set = HashSet::new();
@@ -432,11 +427,11 @@ impl Configuration {
     /// set.insert(UserId::new(77));
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| c.owners(set));
+    /// framework.configure(Configuration::new().owners(set));
     /// ```
-    pub fn owners(&mut self, user_ids: HashSet<UserId>) -> &mut Self {
+    #[must_use]
+    pub fn owners(mut self, user_ids: HashSet<UserId>) -> Self {
         self.owners = user_ids;
-
         self
     }
 
@@ -454,15 +449,15 @@ impl Configuration {
     /// Assign a basic prefix:
     ///
     /// ```rust,no_run
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| c.prefix("!"));
+    /// framework.configure(Configuration::new().prefix("!"));
     /// ```
-    pub fn prefix(&mut self, prefix: impl Into<String>) -> &mut Self {
+    #[must_use]
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
         let p = prefix.into();
         self.prefixes = if p.is_empty() { vec![] } else { vec![p] };
-
         self
     }
 
@@ -478,16 +473,15 @@ impl Configuration {
     /// Assign a set of prefixes the bot can respond to:
     ///
     /// ```rust,no_run
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| c.prefixes(vec!["!", ">", "+"]));
+    /// framework.configure(Configuration::new().prefixes(vec!["!", ">", "+"]));
     /// ```
     #[inline]
-    pub fn prefixes<T: ToString>(&mut self, prefixes: impl IntoIterator<Item = T>) -> &mut Self {
-        self.prefixes =
-            prefixes.into_iter().map(|p| p.to_string()).filter(|p| !p.is_empty()).collect();
-
+    #[must_use]
+    pub fn prefixes(mut self, prefixes: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.prefixes = prefixes.into_iter().map(Into::into).filter(|p| !p.is_empty()).collect();
         self
     }
 
@@ -499,9 +493,9 @@ impl Configuration {
     ///
     /// The `cache` feature is required. If disabled this does absolutely nothing.
     #[inline]
-    pub fn no_dm_prefix(&mut self, b: bool) -> &mut Self {
+    #[must_use]
+    pub fn no_dm_prefix(mut self, b: bool) -> Self {
         self.no_dm_prefix = b;
-
         self
     }
 
@@ -514,12 +508,12 @@ impl Configuration {
     /// Have the args be separated by a comma and a space:
     ///
     /// ```rust,no_run
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     ///
-    /// let framework = StandardFramework::new();
-    /// framework.configure(|c| c.delimiter(", "));
+    /// let framework = StandardFramework::new().configure(Configuration::new().delimiter(", "));
     /// ```
-    pub fn delimiter<I: Into<Delimiter>>(&mut self, delimiter: I) -> &mut Self {
+    #[must_use]
+    pub fn delimiter(mut self, delimiter: impl Into<Delimiter>) -> Self {
         self.delimiters.clear();
         self.delimiters.push(delimiter.into());
 
@@ -536,15 +530,16 @@ impl Configuration {
     /// Have the args be separated by a comma and a space; and a regular space:
     ///
     /// ```rust,no_run
-    /// use serenity::framework::StandardFramework;
+    /// use serenity::framework::standard::{Configuration, StandardFramework};
     ///
     /// let framework = StandardFramework::new();
-    /// framework.configure(|c| c.delimiters(vec![", ", " "]));
+    /// framework.configure(Configuration::new().delimiters(vec![", ", " "]));
     /// ```
-    pub fn delimiters<T: Into<Delimiter>>(
-        &mut self,
-        delimiters: impl IntoIterator<Item = T>,
-    ) -> &mut Self {
+    #[must_use]
+    pub fn delimiters(
+        mut self,
+        delimiters: impl IntoIterator<Item = impl Into<Delimiter>>,
+    ) -> Self {
         self.delimiters.clear();
         self.delimiters.extend(delimiters.into_iter().map(Into::into));
 
@@ -558,7 +553,8 @@ impl Configuration {
     /// insensitive.
     ///
     /// **Note**: Defaults to `false`.
-    pub fn case_insensitivity(&mut self, cs: bool) -> &mut Self {
+    #[must_use]
+    pub fn case_insensitivity(mut self, cs: bool) -> Self {
         self.case_insensitive = cs;
 
         for prefix in &mut self.prefixes {

--- a/src/framework/standard/structures/buckets.rs
+++ b/src/framework/standard/structures/buckets.rs
@@ -420,9 +420,9 @@ impl BucketBuilder {
     ///
     /// Expressed in seconds.
     #[inline]
-    pub fn delay(&mut self, secs: u64) -> &mut Self {
+    #[must_use]
+    pub fn delay(mut self, secs: u64) -> Self {
         self.delay = Duration::from_secs(secs);
-
         self
     }
 
@@ -430,26 +430,26 @@ impl BucketBuilder {
     ///
     /// Expressed in seconds.
     #[inline]
-    pub fn time_span(&mut self, secs: u64) -> &mut Self {
+    #[must_use]
+    pub fn time_span(mut self, secs: u64) -> Self {
         self.time_span = Duration::from_secs(secs);
-
         self
     }
 
     /// Number of invocations allowed per [`Self::time_span`].
     #[inline]
-    pub fn limit(&mut self, n: u32) -> &mut Self {
+    #[must_use]
+    pub fn limit(mut self, n: u32) -> Self {
         self.limit = n;
-
         self
     }
 
     /// Middleware confirming (or denying) that the bucket is eligible to apply. For instance, to
     /// limit the bucket to just one user.
     #[inline]
-    pub fn check(&mut self, check: Check) -> &mut Self {
+    #[must_use]
+    pub fn check(mut self, check: Check) -> Self {
         self.check = Some(check);
-
         self
     }
 
@@ -468,7 +468,7 @@ impl BucketBuilder {
     /// ```rust
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::framework::standard::macros::{command, group};
-    /// use serenity::framework::standard::{CommandResult, StandardFramework};
+    /// use serenity::framework::standard::{BucketBuilder, Configuration, CommandResult, StandardFramework};
     /// use serenity::model::channel::Message;
     /// use serenity::prelude::*;
     ///
@@ -491,18 +491,18 @@ impl BucketBuilder {
     /// let token = std::env::var("DISCORD_TOKEN")?;
     ///
     /// let framework = StandardFramework::new()
-    ///     .bucket("example_bucket", |b| {
+    ///     .bucket("example_bucket", BucketBuilder::default()
     ///         // We initialise the bucket with the function we want to run
-    ///         b.delay_action(|ctx, msg| {
+    ///         .delay_action(|ctx, msg| {
     ///             Box::pin(example_overuse_response(ctx, msg))
     ///         })
     ///         .delay(10) // We set the delay to 10 seconds
     ///         .await_ratelimits(1) // We override the default behavior so that the function actually gets run
-    ///     })
+    ///     )
     ///     .await
     ///     .group(&GENERAL_GROUP);
     ///
-    /// framework.configure(|c| c.prefix("~"));
+    /// framework.configure(Configuration::new().prefix("~"));
     ///
     /// let mut client = Client::builder(&token, GatewayIntents::default())
     /// .framework(framework)
@@ -513,7 +513,8 @@ impl BucketBuilder {
     /// # }
     /// ```
     #[inline]
-    pub fn delay_action(&mut self, action: DelayHook) -> &mut Self {
+    #[must_use]
+    pub fn delay_action(mut self, action: DelayHook) -> Self {
         self.delay_action = Some(action);
         if self.await_ratelimits == 0 {
             self.await_ratelimits = 1;
@@ -524,9 +525,9 @@ impl BucketBuilder {
 
     /// Limit the bucket for a specific type of `target`.
     #[inline]
-    pub fn limit_for(&mut self, target: LimitedFor) -> &mut Self {
+    #[must_use]
+    pub fn limit_for(mut self, target: LimitedFor) -> Self {
         self.limited_for = target;
-
         self
     }
 
@@ -535,9 +536,9 @@ impl BucketBuilder {
     ///
     /// By default this value is `0` and rate limits will cancel instead.
     #[inline]
-    pub fn await_ratelimits(&mut self, amount: u32) -> &mut Self {
+    #[must_use]
+    pub fn await_ratelimits(mut self, amount: u32) -> Self {
         self.await_ratelimits = amount;
-
         self
     }
 


### PR DESCRIPTION
Replaces `&mut self -> &mut self` builders with `self -> Self` and replaces `ToString` with `Into<String>`