### PR TITLE
Fix FixedString<u8> truncation when multibyte characters push over the limit

### DIFF
--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -53,13 +53,13 @@ pub struct Command {
     /// ([source](https://discord.com/developers/docs/interactions/application-commands#retrieving-localized-commands)).
     pub name_localizations: Option<HashMap<String, String>>,
     /// The command description.
-    pub description: FixedString<u8>,
+    pub description: FixedString<u16>,
     /// The localized command description of the selected locale.
     ///
     /// If the description is localized, either this field or [`Self::description_localizations`]
     /// is set, depending on which endpoint this data was retrieved from
     /// ([source](https://discord.com/developers/docs/interactions/application-commands#retrieving-localized-commands)).
-    pub description_localized: Option<FixedString<u8>>,
+    pub description_localized: Option<FixedString<u16>>,
     /// All localized command descriptions.
     ///
     /// If the description is localized, either this field or [`Self::description_localized`] is

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -247,7 +247,7 @@ pub struct InputText {
     #[serde(rename = "type")]
     pub kind: ComponentType,
     /// Developer-defined identifier for the input; max 100 characters
-    pub custom_id: FixedString<u8>,
+    pub custom_id: FixedString<u16>,
     /// The [`InputTextStyle`]. Required when sending modal data.
     ///
     /// Discord docs are wrong here; it says the field is always sent in modal submit interactions
@@ -276,7 +276,7 @@ pub struct InputText {
     pub value: Option<FixedString<u16>>,
     /// Custom placeholder text if the input is empty; max 100 characters
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub placeholder: Option<FixedString<u8>>,
+    pub placeholder: Option<FixedString<u16>>,
 }
 
 enum_number! {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -531,11 +531,11 @@ impl ChannelId {
     /// # Errors
     ///
     /// Same as [`Self::to_channel()`].
-    pub async fn name(self, cache_http: impl CacheHttp) -> Result<FixedString<u8>> {
+    pub async fn name(self, cache_http: impl CacheHttp) -> Result<String> {
         let channel = self.to_channel(cache_http).await?;
 
         Ok(match channel {
-            Channel::Guild(channel) => channel.name,
+            Channel::Guild(channel) => channel.name.into(),
             Channel::Private(channel) => channel.name(),
         })
     }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -73,7 +73,7 @@ pub struct GuildChannel {
     /// **Note**: This is only available for text channels.
     pub last_pin_timestamp: Option<Timestamp>,
     /// The name of the channel. (1-100 characters)
-    pub name: FixedString<u8>,
+    pub name: FixedString<u16>,
     /// Permission overwrites for [`Member`]s and for [`Role`]s.
     #[serde(default)]
     pub permission_overwrites: FixedArray<PermissionOverwrite>,

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -203,8 +203,8 @@ impl PrivateChannel {
 
     /// Returns "DM with $username#discriminator".
     #[must_use]
-    pub fn name(&self) -> FixedString<u8> {
-        format!("DM with {}", self.recipient.tag()).into()
+    pub fn name(&self) -> String {
+        format!("DM with {}", self.recipient.tag())
     }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a certain [`Emoji`].

--- a/src/model/guild/automod.rs
+++ b/src/model/guild/automod.rs
@@ -331,7 +331,7 @@ pub enum Action {
         /// Additional explanation that will be shown to members whenever their message is blocked
         ///
         /// Maximum of 150 characters
-        custom_message: Option<FixedString<u8>>,
+        custom_message: Option<FixedString<u16>>,
     },
     /// Logs user content to a specified channel.
     Alert(ChannelId),
@@ -401,7 +401,7 @@ struct RawActionMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     duration_seconds: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_message: Option<FixedString<u8>>,
+    custom_message: Option<FixedString<u16>>,
 }
 
 /// Helper struct for the (de)serialization of `Action`.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -397,7 +397,7 @@ pub struct InviteStageInstance {
     /// The number of users speaking in the Stage
     pub speaker_count: u64,
     /// The topic of the Stage instance (1-120 characters)
-    pub topic: FixedString<u8>,
+    pub topic: FixedString<u16>,
 }
 
 enum_number! {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -108,7 +108,7 @@ pub struct WebhookGuild {
     /// The unique Id identifying the guild.
     pub id: GuildId,
     /// The name of the guild.
-    pub name: FixedString<u8>,
+    pub name: FixedString<u16>,
     /// The hash of the icon used by the guild.
     ///
     /// In the client, this appears on the guild list on the left-hand side.
@@ -170,7 +170,7 @@ pub struct WebhookChannel {
     /// The unique Id of the channel.
     pub id: ChannelId,
     /// The name of the channel.
-    pub name: FixedString<u8>,
+    pub name: FixedString<u16>,
 }
 
 #[cfg(feature = "model")]


### PR DESCRIPTION
This caused an issue where one GuildChannel had a name over 255 bytes, but under 100 characters, so I did another pass over and increased lengths when needed. In practice without this the only problem is an annoying `error` log and the name being truncated, but good to fix anyway.