### PR TITLE
Fix Channel argument_convert with no cache

### DIFF
--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -59,16 +59,16 @@ async fn lookup_channel_global(
                 return Ok(Channel::Guild(channel.clone()));
             }
         }
-    } else {
-        let channels = ctx.http().get_channels(guild_id).await.map_err(ChannelParseError::Http)?;
-        if let Some(channel) =
-            channels.into_iter().find(|channel| channel.name.eq_ignore_ascii_case(s))
-        {
-            return Ok(Channel::Guild(channel));
-        }
+
+        return Err(ChannelParseError::NotFoundOrMalformed);
     }
 
-    Err(ChannelParseError::NotFoundOrMalformed)
+    let channels = ctx.http().get_channels(guild_id).await.map_err(ChannelParseError::Http)?;
+    if let Some(channel) = channels.into_iter().find(|c| c.name.eq_ignore_ascii_case(s)) {
+        Ok(Channel::Guild(channel))
+    } else {
+        Err(ChannelParseError::NotFoundOrMalformed)
+    }
 }
 
 /// Look up a Channel by a string case-insensitively.


### PR DESCRIPTION
Broken in #2602, that PR moved the `#[cfg(feature = "cache")]` around the entire if else block, which meant the else statement didn't get compiled in if cache was disabled. Caught this by running `cargo check` with cache disabled and seeing that `guild_id` was unused.