### PR TITLE
Remove wrong information in CreateButton constructor

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -55,8 +55,6 @@ impl CreateButton {
 
     /// Creates a normal button with the given custom ID. You must also set [`Self::label`] and/or
     /// [`Self::emoji`] after this.
-    ///
-    /// Clicking this button will not trigger an interaction event in your bot.
     pub fn new(custom_id: impl Into<String>) -> Self {
         Self(Button {
             kind: ComponentType::Button,


### PR DESCRIPTION
This seems to have been a copy-paste related issue from the new_link constructor, which confused me slightly when migrating my bot to 0.12