### PR TITLE
Implement From<Into<String>> for AutocompleteChoice

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -308,6 +308,14 @@ impl AutocompleteChoice {
     }
 }
 
+impl<S: Into<String>> From<S> for AutocompleteChoice {
+    fn from(value: S) -> Self {
+        let value = value.into();
+        let name = value.clone();
+        Self::new(name, value)
+    }
+}
+
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]


### PR DESCRIPTION
This moves all the poise AutocompleteChoice functionality into serenity, so poise's wrapper can be removed when updating to 0.12.