### PR TITLE
Shrink size and cleanup Error

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -57,7 +57,8 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         let mut msg = channel_id
             .send_message(
                 &ctx,
-                CreateMessage::new().add_file(CreateAttachment::url(ctx, IMAGE_URL).await?),
+                CreateMessage::new()
+                    .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
             )
             .await?;
         // Pre-PR, this falsely triggered a MODEL_TYPE_CONVERT Discord error
@@ -69,13 +70,15 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         let mut msg = channel_id
             .send_message(
                 ctx,
-                CreateMessage::new().add_file(CreateAttachment::url(ctx, IMAGE_URL).await?),
+                CreateMessage::new()
+                    .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
             )
             .await?;
         msg.edit(
             ctx,
             EditMessage::new().attachments(
-                EditAttachments::keep_all(&msg).add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
+                EditAttachments::keep_all(&msg)
+                    .add(CreateAttachment::url(ctx, IMAGE_URL_2, "testing1.png").await?),
             ),
         )
         .await?;
@@ -196,7 +199,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
                 ctx,
                 CreateMessage::new()
                     .flags(MessageFlags::IS_VOICE_MESSAGE)
-                    .add_file(CreateAttachment::url(ctx, audio_url).await?),
+                    .add_file(CreateAttachment::url(ctx, audio_url, "testing.ogg").await?),
             )
             .await?;
     } else if let Some(channel) = msg.content.strip_prefix("movetorootandback") {
@@ -231,7 +234,7 @@ async fn interaction(
                 &ctx,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
-                        .add_file(CreateAttachment::url(ctx, IMAGE_URL).await?),
+                        .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
                 ),
             )
             .await?;
@@ -245,7 +248,7 @@ async fn interaction(
                 &ctx,
                 EditInteractionResponse::new().attachments(
                     EditAttachments::keep_all(&msg)
-                        .add(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
+                        .add(CreateAttachment::url(ctx, IMAGE_URL_2, "testing1.png").await?),
                 ),
             )
             .await?;
@@ -286,7 +289,7 @@ async fn interaction(
                 ctx,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
-                        .add_file(CreateAttachment::url(ctx, IMAGE_URL).await?),
+                        .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
                 ),
             )
             .await?;
