### PR TITLE
Fix GUILD_MEMBERS_CHUNK gateway event deserialization

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -242,12 +242,12 @@ impl CacheUpdate for GuildMembersChunkEvent {
     type Output = ();
 
     fn update(&mut self, cache: &Cache) -> Option<()> {
-        for member in self.members.values() {
+        for member in &self.members {
             cache.update_user_entry(&member.user);
         }
 
         if let Some(mut g) = cache.guilds.get_mut(&self.guild_id) {
-            g.members.extend(self.members.clone());
+            g.members.extend(self.members.iter().map(|member| (member.user.id, member.clone())));
         }
 
         None

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -273,7 +273,7 @@ pub struct GuildMembersChunkEvent {
     /// ID of the guild.
     pub guild_id: GuildId,
     /// Set of guild members.
-    pub members: HashMap<UserId, Member>,
+    pub members: Vec<Member>,
     /// Chunk index in the expected chunks for this response (0 <= chunk_index < chunk_count).
     pub chunk_index: u32,
     /// Total number of expected chunks for this response.
@@ -293,7 +293,7 @@ pub struct GuildMembersChunkEvent {
 impl<'de> Deserialize<'de> for GuildMembersChunkEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut event = Self::deserialize(deserializer)?; // calls #[serde(remote)]-generated inherent method
-        event.members.values_mut().for_each(|m| m.guild_id = event.guild_id);
+        event.members.iter_mut().for_each(|m| m.guild_id = event.guild_id);
         Ok(event)
     }
 }


### PR DESCRIPTION
Fixes #2666. This branch has been based on the `next` one due to a change in the public facing API.

## Changes in the public facing API

- `GuildMembersChunkEvent::members` is typed `Vec<Member>` instead of `HashMap<UserId, Member>` to allow a proper deserialization of the Discord's gateway's payload.