### PR TITLE
Remove impl Into<Option>

### DIFF
--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -170,8 +170,8 @@ impl<'a> EditChannel<'a> {
     /// [text]: ChannelType::Text
     /// [voice]: ChannelType::Voice
     #[inline]
-    pub fn category<C: Into<Option<ChannelId>>>(mut self, category: C) -> Self {
-        self.parent_id = Some(category.into());
+    pub fn category(mut self, category: Option<ChannelId>) -> Self {
+        self.parent_id = Some(category);
         self
     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4015,7 +4015,7 @@ impl Http {
         message_id: MessageId,
         reaction_type: &ReactionType,
         limit: u8,
-        after: Option<u64>,
+        after: Option<UserId>,
     ) -> Result<Vec<User>> {
         let mut params = ArrayVec::<_, 2>::new();
         params.push(("limit", limit.to_string()));

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -619,18 +619,12 @@ impl ChannelId {
         message_id: impl Into<MessageId>,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
-        after: impl Into<Option<UserId>>,
+        after: Option<UserId>,
     ) -> Result<Vec<User>> {
         let limit = limit.map_or(50, |x| if x > 100 { 100 } else { x });
 
         http.as_ref()
-            .get_reaction_users(
-                self,
-                message_id.into(),
-                &reaction_type.into(),
-                limit,
-                after.into().map(UserId::get),
-            )
+            .get_reaction_users(self, message_id.into(), &reaction_type.into(), limit, after)
             .await
     }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -826,7 +826,7 @@ impl GuildChannel {
         message_id: impl Into<MessageId>,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
-        after: impl Into<Option<UserId>>,
+        after: Option<UserId>,
     ) -> Result<Vec<User>> {
         self.id.reaction_users(http, message_id, reaction_type, limit, after).await
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -446,7 +446,7 @@ impl Message {
         http: impl AsRef<Http>,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
-        after: impl Into<Option<UserId>>,
+        after: Option<UserId>,
     ) -> Result<Vec<User>> {
         self.channel_id.reaction_users(http, self.id, reaction_type, limit, after).await
     }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -227,7 +227,7 @@ impl PrivateChannel {
         message_id: impl Into<MessageId>,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
-        after: impl Into<Option<UserId>>,
+        after: Option<UserId>,
     ) -> Result<Vec<User>> {
         self.id.reaction_users(http, message_id, reaction_type, limit, after).await
     }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -5,6 +5,7 @@ use std::fmt::Display as _;
 use std::fmt::{self, Write as _};
 use std::str::FromStr;
 
+use nonmax::NonMaxU8;
 #[cfg(feature = "http")]
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::de::{Deserialize, Error as DeError};
@@ -217,7 +218,7 @@ impl Reaction {
         &self,
         http: impl AsRef<Http>,
         reaction_type: R,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
         after: Option<U>,
     ) -> Result<Vec<User>>
     where
@@ -231,10 +232,10 @@ impl Reaction {
         &self,
         http: impl AsRef<Http>,
         reaction_type: &ReactionType,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
-        let mut limit = limit.unwrap_or(50);
+        let mut limit = limit.map_or(50, |limit| limit.get());
 
         if limit > 100 {
             limit = 100;
@@ -242,13 +243,7 @@ impl Reaction {
         }
 
         http.as_ref()
-            .get_reaction_users(
-                self.channel_id,
-                self.message_id,
-                reaction_type,
-                limit,
-                after.map(UserId::get),
-            )
+            .get_reaction_users(self.channel_id, self.message_id, reaction_type, limit, after)
             .await
     }
 }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1102,9 +1102,9 @@ impl GuildId {
         self,
         http: impl AsRef<Http>,
         limit: Option<u64>,
-        after: impl Into<Option<UserId>>,
+        after: Option<UserId>,
     ) -> Result<Vec<Member>> {
-        http.as_ref().get_guild_members(self, limit, after.into().map(UserId::get)).await
+        http.as_ref().get_guild_members(self, limit, after.map(UserId::get)).await
     }
 
     /// Streams over all the members in a guild.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1609,7 +1609,7 @@ impl Guild {
         &self,
         http: impl AsRef<Http>,
         limit: Option<u64>,
-        after: impl Into<Option<UserId>>,
+        after: Option<UserId>,
     ) -> Result<Vec<Member>> {
         self.id.members(http, limit, after).await
     }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1326,7 +1326,7 @@ impl PartialGuild {
         &self,
         http: impl AsRef<Http>,
         limit: Option<u64>,
-        after: impl Into<Option<UserId>>,
+        after: Option<UserId>,
     ) -> Result<Vec<Member>> {
         self.id.members(http, limit, after).await
     }


### PR DESCRIPTION
This signature is hard to use as `None` cannot infer the type of the generic. I also replaced `Option<u8>` with `Option<NonMaxU8>` as it's more efficient and will make the user think of the maximum value.