### PR TITLE
Add repr(packed) to all bitflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,20 @@ async-trait = "0.1.74"
 tracing = { version = "0.1.40", features = ["log"] }
 serde = { version = "1.0.192", features = ["derive"] }
 url = { version = "2.4.1", features = ["serde"] }
-tokio = { version = "1.34.0", features = ["fs", "macros", "rt", "sync", "time", "io-util"] }
+tokio = { version = "1.34.0", features = [
+    "fs",
+    "macros",
+    "rt",
+    "sync",
+    "time",
+    "io-util",
+] }
 futures = { version = "0.3.29", default-features = false, features = ["std"] }
-dep_time = { version = "0.3.30", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
+dep_time = { version = "0.3.30", package = "time", features = [
+    "formatting",
+    "parsing",
+    "serde-well-known",
+] }
 base64 = { version = "0.21.5" }
 secrecy = { version = "0.8.0", features = ["serde"] }
 arrayvec = { version = "0.7.4", features = ["serde"] }
@@ -35,9 +46,15 @@ fxhash = { version = "0.2.1", optional = true }
 simd-json = { version = "0.13.4", optional = true }
 uwl = { version = "0.6.0", optional = true }
 levenshtein = { version = "1.0.5", optional = true }
-chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"], optional = true }
+chrono = { version = "0.4.31", default-features = false, features = [
+    "clock",
+    "serde",
+], optional = true }
 flate2 = { version = "1.0.28", optional = true }
-reqwest = { version = "0.11.22", default-features = false, features = ["multipart", "stream"], optional = true }
+reqwest = { version = "0.11.22", default-features = false, features = [
+    "multipart",
+    "stream",
+], optional = true }
 static_assertions = { version = "1.1.0", optional = true }
 tokio-tungstenite = { version = "0.20.1", optional = true }
 typemap_rev = { version = "0.3.0", optional = true }
@@ -48,7 +65,15 @@ mime_guess = { version = "2.0.4", optional = true }
 dashmap = { version = "5.5.3", features = ["serde"], optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 ed25519-dalek = { version = "2.0.0", optional = true }
-typesize = { version = "0.1.2", optional = true, features = ["url", "time", "serde_json", "secrecy", "dashmap", "parking_lot", "details"] }
+typesize = { version = "0.1.3", optional = true, features = [
+    "url",
+    "time",
+    "serde_json",
+    "secrecy",
+    "dashmap",
+    "parking_lot",
+    "details",
+] }
 # serde feature only allows for serialisation,
 # Serenity workspace crates
 command_attr = { version = "0.5.1", path = "./command_attr", optional = true }
@@ -101,7 +126,14 @@ http = ["mime_guess", "percent-encoding"]
 # TODO: remove dependeny on utils feature
 model = ["builder", "http", "utils"]
 voice_model = ["serenity-voice-model"]
-standard_framework = ["framework", "uwl", "levenshtein", "command_attr", "static_assertions", "parking_lot"]
+standard_framework = [
+    "framework",
+    "uwl",
+    "levenshtein",
+    "command_attr",
+    "static_assertions",
+    "parking_lot",
+]
 # Enables support for Discord API functionality that's not stable yet, as well as serenity APIs that
 # are allowed to change even in semver non-breaking updates.
 unstable_discord_api = []
@@ -116,7 +148,14 @@ chrono = ["dep:chrono", "typesize?/chrono"]
 
 # This enables all parts of the serenity codebase
 # (Note: all feature-gated APIs to be documented should have their features listed here!)
-full = ["default", "collector", "unstable_discord_api", "voice", "voice_model", "interactions_endpoint"]
+full = [
+    "default",
+    "collector",
+    "unstable_discord_api",
+    "voice",
+    "voice_model",
+    "interactions_endpoint",
+]
 
 # Enables simd accelerated parsing.
 simd_json = ["simd-json", "typesize?/simd_json"]
@@ -146,3 +185,6 @@ native_tls_backend = [
 [package.metadata.docs.rs]
 features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch.crates-io]
+bitflags = { git = "https://github.com/GnomedDev/bitflags", branch = "packed-internal" }

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -145,6 +145,7 @@ macro_rules! bitflags {
         }
     ) => {
         $(#[$outer])*
+        #[repr(packed)]
         $vis struct $BitFlags($T);
 
         bitflags::bitflags! {

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -220,6 +220,7 @@ pub const PRESET_VOICE: Permissions = Permissions::from_bits_truncate(
 /// [`User`]: super::user::User
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
+#[repr(packed)]
 pub struct Permissions(u64);
 
 bitflags::bitflags! {


### PR DESCRIPTION
Currently blocked on https://github.com/bitflags/bitflags/pull/388.

Adds `repr(packed)` to all bitflags, this should significantly reduce model sizes as it shrinks `PermissionOverwrite` which (if there is one per channel) could save 49mb on my bot, and that's probably an underestimate. This also somehow shrinks `GuildChannel` by 8 bytes, leading to a guaranteed 56mb memory saving.