### PR TITLE
Handle overflow checks in central locations

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -203,13 +203,13 @@ impl<'a> CreateEmbed<'a> {
     }
 
     #[cfg(feature = "http")]
-    pub(super) fn check_length(&self) -> Result<()> {
+    pub(super) fn get_length(&self) -> usize {
         let mut length = 0;
-        if let Some(ref author) = self.author {
+        if let Some(author) = &self.author {
             length += author.name.chars().count();
         }
 
-        if let Some(ref description) = self.description {
+        if let Some(description) = &self.description {
             length += description.chars().count();
         }
 
@@ -218,16 +218,15 @@ impl<'a> CreateEmbed<'a> {
             length += field.value.chars().count();
         }
 
-        if let Some(ref footer) = self.footer {
+        if let Some(footer) = &self.footer {
             length += footer.text.chars().count();
         }
 
-        if let Some(ref title) = self.title {
+        if let Some(title) = &self.title {
             length += title.chars().count();
         }
 
-        super::check_overflow(length, crate::constants::EMBED_MAX_LENGTH)
-            .map_err(|overflow| Error::Model(ModelError::EmbedTooLarge(overflow)))
+        length
     }
 }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::{check_overflow, Builder};
+use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -9,8 +9,6 @@ use super::{
     CreateEmbed,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::constants;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
@@ -44,19 +42,8 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     }
 
     #[cfg(feature = "http")]
-    fn check_length(&self) -> Result<()> {
-        if let Some(content) = &self.content {
-            check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT)
-                .map_err(|overflow| Error::Model(ModelError::MessageTooLong(overflow)))?;
-        }
-
-        check_overflow(self.embeds.len(), constants::EMBED_MAX_COUNT)
-            .map_err(|_| Error::Model(ModelError::EmbedAmount))?;
-        for embed in self.embeds.iter() {
-            embed.check_length()?;
-        }
-
-        Ok(())
+    fn check_length(&self) -> Result<(), ModelError> {
+        super::check_lengths(self.content.as_deref(), Some(&self.embeds), 0)
     }
 
     /// Set the content of the message.

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::{check_overflow, Builder};
+use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -9,8 +9,6 @@ use super::{
     CreateEmbed,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::constants;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
@@ -82,22 +80,8 @@ impl<'a> CreateMessage<'a> {
     }
 
     #[cfg(feature = "http")]
-    fn check_length(&self) -> Result<()> {
-        if let Some(content) = &self.content {
-            check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT)
-                .map_err(|overflow| Error::Model(ModelError::MessageTooLong(overflow)))?;
-        }
-
-        check_overflow(self.embeds.len(), constants::EMBED_MAX_COUNT)
-            .map_err(|_| Error::Model(ModelError::EmbedAmount))?;
-        for embed in self.embeds.iter() {
-            embed.check_length()?;
-        }
-
-        check_overflow(self.sticker_ids.len(), constants::STICKER_MAX_COUNT)
-            .map_err(|_| Error::Model(ModelError::StickerAmount))?;
-
-        Ok(())
+    fn check_length(&self) -> Result<(), ModelError> {
+        super::check_lengths(self.content.as_deref(), Some(&self.embeds), self.sticker_ids.len())
     }
 
     /// Set the content of the message.

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -276,7 +276,7 @@ impl Builder for CreateMessage<'_> {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the message contents are over the above limits.
+    /// Returns a [`ModelError::TooLarge`] if the message contents are over the above limits.
     ///
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -66,8 +66,8 @@ impl<'a> Builder for CreateWebhook<'a> {
     /// If the `cache` is enabled, returns [`ModelError::InvalidChannelType`] if the corresponding
     /// channel is not of type [`Text`] or [`News`].
     ///
-    /// If the provided name is less than 2 characters, returns [`ModelError::NameTooShort`]. If it
-    /// is more than 100 characters, returns [`ModelError::NameTooLong`].
+    /// If the provided name is less than 2 characters, returns [`ModelError::TooSmall`]. If it
+    /// is more than 100 characters, returns [`ModelError::TooLarge`].
     ///
     /// Returns a [`Error::Http`] if the current user lacks permission, or if invalid data is
     /// given.
@@ -92,11 +92,8 @@ impl<'a> Builder for CreateWebhook<'a> {
             }
         }
 
-        if self.name.len() < 2 {
-            return Err(Error::Model(ModelError::NameTooShort));
-        } else if self.name.len() > 100 {
-            return Err(Error::Model(ModelError::NameTooLong));
-        }
+        crate::model::error::Minimum::WebhookName.check_underflow(self.name.chars().count())?;
+        crate::model::error::Maximum::WebhookName.check_overflow(self.name.chars().count())?;
 
         cache_http.http().create_webhook(ctx, &self, self.audit_log_reason).await
     }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::{check_overflow, Builder};
+use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -9,8 +9,6 @@ use super::{
     CreateEmbed,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::constants;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
@@ -61,21 +59,8 @@ impl<'a> EditMessage<'a> {
     }
 
     #[cfg(feature = "http")]
-    fn check_length(&self) -> Result<()> {
-        if let Some(content) = &self.content {
-            check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT)
-                .map_err(|overflow| Error::Model(ModelError::MessageTooLong(overflow)))?;
-        }
-
-        if let Some(embeds) = &self.embeds {
-            check_overflow(embeds.len(), constants::EMBED_MAX_COUNT)
-                .map_err(|_| Error::Model(ModelError::EmbedAmount))?;
-            for embed in embeds.iter() {
-                embed.check_length()?;
-            }
-        }
-
-        Ok(())
+    fn check_length(&self) -> Result<(), ModelError> {
+        super::check_lengths(self.content.as_deref(), self.embeds.as_deref(), 0)
     }
 
     /// Set the content of the message.

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -228,7 +228,7 @@ impl Builder for EditMessage<'_> {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the message contents are over the above limits.
+    /// Returns a [`ModelError::TooLarge`] if the message contents are over the above limits.
     ///
     /// Returns [`Error::Http`] if the user lacks permission, as well as if invalid data is given.
     ///

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::{check_overflow, Builder};
+use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -9,8 +9,6 @@ use super::{
     CreateEmbed,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::constants;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
@@ -45,21 +43,8 @@ impl<'a> EditWebhookMessage<'a> {
     }
 
     #[cfg(feature = "http")]
-    pub(crate) fn check_length(&self) -> Result<()> {
-        if let Some(content) = &self.content {
-            check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT)
-                .map_err(|overflow| Error::Model(ModelError::MessageTooLong(overflow)))?;
-        }
-
-        if let Some(embeds) = &self.embeds {
-            check_overflow(embeds.len(), constants::EMBED_MAX_COUNT)
-                .map_err(|_| Error::Model(ModelError::EmbedAmount))?;
-            for embed in embeds.iter() {
-                embed.check_length()?;
-            }
-        }
-
-        Ok(())
+    pub(crate) fn check_length(&self) -> Result<(), ModelError> {
+        super::check_lengths(self.content.as_deref(), self.embeds.as_deref(), 0)
     }
 
     /// Set the content of the message.

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::{check_overflow, Builder};
+use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -9,8 +9,6 @@ use super::{
     CreateEmbed,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::constants;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
@@ -90,19 +88,8 @@ impl<'a> ExecuteWebhook<'a> {
     }
 
     #[cfg(feature = "http")]
-    fn check_length(&self) -> Result<()> {
-        if let Some(content) = &self.content {
-            check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT)
-                .map_err(|overflow| Error::Model(ModelError::MessageTooLong(overflow)))?;
-        }
-
-        check_overflow(self.embeds.len(), constants::EMBED_MAX_COUNT)
-            .map_err(|_| Error::Model(ModelError::EmbedAmount))?;
-        for embed in self.embeds.iter() {
-            embed.check_length()?;
-        }
-
-        Ok(())
+    fn check_length(&self) -> Result<(), ModelError> {
+        super::check_lengths(self.content.as_deref(), Some(&self.embeds), 0)
     }
 
     /// Override the default avatar of the webhook with an image URL.

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -30,48 +30,26 @@ pub trait Builder {
 }
 
 #[cfg(feature = "http")]
-pub(crate) fn check_overflow(len: usize, max: usize) -> StdResult<(), usize> {
-    if len > max {
-        Err(len - max)
-    } else {
-        Ok(())
-    }
-}
-
-#[cfg(feature = "http")]
 pub(crate) fn check_lengths(
     content: Option<&str>,
     embeds: Option<&[CreateEmbed<'_>]>,
     stickers: usize,
 ) -> StdResult<(), ModelError> {
-    use crate::constants::{
-        EMBED_MAX_COUNT,
-        EMBED_MAX_LENGTH,
-        MESSAGE_CODE_LIMIT,
-        STICKER_MAX_COUNT,
-    };
+    use crate::model::error::Maximum;
 
     if let Some(content) = content {
-        check_overflow(content.chars().count(), MESSAGE_CODE_LIMIT)
-            .map_err(ModelError::MessageTooLong)?;
+        Maximum::MessageLength.check_overflow(content.chars().count())?;
     }
 
     if let Some(embeds) = embeds {
-        if embeds.len() > EMBED_MAX_COUNT {
-            return Err(ModelError::EmbedAmount);
-        }
+        Maximum::EmbedCount.check_overflow(embeds.len())?;
 
         for embed in embeds {
-            check_overflow(embed.get_length(), EMBED_MAX_LENGTH)
-                .map_err(ModelError::EmbedTooLarge)?;
+            Maximum::EmbedLength.check_overflow(embed.get_length())?;
         }
     }
 
-    if stickers > STICKER_MAX_COUNT {
-        return Err(ModelError::StickerAmount);
-    }
-
-    Ok(())
+    Maximum::StickerCount.check_overflow(stickers)
 }
 
 mod add_member;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,7 @@
 //! A set of constants used by the library.
 
+use nonmax::NonMaxU16;
+
 /// The maximum length of the textual size of an embed.
 pub const EMBED_MAX_LENGTH: usize = 6000;
 
@@ -19,7 +21,10 @@ pub const LARGE_THRESHOLD: u8 = 250;
 pub const MESSAGE_CODE_LIMIT: usize = 2000;
 
 /// The maximum number of members the bot can fetch at once
-pub const MEMBER_FETCH_LIMIT: u64 = 1000;
+pub const MEMBER_FETCH_LIMIT: NonMaxU16 = match NonMaxU16::new(1000) {
+    Some(m) => m,
+    None => unreachable!(),
+};
 
 /// The [UserAgent] sent along with every request.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,15 +44,6 @@ pub enum Error {
     ///
     /// [`model`]: crate::model
     Model(ModelError),
-    /// Input exceeded a limit. Providing the input and the limit that's not supposed to be
-    /// exceeded.
-    ///
-    /// *This only exists for the [`GuildId::ban`] and [`Member::ban`] functions. For their cases,
-    /// it's the "reason".*
-    ///
-    /// [`GuildId::ban`]: crate::model::id::GuildId::ban
-    /// [`Member::ban`]: crate::model::guild::Member::ban
-    ExceededLimit(String, u32),
     /// The input is not in the specified range. Returned by [`GuildId::members`],
     /// [`Guild::members`] and [`PartialGuild::members`]
     ///
@@ -150,7 +141,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Decode(msg, _) | Self::Other(msg) => f.write_str(msg),
-            Self::ExceededLimit(..) => f.write_str("Input exceeded a limit"),
             Self::NotInRange(..) => f.write_str("Input is not in the specified range"),
             Self::Format(inner) => fmt::Display::fmt(&inner, f),
             Self::Io(inner) => fmt::Display::fmt(&inner, f),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use arrayvec::ArrayVec;
+use nonmax::NonMaxU16;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::{HeaderMap as Headers, HeaderValue};
 #[cfg(feature = "utils")]
@@ -3472,15 +3473,9 @@ impl Http {
     pub async fn get_guild_members(
         &self,
         guild_id: GuildId,
-        limit: Option<u64>,
-        after: Option<u64>,
+        limit: Option<NonMaxU16>,
+        after: Option<UserId>,
     ) -> Result<Vec<Member>> {
-        if let Some(l) = limit {
-            if !(1..=constants::MEMBER_FETCH_LIMIT).contains(&l) {
-                return Err(Error::NotInRange("limit", l, 1, constants::MEMBER_FETCH_LIMIT));
-            }
-        }
-
         let mut params = ArrayVec::<_, 2>::new();
         params.push(("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string()));
         if let Some(after) = after {
@@ -4430,7 +4425,7 @@ impl Http {
         &self,
         guild_id: GuildId,
         query: &str,
-        limit: Option<u64>,
+        limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
         let mut value: Value = self
             .fire(Request {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -173,8 +173,8 @@ impl ChannelId {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError::BulkDeleteAmount`] if an attempt was made to delete either 0 or more
-    /// than 100 messages.
+    /// Returns [`ModelError::TooSmall`] or [`ModelError::TooLarge`] if an attempt was made to
+    /// delete either 0 or more than 100 messages.
     ///
     /// Also will return [`Error::Http`] if the current user lacks permission to delete messages.
     ///
@@ -184,17 +184,17 @@ impl ChannelId {
         http: impl AsRef<Http>,
         message_ids: &[MessageId],
     ) -> Result<()> {
+        use crate::model::error::{Maximum, Minimum};
+
         #[derive(serde::Serialize)]
         struct DeleteMessages<'a> {
             messages: &'a [MessageId],
         }
 
-        let len = message_ids.len();
-        if len == 0 || len > 100 {
-            return Err(Error::Model(ModelError::BulkDeleteAmount));
-        }
+        Minimum::BulkDeleteAmount.check_underflow(message_ids.len())?;
+        Maximum::BulkDeleteAmount.check_overflow(message_ids.len())?;
 
-        if len == 1 {
+        if message_ids.len() == 1 {
             self.delete_message(http, message_ids[0]).await
         } else {
             let req = DeleteMessages {
@@ -635,7 +635,7 @@ impl ChannelId {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content length is over the above limit. See
+    /// Returns a [`ModelError::TooLarge`] if the content length is over the above limit. See
     /// [`CreateMessage::execute`] for more details.
     #[inline]
     pub async fn say(

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -374,8 +374,8 @@ impl GuildChannel {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError::BulkDeleteAmount`] if an attempt was made to delete either 0 or more
-    /// than 100 messages.
+    /// Returns [`ModelError::TooSmall`] or [`ModelError::TooLarge`] if an attempt was made to
+    /// delete either 0 or more than 100 messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
@@ -837,7 +837,7 @@ impl GuildChannel {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content length is over the above limit. See
+    /// Returns a [`ModelError::TooLarge`] if the content length is over the above limit. See
     /// [`CreateMessage::execute`] for more details.
     #[inline]
     pub async fn say(

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -347,7 +347,7 @@ impl Message {
     /// the author. Otherwise returns [`Error::Http`] if the user lacks permission, as well as if
     /// invalid data is given.
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the message contents are too long.
+    /// Returns a [`ModelError::TooLarge`] if the message contents are too long.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn edit(
@@ -494,7 +494,12 @@ impl Message {
     /// inner value of how many unicode code points the message is over.
     #[must_use]
     pub fn overflow_length(content: &str) -> Option<usize> {
-        crate::builder::check_overflow(content.chars().count(), constants::MESSAGE_CODE_LIMIT).err()
+        let char_count = content.chars().count();
+        if char_count > constants::MESSAGE_CODE_LIMIT {
+            Some(constants::MESSAGE_CODE_LIMIT - char_count)
+        } else {
+            None
+        }
     }
 
     /// Pins this message to its channel.
@@ -592,7 +597,7 @@ impl Message {
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
     /// does not have the required permissions.
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content of the message is over the above
+    /// Returns a [`ModelError::TooLarge`] if the content of the message is over the above
     /// limit, containing the number of unicode code points over the limit.
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES
@@ -616,7 +621,7 @@ impl Message {
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
     /// does not have the required permissions.
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content of the message is over the above
+    /// Returns a [`ModelError::TooLarge`] if the content of the message is over the above
     /// limit, containing the number of unicode code points over the limit.
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES
@@ -643,7 +648,7 @@ impl Message {
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
     /// does not have the required permissions.
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content of the message is over the above
+    /// Returns a [`ModelError::TooLarge`] if the content of the message is over the above
     /// limit, containing the number of unicode code points over the limit.
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -86,8 +86,8 @@ impl PrivateChannel {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError::BulkDeleteAmount`] if an attempt was made to delete either 0 or more
-    /// than 100 messages.
+    /// Returns [`ModelError::TooSmall`] or [`ModelError::TooLarge`] if an attempt was made to
+    /// delete either 0 or more than 100 messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
@@ -259,7 +259,7 @@ impl PrivateChannel {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::MessageTooLong`] if the content length is over the above limit. See
+    /// Returns a [`ModelError::TooLarge`] if the content length is over the above limit. See
     /// [`CreateMessage::execute`] for more details.
     ///
     /// [`CreateMessage::execute`]: ../../builder/struct.CreateMessage.html#method.execute

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 #[cfg(feature = "model")]
 use futures::stream::Stream;
+use nonmax::NonMaxU16;
 
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -205,7 +206,7 @@ impl GuildId {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::DeleteMessageDaysAmount`] if the number of days' worth of messages
+    /// Returns a [`ModelError::TooLarge`] if the number of days' worth of messages
     /// to delete is over the maximum.
     ///
     /// Also can return [`Error::Http`] if the current user lacks permission.
@@ -222,7 +223,7 @@ impl GuildId {
     /// # Errors
     ///
     /// In addition to the reasons [`Self::ban`] may return an error, may also return
-    /// [`Error::ExceededLimit`] if `reason` is too long.
+    /// [`ModelError::TooLarge`] if `reason` is too long.
     #[inline]
     pub async fn ban_with_reason(
         self,
@@ -241,14 +242,11 @@ impl GuildId {
         dmd: u8,
         reason: Option<&str>,
     ) -> Result<()> {
-        if dmd > 7 {
-            return Err(Error::Model(ModelError::DeleteMessageDaysAmount(dmd)));
-        }
+        use crate::model::error::Maximum;
 
+        Maximum::DeleteMessageDays.check_overflow(dmd.into())?;
         if let Some(reason) = reason {
-            if reason.chars().count() > 512 {
-                return Err(Error::ExceededLimit(reason.to_string(), 512));
-            }
+            Maximum::AuditLogReason.check_overflow(reason.len())?;
         }
 
         http.as_ref().ban_user(self, user, dmd, reason).await
@@ -1102,10 +1100,10 @@ impl GuildId {
     pub async fn members(
         self,
         http: impl AsRef<Http>,
-        limit: Option<u64>,
+        limit: Option<NonMaxU16>,
         after: Option<UserId>,
     ) -> Result<Vec<Member>> {
-        http.as_ref().get_guild_members(self, limit, after.map(UserId::get)).await
+        http.as_ref().get_guild_members(self, limit, after).await
     }
 
     /// Streams over all the members in a guild.
@@ -1246,7 +1244,7 @@ impl GuildId {
         self,
         http: impl AsRef<Http>,
         query: &str,
-        limit: Option<u64>,
+        limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
         http.as_ref().search_guild_members(self, query, limit).await
     }
@@ -1756,13 +1754,13 @@ impl<H: AsRef<Http>> MembersIter<H> {
     /// not return duplicate items.  If there are no more members to be fetched, then this marks
     /// `self.after` as None, indicating that no more calls ought to be made.
     async fn refresh(&mut self) -> Result<()> {
-        // Number of profiles to fetch
-        let grab_size: u64 = 1000;
+        let grab_size = crate::constants::MEMBER_FETCH_LIMIT;
 
+        // Number of profiles to fetch
         self.buffer = self.guild_id.members(&self.http, Some(grab_size), self.after).await?;
 
         // Get the last member.  If shorter than 1000, there are no more results anyway
-        self.after = self.buffer.get(grab_size as usize - 1).map(|member| member.user.id);
+        self.after = self.buffer.get(grab_size.get() as usize - 1).map(|member| member.user.id);
 
         // Reverse to optimize pop()
         self.buffer.reverse();

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -128,7 +128,7 @@ impl Member {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::DeleteMessageDaysAmount`] if the `dmd` is greater than 7. Can also
+    /// Returns a [`ModelError::TooLarge`] if the `dmd` is greater than 7. Can also
     /// return [`Error::Http`] if the current user lacks permission to ban this member.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
@@ -143,7 +143,7 @@ impl Member {
     /// # Errors
     ///
     /// In addition to the errors [`Self::ban`] may return, can also return
-    /// [`Error::ExceededLimit`] if the length of the reason is greater than 512.
+    /// [`ModelError::TooLarge`] if the length of the reason is greater than 512.
     #[inline]
     pub async fn ban_with_reason(
         &self,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -17,7 +17,7 @@ mod welcome_screen;
 #[cfg(feature = "model")]
 use std::borrow::Cow;
 
-use nonmax::NonMaxU64;
+use nonmax::{NonMaxU16, NonMaxU64};
 #[cfg(feature = "model")]
 use tracing::{error, warn};
 
@@ -470,7 +470,7 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::DeleteMessageDaysAmount`] if the number of days' worth of messages
+    /// Returns a [`ModelError::TooLarge`] if the number of days' worth of messages
     /// to delete is over the maximum.
     ///
     /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
@@ -496,7 +496,7 @@ impl Guild {
     /// # Errors
     ///
     /// In addition to the possible reasons [`Self::ban`] may return an error, an
-    /// [`Error::ExceededLimit`] may also be returned if the reason is too long.
+    /// [`ModelError::TooLarge`] may also be returned if the reason is too long.
     #[inline]
     pub async fn ban_with_reason(
         &self,
@@ -1608,7 +1608,7 @@ impl Guild {
     pub async fn members(
         &self,
         http: impl AsRef<Http>,
-        limit: Option<u64>,
+        limit: Option<NonMaxU16>,
         after: Option<UserId>,
     ) -> Result<Vec<Member>> {
         self.id.members(http, limit, after).await
@@ -2056,7 +2056,7 @@ impl Guild {
         &self,
         http: impl AsRef<Http>,
         query: &str,
-        limit: Option<u64>,
+        limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
         self.id.search_members(http, query, limit).await
     }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,4 +1,4 @@
-use nonmax::NonMaxU64;
+use nonmax::{NonMaxU16, NonMaxU64};
 use serde::Serialize;
 
 #[cfg(feature = "model")]
@@ -293,7 +293,7 @@ impl PartialGuild {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::DeleteMessageDaysAmount`] if the number of days' worth of messages
+    /// Returns a [`ModelError::TooLarge`] if the number of days' worth of messages
     /// to delete is over the maximum.
     ///
     /// Also may return [`Error::Http`] if the current user lacks permission.
@@ -1154,7 +1154,7 @@ impl PartialGuild {
         &self,
         http: impl AsRef<Http>,
         query: &str,
-        limit: Option<u64>,
+        limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
         self.id.search_members(http, query, limit).await
     }
@@ -1325,7 +1325,7 @@ impl PartialGuild {
     pub async fn members(
         &self,
         http: impl AsRef<Http>,
-        limit: Option<u64>,
+        limit: Option<NonMaxU16>,
         after: Option<UserId>,
     ) -> Result<Vec<Member>> {
         self.id.members(http, limit, after).await

--- a/src/utils/argument_convert/member.rs
+++ b/src/utils/argument_convert/member.rs
@@ -63,8 +63,9 @@ impl ArgumentConvert for Member {
         // Following code is inspired by discord.py's MemberConvert::query_member_named
 
         // If string is a username+discriminator
+        let limit = nonmax::NonMaxU16::new(100);
         if let Some((name, discrim)) = crate::utils::parse_user_tag(s) {
-            if let Ok(member_results) = guild_id.search_members(ctx.http(), name, Some(100)).await {
+            if let Ok(member_results) = guild_id.search_members(ctx.http(), name, limit).await {
                 if let Some(member) = member_results.into_iter().find(|m| {
                     m.user.name.eq_ignore_ascii_case(name) && m.user.discriminator == discrim
                 }) {
@@ -74,7 +75,7 @@ impl ArgumentConvert for Member {
         }
 
         // If string is username or nickname
-        if let Ok(member_results) = guild_id.search_members(ctx.http(), s, Some(100)).await {
+        if let Ok(member_results) = guild_id.search_members(ctx.http(), s, limit).await {
             if let Some(member) = member_results.into_iter().find(|m| {
                 m.user.name.eq_ignore_ascii_case(s)
                     || m.nick.as_ref().is_some_and(|nick| nick.eq_ignore_ascii_case(s))


### PR DESCRIPTION
This removes multiple error variants and overall cleans up the codebase by moving overflow checks into two ModelError variants.