### PR TITLE
Box Message::thread

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -111,7 +111,7 @@ pub struct Message {
     /// [`Interaction`]: crate::model::application::Interaction
     pub interaction: Option<Box<MessageInteraction>>,
     /// The thread that was started from this message, includes thread member object.
-    pub thread: Option<GuildChannel>,
+    pub thread: Option<Box<GuildChannel>>,
     /// The components of this message
     #[serde(default)]
     pub components: Vec<ActionRow>,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -525,7 +525,7 @@ pub struct MessageUpdateEvent {
     #[serde(default, deserialize_with = "deserialize_some")]
     pub interaction: Option<Option<Box<MessageInteraction>>>,
     #[serde(default, deserialize_with = "deserialize_some")]
-    pub thread: Option<Option<GuildChannel>>,
+    pub thread: Option<Option<Box<GuildChannel>>>,
     pub components: Option<Vec<ActionRow>>,
     pub sticker_items: Option<Vec<StickerItem>>,
     pub position: Option<Option<u64>>,


### PR DESCRIPTION
This trades a heap allocation for messages sent along with thread creation for Message's inline size dropping from 1176 bytes to 760 bytes, 