### PR TITLE
Revert `Request::params` back to `Option`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -240,7 +240,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -273,7 +273,7 @@ impl Http {
                 role_id,
                 user_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -303,7 +303,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: &[("delete_message_days", delete_message_days.to_string())],
+            params: Some(&[("delete_message_days", delete_message_days.to_string())]),
         })
         .await
     }
@@ -324,7 +324,7 @@ impl Http {
             route: Route::ChannelTyping {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -353,7 +353,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -370,7 +370,7 @@ impl Http {
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
             route: Route::StageInstances,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -394,7 +394,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -416,7 +416,7 @@ impl Http {
             route: Route::ChannelThreads {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -438,7 +438,7 @@ impl Http {
             route: Route::ChannelForumPosts {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -464,7 +464,7 @@ impl Http {
             route: Route::GuildEmojis {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -487,7 +487,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: &[],
+            params: None,
         };
 
         if files.is_empty() {
@@ -522,7 +522,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -540,7 +540,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -560,7 +560,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -605,7 +605,7 @@ impl Http {
             headers: None,
             method: LightMethod::Post,
             route: Route::Guilds,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -631,7 +631,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -660,7 +660,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -687,7 +687,7 @@ impl Http {
                 interaction_id,
                 token: interaction_token,
             },
-            params: &[],
+            params: None,
         };
 
         if files.is_empty() {
@@ -729,7 +729,7 @@ impl Http {
             route: Route::ChannelInvites {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -753,7 +753,7 @@ impl Http {
                 channel_id,
                 target_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -768,7 +768,7 @@ impl Http {
             headers: None,
             method: LightMethod::Post,
             route: Route::UserMeDmChannels,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -790,7 +790,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -811,7 +811,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -844,7 +844,7 @@ impl Http {
             route: Route::GuildScheduledEvents {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -873,7 +873,7 @@ impl Http {
             route: Route::GuildStickers {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -903,7 +903,7 @@ impl Http {
             route: Route::Entitlements {
                 application_id: self.try_application_id()?,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -950,7 +950,7 @@ impl Http {
             route: Route::ChannelWebhooks {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -969,7 +969,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -988,7 +988,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1011,7 +1011,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1032,7 +1032,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1048,7 +1048,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1063,7 +1063,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1084,7 +1084,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1105,7 +1105,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1124,7 +1124,7 @@ impl Http {
             route: Route::Invite {
                 code,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1145,7 +1145,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1165,7 +1165,7 @@ impl Http {
             route: Route::ChannelMessagesBulkDelete {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1202,7 +1202,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1224,7 +1224,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1243,7 +1243,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1264,7 +1264,7 @@ impl Http {
                 channel_id,
                 target_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1288,7 +1288,7 @@ impl Http {
                 user_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1310,7 +1310,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1331,7 +1331,7 @@ impl Http {
                 guild_id,
                 role_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1356,7 +1356,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1379,7 +1379,7 @@ impl Http {
                 guild_id,
                 sticker_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1396,7 +1396,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 entitlement_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1433,7 +1433,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1474,7 +1474,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1496,7 +1496,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1516,7 +1516,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1542,7 +1542,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1569,7 +1569,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: &[],
+            params: None,
         };
 
         if new_attachments.is_empty() {
@@ -1605,7 +1605,7 @@ impl Http {
                 token: interaction_token,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1631,7 +1631,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1653,7 +1653,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1681,7 +1681,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1709,7 +1709,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1730,7 +1730,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1757,7 +1757,7 @@ impl Http {
             route: Route::GuildMfa {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
         .map(|mfa: GuildMfaLevel| mfa.level)
@@ -1780,7 +1780,7 @@ impl Http {
             route: Route::GuildWidget {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1802,7 +1802,7 @@ impl Http {
             route: Route::GuildWelcomeScreen {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1827,7 +1827,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -1857,7 +1857,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: &[],
+            params: None,
         };
 
         if new_attachments.is_empty() {
@@ -1890,7 +1890,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1912,7 +1912,7 @@ impl Http {
             route: Route::GuildMemberMe {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1937,7 +1937,7 @@ impl Http {
             route: Route::GuildMemberMe {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1959,7 +1959,7 @@ impl Http {
             route: Route::ChannelFollowNews {
                 channel_id: news_channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -1978,7 +1978,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2003,7 +2003,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 token: interaction_token,
             },
-            params: &[],
+            params: None,
         };
 
         if new_attachments.is_empty() {
@@ -2029,7 +2029,7 @@ impl Http {
             headers: None,
             method: LightMethod::Patch,
             route: Route::UserMe,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2052,7 +2052,7 @@ impl Http {
                     guild_id,
                     role_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -2086,7 +2086,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -2123,7 +2123,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2150,7 +2150,7 @@ impl Http {
                     guild_id,
                     sticker_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -2176,7 +2176,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2226,7 +2226,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2277,7 +2277,7 @@ impl Http {
             route: Route::GuildVoiceStateMe {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2328,7 +2328,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2376,7 +2376,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2456,7 +2456,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: &params,
+            params: Some(&params),
         };
 
         if files.is_empty() {
@@ -2486,11 +2486,6 @@ impl Http {
         token: &str,
         message_id: MessageId,
     ) -> Result<Message> {
-        let mut params = ArrayVec::<_, 1>::new();
-        if let Some(thread_id) = thread_id {
-            params.push(("thread_id", thread_id.to_string()));
-        }
-
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2501,7 +2496,10 @@ impl Http {
                 token,
                 message_id,
             },
-            params: &params,
+            params: thread_id
+                .map(|thread_id| [("thread_id", thread_id.to_string())])
+                .as_ref()
+                .map(<[_; 1]>::as_slice),
         })
         .await
     }
@@ -2516,10 +2514,7 @@ impl Http {
         map: &impl serde::Serialize,
         new_attachments: Vec<CreateAttachment<'_>>,
     ) -> Result<Message> {
-        let mut params = ArrayVec::<_, 1>::new();
-        if let Some(thread_id) = thread_id {
-            params.push(("thread_id", thread_id.to_string()));
-        }
+        let params = thread_id.map(|thread_id| [("thread_id", thread_id.to_string())]);
 
         let mut request = Request {
             body: None,
@@ -2531,7 +2526,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params: &params,
+            params: params.as_ref().map(<[_; 1]>::as_slice),
         };
 
         if new_attachments.is_empty() {
@@ -2555,11 +2550,6 @@ impl Http {
         token: &str,
         message_id: MessageId,
     ) -> Result<()> {
-        let mut params = ArrayVec::<_, 1>::new();
-        if let Some(thread_id) = thread_id {
-            params.push(("thread_id", thread_id.to_string()));
-        }
-
         self.wind(204, Request {
             body: None,
             multipart: None,
@@ -2570,7 +2560,10 @@ impl Http {
                 token,
                 message_id,
             },
-            params: &params,
+            params: thread_id
+                .map(|thread_id| [("thread_id", thread_id.to_string())])
+                .as_ref()
+                .map(<[_; 1]>::as_slice),
         })
         .await
     }
@@ -2592,7 +2585,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusMaintenancesActive,
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -2636,7 +2629,7 @@ impl Http {
             route: Route::GuildBans {
                 guild_id,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -2672,7 +2665,7 @@ impl Http {
             route: Route::GuildAuditLogs {
                 guild_id,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -2689,7 +2682,7 @@ impl Http {
             route: Route::GuildAutomodRules {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2707,7 +2700,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2731,7 +2724,7 @@ impl Http {
             route: Route::GuildAutomodRules {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2757,7 +2750,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2780,7 +2773,7 @@ impl Http {
                 guild_id,
                 rule_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2793,7 +2786,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::GatewayBot,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2808,7 +2801,7 @@ impl Http {
             route: Route::ChannelInvites {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2826,7 +2819,7 @@ impl Http {
             route: Route::ChannelThreadMembers {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2841,7 +2834,7 @@ impl Http {
             route: Route::GuildThreadsActive {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2869,7 +2862,7 @@ impl Http {
             route: Route::ChannelArchivedPublicThreads {
                 channel_id,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -2897,7 +2890,7 @@ impl Http {
             route: Route::ChannelArchivedPrivateThreads {
                 channel_id,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -2925,7 +2918,7 @@ impl Http {
             route: Route::ChannelJoinedPrivateThreads {
                 channel_id,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -2940,7 +2933,7 @@ impl Http {
             route: Route::ChannelThreadMemberMe {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2955,7 +2948,7 @@ impl Http {
             route: Route::ChannelThreadMemberMe {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2975,7 +2968,7 @@ impl Http {
                 channel_id,
                 user_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -2995,7 +2988,7 @@ impl Http {
                 channel_id,
                 user_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3029,7 +3022,7 @@ impl Http {
             route: Route::ChannelWebhooks {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3044,7 +3037,7 @@ impl Http {
             route: Route::Channel {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3059,7 +3052,7 @@ impl Http {
             route: Route::GuildChannels {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3074,7 +3067,7 @@ impl Http {
             route: Route::StageInstance {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3089,7 +3082,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::Oauth2ApplicationCurrent,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3102,7 +3095,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMe,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3117,7 +3110,7 @@ impl Http {
             route: Route::GuildEmojis {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3133,7 +3126,7 @@ impl Http {
                 guild_id,
                 emoji_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3185,7 +3178,7 @@ impl Http {
             route: Route::Entitlements {
                 application_id: self.try_application_id()?,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -3198,7 +3191,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::Gateway,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3213,7 +3206,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3228,7 +3221,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: &[("with_localizations", String::from("true"))],
+            params: Some(&[("with_localizations", String::from("true"))]),
         })
         .await
     }
@@ -3244,7 +3237,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 command_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3259,7 +3252,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3274,7 +3267,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: &[("with_counts", String::from("true"))],
+            params: Some(&[("with_counts", String::from("true"))]),
         })
         .await
     }
@@ -3290,7 +3283,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3310,7 +3303,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: &[("with_localizations", String::from("true"))],
+            params: Some(&[("with_localizations", String::from("true"))]),
         })
         .await
     }
@@ -3331,7 +3324,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3350,7 +3343,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3371,7 +3364,7 @@ impl Http {
                 guild_id,
                 command_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3388,7 +3381,7 @@ impl Http {
             route: Route::GuildWidget {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3403,7 +3396,7 @@ impl Http {
             route: Route::GuildPreview {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3418,7 +3411,7 @@ impl Http {
             route: Route::GuildWelcomeScreen {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3433,7 +3426,7 @@ impl Http {
             route: Route::GuildIntegrations {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3448,7 +3441,7 @@ impl Http {
             route: Route::GuildInvites {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3468,7 +3461,7 @@ impl Http {
             route: Route::GuildVanityUrl {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
         .map(|x: GuildVanityUrl| x.code)
@@ -3503,7 +3496,7 @@ impl Http {
                 route: Route::GuildMembers {
                     guild_id,
                 },
-                params: &params,
+                params: Some(&params),
             })
             .await?;
 
@@ -3528,7 +3521,7 @@ impl Http {
             route: Route::GuildPrune {
                 guild_id,
             },
-            params: &[("days", days.to_string())],
+            params: Some(&[("days", days.to_string())]),
         })
         .await
     }
@@ -3544,7 +3537,7 @@ impl Http {
             route: Route::GuildRegions {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3560,7 +3553,7 @@ impl Http {
                 route: Route::GuildRoles {
                     guild_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -3595,7 +3588,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: &[("with_user_count", with_user_count.to_string())],
+            params: Some(&[("with_user_count", with_user_count.to_string())]),
         })
         .await
     }
@@ -3618,7 +3611,7 @@ impl Http {
             route: Route::GuildScheduledEvents {
                 guild_id,
             },
-            params: &[("with_user_count", with_user_count.to_string())],
+            params: Some(&[("with_user_count", with_user_count.to_string())]),
         })
         .await
     }
@@ -3670,7 +3663,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -3686,7 +3679,7 @@ impl Http {
                 route: Route::GuildStickers {
                     guild_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -3717,7 +3710,7 @@ impl Http {
                     guild_id,
                     sticker_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -3757,7 +3750,7 @@ impl Http {
             route: Route::GuildWebhooks {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3810,7 +3803,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeGuilds,
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -3854,7 +3847,7 @@ impl Http {
                 route: Route::UserMeGuildMember {
                     guild_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -3901,7 +3894,7 @@ impl Http {
             route: Route::Invite {
                 code,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -3918,7 +3911,7 @@ impl Http {
                     guild_id,
                     user_id,
                 },
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -3944,7 +3937,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -3976,7 +3969,7 @@ impl Http {
             route: Route::ChannelMessages {
                 channel_id,
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -3994,7 +3987,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::StickerPacks,
-            params: &[],
+            params: None,
         })
         .await
         .map(|s: StickerPacks| s.sticker_packs)
@@ -4010,7 +4003,7 @@ impl Http {
             route: Route::ChannelPins {
                 channel_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4039,7 +4032,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: &params,
+            params: Some(&params),
         })
         .await
     }
@@ -4054,7 +4047,7 @@ impl Http {
             route: Route::Skus {
                 application_id: self.try_application_id()?,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4069,7 +4062,7 @@ impl Http {
             route: Route::Sticker {
                 sticker_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4091,7 +4084,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusIncidentsUnresolved,
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -4115,7 +4108,7 @@ impl Http {
                 headers: None,
                 method: LightMethod::Get,
                 route: Route::StatusMaintenancesUpcoming,
-                params: &[],
+                params: None,
             })
             .await?;
 
@@ -4132,7 +4125,7 @@ impl Http {
             route: Route::User {
                 user_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4149,7 +4142,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeConnections,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4162,7 +4155,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::UserMeDmChannels,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4175,7 +4168,7 @@ impl Http {
             headers: None,
             method: LightMethod::Get,
             route: Route::VoiceRegions,
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4209,7 +4202,7 @@ impl Http {
             route: Route::Webhook {
                 webhook_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4249,7 +4242,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4286,7 +4279,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4307,7 +4300,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4322,7 +4315,7 @@ impl Http {
             route: Route::UserMeGuild {
                 guild_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4346,7 +4339,7 @@ impl Http {
             route: Route::ChannelMessages {
                 channel_id,
             },
-            params: &[],
+            params: None,
         };
 
         if files.is_empty() {
@@ -4378,7 +4371,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4399,7 +4392,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4426,7 +4419,7 @@ impl Http {
                 user_id,
                 role_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4448,10 +4441,10 @@ impl Http {
                 route: Route::GuildMembersSearch {
                     guild_id,
                 },
-                params: &[
+                params: Some(&[
                     ("query", query.to_string()),
                     ("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string()),
-                ],
+                ]),
             })
             .await?;
 
@@ -4481,7 +4474,7 @@ impl Http {
             route: Route::GuildPrune {
                 guild_id,
             },
-            params: &[("days", days.to_string())],
+            params: Some(&[("days", days.to_string())]),
         })
         .await
     }
@@ -4501,7 +4494,7 @@ impl Http {
                 guild_id,
                 integration_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4562,7 +4555,7 @@ impl Http {
                 channel_id,
                 message_id,
             },
-            params: &[],
+            params: None,
         })
         .await
     }
@@ -4592,7 +4585,7 @@ impl Http {
     /// let channel_id = ChannelId::new(381880193700069377);
     /// let route = Route::ChannelMessages { channel_id };
     ///
-    /// let mut request = Request::new(route, LightMethod::Post, &[]).body(Some(bytes));
+    /// let mut request = Request::new(route, LightMethod::Post).body(Some(bytes));
     ///
     /// let message: Message = http.fire(request).await?;
     ///
@@ -4632,7 +4625,7 @@ impl Http {
     /// let channel_id = ChannelId::new(381880193700069377);
     /// let route = Route::ChannelMessages { channel_id };
     ///
-    /// let mut request = Request::new(route, LightMethod::Post, &[]).body(Some(bytes));
+    /// let mut request = Request::new(route, LightMethod::Post).body(Some(bytes));
     ///
     /// let response = http.request(request).await?;
     ///

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -25,22 +25,18 @@ pub struct Request<'a> {
     pub(super) headers: Option<Headers>,
     pub(super) method: LightMethod,
     pub(super) route: Route<'a>,
-    pub(super) params: &'a [(&'static str, String)],
+    pub(super) params: Option<&'a [(&'static str, String)]>,
 }
 
 impl<'a> Request<'a> {
-    pub fn new(
-        route: Route<'a>,
-        method: LightMethod,
-        params: &'a [(&'static str, String)],
-    ) -> Self {
+    pub fn new(route: Route<'a>, method: LightMethod) -> Self {
         Self {
             body: None,
             multipart: None,
             headers: None,
             method,
             route,
-            params,
+            params: None,
         }
     }
 
@@ -60,7 +56,11 @@ impl<'a> Request<'a> {
     }
 
     pub fn params(mut self, params: &'a [(&'static str, String)]) -> Self {
-        self.params = params;
+        if params.is_empty() {
+            self.params = None;
+        } else {
+            self.params = Some(params);
+        }
         self
     }
 
@@ -78,9 +78,9 @@ impl<'a> Request<'a> {
             path = path.replace("https://discord.com", proxy.trim_end_matches('/'));
         }
 
-        if !self.params.is_empty() {
+        if let Some(params) = self.params {
             path += "?";
-            for (param, value) in self.params {
+            for (param, value) in params {
                 write!(path, "&{param}={value}").unwrap();
             }
         }
@@ -138,11 +138,7 @@ impl<'a> Request<'a> {
     }
 
     #[must_use]
-    pub fn params_ref(&self) -> Option<&[(&'static str, String)]> {
-        if self.params.is_empty() {
-            None
-        } else {
-            Some(self.params)
-        }
+    pub fn params_ref(&self) -> Option<&'a [(&'static str, String)]> {
+        self.params
     }
 }


### PR DESCRIPTION
Follow-up to #2694.

When `Request::params` was made into an ArrayVec, the `Option` around it was removed in order to avoid having to add a turbofish on `None` to specify the value of `MAX_PARAMS`. Also, `Request::new` also needed to be changed so that the value of `MAX_PARAMS` could be inferred. Now that the field is a slice again, we can wrap it in `Option` again (at no cost to size, thanks to niche opts).

We ensure we never store the redundant `Some(&[])` by checking for an empty slice and storing `None` instead. This way, we ensure we never read an empty slice out of the `Some` variant.