### PR TITLE
Fix CreateQuickModal timeout is not affected issue

### DIFF
--- a/src/utils/quick_modal.rs
+++ b/src/utils/quick_modal.rs
@@ -104,10 +104,15 @@ impl CreateQuickModal {
         );
         builder.execute(ctx, (interaction_id, token)).await?;
 
-        let modal_interaction = ModalInteractionCollector::new(&ctx.shard)
-            .custom_ids(vec![modal_custom_id])
-            .next()
-            .await;
+        let collector =
+            ModalInteractionCollector::new(&ctx.shard).custom_ids(vec![modal_custom_id]);
+
+        let collector = match self.timeout {
+            Some(timeout) => collector.timeout(timeout),
+            None => collector,
+        };
+
+        let modal_interaction = collector.next().await;
 
         let Some(modal_interaction) = modal_interaction else { return Ok(None) };
 


### PR DESCRIPTION
I face a problem a timeout value in CreateQuickModal is not used in any codes.

## Expected behaviour
The timeout value is passed to ModalInteractionCollector, and it works.

## Actual behaviour
The timeout value is not passed to ModalInteractionCollector, and it does not work.

## Reproducing

// I think this code is not minimized, but I don't how to do it. Sorry.

```rust
use std::env;
use std::time::Duration;

use serenity::all::InputTextStyle;
use serenity::async_trait;
use serenity::builder::{
    CreateActionRow, CreateButton, CreateCommand, CreateInputText, CreateInteractionResponse,
    CreateInteractionResponseMessage,
};
use serenity::model::{application::Interaction, gateway::Ready, id::GuildId};
use serenity::prelude::*;
use serenity::utils::CreateQuickModal;

struct Handler;

#[async_trait]
impl EventHandler for Handler {
    async fn ready(&self, ctx: Context, _ready: Ready) {
        let guild_id = GuildId::new(
            env::var("GUILD_ID")
                .expect("Expected GUILD_ID in environment")
                .parse()
                .expect("GUILD_ID must be an integer"),
        );

        guild_id
            .set_commands(
                &ctx.http,
                vec![CreateCommand::new("test").description("Test command")],
            )
            .await
            .unwrap();
    }

    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
        match interaction {
            Interaction::Command(command) => {
                command
                    .create_response(
                        &ctx.http,
                        CreateInteractionResponse::Message(
                            CreateInteractionResponseMessage::new().components(vec![
                                CreateActionRow::Buttons(vec![
                                    CreateButton::new("trigger").label("Trigger")
                                ]),
                            ]),
                        ),
                    )
                    .await
                    .unwrap();
            }
            Interaction::Component(v) => {
                println!("Wait for response...");

                let v = v
                    .quick_modal(
                        &ctx,
                        CreateQuickModal::new("The modal")
                            .timeout(Duration::from_secs(5))
                            .field(CreateInputText::new(
                                InputTextStyle::Short,
                                "INPUT",
                                "input",
                            )),
                    )
                    .await
                    .unwrap()
                    .expect("timeout?"); // I expected this expect to be triggered after 5s but not.

                v.interaction
                    .create_response(&ctx.http, CreateInteractionResponse::Acknowledge)
                    .await
                    .unwrap();

                println!("IT IS A RESPONSE XD: {}", v.inputs[0]);
            }
            _ => {}
        }
    }
}

#[tokio::main]
async fn main() {
    let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");

    let mut client = Client::builder(token, GatewayIntents::empty())
        .event_handler(Handler)
        .await
        .expect("Error creating client");

    if let Err(why) = client.start().await {
        println!("Client error: {why:?}");
    }
}

```
