### PR TITLE
Swap git deps for crates.io published versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ dep_time = { version = "0.3.30", package = "time", features = ["formatting", "pa
 base64 = { version = "0.21.5" }
 secrecy = { version = "0.8.0", features = ["serde"] }
 arrayvec = { version = "0.7.4", features = ["serde"] }
-small-fixed-array = { git = "https://github.com/GnomedDev/small-fixed-array", features = ["serde", "log_using_tracing"] }
-bool_to_bitflags = { git = "https://github.com/GnomedDev/bool-to-bitflags", version = "0.1.0" }
+small-fixed-array = { version = "0.1.1", features = ["serde", "log_using_tracing"] }
+bool_to_bitflags = { version = "0.1.0" }
 nonmax = { version = "0.5.5", features = ["serde"] }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }


### PR DESCRIPTION
I've pushed these crates to crates.io now, so serenity doesn't need to git dep anymore.