### PR TITLE
Fix README.md minor error

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ impl EventHandler for Handler {}
 
 #[tokio::main]
 async fn main() {
-    let framework = StandardFramework::new().group(&GENERAL_GROUP);
-    framework.configure(|c| c.prefix("~")); // set the bot's prefix to "~"
+    let framework = StandardFramework::new()
+        .group(&GENERAL_GROUP)
+        .configure(|c| c.prefix("~")); // set the bot's prefix to "~"
 
     // Login with a bot token from the environment
     let token = env::var("DISCORD_TOKEN").expect("token");

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ use serenity::async_trait;
 use serenity::prelude::*;
 use serenity::model::channel::Message;
 use serenity::framework::standard::macros::{command, group};
-use serenity::framework::standard::{StandardFramework, CommandResult};
+use serenity::framework::standard::{StandardFramework, Configuration, CommandResult};
 
 #[group]
 #[commands(ping)]
@@ -61,9 +61,8 @@ impl EventHandler for Handler {}
 
 #[tokio::main]
 async fn main() {
-    let framework = StandardFramework::new()
-        .group(&GENERAL_GROUP)
-        .configure(|c| c.prefix("~")); // set the bot's prefix to "~"
+    let framework = StandardFramework::new().group(&GENERAL_GROUP);
+    framework.configure(Configuration::new().prefix("~")); // set the bot's prefix to "~"
 
     // Login with a bot token from the environment
     let token = env::var("DISCORD_TOKEN").expect("token");


### PR DESCRIPTION
FIX: bad example was re-using the moved `framework` value

## Before and after screenshots of problem and solution 

### Before

![image](https://github.com/serenity-rs/serenity/assets/29107364/cab5760f-e94d-489a-af2b-ee4d893d8fa3)

### After

![image](https://github.com/serenity-rs/serenity/assets/29107364/83f4a692-e18e-4971-97b0-39e222560674)