@@ -295,7 +298,7 @@ async fn interaction(
             .edit_response(
                 ctx,
                 EditInteractionResponse::new()
-                    .new_attachment(CreateAttachment::url(ctx, IMAGE_URL_2).await?),
+                    .new_attachment(CreateAttachment::url(ctx, IMAGE_URL_2, "testing1.png").await?),
             )
             .await?;
 
@@ -303,7 +306,7 @@ async fn interaction(
             .create_followup(
                 ctx,
                 CreateInteractionResponseFollowup::new()
-                    .add_file(CreateAttachment::url(ctx, IMAGE_URL).await?),
+                    .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
             )
             .await?;
     } else if interaction.data.name == "editembeds" {

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -4,10 +4,11 @@ use std::path::Path;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 
-use crate::all::Message;
-use crate::error::Result;
+#[allow(unused)] // Error is used in docs
+use crate::error::{Error, Result};
 #[cfg(feature = "http")]
 use crate::http::Http;
+use crate::model::channel::Message;
 use crate::model::id::AttachmentId;
 
 /// Enum that allows a user to pass a [`Path`] or a [`File`] type to [`send_files`]
@@ -77,7 +78,7 @@ impl<'a> CreateAttachment<'a> {
     ///
     /// # Errors
     ///
-    /// [`Error::Url`] if the URL is invalid, [`Error::Http`] if downloading the data fails.
+    /// Returns [`Error::Http`] if downloading the data fails.
     #[cfg(feature = "http")]
     pub async fn url(
         http: impl AsRef<Http>,

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -12,15 +12,12 @@ use std::fmt;
 pub enum Error {
     /// When a shard has completely failed to reboot after resume and/or reconnect attempts.
     ShardBootFailure,
-    /// When all shards that the client is responsible for have shutdown with an error.
-    Shutdown,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ShardBootFailure => f.write_str("Failed to (re-)boot a shard"),
-            Self::Shutdown => f.write_str("The clients shards shutdown"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use std::error::Error as StdError;
-use std::fmt::{self, Error as FormatError};
+use std::fmt;
 use std::io::Error as IoError;
 
 #[cfg(feature = "http")]
@@ -31,10 +31,6 @@ pub type Result<T, E = Error> = StdResult<T, E>;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
-    /// An error while decoding a payload.
-    Decode(&'static str, Value),
-    /// There was an error with a format.
-    Format(FormatError),
     /// An [`std::io`] error.
     Io(IoError),
     #[cfg_attr(not(feature = "simd_json"), doc = "An error from the [`serde_json`] crate.")]
@@ -44,20 +40,6 @@ pub enum Error {
     ///
     /// [`model`]: crate::model
     Model(ModelError),
-    /// The input is not in the specified range. Returned by [`GuildId::members`],
-    /// [`Guild::members`] and [`PartialGuild::members`]
-    ///
-    /// (param_name, value, range_min, range_max)
-    ///
-    /// [`GuildId::members`]: crate::model::id::GuildId::members
-    /// [`Guild::members`]: crate::model::guild::Guild::members
-    /// [`PartialGuild::members`]: crate::model::guild::PartialGuild::members
-    NotInRange(&'static str, u64, u64, u64),
-    /// Some other error. This is only used for "Expected value \<TYPE\>" errors, when a more
-    /// detailed error can not be easily provided via the [`Error::Decode`] variant.
-    Other(&'static str),
-    /// An error from the [`url`] crate.
-    Url(String),
     /// A [client] error.
     ///
     /// [client]: crate::client
@@ -76,12 +58,6 @@ pub enum Error {
     /// An error from the `tungstenite` crate.
     #[cfg(feature = "gateway")]
     Tungstenite(TungsteniteError),
-}
-
-impl From<FormatError> for Error {
-    fn from(e: FormatError) -> Error {
-        Error::Format(e)
-    }
 }
 
 #[cfg(feature = "gateway")]
@@ -140,13 +116,9 @@ impl From<ReqwestError> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Decode(msg, _) | Self::Other(msg) => f.write_str(msg),
-            Self::NotInRange(..) => f.write_str("Input is not in the specified range"),
-            Self::Format(inner) => fmt::Display::fmt(&inner, f),
             Self::Io(inner) => fmt::Display::fmt(&inner, f),
             Self::Json(inner) => fmt::Display::fmt(&inner, f),
             Self::Model(inner) => fmt::Display::fmt(&inner, f),
-            Self::Url(msg) => f.write_str(msg),
             #[cfg(feature = "client")]
             Self::Client(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "gateway")]
@@ -163,7 +135,6 @@ impl StdError for Error {
     #[cfg_attr(feature = "tracing_instrument", instrument)]
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Self::Format(inner) => Some(inner),
             Self::Io(inner) => Some(inner),
             Self::Json(inner) => Some(inner),
             Self::Model(inner) => Some(inner),

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,7 +57,7 @@ pub enum Error {
     Http(HttpError),
     /// An error from the `tungstenite` crate.
     #[cfg(feature = "gateway")]
-    Tungstenite(TungsteniteError),
+    Tungstenite(Box<TungsteniteError>),
 }
 
 #[cfg(feature = "gateway")]
@@ -88,7 +88,7 @@ impl From<ModelError> for Error {
 #[cfg(feature = "gateway")]
 impl From<TungsteniteError> for Error {
     fn from(e: TungsteniteError) -> Error {
-        Error::Tungstenite(e)
+        Error::Tungstenite(Box::new(e))
     }
 }
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -1002,7 +1002,8 @@ async fn send_grouped_commands_embed(
     for group in groups {
         let mut embed_text = String::default();
 
-        flatten_group_to_string(&mut embed_text, group, 0, help_options).expect("String::write should never fail");
+        flatten_group_to_string(&mut embed_text, group, 0, help_options)
+            .expect("String::write should never fail");
 
         embed = embed.field(group.name, embed_text, true);
     }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -897,7 +897,7 @@ fn flatten_group_to_string(
     group: &GroupCommandsPair,
     nest_level: usize,
     help_options: &HelpOptions,
-) -> Result<(), Error> {
+) -> Result<(), std::fmt::Error> {
     let repeated_indent_str = help_options.indention_prefix.repeat(nest_level);
 
     if nest_level > 0 {
@@ -1002,7 +1002,7 @@ async fn send_grouped_commands_embed(
     for group in groups {
         let mut embed_text = String::default();
 
-        flatten_group_to_string(&mut embed_text, group, 0, help_options)?;
+        flatten_group_to_string(&mut embed_text, group, 0, help_options).expect("String::write should never fail");
 
         embed = embed.field(group.name, embed_text, true);
     }

--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -398,7 +398,7 @@ impl ShardRunner {
     async fn recv_event(&mut self) -> Result<(Option<Event>, Option<ShardAction>, bool)> {
         let gw_event = match self.shard.client.recv_json().await {
             Ok(inner) => Ok(inner),
-            Err(Error::Tungstenite(TungsteniteError::Io(_))) => {
+            Err(Error::Tungstenite(tung_err)) if matches!(*tung_err, TungsteniteError::Io(_)) => {
                 debug!("Attempting to auto-reconnect");
 
                 match self.shard.reconnection_type() {

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -201,17 +201,16 @@ impl Shard {
                 Ok(())
             },
             Err(why) => {
-                match why {
-                    Error::Tungstenite(TungsteniteError::Io(err)) => {
+                if let Error::Tungstenite(err) = &why {
+                    if let TungsteniteError::Io(err) = &**err {
                         if err.raw_os_error() != Some(32) {
                             debug!("[{:?}] Err heartbeating: {:?}", self.shard_info, err);
+                            return Err(Error::Gateway(GatewayError::HeartbeatFailed));
                         }
-                    },
-                    other => {
-                        warn!("[{:?}] Other err w/ keepalive: {:?}", self.shard_info, other);
-                    },
+                    }
                 }
 
+                warn!("[{:?}] Other err w/ keepalive: {:?}", self.shard_info, why);
                 Err(Error::Gateway(GatewayError::HeartbeatFailed))
             },
         }

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -74,10 +74,6 @@ pub enum HttpError {
     InvalidHeader(InvalidHeaderValue),
     /// Reqwest's Error contain information on why sending a request failed.
     Request(ReqwestError),
-    /// When using a proxy with an invalid scheme.
-    InvalidScheme,
-    /// When using a proxy with an invalid port.
-    InvalidPort,
     /// When an application id was expected but missing.
     ApplicationIdMissing,
 }
@@ -165,8 +161,6 @@ impl fmt::Display for HttpError {
             Self::InvalidWebhook => f.write_str("Provided URL is not a valid webhook."),
             Self::InvalidHeader(_) => f.write_str("Provided value is an invalid header value."),
             Self::Request(_) => f.write_str("Error while sending HTTP request."),
-            Self::InvalidScheme => f.write_str("Invalid Url scheme."),
-            Self::InvalidPort => f.write_str("Invalid port."),
             Self::ApplicationIdMissing => f.write_str("Application id was expected but missing."),
         }
     }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -8,7 +8,7 @@ use reqwest::header::{
     CONTENT_TYPE,
     USER_AGENT,
 };
-use reqwest::{Client, RequestBuilder as ReqwestRequestBuilder, Url};
+use reqwest::{Client, RequestBuilder as ReqwestRequestBuilder};
 
 use super::multipart::Multipart;
 use super::routing::Route;
@@ -87,8 +87,7 @@ impl<'a> Request<'a> {
             }
         }
 
-        let mut builder = client
-            .request(self.method.reqwest_method(), Url::parse(&path).map_err(HttpError::Url)?);
+        let mut builder = client.request(self.method.reqwest_method(), path);
 
         let mut headers = self.headers.unwrap_or_default();
         headers.insert(USER_AGENT, HeaderValue::from_static(constants::USER_AGENT));

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -205,10 +205,6 @@ pub enum Error {
     ///
     /// [`Cache`]: crate::cache::Cache
     ItemMissing,
-    /// Indicates that a member, role or channel from the wrong [`Guild`] was provided.
-    ///
-    /// [`Guild`]: super::guild::Guild
-    WrongGuild,
     /// Indicates that the current user is attempting to Direct Message another bot user, which is
     /// disallowed by the API.
     MessagingBot,
@@ -216,15 +212,10 @@ pub enum Error {
     ///
     /// [`ChannelType`]: super::channel::ChannelType
     InvalidChannelType,
-    /// Indicates that the bot is not author of the message. This error is returned in
-    /// private/direct channels.
-    NotAuthor,
     /// Indicates that the webhook token is missing.
     NoTokenSet,
     /// When attempting to delete a built in nitro sticker instead of a guild sticker.
     DeleteNitroSticker,
-    /// Indicates that the sticker file is missing.
-    NoStickerFileSet,
     /// When attempting to edit a voice message.
     CannotEditVoiceMessage,
 }
@@ -266,14 +257,11 @@ impl fmt::Display for Error {
             } => f.write_str("Invalid permissions."),
             Self::InvalidUser => f.write_str("The current user cannot perform the action."),
             Self::ItemMissing => f.write_str("The required item is missing from the cache."),
-            Self::WrongGuild => f.write_str("Provided member or channel is from the wrong guild."),
             Self::MessageAlreadyCrossposted => f.write_str("Message already crossposted."),
             Self::CannotCrosspostMessage => f.write_str("Cannot crosspost this message type."),
             Self::MessagingBot => f.write_str("Attempted to message another bot user."),
-            Self::NotAuthor => f.write_str("The bot is not author of this message."),
             Self::NoTokenSet => f.write_str("Token is not set."),
             Self::DeleteNitroSticker => f.write_str("Cannot delete an official sticker."),
-            Self::NoStickerFileSet => f.write_str("Sticker file is not set."),
             Self::CannotEditVoiceMessage => f.write_str("Cannot edit voice message."),
         }
     }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1093,7 +1093,7 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the API returns an error, may also return
-    /// [`Error::NotInRange`] if the input is not within range.
+    /// [`ModelError::TooSmall`] or [`ModelError::TooLarge`] if the limit is not within range.
     ///
     /// [`User`]: crate::model::user::User
     #[inline]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1601,7 +1601,7 @@ impl Guild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the API returns an error, may also return
-    /// [`Error::NotInRange`] if the input is not within range.
+    /// [`ModelError::TooSmall`] or [`ModelError::TooLarge`] if the limit is not within range.
     ///
     /// [`User`]: crate::model::user::User
     #[inline]

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1318,7 +1318,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the API returns an error, may also return
-    /// [`Error::NotInRange`] if the input is not within range.
+    /// [`ModelError::TooSmall`] or [`ModelError::TooLarge`] if the limit is not within range.
     ///
     /// [`User`]: crate::model::user::User
     #[inline]


### PR DESCRIPTION
Shrinks size_of<Error> from 136 bytes to 64 bytes, while removing unused variants. This will improve performance for any method returning `Result<T>` where `T` is less than the size of `Error` as both Result's Ok and Err have to be allocated stack space.