### PR TITLE
Provide Arc<Data> instead of &Data

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -94,9 +94,9 @@ impl Context {
     ///
     /// [`ClientBuilder::data`]: super::ClientBuilder::data
     #[must_use]
-    pub fn data<Data: Send + Sync + 'static>(&self) -> &Data {
-        self.data
-            .downcast_ref()
+    pub fn data<Data: Send + Sync + 'static>(&self) -> Arc<Data> {
+        Arc::clone(&self.data)
+            .downcast()
             .expect("Type provided to Context should be the same as ClientBuilder::data.")
     }
 


### PR DESCRIPTION
This incurs an extra ref count, but this should be negligible for the more permissive type. An explanation of how this works is that:

- Arc is just a shared pointer to ArcInner
- ArcInner stores the concrete Data type
- Each Arc stores the dyn vtable ptr
- Arc checks the vtable ptr to get the type id, then it can just give out a new Arc referring to the ArcInner concretely.