### PR TITLE
Apply repr(packed) to bitflags types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["examples/*"]
 
 [dependencies]
 # Required dependencies
-bitflags = "2.4.1"
+bitflags = "2.4.2"
 serde_json = "1.0.108"
 async-trait = "0.1.74"
 tracing = { version = "0.1.40", features = ["log"] }

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -145,6 +145,7 @@ macro_rules! bitflags {
         }
     ) => {
         $(#[$outer])*
+        #[repr(packed)]
         $vis struct $BitFlags($T);
 
         bitflags::bitflags! {

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -220,6 +220,7 @@ pub const PRESET_VOICE: Permissions = Permissions::from_bits_truncate(
 /// [`User`]: super::user::User
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
+#[repr(packed)]
 pub struct Permissions(u64);
 
 bitflags::bitflags! {


### PR DESCRIPTION
This most importantly affects `Permissions`, which shrinks `PermissionOverwrites`, which is the biggest contributor to memory usage on a lot of bots. It also affects a lot of other types though, and is the tipping point of a couple types no longer requiring 8 byte alignment! https://www.diffchecker.com/lojPd2ZK/