### PR TITLE
Remove unused warning allows

### DIFF
--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -33,7 +33,6 @@ macro_rules! event_handler {
 
         /// This enum stores every possible event that an [`EventHandler`] can receive.
         #[non_exhaustive]
-        #[allow(clippy::large_enum_variant)] // TODO: do some boxing to fix this
         #[derive(Clone, Debug)]
         pub enum FullEvent {
             $(

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -81,7 +81,6 @@ impl<'a> From<&'a str> for Delimiter {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(clippy::enum_variant_names)]
 enum TokenKind {
     Argument,
     QuotedArgument,

--- a/src/framework/standard/parse/mod.rs
+++ b/src/framework/standard/parse/mod.rs
@@ -172,7 +172,6 @@ async fn find_prefix<'a>(
 /// - Nothing
 ///
 /// In all cases, whitespace after the prefix is cleared.
-#[allow(clippy::needless_lifetimes)] // Clippy and the compiler disagree
 pub async fn prefix<'a>(
     ctx: &Context,
     msg: &Message,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -34,7 +34,6 @@ use crate::model::Timestamp;
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 #[non_exhaustive]
-#[allow(clippy::large_enum_variant)] // https://github.com/rust-lang/rust-clippy/issues/9798
 pub enum Channel {
     /// A channel within a [`Guild`].
     Guild(GuildChannel),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1115,7 +1115,6 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 /// Event received over a websocket connection
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#receive-events).
-#[allow(clippy::large_enum_variant)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -218,7 +218,6 @@ pub mod comma_separated_string {
         Ok(vec)
     }
 
-    #[allow(clippy::ptr_arg)]
     pub fn serialize<S: Serializer>(
         vec: &FixedArray<FixedString>,
         serializer: S,


### PR DESCRIPTION
Seems like a couple of clippy bugs have been fixed and I've shrunk model sizes enough to make `large_enum_variant` go away.