### PR TITLE
Cleanup documentation examples

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -138,51 +138,6 @@ impl CreateEmbed {
     /// let timestamp: Timestamp = "2004-06-08T16:04:23Z".parse().expect("Invalid timestamp!");
     /// let embed = CreateEmbed::new().title("hello").timestamp(timestamp);
     /// ```
-    ///
-    /// Creating a join-log:
-    ///
-    /// Note: this example isn't efficient and is for demonstrative purposes.
-    ///
-    /// ```rust,no_run
-    /// # #[cfg(all(feature = "cache", feature = "client"))]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// use serenity::builder::{CreateEmbed, CreateEmbedAuthor, CreateMessage};
-    /// use serenity::model::guild::Member;
-    /// use serenity::model::id::GuildId;
-    /// use serenity::prelude::*;
-    ///
-    /// struct Handler;
-    ///
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn guild_member_addition(&self, context: Context, member: Member) {
-    ///         let guild_id = member.guild_id;
-    ///         if let Ok(guild) = guild_id.to_partial_guild(&context).await {
-    ///             let channels = guild.channels(&context).await.unwrap();
-    ///
-    ///             let channel_search = channels.values().find(|c| c.name == "join-log");
-    ///
-    ///             if let Some(channel) = channel_search {
-    ///                 let icon_url = member.user.face();
-    ///                 let author = CreateEmbedAuthor::new(member.user.name).icon_url(icon_url);
-    ///                 let mut embed = CreateEmbed::new().title("Member Join").author(author);
-    ///                 if let Some(joined_at) = member.joined_at {
-    ///                     embed = embed.timestamp(joined_at);
-    ///                 }
-    ///                 let builder = CreateMessage::new().embed(embed);
-    ///                 let _ = channel.send_message(&context, builder).await;
-    ///             }
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     pub fn timestamp<T: Into<Timestamp>>(mut self, timestamp: T) -> Self {
         self.0.timestamp = Some(timestamp.into());

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -15,55 +15,11 @@ use crate::model::prelude::*;
 /// Create an invite with a max age of 3600 seconds and 10 max uses:
 ///
 /// ```rust,no_run
-/// # #[cfg(all(feature = "cache", feature = "client"))]
-/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// # use serenity::prelude::*;
-/// # use serenity::model::prelude::*;
-/// # use serenity::model::channel::Channel;
+/// # use serenity::{prelude::*, model::prelude::*};
 /// use serenity::builder::CreateInvite;
-///
-/// struct Handler;
-///
-/// #[serenity::async_trait]
-/// impl EventHandler for Handler {
-///     async fn message(&self, context: Context, msg: Message) {
-///         if msg.content == "!createinvite" {
-///             let channel_opt = context.cache.channel(msg.channel_id).as_deref().cloned();
-///             let channel = match channel_opt {
-///                 Some(channel) => channel,
-///                 None => {
-///                     let _ = msg.channel_id.say(&context, "Error creating invite").await;
-///                     return;
-///                 },
-///             };
-///
-///             let builder = CreateInvite::new().max_age(3600).max_uses(10);
-///             let creation = channel.create_invite(&context, builder).await;
-///
-///             let invite = match creation {
-///                 Ok(invite) => invite,
-///                 Err(why) => {
-///                     println!("Err creating invite: {:?}", why);
-///                     if let Err(why) =
-///                         msg.channel_id.say(&context, "Error creating invite").await
-///                     {
-///                         println!("Err sending err msg: {:?}", why);
-///                     }
-///
-///                     return;
-///                 },
-///             };
-///
-///             let content = format!("Here's your invite: {}", invite.url());
-///             let _ = msg.channel_id.say(&context, &content).await;
-///         }
-///     }
-/// }
-///
-/// let mut client =
-///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-///
-/// client.start().await?;
+/// # async fn run(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
+/// let builder = CreateInvite::new().max_age(3600).max_uses(10);
+/// let creation = channel.create_invite(&context, builder).await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -108,17 +64,11 @@ impl<'a> CreateInvite<'a> {
     /// Create an invite with a max age of `3600` seconds, or 1 hour:
     ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "cache", feature = "client"))]
