### PR TITLE
Add unusual_dm_activity_until to Member and PartialMember

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -205,6 +205,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                 member.mute.clone_from(&self.mute);
                 member.avatar.clone_from(&self.avatar);
                 member.communication_disabled_until.clone_from(&self.communication_disabled_until);
+                member.unusual_dm_activity_until.clone_from(&self.unusual_dm_activity_until);
 
                 item
             } else {
@@ -226,6 +227,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     avatar: self.avatar,
                     communication_disabled_until: self.communication_disabled_until,
                     flags: GuildMemberFlags::default(),
+                    unusual_dm_activity_until: self.unusual_dm_activity_until,
                 });
             }
 
@@ -416,6 +418,7 @@ impl CacheUpdate for PresenceUpdateEvent {
                         avatar: None,
                         communication_disabled_until: None,
                         flags: GuildMemberFlags::default(),
+                        unusual_dm_activity_until: None,
                     });
                 }
             }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -266,6 +266,7 @@ pub struct GuildMemberUpdateEvent {
     pub mute: bool,
     pub avatar: Option<ImageHash>,
     pub communication_disabled_until: Option<Timestamp>,
+    pub unusual_dm_activity_until: Option<Timestamp>,
 }
 
 /// Requires no gateway intents.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -61,7 +61,7 @@ pub struct Member {
     /// The unique Id of the guild that the member is a part of.
     #[serde(default)]
     pub guild_id: GuildId,
-    /// If the member is current flagged for sending excessive DMs to non-friend server members
+    /// If the member is currently flagged for sending excessive DMs to non-friend server members
     /// in the last 24 hours.
     ///
     /// Will be None if the user is not currently flagged.
@@ -597,7 +597,7 @@ pub struct PartialMember {
     ///
     /// [`Interaction`]: crate::model::application::Interaction
     pub permissions: Option<Permissions>,
-    /// If the member is current flagged for sending excessive DMs to non-friend server members
+    /// If the member is currently flagged for sending excessive DMs to non-friend server members
     /// in the last 24 hours.
     ///
     /// Will be None if the user is not currently flagged.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -61,6 +61,11 @@ pub struct Member {
     /// The unique Id of the guild that the member is a part of.
     #[serde(default)]
     pub guild_id: GuildId,
+    /// If the member is current flagged for sending excessive DMs to non-friend server members
+    /// in the last 24 hours.
+    ///
+    /// Will be None if the user is not currently flagged.
+    pub unusual_dm_activity_until: Option<Timestamp>,
 }
 
 bitflags! {
@@ -592,6 +597,11 @@ pub struct PartialMember {
     ///
     /// [`Interaction`]: crate::model::application::Interaction
     pub permissions: Option<Permissions>,
+    /// If the member is current flagged for sending excessive DMs to non-friend server members
+    /// in the last 24 hours.
+    ///
+    /// Will be None if the user is not currently flagged.
+    pub unusual_dm_activity_until: Option<Timestamp>,
 }
 
 impl From<PartialMember> for Member {
@@ -610,6 +620,7 @@ impl From<PartialMember> for Member {
             permissions: partial.permissions,
             communication_disabled_until: None,
             guild_id: partial.guild_id.unwrap_or_default(),
+            unusual_dm_activity_until: partial.unusual_dm_activity_until,
         }
     }
 }
@@ -627,6 +638,7 @@ impl From<Member> for PartialMember {
             guild_id: Some(member.guild_id),
             user: Some(member.user),
             permissions: member.permissions,
+            unusual_dm_activity_until: member.unusual_dm_activity_until,
         }
     }
 }


### PR DESCRIPTION
I'm assuming this change doesn't count as a breaking change in any way that you consider so, but if it needs to be moved to next the base can be changed cleanly.

There is currently no docs for this feature so this is done from what I can test. I can show some sample member objects if that makes it easier to prove this is fine.

I'm not the most familiar with the serenity codebase so I hope I didn't miss anything immediately obvious.