### PR TITLE
Swap Id from NonZero to NonMax

### DIFF
--- a/src/builder/create_command_permission.rs
+++ b/src/builder/create_command_permission.rs
@@ -101,7 +101,7 @@ impl CreateCommandPermission {
     /// Creates a permission overwrite for all channels in a guild
     pub fn all_channels(guild_id: GuildId, allow: bool) -> Self {
         Self(CommandPermission {
-            id: std::num::NonZeroU64::new(guild_id.get() - 1).expect("guild ID was 1").into(),
+            id: CommandPermissionId::new(guild_id.get() - 1),
             kind: CommandPermissionType::Channel,
             permission: allow,
         })

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1,11 +1,10 @@
 use std::borrow::Cow;
-use std::num::NonZeroU64;
 
 use crate::model::id::*;
 
 /// Used to group requests together for ratelimiting.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct RatelimitingBucket(Option<(RouteKind, Option<NonZeroU64>)>);
+pub struct RatelimitingBucket(Option<(RouteKind, Option<GenericId>)>);
 
 impl RatelimitingBucket {
     #[must_use]
@@ -17,7 +16,7 @@ impl RatelimitingBucket {
 enum RatelimitingKind {
     /// Requests with the same path and major parameter (usually an Id) should be grouped together
     /// for ratelimiting.
-    PathAndId(NonZeroU64),
+    PathAndId(GenericId),
     /// Requests with the same path should be ratelimited together.
     Path,
 }
@@ -92,103 +91,103 @@ macro_rules! routes {
 routes! ('a, {
     Channel { channel_id: ChannelId },
     api!("/channels/{}", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelInvites { channel_id: ChannelId },
     api!("/channels/{}/invites", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessage { channel_id: ChannelId, message_id: MessageId },
     api!("/channels/{}/messages/{}", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessageCrosspost { channel_id: ChannelId, message_id: MessageId },
     api!("/channels/{}/messages/{}/crosspost", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessageReaction { channel_id: ChannelId, message_id: MessageId, user_id: UserId, reaction: &'a str },
     api!("/channels/{}/messages/{}/reactions/{}/{}", channel_id, message_id, reaction, user_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessageReactionMe { channel_id: ChannelId, message_id: MessageId, reaction: &'a str },
     api!("/channels/{}/messages/{}/reactions/{}/@me", channel_id, message_id, reaction),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessageReactionEmoji { channel_id: ChannelId, message_id: MessageId, reaction: &'a str },
     api!("/channels/{}/messages/{}/reactions/{}", channel_id, message_id, reaction),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessageReactions { channel_id: ChannelId, message_id: MessageId },
     api!("/channels/{}/messages/{}/reactions", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessages { channel_id: ChannelId },
     api!("/channels/{}/messages", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessagesBulkDelete { channel_id: ChannelId },
     api!("/channels/{}/messages/bulk-delete", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelFollowNews { channel_id: ChannelId },
     api!("/channels/{}/followers", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelPermission { channel_id: ChannelId, target_id: TargetId },
     api!("/channels/{}/permissions/{}", channel_id, target_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelPin { channel_id: ChannelId, message_id: MessageId },
     api!("/channels/{}/pins/{}", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelPins { channel_id: ChannelId },
     api!("/channels/{}/pins", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelTyping { channel_id: ChannelId },
     api!("/channels/{}/typing", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelWebhooks { channel_id: ChannelId },
     api!("/channels/{}/webhooks", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelMessageThreads { channel_id: ChannelId, message_id: MessageId },
     api!("/channels/{}/messages/{}/threads", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelThreads { channel_id: ChannelId },
     api!("/channels/{}/threads", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelForumPosts { channel_id: ChannelId },
     api!("/channels/{}/threads", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelThreadMember { channel_id: ChannelId, user_id: UserId },
     api!("/channels/{}/thread-members/{}", channel_id, user_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelThreadMemberMe { channel_id: ChannelId },
     api!("/channels/{}/thread-members/@me", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelThreadMembers { channel_id: ChannelId },
     api!("/channels/{}/thread-members", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelArchivedPublicThreads { channel_id: ChannelId },
     api!("/channels/{}/threads/archived/public", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelArchivedPrivateThreads { channel_id: ChannelId },
     api!("/channels/{}/threads/archived/private", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelJoinedPrivateThreads { channel_id: ChannelId },
     api!("/channels/{}/users/@me/threads/archived/private", channel_id),
-    Some(RatelimitingKind::PathAndId(channel_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     Gateway,
     api!("/gateway"),
@@ -200,147 +199,147 @@ routes! ('a, {
 
     Guild { guild_id: GuildId },
     api!("/guilds/{}", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildAuditLogs { guild_id: GuildId },
     api!("/guilds/{}/audit-logs", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildAutomodRule { guild_id: GuildId, rule_id: RuleId },
     api!("/guilds/{}/auto-moderation/rules/{}", guild_id, rule_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildAutomodRules { guild_id: GuildId },
     api!("/guilds/{}/auto-moderation/rules", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildBan { guild_id: GuildId, user_id: UserId },
     api!("/guilds/{}/bans/{}", guild_id, user_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildBans { guild_id: GuildId },
     api!("/guilds/{}/bans", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildChannels { guild_id: GuildId },
     api!("/guilds/{}/channels", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildWidget { guild_id: GuildId },
     api!("/guilds/{}/widget", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildPreview { guild_id: GuildId },
     api!("/guilds/{}/preview", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildEmojis { guild_id: GuildId },
     api!("/guilds/{}/emojis", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildEmoji { guild_id: GuildId, emoji_id: EmojiId },
     api!("/guilds/{}/emojis/{}", guild_id, emoji_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildIntegration { guild_id: GuildId, integration_id: IntegrationId },
     api!("/guilds/{}/integrations/{}", guild_id, integration_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildIntegrationSync { guild_id: GuildId, integration_id: IntegrationId },
     api!("/guilds/{}/integrations/{}/sync", guild_id, integration_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildIntegrations { guild_id: GuildId },
     api!("/guilds/{}/integrations", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildInvites { guild_id: GuildId },
     api!("/guilds/{}/invites", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildMember { guild_id: GuildId, user_id: UserId },
     api!("/guilds/{}/members/{}", guild_id, user_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildMemberRole { guild_id: GuildId, user_id: UserId, role_id: RoleId },
     api!("/guilds/{}/members/{}/roles/{}", guild_id, user_id, role_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildMembers { guild_id: GuildId },
     api!("/guilds/{}/members", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildMembersSearch { guild_id: GuildId },
     api!("/guilds/{}/members/search", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildMemberMe { guild_id: GuildId },
     api!("/guilds/{}/members/@me", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildMfa { guild_id: GuildId },
     api!("/guilds/{}/mfa", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildPrune { guild_id: GuildId },
     api!("/guilds/{}/prune", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildRegions { guild_id: GuildId },
     api!("/guilds/{}/regions", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildRole { guild_id: GuildId, role_id: RoleId },
     api!("/guilds/{}/roles/{}", guild_id, role_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildRoles { guild_id: GuildId },
     api!("/guilds/{}/roles", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildScheduledEvent { guild_id: GuildId, event_id: ScheduledEventId },
     api!("/guilds/{}/scheduled-events/{}", guild_id, event_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildScheduledEvents { guild_id: GuildId },
     api!("/guilds/{}/scheduled-events", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildScheduledEventUsers { guild_id: GuildId, event_id: ScheduledEventId },
     api!("/guilds/{}/scheduled-events/{}/users", guild_id, event_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildSticker { guild_id: GuildId, sticker_id: StickerId },
     api!("/guilds/{}/stickers/{}", guild_id, sticker_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildStickers { guild_id: GuildId },
     api!("/guilds/{}/stickers", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildVanityUrl { guild_id: GuildId },
     api!("/guilds/{}/vanity-url", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildVoiceStates { guild_id: GuildId, user_id: UserId },
     api!("/guilds/{}/voice-states/{}", guild_id, user_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildVoiceStateMe { guild_id: GuildId },
     api!("/guilds/{}/voice-states/@me", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildWebhooks { guild_id: GuildId },
     api!("/guilds/{}/webhooks", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildWelcomeScreen { guild_id: GuildId },
     api!("/guilds/{}/welcome-screen", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     GuildThreadsActive { guild_id: GuildId },
     api!("/guilds/{}/threads/active", guild_id),
-    Some(RatelimitingKind::PathAndId(guild_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
     Guilds,
     api!("/guilds"),
@@ -408,67 +407,67 @@ routes! ('a, {
 
     Webhook { webhook_id: WebhookId },
     api!("/webhooks/{}", webhook_id),
-    Some(RatelimitingKind::PathAndId(webhook_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(webhook_id.get())));
 
     WebhookWithToken { webhook_id: WebhookId, token: &'a str },
     api!("/webhooks/{}/{}", webhook_id, token),
-    Some(RatelimitingKind::PathAndId(webhook_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(webhook_id.get())));
 
     WebhookMessage { webhook_id: WebhookId, token: &'a str, message_id: MessageId },
     api!("/webhooks/{}/{}/messages/{}", webhook_id, token, message_id),
-    Some(RatelimitingKind::PathAndId(webhook_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(webhook_id.get())));
 
     WebhookOriginalInteractionResponse { application_id: ApplicationId, token: &'a str },
     api!("/webhooks/{}/{}/messages/@original", application_id, token),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     WebhookFollowupMessage { application_id: ApplicationId, token: &'a str, message_id: MessageId },
     api!("/webhooks/{}/{}/messages/{}", application_id, token, message_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     WebhookFollowupMessages { application_id: ApplicationId, token: &'a str },
     api!("/webhooks/{}/{}", application_id, token),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     InteractionResponse { interaction_id: InteractionId, token: &'a str },
     api!("/interactions/{}/{}/callback", interaction_id, token),
-    Some(RatelimitingKind::PathAndId(interaction_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(interaction_id.get())));
 
     Command { application_id: ApplicationId, command_id: CommandId },
     api!("/applications/{}/commands/{}", application_id, command_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     Commands { application_id: ApplicationId },
     api!("/applications/{}/commands", application_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     GuildCommand { application_id: ApplicationId, guild_id: GuildId, command_id: CommandId },
     api!("/applications/{}/guilds/{}/commands/{}", application_id, guild_id, command_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     GuildCommandPermissions { application_id: ApplicationId, guild_id: GuildId, command_id: CommandId },
     api!("/applications/{}/guilds/{}/commands/{}/permissions", application_id, guild_id, command_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     GuildCommands { application_id: ApplicationId, guild_id: GuildId },
     api!("/applications/{}/guilds/{}/commands", application_id, guild_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     GuildCommandsPermissions { application_id: ApplicationId, guild_id: GuildId },
     api!("/applications/{}/guilds/{}/commands/permissions", application_id, guild_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     Skus { application_id: ApplicationId },
     api!("/applications/{}/skus", application_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     Entitlement { application_id: ApplicationId, entitlement_id: EntitlementId },
     api!("/applications/{}/entitlements/{}", application_id, entitlement_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     Entitlements { application_id: ApplicationId },
     api!("/applications/{}/entitlements", application_id),
-    Some(RatelimitingKind::PathAndId(application_id.into()));
+    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
 
     StageInstances,
     api!("/stage-instances"),

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -1,9 +1,20 @@
 //! A collection of newtypes defining type-strong IDs.
 
 use std::fmt;
-use std::num::{NonZeroI64, NonZeroU64};
+
+use nonmax::NonMaxU64;
 
 use super::Timestamp;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParseIdError(nonmax::ParseIntError);
+
+impl std::error::Error for ParseIdError {}
+impl std::fmt::Display for ParseIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 macro_rules! id_u64 {
     ($($name:ident;)*) => {
@@ -11,14 +22,14 @@ macro_rules! id_u64 {
             impl $name {
                 #[doc = concat!("Creates a new ", stringify!($name), " from a u64.")]
                 /// # Panics
-                /// Panics if `id` is zero.
+                /// Panics if `id` is u64::MAX.
                 #[inline]
                 #[must_use]
                 #[track_caller]
                 pub const fn new(id: u64) -> Self {
-                    match NonZeroU64::new(id) {
+                    match NonMaxU64::new(id) {
                         Some(inner) => Self(inner),
-                        None => panic!(concat!("Attempted to call ", stringify!($name), "::new with invalid (0) value"))
+                        None => panic!(concat!("Attempted to call ", stringify!($name), "::new with invalid (u64::MAX) value"))
                     }
                 }
 
@@ -26,19 +37,16 @@ macro_rules! id_u64 {
                 #[inline]
                 #[must_use]
                 pub const fn get(self) -> u64 {
-                    self.0.get()
+                    // By wrapping `self.0` in a block, it forces a Copy, as NonMax::get takes &self.
+                    // If removed, the compiler will auto-ref to `&self.0`, which is a
+                    // reference to a packed field and therefore errors.
+                    {self.0}.get()
                 }
 
                 #[doc = concat!("Retrieves the time that the ", stringify!($name), " was created.")]
                 #[must_use]
                 pub fn created_at(&self) -> Timestamp {
                     Timestamp::from_discord_id(self.get())
-                }
-            }
-
-            impl Default for $name {
-                fn default() -> Self {
-                    Self(NonZeroU64::MIN)
                 }
             }
 
@@ -63,12 +71,6 @@ macro_rules! id_u64 {
                 }
             }
 
-            impl From<NonZeroU64> for $name {
-                fn from(id: NonZeroU64) -> $name {
-                    $name(id)
-                }
-            }
-
             impl PartialEq<u64> for $name {
                 fn eq(&self, u: &u64) -> bool {
                     self.get() == *u
@@ -77,20 +79,8 @@ macro_rules! id_u64 {
 
             impl fmt::Display for $name {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    let inner = self.0;
-                    fmt::Display::fmt(&inner, f)
-                }
-            }
-
-            impl From<$name> for NonZeroU64 {
-                fn from(id: $name) -> NonZeroU64 {
-                    id.0
-                }
-            }
-
-            impl From<$name> for NonZeroI64 {
-                fn from(id: $name) -> NonZeroI64 {
-                    NonZeroI64::new(id.get() as i64).unwrap()
+                    // See comment in Self::get for block.
+                    fmt::Display::fmt(&{self.0}, f)
                 }
             }
 
@@ -107,10 +97,10 @@ macro_rules! id_u64 {
             }
 
             impl std::str::FromStr for $name {
-                type Err = <u64 as std::str::FromStr>::Err;
+                type Err = ParseIdError;
 
                 fn from_str(s: &str) -> Result<Self, Self::Err> {
-                    Ok(Self(s.parse()?))
+                    s.parse().map(Self).map_err(ParseIdError)
                 }
             }
 
@@ -122,135 +112,181 @@ macro_rules! id_u64 {
 
 /// An identifier for an Application.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct ApplicationId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct ApplicationId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a Channel
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct ChannelId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct ChannelId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for an Emoji
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct EmojiId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct EmojiId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for an unspecific entity.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
 // TODO: replace occurences of `#[serde(with = "snowflake")] u64` in the codebase with GenericId
-pub struct GenericId(#[serde(with = "snowflake")] NonZeroU64);
+pub struct GenericId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a Guild
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct GuildId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct GuildId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for an Integration
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct IntegrationId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct IntegrationId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a Message
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct MessageId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct MessageId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a Role
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct RoleId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct RoleId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for an auto moderation rule
 #[repr(packed)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct RuleId(#[serde(with = "snowflake")] NonZeroU64);
+pub struct RuleId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a Scheduled Event
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct ScheduledEventId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct ScheduledEventId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a User
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct UserId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct UserId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a [`Webhook`][super::webhook::Webhook]
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct WebhookId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct WebhookId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for an audit log entry.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct AuditLogEntryId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct AuditLogEntryId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for an attachment.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct AttachmentId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct AttachmentId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a sticker.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct StickerId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct StickerId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a sticker pack.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct StickerPackId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct StickerPackId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a sticker pack banner.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct StickerPackBannerId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct StickerPackBannerId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a SKU.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct SkuId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct SkuId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for an interaction.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct InteractionId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct InteractionId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a slash command.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct CommandId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct CommandId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a slash command permission Id. Can contain
 /// a [`RoleId`] or [`UserId`].
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct CommandPermissionId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct CommandPermissionId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a slash command version Id.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct CommandVersionId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct CommandVersionId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a slash command target Id. Can contain
 /// a [`UserId`] or [`MessageId`].
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct TargetId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct TargetId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a stage channel instance.
 #[repr(packed)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct StageInstanceId(#[serde(with = "snowflake")] NonZeroU64);
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct StageInstanceId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for a forum tag.
 #[repr(packed)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct ForumTagId(#[serde(with = "snowflake")] NonZeroU64);
+pub struct ForumTagId(#[serde(with = "snowflake")] NonMaxU64);
 
 /// An identifier for an entitlement.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct EntitlementId(#[serde(with = "snowflake")] pub NonZeroU64);
+pub struct EntitlementId(#[serde(with = "snowflake")] pub NonMaxU64);
 
 id_u64! {
     AttachmentId;
@@ -286,7 +322,7 @@ id_u64! {
 /// This identifier is special, it simply models internal IDs for type safety,
 /// and therefore cannot be [`Serialize`]d or [`Deserialize`]d.
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct ShardId(pub u16);
 
 impl fmt::Display for ShardId {
@@ -321,27 +357,27 @@ impl fmt::Display for ShardId {
 pub(crate) mod snowflake {
     use std::convert::TryFrom;
     use std::fmt;
-    use std::num::NonZeroU64;
 
+    use nonmax::NonMaxU64;
     use serde::de::{Error, Visitor};
     use serde::{Deserializer, Serializer};
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<NonZeroU64, D::Error> {
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<NonMaxU64, D::Error> {
         deserializer.deserialize_any(SnowflakeVisitor)
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn serialize<S: Serializer>(id: &NonZeroU64, serializer: S) -> Result<S::Ok, S::Error> {
+    pub fn serialize<S: Serializer>(id: &NonMaxU64, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.collect_str(&id.get())
     }
 
     struct SnowflakeVisitor;
 
     impl<'de> Visitor<'de> for SnowflakeVisitor {
-        type Value = NonZeroU64;
+        type Value = NonMaxU64;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("a non-zero string or integer snowflake")
+            formatter.write_str("a string or integer snowflake that is not u64::MAX")
         }
 
         // Called by formats like TOML.
@@ -350,7 +386,7 @@ pub(crate) mod snowflake {
         }
 
         fn visit_u64<E: Error>(self, value: u64) -> Result<Self::Value, E> {
-            NonZeroU64::new(value).ok_or_else(|| Error::custom("invalid value, expected non-zero"))
+            NonMaxU64::new(value).ok_or_else(|| Error::custom("invalid value, expected non-max"))
         }
 
         fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
@@ -361,7 +397,7 @@ pub(crate) mod snowflake {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
+    use nonmax::NonMaxU64;
 
     use super::GuildId;
 
@@ -383,7 +419,7 @@ mod tests {
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
         struct S {
             #[serde(with = "snowflake")]
-            id: NonZeroU64,
+            id: NonMaxU64,
         }
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -395,7 +431,7 @@ mod tests {
         assert_json(&id, json!("175928847299117063"));
 
         let s = S {
-            id: NonZeroU64::new(17_5928_8472_9911_7063).unwrap(),
+            id: NonMaxU64::new(17_5928_8472_9911_7063).unwrap(),
         };
         assert_json(&s, json!({"id": "175928847299117063"}));
 

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -206,8 +206,8 @@ mod test {
         #[cfg(feature = "model")]
         assert_eq!(channel.mention().to_string(), "<#4>");
         assert_eq!(member.mention().to_string(), "<@6>");
-        assert_eq!(role.mention().to_string(), "<@&1>");
-        assert_eq!(role.id.mention().to_string(), "<@&1>");
+        assert_eq!(role.mention().to_string(), "<@&0>");
+        assert_eq!(role.id.mention().to_string(), "<@&0>");
         assert_eq!(user.mention().to_string(), "<@6>");
         assert_eq!(user.id.mention().to_string(), "<@6>");
     }

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -254,7 +254,7 @@ mod tests {
         <@!i)/==(<<>z/9080)> <@!1231invalid> <@invalid123> \
         <@123invalid> <@> <@ ";
 
-        let without_user_mentions = "@Ferris <@!000000000000000000> @invalid-user @invalid-user \
+        let without_user_mentions = "@Ferris @invalid-user @invalid-user @invalid-user \
         <@!123123123123123123123> @invalid-user @invalid-user <@!invalid> \
         <@invalid> <@日本語 한국어$§)[/__#\\(/&2032$§#> \
         <@!i)/==(<<>z/9080)> <@!1231invalid> <@invalid123> \


### PR DESCRIPTION
Discord seems to internally default Ids to 0, which is a bug whenever exposed, but this makes ID parsing more resilient. I also took the liberty to remove the NonZero From implementations, to prevent future headaches, as it was impossible to not break public API as we exposed NonZero in Id::parse.