### PR TITLE
Bitpack boolean fields using fancy proc macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ base64 = { version = "0.21.5" }
 secrecy = { version = "0.8.0", features = ["serde"] }
 arrayvec = { version = "0.7.4", features = ["serde"] }
 small-fixed-array = { git = "https://github.com/GnomedDev/small-fixed-array", features = ["serde", "log_using_tracing"] }
+bool_to_bitflags = { git = "https://github.com/GnomedDev/bool-to-bitflags", version = "0.1.0" }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
 simd-json = { version = "0.13.4", optional = true }
@@ -125,7 +126,7 @@ simd_json = ["simd-json", "typesize?/simd_json"]
 # Enables temporary caching in functions that retrieve data via the HTTP API.
 temp_cache = ["cache", "mini-moka", "typesize?/mini_moka"]
 
-typesize = ["dep:typesize", "small-fixed-array/typesize"]
+typesize = ["dep:typesize", "small-fixed-array/typesize", "bool_to_bitflags/typesize"]
 
 # Removed feature (https://github.com/serenity-rs/serenity/pull/2246)
 absolute_ratelimits = []

--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -348,7 +348,7 @@ async fn say(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
             if let Some(guild) = msg.guild(&ctx.cache) {
                 // By default roles, users, and channel mentions are cleaned.
                 let settings = ContentSafeOptions::default()
-                    // We do not want to clean channal mentions as they do not ping users.
+                    // We do not want to clean channel mentions as they do not ping users.
                     .clean_channel(false);
 
                 x = content_safe(&guild, x, &settings, &msg.mentions);

--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -351,7 +351,7 @@ async fn say(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
                     // We do not want to clean channel mentions as they do not ping users.
                     .clean_channel(false);
 
-                x = content_safe(&guild, x, &settings, &msg.mentions);
+                x = content_safe(&guild, x, settings, &msg.mentions);
             }
 
             msg.channel_id.say(&ctx.http, x).await?;

--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -32,8 +32,7 @@ impl CreateCommandOption {
             name_localizations: None,
             description: description.into().into(),
             description_localizations: None,
-            required: false,
-            autocomplete: false,
+            __generated_flags: CommandOptionGeneratedFlags::empty(),
             min_value: None,
             max_value: None,
             min_length: None,
@@ -106,7 +105,7 @@ impl CreateCommandOption {
     ///
     /// **Note**: This defaults to `false`.
     pub fn required(mut self, required: bool) -> Self {
-        self.0.required = required;
+        self.0.set_required(required);
         self
     }
 
@@ -205,7 +204,7 @@ impl CreateCommandOption {
     /// - May not be set to `true` if `choices` are set
     /// - Options using `autocomplete` are not confined to only use given choices
     pub fn set_autocomplete(mut self, value: bool) -> Self {
-        self.0.autocomplete = value;
+        self.0.set_autocomplete(value);
         self
     }
 

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -77,8 +77,8 @@ impl<'a> EditRole<'a> {
     /// Creates a new builder with the values of the given [`Role`].
     pub fn from_role(role: &Role) -> Self {
         EditRole {
-            hoist: Some(role.hoist),
-            mentionable: Some(role.mentionable),
+            hoist: Some(role.hoist()),
+            mentionable: Some(role.mentionable()),
             name: Some(role.name.clone()),
             permissions: Some(role.permissions.bits()),
             position: Some(role.position),

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -101,24 +101,56 @@ impl From<(bool, bool, bool)> for WithWhiteSpace {
 /// [`Client`]: crate::Client
 /// [`StandardFramework`]: super::StandardFramework
 /// [default implementation]: Self::default
+#[bool_to_bitflags::bool_to_bitflags(
+    getter_prefix = "get_",
+    setter_prefix = "",
+    private_getters,
+    document_setters,
+    owning_setters
+)]
 #[derive(Clone)]
 pub struct Configuration {
-    pub(crate) allow_dm: bool,
     pub(crate) with_whitespace: WithWhiteSpace,
-    pub(crate) by_space: bool,
     pub(crate) blocked_guilds: HashSet<GuildId>,
     pub(crate) blocked_users: HashSet<UserId>,
     pub(crate) allowed_channels: HashSet<ChannelId>,
     pub(crate) disabled_commands: HashSet<String>,
     pub(crate) dynamic_prefixes: Vec<DynamicPrefixHook>,
-    pub(crate) ignore_bots: bool,
-    pub(crate) ignore_webhooks: bool,
     pub(crate) on_mention: Option<String>,
     pub(crate) owners: HashSet<UserId>,
     pub(crate) prefixes: Vec<String>,
-    pub(crate) no_dm_prefix: bool,
     pub(crate) delimiters: Vec<Delimiter>,
-    pub(crate) case_insensitive: bool,
+    /// If set to false, bot will ignore any private messages.
+    ///
+    /// **Note**: Defaults to `true`.
+    pub allow_dm: bool,
+    /// Whether the framework should split the message by a space first to parse the group or
+    /// command. If set to false, it will only test part of the message by the *length* of the
+    /// group's or command's names.
+    ///
+    /// **Note**: Defaults to `true`
+    pub by_space: bool,
+    /// Whether the bot should respond to other bots.
+    ///
+    /// For example, if this is set to false, then the bot will respond to any other bots including
+    /// itself.
+    ///
+    /// **Note**: Defaults to `true`.
+    pub ignore_bots: bool,
+    /// If set to true, bot will ignore all commands called by webhooks.
+    ///
+    /// **Note**: Defaults to `true`.
+    pub ignore_webhooks: bool,
+    /// Sets whether command execution can be done without a prefix. Works only in private
+    /// channels.
+    ///
+    /// **Note**: Defaults to `false`.
+    ///
+    /// # Note
+    ///
+    /// The `cache` feature is required. If disabled this does absolutely nothing.
+    pub no_dm_prefix: bool,
+    case_insensitive: bool,
 }
 
 impl Configuration {
@@ -126,15 +158,6 @@ impl Configuration {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// If set to false, bot will ignore any private messages.
-    ///
-    /// **Note**: Defaults to `true`.
-    #[must_use]
-    pub fn allow_dm(mut self, allow_dm: bool) -> Self {
-        self.allow_dm = allow_dm;
-        self
     }
 
     /// Whether to allow whitespace being optional between a prefix/group-prefix/command and a
@@ -162,17 +185,6 @@ impl Configuration {
     #[must_use]
     pub fn with_whitespace(mut self, with: impl Into<WithWhiteSpace>) -> Self {
         self.with_whitespace = with.into();
-        self
-    }
-
-    /// Whether the framework should split the message by a space first to parse the group or
-    /// command. If set to false, it will only test part of the message by the *length* of the
-    /// group's or command's names.
-    ///
-    /// **Note**: Defaults to `true`
-    #[must_use]
-    pub fn by_space(mut self, b: bool) -> Self {
-        self.by_space = b;
         self
     }
 
@@ -351,27 +363,6 @@ impl Configuration {
         self
     }
 
-    /// Whether the bot should respond to other bots.
-    ///
-    /// For example, if this is set to false, then the bot will respond to any other bots including
-    /// itself.
-    ///
-    /// **Note**: Defaults to `true`.
-    #[must_use]
-    pub fn ignore_bots(mut self, ignore_bots: bool) -> Self {
-        self.ignore_bots = ignore_bots;
-        self
-    }
-
-    /// If set to true, bot will ignore all commands called by webhooks.
-    ///
-    /// **Note**: Defaults to `true`.
-    #[must_use]
-    pub fn ignore_webhooks(mut self, ignore_webhooks: bool) -> Self {
-        self.ignore_webhooks = ignore_webhooks;
-        self
-    }
-
     /// Whether or not to respond to commands initiated with `id_to_mention`.
     ///
     /// **Note**: that this can be used in conjunction with [`Self::prefix`].
@@ -485,20 +476,6 @@ impl Configuration {
         self
     }
 
-    /// Sets whether command execution can be done without a prefix. Works only in private channels.
-    ///
-    /// **Note**: Defaults to `false`.
-    ///
-    /// # Note
-    ///
-    /// The `cache` feature is required. If disabled this does absolutely nothing.
-    #[inline]
-    #[must_use]
-    pub fn no_dm_prefix(mut self, b: bool) -> Self {
-        self.no_dm_prefix = b;
-        self
-    }
-
     /// Sets a single delimiter to be used when splitting the content after a command.
     ///
     /// **Note**: Defaults to a vector with a single element of `' '`.
@@ -555,7 +532,7 @@ impl Configuration {
     /// **Note**: Defaults to `false`.
     #[must_use]
     pub fn case_insensitivity(mut self, cs: bool) -> Self {
-        self.case_insensitive = cs;
+        self = self.case_insensitive(cs);
 
         for prefix in &mut self.prefixes {
             *prefix = prefix.to_lowercase();
@@ -585,23 +562,20 @@ impl Default for Configuration {
     /// - **owners** to an empty HashSet
     /// - **prefix** to "~"
     fn default() -> Configuration {
-        Configuration {
-            allow_dm: true,
+        let config = Configuration {
+            __generated_flags: ConfigurationGeneratedFlags::empty(),
             with_whitespace: WithWhiteSpace::default(),
-            by_space: true,
             blocked_guilds: HashSet::default(),
             blocked_users: HashSet::default(),
             allowed_channels: HashSet::default(),
-            case_insensitive: false,
             delimiters: vec![Delimiter::Single(' ')],
             disabled_commands: HashSet::default(),
             dynamic_prefixes: Vec::new(),
-            ignore_bots: true,
-            ignore_webhooks: true,
-            no_dm_prefix: false,
             on_mention: None,
             owners: HashSet::default(),
             prefixes: vec![String::from("~")],
-        }
+        };
+
+        config.allow_dm(true).by_space(true).ignore_bots(true).ignore_webhooks(true)
     }
 }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -197,8 +197,8 @@ impl StandardFramework {
     fn should_ignore(&self, msg: &Message) -> bool {
         let config = self.config.read();
 
-        (config.ignore_bots && msg.author.bot)
-            || (config.ignore_webhooks && msg.webhook_id.is_some())
+        (config.get_ignore_bots() && msg.author.bot())
+            || (config.get_ignore_webhooks() && msg.webhook_id.is_some())
     }
 
     async fn should_fail<'a>(
@@ -631,7 +631,7 @@ impl Framework for StandardFramework {
             return;
         }
 
-        if prefix.is_none() && !(config.no_dm_prefix && msg.is_private()) {
+        if prefix.is_none() && !(config.get_no_dm_prefix() && msg.is_private()) {
             if let Some(normal) = &self.normal_message {
                 normal(&mut ctx, &msg).await;
             }
@@ -678,7 +678,7 @@ impl Framework for StandardFramework {
 
         match invoke {
             Invoke::Help(name) => {
-                if !config.allow_dm && msg.is_private() {
+                if !config.get_allow_dm() && msg.is_private() {
                     return;
                 }
 

--- a/src/framework/standard/parse/map.rs
+++ b/src/framework/standard/parse/map.rs
@@ -37,8 +37,11 @@ impl CommandMap {
                 map.min_length = std::cmp::min(len, map.min_length);
                 map.max_length = std::cmp::max(len, map.max_length);
 
-                let name =
-                    if conf.case_insensitive { name.to_lowercase() } else { (*name).to_string() };
+                let name = if conf.get_case_insensitive() {
+                    name.to_lowercase()
+                } else {
+                    (*name).to_string()
+                };
 
                 map.cmds.insert(name, (*cmd, Arc::clone(&sub_map)));
             }

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -99,7 +99,7 @@ fn permissions_in(
 
 #[inline]
 fn to_lowercase<'a>(config: &Configuration, s: &'a str) -> Cow<'a, str> {
-    if config.case_insensitive {
+    if config.get_case_insensitive() {
         Cow::Owned(s.to_lowercase())
     } else {
         Cow::Borrowed(s)
@@ -213,7 +213,7 @@ async fn check_discrepancy(
         return Err(DispatchError::OnlyForDM);
     }
 
-    if (!config.allow_dm || options.only_in() == OnlyIn::Guild) && msg.is_private() {
+    if (!config.get_allow_dm() || options.only_in() == OnlyIn::Guild) && msg.is_private() {
         return Err(DispatchError::OnlyForGuilds);
     }
 
@@ -282,7 +282,7 @@ fn parse_cmd<'a>(
 ) -> BoxFuture<'a, Result<&'static Command, ParseError>> {
     async move {
         let (n, r) =
-            try_parse(stream, map, config.by_space, |s| to_lowercase(config, s).into_owned());
+            try_parse(stream, map, config.get_by_space(), |s| to_lowercase(config, s).into_owned());
 
         if config.disabled_commands.contains(&n) {
             return Err(ParseError::Dispatch {
@@ -328,7 +328,7 @@ fn parse_group<'a>(
     map: &'a GroupMap,
 ) -> BoxFuture<'a, Result<(&'static CommandGroup, Arc<CommandMap>), ParseError>> {
     async move {
-        let (n, o) = try_parse(stream, map, config.by_space, ToString::to_string);
+        let (n, o) = try_parse(stream, map, config.get_by_space(), ToString::to_string);
 
         if let Some((group, map, commands)) = o {
             stream.increment(n.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@
 #![allow(
     // Allowed to avoid breaking changes.
     clippy::module_name_repetitions,
-    clippy::struct_excessive_bools,
     clippy::unused_self,
     // Allowed as they are too pedantic
     clippy::cast_possible_truncation,

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -23,8 +23,9 @@ use crate::model::Permissions;
 /// The base command model that belongs to an application.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct Command {
     /// The command Id.
@@ -236,8 +237,9 @@ enum_number! {
 /// The parameters for an [`Command`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct CommandOption {
     /// The option type.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -31,8 +31,9 @@ use crate::utils;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object) with some
 /// [extra fields](https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct Message {
     /// The unique Id of the message. Can be used to calculate the creation date of the message.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -434,8 +434,9 @@ pub struct StageInstance {
 /// A thread data.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct ThreadMetadata {
     /// Whether the thread is archived.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -403,7 +403,7 @@ impl From<char> for ReactionType {
 impl From<Emoji> for ReactionType {
     fn from(emoji: Emoji) -> ReactionType {
         ReactionType::Custom {
-            animated: emoji.animated,
+            animated: emoji.animated(),
             id: emoji.id,
             name: Some(emoji.name),
         }

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -6,7 +6,8 @@ use crate::internal::prelude::*;
 /// Information about a connection between the current user and a third party service.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-connection-structure).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[bool_to_bitflags::bool_to_bitflags]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct Connection {
     /// The ID of the account on the other side of this connection.

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -249,8 +249,9 @@ pub struct GuildMemberRemoveEvent {
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-update).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct GuildMemberUpdateEvent {
     pub guild_id: GuildId,
@@ -594,15 +595,15 @@ impl MessageUpdateEvent {
         if let Some(x) = content { message.content = x.clone() }
         if let Some(x) = timestamp { message.timestamp = x.clone() }
         message.edited_timestamp = *edited_timestamp;
-        if let Some(x) = tts { message.tts = x.clone() }
-        if let Some(x) = mention_everyone { message.mention_everyone = x.clone() }
+        if let Some(x) = tts { message.set_tts(*x) }
+        if let Some(x) = mention_everyone { message.set_mention_everyone(*x) }
         if let Some(x) = mentions { message.mentions = x.clone() }
         if let Some(x) = mention_roles { message.mention_roles = x.clone() }
         if let Some(x) = mention_channels { message.mention_channels = x.clone() }
         if let Some(x) = attachments { message.attachments = x.clone() }
         if let Some(x) = embeds { message.embeds = x.clone() }
         if let Some(x) = reactions { message.reactions = x.clone() }
-        if let Some(x) = pinned { message.pinned = x.clone() }
+        if let Some(x) = pinned { message.set_pinned(*x) }
         if let Some(x) = webhook_id { message.webhook_id = x.clone() }
         if let Some(x) = kind { message.kind = x.clone() }
         if let Some(x) = activity { message.activity = x.clone() }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -238,8 +238,9 @@ pub struct ClientStatus {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object),
 /// [modification description](https://discord.com/developers/docs/topics/gateway-events#presence-update).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct PresenceUser {
     pub id: UserId,
@@ -261,9 +262,9 @@ impl PresenceUser {
     /// If one of [`User`]'s required fields is None in `self`, None is returned.
     #[must_use]
     pub fn into_user(self) -> Option<User> {
-        Some(User {
+        let (bot, verified, mfa_enabled) = (self.bot()?, self.verified(), self.mfa_enabled());
+        let mut user = User {
             avatar: self.avatar,
-            bot: self.bot?,
             discriminator: self.discriminator,
             global_name: None,
             id: self.id,
@@ -272,14 +273,18 @@ impl PresenceUser {
             banner: None,
             accent_colour: None,
             member: None,
-            system: false,
-            mfa_enabled: self.mfa_enabled.unwrap_or_default(),
             locale: None,
-            verified: self.verified,
             email: self.email,
             flags: self.public_flags.unwrap_or_default(),
             premium_type: PremiumType::None,
-        })
+            __generated_flags: UserGeneratedFlags::empty(),
+        };
+
+        user.set_bot(bot);
+        user.set_verified(verified);
+        user.set_mfa_enabled(mfa_enabled.unwrap_or_default());
+
+        Some(user)
     }
 
     /// Attempts to convert this [`PresenceUser`] instance into a [`User`].

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -9,8 +9,9 @@ use crate::model::utils::default_true;
 /// integration. Emojis created using the API only work within the guild it was created in.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/emoji#emoji-object).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct Emoji {
     /// Whether the emoji is animated.
@@ -62,7 +63,7 @@ impl Emoji {
     #[inline]
     #[must_use]
     pub fn url(&self) -> String {
-        let extension = if self.animated { "gif" } else { "png" };
+        let extension = if self.animated() { "gif" } else { "png" };
         cdn!("/emojis/{}.{}", self.id, extension)
     }
 }
@@ -73,7 +74,7 @@ impl fmt::Display for Emoji {
     /// This is in the format of either `<:NAME:EMOJI_ID>` for normal emojis, or
     /// `<a:NAME:EMOJI_ID>` for animated emojis.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.animated {
+        if self.animated() {
             f.write_str("<a:")?;
         } else {
             f.write_str("<:")?;

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -6,8 +6,9 @@ use crate::model::Timestamp;
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-object),
 /// [extra fields 1](https://discord.com/developers/docs/topics/gateway-events#integration-create),
 /// [extra fields 2](https://discord.com/developers/docs/topics/gateway-events#integration-update),
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct Integration {
     pub id: IntegrationId,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -95,8 +95,9 @@ pub struct AfkMetadata {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object) plus
 /// [extension](https://discord.com/developers/docs/topics/gateway-events#guild-create).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct Guild {
     /// The unique Id identifying the guild.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -16,8 +16,9 @@ use crate::model::utils::is_false;
 /// permissions.
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct Role {
     /// The Id of the role. Can be used to calculate the role's creation date.
@@ -174,7 +175,8 @@ impl<'a> From<&'a Role> for RoleId {
 /// The tags of a [`Role`].
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure).
-#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[bool_to_bitflags::bool_to_bitflags]
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[non_exhaustive]
 pub struct RoleTags {
@@ -238,14 +240,8 @@ mod tests {
 
     #[test]
     fn premium_subscriber_role_serde() {
-        let value = RoleTags {
-            bot_id: None,
-            integration_id: None,
-            premium_subscriber: true,
-            subscription_listing_id: None,
-            available_for_purchase: false,
-            guild_connections: false,
-        };
+        let mut value = RoleTags::default();
+        value.set_premium_subscriber(true);
 
         assert_json(
             &value,
@@ -255,14 +251,7 @@ mod tests {
 
     #[test]
     fn non_premium_subscriber_role_serde() {
-        let value = RoleTags {
-            bot_id: None,
-            integration_id: None,
-            premium_subscriber: false,
-            subscription_listing_id: None,
-            available_for_purchase: false,
-            guild_connections: false,
-        };
+        let value = RoleTags::default();
 
         assert_json(
             &value,

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -188,14 +188,11 @@ mod test {
 
     #[test]
     fn test_mention() {
+        let role = Role::default();
         let channel = Channel::Guild(GuildChannel {
             id: ChannelId::new(4),
             ..Default::default()
         });
-        let role = Role {
-            id: RoleId::new(2),
-            ..Default::default()
-        };
         let user = User {
             id: UserId::new(6),
             ..Default::default()
@@ -209,8 +206,8 @@ mod test {
         #[cfg(feature = "model")]
         assert_eq!(channel.mention().to_string(), "<#4>");
         assert_eq!(member.mention().to_string(), "<@6>");
-        assert_eq!(role.mention().to_string(), "<@&2>");
-        assert_eq!(role.id.mention().to_string(), "<@&2>");
+        assert_eq!(role.mention().to_string(), "<@&1>");
+        assert_eq!(role.id.mention().to_string(), "<@&1>");
         assert_eq!(user.mention().to_string(), "<@6>");
         assert_eq!(user.id.mention().to_string(), "<@6>");
     }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -223,8 +223,9 @@ impl OnlineStatus {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object), existence of
 /// additional partial member field documented [here](https://discord.com/developers/docs/topics/gateway-events#message-create).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct User {
     /// The unique Id of the user. Can be used to calculate the account's creation date.
@@ -400,7 +401,7 @@ impl User {
     /// See [`UserId::create_dm_channel`] for what errors may be returned.
     #[inline]
     pub async fn create_dm_channel(&self, cache_http: impl CacheHttp) -> Result<PrivateChannel> {
-        if self.bot {
+        if self.bot() {
             return Err(Error::Model(ModelError::MessagingBot));
         }
 

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -11,7 +11,8 @@ use crate::model::Timestamp;
 /// Information about an available voice region.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/voice#voice-region-object).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[bool_to_bitflags::bool_to_bitflags]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub struct VoiceRegion {
     /// Whether it is a custom voice region, which is used for events.
@@ -29,8 +30,9 @@ pub struct VoiceRegion {
 /// A user's state within a voice channel.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/voice#voice-state-object).
+#[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(remote = "Self")]
 #[non_exhaustive]
 pub struct VoiceState {
@@ -53,7 +55,7 @@ pub struct VoiceState {
 }
 
 // Manual impl needed to insert guild_id into Member
-impl<'de> Deserialize<'de> for VoiceState {
+impl<'de> Deserialize<'de> for VoiceStateGeneratedOriginal {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // calls #[serde(remote)]-generated inherent method
         let mut state = Self::deserialize(deserializer)?;
@@ -64,7 +66,7 @@ impl<'de> Deserialize<'de> for VoiceState {
     }
 }
 
-impl Serialize for VoiceState {
+impl Serialize for VoiceStateGeneratedOriginal {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // calls #[serde(remote)]-generated inherent method
         Self::serialize(self, serializer)

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -5,14 +5,36 @@ use crate::model::mention::Mention;
 use crate::model::user::User;
 
 /// Struct that allows to alter [`content_safe`]'s behaviour.
+#[bool_to_bitflags::bool_to_bitflags(
+    getter_prefix = "get_",
+    setter_prefix = "",
+    private_getters,
+    document_setters,
+    owning_setters
+)]
 #[derive(Clone, Debug)]
 pub struct ContentSafeOptions {
-    clean_role: bool,
-    clean_user: bool,
-    clean_channel: bool,
-    clean_here: bool,
-    clean_everyone: bool,
-    show_discriminator: bool,
+    /// [`content_safe`] will replace role mentions (`<@&{id}>`) with its name prefixed with `@`
+    /// (`@rolename`) or with `@deleted-role` if the identifier is invalid.
+    pub clean_role: bool,
+    /// If set to true, [`content_safe`] will replace user mentions (`<@!{id}>` or `<@{id}>`) with
+    /// the user's name prefixed with `@` (`@username`) or with `@invalid-user` if the identifier
+    /// is invalid.
+    pub clean_user: bool,
+    /// If set to true, [`content_safe`] will replace channel mentions (`<#{id}>`) with the
+    /// channel's name prefixed with `#` (`#channelname`) or with `#deleted-channel` if the
+    /// identifier is invalid.
+    pub clean_channel: bool,
+    /// If set, [`content_safe`] will replace `@here` with a non-pinging alternative.
+    pub clean_here: bool,
+    /// If set, [`content_safe`] will replace `@everyone` with a non-pinging alternative.
+    pub clean_everyone: bool,
+    /// If set to true, if [`content_safe`] replaces a user mention it will add their four digit
+    /// discriminator with a preceding `#`, turning `@username` to `@username#discriminator`.
+    ///
+    /// This option is ignored if the username is a next-gen username, and
+    /// therefore does not have a discriminator.
+    pub show_discriminator: bool,
 }
 
 impl ContentSafeOptions {
@@ -20,75 +42,13 @@ impl ContentSafeOptions {
     pub fn new() -> Self {
         ContentSafeOptions::default()
     }
-
-    /// [`content_safe`] will replace role mentions (`<@&{id}>`) with its name prefixed with `@`
-    /// (`@rolename`) or with `@deleted-role` if the identifier is invalid.
-    #[must_use]
-    pub fn clean_role(mut self, b: bool) -> Self {
-        self.clean_role = b;
-
-        self
-    }
-
-    /// If set to true, [`content_safe`] will replace user mentions (`<@!{id}>` or `<@{id}>`) with
-    /// the user's name prefixed with `@` (`@username`) or with `@invalid-user` if the identifier
-    /// is invalid.
-    #[must_use]
-    pub fn clean_user(mut self, b: bool) -> Self {
-        self.clean_user = b;
-
-        self
-    }
-
-    /// If set to true, [`content_safe`] will replace channel mentions (`<#{id}>`) with the
-    /// channel's name prefixed with `#` (`#channelname`) or with `#deleted-channel` if the
-    /// identifier is invalid.
-    #[must_use]
-    pub fn clean_channel(mut self, b: bool) -> Self {
-        self.clean_channel = b;
-
-        self
-    }
-
-    /// If set to true, if [`content_safe`] replaces a user mention it will add their four digit
-    /// discriminator with a preceding `#`, turning `@username` to `@username#discriminator`.
-    ///
-    /// This option is ignored if the username is a next-gen username, and
-    /// therefore does not have a discriminator.
-    #[must_use]
-    pub fn show_discriminator(mut self, b: bool) -> Self {
-        self.show_discriminator = b;
-
-        self
-    }
-
-    /// If set, [`content_safe`] will replace `@here` with a non-pinging alternative.
-    #[must_use]
-    pub fn clean_here(mut self, b: bool) -> Self {
-        self.clean_here = b;
-
-        self
-    }
-
-    /// If set, [`content_safe`] will replace `@everyone` with a non-pinging alternative.
-    #[must_use]
-    pub fn clean_everyone(mut self, b: bool) -> Self {
-        self.clean_everyone = b;
-
-        self
-    }
 }
 
 impl Default for ContentSafeOptions {
     /// Instantiates with all options set to `true`.
     fn default() -> Self {
         ContentSafeOptions {
-            clean_role: true,
-            clean_user: true,
-            clean_channel: true,
-            clean_here: true,
-            clean_everyone: true,
-            show_discriminator: true,
+            __generated_flags: ContentSafeOptionsGeneratedFlags::all(),
         }
     }
 }
@@ -143,11 +103,11 @@ pub fn content_safe(
 ) -> String {
     let mut content = clean_mentions(guild, s, options, users);
 
-    if options.clean_here {
+    if options.get_clean_here() {
         content = content.replace("@here", "@\u{200B}here");
     }
 
-    if options.clean_everyone {
+    if options.get_clean_everyone() {
         content = content.replace("@everyone", "@\u{200B}everyone");
     }
 
@@ -177,12 +137,12 @@ fn clean_mentions(
                     let mut chars = mention_str.chars();
                     chars.next();
                     let should_parse = match chars.next() {
-                        Some('#') => options.clean_channel,
+                        Some('#') => options.get_clean_channel(),
                         Some('@') => {
                             if let Some('&') = chars.next() {
-                                options.clean_role
+                                options.get_clean_role()
                             } else {
-                                options.clean_user
+                                options.get_clean_user()
                             }
                         },
                         _ => false,
@@ -230,13 +190,13 @@ fn clean_mention(
             .map_or(Cow::Borrowed("@deleted-role"), |role| format!("@{}", role.name).into()),
         Mention::User(id) => {
             if let Some(member) = guild.members.get(&id) {
-                if options.show_discriminator {
+                if options.get_show_discriminator() {
                     format!("@{}", member.distinct()).into()
                 } else {
                     format!("@{}", member.display_name()).into()
                 }
             } else if let Some(user) = users.iter().find(|u| u.id == id) {
-                if options.show_discriminator {
+                if options.get_show_discriminator() {
                     format!("@{}", user.tag()).into()
                 } else {
                     format!("@{}", user.name).into()
@@ -314,7 +274,8 @@ mod tests {
             content_safe(&no_member_guild, "<@100000000000000001>", &options, &[])
         );
 
-        let options = ContentSafeOptions::default().show_discriminator(false);
+        let mut options = ContentSafeOptions::default();
+        options = options.show_discriminator(false);
         assert_eq!(
             format!("@{}", user.name),
             content_safe(&no_member_guild, "<@!100000000000000000>", &options, &[user.clone()])
@@ -330,7 +291,7 @@ mod tests {
             content_safe(&guild, "<@100000000000000000>", &options, &[])
         );
 
-        let options = options.clean_user(false);
+        options = options.clean_user(false);
         assert_eq!(with_user_mentions, content_safe(&guild, with_user_mentions, &options, &[]));
 
         // Channel mentions
@@ -347,7 +308,7 @@ mod tests {
             content_safe(&guild, with_channel_mentions, &options, &[])
         );
 
-        let options = options.clean_channel(false);
+        options = options.clean_channel(false);
         assert_eq!(
             with_channel_mentions,
             content_safe(&guild, with_channel_mentions, &options, &[])
@@ -364,12 +325,11 @@ mod tests {
 
         assert_eq!(without_role_mentions, content_safe(&guild, with_role_mentions, &options, &[]));
 
-        let options = options.clean_role(false);
+        options = options.clean_role(false);
         assert_eq!(with_role_mentions, content_safe(&guild, with_role_mentions, &options, &[]));
 
         // Everyone mentions
         let with_everyone_mention = "@everyone";
-
         let without_everyone_mention = "@\u{200B}everyone";
 
         assert_eq!(
@@ -377,7 +337,7 @@ mod tests {
             content_safe(&guild, with_everyone_mention, &options, &[])
         );
 
-        let options = options.clean_everyone(false);
+        options = options.clean_everyone(false);
         assert_eq!(
             with_everyone_mention,
             content_safe(&guild, with_everyone_mention, &options, &[])
@@ -390,7 +350,7 @@ mod tests {
 
         assert_eq!(without_here_mention, content_safe(&guild, with_here_mention, &options, &[]));
 
-        let options = options.clean_here(false);
+        options = options.clean_here(false);
         assert_eq!(with_here_mention, content_safe(&guild, with_here_mention, &options, &[]));
     }
 }

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -128,7 +128,7 @@ impl CustomMessage {
     /// If not used, the default value is `false`.
     #[inline]
     pub fn mention_everyone(&mut self, mentions: bool) -> &mut Self {
-        self.msg.mention_everyone = mentions;
+        self.msg.set_mention_everyone(mentions);
 
         self
     }
@@ -158,7 +158,7 @@ impl CustomMessage {
     /// If not used, the default value is `false`.
     #[inline]
     pub fn pinned(&mut self, pinned: bool) -> &mut Self {
-        self.msg.pinned = pinned;
+        self.msg.set_pinned(pinned);
 
         self
     }
@@ -188,7 +188,7 @@ impl CustomMessage {
     /// If not used, the default value is `false`.
     #[inline]
     pub fn tts(&mut self, tts: bool) -> &mut Self {
-        self.msg.tts = tts;
+        self.msg.set_tts(tts);
 
         self
     }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -983,6 +983,7 @@ pub enum ContentModifier {
     Spoiler,
 }
 
+#[bool_to_bitflags::bool_to_bitflags]
 /// Describes formatting on string content
 #[derive(Clone, Debug, Default)]
 pub struct Content {
@@ -1049,22 +1050,22 @@ impl Content {
     pub fn apply(&mut self, modifier: &ContentModifier) {
         match *modifier {
             ContentModifier::Italic => {
-                self.italic = true;
+                self.set_italic(true);
             },
             ContentModifier::Bold => {
-                self.bold = true;
+                self.set_bold(true);
             },
             ContentModifier::Strikethrough => {
-                self.strikethrough = true;
+                self.set_strikethrough(true);
             },
             ContentModifier::Code => {
-                self.code = true;
+                self.set_code(true);
             },
             ContentModifier::Underline => {
-                self.underline = true;
+                self.set_underline(true);
             },
             ContentModifier::Spoiler => {
-                self.spoiler = true;
+                self.set_spoiler(true);
             },
         }
     }
@@ -1072,53 +1073,53 @@ impl Content {
 
 impl std::fmt::Display for Content {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.spoiler {
+        if self.spoiler() {
             fmt.write_str("||")?;
         }
 
-        if self.bold {
+        if self.bold() {
             fmt.write_str("**")?;
         }
 
-        if self.italic {
+        if self.italic() {
             fmt.write_char('*')?;
         }
 
-        if self.strikethrough {
+        if self.strikethrough() {
             fmt.write_str("~~")?;
         }
 
-        if self.underline {
+        if self.underline() {
             fmt.write_str("__")?;
         }
 
-        if self.code {
+        if self.code() {
             fmt.write_char('`')?;
         }
 
         fmt.write_str(&self.inner)?;
 
-        if self.code {
+        if self.code() {
             fmt.write_char('`')?;
         }
 
-        if self.underline {
+        if self.underline() {
             fmt.write_str("__")?;
         }
 
-        if self.strikethrough {
+        if self.strikethrough() {
             fmt.write_str("~~")?;
         }
 
-        if self.italic {
+        if self.italic() {
             fmt.write_char('*')?;
         }
 
-        if self.bold {
+        if self.bold() {
             fmt.write_str("**")?;
         }
 
-        if self.spoiler {
+        if self.spoiler() {
             fmt.write_str("||")?;
         }
 
@@ -1195,18 +1196,18 @@ mod test {
 
     #[test]
     fn mentions() {
-        let content_emoji = MessageBuilder::new()
-            .emoji(&Emoji {
-                animated: false,
-                available: true,
-                id: EmojiId::new(32),
-                name: "Rohrkatze".to_string().into(),
-                managed: false,
-                require_colons: true,
-                roles: vec![].into(),
-                user: None,
-            })
-            .build();
+        let mut emoji = Emoji {
+            id: EmojiId::new(32),
+            name: "Rohrkatze".to_string().into(),
+            roles: vec![].into(),
+            user: None,
+            __generated_flags: EmojiGeneratedFlags::empty(),
+        };
+
+        emoji.set_available(true);
+        emoji.set_require_colons(true);
+
+        let content_emoji = MessageBuilder::new().emoji(&emoji).build();
         let content_mentions = MessageBuilder::new()
             .channel(ChannelId::new(1))
             .mention(&UserId::new(2))


### PR DESCRIPTION
Uses my bool_to_bitflags macro to remove boolean (and optional boolean) fields from structs and pack them into a bitflags invocation, so a struct with many bools will only use one or two bytes, instead of a byte per bool as is. This requires using getters and setters for the boolean fields, which changes user experience and is hard to document, which is a significant downside.

I'm torn on this change. It requires using getters and setters, but is such a nice change and will just become more and more efficient as time goes on. But currently isn't too worth it, just shaving a couple bytes off of a couple things, due to alignment requirements probably. https://www.diffchecker.com/4DRpTX1K/