### PR TITLE
Add temporary non-breaking workaround for Id deserialization issues

### DIFF
--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -36,6 +36,7 @@ pub struct BotGateway {
 #[non_exhaustive]
 pub struct Activity {
     /// The ID of the application for the activity.
+    #[serde(deserialize_with = "deserialize_buggy_id")]
     pub application_id: Option<ApplicationId>,
     /// Images for the presence and their texts.
     pub assets: Option<ActivityAssets>,


### PR DESCRIPTION
Non-breaking counterpart to #2689. This deserialize helper should be applied to all fields which have been seen to have this behavior.