### PR TITLE
Remove TryFrom uses

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -1,5 +1,4 @@
 use std::cmp::Ordering;
-use std::convert::TryFrom;
 #[cfg(doc)]
 use std::fmt::Display as _;
 use std::fmt::{self, Write as _};
@@ -482,8 +481,6 @@ impl<'a> TryFrom<&'a str> for ReactionType {
     /// Creating a [`ReactionType`] from a custom emoji argument in the following format:
     ///
     /// ```rust
-    /// use std::convert::TryFrom;
-    ///
     /// use serenity::model::channel::ReactionType;
     /// use serenity::model::id::EmojiId;
     ///

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -319,7 +319,6 @@ impl fmt::Display for ShardId {
 /// }
 /// ```
 pub(crate) mod snowflake {
-    use std::convert::TryFrom;
     use std::fmt;
     use std::num::NonZeroU64;
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -53,7 +53,6 @@ use crate::model::utils::avatar_url;
 /// }
 /// ```
 pub(crate) mod discriminator {
-    use std::convert::TryFrom;
     use std::fmt;
 
     use serde::de::{Error, Visitor};

--- a/tests/test_reaction.rs
+++ b/tests/test_reaction.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::str::FromStr;
 
 use serenity::model::channel::ReactionType;


### PR DESCRIPTION
These were required in edition 2018, but not in 2021.