### PR TITLE
 Implement max_concurrency support 

### DIFF
--- a/src/gateway/bridge/mod.rs
+++ b/src/gateway/bridge/mod.rs
@@ -61,6 +61,7 @@ pub use self::shard_runner_message::ShardRunnerMessage;
 #[cfg(feature = "voice")]
 pub use self::voice::VoiceGatewayManager;
 use super::ChunkGuildFilter;
+use crate::all::ShardInfo;
 use crate::gateway::ConnectionStage;
 use crate::model::event::Event;
 use crate::model::id::ShardId;
@@ -68,9 +69,8 @@ use crate::model::id::ShardId;
 /// A message to be sent to the [`ShardQueuer`].
 #[derive(Clone, Debug)]
 pub enum ShardQueuerMessage {
-    /// Message to start a shard, where the 0-index element is the ID of the Shard to start and the
-    /// 1-index element is the total shards in use.
-    Start(ShardId, ShardId),
+    /// Message to start a shard.
+    Start(ShardInfo),
     /// Message to shutdown the shard queuer.
     Shutdown,
     /// Message to dequeue/shutdown a shard.

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -363,7 +363,7 @@ pub struct ShardManagerOptions {
     pub framework: Arc<OnceLock<Arc<dyn Framework>>>,
     #[cfg(feature = "voice")]
     pub voice_manager: Option<Arc<dyn VoiceGatewayManager>>,
-    pub ws_url: Arc<Mutex<String>>,
+    pub ws_url: Arc<str>,
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,
     pub http: Arc<Http>,

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::num::NonZeroU16;
 use std::sync::Arc;
 #[cfg(feature = "framework")]
 use std::sync::OnceLock;
@@ -68,6 +69,7 @@ use crate::model::gateway::GatewayIntents;
 /// let ws_url = Arc::from(http.get_gateway().await?.url);
 /// let data = Arc::new(RwLock::new(TypeMap::new()));
 /// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
+/// let max_concurrency = std::num::NonZeroU16::new(1).expect("1 != 0");
 /// let framework = Arc::new(StandardFramework::new()) as Arc<dyn Framework + 'static>;
 ///
 /// ShardManager::new(ShardManagerOptions {
@@ -83,6 +85,7 @@ use crate::model::gateway::GatewayIntents;
 ///     # http,
 ///     intents: GatewayIntents::non_privileged(),
 ///     presence: None,
+///     max_concurrency,
 /// });
 /// # Ok(())
 /// # }
@@ -144,6 +147,7 @@ impl ShardManager {
             http: opt.http,
             intents: opt.intents,
             presence: opt.presence,
+            max_concurrency: opt.max_concurrency,
         };
 
         spawn_named("shard_queuer::run", async move {
@@ -364,4 +368,5 @@ pub struct ShardManagerOptions {
     pub http: Arc<Http>,
     pub intents: GatewayIntents,
     pub presence: Option<PresenceData>,
+    pub max_concurrency: NonZeroU16,
 }

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -65,7 +65,7 @@ use crate::model::gateway::GatewayIntents;
 /// impl RawEventHandler for Handler {}
 ///
 /// # let http: Arc<Http> = unimplemented!();
-/// let ws_url = Arc::new(Mutex::new(http.get_gateway().await?.url));
+/// let ws_url = Arc::from(http.get_gateway().await?.url);
 /// let data = Arc::new(RwLock::new(TypeMap::new()));
 /// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
 /// let framework = Arc::new(StandardFramework::new()) as Arc<dyn Framework + 'static>;
@@ -75,12 +75,6 @@ use crate::model::gateway::GatewayIntents;
 ///     event_handlers: vec![event_handler],
 ///     raw_event_handlers: vec![],
 ///     framework: Arc::new(OnceLock::from(framework)),
-///     // the shard index to start initiating from
-///     shard_index: 0,
-///     // the number of shards to initiate (this initiates 0, 1, and 2)
-///     shard_init: 3,
-///     // the total number of shards in use
-///     shard_total: 5,
 ///     # #[cfg(feature = "voice")]
 ///     # voice_manager: None,
 ///     ws_url,
@@ -195,12 +189,13 @@ impl ShardManager {
     /// Restarting a shard by ID:
     ///
     /// ```rust,no_run
+    /// use serenity::model::gateway::ShardInfo;
     /// use serenity::model::id::ShardId;
     /// use serenity::prelude::*;
     ///
     /// # async fn run(client: Client) {
     /// // restart shard ID 7
-    /// client.shard_manager.restart(ShardId(7)).await;
+    /// client.shard_manager.restart(ShardInfo::new(ShardId(7), 10)).await;
     /// # }
     /// ```
     ///

--- a/src/gateway/bridge/shard_messenger.rs
+++ b/src/gateway/bridge/shard_messenger.rs
@@ -58,24 +58,17 @@ impl ShardMessenger {
     /// parameter:
     ///
     /// ```rust,no_run
-    /// # use tokio::sync::Mutex;
-    /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::model::id::ShardId;
     /// # use serenity::gateway::{ChunkGuildFilter, Shard};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let mutex = Arc::new(Mutex::new("".to_string()));
-    /// #
-    /// #     let shard_info = ShardInfo {
-    /// #         id: ShardId(0),
-    /// #         total: 1,
-    /// #     };
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
-    /// #
+    /// # async fn run(mut shard: Shard) -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::model::id::GuildId;
     ///
-    /// shard.chunk_guild(GuildId::new(81384788765712384), Some(2000), false, ChunkGuildFilter::None, None);
+    /// shard.chunk_guild(
+    ///     GuildId::new(81384788765712384),
+    ///     Some(2000),
+    ///     false,
+    ///     ChunkGuildFilter::None,
+    ///     None,
+    /// );
     /// # Ok(())
     /// # }
     /// ```
@@ -84,22 +77,8 @@ impl ShardMessenger {
     /// and a nonce of `"request"`:
     ///
     /// ```rust,no_run
-    /// # use tokio::sync::Mutex;
-    /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::model::id::ShardId;
     /// # use serenity::gateway::{ChunkGuildFilter, Shard};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let mutex = Arc::new(Mutex::new("".to_string()));
-    /// #
-    /// #     let shard_info = ShardInfo {
-    /// #         id: ShardId(0),
-    /// #         total: 1,
-    /// #     };
-    /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;;
-    /// #
+    /// # async fn run(mut shard: Shard) -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::model::id::GuildId;
     ///
     /// shard.chunk_guild(
@@ -138,21 +117,8 @@ impl ShardMessenger {
     /// Setting the current activity to playing `"Heroes of the Storm"`:
     ///
     /// ```rust,no_run
-    /// # use tokio::sync::Mutex;
-    /// # use serenity::gateway::{Shard};
-    /// # use serenity::model::id::ShardId;
-    /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let mutex = Arc::new(Mutex::new("".to_string()));
-    /// #
-    /// #     let shard_info = ShardInfo {
-    /// #         id: ShardId(0),
-    /// #         total: 1,
-    /// #     };
-    /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
+    /// # use serenity::gateway::Shard;
+    /// # async fn run(mut shard: Shard) -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::gateway::ActivityData;
     ///
     /// shard.set_activity(Some(ActivityData::playing("Heroes of the Storm")));
@@ -172,20 +138,8 @@ impl ShardMessenger {
     /// Set the current user as playing `"Heroes of the Storm"` and being online:
     ///
     /// ```rust,ignore
-    /// # use tokio::sync::Mutex;
     /// # use serenity::gateway::Shard;
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let mutex = Arc::new(Mutex::new("".to_string()));
-    /// #
-    /// #     let shard_info = ShardInfo {
-    /// #         id: 0,
-    /// #         total: 1,
-    /// #     };
-    /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, None).await?;
-    /// #
+    /// # async fn run(shard: Shard) -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::gateway::ActivityData;
     /// use serenity::model::user::OnlineStatus;
     ///
@@ -214,21 +168,8 @@ impl ShardMessenger {
     /// Setting the current online status for the shard to [`DoNotDisturb`].
     ///
     /// ```rust,no_run
-    /// # use tokio::sync::Mutex;
-    /// # use serenity::gateway::{Shard};
-    /// # use serenity::model::id::ShardId;
-    /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let mutex = Arc::new(Mutex::new("".to_string()));
-    /// #     let shard_info = ShardInfo {
-    /// #         id: ShardId(0),
-    /// #         total: 1,
-    /// #     };
-    /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
-    /// #
+    /// # use serenity::gateway::Shard;
+    /// # async fn run(mut shard: Shard) -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::model::user::OnlineStatus;
     ///
     /// shard.set_status(OnlineStatus::DoNotDisturb);

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -72,7 +72,7 @@ pub struct ShardQueuer {
     #[cfg(feature = "voice")]
     pub voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
     /// A copy of the URL to use to connect to the gateway.
-    pub ws_url: Arc<Mutex<String>>,
+    pub ws_url: Arc<str>,
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,
     pub http: Arc<Http>,

--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -458,12 +458,12 @@ impl ShardRunner {
 
         self.update_manager().await;
 
-        let shard_id = self.shard.shard_info().id;
-        self.manager.restart_shard(shard_id).await;
+        let shard_info = self.shard.shard_info();
+        self.manager.restart_shard(shard_info).await;
 
         #[cfg(feature = "voice")]
         if let Some(voice_manager) = &self.voice_manager {
-            voice_manager.deregister_shard(shard_id.0).await;
+            voice_manager.deregister_shard(shard_info.id.0).await;
         }
 
         Ok(())

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -104,7 +104,7 @@ impl Shard {
     /// };
     ///
     /// // retrieve the gateway response, which contains the URL to connect to
-    /// let gateway = Arc::new(Mutex::new(http.get_gateway().await?.url));
+    /// let gateway = Arc::from(http.get_gateway().await?.url);
     /// let shard = Shard::new(gateway, &token, shard_info, GatewayIntents::all(), None).await?;
     ///
     /// // at this point, you can create a `loop`, and receive events and match
@@ -593,24 +593,19 @@ impl Shard {
     /// specifying a query parameter:
     ///
     /// ```rust,no_run
-    /// # use tokio::sync::Mutex;
     /// # use serenity::gateway::{ChunkGuildFilter, Shard};
-    /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
-    /// # use serenity::model::id::ShardId;
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let mutex = Arc::new(Mutex::new("".to_string()));
-    /// #     let shard_info = ShardInfo {
-    /// #          id: ShardId(0),
-    /// #          total: 1,
-    /// #     };
-    /// #
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
-    /// #
+    /// # async fn run(mut shard: Shard) -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::model::id::GuildId;
     ///
-    /// shard.chunk_guild(GuildId::new(81384788765712384), Some(2000), false, ChunkGuildFilter::None, None).await?;
+    /// shard
+    ///     .chunk_guild(
+    ///         GuildId::new(81384788765712384),
+    ///         Some(2000),
+    ///         false,
+    ///         ChunkGuildFilter::None,
+    ///         None,
+    ///     )
+    ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -619,22 +614,8 @@ impl Shard {
     /// `"do"` and a nonce of `"request"`:
     ///
     /// ```rust,no_run
-    /// # use tokio::sync::Mutex;
-    /// # use serenity::model::gateway::{GatewayIntents, ShardInfo};
     /// # use serenity::gateway::{ChunkGuildFilter, Shard};
-    /// # use serenity::model::id::ShardId;
-    /// # use std::error::Error;
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     let mutex = Arc::new(Mutex::new("".to_string()));
-    /// #
-    /// #     let shard_info = ShardInfo {
-    /// #          id: ShardId(0),
-    /// #          total: 1,
-    /// #     };
-    /// #     let mut shard = Shard::new(mutex.clone(), "", shard_info, GatewayIntents::all(), None).await?;
-    /// #
+    /// # async fn run(mut shard: Shard) -> Result<(), Box<dyn std::error::Error>> {
     /// use serenity::model::id::GuildId;
     ///
     /// shard

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -363,7 +363,7 @@ pub struct SessionStartLimit {
     /// The total number of session starts within the ratelimit period allowed.
     pub total: u64,
     /// The number of identify requests allowed per 5 seconds.
-    pub max_concurrency: u64,
+    pub max_concurrency: NonZeroU16,
 }
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -375,7 +375,7 @@ pub struct ShardInfo {
 
 impl ShardInfo {
     #[must_use]
-    pub(crate) fn new(id: ShardId, total: u32) -> Self {
+    pub fn new(id: ShardId, total: u32) -> Self {
         Self {
             id,
             total,


### PR DESCRIPTION
Implements support for the [max concurrency](https://discord.com/developers/docs/topics/gateway#sharding-max-concurrency) system. This allows bots on very large sharding to start up multiple shards in parallel to cut startup times down quite a bit. I've personally tested this using my bot with 256 shards and a max_concurrency of 16 and it worked flawlessly.