### PR TITLE
Store Request::params as a slice, instead of owning ArrayVec

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -240,7 +240,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -273,7 +273,7 @@ impl Http {
                 role_id,
                 user_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -303,7 +303,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: [("delete_message_days", delete_message_days.to_string())].into(),
+            params: &[("delete_message_days", delete_message_days.to_string())],
         })
         .await
     }
@@ -324,7 +324,7 @@ impl Http {
             route: Route::ChannelTyping {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -353,7 +353,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -370,7 +370,7 @@ impl Http {
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
             route: Route::StageInstances,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -394,7 +394,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -416,7 +416,7 @@ impl Http {
             route: Route::ChannelThreads {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -438,7 +438,7 @@ impl Http {
             route: Route::ChannelForumPosts {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -464,7 +464,7 @@ impl Http {
             route: Route::GuildEmojis {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -487,7 +487,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: [].into(),
+            params: &[],
         };
 
         if files.is_empty() {
@@ -522,7 +522,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -540,7 +540,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -560,7 +560,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -605,7 +605,7 @@ impl Http {
             headers: None,
             method: LightMethod::Post,
             route: Route::Guilds,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -631,7 +631,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -660,7 +660,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -687,7 +687,7 @@ impl Http {
                 interaction_id,
                 token: interaction_token,
             },
-            params: [].into(),
+            params: &[],
         };
 
         if files.is_empty() {
@@ -729,7 +729,7 @@ impl Http {
             route: Route::ChannelInvites {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -753,7 +753,7 @@ impl Http {
                 channel_id,
                 target_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -768,7 +768,7 @@ impl Http {
             headers: None,
             method: LightMethod::Post,
             route: Route::UserMeDmChannels,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -790,7 +790,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -811,7 +811,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -844,7 +844,7 @@ impl Http {
             route: Route::GuildScheduledEvents {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -873,7 +873,7 @@ impl Http {
             route: Route::GuildStickers {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -903,7 +903,7 @@ impl Http {
             route: Route::Entitlements {
                 application_id: self.try_application_id()?,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -950,7 +950,7 @@ impl Http {
             route: Route::ChannelWebhooks {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -969,7 +969,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -988,7 +988,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1011,7 +1011,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1032,7 +1032,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1048,7 +1048,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1063,7 +1063,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1084,7 +1084,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1105,7 +1105,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1124,7 +1124,7 @@ impl Http {
             route: Route::Invite {
                 code,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1145,7 +1145,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1165,7 +1165,7 @@ impl Http {
             route: Route::ChannelMessagesBulkDelete {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1202,7 +1202,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1224,7 +1224,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1243,7 +1243,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1264,7 +1264,7 @@ impl Http {
                 channel_id,
                 target_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1288,7 +1288,7 @@ impl Http {
                 user_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1310,7 +1310,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1331,7 +1331,7 @@ impl Http {
                 guild_id,
                 role_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1356,7 +1356,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1379,7 +1379,7 @@ impl Http {
                 guild_id,
                 sticker_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1396,7 +1396,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 entitlement_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1433,7 +1433,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1474,7 +1474,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1496,7 +1496,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1516,7 +1516,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1542,7 +1542,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1569,7 +1569,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         };
 
         if new_attachments.is_empty() {
@@ -1605,7 +1605,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1631,7 +1631,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1653,7 +1653,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1681,7 +1681,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1709,7 +1709,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1730,7 +1730,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1757,7 +1757,7 @@ impl Http {
             route: Route::GuildMfa {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
         .map(|mfa: GuildMfaLevel| mfa.level)
@@ -1780,7 +1780,7 @@ impl Http {
             route: Route::GuildWidget {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1802,7 +1802,7 @@ impl Http {
             route: Route::GuildWelcomeScreen {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1827,7 +1827,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -1857,7 +1857,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         };
 
         if new_attachments.is_empty() {
@@ -1890,7 +1890,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1912,7 +1912,7 @@ impl Http {
             route: Route::GuildMemberMe {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1937,7 +1937,7 @@ impl Http {
             route: Route::GuildMemberMe {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1959,7 +1959,7 @@ impl Http {
             route: Route::ChannelFollowNews {
                 channel_id: news_channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -1978,7 +1978,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2003,7 +2003,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: [].into(),
+            params: &[],
         };
 
         if new_attachments.is_empty() {
@@ -2029,7 +2029,7 @@ impl Http {
             headers: None,
             method: LightMethod::Patch,
             route: Route::UserMe,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2052,7 +2052,7 @@ impl Http {
                     guild_id,
                     role_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -2086,7 +2086,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -2123,7 +2123,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2150,7 +2150,7 @@ impl Http {
                     guild_id,
                     sticker_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -2176,7 +2176,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2226,7 +2226,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2277,7 +2277,7 @@ impl Http {
             route: Route::GuildVoiceStateMe {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2328,7 +2328,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2376,7 +2376,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2456,7 +2456,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params,
+            params: &params,
         };
 
         if files.is_empty() {
@@ -2501,7 +2501,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -2531,7 +2531,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params,
+            params: &params,
         };
 
         if new_attachments.is_empty() {
@@ -2570,7 +2570,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -2592,7 +2592,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusMaintenancesActive,
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -2636,7 +2636,7 @@ impl Http {
             route: Route::GuildBans {
                 guild_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -2672,7 +2672,7 @@ impl Http {
             route: Route::GuildAuditLogs {
                 guild_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -2689,7 +2689,7 @@ impl Http {
             route: Route::GuildAutomodRules {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2707,7 +2707,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2731,7 +2731,7 @@ impl Http {
             route: Route::GuildAutomodRules {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2757,7 +2757,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2780,7 +2780,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2793,7 +2793,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::GatewayBot,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2808,7 +2808,7 @@ impl Http {
             route: Route::ChannelInvites {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2826,7 +2826,7 @@ impl Http {
             route: Route::ChannelThreadMembers {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2841,7 +2841,7 @@ impl Http {
             route: Route::GuildThreadsActive {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2869,7 +2869,7 @@ impl Http {
             route: Route::ChannelArchivedPublicThreads {
                 channel_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -2897,7 +2897,7 @@ impl Http {
             route: Route::ChannelArchivedPrivateThreads {
                 channel_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -2925,7 +2925,7 @@ impl Http {
             route: Route::ChannelJoinedPrivateThreads {
                 channel_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -2940,7 +2940,7 @@ impl Http {
             route: Route::ChannelThreadMemberMe {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2955,7 +2955,7 @@ impl Http {
             route: Route::ChannelThreadMemberMe {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2975,7 +2975,7 @@ impl Http {
                 channel_id,
                 user_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -2995,7 +2995,7 @@ impl Http {
                 channel_id,
                 user_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3029,7 +3029,7 @@ impl Http {
             route: Route::ChannelWebhooks {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3044,7 +3044,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3059,7 +3059,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3074,7 +3074,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3089,7 +3089,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::Oauth2ApplicationCurrent,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3102,7 +3102,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMe,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3117,7 +3117,7 @@ impl Http {
             route: Route::GuildEmojis {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3133,7 +3133,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3185,7 +3185,7 @@ impl Http {
             route: Route::Entitlements {
                 application_id: self.try_application_id()?,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -3198,7 +3198,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::Gateway,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3213,7 +3213,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3228,7 +3228,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: [("with_localizations", String::from("true"))].into(),
+            params: &[("with_localizations", String::from("true"))],
         })
         .await
     }
@@ -3244,7 +3244,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3259,7 +3259,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3274,7 +3274,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: [("with_counts", String::from("true"))].into(),
+            params: &[("with_counts", String::from("true"))],
         })
         .await
     }
@@ -3290,7 +3290,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3310,7 +3310,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: [("with_localizations", String::from("true"))].into(),
+            params: &[("with_localizations", String::from("true"))],
         })
         .await
     }
@@ -3331,7 +3331,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3350,7 +3350,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3371,7 +3371,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3388,7 +3388,7 @@ impl Http {
             route: Route::GuildWidget {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3403,7 +3403,7 @@ impl Http {
             route: Route::GuildPreview {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3418,7 +3418,7 @@ impl Http {
             route: Route::GuildWelcomeScreen {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3433,7 +3433,7 @@ impl Http {
             route: Route::GuildIntegrations {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3448,7 +3448,7 @@ impl Http {
             route: Route::GuildInvites {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3468,7 +3468,7 @@ impl Http {
             route: Route::GuildVanityUrl {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
         .map(|x: GuildVanityUrl| x.code)
@@ -3503,7 +3503,7 @@ impl Http {
                 route: Route::GuildMembers {
                     guild_id,
                 },
-                params,
+                params: &params,
             })
             .await?;
 
@@ -3528,7 +3528,7 @@ impl Http {
             route: Route::GuildPrune {
                 guild_id,
             },
-            params: [("days", days.to_string())].into(),
+            params: &[("days", days.to_string())],
         })
         .await
     }
@@ -3544,7 +3544,7 @@ impl Http {
             route: Route::GuildRegions {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3560,7 +3560,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -3595,7 +3595,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: [("with_user_count", with_user_count.to_string())].into(),
+            params: &[("with_user_count", with_user_count.to_string())],
         })
         .await
     }
@@ -3618,7 +3618,7 @@ impl Http {
             route: Route::GuildScheduledEvents {
                 guild_id,
             },
-            params: [("with_user_count", with_user_count.to_string())].into(),
+            params: &[("with_user_count", with_user_count.to_string())],
         })
         .await
     }
@@ -3670,7 +3670,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -3686,7 +3686,7 @@ impl Http {
                 route: Route::GuildStickers {
                     guild_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -3717,7 +3717,7 @@ impl Http {
                     guild_id,
                     sticker_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -3757,7 +3757,7 @@ impl Http {
             route: Route::GuildWebhooks {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3810,7 +3810,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeGuilds,
-            params,
+            params: &params,
         })
         .await
     }
@@ -3854,7 +3854,7 @@ impl Http {
                 route: Route::UserMeGuildMember {
                     guild_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -3901,7 +3901,7 @@ impl Http {
             route: Route::Invite {
                 code,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -3918,7 +3918,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -3944,7 +3944,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -3976,7 +3976,7 @@ impl Http {
             route: Route::ChannelMessages {
                 channel_id,
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -3994,7 +3994,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::StickerPacks,
-            params: [].into(),
+            params: &[],
         })
         .await
         .map(|s: StickerPacks| s.sticker_packs)
@@ -4010,7 +4010,7 @@ impl Http {
             route: Route::ChannelPins {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4039,7 +4039,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params,
+            params: &params,
         })
         .await
     }
@@ -4054,7 +4054,7 @@ impl Http {
             route: Route::Skus {
                 application_id: self.try_application_id()?,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4069,7 +4069,7 @@ impl Http {
             route: Route::Sticker {
                 sticker_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4091,7 +4091,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusIncidentsUnresolved,
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -4115,7 +4115,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusMaintenancesUpcoming,
-                params: [].into(),
+                params: &[],
             })
             .await?;
 
@@ -4132,7 +4132,7 @@ impl Http {
             route: Route::User {
                 user_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4149,7 +4149,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeConnections,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4162,7 +4162,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeDmChannels,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4175,7 +4175,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::VoiceRegions,
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4209,7 +4209,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4249,7 +4249,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4286,7 +4286,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4307,7 +4307,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4322,7 +4322,7 @@ impl Http {
             route: Route::UserMeGuild {
                 guild_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4346,7 +4346,7 @@ impl Http {
             route: Route::ChannelMessages {
                 channel_id,
             },
-            params: [].into(),
+            params: &[],
         };
 
         if files.is_empty() {
@@ -4378,7 +4378,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4399,7 +4399,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4426,7 +4426,7 @@ impl Http {
                 user_id,
                 role_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4448,11 +4448,10 @@ impl Http {
                 route: Route::GuildMembersSearch {
                     guild_id,
                 },
-                params: [
+                params: &[
                     ("query", query.to_string()),
                     ("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string()),
-                ]
-                .into(),
+                ],
             })
             .await?;
 
@@ -4482,7 +4481,7 @@ impl Http {
             route: Route::GuildPrune {
                 guild_id,
             },
-            params: [("days", days.to_string())].into(),
+            params: &[("days", days.to_string())],
         })
         .await
     }
@@ -4502,7 +4501,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4563,7 +4562,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: [].into(),
+            params: &[],
         })
         .await
     }
@@ -4593,7 +4592,7 @@ impl Http {
     /// let channel_id = ChannelId::new(381880193700069377);
     /// let route = Route::ChannelMessages { channel_id };
     ///
-    /// let mut request = Request::new(route, LightMethod::Post, []).body(Some(bytes));
+    /// let mut request = Request::new(route, LightMethod::Post, &[]).body(Some(bytes));
     ///
     /// let message: Message = http.fire(request).await?;
     ///
@@ -4605,10 +4604,7 @@ impl Http {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn fire<T: DeserializeOwned, const MAX_PARAMS: usize>(
-        &self,
-        req: Request<'_, MAX_PARAMS>,
-    ) -> Result<T> {
+    pub async fn fire<T: DeserializeOwned>(&self, req: Request<'_>) -> Result<T> {
         let response = self.request(req).await?;
         decode_resp(response).await
     }
@@ -4636,7 +4632,7 @@ impl Http {
     /// let channel_id = ChannelId::new(381880193700069377);
     /// let route = Route::ChannelMessages { channel_id };
     ///
-    /// let mut request = Request::new(route, LightMethod::Post, []).body(Some(bytes));
+    /// let mut request = Request::new(route, LightMethod::Post, &[]).body(Some(bytes));
     ///
     /// let response = http.request(request).await?;
     ///
@@ -4645,10 +4641,7 @@ impl Http {
     /// # }
     /// ```
     #[instrument]
-    pub async fn request<const MAX_PARAMS: usize>(
-        &self,
-        req: Request<'_, MAX_PARAMS>,
-    ) -> Result<ReqwestResponse> {
+    pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
         let method = req.method.reqwest_method();
         let response = if let Some(ratelimiter) = &self.ratelimiter {
             ratelimiter.perform(req).await?
@@ -4671,11 +4664,7 @@ impl Http {
     ///
     /// This is a function that performs a light amount of work and returns an empty tuple, so it's
     /// called "self.wind" to denote that it's lightweight.
-    pub(super) async fn wind<const MAX_PARAMS: usize>(
-        &self,
-        expected: u16,
-        req: Request<'_, MAX_PARAMS>,
-    ) -> Result<()> {
+    pub(super) async fn wind(&self, expected: u16, req: Request<'_>) -> Result<()> {
         let method = req.method.reqwest_method();
         let response = self.request(req).await?;
 

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -179,10 +179,7 @@ impl Ratelimiter {
     ///
     /// Only error kind that may be returned is [`Error::Http`].
     #[instrument]
-    pub async fn perform<const MAX_PARAMS: usize>(
-        &self,
-        req: Request<'_, MAX_PARAMS>,
-    ) -> Result<Response> {
+    pub async fn perform(&self, req: Request<'_>) -> Result<Response> {
         loop {
             // This will block if another thread hit the global ratelimit.
             drop(self.global.lock().await);
@@ -281,9 +278,9 @@ pub struct Ratelimit {
 
 impl Ratelimit {
     #[instrument(skip(ratelimit_callback))]
-    pub async fn pre_hook<const MAX_PARAMS: usize>(
+    pub async fn pre_hook(
         &mut self,
-        req: &Request<'_, MAX_PARAMS>,
+        req: &Request<'_>,
         ratelimit_callback: &(dyn Fn(RatelimitInfo) + Send + Sync),
     ) {
         if self.limit() == 0 {
@@ -327,10 +324,10 @@ impl Ratelimit {
     }
 
     #[instrument(skip(ratelimit_callback))]
-    pub async fn post_hook<const MAX_PARAMS: usize>(
+    pub async fn post_hook(
         &mut self,
         response: &Response,
-        req: &Request<'_, MAX_PARAMS>,
+        req: &Request<'_>,
         ratelimit_callback: &(dyn Fn(RatelimitInfo) + Send + Sync),
         absolute_ratelimits: bool,
     ) -> Result<bool> {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,6 +1,5 @@
 use std::fmt::Write;
 
-use arrayvec::ArrayVec;
 use reqwest::header::{
     HeaderMap as Headers,
     HeaderValue,
@@ -20,20 +19,20 @@ use crate::internal::prelude::*;
 
 #[derive(Clone, Debug)]
 #[must_use]
-pub struct Request<'a, const MAX_PARAMS: usize> {
+pub struct Request<'a> {
     pub(super) body: Option<Vec<u8>>,
     pub(super) multipart: Option<Multipart<'a>>,
     pub(super) headers: Option<Headers>,
     pub(super) method: LightMethod,
     pub(super) route: Route<'a>,
-    pub(super) params: ArrayVec<(&'static str, String), MAX_PARAMS>,
+    pub(super) params: &'a [(&'static str, String)],
 }
 
-impl<'a, const MAX_PARAMS: usize> Request<'a, MAX_PARAMS> {
+impl<'a> Request<'a> {
     pub fn new(
         route: Route<'a>,
         method: LightMethod,
-        params: [(&'static str, String); MAX_PARAMS],
+        params: &'a [(&'static str, String)],
     ) -> Self {
         Self {
             body: None,
@@ -41,7 +40,7 @@ impl<'a, const MAX_PARAMS: usize> Request<'a, MAX_PARAMS> {
             headers: None,
             method,
             route,
-            params: params.into(),
+            params,
         }
     }
 
@@ -60,8 +59,8 @@ impl<'a, const MAX_PARAMS: usize> Request<'a, MAX_PARAMS> {
         self
     }
 
-    pub fn params(mut self, params: [(&'static str, String); MAX_PARAMS]) -> Self {
-        self.params = params.into();
+    pub fn params(mut self, params: &'a [(&'static str, String)]) -> Self {
+        self.params = params;
         self
     }
 
@@ -143,16 +142,7 @@ impl<'a, const MAX_PARAMS: usize> Request<'a, MAX_PARAMS> {
         if self.params.is_empty() {
             None
         } else {
-            Some(&self.params)
-        }
-    }
-
-    #[must_use]
-    pub fn params_mut(&mut self) -> Option<&mut [(&'static str, String)]> {
-        if self.params.is_empty() {
-            None
-        } else {
-            Some(&mut self.params)
+            Some(self.params)
         }
     }
 }


### PR DESCRIPTION
This, 
1. Shrinks the size of Request, when copied around, as it doesn't have to store the max capacity at all times
2. Shrinks llvm-lines (compile time metric) for my bot in debug from `1,153,519` to `1,131,480` as no monomorphisation has to be performed for `MAX_PARAMS`.