-    /// # use serenity::client::Context;
-    /// # #[cfg(feature = "framework")]
-    /// # use serenity::framework::standard::{CommandResult, macros::command};
-    /// # use serenity::model::id::ChannelId;
+    /// # use serenity::model::prelude::*;
     /// # use serenity::builder::CreateInvite;
+    /// # use serenity::http::CacheHttp;
     /// #
-    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
-    /// # #[command]
-    /// # async fn example(context: &Context) -> CommandResult {
-    /// # let channel = context.cache.channel(81384788765712384).unwrap().clone();
+    /// # async fn example(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = CreateInvite::new().max_age(3600);
     /// let invite = channel.create_invite(context, builder).await?;
     /// # Ok(())
@@ -139,18 +89,14 @@ impl<'a> CreateInvite<'a> {
     ///
     /// Create an invite with a max use limit of `5`:
     ///
+    /// Create an invite with a max age of `3600` seconds, or 1 hour:
+    ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "cache", feature = "client"))]
-    /// # use serenity::client::Context;
-    /// # #[cfg(feature = "framework")]
-    /// # use serenity::framework::standard::{CommandResult, macros::command};
-    /// # use serenity::model::id::ChannelId;
+    /// # use serenity::model::prelude::*;
     /// # use serenity::builder::CreateInvite;
+    /// # use serenity::http::CacheHttp;
     /// #
-    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
-    /// # #[command]
-    /// # async fn example(context: &Context) -> CommandResult {
-    /// # let channel = context.cache.channel(81384788765712384).unwrap().clone();
+    /// # async fn example(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = CreateInvite::new().max_uses(5);
     /// let invite = channel.create_invite(context, builder).await?;
     /// # Ok(())
@@ -170,17 +116,11 @@ impl<'a> CreateInvite<'a> {
     /// Create an invite which is temporary:
     ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "cache", feature = "client"))]
-    /// # use serenity::client::Context;
-    /// # #[cfg(feature = "framework")]
-    /// # use serenity::framework::standard::{CommandResult, macros::command};
-    /// # use serenity::model::id::ChannelId;
+    /// # use serenity::model::prelude::*;
     /// # use serenity::builder::CreateInvite;
+    /// # use serenity::http::CacheHttp;
     /// #
-    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
-    /// # #[command]
-    /// # async fn example(context: &Context) -> CommandResult {
-    /// # let channel = context.cache.channel(81384788765712384).unwrap().clone();
+    /// # async fn example(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = CreateInvite::new().temporary(true);
     /// let invite = channel.create_invite(context, builder).await?;
     /// # Ok(())
@@ -200,17 +140,11 @@ impl<'a> CreateInvite<'a> {
     /// Create an invite which is unique:
     ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "cache", feature = "client"))]
-    /// # use serenity::client::Context;
-    /// # #[cfg(feature = "framework")]
-    /// # use serenity::framework::standard::{CommandResult, macros::command};
-    /// # use serenity::model::id::ChannelId;
+    /// # use serenity::model::prelude::*;
     /// # use serenity::builder::CreateInvite;
+    /// # use serenity::http::CacheHttp;
     /// #
-    /// # #[cfg(all(feature = "cache", feature = "client", feature = "framework", feature = "http"))]
-    /// # #[command]
-    /// # async fn example(context: &Context) -> CommandResult {
-    /// # let channel = context.cache.channel(81384788765712384).unwrap().clone();
+    /// # async fn example(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = CreateInvite::new().unique(true);
     /// let invite = channel.create_invite(context, builder).await?;
     /// # Ok(())

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -25,15 +25,9 @@ use crate::model::prelude::*;
 /// # use serenity::builder::EditMessage;
 /// # use serenity::model::channel::Message;
 /// # use serenity::model::id::ChannelId;
