### PR TITLE
Fix typesize by adding CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
             features: model http rustls_backend
           - name: chrono
             features: chrono
-          - name: unstable Discord API features
-            features: default unstable_discord_api
+          - name: unstable API + typesize
+            features: default unstable_discord_api typesize
             dont-test: true
           - name: builder without model
             features: builder

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -374,7 +374,6 @@ pub struct ShardInfo {
 }
 
 impl ShardInfo {
-    #[cfg(feature = "client")]
     #[must_use]
     pub(crate) fn new(id: ShardId, total: u32) -> Self {
         Self {

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -647,6 +647,7 @@ impl From<Member> for PartialMember {
     }
 }
 
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PartialThreadMember {


### PR DESCRIPTION
I also fixed a small whoops with ShardInfo::new being client gated when cache uses it, but didn't get to use that combination because of utils being gated. Feature rework when.