### PR TITLE
Remove Into<Id> and AsRef<str>

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -351,7 +351,7 @@ async fn say(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
                     // We do not want to clean channel mentions as they do not ping users.
                     .clean_channel(false);
 
-                x = content_safe(&guild, x, settings, &msg.mentions);
+                x = content_safe(&guild, &x, settings, &msg.mentions);
             }
 
             msg.channel_id.say(&ctx.http, x).await?;

--- a/examples/e11_gateway_intents/src/main.rs
+++ b/examples/e11_gateway_intents/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
     let intents =
         GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT;
     // Build our client.
-    let mut client = Client::builder(token, intents)
+    let mut client = Client::builder(&token, intents)
         .event_handler(Handler)
         .await
         .expect("Error creating client");

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -75,7 +75,7 @@ async fn main() {
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
 
     // Build our client.
-    let mut client = Client::builder(token, GatewayIntents::empty())
+    let mut client = Client::builder(&token, GatewayIntents::empty())
         .event_handler(Handler)
         .await
         .expect("Error creating client");

--- a/examples/e15_simple_dashboard/src/main.rs
+++ b/examples/e15_simple_dashboard/src/main.rs
@@ -414,7 +414,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client = Client::builder(token, intents)
+    let mut client = Client::builder(&token, intents)
         .event_handler(Handler)
         .framework(framework)
         .type_map_insert::<RillRateComponents>(components)

--- a/examples/e17_message_components/src/main.rs
+++ b/examples/e17_message_components/src/main.rs
@@ -144,7 +144,7 @@ async fn main() {
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
-    let mut client = Client::builder(token, intents)
+    let mut client = Client::builder(&token, intents)
         .event_handler(Handler)
         .await
         .expect("Error creating client");

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -403,5 +403,5 @@ async fn main() -> Result<(), serenity::Error> {
     env_logger::init();
     let token = std::env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
     let intents = GatewayIntents::non_privileged() | GatewayIntents::MESSAGE_CONTENT;
-    Client::builder(token, intents).event_handler(Handler).await?.start().await
+    Client::builder(&token, intents).event_handler(Handler).await?.start().await
 }

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -71,8 +71,8 @@ impl<'a> CreateBotAuthParameters<'a> {
     }
 
     /// Specify the client Id of your application.
-    pub fn client_id(mut self, client_id: impl Into<ApplicationId>) -> Self {
-        self.client_id = Some(client_id.into());
+    pub fn client_id(mut self, client_id: ApplicationId) -> Self {
+        self.client_id = Some(client_id);
         self
     }
 
@@ -107,8 +107,8 @@ impl<'a> CreateBotAuthParameters<'a> {
     }
 
     /// Specify the Id of the guild to prefill the dropdown picker for the user.
-    pub fn guild_id(mut self, guild_id: impl Into<GuildId>) -> Self {
-        self.guild_id = Some(guild_id.into());
+    pub fn guild_id(mut self, guild_id: GuildId) -> Self {
+        self.guild_id = Some(guild_id);
         self
     }
 

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -97,8 +97,8 @@ impl<'a> CreateChannel<'a> {
     /// Only for [`ChannelType::Text`], [`ChannelType::Voice`], [`ChannelType::News`],
     /// [`ChannelType::Stage`], [`ChannelType::Forum`]
     #[doc(alias = "parent_id")]
-    pub fn category(mut self, id: impl Into<ChannelId>) -> Self {
-        self.parent_id = Some(id.into());
+    pub fn category(mut self, id: ChannelId) -> Self {
+        self.parent_id = Some(id);
         self
     }
 

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -207,8 +207,8 @@ impl<'a> CreateMessage<'a> {
     ///
     /// **Note**: This will replace all existing stickers. Use [`Self::add_sticker_id()`] to keep
     /// existing stickers.
-    pub fn sticker_id(self, sticker_id: impl Into<StickerId>) -> Self {
-        self.sticker_ids(vec![sticker_id.into()])
+    pub fn sticker_id(self, sticker_id: StickerId) -> Self {
+        self.sticker_ids(vec![sticker_id])
     }
 
     /// Sets a list of sticker IDs to include in the message.
@@ -228,8 +228,8 @@ impl<'a> CreateMessage<'a> {
     ///
     /// **Note**: This will keep all existing stickers. Use [`Self::sticker_id()`] to replace
     /// existing sticker.
-    pub fn add_sticker_id(mut self, sticker_id: impl Into<StickerId>) -> Self {
-        self.sticker_ids.to_mut().push(sticker_id.into());
+    pub fn add_sticker_id(mut self, sticker_id: StickerId) -> Self {
+        self.sticker_ids.to_mut().push(sticker_id);
         self
     }
 
@@ -239,11 +239,8 @@ impl<'a> CreateMessage<'a> {
     ///
     /// **Note**: This will keep all existing stickers. Use [`Self::sticker_ids()`] to replace
     /// existing stickers.
-    pub fn add_sticker_ids<T: Into<StickerId>>(
-        mut self,
-        sticker_ids: impl IntoIterator<Item = T>,
-    ) -> Self {
-        self.sticker_ids.to_mut().extend(sticker_ids.into_iter().map(Into::into));
+    pub fn add_sticker_ids(mut self, sticker_ids: impl IntoIterator<Item = StickerId>) -> Self {
+        self.sticker_ids.to_mut().extend(sticker_ids);
         self
     }
 

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -62,8 +62,8 @@ impl<'a> CreateScheduledEvent<'a> {
 
     /// Sets the channel id of the scheduled event. Required if [`Self::kind`] is
     /// [`ScheduledEventType::StageInstance`] or [`ScheduledEventType::Voice`].
-    pub fn channel_id<C: Into<ChannelId>>(mut self, channel_id: C) -> Self {
-        self.channel_id = Some(channel_id.into());
+    pub fn channel_id(mut self, channel_id: ChannelId) -> Self {
+        self.channel_id = Some(channel_id);
         self
     }
 

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -145,8 +145,8 @@ impl<'a> EditGuild<'a> {
     /// Transfers the ownership of the guild to another user by Id.
     ///
     /// **Note**: The current user must be the owner of the guild.
-    pub fn owner(mut self, user_id: impl Into<UserId>) -> Self {
-        self.owner_id = Some(user_id.into());
+    pub fn owner(mut self, user_id: UserId) -> Self {
+        self.owner_id = Some(user_id);
         self
     }
 

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -111,8 +111,8 @@ impl<'a> CreateGuildWelcomeChannel<'a> {
     }
 
     /// The Id of the channel to show.
-    pub fn id(mut self, id: impl Into<ChannelId>) -> Self {
-        self.channel_id = id.into();
+    pub fn id(mut self, id: ChannelId) -> Self {
+        self.channel_id = id;
         self
     }
 

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -34,8 +34,8 @@ impl<'a> EditGuildWidget<'a> {
     }
 
     /// The server description shown in the welcome screen.
-    pub fn channel_id(mut self, id: impl Into<ChannelId>) -> Self {
-        self.channel_id = Some(id.into());
+    pub fn channel_id(mut self, id: ChannelId) -> Self {
+        self.channel_id = Some(id);
         self
     }
 

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -85,8 +85,8 @@ impl<'a> EditMember<'a> {
     /// **Note**: Requires the [Move Members] permission.
     ///
     /// [Move Members]: Permissions::MOVE_MEMBERS
-    pub fn voice_channel(mut self, channel_id: impl Into<ChannelId>) -> Self {
-        self.channel_id = Some(Some(channel_id.into()));
+    pub fn voice_channel(mut self, channel_id: ChannelId) -> Self {
+        self.channel_id = Some(Some(channel_id));
         self
     }
 

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -50,8 +50,8 @@ impl<'a> EditScheduledEvent<'a> {
     /// [`kind`]: EditScheduledEvent::kind
     /// [`Voice`]: ScheduledEventType::Voice
     /// [`External`]: ScheduledEventType::External
-    pub fn channel_id(mut self, channel_id: impl Into<ChannelId>) -> Self {
-        self.channel_id = Some(Some(channel_id.into()));
+    pub fn channel_id(mut self, channel_id: ChannelId) -> Self {
+        self.channel_id = Some(Some(channel_id));
         self
     }
 

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -37,8 +37,8 @@ impl<'a> EditWebhook<'a> {
     }
 
     /// Set the channel to move the webhook to.
-    pub fn channel_id(mut self, channel_id: impl Into<ChannelId>) -> Self {
-        self.channel_id = Some(channel_id.into());
+    pub fn channel_id(mut self, channel_id: ChannelId) -> Self {
+        self.channel_id = Some(channel_id);
         self
     }
 

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -57,8 +57,8 @@ impl<'a> EditWebhookMessage<'a> {
 
     /// Edits a message within a given thread. If the provided thread Id doesn't belong to the
     /// current webhook, the API will return an error.
-    pub fn in_thread(mut self, thread_id: impl Into<ChannelId>) -> Self {
-        self.thread_id = Some(thread_id.into());
+    pub fn in_thread(mut self, thread_id: ChannelId) -> Self {
+        self.thread_id = Some(thread_id);
         self
     }
 

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -161,20 +161,20 @@ impl<'a> ExecuteWebhook<'a> {
     /// ```rust,no_run
     /// # use serenity::builder::ExecuteWebhook;
     /// # use serenity::http::Http;
-    /// # use serenity::model::webhook::Webhook;
+    /// # use serenity::model::{id::ChannelId, webhook::Webhook};
     /// #
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// let url = "https://discord.com/api/webhooks/245037420704169985/ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV";
     /// let mut webhook = Webhook::from_url(&http, url).await?;
     ///
-    /// let builder = ExecuteWebhook::new().in_thread(12345678).content("test");
+    /// let builder = ExecuteWebhook::new().in_thread(ChannelId::new(12345678)).content("test");
     /// webhook.execute(&http, false, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn in_thread(mut self, thread_id: impl Into<ChannelId>) -> Self {
-        self.thread_id = Some(thread_id.into());
+    pub fn in_thread(mut self, thread_id: ChannelId) -> Self {
+        self.thread_id = Some(thread_id);
         self
     }
 

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -60,21 +60,21 @@ impl GetMessages {
     }
 
     /// Indicates to retrieve the messages after a specific message, given its Id.
-    pub fn after(mut self, message_id: impl Into<MessageId>) -> Self {
-        self.search_filter = Some(SearchFilter::After(message_id.into()));
+    pub fn after(mut self, message_id: MessageId) -> Self {
+        self.search_filter = Some(SearchFilter::After(message_id));
         self
     }
 
     /// Indicates to retrieve the messages _around_ a specific message, in other words in either
     /// direction from the message in time.
-    pub fn around(mut self, message_id: impl Into<MessageId>) -> Self {
-        self.search_filter = Some(SearchFilter::Around(message_id.into()));
+    pub fn around(mut self, message_id: MessageId) -> Self {
+        self.search_filter = Some(SearchFilter::Around(message_id));
         self
     }
 
     /// Indicates to retrieve the messages before a specific message, given its Id.
-    pub fn before(mut self, message_id: impl Into<MessageId>) -> Self {
-        self.search_filter = Some(SearchFilter::Before(message_id.into()));
+    pub fn before(mut self, message_id: MessageId) -> Self {
+        self.search_filter = Some(SearchFilter::Before(message_id));
         self
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -348,11 +348,7 @@ impl Cache {
     }
 
     /// Retrieves a [`GuildChannel`] from the cache based on the given Id.
-    pub fn channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannelRef<'_>> {
-        self._channel(id.into())
-    }
-
-    fn _channel(&self, id: ChannelId) -> Option<GuildChannelRef<'_>> {
+    pub fn channel(&self, id: ChannelId) -> Option<GuildChannelRef<'_>> {
         let guild_id = *self.channels.get(&id)?;
         let guild_ref = self.guilds.get(&guild_id)?;
         let channel = guild_ref.try_map(|g| g.channels.get(&id)).ok();
@@ -386,17 +382,16 @@ impl Cache {
     /// Find all messages by user ID 8 in channel ID 7:
     ///
     /// ```rust,no_run
+    /// # use serenity::model::id::ChannelId;
+    /// #
     /// # let cache: serenity::cache::Cache = todo!();
-    /// let messages_in_channel = cache.channel_messages(7);
+    /// let messages_in_channel = cache.channel_messages(ChannelId::new(7));
     /// let messages_by_user = messages_in_channel
     ///     .as_ref()
     ///     .map(|msgs| msgs.values().filter(|m| m.author.id == 8).collect::<Vec<_>>());
     /// ```
-    pub fn channel_messages(
-        &self,
-        channel_id: impl Into<ChannelId>,
-    ) -> Option<ChannelMessagesRef<'_>> {
-        self.messages.get(&channel_id.into()).map(CacheRef::from_ref)
+    pub fn channel_messages(&self, channel_id: ChannelId) -> Option<ChannelMessagesRef<'_>> {
+        self.messages.get(&channel_id).map(CacheRef::from_ref)
     }
 
     /// Gets a reference to a guild from the cache based on the given `id`.
@@ -407,18 +402,15 @@ impl Cache {
     ///
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
+    /// # use serenity::model::id::GuildId;
     /// #
     /// # let cache = Cache::default();
     /// // assuming the cache is in scope, e.g. via `Context`
-    /// if let Some(guild) = cache.guild(7) {
+    /// if let Some(guild) = cache.guild(GuildId::new(7)) {
     ///     println!("Guild name: {}", guild.name);
     /// };
     /// ```
-    pub fn guild<G: Into<GuildId>>(&self, id: G) -> Option<GuildRef<'_>> {
-        self._guild(id.into())
-    }
-
-    fn _guild(&self, id: GuildId) -> Option<GuildRef<'_>> {
+    pub fn guild(&self, id: GuildId) -> Option<GuildRef<'_>> {
         self.guilds.get(&id).map(CacheRef::from_ref)
     }
 
@@ -470,12 +462,8 @@ impl Cache {
     ///
     /// [`EventHandler::message`]: crate::client::EventHandler::message
     /// [`members`]: crate::model::guild::Guild::members
-    pub fn member(
-        &self,
-        guild_id: impl Into<GuildId>,
-        user_id: impl Into<UserId>,
-    ) -> Option<MemberRef<'_>> {
-        self._member(guild_id.into(), user_id.into())
+    pub fn member(&self, guild_id: GuildId, user_id: UserId) -> Option<MemberRef<'_>> {
+        self._member(guild_id, user_id)
     }
 
     fn _member(&self, guild_id: GuildId, user_id: UserId) -> Option<MemberRef<'_>> {
@@ -483,8 +471,8 @@ impl Cache {
         Some(CacheRef::from_mapped_ref(member))
     }
 
-    pub fn guild_roles(&self, guild_id: impl Into<GuildId>) -> Option<GuildRolesRef<'_>> {
-        self._guild_roles(guild_id.into())
+    pub fn guild_roles(&self, guild_id: GuildId) -> Option<GuildRolesRef<'_>> {
+        self._guild_roles(guild_id)
     }
 
     fn _guild_roles(&self, guild_id: GuildId) -> Option<GuildRolesRef<'_>> {
@@ -498,8 +486,8 @@ impl Cache {
     }
 
     /// This method returns all channels from a guild of with the given `guild_id`.
-    pub fn guild_channels(&self, guild_id: impl Into<GuildId>) -> Option<GuildChannelsRef<'_>> {
-        self._guild_channels(guild_id.into())
+    pub fn guild_channels(&self, guild_id: GuildId) -> Option<GuildChannelsRef<'_>> {
+        self._guild_channels(guild_id)
     }
 
     fn _guild_channels(&self, guild_id: GuildId) -> Option<GuildChannelsRef<'_>> {
@@ -540,15 +528,7 @@ impl Cache {
     /// ```
     ///
     /// [`EventHandler::message`]: crate::client::EventHandler::message
-    pub fn message<C, M>(&self, channel_id: C, message_id: M) -> Option<MessageRef<'_>>
-    where
-        C: Into<ChannelId>,
-        M: Into<MessageId>,
-    {
-        self._message(channel_id.into(), message_id.into())
-    }
-
-    fn _message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<MessageRef<'_>> {
+    pub fn message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<MessageRef<'_>> {
         #[cfg(feature = "temp_cache")]
         if let Some(message) = self.temp_messages.get(&message_id) {
             return Some(CacheRef::from_arc(message));
@@ -569,26 +549,19 @@ impl Cache {
     /// Retrieve a role from the cache and print its name:
     ///
     /// ```rust,no_run
+    /// # use serenity::model::id::{GuildId, RoleId};
     /// # use serenity::cache::Cache;
     /// #
     /// # let cache = Cache::default();
     /// // assuming the cache is in scope, e.g. via `Context`
-    /// if let Some(role) = cache.role(7, 77) {
+    /// if let Some(role) = cache.role(GuildId::new(7), RoleId::new(77)) {
     ///     println!("Role with Id 77 is called {}", role.name);
     /// };
     /// ```
     ///
     /// [`Guild`]: crate::model::guild::Guild
     /// [`roles`]: crate::model::guild::Guild::roles
-    pub fn role<G, R>(&self, guild_id: G, role_id: R) -> Option<GuildRoleRef<'_>>
-    where
-        G: Into<GuildId>,
-        R: Into<RoleId>,
-    {
-        self._role(guild_id.into(), role_id.into())
-    }
-
-    fn _role(&self, guild_id: GuildId, role_id: RoleId) -> Option<GuildRoleRef<'_>> {
+    pub fn role(&self, guild_id: GuildId, role_id: RoleId) -> Option<GuildRoleRef<'_>> {
         let role = self.guilds.get(&guild_id)?.try_map(|g| g.roles.get(&role_id)).ok()?;
         Some(CacheRef::from_mapped_ref(role))
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -82,7 +82,23 @@ pub struct ClientBuilder {
 
 #[cfg(feature = "gateway")]
 impl ClientBuilder {
-    fn _new(http: Http, intents: GatewayIntents) -> Self {
+    /// Construct a new builder to call methods on for the client construction. The `token` will
+    /// automatically be prefixed "Bot " if not already.
+    ///
+    /// **Panic**: If you have enabled the `framework`-feature (on by default), you must specify a
+    /// framework via the [`Self::framework`] method, otherwise awaiting the builder will cause a
+    /// panic.
+    pub fn new(token: &str, intents: GatewayIntents) -> Self {
+        Self::new_with_http(Http::new(token), intents)
+    }
+
+    /// Construct a new builder with a [`Http`] instance to calls methods on for the client
+    /// construction.
+    ///
+    /// **Panic**: If you have enabled the `framework`-feature (on by default), you must specify a
+    /// framework via the [`Self::framework`] method, otherwise awaiting the builder will cause a
+    /// panic.
+    pub fn new_with_http(http: Http, intents: GatewayIntents) -> Self {
         Self {
             data: TypeMap::new(),
             http,
@@ -99,31 +115,10 @@ impl ClientBuilder {
         }
     }
 
-    /// Construct a new builder to call methods on for the client construction. The `token` will
-    /// automatically be prefixed "Bot " if not already.
-    ///
-    /// **Panic**: If you have enabled the `framework`-feature (on by default), you must specify a
-    /// framework via the [`Self::framework`] method, otherwise awaiting the builder will cause a
-    /// panic.
-    pub fn new(token: impl AsRef<str>, intents: GatewayIntents) -> Self {
-        Self::_new(Http::new(token.as_ref()), intents)
-    }
-
-    /// Construct a new builder with a [`Http`] instance to calls methods on for the client
-    /// construction.
-    ///
-    /// **Panic**: If you have enabled the `framework`-feature (on by default), you must specify a
-    /// framework via the [`Self::framework`] method, otherwise awaiting the builder will cause a
-    /// panic.
-    pub fn new_with_http(http: Http, intents: GatewayIntents) -> Self {
-        Self::_new(http, intents)
-    }
-
     /// Sets a token for the bot. If the token is not prefixed "Bot ", this method will
     /// automatically do so.
-    pub fn token(mut self, token: impl AsRef<str>) -> Self {
-        self.http = Http::new(token.as_ref());
-
+    pub fn token(mut self, token: &str) -> Self {
+        self.http = Http::new(token);
         self
     }
 
@@ -597,7 +592,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn builder(token: impl AsRef<str>, intents: GatewayIntents) -> ClientBuilder {
+    pub fn builder(token: &str, intents: GatewayIntents) -> ClientBuilder {
         ClientBuilder::new(token, intents)
     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -65,7 +65,7 @@ pub struct HttpBuilder {
 impl HttpBuilder {
     /// Construct a new builder to call methods on for the HTTP construction. The `token` will
     /// automatically be prefixed "Bot " if not already.
-    pub fn new(token: impl AsRef<str>) -> Self {
+    pub fn new(token: &str) -> Self {
         Self {
             client: None,
             ratelimiter: None,
@@ -84,7 +84,7 @@ impl HttpBuilder {
 
     /// Sets a token for the bot. If the token is not prefixed "Bot ", this method will
     /// automatically do so.
-    pub fn token(mut self, token: impl AsRef<str>) -> Self {
+    pub fn token(mut self, token: &str) -> Self {
         self.token = SecretString::new(parse_token(token));
         self
     }
@@ -157,8 +157,8 @@ impl HttpBuilder {
     }
 }
 
-fn parse_token(token: impl AsRef<str>) -> String {
-    let token = token.as_ref().trim();
+fn parse_token(token: &str) -> String {
+    let token = token.trim();
 
     if token.starts_with("Bot ") || token.starts_with("Bearer ") {
         token.to_string()

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -169,10 +169,10 @@ impl CommandInteraction {
     pub async fn edit_followup(
         &self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (Some(message_id.into()), &self.token)).await
+        builder.execute(cache_http, (Some(message_id), &self.token)).await
     }
 
     /// Deletes a followup message.
@@ -181,12 +181,12 @@ impl CommandInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_followup<M: Into<MessageId>>(
+    pub async fn delete_followup(
         &self,
         http: impl AsRef<Http>,
-        message_id: M,
+        message_id: MessageId,
     ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id.into()).await
+        http.as_ref().delete_followup_message(&self.token, message_id).await
     }
 
     /// Gets a followup message.
@@ -195,12 +195,12 @@ impl CommandInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was
     /// deleted.
-    pub async fn get_followup<M: Into<MessageId>>(
+    pub async fn get_followup(
         &self,
         http: impl AsRef<Http>,
-        message_id: M,
+        message_id: MessageId,
     ) -> Result<Message> {
-        http.as_ref().get_followup_message(&self.token, message_id.into()).await
+        http.as_ref().get_followup_message(&self.token, message_id).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -150,10 +150,10 @@ impl ComponentInteraction {
     pub async fn edit_followup(
         &self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (Some(message_id.into()), &self.token)).await
+        builder.execute(cache_http, (Some(message_id), &self.token)).await
     }
 
     /// Deletes a followup message.
@@ -162,12 +162,12 @@ impl ComponentInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_followup<M: Into<MessageId>>(
+    pub async fn delete_followup(
         &self,
         http: impl AsRef<Http>,
-        message_id: M,
+        message_id: MessageId,
     ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id.into()).await
+        http.as_ref().delete_followup_message(&self.token, message_id).await
     }
 
     /// Gets a followup message.
@@ -176,12 +176,12 @@ impl ComponentInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was
     /// deleted.
-    pub async fn get_followup<M: Into<MessageId>>(
+    pub async fn get_followup(
         &self,
         http: impl AsRef<Http>,
-        message_id: M,
+        message_id: MessageId,
     ) -> Result<Message> {
-        http.as_ref().get_followup_message(&self.token, message_id.into()).await
+        http.as_ref().get_followup_message(&self.token, message_id).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -149,10 +149,10 @@ impl ModalInteraction {
     pub async fn edit_followup(
         &self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (Some(message_id.into()), &self.token)).await
+        builder.execute(cache_http, (Some(message_id), &self.token)).await
     }
 
     /// Deletes a followup message.
@@ -161,12 +161,12 @@ impl ModalInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_followup<M: Into<MessageId>>(
+    pub async fn delete_followup(
         &self,
         http: impl AsRef<Http>,
-        message_id: M,
+        message_id: MessageId,
     ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id.into()).await
+        http.as_ref().delete_followup_message(&self.token, message_id).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -120,10 +120,10 @@ impl ChannelId {
     pub async fn create_reaction(
         self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.as_ref().create_reaction(self, message_id.into(), &reaction_type.into()).await
+        http.as_ref().create_reaction(self, message_id, &reaction_type.into()).await
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
@@ -151,12 +151,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission to delete the message.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_message(
-        self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-    ) -> Result<()> {
-        http.as_ref().delete_message(self, message_id.into(), None).await
+    pub async fn delete_message(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+        http.as_ref().delete_message(self, message_id, None).await
     }
 
     /// Deletes all messages by Ids from the given vector in the given channel.
@@ -236,12 +232,11 @@ impl ChannelId {
     pub async fn delete_reaction(
         self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
         let http = http.as_ref();
-        let message_id = message_id.into();
         let reaction_type = reaction_type.into();
         match user_id {
             Some(user_id) => http.delete_reaction(self, message_id, user_id, &reaction_type).await,
@@ -262,9 +257,9 @@ impl ChannelId {
     pub async fn delete_reactions(
         self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
     ) -> Result<()> {
-        http.as_ref().delete_message_reactions(self, message_id.into()).await
+        http.as_ref().delete_message_reactions(self, message_id).await
     }
 
     /// Deletes all [`Reaction`]s of the given emoji to a message within the channel.
@@ -279,12 +274,10 @@ impl ChannelId {
     pub async fn delete_reaction_emoji(
         self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.as_ref()
-            .delete_message_reaction_emoji(self, message_id.into(), &reaction_type.into())
-            .await
+        http.as_ref().delete_message_reaction_emoji(self, message_id, &reaction_type.into()).await
     }
 
     /// Edits a channel's settings.
@@ -342,10 +335,10 @@ impl ChannelId {
     pub async fn edit_message(
         self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         builder: EditMessage<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (self, message_id.into())).await
+        builder.execute(cache_http, (self, message_id)).await
     }
 
     /// Follows the News Channel
@@ -361,9 +354,9 @@ impl ChannelId {
     pub async fn follow(
         self,
         http: impl AsRef<Http>,
-        target_channel_id: impl Into<ChannelId>,
+        target_channel_id: ChannelId,
     ) -> Result<FollowedChannel> {
-        http.as_ref().follow_news_channel(self, target_channel_id.into()).await
+        http.as_ref().follow_news_channel(self, target_channel_id).await
     }
 
     /// Attempts to find a [`GuildChannel`] by its Id in the cache.
@@ -438,10 +431,8 @@ impl ChannelId {
     pub async fn message(
         self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
     ) -> Result<Message> {
-        let message_id = message_id.into();
-
         #[cfg(feature = "cache")]
         if let Some(cache) = cache_http.cache() {
             if let Some(message) = cache.message(self, message_id) {
@@ -539,8 +530,8 @@ impl ChannelId {
     /// many pinned messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn pin(self, http: impl AsRef<Http>, message_id: impl Into<MessageId>) -> Result<()> {
-        http.as_ref().pin_message(self, message_id.into(), None).await
+    pub async fn pin(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+        http.as_ref().pin_message(self, message_id, None).await
     }
 
     /// Crossposts a [`Message`].
@@ -556,12 +547,8 @@ impl ChannelId {
     /// author of the message.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn crosspost(
-        self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-    ) -> Result<Message> {
-        http.as_ref().crosspost_message(self, message_id.into()).await
+    pub async fn crosspost(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<Message> {
+        http.as_ref().crosspost_message(self, message_id).await
     }
 
     /// Gets the list of [`Message`]s which are pinned to the channel.
@@ -602,7 +589,7 @@ impl ChannelId {
     pub async fn reaction_users(
         self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
         after: Option<UserId>,
@@ -610,7 +597,7 @@ impl ChannelId {
         let limit = limit.map_or(50, |x| if x > 100 { 100 } else { x });
 
         http.as_ref()
-            .get_reaction_users(self, message_id.into(), &reaction_type.into(), limit, after)
+            .get_reaction_users(self, message_id, &reaction_type.into(), limit, after)
             .await
     }
 
@@ -778,12 +765,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn unpin(
-        self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-    ) -> Result<()> {
-        http.as_ref().unpin_message(self, message_id.into(), None).await
+    pub async fn unpin(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+        http.as_ref().unpin_message(self, message_id, None).await
     }
 
     /// Retrieves the channel's webhooks.
@@ -914,10 +897,10 @@ impl ChannelId {
     pub async fn create_thread_from_message(
         self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        builder.execute(cache_http, (self, Some(message_id.into()))).await
+        builder.execute(cache_http, (self, Some(message_id))).await
     }
 
     /// Creates a thread that is not connected to a message.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -412,7 +412,7 @@ impl GuildChannel {
     pub async fn delete_reaction(
         &self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
@@ -433,7 +433,7 @@ impl GuildChannel {
     pub async fn delete_reactions(
         &self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
     ) -> Result<()> {
         self.id.delete_reactions(http, message_id).await
     }
@@ -495,7 +495,7 @@ impl GuildChannel {
     pub async fn edit_message(
         &self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         builder: EditMessage<'_>,
     ) -> Result<Message> {
         self.id.edit_message(cache_http, message_id, builder).await
@@ -558,10 +558,10 @@ impl GuildChannel {
     pub async fn edit_voice_state(
         &self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         builder: EditVoiceState,
     ) -> Result<()> {
-        builder.execute(cache_http, (self.guild_id, self.id, Some(user_id.into()))).await
+        builder.execute(cache_http, (self.guild_id, self.id, Some(user_id))).await
     }
 
     /// Edits the current user's voice state in a stage channel.
@@ -629,7 +629,7 @@ impl GuildChannel {
     pub async fn follow(
         &self,
         http: impl AsRef<Http>,
-        target_channel_id: impl Into<ChannelId>,
+        target_channel_id: ChannelId,
     ) -> Result<FollowedChannel> {
         self.id.follow(http, target_channel_id).await
     }
@@ -675,7 +675,7 @@ impl GuildChannel {
     pub async fn message(
         &self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
     ) -> Result<Message> {
         self.id.message(cache_http, message_id).await
     }
@@ -725,7 +725,7 @@ impl GuildChannel {
     ///             None => return,
     ///         };
     ///
-    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, &msg.author) {
+    ///         if let Ok(permissions) = channel.permissions_for_user(&context.cache, msg.author.id) {
     ///             println!("The user's permissions: {:?}", permissions);
     ///         }
     ///     }
@@ -743,11 +743,10 @@ impl GuildChannel {
     pub fn permissions_for_user(
         &self,
         cache: impl AsRef<Cache>,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
     ) -> Result<Permissions> {
         let guild = self.guild(&cache).ok_or(Error::Model(ModelError::GuildNotFound))?;
-        let member =
-            guild.members.get(&user_id.into()).ok_or(Error::Model(ModelError::MemberNotFound))?;
+        let member = guild.members.get(&user_id).ok_or(Error::Model(ModelError::MemberNotFound))?;
         Ok(guild.user_permissions_in(self, member))
     }
 
@@ -761,11 +760,7 @@ impl GuildChannel {
     /// too many pinned messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn pin(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-    ) -> Result<()> {
+    pub async fn pin(&self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
         self.id.pin(http, message_id).await
     }
 
@@ -806,7 +801,7 @@ impl GuildChannel {
     pub async fn reaction_users(
         &self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
         after: Option<UserId>,
@@ -918,11 +913,7 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn unpin(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-    ) -> Result<()> {
+    pub async fn unpin(&self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
         self.id.unpin(http, message_id).await
     }
 
@@ -972,8 +963,8 @@ impl GuildChannel {
             ChannelType::News | ChannelType::Text => Ok(guild
                 .members
                 .iter()
-                .filter(|e| {
-                    self.permissions_for_user(cache, e.0)
+                .filter(|(id, _)| {
+                    self.permissions_for_user(cache, **id)
                         .map(|p| p.contains(Permissions::VIEW_CHANNEL))
                         .unwrap_or(false)
                 })
@@ -1094,7 +1085,7 @@ impl GuildChannel {
     pub async fn create_thread_from_message(
         &self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
         self.id.create_thread_from_message(cache_http, message_id, builder).await

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -688,8 +688,8 @@ impl Message {
     }
 
     /// Checks whether the message mentions passed [`UserId`].
-    pub fn mentions_user_id(&self, id: impl Into<UserId>) -> bool {
-        let id = id.into();
+    #[must_use]
+    pub fn mentions_user_id(&self, id: UserId) -> bool {
         self.mentions.iter().any(|mentioned_user| mentioned_user.id == id)
     }
 

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -60,7 +60,7 @@ impl PrivateChannel {
     pub async fn create_reaction(
         &self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
         self.id.create_reaction(http, message_id, reaction_type).await
@@ -119,7 +119,7 @@ impl PrivateChannel {
     pub async fn delete_reaction(
         &self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
@@ -145,7 +145,7 @@ impl PrivateChannel {
     pub async fn edit_message(
         &self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         builder: EditMessage<'_>,
     ) -> Result<Message> {
         self.id.edit_message(cache_http, message_id, builder).await
@@ -169,7 +169,7 @@ impl PrivateChannel {
     pub async fn message(
         &self,
         cache_http: impl CacheHttp,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
     ) -> Result<Message> {
         self.id.message(cache_http, message_id).await
     }
@@ -213,7 +213,7 @@ impl PrivateChannel {
     pub async fn reaction_users(
         &self,
         http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
+        message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
         after: Option<UserId>,
@@ -226,11 +226,7 @@ impl PrivateChannel {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the number of pinned messages would exceed the 50 message limit.
-    pub async fn pin(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-    ) -> Result<()> {
+    pub async fn pin(&self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
         self.id.pin(http, message_id).await
     }
 
@@ -346,11 +342,7 @@ impl PrivateChannel {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, if the message was deleted,
     /// or if the channel already has the limit of 50 pinned messages.
-    pub async fn unpin(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: impl Into<MessageId>,
-    ) -> Result<()> {
+    pub async fn unpin(&self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
         self.id.unpin(http, message_id).await
     }
 }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -211,18 +211,14 @@ impl Reaction {
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     /// [permissions]: crate::model::permissions
-    pub async fn users<R, U>(
+    pub async fn users(
         &self,
         http: impl AsRef<Http>,
-        reaction_type: R,
+        reaction_type: impl Into<ReactionType>,
         limit: Option<NonMaxU8>,
-        after: Option<U>,
-    ) -> Result<Vec<User>>
-    where
-        R: Into<ReactionType>,
-        U: Into<UserId>,
-    {
-        self._users(http, &reaction_type.into(), limit, after.map(Into::into)).await
+        after: Option<UserId>,
+    ) -> Result<Vec<User>> {
+        self._users(http, &reaction_type.into(), limit, after).await
     }
 
     async fn _users(

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -117,7 +117,7 @@ impl fmt::Display for Minimum {
 /// #[cfg(feature = "client")]
 /// impl EventHandler for Handler {
 ///     async fn guild_ban_removal(&self, context: Context, guild_id: GuildId, user: User) {
-///         match guild_id.ban(&context, user, 8).await {
+///         match guild_id.ban(&context, user.id, 8).await {
 ///             Ok(()) => {
 ///                 // Ban successful.
 ///             },

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -65,12 +65,8 @@ impl GuildId {
     /// Returns an [`Error::Http`] if a rule with the given ID does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rule(
-        self,
-        http: impl AsRef<Http>,
-        rule_id: impl Into<RuleId>,
-    ) -> Result<Rule> {
-        http.as_ref().get_automod_rule(self, rule_id.into()).await
+    pub async fn automod_rule(self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<Rule> {
+        http.as_ref().get_automod_rule(self, rule_id).await
     }
 
     /// Creates an auto moderation [`Rule`] in the guild.
@@ -133,10 +129,10 @@ impl GuildId {
     pub async fn edit_automod_rule(
         self,
         cache_http: impl CacheHttp,
-        rule_id: impl Into<RuleId>,
+        rule_id: RuleId,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        builder.execute(cache_http, (self, Some(rule_id.into()))).await
+        builder.execute(cache_http, (self, Some(rule_id))).await
     }
 
     /// Deletes an auto moderation [`Rule`] from the guild.
@@ -149,12 +145,8 @@ impl GuildId {
     /// does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn delete_automod_rule(
-        self,
-        http: impl AsRef<Http>,
-        rule_id: impl Into<RuleId>,
-    ) -> Result<()> {
-        http.as_ref().delete_automod_rule(self, rule_id.into(), None).await
+    pub async fn delete_automod_rule(self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<()> {
+        http.as_ref().delete_automod_rule(self, rule_id, None).await
     }
 
     /// Adds a [`User`] to this guild with a valid OAuth2 access token.
@@ -168,10 +160,10 @@ impl GuildId {
     pub async fn add_member(
         self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         builder: AddMember<'_>,
     ) -> Result<Option<Member>> {
-        builder.execute(cache_http, (self, user_id.into())).await
+        builder.execute(cache_http, (self, user_id)).await
     }
 
     /// Ban a [`User`] from the guild, deleting a number of days' worth of messages (`dmd`) between
@@ -206,8 +198,8 @@ impl GuildId {
     /// Also can return [`Error::Http`] if the current user lacks permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn ban(self, http: impl AsRef<Http>, user: impl Into<UserId>, dmd: u8) -> Result<()> {
-        self._ban(http, user.into(), dmd, None).await
+    pub async fn ban(self, http: impl AsRef<Http>, user: UserId, dmd: u8) -> Result<()> {
+        self._ban(http, user, dmd, None).await
     }
 
     /// Ban a [`User`] from the guild with a reason. Refer to [`Self::ban`] to further
@@ -220,11 +212,11 @@ impl GuildId {
     pub async fn ban_with_reason(
         self,
         http: impl AsRef<Http>,
-        user: impl Into<UserId>,
+        user: UserId,
         dmd: u8,
-        reason: impl AsRef<str>,
+        reason: &str,
     ) -> Result<()> {
-        self._ban(http, user.into(), dmd, Some(reason.as_ref())).await
+        self._ban(http, user, dmd, Some(reason)).await
     }
 
     async fn _ban(
@@ -381,10 +373,9 @@ impl GuildId {
     pub async fn create_integration(
         self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
         kind: &str,
     ) -> Result<()> {
-        let integration_id = integration_id.into();
         let map = json!({
             "id": integration_id,
             "type": kind,
@@ -476,12 +467,8 @@ impl GuildId {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_emoji(
-        self,
-        http: impl AsRef<Http>,
-        emoji_id: impl Into<EmojiId>,
-    ) -> Result<()> {
-        http.as_ref().delete_emoji(self, emoji_id.into(), None).await
+    pub async fn delete_emoji(self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<()> {
+        http.as_ref().delete_emoji(self, emoji_id, None).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -497,9 +484,9 @@ impl GuildId {
     pub async fn delete_integration(
         self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
     ) -> Result<()> {
-        http.as_ref().delete_guild_integration(self, integration_id.into(), None).await
+        http.as_ref().delete_guild_integration(self, integration_id, None).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -514,12 +501,8 @@ impl GuildId {
     /// does not exist.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn delete_role(
-        self,
-        http: impl AsRef<Http>,
-        role_id: impl Into<RoleId>,
-    ) -> Result<()> {
-        http.as_ref().delete_role(self, role_id.into(), None).await
+    pub async fn delete_role(self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
+        http.as_ref().delete_role(self, role_id, None).await
     }
 
     /// Deletes a specified scheduled event in the guild.
@@ -536,9 +519,9 @@ impl GuildId {
     pub async fn delete_scheduled_event(
         self,
         http: impl AsRef<Http>,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
     ) -> Result<()> {
-        http.as_ref().delete_scheduled_event(self, event_id.into()).await
+        http.as_ref().delete_scheduled_event(self, event_id).await
     }
 
     /// Deletes a [`Sticker`] by id from the guild.
@@ -554,12 +537,8 @@ impl GuildId {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_sticker(
-        self,
-        http: impl AsRef<Http>,
-        sticker_id: impl Into<StickerId>,
-    ) -> Result<()> {
-        http.as_ref().delete_sticker(self, sticker_id.into(), None).await
+    pub async fn delete_sticker(self, http: impl AsRef<Http>, sticker_id: StickerId) -> Result<()> {
+        http.as_ref().delete_sticker(self, sticker_id, None).await
     }
 
     /// Edits the current guild with new data where specified.
@@ -596,14 +575,14 @@ impl GuildId {
     pub async fn edit_emoji(
         self,
         http: impl AsRef<Http>,
-        emoji_id: impl Into<EmojiId>,
+        emoji_id: EmojiId,
         name: &str,
     ) -> Result<Emoji> {
         let map = json!({
             "name": name,
         });
 
-        http.as_ref().edit_emoji(self, emoji_id.into(), &map, None).await
+        http.as_ref().edit_emoji(self, emoji_id, &map, None).await
     }
 
     /// Edits the properties a guild member, such as muting or nicknaming them. Returns the new
@@ -637,10 +616,10 @@ impl GuildId {
     pub async fn edit_member(
         self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         builder: EditMember<'_>,
     ) -> Result<Member> {
-        builder.execute(cache_http, (self, user_id.into())).await
+        builder.execute(cache_http, (self, user_id)).await
     }
 
     /// Edits the guild's MFA level. Returns the new level on success.
@@ -716,10 +695,10 @@ impl GuildId {
     pub async fn edit_role(
         self,
         cache_http: impl CacheHttp,
-        role_id: impl Into<RoleId>,
+        role_id: RoleId,
         builder: EditRole<'_>,
     ) -> Result<Role> {
-        builder.execute(cache_http, (self, Some(role_id.into()))).await
+        builder.execute(cache_http, (self, Some(role_id))).await
     }
 
     /// Modifies a scheduled event in the guild with the data set, if any.
@@ -737,10 +716,10 @@ impl GuildId {
     pub async fn edit_scheduled_event(
         self,
         cache_http: impl CacheHttp,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
         builder: EditScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
-        builder.execute(cache_http, (self, event_id.into())).await
+        builder.execute(cache_http, (self, event_id)).await
     }
 
     /// Edits a sticker.
@@ -775,10 +754,10 @@ impl GuildId {
     pub async fn edit_sticker(
         self,
         cache_http: impl CacheHttp,
-        sticker_id: impl Into<StickerId>,
+        sticker_id: StickerId,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
-        builder.execute(cache_http, (self, sticker_id.into())).await
+        builder.execute(cache_http, (self, sticker_id)).await
     }
 
     /// Edit the position of a [`Role`] relative to all others in the [`Guild`].
@@ -800,10 +779,10 @@ impl GuildId {
     pub async fn edit_role_position(
         self,
         http: impl AsRef<Http>,
-        role_id: impl Into<RoleId>,
+        role_id: RoleId,
         position: u16,
     ) -> Result<Vec<Role>> {
-        http.as_ref().edit_role_position(self, role_id.into(), position, None).await
+        http.as_ref().edit_role_position(self, role_id, position, None).await
     }
 
     /// Edits the guild's welcome screen.
@@ -973,8 +952,8 @@ impl GuildId {
     /// Returns [`Error::Http`] if the member cannot be kicked by the current user.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    pub async fn kick(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        http.as_ref().kick_member(self, user_id.into(), None).await
+    pub async fn kick(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+        http.as_ref().kick_member(self, user_id, None).await
     }
 
     /// # Errors
@@ -984,10 +963,10 @@ impl GuildId {
     pub async fn kick_with_reason(
         self,
         http: impl AsRef<Http>,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         reason: &str,
     ) -> Result<()> {
-        http.as_ref().kick_member(self, user_id.into(), Some(reason)).await
+        http.as_ref().kick_member(self, user_id, Some(reason)).await
     }
 
     /// Returns a guild [`Member`] object for the current user.
@@ -1021,13 +1000,7 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the user is not in the guild, or if the guild is otherwise
     /// unavailable
-    pub async fn member(
-        self,
-        cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
-    ) -> Result<Member> {
-        let user_id = user_id.into();
-
+    pub async fn member(self, cache_http: impl CacheHttp, user_id: UserId) -> Result<Member> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
@@ -1104,10 +1077,10 @@ impl GuildId {
     pub async fn move_member(
         self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
-        channel_id: impl Into<ChannelId>,
+        user_id: UserId,
+        channel_id: ChannelId,
     ) -> Result<Member> {
-        let builder = EditMember::new().voice_channel(channel_id.into());
+        let builder = EditMember::new().voice_channel(channel_id);
         self.edit_member(cache_http, user_id, builder).await
     }
 
@@ -1131,7 +1104,7 @@ impl GuildId {
     pub async fn disconnect_member(
         self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
     ) -> Result<Member> {
         self.edit_member(cache_http, user_id, EditMember::new().disconnect_member()).await
     }
@@ -1215,10 +1188,10 @@ impl GuildId {
     pub async fn scheduled_event(
         self,
         http: impl AsRef<Http>,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
         with_user_count: bool,
     ) -> Result<ScheduledEvent> {
-        http.as_ref().get_scheduled_event(self, event_id.into(), with_user_count).await
+        http.as_ref().get_scheduled_event(self, event_id, with_user_count).await
     }
 
     /// Fetches a list of all scheduled events in the guild. If `with_user_count` is set to `true`,
@@ -1254,10 +1227,10 @@ impl GuildId {
     pub async fn scheduled_event_users(
         self,
         http: impl AsRef<Http>,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
         limit: Option<u64>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        http.as_ref().get_scheduled_event_users(self, event_id.into(), limit, None, None).await
+        http.as_ref().get_scheduled_event_users(self, event_id, limit, None, None).await
     }
 
     /// Fetches a list of interested users for the specified event, with additional options and
@@ -1274,14 +1247,12 @@ impl GuildId {
     pub async fn scheduled_event_users_optioned(
         self,
         http: impl AsRef<Http>,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
         limit: Option<u64>,
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        http.as_ref()
-            .get_scheduled_event_users(self, event_id.into(), limit, target, with_member)
-            .await
+        http.as_ref().get_scheduled_event_users(self, event_id, limit, target, with_member).await
     }
 
     /// Returns the Id of the shard associated with the guild.
@@ -1336,9 +1307,9 @@ impl GuildId {
     pub async fn start_integration_sync(
         self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
     ) -> Result<()> {
-        http.as_ref().start_integration_sync(self, integration_id.into()).await
+        http.as_ref().start_integration_sync(self, integration_id).await
     }
 
     /// Starts a prune of [`Member`]s.
@@ -1365,8 +1336,8 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user does not have permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn unban(self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
-        http.as_ref().remove_ban(self, user_id.into(), None).await
+    pub async fn unban(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+        http.as_ref().remove_ban(self, user_id, None).await
     }
 
     /// Retrieve's the guild's vanity URL.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -98,8 +98,8 @@ impl Member {
     /// Id does not exist.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn add_role(&self, http: impl AsRef<Http>, role_id: impl Into<RoleId>) -> Result<()> {
-        http.as_ref().add_member_role(self.guild_id, self.user.id, role_id.into(), None).await
+    pub async fn add_role(&self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
+        http.as_ref().add_member_role(self.guild_id, self.user.id, role_id, None).await
     }
 
     /// Adds one or multiple [`Role`]s to the member.
@@ -113,7 +113,7 @@ impl Member {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn add_roles(&self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
-        for role_id in role_ids {
+        for &role_id in role_ids {
             self.add_role(http.as_ref(), role_id).await?;
         }
 
@@ -146,7 +146,7 @@ impl Member {
         &self,
         http: impl AsRef<Http>,
         dmd: u8,
-        reason: impl AsRef<str>,
+        reason: &str,
     ) -> Result<()> {
         self.guild_id.ban_with_reason(http, self.user.id, dmd, reason).await
     }
@@ -396,7 +396,7 @@ impl Member {
     pub async fn move_to_voice_channel(
         &self,
         cache_http: impl CacheHttp,
-        channel: impl Into<ChannelId>,
+        channel: ChannelId,
     ) -> Result<Member> {
         self.guild_id.move_member(cache_http, self.user.id, channel).await
     }
@@ -448,12 +448,8 @@ impl Member {
     /// lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn remove_role(
-        &self,
-        http: impl AsRef<Http>,
-        role_id: impl Into<RoleId>,
-    ) -> Result<()> {
-        http.as_ref().remove_member_role(self.guild_id, self.user.id, role_id.into(), None).await
+    pub async fn remove_role(&self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
+        http.as_ref().remove_member_role(self.guild_id, self.user.id, role_id, None).await
     }
 
     /// Removes one or multiple [`Role`]s from the member.
@@ -467,7 +463,7 @@ impl Member {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn remove_roles(&self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
-        for role_id in role_ids {
+        for &role_id in role_ids {
             self.remove_role(http.as_ref(), role_id).await?;
         }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -305,11 +305,7 @@ impl Guild {
     /// Returns an [`Error::Http`] if a rule with the given ID does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rule(
-        &self,
-        http: impl AsRef<Http>,
-        rule_id: impl Into<RuleId>,
-    ) -> Result<Rule> {
+    pub async fn automod_rule(&self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<Rule> {
         self.id.automod_rule(http, rule_id).await
     }
 
@@ -346,7 +342,7 @@ impl Guild {
     pub async fn edit_automod_rule(
         &self,
         cache_http: impl CacheHttp,
-        rule_id: impl Into<RuleId>,
+        rule_id: RuleId,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
         self.id.edit_automod_rule(cache_http, rule_id, builder).await
@@ -362,11 +358,7 @@ impl Guild {
     /// does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn delete_automod_rule(
-        &self,
-        http: impl AsRef<Http>,
-        rule_id: impl Into<RuleId>,
-    ) -> Result<()> {
+    pub async fn delete_automod_rule(&self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<()> {
         self.id.delete_automod_rule(http, rule_id).await
     }
 
@@ -430,12 +422,7 @@ impl Guild {
     }
 
     #[cfg(feature = "cache")]
-    pub fn channel_id_from_name(
-        &self,
-        cache: impl AsRef<Cache>,
-        name: impl AsRef<str>,
-    ) -> Option<ChannelId> {
-        let name = name.as_ref();
+    pub fn channel_id_from_name(&self, cache: impl AsRef<Cache>, name: &str) -> Option<ChannelId> {
         let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
         for (id, channel) in guild_channels.iter() {
@@ -475,13 +462,8 @@ impl Guild {
     /// Otherwise returns [`Error::Http`] if the member cannot be banned.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn ban(
-        &self,
-        cache_http: impl CacheHttp,
-        user: impl Into<UserId>,
-        dmd: u8,
-    ) -> Result<()> {
-        self._ban_with_reason(cache_http, user.into(), dmd, "").await
+    pub async fn ban(&self, cache_http: impl CacheHttp, user: UserId, dmd: u8) -> Result<()> {
+        self.ban_with_reason(cache_http, user, dmd, "").await
     }
 
     /// Ban a [`User`] from the guild with a reason. Refer to [`Self::ban`] to further
@@ -492,16 +474,6 @@ impl Guild {
     /// In addition to the possible reasons [`Self::ban`] may return an error, an
     /// [`ModelError::TooLarge`] may also be returned if the reason is too long.
     pub async fn ban_with_reason(
-        &self,
-        cache_http: impl CacheHttp,
-        user: impl Into<UserId>,
-        dmd: u8,
-        reason: impl AsRef<str>,
-    ) -> Result<()> {
-        self._ban_with_reason(cache_http, user.into(), dmd, reason.as_ref()).await
-    }
-
-    async fn _ban_with_reason(
         &self,
         cache_http: impl CacheHttp,
         user: UserId,
@@ -564,7 +536,7 @@ impl Guild {
     pub async fn add_member(
         &self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         builder: AddMember<'_>,
     ) -> Result<Option<Member>> {
         self.id.add_member(cache_http, user_id, builder).await
@@ -722,7 +694,7 @@ impl Guild {
     pub async fn create_integration(
         &self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
         kind: &str,
     ) -> Result<()> {
         self.id.create_integration(http, integration_id, kind).await
@@ -959,11 +931,7 @@ impl Guild {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_emoji(
-        &self,
-        http: impl AsRef<Http>,
-        emoji_id: impl Into<EmojiId>,
-    ) -> Result<()> {
+    pub async fn delete_emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<()> {
         self.id.delete_emoji(http, emoji_id).await
     }
 
@@ -980,7 +948,7 @@ impl Guild {
     pub async fn delete_integration(
         &self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
     ) -> Result<()> {
         self.id.delete_integration(http, integration_id).await
     }
@@ -996,11 +964,7 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user lacks permission to delete the role.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn delete_role(
-        &self,
-        http: impl AsRef<Http>,
-        role_id: impl Into<RoleId>,
-    ) -> Result<()> {
+    pub async fn delete_role(&self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
         self.id.delete_role(http, role_id).await
     }
 
@@ -1018,7 +982,7 @@ impl Guild {
     pub async fn delete_scheduled_event(
         &self,
         http: impl AsRef<Http>,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
     ) -> Result<()> {
         self.id.delete_scheduled_event(http, event_id).await
     }
@@ -1039,7 +1003,7 @@ impl Guild {
     pub async fn delete_sticker(
         &self,
         http: impl AsRef<Http>,
-        sticker_id: impl Into<StickerId>,
+        sticker_id: StickerId,
     ) -> Result<()> {
         self.id.delete_sticker(http, sticker_id).await
     }
@@ -1108,7 +1072,7 @@ impl Guild {
     pub async fn edit_emoji(
         &self,
         http: impl AsRef<Http>,
-        emoji_id: impl Into<EmojiId>,
+        emoji_id: EmojiId,
         name: &str,
     ) -> Result<Emoji> {
         self.id.edit_emoji(http, emoji_id, name).await
@@ -1130,7 +1094,7 @@ impl Guild {
     pub async fn edit_member(
         &self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         builder: EditMember<'_>,
     ) -> Result<Member> {
         self.id.edit_member(cache_http, user_id, builder).await
@@ -1198,7 +1162,7 @@ impl Guild {
     pub async fn edit_role(
         &self,
         cache_http: impl CacheHttp,
-        role_id: impl Into<RoleId>,
+        role_id: RoleId,
         builder: EditRole<'_>,
     ) -> Result<Role> {
         self.id.edit_role(cache_http, role_id, builder).await
@@ -1223,7 +1187,7 @@ impl Guild {
     pub async fn edit_role_position(
         &self,
         http: impl AsRef<Http>,
-        role_id: impl Into<RoleId>,
+        role_id: RoleId,
         position: u16,
     ) -> Result<Vec<Role>> {
         self.id.edit_role_position(http, role_id, position).await
@@ -1244,7 +1208,7 @@ impl Guild {
     pub async fn edit_scheduled_event(
         &self,
         cache_http: impl CacheHttp,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
         builder: EditScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
         self.id.edit_scheduled_event(cache_http, event_id, builder).await
@@ -1285,7 +1249,7 @@ impl Guild {
     pub async fn edit_sticker(
         &self,
         cache_http: impl CacheHttp,
-        sticker_id: impl Into<StickerId>,
+        sticker_id: StickerId,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
         self.id.edit_sticker(cache_http, sticker_id, builder).await
@@ -1333,11 +1297,8 @@ impl Guild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild.
-    pub async fn get(
-        cache_http: impl CacheHttp,
-        guild_id: impl Into<GuildId>,
-    ) -> Result<PartialGuild> {
-        guild_id.into().to_partial_guild(cache_http).await
+    pub async fn get(cache_http: impl CacheHttp, guild_id: GuildId) -> Result<PartialGuild> {
+        guild_id.to_partial_guild(cache_http).await
     }
 
     /// Returns which of two [`User`]s has a higher [`Member`] hierarchy.
@@ -1356,10 +1317,10 @@ impl Guild {
     pub fn greater_member_hierarchy(
         &self,
         cache: impl AsRef<Cache>,
-        lhs_id: impl Into<UserId>,
-        rhs_id: impl Into<UserId>,
+        lhs_id: UserId,
+        rhs_id: UserId,
     ) -> Option<UserId> {
-        self._greater_member_hierarchy(&cache, lhs_id.into(), rhs_id.into())
+        self._greater_member_hierarchy(&cache, lhs_id, rhs_id)
     }
 
     #[cfg(feature = "cache")]
@@ -1495,7 +1456,7 @@ impl Guild {
     /// Returns [`Error::Http`] if the member cannot be kicked by the current user.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    pub async fn kick(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
+    pub async fn kick(&self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
         self.id.kick(http, user_id).await
     }
 
@@ -1506,7 +1467,7 @@ impl Guild {
     pub async fn kick_with_reason(
         &self,
         http: impl AsRef<Http>,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         reason: &str,
     ) -> Result<()> {
         self.id.kick_with_reason(http, user_id, reason).await
@@ -1546,10 +1507,8 @@ impl Guild {
     pub async fn member(
         &self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
     ) -> Result<Cow<'_, Member>> {
-        let user_id = user_id.into();
-
         if let Some(member) = self.members.get(&user_id) {
             Ok(Cow::Borrowed(member))
         } else {
@@ -1866,8 +1825,8 @@ impl Guild {
     pub async fn move_member(
         &self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
-        channel_id: impl Into<ChannelId>,
+        user_id: UserId,
+        channel_id: ChannelId,
     ) -> Result<Member> {
         self.id.move_member(cache_http, user_id, channel_id).await
     }
@@ -2036,7 +1995,7 @@ impl Guild {
     pub async fn scheduled_event(
         &self,
         http: impl AsRef<Http>,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
         with_user_count: bool,
     ) -> Result<ScheduledEvent> {
         self.id.scheduled_event(http, event_id, with_user_count).await
@@ -2075,7 +2034,7 @@ impl Guild {
     pub async fn scheduled_event_users(
         &self,
         http: impl AsRef<Http>,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
         limit: Option<u64>,
     ) -> Result<Vec<ScheduledEventUser>> {
         self.id.scheduled_event_users(http, event_id, limit).await
@@ -2095,7 +2054,7 @@ impl Guild {
     pub async fn scheduled_event_users_optioned(
         &self,
         http: impl AsRef<Http>,
-        event_id: impl Into<ScheduledEventId>,
+        event_id: ScheduledEventId,
         limit: Option<u64>,
         target: Option<UserPagination>,
         with_member: Option<bool>,
@@ -2159,7 +2118,7 @@ impl Guild {
     pub async fn start_integration_sync(
         &self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
     ) -> Result<()> {
         self.id.start_integration_sync(http, integration_id).await
     }
@@ -2205,11 +2164,7 @@ impl Guild {
     /// Otherwise will return an [`Error::Http`] if the current user does not have permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn unban(
-        &self,
-        cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
-    ) -> Result<()> {
+    pub async fn unban(&self, cache_http: impl CacheHttp, user_id: UserId) -> Result<()> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -207,11 +207,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if a rule with the given ID does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rule(
-        &self,
-        http: impl AsRef<Http>,
-        rule_id: impl Into<RuleId>,
-    ) -> Result<Rule> {
+    pub async fn automod_rule(&self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<Rule> {
         self.id.automod_rule(http, rule_id).await
     }
 
@@ -248,7 +244,7 @@ impl PartialGuild {
     pub async fn edit_automod_rule(
         &self,
         cache_http: impl CacheHttp,
-        rule_id: impl Into<RuleId>,
+        rule_id: RuleId,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
         self.id.edit_automod_rule(cache_http, rule_id, builder).await
@@ -264,11 +260,7 @@ impl PartialGuild {
     /// does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn delete_automod_rule(
-        &self,
-        http: impl AsRef<Http>,
-        rule_id: impl Into<RuleId>,
-    ) -> Result<()> {
+    pub async fn delete_automod_rule(&self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<()> {
         self.id.delete_automod_rule(http, rule_id).await
     }
 
@@ -294,12 +286,7 @@ impl PartialGuild {
     /// Also may return [`Error::Http`] if the current user lacks permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn ban(
-        &self,
-        http: impl AsRef<Http>,
-        user: impl Into<UserId>,
-        dmd: u8,
-    ) -> Result<()> {
+    pub async fn ban(&self, http: impl AsRef<Http>, user: UserId, dmd: u8) -> Result<()> {
         self.ban_with_reason(http, user, dmd, "").await
     }
 
@@ -313,9 +300,9 @@ impl PartialGuild {
     pub async fn ban_with_reason(
         &self,
         http: impl AsRef<Http>,
-        user: impl Into<UserId>,
+        user: UserId,
         dmd: u8,
-        reason: impl AsRef<str>,
+        reason: &str,
     ) -> Result<()> {
         self.id.ban_with_reason(http, user, dmd, reason).await
     }
@@ -374,12 +361,7 @@ impl PartialGuild {
     }
 
     #[cfg(feature = "cache")]
-    pub fn channel_id_from_name(
-        &self,
-        cache: impl AsRef<Cache>,
-        name: impl AsRef<str>,
-    ) -> Option<ChannelId> {
-        let name = name.as_ref();
+    pub fn channel_id_from_name(&self, cache: impl AsRef<Cache>, name: &str) -> Option<ChannelId> {
         let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
         for (id, channel) in guild_channels.iter() {
@@ -474,7 +456,7 @@ impl PartialGuild {
     pub async fn create_integration(
         &self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
         kind: &str,
     ) -> Result<()> {
         self.id.create_integration(http, integration_id, kind).await
@@ -680,11 +662,7 @@ impl PartialGuild {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_emoji(
-        &self,
-        http: impl AsRef<Http>,
-        emoji_id: impl Into<EmojiId>,
-    ) -> Result<()> {
+    pub async fn delete_emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<()> {
         self.id.delete_emoji(http, emoji_id).await
     }
 
@@ -701,7 +679,7 @@ impl PartialGuild {
     pub async fn delete_integration(
         &self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
     ) -> Result<()> {
         self.id.delete_integration(http, integration_id).await
     }
@@ -718,11 +696,7 @@ impl PartialGuild {
     /// does not exist in the Guild.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn delete_role(
-        &self,
-        http: impl AsRef<Http>,
-        role_id: impl Into<RoleId>,
-    ) -> Result<()> {
+    pub async fn delete_role(&self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
         self.id.delete_role(http, role_id).await
     }
 
@@ -742,7 +716,7 @@ impl PartialGuild {
     pub async fn delete_sticker(
         &self,
         http: impl AsRef<Http>,
-        sticker_id: impl Into<StickerId>,
+        sticker_id: StickerId,
     ) -> Result<()> {
         self.id.delete_sticker(http, sticker_id).await
     }
@@ -791,7 +765,7 @@ impl PartialGuild {
     pub async fn edit_emoji(
         &self,
         http: impl AsRef<Http>,
-        emoji_id: impl Into<EmojiId>,
+        emoji_id: EmojiId,
         name: &str,
     ) -> Result<Emoji> {
         self.id.edit_emoji(http, emoji_id, name).await
@@ -813,7 +787,7 @@ impl PartialGuild {
     pub async fn edit_member(
         &self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         builder: EditMember<'_>,
     ) -> Result<Member> {
         self.id.edit_member(cache_http, user_id, builder).await
@@ -871,7 +845,7 @@ impl PartialGuild {
     pub async fn edit_role(
         &self,
         cache_http: impl CacheHttp,
-        role_id: impl Into<RoleId>,
+        role_id: RoleId,
         builder: EditRole<'_>,
     ) -> Result<Role> {
         self.id.edit_role(cache_http, role_id, builder).await
@@ -896,7 +870,7 @@ impl PartialGuild {
     pub async fn edit_role_position(
         &self,
         http: impl AsRef<Http>,
-        role_id: impl Into<RoleId>,
+        role_id: RoleId,
         position: u16,
     ) -> Result<Vec<Role>> {
         self.id.edit_role_position(http, role_id, position).await
@@ -937,7 +911,7 @@ impl PartialGuild {
     pub async fn edit_sticker(
         &self,
         cache_http: impl CacheHttp,
-        sticker_id: impl Into<StickerId>,
+        sticker_id: StickerId,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
         self.id.edit_sticker(cache_http, sticker_id, builder).await
@@ -983,11 +957,8 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Http`] if the current user is not
     /// in the guild.
-    pub async fn get(
-        cache_http: impl CacheHttp,
-        guild_id: impl Into<GuildId>,
-    ) -> Result<PartialGuild> {
-        guild_id.into().to_partial_guild(cache_http).await
+    pub async fn get(cache_http: impl CacheHttp, guild_id: GuildId) -> Result<PartialGuild> {
+        guild_id.to_partial_guild(cache_http).await
     }
 
     /// Returns which of two [`User`]s has a higher [`Member`] hierarchy.
@@ -1006,10 +977,10 @@ impl PartialGuild {
     pub fn greater_member_hierarchy(
         &self,
         cache: impl AsRef<Cache>,
-        lhs_id: impl Into<UserId>,
-        rhs_id: impl Into<UserId>,
+        lhs_id: UserId,
+        rhs_id: UserId,
     ) -> Option<UserId> {
-        self._greater_member_hierarchy(&cache, lhs_id.into(), rhs_id.into())
+        self._greater_member_hierarchy(&cache, lhs_id, rhs_id)
     }
 
     #[cfg(feature = "cache")]
@@ -1160,7 +1131,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the member cannot be kicked by the current user.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    pub async fn kick(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
+    pub async fn kick(&self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
         self.id.kick(http, user_id).await
     }
 
@@ -1171,7 +1142,7 @@ impl PartialGuild {
     pub async fn kick_with_reason(
         &self,
         http: impl AsRef<Http>,
-        user_id: impl Into<UserId>,
+        user_id: UserId,
         reason: &str,
     ) -> Result<()> {
         self.id.kick_with_reason(http, user_id, reason).await
@@ -1261,11 +1232,7 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Http`] if the member is not in the Guild, or if the Guild is otherwise
     /// unavailable.
-    pub async fn member(
-        &self,
-        cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
-    ) -> Result<Member> {
+    pub async fn member(&self, cache_http: impl CacheHttp, user_id: UserId) -> Result<Member> {
         self.id.member(cache_http, user_id).await
     }
 
@@ -1304,8 +1271,8 @@ impl PartialGuild {
     pub async fn move_member(
         &self,
         cache_http: impl CacheHttp,
-        user_id: impl Into<UserId>,
-        channel_id: impl Into<ChannelId>,
+        user_id: UserId,
+        channel_id: ChannelId,
     ) -> Result<Member> {
         self.id.move_member(cache_http, user_id, channel_id).await
     }
@@ -1393,7 +1360,7 @@ impl PartialGuild {
     pub async fn start_integration_sync(
         &self,
         http: impl AsRef<Http>,
-        integration_id: impl Into<IntegrationId>,
+        integration_id: IntegrationId,
     ) -> Result<()> {
         self.id.start_integration_sync(http, integration_id).await
     }
@@ -1408,7 +1375,7 @@ impl PartialGuild {
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
     /// [`Guild::unban`]: crate::model::guild::Guild::unban
-    pub async fn unban(&self, http: impl AsRef<Http>, user_id: impl Into<UserId>) -> Result<()> {
+    pub async fn unban(&self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
         self.id.unban(http, user_id).await
     }
 

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -76,10 +76,10 @@ impl Invite {
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     pub async fn create(
         cache_http: impl CacheHttp,
-        channel_id: impl Into<ChannelId>,
+        channel_id: ChannelId,
         builder: CreateInvite<'_>,
     ) -> Result<RichInvite> {
-        channel_id.into().create_invite(cache_http, builder).await
+        channel_id.create_invite(cache_http, builder).await
     }
 
     /// Deletes the invite.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -519,10 +519,10 @@ impl User {
     pub async fn has_role(
         &self,
         cache_http: impl CacheHttp,
-        guild_id: impl Into<GuildId>,
-        role: impl Into<RoleId>,
+        guild_id: GuildId,
+        role: RoleId,
     ) -> Result<bool> {
-        guild_id.into().member(cache_http, self).await.map(|m| m.roles.contains(&role.into()))
+        guild_id.member(cache_http, self.id).await.map(|m| m.roles.contains(&role))
     }
 
     /// Refreshes the information about the user.
@@ -578,13 +578,7 @@ impl User {
     /// Returns the user's nickname in the given `guild_id`.
     ///
     /// If none is used, it returns [`None`].
-    pub async fn nick_in(
-        &self,
-        cache_http: impl CacheHttp,
-        guild_id: impl Into<GuildId>,
-    ) -> Option<String> {
-        let guild_id = guild_id.into();
-
+    pub async fn nick_in(&self, cache_http: impl CacheHttp, guild_id: GuildId) -> Option<String> {
         // This can't be removed because `GuildId::member` clones the entire `Member` struct if
         // it's present in the cache, which is expensive.
         #[cfg(feature = "cache")]
@@ -600,7 +594,7 @@ impl User {
 
         // At this point we're guaranteed to do an API call.
         guild_id
-            .member(cache_http, &self.id)
+            .member(cache_http, self.id)
             .await
             .ok()
             .and_then(|member| member.nick)

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -245,8 +245,8 @@ impl Webhook {
     ///
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's
     /// response.
-    pub async fn from_id(http: impl AsRef<Http>, webhook_id: impl Into<WebhookId>) -> Result<Self> {
-        http.as_ref().get_webhook(webhook_id.into()).await
+    pub async fn from_id(http: impl AsRef<Http>, webhook_id: WebhookId) -> Result<Self> {
+        http.as_ref().get_webhook(webhook_id).await
     }
 
     /// Retrieves a webhook given its Id and unique token.
@@ -279,10 +279,10 @@ impl Webhook {
     /// response.
     pub async fn from_id_with_token(
         http: impl AsRef<Http>,
-        webhook_id: impl Into<WebhookId>,
+        webhook_id: WebhookId,
         token: &str,
     ) -> Result<Self> {
-        http.as_ref().get_webhook_with_token(webhook_id.into(), token).await
+        http.as_ref().get_webhook_with_token(webhook_id, token).await
     }
 
     /// Retrieves a webhook given its url.

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -90,12 +90,8 @@ impl Default for ContentSafeOptions {
 ///     }
 /// }
 /// ```
-pub fn content_safe(
-    guild: &Guild,
-    s: impl AsRef<str>,
-    options: ContentSafeOptions,
-    users: &[User],
-) -> String {
+#[must_use]
+pub fn content_safe(guild: &Guild, s: &str, options: ContentSafeOptions, users: &[User]) -> String {
     let mut content = clean_mentions(guild, s, options, users);
 
     if options.get_clean_here() {
@@ -109,13 +105,7 @@ pub fn content_safe(
     content
 }
 
-fn clean_mentions(
-    guild: &Guild,
-    s: impl AsRef<str>,
-    options: ContentSafeOptions,
-    users: &[User],
-) -> String {
-    let s = s.as_ref();
+fn clean_mentions(guild: &Guild, s: &str, options: ContentSafeOptions, users: &[User]) -> String {
     let mut content = String::with_capacity(s.len());
     let mut brackets = s.match_indices(|c| c == '<' || c == '>').peekable();
     let mut progress = 0;

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -113,11 +113,7 @@ impl MessageBuilder {
     /// [`Channel`]: crate::model::channel::Channel
     /// [`GuildChannel`]: crate::model::channel::GuildChannel
     /// [Display implementation]: ChannelId#impl-Display
-    pub fn channel<C: Into<ChannelId>>(&mut self, channel: C) -> &mut Self {
-        self._channel(channel.into())
-    }
-
-    fn _channel(&mut self, channel: ChannelId) -> &mut Self {
+    pub fn channel(&mut self, channel: ChannelId) -> &mut Self {
         self._push(&channel.mention());
         self
     }
@@ -816,31 +812,25 @@ impl MessageBuilder {
 
     /// Mentions the [`Role`] in the built message.
     ///
-    /// This accepts anything that converts _into_ a [`RoleId`]. Refer to [`RoleId`]'s
-    /// documentation for more information.
-    ///
     /// Refer to [`RoleId`]'s [Display implementation] for more information on how this is
     /// formatted.
     ///
     /// [`Role`]: crate::model::guild::Role
     /// [Display implementation]: RoleId#impl-Display
-    pub fn role<R: Into<RoleId>>(&mut self, role: R) -> &mut Self {
-        self._push(&role.into().mention());
+    pub fn role(&mut self, role: RoleId) -> &mut Self {
+        self._push(&role.mention());
         self
     }
 
     /// Mentions the [`User`] in the built message.
-    ///
-    /// This accepts anything that converts _into_ a [`UserId`]. Refer to [`UserId`]'s
-    /// documentation for more information.
     ///
     /// Refer to [`UserId`]'s [Display implementation] for more information on how this is
     /// formatted.
     ///
     /// [`User`]: crate::model::user::User
     /// [Display implementation]: UserId#impl-Display
-    pub fn user<U: Into<UserId>>(&mut self, user: U) -> &mut Self {
-        self._push(&user.into().mention());
+    pub fn user(&mut self, user: UserId) -> &mut Self {
+        self._push(&user.mention());
         self
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -258,11 +258,9 @@ pub fn parse_channel_mention(mention: &str) -> Option<ChannelId> {
 /// ```
 ///
 /// [`Emoji`]: crate::model::guild::Emoji
-pub fn parse_emoji(mention: impl AsRef<str>) -> Option<EmojiIdentifier> {
-    let mention = mention.as_ref();
-
+#[must_use]
+pub fn parse_emoji(mention: &str) -> Option<EmojiIdentifier> {
     let len = mention.len();
-
     if !(6..=56).contains(&len) {
         return None;
     }
@@ -325,8 +323,8 @@ pub fn parse_emoji(mention: impl AsRef<str>) -> Option<EmojiIdentifier> {
 ///
 /// assert_eq!(parse_quotes(command), expected);
 /// ```
-pub fn parse_quotes(s: impl AsRef<str>) -> Vec<String> {
-    let s = s.as_ref();
+#[must_use]
+pub fn parse_quotes(s: &str) -> Vec<String> {
     let mut args = vec![];
     let mut in_string = false;
     let mut escaping = false;

--- a/src/utils/token.rs
+++ b/src/utils/token.rs
@@ -27,9 +27,9 @@ use std::{fmt, str};
 ///
 /// Returns a [`InvalidToken`] when one of the above checks fail. The type of failure is not
 /// specified.
-pub fn validate(token: impl AsRef<str>) -> Result<(), InvalidToken> {
+pub fn validate(token: &str) -> Result<(), InvalidToken> {
     // Tokens can be preceded by "Bot " (that's how the Discord API expects them)
-    let mut parts = token.as_ref().trim_start_matches("Bot ").split('.');
+    let mut parts = token.trim_start_matches("Bot ").split('.');
 
     let is_valid = parts.next().is_some_and(|p| !p.is_empty())
         && parts.next().is_some_and(|p| !p.is_empty())


### PR DESCRIPTION
Into<Id> is often entirely unnecessary, and at worst hides the type of the Id with hard-coded Ids. This fixes this by just using the Id type itself, which also helps with monomorphisation bloat.

I also removed `AsRef<str>`, as this can just be `&str` without requiring a generic and without requiring a call to as_ref in the function, while also not accidentally taking ownership of a `String` passed in misleadingly.