### PR TITLE
Add UserPublicFlags::SPAMMER

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -349,6 +349,9 @@ bitflags! {
         const DISCORD_CERTIFIED_MODERATOR = 1 << 18;
         /// Bot's running with HTTP interactions
         const BOT_HTTP_INTERACTIONS = 1 << 19;
+        /// User's flag for suspected spam activity.
+        #[cfg(feature = "unstable_discord_api")]
+        const SPAMMER = 1 << 20;
         /// User's flag as active developer
         const ACTIVE_DEVELOPER = 1 << 22;
     }


### PR DESCRIPTION
For the most part this is stealing off discord.py.

https://github.com/Rapptz/discord.py/blob/078b500657c651f72a6ca78ada23332422e23adf/discord/enums.py#L492-L512

The only one I can actually verify what it means/its the right value is spammer, which i have tested and it lines up correctly. If you don't want potentially wrong flags, I can remove all but the spammer flag which I have personally tested.

I'm only actually bothered about the spammer flag anyway.

Wasn't sure how to match up with the current documentation, "flag as" instead of "flag for" in these cases looked a bit weird, so I'm open to suggestions there.

If this should be moved to `next` it should be a clean change without any additional messing around.