### PR TITLE
remove references to nonexistent `new` fields.

### DIFF
--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -301,7 +301,7 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    /// Creates a new builder with the given name and description, leaving all other fields empty.
+    /// Creates a new builder with the given name, leaving all other fields empty.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             kind: None,
@@ -361,8 +361,7 @@ impl CreateCommand {
         self
     }
 
-    /// Specifies the description of the application command, replacing the current value as set in
-    /// [`Self::new`].
+    /// Specifies the description of the application command.
     ///
     /// **Note**: Must be between 1 and 100 characters long.
     pub fn description(mut self, description: impl Into<String>) -> Self {

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -41,7 +41,7 @@ impl<'a> CreateSticker<'a> {
         self
     }
 
-    /// Set the description of the sticker, replacing the current value as set in [`Self::new`].
+    /// Set the description of the sticker.
     ///
     /// **Note**: Must be empty or 2-100 characters.
     pub fn description(mut self, description: impl Into<String>) -> Self {
@@ -49,8 +49,7 @@ impl<'a> CreateSticker<'a> {
         self
     }
 
-    /// The Discord name of a unicode emoji representing the sticker's expression. Replaces the
-    /// current value as set in [`Self::new`].
+    /// The Discord name of a unicode emoji representing the sticker's expression.
     ///
     /// **Note**: Max 200 characters long.
     pub fn tags(mut self, tags: impl Into<String>) -> Self {


### PR DESCRIPTION
seem to be some typos. this pr is also intended to maybe add the missing fields in the next breaking version of serenity.