### PR TITLE
Fix weirdness with Id::default

### DIFF
--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -38,12 +38,7 @@ macro_rules! id_u64 {
 
             impl Default for $name {
                 fn default() -> Self {
-                    // Have the possible panic at compile time. `unwrap()` is not const-stable
-                    const ONE: NonZeroU64 = match NonZeroU64::new(1) {
-                        Some(x) => x,
-                        None => unreachable!(),
-                    };
-                    Self(ONE)
+                    Self(NonZeroU64::MIN)
                 }
             }
 


### PR DESCRIPTION
Just uses NonZeroU64::MIN instead of making a const then using it, which would never panic anyway so the comment is inaccurate (not possible).