### PR TITLE
Fix deserialization of `GuildMembersChunkEvent`

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -13,7 +13,14 @@ use serde::Serialize;
 
 use super::application::ActionRow;
 use super::prelude::*;
-use super::utils::{deserialize_val, emojis, remove_from_map, remove_from_map_opt, stickers};
+use super::utils::{
+    deserialize_val,
+    emojis,
+    members,
+    remove_from_map,
+    remove_from_map_opt,
+    stickers,
+};
 use crate::constants::Opcode;
 use crate::internal::prelude::*;
 use crate::model::application::{CommandPermissions, Interaction};
@@ -273,6 +280,7 @@ pub struct GuildMembersChunkEvent {
     /// ID of the guild.
     pub guild_id: GuildId,
     /// Set of guild members.
+    #[serde(with = "members")]
     pub members: HashMap<UserId, Member>,
     /// Chunk index in the expected chunks for this response (0 <= chunk_index < chunk_count).
     pub chunk_index: u32,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -256,8 +256,7 @@ pub struct Guild {
     ///
     /// Members might not all be available when the [`ReadyEvent`] is received if the
     /// [`Self::member_count`] is greater than the [`LARGE_THRESHOLD`] set by the library.
-    #[serde(serialize_with = "serialize_map_values")]
-    #[serde(deserialize_with = "deserialize_members")]
+    #[serde(with = "members")]
     pub members: HashMap<UserId, Member>,
     /// All voice and text channels contained within a guild.
     ///

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -113,10 +113,23 @@ pub fn deserialize_guild_channels<'de, D: Deserializer<'de>>(
     Ok(map)
 }
 
-pub fn deserialize_members<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> StdResult<HashMap<UserId, Member>, D::Error> {
-    deserializer.deserialize_seq(SequenceToMapVisitor::new(|member: &Member| member.user.id))
+/// Used with `#[serde(with = "members")]
+pub mod members {
+    use std::collections::HashMap;
+
+    use serde::Deserializer;
+
+    use super::SequenceToMapVisitor;
+    use crate::model::guild::Member;
+    use crate::model::id::UserId;
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<UserId, Member>, D::Error> {
+        deserializer.deserialize_seq(SequenceToMapVisitor::new(|member: &Member| member.user.id))
+    }
+
+    pub use super::serialize_map_values as serialize;
 }
 
 /// Used with `#[serde(with = "presences")]`


### PR DESCRIPTION
Specifically, the `members` field was being incorrectly deserialized. In #2287, the logic for collecting the received array of members into a hashmap was removed, meaning the deserializer now looked for a map instead of a sequence, causing deserialization to fail. This PR adds that logic back.

Closes #2666