### PR TITLE
Get rid of IntoIterator generics where inefficent

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -288,7 +288,7 @@ async fn main() {
             // In this case, if "," would be first, a message would never be delimited at ", ",
             // forcing you to trim your arguments if you want to avoid whitespaces at the start of
             // each.
-            .delimiters(vec![", ", ","])
+            .delimiters(vec![", ".into(), ",".into()])
             // Sets the bot's owners. These will be used for commands that are owners only.
             .owners(owners),
     );

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
             .with_whitespace(true)
             .on_mention(Some(bot_id))
             .prefix("~")
-            .delimiters(vec![", ", ","]),
+            .delimiters(vec![", ".into(), ",".into()]),
     );
 
     let intents = GatewayIntents::GUILD_MESSAGES

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -102,7 +102,12 @@ impl<'a> Builder for CreateSticker<'a> {
             Permissions::CREATE_GUILD_EXPRESSIONS,
         )?;
 
-        let map = [("name", self.name), ("tags", self.tags), ("description", self.description)];
+        let map = vec![
+            ("name".into(), self.name),
+            ("tags".into(), self.tags),
+            ("description".into(), self.description),
+        ];
+
         cache_http.http().create_sticker(ctx, map, self.file, self.audit_log_reason).await
     }
 }

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -39,7 +39,7 @@ type Result<T, E> = ::std::result::Result<T, Error<E>>;
 #[derive(Debug, Clone)]
 pub enum Delimiter {
     Single(char),
-    Multiple(String),
+    Multiple(Cow<'static, str>),
 }
 
 impl Delimiter {
@@ -62,21 +62,14 @@ impl From<char> for Delimiter {
 impl From<String> for Delimiter {
     #[inline]
     fn from(s: String) -> Delimiter {
-        Delimiter::Multiple(s)
+        Delimiter::Multiple(Cow::Owned(s))
     }
 }
 
-impl<'a> From<&'a String> for Delimiter {
+impl From<&'static str> for Delimiter {
     #[inline]
-    fn from(s: &'a String) -> Delimiter {
-        Delimiter::Multiple(s.clone())
-    }
-}
-
-impl<'a> From<&'a str> for Delimiter {
-    #[inline]
-    fn from(s: &'a str) -> Delimiter {
-        Delimiter::Multiple(s.to_string())
+    fn from(s: &'static str) -> Delimiter {
+        Delimiter::Multiple(Cow::Borrowed(s))
     }
 }
 
@@ -353,7 +346,7 @@ impl Args {
             .iter()
             .filter(|d| match d {
                 Delimiter::Single(c) => message.contains(*c),
-                Delimiter::Multiple(s) => message.contains(s),
+                Delimiter::Multiple(s) => message.contains(s.as_ref()),
             })
             .map(Delimiter::to_str)
             .collect::<Vec<_>>();

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -725,7 +725,7 @@ impl Framework for StandardFramework {
                                 v.push(Delimiter::Single(delim.chars().next().unwrap()));
                             } else {
                                 // This too.
-                                v.push(Delimiter::Multiple((*delim).to_string()));
+                                v.push(Delimiter::Multiple(Cow::Borrowed(delim)));
                             }
                         }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -857,7 +857,7 @@ impl Http {
     pub async fn create_sticker(
         &self,
         guild_id: GuildId,
-        map: impl IntoIterator<Item = (&'static str, Cow<'static, str>)>,
+        fields: Vec<(Cow<'static, str>, Cow<'static, str>)>,
         file: CreateAttachment<'_>,
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {
@@ -865,8 +865,8 @@ impl Http {
             body: None,
             multipart: Some(Multipart {
                 upload: MultipartUpload::File(file),
-                fields: map.into_iter().map(|(k, v)| (k.into(), v)).collect(),
                 payload_json: None,
+                fields,
             }),
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -1154,7 +1154,7 @@ impl Http {
     pub async fn delete_messages(
         &self,
         channel_id: ChannelId,
-        map: &Value,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(204, Request {
@@ -1718,7 +1718,7 @@ impl Http {
     pub async fn edit_guild_channel_positions(
         &self,
         guild_id: GuildId,
-        value: &Value,
+        value: &impl serde::Serialize,
     ) -> Result<()> {
         let body = to_vec(value)?;
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -30,8 +30,6 @@ use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
 use crate::internal::prelude::*;
-#[cfg(feature = "model")]
-use crate::json::json;
 use crate::model::prelude::*;
 
 #[cfg(feature = "model")]
@@ -181,26 +179,29 @@ impl ChannelId {
     /// Also will return [`Error::Http`] if the current user lacks permission to delete messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_messages<T: AsRef<MessageId>>(
+    pub async fn delete_messages(
         self,
         http: impl AsRef<Http>,
-        message_ids: impl IntoIterator<Item = T>,
+        message_ids: &[MessageId],
     ) -> Result<()> {
-        let ids =
-            message_ids.into_iter().map(|message_id| *message_id.as_ref()).collect::<Vec<_>>();
+        #[derive(serde::Serialize)]
+        struct DeleteMessages<'a> {
+            messages: &'a [MessageId],
+        }
 
-        let len = ids.len();
-
+        let len = message_ids.len();
         if len == 0 || len > 100 {
             return Err(Error::Model(ModelError::BulkDeleteAmount));
         }
 
-        if ids.len() == 1 {
-            self.delete_message(http, ids[0]).await
+        if len == 1 {
+            self.delete_message(http, message_ids[0]).await
         } else {
-            let map = json!({ "messages": ids });
+            let req = DeleteMessages {
+                messages: message_ids,
+            };
 
-            http.as_ref().delete_messages(self, &map, None).await
+            http.as_ref().delete_messages(self, &req, None).await
         }
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -379,10 +379,10 @@ impl GuildChannel {
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
-    pub async fn delete_messages<T: AsRef<MessageId>>(
+    pub async fn delete_messages(
         &self,
         http: impl AsRef<Http>,
-        message_ids: impl IntoIterator<Item = T>,
+        message_ids: &[MessageId],
     ) -> Result<()> {
         self.id.delete_messages(http, message_ids).await
     }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -91,10 +91,10 @@ impl PrivateChannel {
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     #[inline]
-    pub async fn delete_messages<T: AsRef<MessageId>>(
+    pub async fn delete_messages(
         &self,
         http: impl AsRef<Http>,
-        message_ids: impl IntoIterator<Item = T>,
+        message_ids: &[MessageId],
     ) -> Result<()> {
         self.id.delete_messages(http, message_ids).await
     }

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -35,8 +35,8 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn attachments(&mut self, attachments: impl IntoIterator<Item = Attachment>) -> &mut Self {
-        self.msg.attachments = attachments.into_iter().collect();
+    pub fn attachments(&mut self, attachments: Vec<Attachment>) -> &mut Self {
+        self.msg.attachments = attachments.into();
 
         self
     }
@@ -85,8 +85,8 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn embeds(&mut self, embeds: impl IntoIterator<Item = Embed>) -> &mut Self {
-        self.msg.embeds = embeds.into_iter().collect();
+    pub fn embeds(&mut self, embeds: Vec<Embed>) -> &mut Self {
+        self.msg.embeds = embeds.into();
 
         self
     }
@@ -137,8 +137,8 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn mention_roles(&mut self, roles: impl IntoIterator<Item = RoleId>) -> &mut Self {
-        self.msg.mention_roles = roles.into_iter().collect();
+    pub fn mention_roles(&mut self, roles: Vec<RoleId>) -> &mut Self {
+        self.msg.mention_roles = roles.into();
 
         self
     }
@@ -147,8 +147,8 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn mentions(&mut self, mentions: impl IntoIterator<Item = User>) -> &mut Self {
-        self.msg.mentions = mentions.into_iter().collect();
+    pub fn mentions(&mut self, mentions: Vec<User>) -> &mut Self {
+        self.msg.mentions = mentions.into();
 
         self
     }
@@ -167,8 +167,8 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     #[inline]
-    pub fn reactions(&mut self, reactions: impl IntoIterator<Item = MessageReaction>) -> &mut Self {
-        self.msg.reactions = reactions.into_iter().collect();
+    pub fn reactions(&mut self, reactions: Vec<MessageReaction>) -> &mut Self {
+        self.msg.reactions = reactions.into();
 
         self
     }


### PR DESCRIPTION
This removes inefficient IntoIter generics and instead takes what is actually required. I also reworked `reorder_channels` to allow for keeping the generic, as it actually does only just need iterator semantics.