### PR TITLE
Remove `Event::Unknown` variant

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use tracing::debug;
-
 #[cfg(feature = "gateway")]
 use super::event_handler::{EventHandler, RawEventHandler};
 use super::{Context, FullEvent};
@@ -368,10 +366,6 @@ fn update_cache_with_event(
         },
         Event::TypingStart(event) => FullEvent::TypingStart {
             event,
-        },
-        Event::Unknown(event) => {
-            debug!("An unknown event was received: {event:?}");
-            return None;
         },
         Event::UserUpdate(mut event) => {
             let before = if_cache!(event.update(cache));

--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -396,8 +396,11 @@ impl ShardRunner {
     /// successful.
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     async fn recv_event(&mut self) -> Result<(Option<Event>, Option<ShardAction>, bool)> {
-        let gw_event = match self.shard.client.recv_json().await {
-            Ok(inner) => Ok(inner),
+        let gateway_event = match self.shard.client.recv_json().await {
+            Ok(Some(inner)) => Ok(inner),
+            Ok(None) => {
+                return Ok((None, None, true));
+            },
             Err(Error::Tungstenite(tung_err)) if matches!(*tung_err, TungsteniteError::Io(_)) => {
                 debug!("Attempting to auto-reconnect");
 
@@ -420,13 +423,7 @@ impl ShardRunner {
             Err(why) => Err(why),
         };
 
-        let event = match gw_event {
-            Ok(Some(event)) => Ok(event),
-            Ok(None) => return Ok((None, None, true)),
-            Err(why) => Err(why),
-        };
-
-        let action = match self.shard.handle_event(&event) {
+        let action = match self.shard.handle_event(&gateway_event) {
             Ok(Some(action)) => Some(action),
             Ok(None) => None,
             Err(why) => {
@@ -447,18 +444,18 @@ impl ShardRunner {
             },
         };
 
-        if let Ok(GatewayEvent::HeartbeatAck) = event {
+        if let Ok(GatewayEvent::HeartbeatAck) = gateway_event {
             self.update_manager().await;
         }
 
         #[cfg(feature = "voice")]
         {
-            if let Ok(GatewayEvent::Dispatch(_, ref event)) = event {
+            if let Ok(GatewayEvent::Dispatch(_, ref event)) = gateway_event {
                 self.handle_voice_event(event).await;
             }
         }
 
-        let event = match event {
+        let event = match gateway_event {
             Ok(GatewayEvent::Dispatch(_, event)) => Some(event),
             _ => None,
         };

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -475,7 +475,11 @@ impl Shard {
                 Ok(Some(ShardAction::Reconnect(self.reconnection_type())))
             },
             Err(why) => {
-                warn!("[{:?}] Unhandled error: {:?}", self.shard_info, why);
+                if let Error::Json(_) = why {
+                    // Deserialization errors already get logged when the event is first received
+                } else {
+                    warn!("[{:?}] Unhandled error: {:?}", self.shard_info, why);
+                }
 
                 Ok(None)
             },

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1311,21 +1311,13 @@ pub enum Event {
     EntitlementUpdate(EntitlementUpdateEvent),
     /// A user's entitlement was deleted by Discord, or refunded.
     EntitlementDelete(EntitlementDeleteEvent),
-    /// An event type not covered by the above
-    #[serde(untagged)]
-    Unknown(UnknownEvent),
 }
 
 impl Event {
-    /// Return the event name of this event. Returns [`None`] if the event is
-    /// [`Unknown`](Event::Unknown).
+    /// Returns the event name of this event.
     #[must_use]
     pub fn name(&self) -> Option<String> {
-        if let Self::Unknown(_) = self {
-            None
-        } else {
-            let map = serde_json::to_value(self).ok()?;
-            Some(map.get("t")?.as_str()?.to_string())
-        }
+        let map = serde_json::to_value(self).ok()?;
+        Some(map.get("t")?.as_str()?.to_string())
     }
 }


### PR DESCRIPTION
If deserialization fails, we should allow the specific deserialization error to be logged so that it can be reported to the serenity maintainers. As it stands, any events that fail to deserialize normally will "succeed" when deserialized into the `Unknown` variant, throwing away any extra information about the error.

Because deserialization errors are immediately logged when they happen, explicitly whitelist `Error::Json` in `Shard::handle_event` to prevent duplicate logs.