### PR TITLE
Efficently generalize String or Int deserialisation

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -23,6 +23,7 @@ use crate::gateway::ShardMessenger;
 use crate::http::{CacheHttp, Http};
 use crate::model::application::{ActionRow, MessageInteraction};
 use crate::model::prelude::*;
+use crate::model::utils::StrOrInt;
 #[cfg(all(feature = "model", feature = "cache"))]
 use crate::utils;
 
@@ -1117,11 +1118,17 @@ impl MessageId {
 }
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 pub enum Nonce {
     String(String),
     Number(u64),
+}
+
+impl<'de> serde::Deserialize<'de> for Nonce {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        Ok(StrOrInt::deserialize(deserializer)?.into_enum(Self::String, Self::Number))
+    }
 }
 
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#role-subscription-data-object)

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -11,6 +11,7 @@ use crate::model::guild::{
 use crate::model::id::{ApplicationId, ChannelId, GenericId, GuildId, RoleId, UserId};
 use crate::model::misc::ImageHash;
 use crate::model::sticker::StickerFormatType;
+use crate::model::utils::StrOrInt;
 use crate::model::{Permissions, Timestamp};
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -22,12 +23,18 @@ pub struct AffectedRole {
 }
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Clone)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum EntityType {
     Int(u64),
     Str(String),
+}
+
+impl<'de> serde::Deserialize<'de> for EntityType {
+    fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(StrOrInt::deserialize(deserializer)?.into_enum(Self::Str, Self::Int))
+    }
 }
 
 macro_rules! generate_change {

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -38,8 +38,10 @@
 #[cfg(feature = "model")]
 use std::fmt;
 
-use serde::de::{Deserialize, Deserializer, Error as DeError};
+use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
+
+use super::utils::StrOrInt;
 
 /// This macro generates the [`Permissions::get_permission_names`] method.
 ///
@@ -804,21 +806,10 @@ impl Permissions {
 // but audit log changes are sent as an int, which is probably a problem.
 impl<'de> Deserialize<'de> for Permissions {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(serde::Deserialize)]
-        #[serde(untagged)]
-        enum StrOrInt<'a> {
-            Str(&'a str),
-            String(String),
-            Integer(u64),
-        }
+        let val = StrOrInt::deserialize(deserializer)?;
+        let val = val.parse().map_err(serde::de::Error::custom)?;
 
-        let permissions_num = match StrOrInt::deserialize(deserializer)? {
-            StrOrInt::String(permissions) => permissions.parse().map_err(DeError::custom)?,
-            StrOrInt::Str(permissions) => permissions.parse().map_err(DeError::custom)?,
-            StrOrInt::Integer(permissions) => permissions,
-        };
-
-        Ok(Permissions::from_bits_truncate(permissions_num))
+        Ok(Permissions::from_bits_truncate(val))
     }
 }
 


### PR DESCRIPTION
Generalizes String or Int logic into one, efficient enum which is zero-copy if possible and does not use `untagged` deserialization (which is slow).