-/// # #[cfg(feature = "client")]
-/// # use serenity::client::Context;
-/// # #[cfg(feature = "framework")]
-/// # use serenity::framework::standard::{CommandResult, macros::command};
-/// #
-/// # #[cfg(all(feature = "model", feature = "utils", feature = "framework"))]
-/// # #[command]
-/// # async fn example(ctx: &Context) -> CommandResult {
-/// # let mut message: Message = unimplemented!();
+/// # use serenity::http::CacheHttp;
+///
+/// # async fn example(ctx: impl CacheHttp, mut message: Message) -> Result<(), Box<dyn std::error::Error>> {
 /// let builder = EditMessage::new().content("hello");
 /// message.edit(ctx, builder).await?;
 /// # Ok(())

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -295,27 +295,15 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::prelude::*;
-    /// #
-    /// # #[cfg(feature = "client")]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// use std::thread;
-    /// use std::time::Duration;
-    ///
     /// struct Handler;
     ///
     /// #[serenity::async_trait]
+    /// # #[cfg(feature = "client")]
     /// impl EventHandler for Handler {
     ///     async fn cache_ready(&self, ctx: Context, _: Vec<GuildId>) {
     ///         println!("{} unknown members", ctx.cache.unknown_members());
     ///     }
     /// }
-    ///
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// [`Shard::chunk_guild`]: crate::gateway::Shard::chunk_guild
@@ -657,10 +645,8 @@ impl Cache {
     ///
     /// ```rust,no_run
     /// # use serenity::client::Context;
-    /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// #
-    /// # #[command]
-    /// # async fn test(context: &Context) -> CommandResult {
+    /// # async fn test(context: &Context) -> Result<(), Box<dyn std::error::Error>> {
     /// if let Some(user) = context.cache.user(7) {
     ///     println!("User with Id 7 is currently named {}", user.name);
     /// }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -90,7 +90,7 @@ impl Context {
     /// # use serenity::prelude::*;
     /// # use serenity::model::channel::Message;
     /// #
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
@@ -100,14 +100,6 @@ impl Context {
     ///         }
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// [`Online`]: OnlineStatus::Online
@@ -127,7 +119,7 @@ impl Context {
     /// # use serenity::prelude::*;
     /// # use serenity::model::channel::Message;
     /// #
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
@@ -137,14 +129,6 @@ impl Context {
     ///         }
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// [`Idle`]: OnlineStatus::Idle
@@ -164,7 +148,7 @@ impl Context {
     /// # use serenity::prelude::*;
     /// # use serenity::model::channel::Message;
     /// #
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
@@ -174,14 +158,6 @@ impl Context {
     ///         }
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb
@@ -195,31 +171,24 @@ impl Context {
     ///
     /// # Examples
     ///
-    /// Set the current user to being invisible on the shard when an [`Event::Ready`] is received:
+    /// Set the current user to being invisible on the shard:
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// # use serenity::model::gateway::Ready;
+    /// # use serenity::model::channel::Message;
     /// #
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, ctx: Context, _: Ready) {
-    ///         ctx.invisible();
+    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///         if msg.content == "!invisible" {
+    ///             ctx.invisible();
+    ///         }
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
-    /// [`Event::Ready`]: crate::model::event::Event::Ready
     /// [`Invisible`]: OnlineStatus::Invisible
     #[cfg(feature = "gateway")]
     #[inline]
@@ -234,28 +203,22 @@ impl Context {
     ///
     /// # Examples
     ///
-    /// Reset the presence when an [`Event::Resumed`] is received:
+    /// Reset the current user's presence on the shard:
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// # use serenity::model::event::ResumedEvent;
+    /// # use serenity::model::channel::Message;
     /// #
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn resume(&self, ctx: Context, _: ResumedEvent) {
-    ///         ctx.reset_presence();
+    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///         if msg.content == "!reset_presence" {
+    ///             ctx.reset_presence();
+    ///         }
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// [`Event::Resumed`]: crate::model::event::Event::Resumed
@@ -275,10 +238,9 @@ impl Context {
     /// ```rust,no_run
     /// # use serenity::prelude::*;
     /// # use serenity::model::channel::Message;
-    /// #
-    /// use serenity::gateway::ActivityData;
+    /// # struct Handler;
     ///
-    /// struct Handler;
+    /// use serenity::gateway::ActivityData;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
@@ -290,14 +252,6 @@ impl Context {
     ///         }
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     #[cfg(feature = "gateway")]
     #[inline]
@@ -314,8 +268,7 @@ impl Context {
     /// ```rust,no_run
     /// # use serenity::prelude::*;
     /// # use serenity::model::gateway::Ready;
-    /// #
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
@@ -325,14 +278,6 @@ impl Context {
     ///         ctx.set_presence(None, OnlineStatus::Idle);
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// Setting the current user as playing `"Heroes of the Storm"`, while being [`DoNotDisturb`]:
@@ -340,8 +285,7 @@ impl Context {
     /// ```rust,no_run
     /// # use serenity::prelude::*;
     /// # use serenity::model::gateway::Ready;
-    /// #
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
@@ -355,14 +299,6 @@ impl Context {
     ///         context.set_presence(Some(activity), status);
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -567,15 +567,8 @@ pub struct Client {
     /// # use serenity::prelude::*;
     /// # use std::time::Duration;
     /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
-    /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
-    ///
+    /// # fn run(client: Client) {
+    /// // Create a clone of the `Arc` containing the shard manager.
     /// let shard_manager = client.shard_manager.clone();
     ///
     /// tokio::spawn(async move {
@@ -586,26 +579,16 @@ pub struct Client {
     ///         tokio::time::sleep(Duration::from_millis(5000)).await;
     ///     }
     /// });
-    /// # Ok(())
     /// # }
     /// ```
     ///
     /// Shutting down all connections after one minute of operation:
     ///
     /// ```rust,no_run
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// use std::time::Duration;
-    ///
-    /// use serenity::prelude::*;
-    ///
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
-    /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
-    ///
+    /// # use serenity::prelude::*;
+    /// # use std::time::Duration;
+    /// #
+    /// # fn run(client: Client) {
     /// // Create a clone of the `Arc` containing the shard manager.
     /// let shard_manager = client.shard_manager.clone();
     ///
@@ -618,9 +601,6 @@ pub struct Client {
     ///
     ///     println!("Shutdown shard manager!");
     /// });
-    ///
-    /// println!("Client shutdown: {:?}", client.start().await);
-    /// # Ok(())
     /// # }
     /// ```
     pub shard_manager: Arc<ShardManager>,
@@ -670,14 +650,9 @@ impl Client {
     /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, GatewayIntents::default()).await?;
     ///
     /// if let Err(why) = client.start().await {
     ///     println!("Err with client: {:?}", why);
@@ -712,14 +687,9 @@ impl Client {
     /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, GatewayIntents::default()).await?;
     ///
     /// if let Err(why) = client.start_autosharded().await {
     ///     println!("Err with client: {:?}", why);
@@ -763,14 +733,9 @@ impl Client {
     /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, GatewayIntents::default()).await?;
     ///
     /// if let Err(why) = client.start_shard(3, 5).await {
     ///     println!("Err with client: {:?}", why);
@@ -787,14 +752,9 @@ impl Client {
     /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, GatewayIntents::default()).await?;
     ///
     /// if let Err(why) = client.start_shard(0, 1).await {
     ///     println!("Err with client: {:?}", why);
@@ -833,14 +793,9 @@ impl Client {
     /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, GatewayIntents::default()).await?;
     ///
     /// if let Err(why) = client.start_shards(8).await {
     ///     println!("Err with client: {:?}", why);
@@ -879,14 +834,9 @@ impl Client {
     /// # use serenity::prelude::*;
     /// use serenity::Client;
     ///
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
     /// # async fn run() -> Result<(), Box<dyn Error>> {
     /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
+    /// let mut client = Client::builder(&token, GatewayIntents::default()).await?;
     ///
     /// if let Err(why) = client.start_shard_range(4..7, 10).await {
     ///     println!("Err with client: {:?}", why);

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -217,29 +217,15 @@ impl ShardManager {
     ///
     /// # Examples
     ///
-    /// Creating a client and then restarting a shard by ID:
-    ///
-    /// _(note: in reality this precise code doesn't have an effect since the shard would not yet
-    /// have been initialized via [`Self::initialize`], but the concept is the same)_
+    /// Restarting a shard by ID:
     ///
     /// ```rust,no_run
-    /// use std::env;
-    ///
     /// use serenity::model::id::ShardId;
     /// use serenity::prelude::*;
     ///
-    /// struct Handler;
-    ///
-    /// impl EventHandler for Handler {}
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
-    ///
+    /// # async fn run(client: Client) {
     /// // restart shard ID 7
     /// client.shard_manager.restart(ShardId(7)).await;
-    /// # Ok(())
     /// # }
     /// ```
     ///

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -91,8 +91,6 @@ impl Attachment {
     /// Download all of the attachments associated with a [`Message`]:
     ///
     /// ```rust,no_run
-    /// # #[cfg(feature = "client")]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::io::Write;
     /// use std::path::Path;
     ///
@@ -101,9 +99,10 @@ impl Attachment {
     /// use tokio::fs::File;
     /// use tokio::io::AsyncWriteExt;
     ///
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
+    /// # #[cfg(feature = "client")]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, mut message: Message) {
     ///         for attachment in message.attachments {
@@ -140,18 +139,7 @@ impl Attachment {
     ///                 .await;
     ///         }
     ///     }
-    ///
-    ///     async fn ready(&self, _: Context, ready: Ready) {
-    ///         println!("{} is connected!", ready.user.name);
-    ///     }
     /// }
-    /// let token = std::env::var("DISCORD_TOKEN")?;
-    /// let mut client =
-    ///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// # Errors

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -727,9 +727,9 @@ impl GuildChannel {
     /// Calculate the permissions of a [`User`] who posted a [`Message`] in a channel:
     ///
     /// ```rust,no_run
-    /// use serenity::model::prelude::*;
-    /// use serenity::prelude::*;
-    /// struct Handler;
+    /// # use serenity::model::prelude::*;
+    /// # use serenity::prelude::*;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
@@ -744,57 +744,6 @@ impl GuildChannel {
     ///         }
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// Check if the current user has the [Attach Files] and [Send Messages] permissions (note:
-    /// serenity will automatically check this for; this is for demonstrative purposes):
-    ///
-    /// ```rust,no_run
-    /// use serenity::builder::{CreateAttachment, CreateMessage};
-    /// use serenity::model::channel::Channel;
-    /// use serenity::model::prelude::*;
-    /// use serenity::prelude::*;
-    /// use tokio::fs::File;
-    ///
-    /// struct Handler;
-    ///
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn message(&self, context: Context, mut msg: Message) {
-    ///         let current_user_id = context.cache.current_user().id;
-    ///         let permissions = match context.cache.channel(msg.channel_id) {
-    ///             Some(channel) => channel.permissions_for_user(&context.cache, current_user_id),
-    ///             None => return,
-    ///         };
-    ///
-    ///         if let Ok(permissions) = permissions {
-    ///             if !permissions.contains(Permissions::ATTACH_FILES | Permissions::SEND_MESSAGES) {
-    ///                 return;
-    ///             }
-    ///
-    ///             let file = CreateAttachment::path("cat.png").await.unwrap();
-    ///
-    ///             let builder = CreateMessage::new().content("here's a cat");
-    ///             let _ = msg.channel_id.send_files(&context.http, [file], builder).await;
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     ///
     /// # Errors

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -382,18 +382,13 @@ impl From<char> for ReactionType {
     /// Reacting to a message with an apple:
     ///
     /// ```rust,no_run
-    /// # #[cfg(feature = "client")]
-    /// # use serenity::client::Context;
-    /// # #[cfg(feature = "framework")]
-    /// # use serenity::framework::standard::{CommandResult, macros::command};
+    /// # #[cfg(feature = "http")]
+    /// # use serenity::http::CacheHttp;
     /// # use serenity::model::channel::Message;
     /// # use serenity::model::id::ChannelId;
     /// #
-    /// # #[cfg(all(feature = "client", feature = "framework", feature = "http"))]
-    /// # #[command]
-    /// # async fn example(ctx: &Context) -> CommandResult {
-    /// # let message: Message = unimplemented!();
-    /// #
+    /// # #[cfg(feature = "http")]
+    /// # async fn example(ctx: impl CacheHttp, message: Message) -> Result<(), Box<dyn std::error::Error>> {
     /// message.react(ctx, '🍎').await?;
     /// # Ok(())
     /// # }

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -12,20 +12,18 @@ use super::Permissions;
 /// # Examples
 ///
 /// Matching an [`Error`] with this variant would look something like the following for the
-/// [`GuildId::ban`] method, which in this example is used to re-ban all members with an odd
-/// discriminator:
+/// [`GuildId::ban`] method, which in this example is used to re-ban all members.
 ///
 /// ```rust,no_run
-/// # #[cfg(all(feature = "client", feature = "model"))]
-/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// use serenity::model::prelude::*;
 /// use serenity::model::ModelError;
 /// use serenity::prelude::*;
 /// use serenity::Error;
 ///
-/// struct Handler;
+/// # struct Handler;
 ///
 /// #[serenity::async_trait]
+/// #[cfg(feature = "client")]
 /// impl EventHandler for Handler {
 ///     async fn guild_ban_removal(&self, context: Context, guild_id: GuildId, user: User) {
 ///         match guild_id.ban(&context, user, 8).await {
@@ -41,13 +39,6 @@ use super::Permissions;
 ///         }
 ///     }
 /// }
-/// let token = std::env::var("DISCORD_BOT_TOKEN")?;
-/// let mut client =
-///     Client::builder(&token, GatewayIntents::default()).event_handler(Handler).await?;
-///
-/// client.start().await?;
-/// # Ok(())
-/// # }
 /// ```
 ///
 /// [`Error`]: crate::Error

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -67,14 +67,10 @@ impl Emoji {
     /// Delete a given emoji:
     ///
     /// ```rust,no_run
-    /// # use serenity::json::{json, from_value};
-    /// # use serenity::framework::standard::{CommandResult, macros::command};
     /// # use serenity::client::Context;
-    /// # use serenity::model::prelude::{EmojiId, Emoji};
+    /// # use serenity::model::prelude::Emoji;
     /// #
-    /// # #[command]
-    /// # async fn example(ctx: &Context) -> CommandResult {
-    /// # let mut emoji: Emoji = unimplemented!();
+    /// # async fn example(ctx: &Context, emoji: Emoji) -> Result<(), Box<dyn std::error::Error>> {
     /// // assuming emoji has been set already
     /// match emoji.delete(&ctx).await {
     ///     Ok(()) => println!("Emoji deleted."),

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2386,14 +2386,12 @@ impl Guild {
     /// Obtain a reference to a [`Role`] by its name.
     ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "cache", feature = "client"))]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// use serenity::model::prelude::*;
-    /// use serenity::prelude::*;
-    ///
-    /// struct Handler;
+    /// # use serenity::model::prelude::*;
+    /// # use serenity::prelude::*;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
+    /// #[cfg(all(feature = "cache", feature = "client"))]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if let Some(guild_id) = msg.guild_id {
@@ -2405,13 +2403,6 @@ impl Guild {
     ///         }
     ///     }
     /// }
-    ///
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     #[must_use]
     pub fn role_by_name(&self, role_name: &str) -> Option<&Role> {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1509,14 +1509,12 @@ impl PartialGuild {
     /// Obtain a reference to a [`Role`] by its name.
     ///
     /// ```rust,no_run
-    /// # #[cfg(all(feature = "client", feature = "cache"))]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// use serenity::model::prelude::*;
-    /// use serenity::prelude::*;
-    ///
-    /// struct Handler;
+    /// # use serenity::model::prelude::*;
+    /// # use serenity::prelude::*;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
+    /// #[cfg(all(feature = "cache", feature = "client"))]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, msg: Message) {
     ///         if let Some(guild_id) = msg.guild_id {
@@ -1528,13 +1526,6 @@ impl PartialGuild {
     ///         }
     ///     }
     /// }
-    ///
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     #[inline]
     #[must_use]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -431,61 +431,28 @@ impl User {
     ///
     /// # Examples
     ///
-    /// When a user sends a message with a content of `"~help"`, DM the author a help message, and
-    /// then react with `'👌'` to verify message sending:
+    /// When a user sends a message with a content of `"~help"`, DM the author a help message
     ///
     /// ```rust,no_run
-    /// # #[cfg(feature = "client")] {
     /// # use serenity::prelude::*;
     /// # use serenity::model::prelude::*;
-    /// #
-    /// use serenity::builder::{CreateBotAuthParameters, CreateMessage};
-    ///
-    /// struct Handler;
+    /// # struct Handler;
+    /// use serenity::builder::CreateMessage;
     ///
     /// #[serenity::async_trait]
+    /// # #[cfg(feature = "client")]
     /// impl EventHandler for Handler {
-    /// #   #[cfg(feature = "cache")]
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "~help" {
-    ///             let url = match CreateBotAuthParameters::new()
-    ///                 .permissions(Permissions::empty())
-    ///                 .scopes(&[Scope::Bot])
-    ///                 .auto_client_id(&ctx)
-    ///                 .await
-    ///             {
-    ///                 Ok(v) => v.build(),
-    ///                 Err(why) => {
-    ///                     println!("Error creating invite url: {:?}", why);
-    ///                     return;
-    ///                 },
-    ///             };
+    ///             let builder = CreateMessage::new().content("Helpful info here.");
     ///
-    ///             let help = format!("Helpful info here. Invite me with this link: <{}>", url);
-    ///
-    ///             let builder = CreateMessage::new().content(help);
-    ///             let dm = msg.author.direct_message(&ctx, builder).await;
-    ///
-    ///             match dm {
-    ///                 Ok(_) => {
-    ///                     let _ = msg.react(&ctx, '👌').await;
-    ///                 },
-    ///                 Err(why) => {
-    ///                     println!("Err sending help: {:?}", why);
-    ///
-    ///                     let _ = msg.reply(&ctx, "There was an error DMing you help.").await;
-    ///                 },
+    ///             if let Err(why) = msg.author.direct_message(&ctx, builder).await {
+    ///                 println!("Err sending help: {why:?}");
+    ///                 let _ = msg.reply(&ctx, "There was an error DMing you help.").await;
     ///             };
     ///         }
     ///     }
     /// }
-    ///
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    /// # Ok(())
-    /// # }
-    /// # }
     /// ```
     ///
     /// # Errors
@@ -591,35 +558,20 @@ impl User {
     /// Make a command to tell the user what their tag is:
     ///
     /// ```rust,no_run
-    /// # #[cfg(feature = "client")]
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # use serenity::prelude::*;
     /// # use serenity::model::prelude::*;
-    /// #
-    /// use serenity::utils::ContentModifier::Bold;
-    /// use serenity::utils::MessageBuilder;
-    ///
-    /// struct Handler;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
+    /// # #[cfg(feature = "client")]
     /// impl EventHandler for Handler {
     ///     async fn message(&self, context: Context, msg: Message) {
     ///         if msg.content == "!mytag" {
-    ///             let content = MessageBuilder::new()
-    ///                 .push("Your tag is ")
-    ///                 .push(Bold + msg.author.tag())
-    ///                 .build();
-    ///
+    ///             let content = format!("Your tag is: {}", msg.author.tag());
     ///             let _ = msg.channel_id.say(&context.http, &content).await;
     ///         }
     ///     }
     /// }
-    /// let mut client =
-    ///     Client::builder("token", GatewayIntents::default()).event_handler(Handler).await?;
-    ///
-    /// client.start().await?;
-    /// # Ok(())
-    /// # }
     /// ```
     #[inline]
     #[must_use]


### PR DESCRIPTION
This removes examples which are superfluous or otherwise useless, simplifies existing examples down to just show the method being demonstrated, and otherwise deleted duplicate code in every example that was not required.

This helps with larger changes to serenity as we don't have to maintain and keep up to date 50 small bots in-tree in form of doc examples. It also makes documentation clearer for users as they don't have to wade through the same code over and over again to understand concepts.

Note for the time: I don't personally expect this to be a part of 0.12, it could possibly be a part of 0.12.1 but it will only help for next (0.13).