### PR TITLE
Encode timestamps in RFC3339

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2799,7 +2799,7 @@ impl Http {
     pub async fn get_channel_archived_public_threads(
         &self,
         channel_id: ChannelId,
-        before: Option<u64>,
+        before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
         let mut params = ArrayVec::<_, 2>::new();
@@ -2827,7 +2827,7 @@ impl Http {
     pub async fn get_channel_archived_private_threads(
         &self,
         channel_id: ChannelId,
-        before: Option<u64>,
+        before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
         let mut params = ArrayVec::<_, 2>::new();
@@ -2855,7 +2855,7 @@ impl Http {
     pub async fn get_channel_joined_archived_private_threads(
         &self,
         channel_id: ChannelId,
-        before: Option<u64>,
+        before: Option<ChannelId>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
         let mut params = ArrayVec::<_, 2>::new();

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1022,7 +1022,7 @@ impl ChannelId {
     pub async fn get_archived_private_threads(
         self,
         http: impl AsRef<Http>,
-        before: Option<u64>,
+        before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
         http.as_ref().get_channel_archived_private_threads(self, before, limit).await
@@ -1036,7 +1036,7 @@ impl ChannelId {
     pub async fn get_archived_public_threads(
         self,
         http: impl AsRef<Http>,
-        before: Option<u64>,
+        before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
         http.as_ref().get_channel_archived_public_threads(self, before, limit).await
@@ -1050,7 +1050,7 @@ impl ChannelId {
     pub async fn get_joined_archived_private_threads(
         self,
         http: impl AsRef<Http>,
-        before: Option<u64>,
+        before: Option<ChannelId>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
         http.as_ref().get_channel_joined_archived_private_threads(self, before, limit).await


### PR DESCRIPTION
This PR fixes #2664, but I am unsure if it should be unwrapped. It would be better to output an error if we cannot encode them. Also, please tell me if [it is ok to encode in RFC3339 instead of ISO 8601](https://stackoverflow.com/a/522281/1941280).