### PR TITLE
Get rid of TypeMap and replace with Data generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ flate2 = { version = "1.0.28", optional = true }
 reqwest = { version = "0.11.22", default-features = false, features = ["multipart", "stream"], optional = true }
 static_assertions = { version = "1.1.0", optional = true }
 tokio-tungstenite = { version = "0.20.1", optional = true }
-typemap_rev = { version = "0.3.0", optional = true }
 bytes = { version = "1.5.0", optional = true }
 percent-encoding = { version = "2.3.0", optional = true }
 mini-moka = { version = "0.10.2", optional = true }
@@ -53,6 +52,7 @@ typesize = { version = "0.1.2", optional = true, features = ["url", "time", "ser
 # Serenity workspace crates
 command_attr = { version = "0.5.1", path = "./command_attr", optional = true }
 serenity-voice-model = { version = "0.2.0", path = "./voice-model", optional = true }
+derivative = "2.2.0"
 
 [dev-dependencies.http_crate]
 version = "0.2.11"
@@ -88,7 +88,7 @@ cache = ["fxhash", "dashmap", "parking_lot"]
 collector = ["gateway", "model"]
 # Wraps the gateway and http functionality into a single interface
 # TODO: should this require "gateway"?
-client = ["http", "typemap_rev"]
+client = ["http"]
 # Enables the Framework trait which is an abstraction for old-style text commands.
 framework = ["client", "model", "utils"]
 # Enables gateway support, which allows bots to listen for Discord events.

--- a/command_attr/src/lib.rs
+++ b/command_attr/src/lib.rs
@@ -185,8 +185,9 @@ pub fn command(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let cooked = fun.cooked.clone();
 
-    let options_path = quote!(serenity::framework::standard::CommandOptions);
-    let command_path = quote!(serenity::framework::standard::Command);
+    let data_generic = &fun.data_generic;
+    let options_path = quote!(serenity::framework::standard::CommandOptions::<#data_generic>);
+    let command_path = quote!(serenity::framework::standard::Command::<#data_generic>);
 
     populate_fut_lifetimes_on_refs(&mut fun.args);
     let args = fun.args;
@@ -464,8 +465,9 @@ pub fn help(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let cooked = fun.cooked.clone();
 
+    let data_generic = &fun.data_generic;
     let options_path = quote!(serenity::framework::standard::HelpOptions);
-    let command_path = quote!(serenity::framework::standard::HelpCommand);
+    let command_path = quote!(serenity::framework::standard::HelpCommand::<#data_generic>);
 
     let body = fun.body;
     let ret = fun.ret;
@@ -698,9 +700,10 @@ pub fn group(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let sub_groups = sub_groups.into_iter().map(|c| c.with_suffix(GROUP)).collect::<Vec<_>>();
 
+    let data_generic = &group.data_generic;
     let options = group.name.with_suffix(GROUP_OPTIONS);
-    let options_path = quote!(serenity::framework::standard::GroupOptions);
-    let group_path = quote!(serenity::framework::standard::CommandGroup);
+    let options_path = quote!(serenity::framework::standard::GroupOptions::<#data_generic>);
+    let group_path = quote!(serenity::framework::standard::CommandGroup::<#data_generic>);
 
     (quote! {
         #(#cooked)*
@@ -785,13 +788,14 @@ pub fn check(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let name = if name == "<fn>" { fun.name.clone() } else { Ident::new(&name, Span::call_site()) };
     let name = name.with_suffix(CHECK);
 
-    let check = quote!(serenity::framework::standard::Check);
+    let data_generic = fun.data_generic;
     let cooked = fun.cooked;
     let body = fun.body;
     let ret = fun.ret;
     populate_fut_lifetimes_on_refs(&mut fun.args);
     let args = fun.args;
 
+    let check = quote!(serenity::framework::standard::Check::<#data_generic>);
     (quote! {
         #[allow(missing_docs)]
         pub static #name: #check = #check {

--- a/command_attr/src/structures.rs
+++ b/command_attr/src/structures.rs
@@ -136,6 +136,7 @@ pub struct CommandFun {
     pub cooked: Vec<Attribute>,
     pub visibility: Visibility,
     pub name: Ident,
+    pub data_generic: Ident,
     pub args: Vec<Argument>,
     pub ret: Type,
     pub body: Vec<Stmt>,
@@ -156,6 +157,10 @@ impl Parse for CommandFun {
 
         input.parse::<Token![fn]>()?;
         let name = input.parse()?;
+
+        input.parse::<Token![<]>()?;
+        let data_generic = input.parse()?;
+        input.parse::<Token![>]>()?;
 
         // (...)
         let Parenthesised(args) = input.parse::<Parenthesised<FnArg>>()?;
@@ -180,6 +185,7 @@ impl Parse for CommandFun {
             cooked,
             visibility,
             name,
+            data_generic,
             args,
             ret,
             body,
@@ -194,6 +200,7 @@ impl ToTokens for CommandFun {
             cooked,
             visibility,
             name,
+            data_generic: _,
             args,
             ret,
             body,
@@ -574,6 +581,7 @@ pub struct GroupStruct {
     pub cooked: Vec<Attribute>,
     pub attributes: Vec<Attribute>,
     pub name: Ident,
+    pub data_generic: Ident,
 }
 
 impl Parse for GroupStruct {
@@ -590,6 +598,10 @@ impl Parse for GroupStruct {
 
         let name = input.parse()?;
 
+        input.parse::<Token![<]>()?;
+        let data_generic = input.parse()?;
+        input.parse::<Token![>]>()?;
+
         input.parse::<Token![;]>()?;
 
         Ok(Self {
@@ -597,6 +609,7 @@ impl Parse for GroupStruct {
             cooked,
             attributes,
             name,
+            data_generic,
         })
     }
 }
@@ -608,6 +621,7 @@ impl ToTokens for GroupStruct {
             cooked,
             attributes: _,
             name,
+            data_generic: _,
         } = self;
 
         stream.extend(quote! {

--- a/command_attr/src/util.rs
+++ b/command_attr/src/util.rs
@@ -202,13 +202,16 @@ pub fn create_declaration_validations(fun: &mut CommandFun, dec_for: DeclarFor) 
         ));
     }
 
-    let context: Type = parse_quote!(&serenity::client::Context);
+    let data_generic = &fun.data_generic;
+    let context: Type = parse_quote!(&serenity::client::Context::<#data_generic>);
     let message: Type = parse_quote!(&serenity::model::channel::Message);
     let args: Type = parse_quote!(serenity::framework::standard::Args);
     let args2: Type = parse_quote!(&mut serenity::framework::standard::Args);
-    let options: Type = parse_quote!(&serenity::framework::standard::CommandOptions);
+    let options: Type =
+        parse_quote!(&serenity::framework::standard::CommandOptions::<#data_generic>);
     let hoptions: Type = parse_quote!(&'static serenity::framework::standard::HelpOptions);
-    let groups: Type = parse_quote!(&[&'static serenity::framework::standard::CommandGroup]);
+    let groups: Type =
+        parse_quote!(&[&'static serenity::framework::standard::CommandGroup::<#data_generic>]);
     let owners: Type = parse_quote!(std::collections::HashSet<serenity::model::id::UserId>);
 
     let mut index = 0;

--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -5,10 +5,14 @@ use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     // Set a handler for the `message` event - so that whenever a new message is received - the
     // closure (or function) passed will be called.
     //
@@ -46,8 +50,10 @@ async fn main() {
 
     // Create a new instance of the Client, logging in as a bot. This will automatically prepend
     // your bot token with "Bot ", which is a requirement by Discord for bot users.
-    let mut client =
-        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token, intents, ())
+        .event_handler(Handler)
+        .await
+        .expect("Err creating client");
 
     // Finally, start a single shard, and start listening to events.
     //

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -22,8 +22,12 @@ use serenity::prelude::*;
 // console. This confirms that guild sharding works.
 struct Handler;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
         if msg.content == "!ping" {
             println!("Shard {}", ctx.shard_id);
@@ -46,8 +50,10 @@ async fn main() {
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client =
-        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token, intents, ())
+        .event_handler(Handler)
+        .await
+        .expect("Err creating client");
 
     // The total number of shards to use. The "current shard number" of a shard - that is, the
     // shard it is assigned to - is indexed at 0, while the total shard count is indexed at 1.

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -6,10 +6,14 @@ use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<Data>;
+
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn message(&self, context: Context, msg: Message) {
         if msg.content == "!messageme" {
             // If the `utils`-feature is enabled, then model structs will have a lot of useful
@@ -39,8 +43,11 @@ async fn main() {
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client =
-        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
+
+    let mut client = Client::builder(&token, intents, ())
+        .event_handler(Handler)
+        .await
+        .expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {why:?}");

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -6,10 +6,14 @@ use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 use serenity::utils::MessageBuilder;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn message(&self, context: Context, msg: Message) {
         if msg.content == "!ping" {
             let channel = match msg.channel_id.to_channel(&context).await {
@@ -50,8 +54,10 @@ async fn main() {
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client =
-        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token, intents, ())
+        .event_handler(Handler)
+        .await
+        .expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {why:?}");

--- a/examples/e05_command_framework/Cargo.toml
+++ b/examples/e05_command_framework/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["my name <my@email.address>"]
 edition = "2018"
 
+[dependencies.dashmap]
+version = "5"
+
 [dependencies.serenity]
 features = ["framework", "standard_framework", "rustls_backend"]
 path = "../../"

--- a/examples/e06_sample_bot_structure/src/commands/math.rs
+++ b/examples/e06_sample_bot_structure/src/commands/math.rs
@@ -1,10 +1,11 @@
 use serenity::framework::standard::macros::command;
 use serenity::framework::standard::{Args, CommandResult};
 use serenity::model::prelude::*;
-use serenity::prelude::*;
+
+use crate::{Context, Data};
 
 #[command]
-pub async fn multiply(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+pub async fn multiply<Data>(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
     let one = args.single::<f64>()?;
     let two = args.single::<f64>()?;
 

--- a/examples/e06_sample_bot_structure/src/commands/meta.rs
+++ b/examples/e06_sample_bot_structure/src/commands/meta.rs
@@ -1,10 +1,11 @@
 use serenity::framework::standard::macros::command;
 use serenity::framework::standard::CommandResult;
 use serenity::model::prelude::*;
-use serenity::prelude::*;
+
+use crate::{Context, Data};
 
 #[command]
-async fn ping(ctx: &Context, msg: &Message) -> CommandResult {
+async fn ping<Data>(ctx: &Context, msg: &Message) -> CommandResult {
     msg.channel_id.say(&ctx.http, "Pong!").await?;
 
     Ok(())

--- a/examples/e06_sample_bot_structure/src/commands/owner.rs
+++ b/examples/e06_sample_bot_structure/src/commands/owner.rs
@@ -1,23 +1,15 @@
 use serenity::framework::standard::macros::command;
 use serenity::framework::standard::CommandResult;
 use serenity::model::prelude::*;
-use serenity::prelude::*;
 
-use crate::ShardManagerContainer;
+use crate::{Context, Data};
 
 #[command]
 #[owners_only]
-async fn quit(ctx: &Context, msg: &Message) -> CommandResult {
-    let data = ctx.data.read().await;
-
-    if let Some(manager) = data.get::<ShardManagerContainer>() {
-        msg.reply(ctx, "Shutting down!").await?;
-        manager.shutdown_all().await;
-    } else {
-        msg.reply(ctx, "There was a problem getting the shard manager").await?;
-
-        return Ok(());
-    }
+async fn quit<Data>(ctx: &Context, msg: &Message) -> CommandResult {
+    let shard_manager = ctx.data.shard_manager.get().unwrap();
+    msg.reply(ctx, "Shutting down!").await?;
+    shard_manager.shutdown_all().await;
 
     Ok(())
 }

--- a/examples/e08_shard_manager/src/main.rs
+++ b/examples/e08_shard_manager/src/main.rs
@@ -27,10 +27,14 @@ use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 use tokio::time::sleep;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn ready(&self, _: Context, ready: Ready) {
         if let Some(shard) = ready.shard {
             // Note that array index 0 is 0-indexed, while index 1 is 1-indexed.
@@ -49,8 +53,10 @@ async fn main() {
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client =
-        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token, intents, ())
+        .event_handler(Handler)
+        .await
+        .expect("Err creating client");
 
     // Here we clone a lock to the Shard Manager, and then move it into a new thread. The thread
     // will unlock the manager and print shards' status on a loop.

--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -7,10 +7,14 @@ use serenity::model::gateway::Ready;
 use serenity::model::Timestamp;
 use serenity::prelude::*;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
         if msg.content == "!hello" {
             // The create message builder allows you to easily create embeds and messages using a
@@ -55,8 +59,10 @@ async fn main() {
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client =
-        Client::builder(&token, intents).event_handler(Handler).await.expect("Err creating client");
+    let mut client = Client::builder(&token, intents, ())
+        .event_handler(Handler)
+        .await
+        .expect("Err creating client");
 
     if let Err(why) = client.start().await {
         println!("Client error: {why:?}");

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -10,7 +10,6 @@ use serenity::framework::standard::macros::{command, group, help};
 use serenity::framework::standard::{
     help_commands,
     Args,
-    CommandGroup,
     CommandResult,
     Configuration,
     HelpOptions,
@@ -22,12 +21,17 @@ use serenity::http::Http;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<Data>;
+type CommandGroup = serenity::framework::standard::CommandGroup<Data>;
+
 #[group("collector")]
 #[commands(challenge)]
-struct Collector;
+struct Collector<Data>;
 
 #[help]
-async fn my_help(
+async fn my_help<Data>(
     context: &Context,
     msg: &Message,
     args: Args,
@@ -42,7 +46,7 @@ async fn my_help(
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn ready(&self, _: Context, ready: Ready) {
         println!("{} is connected!", ready.user.name);
     }
@@ -76,7 +80,7 @@ async fn main() {
         | GatewayIntents::MESSAGE_CONTENT
         | GatewayIntents::GUILD_MESSAGE_REACTIONS;
 
-    let mut client = Client::builder(&token, intents)
+    let mut client = Client::builder(&token, intents, ())
         .event_handler(Handler)
         .framework(framework)
         .await
@@ -88,7 +92,7 @@ async fn main() {
 }
 
 #[command]
-async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
+async fn challenge<Data>(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
     let mut score = 0u32;
     let _ = msg.reply(ctx, "How was that crusty crab called again? 10 seconds time!").await;
 

--- a/examples/e11_gateway_intents/src/main.rs
+++ b/examples/e11_gateway_intents/src/main.rs
@@ -5,10 +5,14 @@ use serenity::model::channel::Message;
 use serenity::model::gateway::{GatewayIntents, Presence, Ready};
 use serenity::prelude::*;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     // This event will be dispatched for guilds, but not for direct messages.
     async fn message(&self, _ctx: Context, msg: Message) {
         println!("Received message: {}", msg.content);
@@ -34,7 +38,7 @@ async fn main() {
     let intents =
         GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT;
     // Build our client.
-    let mut client = Client::builder(token, intents)
+    let mut client = Client::builder(token, intents, ())
         .event_handler(Handler)
         .await
         .expect("Error creating client");

--- a/examples/e12_global_data/Cargo.toml
+++ b/examples/e12_global_data/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
+dashmap = "5"
 serenity = { path = "../../" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e13_parallel_loops/src/main.rs
+++ b/examples/e13_parallel_loops/src/main.rs
@@ -12,12 +12,16 @@ use serenity::model::gateway::Ready;
 use serenity::model::id::{ChannelId, GuildId};
 use serenity::prelude::*;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Handler {
     is_loop_running: AtomicBool,
 }
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
         if msg.content.starts_with("!ping") {
             if let Err(why) = msg.channel_id.say(&ctx.http, "Pong!").await {
@@ -112,7 +116,8 @@ async fn main() {
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::GUILDS
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client = Client::builder(&token, intents)
+
+    let mut client = Client::builder(&token, intents, ())
         .event_handler(Handler {
             is_loop_running: AtomicBool::new(false),
         })

--- a/examples/e14_slash_commands/src/commands/modal.rs
+++ b/examples/e14_slash_commands/src/commands/modal.rs
@@ -1,7 +1,8 @@
 use serenity::builder::*;
 use serenity::model::prelude::*;
-use serenity::prelude::*;
 use serenity::utils::CreateQuickModal;
+
+use crate::Context;
 
 pub async fn run(ctx: &Context, interaction: &CommandInteraction) -> Result<(), serenity::Error> {
     let modal = CreateQuickModal::new("About you")

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -9,10 +9,14 @@ use serenity::model::gateway::Ready;
 use serenity::model::id::GuildId;
 use serenity::prelude::*;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
         if let Interaction::Command(command) = interaction {
             println!("Received command interaction: {command:#?}");
@@ -75,7 +79,7 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
     // Build our client.
-    let mut client = Client::builder(token, GatewayIntents::empty())
+    let mut client = Client::builder(token, GatewayIntents::empty(), ())
         .event_handler(Handler)
         .await
         .expect("Error creating client");

--- a/examples/e16_sqlite_database/src/main.rs
+++ b/examples/e16_sqlite_database/src/main.rs
@@ -6,12 +6,16 @@ use serenity::async_trait;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Bot {
     database: sqlx::SqlitePool,
 }
 
 #[async_trait]
-impl EventHandler for Bot {
+impl EventHandler<Data> for Bot {
     async fn message(&self, ctx: Context, msg: Message) {
         let user_id = msg.author.id.get() as i64;
 
@@ -96,6 +100,6 @@ async fn main() {
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
     let mut client =
-        Client::builder(&token, intents).event_handler(bot).await.expect("Err creating client");
+        Client::builder(&token, intents, ()).event_handler(bot).await.expect("Err creating client");
     client.start().await.unwrap();
 }

--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -12,7 +12,7 @@ use serenity::builder::{
     CreateSelectMenuKind,
     CreateSelectMenuOption,
 };
-use serenity::client::{Context, EventHandler};
+use serenity::client::EventHandler;
 use serenity::futures::StreamExt;
 use serenity::model::prelude::*;
 use serenity::prelude::*;
@@ -24,10 +24,14 @@ fn sound_button(name: &str, emoji: ReactionType) -> CreateButton {
     CreateButton::new(name).emoji(emoji)
 }
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 struct Handler;
 
 #[async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
         if msg.content != "animal" {
             return;
@@ -143,7 +147,7 @@ async fn main() {
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client = Client::builder(token, intents)
+    let mut client = Client::builder(token, intents, ())
         .event_handler(Handler)
         .await
         .expect("Error creating client");

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -4,6 +4,10 @@ use serenity::prelude::*;
 
 mod model_type_sizes;
 
+// We don't need to store any state, so we define our `D`ata generic as `()`.
+type Data = ();
+type Context = serenity::client::Context<()>;
+
 const IMAGE_URL: &str = "https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png";
 const IMAGE_URL_2: &str = "https://rustacean.net/assets/rustlogo.png";
 
@@ -356,7 +360,7 @@ async fn interaction(
 
 struct Handler;
 #[serenity::async_trait]
-impl EventHandler for Handler {
+impl EventHandler<Data> for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
         message(&ctx, msg).await.unwrap();
     }
@@ -390,5 +394,5 @@ async fn main() -> Result<(), serenity::Error> {
     env_logger::init();
     let token = std::env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
     let intents = GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT;
-    Client::builder(token, intents).event_handler(Handler).await?.start().await
+    Client::builder(token, intents, ()).event_handler(Handler).await?.start().await
 }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -131,7 +131,7 @@ impl EditMessage {
     /// ```rust,no_run
     /// # use serenity::all::*;
     /// # #[cfg(feature = "collector")]
-    /// # async fn test(ctx: &Context, channel_id: ChannelId) -> Result<(), Error> {
+    /// # async fn test(ctx: &Context<()>, channel_id: ChannelId) -> Result<(), Error> {
     /// use std::time::Duration;
     ///
     /// use futures::StreamExt;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -302,11 +302,13 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::prelude::*;
+    /// # type Data = ();
+    /// # type Context = serenity::client::Context<Data>;
     /// struct Handler;
     ///
     /// #[serenity::async_trait]
     /// # #[cfg(feature = "client")]
-    /// impl EventHandler for Handler {
+    /// impl EventHandler<Data> for Handler {
     ///     async fn cache_ready(&self, ctx: Context, _: Vec<GuildId>) {
     ///         println!("{} unknown members", ctx.cache.unknown_members());
     ///     }
@@ -343,11 +345,12 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::prelude::*;
-    /// #
-    /// struct Handler;
+    /// # type Data = ();
+    /// # type Context = serenity::client::Context<Data>;
+    /// # struct Handler;
     ///
     /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
+    /// impl EventHandler<Data> for Handler {
     ///     async fn ready(&self, context: Context, _: Ready) {
     ///         let guilds = context.cache.guilds().len();
     ///
@@ -658,7 +661,7 @@ impl Cache {
     /// ```rust,no_run
     /// # use serenity::client::Context;
     /// #
-    /// # async fn test(context: &Context) -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn test(context: &Context<()>) -> Result<(), Box<dyn std::error::Error>> {
     /// if let Some(user) = context.cache.user(7) {
     ///     println!("User with Id 7 is currently named {}", user.name);
     /// }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -42,12 +42,12 @@ macro_rules! update_cache {
     ($cache:ident, $event:ident) => {};
 }
 
-pub(crate) fn dispatch_model(
+pub(crate) fn dispatch_model<D: Send + Sync + 'static>(
     event: Event,
-    context: &Context,
-    #[cfg(feature = "framework")] framework: Option<Arc<dyn Framework>>,
-    event_handlers: Vec<Arc<dyn EventHandler>>,
-    raw_event_handlers: Vec<Arc<dyn RawEventHandler>>,
+    context: &Context<D>,
+    #[cfg(feature = "framework")] framework: Option<Arc<dyn Framework<D>>>,
+    event_handlers: Vec<Arc<dyn EventHandler<D>>>,
+    raw_event_handlers: Vec<Arc<dyn RawEventHandler<D>>>,
 ) {
     for raw_handler in raw_event_handlers {
         let (context, event) = (context.clone(), event.clone());

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -18,11 +18,11 @@ macro_rules! event_handler {
     )* ) => {
         /// The core trait for handling events by serenity.
         #[async_trait]
-        pub trait EventHandler: Send + Sync {
+        pub trait EventHandler<D: Send + Sync>: Send + Sync {
             $(
                 $( #[doc = $doc] )*
                 $( #[cfg(feature = $feature)] )?
-                async fn $method_name(&self, $($context: Context,)? $( $arg_name: $arg_type ),*) {
+                async fn $method_name(&self, $($context: Context<D>,)? $( $arg_name: $arg_type ),*) {
                     // Suppress unused argument warnings
                     drop(( $($context,)? $($arg_name),* ))
                 }
@@ -48,7 +48,7 @@ macro_rules! event_handler {
             ///
             /// ```rust,no_run
             /// # use serenity::client::{Context, FullEvent};
-            /// # fn _foo(ctx: Context, event: FullEvent) {
+            /// # fn _foo(ctx: Context<()>, event: FullEvent) {
             /// if let FullEvent::Message { .. } = &event {
             ///     assert_eq!(event.snake_case_name(), "message");
             /// }
@@ -65,7 +65,7 @@ macro_rules! event_handler {
             }
 
             /// Runs the given [`EventHandler`]'s code for this event.
-            pub async fn dispatch(self, ctx: Context, handler: &dyn EventHandler) {
+            pub async fn dispatch<D: Send + Sync>(self, ctx: Context<D>, handler: &dyn EventHandler<D>) {
                 match self {
                     $(
                         $( #[cfg(feature = $feature)] )?
@@ -459,7 +459,7 @@ event_handler! {
 
 /// This core trait for handling raw events
 #[async_trait]
-pub trait RawEventHandler: Send + Sync {
+pub trait RawEventHandler<D: Send + Sync>: Send + Sync {
     /// Dispatched when any event occurs
-    async fn raw_event(&self, _ctx: Context, _ev: Event) {}
+    async fn raw_event(&self, _ctx: Context<D>, _ev: Event) {}
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,6 +1,3 @@
-// Or we'll get deprecation warnings from our own deprecated type (seriously Rust?)
-#![allow(deprecated)]
-
 use futures::future::pending;
 use futures::{Stream, StreamExt as _};
 
@@ -127,12 +124,6 @@ macro_rules! make_specific_collector {
                 stream.take_until(Box::pin(timeout))
             }
 
-            /// Deprecated, use [`Self::stream()`] instead.
-            #[deprecated = "use `.stream()` instead"]
-            pub fn build(self) -> impl Stream<Item = $item_type> {
-                self.stream()
-            }
-
             #[doc = concat!("Returns the next [`", stringify!($item_type), "`] which passes the filters.")]
             #[doc = concat!("You can also call `.await` on the [`", stringify!($collector_type), "`] directly.")]
             pub async fn next(self) -> Option<$item_type> {
@@ -194,9 +185,4 @@ make_specific_collector!(
     author_id: UserId => message.author.id == *author_id,
     channel_id: ChannelId => message.channel_id == *channel_id,
     guild_id: GuildId => message.guild_id.map_or(true, |g| g == *guild_id),
-);
-make_specific_collector!(
-    #[deprecated = "prefer the stand-alone collect() function to collect arbitrary events"]
-    EventCollector, Event,
-    event => event,
 );

--- a/src/framework/standard/structures/check.rs
+++ b/src/framework/standard/structures/check.rs
@@ -27,39 +27,31 @@ pub enum Reason {
 
 impl Error for Reason {}
 
-pub type CheckFunction = for<'fut> fn(
-    &'fut Context,
+pub type CheckFunction<D> = for<'fut> fn(
+    &'fut Context<D>,
     &'fut Message,
     &'fut mut Args,
-    &'fut CommandOptions,
+    &'fut CommandOptions<D>,
 ) -> BoxFuture<'fut, Result<(), Reason>>;
 
 /// A check can be part of a command or group and will be executed to determine whether a user is
 /// permitted to use related item.
 ///
 /// Additionally, a check may hold additional settings.
-pub struct Check {
+#[derive(derivative::Derivative)]
+#[derivative(Debug(bound = ""), PartialEq(bound = ""))]
+pub struct Check<D: Send + Sync + 'static> {
     /// Name listed in help-system.
     pub name: &'static str,
     /// Function that will be executed.
-    pub function: CheckFunction,
+    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    pub function: CheckFunction<D>,
     /// Whether a check should be evaluated in the help-system. `false` will ignore check and won't
     /// fail execution.
     pub check_in_help: bool,
     /// Whether a check shall be listed in the help-system. `false` won't affect whether the check
     /// will be evaluated help, solely [`Self::check_in_help`] sets this.
     pub display_in_help: bool,
-}
-
-impl fmt::Debug for Check {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Check")
-            .field("name", &self.name)
-            .field("function", &"<fn>")
-            .field("check_in_help", &self.check_in_help)
-            .field("display_in_help", &self.display_in_help)
-            .finish()
-    }
 }
 
 impl fmt::Display for Reason {
@@ -75,11 +67,5 @@ impl fmt::Display for Reason {
                 write!(f, "UserAndLog {{user: {user}, log: {log}}}")
             },
         }
-    }
-}
-
-impl PartialEq for Check {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
     }
 }

--- a/src/gateway/bridge/shard_messenger.rs
+++ b/src/gateway/bridge/shard_messenger.rs
@@ -32,7 +32,7 @@ impl ShardMessenger {
     /// [`Client`]: crate::Client
     #[inline]
     #[must_use]
-    pub fn new(shard: &ShardRunner) -> Self {
+    pub fn new<D: Send + Sync + 'static>(shard: &ShardRunner<D>) -> Self {
         Self {
             tx: shard.runner_tx(),
             #[cfg(feature = "collector")]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -6,6 +6,7 @@ use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use arrayvec::ArrayVec;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::{HeaderMap as Headers, HeaderValue};
 #[cfg(feature = "utils")]
@@ -235,7 +236,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -268,7 +269,7 @@ impl Http {
                 role_id,
                 user_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -298,7 +299,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: Some(vec![("delete_message_days", delete_message_days.to_string())]),
+            params: [("delete_message_days", delete_message_days.to_string())].into(),
         })
         .await
     }
@@ -319,7 +320,7 @@ impl Http {
             route: Route::ChannelTyping {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -348,7 +349,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -365,7 +366,7 @@ impl Http {
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
             route: Route::StageInstances,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -389,7 +390,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -411,7 +412,7 @@ impl Http {
             route: Route::ChannelThreads {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -433,7 +434,7 @@ impl Http {
             route: Route::ChannelForumPosts {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -459,7 +460,7 @@ impl Http {
             route: Route::GuildEmojis {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -482,7 +483,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: None,
+            params: [].into(),
         };
 
         if files.is_empty() {
@@ -517,7 +518,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -535,7 +536,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -555,7 +556,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -600,7 +601,7 @@ impl Http {
             headers: None,
             method: LightMethod::Post,
             route: Route::Guilds,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -626,7 +627,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -655,7 +656,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -682,7 +683,7 @@ impl Http {
                 interaction_id,
                 token: interaction_token,
             },
-            params: None,
+            params: [].into(),
         };
 
         if files.is_empty() {
@@ -724,7 +725,7 @@ impl Http {
             route: Route::ChannelInvites {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -748,7 +749,7 @@ impl Http {
                 channel_id,
                 target_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -763,7 +764,7 @@ impl Http {
             headers: None,
             method: LightMethod::Post,
             route: Route::UserMeDmChannels,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -785,7 +786,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -806,7 +807,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -839,7 +840,7 @@ impl Http {
             route: Route::GuildScheduledEvents {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -868,7 +869,7 @@ impl Http {
             route: Route::GuildStickers {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -915,7 +916,7 @@ impl Http {
             route: Route::ChannelWebhooks {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -934,7 +935,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -953,7 +954,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -976,7 +977,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -997,7 +998,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1013,7 +1014,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1028,7 +1029,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1049,7 +1050,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1070,7 +1071,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1089,7 +1090,7 @@ impl Http {
             route: Route::Invite {
                 code,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1110,7 +1111,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1130,7 +1131,7 @@ impl Http {
             route: Route::ChannelMessagesBulkDelete {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1167,7 +1168,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1189,7 +1190,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1208,7 +1209,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1229,7 +1230,7 @@ impl Http {
                 channel_id,
                 target_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1253,7 +1254,7 @@ impl Http {
                 user_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1275,7 +1276,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1296,7 +1297,7 @@ impl Http {
                 guild_id,
                 role_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1321,7 +1322,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1344,7 +1345,7 @@ impl Http {
                 guild_id,
                 sticker_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1381,7 +1382,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1422,7 +1423,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1444,7 +1445,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1464,7 +1465,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1490,7 +1491,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1517,7 +1518,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         };
 
         if new_attachments.is_empty() {
@@ -1553,7 +1554,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1579,7 +1580,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1601,7 +1602,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1629,7 +1630,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1657,7 +1658,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1678,7 +1679,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1705,7 +1706,7 @@ impl Http {
             route: Route::GuildMfa {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
         .map(|mfa: GuildMfaLevel| mfa.level)
@@ -1728,7 +1729,7 @@ impl Http {
             route: Route::GuildWidget {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1750,7 +1751,7 @@ impl Http {
             route: Route::GuildWelcomeScreen {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1775,7 +1776,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -1805,7 +1806,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         };
 
         if new_attachments.is_empty() {
@@ -1838,7 +1839,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1860,7 +1861,7 @@ impl Http {
             route: Route::GuildMemberMe {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1885,7 +1886,7 @@ impl Http {
             route: Route::GuildMemberMe {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1907,7 +1908,7 @@ impl Http {
             route: Route::ChannelFollowNews {
                 channel_id: news_channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1926,7 +1927,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -1951,7 +1952,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: None,
+            params: [].into(),
         };
 
         if new_attachments.is_empty() {
@@ -1977,7 +1978,7 @@ impl Http {
             headers: None,
             method: LightMethod::Patch,
             route: Route::UserMe,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2000,7 +2001,7 @@ impl Http {
                     guild_id,
                     role_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -2034,7 +2035,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -2071,7 +2072,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2098,7 +2099,7 @@ impl Http {
                     guild_id,
                     sticker_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -2124,7 +2125,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2174,7 +2175,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2225,7 +2226,7 @@ impl Http {
             route: Route::GuildVoiceStateMe {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2276,7 +2277,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2324,7 +2325,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2388,7 +2389,9 @@ impl Http {
         files: Vec<CreateAttachment>,
         map: &impl serde::Serialize,
     ) -> Result<Option<Message>> {
-        let mut params = vec![("wait", wait.to_string())];
+        let mut params = ArrayVec::<_, 2>::new();
+
+        params.push(("wait", wait.to_string()));
         if let Some(thread_id) = thread_id {
             params.push(("thread_id", thread_id.to_string()));
         }
@@ -2402,7 +2405,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: Some(params),
+            params,
         };
 
         if files.is_empty() {
@@ -2432,6 +2435,11 @@ impl Http {
         token: &str,
         message_id: MessageId,
     ) -> Result<Message> {
+        let mut params = ArrayVec::<_, 1>::new();
+        if let Some(thread_id) = thread_id {
+            params.push(("thread_id", thread_id.to_string()));
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2442,7 +2450,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params: thread_id.map(|thread_id| vec![("thread_id", thread_id.to_string())]),
+            params,
         })
         .await
     }
@@ -2457,6 +2465,11 @@ impl Http {
         map: &impl serde::Serialize,
         new_attachments: Vec<CreateAttachment>,
     ) -> Result<Message> {
+        let mut params = ArrayVec::<_, 1>::new();
+        if let Some(thread_id) = thread_id {
+            params.push(("thread_id", thread_id.to_string()));
+        }
+
         let mut request = Request {
             body: None,
             multipart: None,
@@ -2467,7 +2480,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params: thread_id.map(|thread_id| vec![("thread_id", thread_id.to_string())]),
+            params,
         };
 
         if new_attachments.is_empty() {
@@ -2491,6 +2504,11 @@ impl Http {
         token: &str,
         message_id: MessageId,
     ) -> Result<()> {
+        let mut params = ArrayVec::<_, 1>::new();
+        if let Some(thread_id) = thread_id {
+            params.push(("thread_id", thread_id.to_string()));
+        }
+
         self.wind(204, Request {
             body: None,
             multipart: None,
@@ -2501,7 +2519,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params: thread_id.map(|thread_id| vec![("thread_id", thread_id.to_string())]),
+            params,
         })
         .await
     }
@@ -2523,7 +2541,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusMaintenancesActive,
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -2546,7 +2564,7 @@ impl Http {
         target: Option<UserPagination>,
         limit: Option<u8>,
     ) -> Result<Vec<Ban>> {
-        let mut params = vec![];
+        let mut params = ArrayVec::<_, 2>::new();
 
         if let Some(limit) = limit {
             params.push(("limit", limit.to_string()));
@@ -2567,7 +2585,7 @@ impl Http {
             route: Route::GuildBans {
                 guild_id,
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -2581,7 +2599,7 @@ impl Http {
         before: Option<AuditLogEntryId>,
         limit: Option<u8>,
     ) -> Result<AuditLogs> {
-        let mut params = vec![];
+        let mut params = ArrayVec::<_, 4>::new();
         if let Some(action_type) = action_type {
             params.push(("action_type", action_type.num().to_string()));
         }
@@ -2603,7 +2621,7 @@ impl Http {
             route: Route::GuildAuditLogs {
                 guild_id,
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -2620,7 +2638,7 @@ impl Http {
             route: Route::GuildAutomodRules {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2638,7 +2656,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2662,7 +2680,7 @@ impl Http {
             route: Route::GuildAutomodRules {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2688,7 +2706,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2711,7 +2729,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2724,7 +2742,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::GatewayBot,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2739,7 +2757,7 @@ impl Http {
             route: Route::ChannelInvites {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2757,7 +2775,7 @@ impl Http {
             route: Route::ChannelThreadMembers {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2772,7 +2790,7 @@ impl Http {
             route: Route::GuildThreadsActive {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2784,7 +2802,7 @@ impl Http {
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        let mut params = vec![];
+        let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
             params.push(("before", before.to_string()));
         }
@@ -2800,7 +2818,7 @@ impl Http {
             route: Route::ChannelArchivedPublicThreads {
                 channel_id,
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -2812,7 +2830,7 @@ impl Http {
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        let mut params = vec![];
+        let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
             params.push(("before", before.to_string()));
         }
@@ -2828,7 +2846,7 @@ impl Http {
             route: Route::ChannelArchivedPrivateThreads {
                 channel_id,
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -2840,7 +2858,7 @@ impl Http {
         before: Option<u64>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        let mut params = vec![];
+        let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
             params.push(("before", before.to_string()));
         }
@@ -2856,7 +2874,7 @@ impl Http {
             route: Route::ChannelJoinedPrivateThreads {
                 channel_id,
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -2871,7 +2889,7 @@ impl Http {
             route: Route::ChannelThreadMemberMe {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2886,7 +2904,7 @@ impl Http {
             route: Route::ChannelThreadMemberMe {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2906,7 +2924,7 @@ impl Http {
                 channel_id,
                 user_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2926,7 +2944,7 @@ impl Http {
                 channel_id,
                 user_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2960,7 +2978,7 @@ impl Http {
             route: Route::ChannelWebhooks {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2975,7 +2993,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -2990,7 +3008,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3005,7 +3023,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3020,7 +3038,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::Oauth2ApplicationCurrent,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3033,7 +3051,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMe,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3048,7 +3066,7 @@ impl Http {
             route: Route::GuildEmojis {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3064,7 +3082,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3077,7 +3095,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::Gateway,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3092,7 +3110,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3107,7 +3125,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: Some(vec![("with_localizations", true.to_string())]),
+            params: [("with_localizations", String::from("true"))].into(),
         })
         .await
     }
@@ -3123,7 +3141,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3138,7 +3156,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3153,7 +3171,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: Some(vec![("with_counts", true.to_string())]),
+            params: [("with_counts", String::from("true"))].into(),
         })
         .await
     }
@@ -3169,7 +3187,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3189,7 +3207,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: Some(vec![("with_localizations", true.to_string())]),
+            params: [("with_localizations", String::from("true"))].into(),
         })
         .await
     }
@@ -3210,7 +3228,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3229,7 +3247,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3250,7 +3268,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3267,7 +3285,7 @@ impl Http {
             route: Route::GuildWidget {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3282,7 +3300,7 @@ impl Http {
             route: Route::GuildPreview {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3297,7 +3315,7 @@ impl Http {
             route: Route::GuildWelcomeScreen {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3312,7 +3330,7 @@ impl Http {
             route: Route::GuildIntegrations {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3327,7 +3345,7 @@ impl Http {
             route: Route::GuildInvites {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3339,7 +3357,7 @@ impl Http {
             code: String,
         }
 
-        self.fire::<GuildVanityUrl>(Request {
+        self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -3347,10 +3365,10 @@ impl Http {
             route: Route::GuildVanityUrl {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
-        .map(|x| x.code)
+        .map(|x: GuildVanityUrl| x.code)
     }
 
     /// Gets the members of a guild. Optionally pass a `limit` and the Id of the user to offset the
@@ -3367,8 +3385,8 @@ impl Http {
             }
         }
 
-        let mut params =
-            vec![("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string())];
+        let mut params = ArrayVec::<_, 2>::new();
+        params.push(("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string()));
         if let Some(after) = after {
             params.push(("after", after.to_string()));
         }
@@ -3382,7 +3400,7 @@ impl Http {
                 route: Route::GuildMembers {
                     guild_id,
                 },
-                params: Some(params),
+                params,
             })
             .await?;
 
@@ -3407,7 +3425,7 @@ impl Http {
             route: Route::GuildPrune {
                 guild_id,
             },
-            params: Some(vec![("days", days.to_string())]),
+            params: [("days", days.to_string())].into(),
         })
         .await
     }
@@ -3423,7 +3441,7 @@ impl Http {
             route: Route::GuildRegions {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3439,7 +3457,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -3474,7 +3492,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: Some(vec![("with_user_count", with_user_count.to_string())]),
+            params: [("with_user_count", with_user_count.to_string())].into(),
         })
         .await
     }
@@ -3497,7 +3515,7 @@ impl Http {
             route: Route::GuildScheduledEvents {
                 guild_id,
             },
-            params: Some(vec![("with_user_count", with_user_count.to_string())]),
+            params: [("with_user_count", with_user_count.to_string())].into(),
         })
         .await
     }
@@ -3526,7 +3544,7 @@ impl Http {
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        let mut params = vec![];
+        let mut params = ArrayVec::<_, 3>::new();
         if let Some(limit) = limit {
             params.push(("limit", limit.to_string()));
         }
@@ -3549,7 +3567,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -3565,7 +3583,7 @@ impl Http {
                 route: Route::GuildStickers {
                     guild_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -3596,7 +3614,7 @@ impl Http {
                     guild_id,
                     sticker_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -3636,7 +3654,7 @@ impl Http {
             route: Route::GuildWebhooks {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3672,7 +3690,7 @@ impl Http {
         target: Option<GuildPagination>,
         limit: Option<u64>,
     ) -> Result<Vec<GuildInfo>> {
-        let mut params = vec![];
+        let mut params = ArrayVec::<_, 2>::new();
         if let Some(limit) = limit {
             params.push(("limit", limit.to_string()));
         }
@@ -3689,7 +3707,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeGuilds,
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -3733,7 +3751,7 @@ impl Http {
                 route: Route::UserMeGuildMember {
                     guild_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -3765,10 +3783,9 @@ impl Http {
         #[cfg(feature = "utils")]
         let code = crate::utils::parse_invite(code);
 
-        let mut params = vec![
-            ("member_counts", member_counts.to_string()),
-            ("expiration", expiration.to_string()),
-        ];
+        let mut params = ArrayVec::<_, 3>::new();
+        params.push(("member_counts", member_counts.to_string()));
+        params.push(("expiration", expiration.to_string()));
         if let Some(event_id) = event_id {
             params.push(("event_id", event_id.to_string()));
         }
@@ -3781,7 +3798,7 @@ impl Http {
             route: Route::Invite {
                 code,
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -3798,7 +3815,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -3824,7 +3841,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3836,7 +3853,7 @@ impl Http {
         target: Option<MessagePagination>,
         limit: Option<u8>,
     ) -> Result<Vec<Message>> {
-        let mut params = vec![];
+        let mut params = ArrayVec::<_, 2>::new();
         if let Some(limit) = limit {
             params.push(("limit", limit.to_string()));
         }
@@ -3856,7 +3873,7 @@ impl Http {
             route: Route::ChannelMessages {
                 channel_id,
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -3868,16 +3885,16 @@ impl Http {
             sticker_packs: Vec<StickerPack>,
         }
 
-        self.fire::<StickerPacks>(Request {
+        self.fire(Request {
             body: None,
             multipart: None,
             headers: None,
             method: LightMethod::Get,
             route: Route::StickerPacks,
-            params: None,
+            params: [].into(),
         })
         .await
-        .map(|s| s.sticker_packs)
+        .map(|s: StickerPacks| s.sticker_packs)
     }
 
     /// Gets all pins of a channel.
@@ -3890,7 +3907,7 @@ impl Http {
             route: Route::ChannelPins {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3904,7 +3921,8 @@ impl Http {
         limit: u8,
         after: Option<u64>,
     ) -> Result<Vec<User>> {
-        let mut params = vec![("limit", limit.to_string())];
+        let mut params = ArrayVec::<_, 2>::new();
+        params.push(("limit", limit.to_string()));
         if let Some(after) = after {
             params.push(("after", after.to_string()));
         }
@@ -3918,7 +3936,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: Some(params),
+            params,
         })
         .await
     }
@@ -3933,7 +3951,7 @@ impl Http {
             route: Route::Sticker {
                 sticker_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -3955,7 +3973,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusIncidentsUnresolved,
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -3979,7 +3997,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusMaintenancesUpcoming,
-                params: None,
+                params: [].into(),
             })
             .await?;
 
@@ -3996,7 +4014,7 @@ impl Http {
             route: Route::User {
                 user_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4013,7 +4031,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeConnections,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4026,7 +4044,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeDmChannels,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4039,7 +4057,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::VoiceRegions,
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4073,7 +4091,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4113,7 +4131,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4150,7 +4168,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4171,7 +4189,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4186,7 +4204,7 @@ impl Http {
             route: Route::UserMeGuild {
                 guild_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4210,7 +4228,7 @@ impl Http {
             route: Route::ChannelMessages {
                 channel_id,
             },
-            params: None,
+            params: [].into(),
         };
 
         if files.is_empty() {
@@ -4242,7 +4260,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4263,7 +4281,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4290,7 +4308,7 @@ impl Http {
                 user_id,
                 role_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4312,10 +4330,11 @@ impl Http {
                 route: Route::GuildMembersSearch {
                     guild_id,
                 },
-                params: Some(vec![
+                params: [
                     ("query", query.to_string()),
                     ("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string()),
-                ]),
+                ]
+                .into(),
             })
             .await?;
 
@@ -4345,7 +4364,7 @@ impl Http {
             route: Route::GuildPrune {
                 guild_id,
             },
-            params: Some(vec![("days", days.to_string())]),
+            params: [("days", days.to_string())].into(),
         })
         .await
     }
@@ -4365,7 +4384,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4426,7 +4445,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: None,
+            params: [].into(),
         })
         .await
     }
@@ -4456,9 +4475,9 @@ impl Http {
     /// let channel_id = ChannelId::new(381880193700069377);
     /// let route = Route::ChannelMessages { channel_id };
     ///
-    /// let mut request = Request::new(route, LightMethod::Post).body(Some(bytes));
+    /// let mut request = Request::new(route, LightMethod::Post, []).body(Some(bytes));
     ///
-    /// let message = http.fire::<Message>(request).await?;
+    /// let message: Message = http.fire(request).await?;
     ///
     /// println!("Message content: {}", message.content);
     /// # Ok(())
@@ -4468,7 +4487,10 @@ impl Http {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn fire<T: DeserializeOwned>(&self, req: Request<'_>) -> Result<T> {
+    pub async fn fire<T: DeserializeOwned, const MAX_PARAMS: usize>(
+        &self,
+        req: Request<'_, MAX_PARAMS>,
+    ) -> Result<T> {
         let response = self.request(req).await?;
         decode_resp(response).await
     }
@@ -4496,7 +4518,7 @@ impl Http {
     /// let channel_id = ChannelId::new(381880193700069377);
     /// let route = Route::ChannelMessages { channel_id };
     ///
-    /// let mut request = Request::new(route, LightMethod::Post).body(Some(bytes));
+    /// let mut request = Request::new(route, LightMethod::Post, []).body(Some(bytes));
     ///
     /// let response = http.request(request).await?;
     ///
@@ -4505,7 +4527,10 @@ impl Http {
     /// # }
     /// ```
     #[instrument]
-    pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
+    pub async fn request<const MAX_PARAMS: usize>(
+        &self,
+        req: Request<'_, MAX_PARAMS>,
+    ) -> Result<ReqwestResponse> {
         let method = req.method.reqwest_method();
         let response = if let Some(ratelimiter) = &self.ratelimiter {
             ratelimiter.perform(req).await?
@@ -4528,7 +4553,11 @@ impl Http {
     ///
     /// This is a function that performs a light amount of work and returns an empty tuple, so it's
     /// called "self.wind" to denote that it's lightweight.
-    pub(super) async fn wind(&self, expected: u16, req: Request<'_>) -> Result<()> {
+    pub(super) async fn wind<const MAX_PARAMS: usize>(
+        &self,
+        expected: u16,
+        req: Request<'_, MAX_PARAMS>,
+    ) -> Result<()> {
         let method = req.method.reqwest_method();
         let response = self.request(req).await?;
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -95,7 +95,7 @@ where
 }
 
 #[cfg(feature = "client")]
-impl CacheHttp for Context {
+impl<D: Send + Sync + 'static> CacheHttp for Context<D> {
     fn http(&self) -> &Http {
         &self.http
     }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -18,9 +18,6 @@ use super::{HttpError, LightMethod};
 use crate::constants;
 use crate::internal::prelude::*;
 
-#[deprecated = "use Request directly now"]
-pub type RequestBuilder<'a, const MAX_PARAMS: usize> = Request<'a, MAX_PARAMS>;
-
 #[derive(Clone, Debug)]
 #[must_use]
 pub struct Request<'a, const MAX_PARAMS: usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@
     clippy::clone_on_ref_ptr,
     clippy::non_ascii_literal,
     clippy::fallible_impl_from,
-    clippy::let_underscore_must_use,
     clippy::format_collect,
     clippy::format_push_string,
     clippy::pedantic

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -230,9 +230,9 @@ impl CommandInteraction {
     ///
     /// See [`CreateQuickModal::execute()`].
     #[cfg(all(feature = "collector", feature = "utils"))]
-    pub async fn quick_modal(
+    pub async fn quick_modal<D: Send + Sync + 'static>(
         &self,
-        ctx: &Context,
+        ctx: &Context<D>,
         builder: CreateQuickModal,
     ) -> Result<Option<QuickModalResponse>> {
         builder.execute(ctx, self.id, &self.token).await

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -211,9 +211,9 @@ impl ComponentInteraction {
     ///
     /// See [`CreateQuickModal::execute()`].
     #[cfg(all(feature = "collector", feature = "utils"))]
-    pub async fn quick_modal(
+    pub async fn quick_modal<D: Send + Sync + 'static>(
         &self,
-        ctx: &Context,
+        ctx: &Context<D>,
         builder: CreateQuickModal,
     ) -> Result<Option<QuickModalResponse>> {
         builder.execute(ctx, self.id, &self.token).await

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -98,12 +98,14 @@ impl Attachment {
     /// use serenity::prelude::*;
     /// use tokio::fs::File;
     /// use tokio::io::AsyncWriteExt;
-    ///
+    /// # type Data = ();
+    /// # #[cfg(feature = "client")]
+    /// # type Context = serenity::client::Context<Data>;
     /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// # #[cfg(feature = "client")]
-    /// impl EventHandler for Handler {
+    /// impl EventHandler<Data> for Handler {
     ///     async fn message(&self, context: Context, mut message: Message) {
     ///         for attachment in message.attachments {
     ///             let content = match attachment.download().await {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -729,10 +729,12 @@ impl GuildChannel {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::prelude::*;
+    /// # type Data = ();
+    /// # type Context = serenity::client::Context<Data>;
     /// # struct Handler;
     ///
     /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
+    /// impl EventHandler<Data> for Handler {
     ///     async fn message(&self, context: Context, msg: Message) {
     ///         let channel = match context.cache.channel(msg.channel_id) {
     ///             Some(channel) => channel,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -766,32 +766,6 @@ impl GuildChannel {
         Ok(guild.user_permissions_in(self, member))
     }
 
-    /// Calculates the permissions of a role.
-    ///
-    /// The Id of the argument must be a [`Role`] of the [`Guild`] that the channel is in.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ModelError::GuildNotFound`] if the channel's guild could not be found in the
-    /// [`Cache`].
-    ///
-    /// Returns a [`ModelError::RoleNotFound`] if the given role could not be found in the
-    /// [`Cache`].
-    #[cfg(feature = "cache")]
-    #[inline]
-    #[deprecated = "this function ignores other roles the user may have as well as user-specific permissions; use Guild::user_permissions_in instead"]
-    #[allow(deprecated)]
-    pub fn permissions_for_role(
-        &self,
-        cache: impl AsRef<Cache>,
-        role_id: impl Into<RoleId>,
-    ) -> Result<Permissions> {
-        let guild = self.guild(&cache).ok_or(Error::Model(ModelError::GuildNotFound))?;
-        let role =
-            guild.roles.get(&role_id.into()).ok_or(Error::Model(ModelError::RoleNotFound))?;
-        guild.role_permissions_in(self, role)
-    }
-
     /// Pins a [`Message`] to the channel.
     ///
     /// **Note**: Requires the [Manage Messages] permission.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -28,10 +28,6 @@ use crate::model::prelude::*;
 use crate::model::utils::is_false;
 use crate::model::Timestamp;
 
-#[deprecated = "use CreateAttachment instead"]
-#[cfg(feature = "model")]
-pub type AttachmentType<'a> = crate::builder::CreateAttachment;
-
 /// A container for any channel.
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -19,12 +19,14 @@ use super::Permissions;
 /// use serenity::model::ModelError;
 /// use serenity::prelude::*;
 /// use serenity::Error;
-///
+/// # type Data = ();
+/// # #[cfg(feature = "client")]
+/// # type Context = serenity::client::Context<Data>;
 /// # struct Handler;
 ///
 /// #[serenity::async_trait]
 /// #[cfg(feature = "client")]
-/// impl EventHandler for Handler {
+/// impl EventHandler<Data> for Handler {
 ///     async fn guild_ban_removal(&self, context: Context, guild_id: GuildId, user: User) {
 ///         match guild_id.ban(&context, user, 8).await {
 ///             Ok(()) => {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -541,7 +541,6 @@ impl MessageUpdateEvent {
     pub fn apply_to_message(&self, message: &mut Message) {
         // Destructure, so we get an `unused` warning when we forget to process one of the fields
         // in this method
-        #[allow(deprecated)] // yes rust, exhaustive means exhaustive, even the deprecated ones
         let Self {
             id,
             channel_id,

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -485,9 +485,6 @@ bitflags! {
         /// - GUILD_BAN_ADD
         /// - GUILD_BAN_REMOVE
         const GUILD_MODERATION = 1 << 2;
-        /// Backwards compatibility with old gateway event name. Same as GUILD_MODERATION
-        #[deprecated = "Use [`Self::GUILD_MODERATION`] instead"]
-        const GUILD_BANS = 1 << 2;
 
         /// Enables the following gateway events:
         /// - GUILD_EMOJIS_UPDATE
@@ -618,18 +615,6 @@ impl GatewayIntents {
     #[must_use]
     pub const fn guild_members(self) -> bool {
         self.contains(Self::GUILD_MEMBERS)
-    }
-
-    /// Shorthand for checking that the set of intents contains the [GUILD_BANS] intent.
-    ///
-    /// [GUILD_BANS]: Self::GUILD_BANS
-    ///
-    /// This is the same as calling guild_moderation since Discord changed the name
-    #[must_use]
-    #[deprecated = "Use [`Self::guild_moderation`] instead"]
-    pub const fn guild_bans(self) -> bool {
-        #[allow(deprecated)] // this is a deprecated method itself
-        self.contains(Self::GUILD_BANS)
     }
 
     /// Shorthand for checking that the set of intents contains the [GUILD_MODERATION] intent.

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -68,7 +68,7 @@ impl Emoji {
     /// # use serenity::client::Context;
     /// # use serenity::model::prelude::Emoji;
     /// #
-    /// # async fn example(ctx: &Context, emoji: Emoji) -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn example(ctx: &Context<()>, emoji: Emoji) -> Result<(), Box<dyn std::error::Error>> {
     /// // assuming emoji has been set already
     /// match emoji.delete(&ctx).await {
     ///     Ok(()) => println!("Emoji deleted."),

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2304,11 +2304,13 @@ impl Guild {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::prelude::*;
+    /// # type Data = ();
+    /// #[cfg(all(feature = "cache", feature = "client"))]
+    /// # type Context = serenity::client::Context<Data>;
     /// # struct Handler;
-    ///
     /// #[serenity::async_trait]
     /// #[cfg(all(feature = "cache", feature = "client"))]
-    /// impl EventHandler for Handler {
+    /// impl EventHandler<Data> for Handler {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if let Some(guild_id) = msg.guild_id {
     ///             if let Some(guild) = guild_id.to_guild_cached(&ctx) {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1500,11 +1500,14 @@ impl PartialGuild {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::prelude::*;
+    /// # type Data = ();
+    /// # #[cfg(all(feature = "cache", feature = "client"))]
+    /// # type Context = serenity::client::Context<Data>;
     /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// #[cfg(all(feature = "cache", feature = "client"))]
-    /// impl EventHandler for Handler {
+    /// impl EventHandler<Data> for Handler {
     ///     async fn message(&self, context: Context, msg: Message) {
     ///         if let Some(guild_id) = msg.guild_id {
     ///             if let Some(guild) = guild_id.to_guild_cached(&context) {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1361,17 +1361,6 @@ impl PartialGuild {
         Guild::_user_permissions_in(Some(channel), member, &self.roles, self.owner_id, self.id)
     }
 
-    /// Calculate a [`Role`]'s permissions in a given channel in the guild.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Model`] if the [`Role`] or [`Channel`] is not from this [`Guild`].
-    #[inline]
-    #[deprecated = "this function ignores other roles the user may have as well as user-specific permissions; use user_permissions_in instead"]
-    pub fn role_permissions_in(&self, channel: &GuildChannel, role: &Role) -> Result<Permissions> {
-        Guild::_role_permissions_in(channel, role, self.id)
-    }
-
     /// Gets the number of [`Member`]s that would be pruned with the given number of days.
     ///
     /// Requires the [Kick Members] permission.

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -25,8 +25,8 @@ pub trait Mentionable {
     /// # use serenity::model::guild::Member;
     /// # use serenity::model::channel::GuildChannel;
     /// # use serenity::model::id::ChannelId;
-    /// # use serenity::prelude::Context;
     /// # use serenity::Error;
+    /// # type Context = serenity::client::Context<()>;
     /// use serenity::model::mention::Mentionable;
     /// async fn greet(
     ///     ctx: Context,

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -319,8 +319,6 @@ bitflags::bitflags! {
         /// Allows for editing and deleting emojis, stickers, and soundboard sounds created by all
         /// users.
         const MANAGE_GUILD_EXPRESSIONS = 1 << 30;
-        #[deprecated = "use `Permissions::MANAGE_GUILD_EXPRESSIONS` instead"]
-        const MANAGE_EMOJIS_AND_STICKERS = 1 << 30;
         /// Allows members to use application commands, including slash commands and context menu
         /// commands.
         const USE_APPLICATION_COMMANDS = 1 << 31;
@@ -591,13 +589,6 @@ impl Permissions {
     #[must_use]
     pub const fn manage_channels(self) -> bool {
         self.contains(Self::MANAGE_CHANNELS)
-    }
-
-    #[deprecated = "use `manage_guild_expressions` instead"]
-    #[must_use]
-    pub const fn manage_emojis_and_stickers(self) -> bool {
-        #[allow(deprecated)]
-        self.contains(Self::MANAGE_EMOJIS_AND_STICKERS)
     }
 
     /// Shorthand for checking that the set of permissions contains the [Manage Events] permission.

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -9,23 +9,6 @@ use crate::model::utils::comma_separated_string;
 
 #[cfg(feature = "model")]
 impl StickerId {
-    /// Delete a guild sticker.
-    ///
-    /// **Note**: If the sticker was created by the current user, requires either the [Create Guild
-    /// Expressions] or the [Manage Guild Expressions] permission. Otherwise, the [Manage Guild
-    /// Expressions] permission is required.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission.
-    ///
-    /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
-    /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    #[deprecated = "use `GuildId::delete_sticker` instead"]
-    pub async fn delete(self, http: impl AsRef<Http>, guild_id: impl Into<GuildId>) -> Result<()> {
-        guild_id.into().delete_sticker(http, self).await
-    }
-
     /// Requests the sticker via the REST API to get a [`Sticker`] with all details.
     ///
     /// # Errors
@@ -34,28 +17,6 @@ impl StickerId {
     /// otherwise unavailable.
     pub async fn to_sticker(self, http: impl AsRef<Http>) -> Result<Sticker> {
         http.as_ref().get_sticker(self).await
-    }
-
-    /// Edits the sticker.
-    ///
-    /// **Note**: If the sticker was created by the current user, requires either the [Create Guild
-    /// Expressions] or the [Manage Guild Expressions] permission. Otherwise, the [Manage Guild
-    /// Expressions] permission is required.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    ///
-    /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
-    /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    #[deprecated = "use `GuildId::edit_sticker` instead"]
-    pub async fn edit(
-        self,
-        cache_http: impl CacheHttp,
-        guild_id: impl Into<GuildId>,
-        builder: EditSticker<'_>,
-    ) -> Result<Sticker> {
-        guild_id.into().edit_sticker(cache_http, self, builder).await
     }
 }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -436,12 +436,15 @@ impl User {
     /// ```rust,no_run
     /// # use serenity::prelude::*;
     /// # use serenity::model::prelude::*;
+    /// # type Data = ();
+    /// # #[cfg(feature = "client")]
+    /// # type Context = serenity::client::Context<Data>;
     /// # struct Handler;
     /// use serenity::builder::CreateMessage;
     ///
     /// #[serenity::async_trait]
     /// # #[cfg(feature = "client")]
-    /// impl EventHandler for Handler {
+    /// impl EventHandler<Data> for Handler {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "~help" {
     ///             let builder = CreateMessage::new().content("Helpful info here.");
@@ -560,11 +563,14 @@ impl User {
     /// ```rust,no_run
     /// # use serenity::prelude::*;
     /// # use serenity::model::prelude::*;
+    /// # type Data = ();
+    /// # #[cfg(feature = "client")]
+    /// # type Context = serenity::client::Context<Data>;
     /// # struct Handler;
     ///
     /// #[serenity::async_trait]
     /// # #[cfg(feature = "client")]
-    /// impl EventHandler for Handler {
+    /// impl EventHandler<Data> for Handler {
     ///     async fn message(&self, context: Context, msg: Message) {
     ///         if msg.content == "!mytag" {
     ///             let content = format!("Your tag is: {}", msg.author.tag());

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,8 +14,6 @@
 //! [`serenity::Error`]: crate::Error
 
 pub use tokio::sync::{Mutex, RwLock};
-#[cfg(feature = "client")]
-pub use typemap_rev::{TypeMap, TypeMapKey};
 
 #[cfg(feature = "client")]
 pub use crate::client::Context;

--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -79,7 +79,7 @@ async fn lookup_channel_global(
 ///
 /// The lookup strategy is as follows (in order):
 /// 1. Lookup by ID.
-/// 2. [Lookup by mention](`crate::utils::parse_channel`).
+/// 2. [Lookup by mention](`crate::utils::parse_channel_mention`).
 /// 3. Lookup by name.
 #[async_trait::async_trait]
 impl ArgumentConvert for Channel {

--- a/src/utils/argument_convert/member.rs
+++ b/src/utils/argument_convert/member.rs
@@ -35,7 +35,7 @@ impl fmt::Display for MemberParseError {
 ///
 /// The lookup strategy is as follows (in order):
 /// 1. Lookup by ID.
-/// 2. [Lookup by mention](`crate::utils::parse_username`).
+/// 2. [Lookup by mention](`crate::utils::parse_user_mention`).
 /// 3. [Lookup by name#discrim](`crate::utils::parse_user_tag`).
 /// 4. Lookup by name
 /// 5. Lookup by nickname

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -45,7 +45,7 @@ impl fmt::Display for RoleParseError {
 ///
 /// The lookup strategy is as follows (in order):
 /// 1. Lookup by ID
-/// 2. [Lookup by mention](`crate::utils::parse_role`).
+/// 2. [Lookup by mention](`crate::utils::parse_role_mention`).
 /// 3. Lookup by name (case-insensitive)
 #[async_trait::async_trait]
 impl ArgumentConvert for Role {

--- a/src/utils/argument_convert/user.rs
+++ b/src/utils/argument_convert/user.rs
@@ -59,7 +59,7 @@ fn lookup_by_global_cache(ctx: impl CacheHttp, s: &str) -> Option<User> {
 ///
 /// The lookup strategy is as follows (in order):
 /// 1. Lookup by ID.
-/// 2. [Lookup by mention](`crate::utils::parse_username`).
+/// 2. [Lookup by mention](`crate::utils::parse_user_mention`).
 /// 3. [Lookup by name#discrim](`crate::utils::parse_user_tag`).
 /// 4. Lookup by name
 #[async_trait::async_trait]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -113,22 +113,22 @@ pub fn parse_user_tag(s: &str) -> Option<(&str, Option<NonZeroU16>)> {
 ///
 /// ```rust
 /// use serenity::model::id::UserId;
-/// use serenity::utils::parse_username;
+/// use serenity::utils::parse_user_mention;
 ///
 /// // regular username mention
-/// assert_eq!(parse_username("<@114941315417899012>"), Some(UserId::new(114941315417899012)));
+/// assert_eq!(parse_user_mention("<@114941315417899012>"), Some(UserId::new(114941315417899012)));
 ///
 /// // nickname mention
-/// assert_eq!(parse_username("<@!114941315417899012>"), Some(UserId::new(114941315417899012)));
+/// assert_eq!(parse_user_mention("<@!114941315417899012>"), Some(UserId::new(114941315417899012)));
 /// ```
 ///
 /// Asserting that an invalid username or nickname mention returns [`None`]:
 ///
 /// ```rust
-/// use serenity::utils::parse_username;
+/// use serenity::utils::parse_user_mention;
 ///
-/// assert!(parse_username("<@1149413154aa17899012").is_none());
-/// assert!(parse_username("<@!11494131541789a90b1c2").is_none());
+/// assert!(parse_user_mention("<@1149413154aa17899012").is_none());
+/// assert!(parse_user_mention("<@!11494131541789a90b1c2").is_none());
 /// ```
 ///
 /// [`User`]: crate::model::user::User
@@ -148,11 +148,6 @@ pub fn parse_user_mention(mention: &str) -> Option<UserId> {
     }
 }
 
-#[deprecated = "use `utils::parse_user_mention` instead"]
-pub fn parse_username(mention: impl AsRef<str>) -> Option<UserId> {
-    parse_user_mention(mention.as_ref())
-}
-
 /// Retrieves an Id from a role mention.
 ///
 /// If the mention is invalid, then [`None`] is returned.
@@ -163,17 +158,17 @@ pub fn parse_username(mention: impl AsRef<str>) -> Option<UserId> {
 ///
 /// ```rust
 /// use serenity::model::id::RoleId;
-/// use serenity::utils::parse_role;
+/// use serenity::utils::parse_role_mention;
 ///
-/// assert_eq!(parse_role("<@&136107769680887808>"), Some(RoleId::new(136107769680887808)));
+/// assert_eq!(parse_role_mention("<@&136107769680887808>"), Some(RoleId::new(136107769680887808)));
 /// ```
 ///
 /// Asserting that an invalid role mention returns [`None`]:
 ///
 /// ```rust
-/// use serenity::utils::parse_role;
+/// use serenity::utils::parse_role_mention;
 ///
-/// assert!(parse_role("<@&136107769680887808").is_none());
+/// assert!(parse_role_mention("<@&136107769680887808").is_none());
 /// ```
 ///
 /// [`Role`]: crate::model::guild::Role
@@ -191,11 +186,6 @@ pub fn parse_role_mention(mention: &str) -> Option<RoleId> {
     }
 }
 
-#[deprecated = "use `utils::parse_role_mention` instead"]
-pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
-    parse_role_mention(mention.as_ref())
-}
-
 /// Retrieves an Id from a channel mention.
 ///
 /// If the channel mention is invalid, then [`None`] is returned.
@@ -206,18 +196,21 @@ pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
 ///
 /// ```rust
 /// use serenity::model::id::ChannelId;
-/// use serenity::utils::parse_channel;
+/// use serenity::utils::parse_channel_mention;
 ///
-/// assert_eq!(parse_channel("<#81384788765712384>"), Some(ChannelId::new(81384788765712384)));
+/// assert_eq!(
+///     parse_channel_mention("<#81384788765712384>"),
+///     Some(ChannelId::new(81384788765712384))
+/// );
 /// ```
 ///
 /// Asserting that an invalid channel mention returns [`None`]:
 ///
 /// ```rust
-/// use serenity::utils::parse_channel;
+/// use serenity::utils::parse_channel_mention;
 ///
-/// assert!(parse_channel("<#!81384788765712384>").is_none());
-/// assert!(parse_channel("<#81384788765712384").is_none());
+/// assert!(parse_channel_mention("<#!81384788765712384>").is_none());
+/// assert!(parse_channel_mention("<#81384788765712384").is_none());
 /// ```
 ///
 /// [`Channel`]: crate::model::channel::Channel
@@ -233,11 +226,6 @@ pub fn parse_channel_mention(mention: &str) -> Option<ChannelId> {
     } else {
         None
     }
-}
-
-#[deprecated = "use `utils::parse_channel_mention` instead"]
-pub fn parse_channel(mention: impl AsRef<str>) -> Option<ChannelId> {
-    parse_channel_mention(mention.as_ref())
 }
 
 /// Retrieves the animated state, name and Id from an emoji mention, in the form of an

--- a/src/utils/quick_modal.rs
+++ b/src/utils/quick_modal.rs
@@ -19,7 +19,7 @@ pub struct QuickModalResponse {
 ///
 /// ```rust
 /// # use serenity::{builder::*, model::prelude::*, prelude::*, utils::CreateQuickModal, Result};
-/// # async fn _foo(ctx: &Context, interaction: &CommandInteraction) -> Result<()> {
+/// # async fn _foo(ctx: &Context<()>, interaction: &CommandInteraction) -> Result<()> {
 /// let modal = CreateQuickModal::new("About you")
 ///     .timeout(std::time::Duration::from_secs(600))
 ///     .short_field("First name")
@@ -84,9 +84,9 @@ impl CreateQuickModal {
     /// # Errors
     ///
     /// See [`CreateInteractionResponse::execute()`].
-    pub async fn execute(
+    pub async fn execute<D: Send + Sync + 'static>(
         self,
-        ctx: &Context,
+        ctx: &Context<D>,
         interaction_id: InteractionId,
         token: &str,
     ) -> Result<Option<QuickModalResponse>, crate::Error> {


### PR DESCRIPTION
This PR gets rid of the `Client::data` typemap entirely, swapping with a generic `Arc<D>` that the user can provide. This allows much more flexibility for users and much less overhead. It also gets rid of the somewhat weird concept of a typemap from the beginner's view. Using a generic data parameter has been praised in poise for a while, so it's time to bring this over.

On the user side, a couple of changes had to be made:
- Client::builder now takes a third argument for the data value
- A lot of the types are now generic over the data, which is the major downside of this approach
- The standard framework had to be somewhat modified, with each macro now using generic syntax to provide the Data type.

These changes can be seen in the changes to the examples, which look pretty good to me.