### PR TITLE
Remove some pedantic lints from the whitelist

### DIFF
--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -126,7 +126,7 @@ impl Builder for EditInteractionResponse<'_> {
     ) -> Result<Self::Built> {
         self.0.check_length()?;
 
-        let files = self.0.attachments.as_mut().map_or(Vec::new(), |a| a.take_files());
+        let files = self.0.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
 
         cache_http.http().edit_original_interaction_response(ctx, &self, files).await
     }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -240,7 +240,7 @@ impl Builder for EditMessage<'_> {
     ) -> Result<Self::Built> {
         self.check_length()?;
 
-        let files = self.attachments.as_mut().map_or(Vec::new(), |a| a.take_files());
+        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
 
         cache_http.http().edit_message(ctx.0, ctx.1, &self, files).await
     }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -170,7 +170,7 @@ impl Builder for EditWebhookMessage<'_> {
     ) -> Result<Self::Built> {
         self.check_length()?;
 
-        let files = self.attachments.as_mut().map_or(Vec::new(), |a| a.take_files());
+        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
 
         cache_http
             .http()

--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -39,7 +39,7 @@ impl<K: Eq + Hash, V> MaybeMap<K, V> {
     }
 
     pub fn len(&self) -> usize {
-        self.0.as_ref().map_or(0, |map| map.len())
+        self.0.as_ref().map_or(0, DashMap::len)
     }
 
     pub fn shrink_to_fit(&self) {

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -328,7 +328,7 @@ impl ShardQueue {
     /// Pops a `ShardId` from every bucket containing at least one and returns them all as a `Vec`.
     pub fn pop_batch(&mut self) -> Vec<ShardId> {
         (0..self.max_concurrency.get())
-            .filter_map(|i| self.buckets.get_mut(&i).and_then(|bucket| bucket.pop_front()))
+            .filter_map(|i| self.buckets.get_mut(&i).and_then(VecDeque::pop_front))
             .collect()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,29 +59,22 @@
     clippy::non_ascii_literal,
     clippy::fallible_impl_from,
     clippy::let_underscore_must_use,
-    clippy::format_collect,
     clippy::format_push_string,
     clippy::pedantic
 )]
 #![allow(
-    // Allowed to avoid breaking changes.
-    clippy::module_name_repetitions,
-    clippy::unused_self,
     // Allowed as they are too pedantic
     clippy::cast_possible_truncation,
+    clippy::module_name_repetitions,
     clippy::unreadable_literal,
     clippy::cast_possible_wrap,
     clippy::wildcard_imports,
     clippy::cast_sign_loss,
     clippy::too_many_lines,
     clippy::doc_markdown,
-    clippy::cast_lossless,
-    clippy::redundant_closure_for_method_calls,
-    // Covered by other lints
-    clippy::missing_panics_doc, // clippy::unwrap_used
+    clippy::missing_panics_doc,
 )]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
-#![type_length_limit = "3294819"] // needed so ShardRunner::run compiles with instrument.
 
 #[macro_use]
 extern crate serde;

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -202,25 +202,6 @@ impl Colour {
     }
 }
 
-impl From<i32> for Colour {
-    /// Constructs a Colour from a i32.
-    ///
-    /// This is used for functions that accept `Into<Colour>`.
-    ///
-    /// This is useful when providing hex values.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::model::Colour;
-    ///
-    /// assert_eq!(Colour::from(0xDEA584).tuple(), (222, 165, 132));
-    /// ```
-    fn from(value: i32) -> Colour {
-        Colour(value as u32)
-    }
-}
-
 impl From<u32> for Colour {
     /// Constructs a Colour from a u32.
     ///
@@ -234,24 +215,7 @@ impl From<u32> for Colour {
     /// assert_eq!(Colour::from(6573123u32).r(), 100);
     /// ```
     fn from(value: u32) -> Colour {
-        Colour(value)
-    }
-}
-
-impl From<u64> for Colour {
-    /// Constructs a Colour from a u32.
-    ///
-    /// This is used for functions that accept `Into<Colour>`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use serenity::model::Colour;
-    ///
-    /// assert_eq!(Colour::from(6573123u64).r(), 100);
-    /// ```
-    fn from(value: u64) -> Colour {
-        Colour(value as u32)
+        Colour(value & 0xffffff)
     }
 }
 
@@ -446,8 +410,6 @@ mod test {
 
     #[test]
     fn from() {
-        assert_eq!(Colour::from(7i32).0, 7);
         assert_eq!(Colour::from(7u32).0, 7);
-        assert_eq!(Colour::from(7u64).0, 7);
     }
 }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -277,7 +277,7 @@ pub mod secret {
         secret: &Option<Secret<S>>,
         serializer: Sr,
     ) -> Result<Sr::Ok, Sr::Error> {
-        secret.as_ref().map(|s| s.expose_secret()).serialize(serializer)
+        secret.as_ref().map(ExposeSecret::expose_secret).serialize(serializer)
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -484,7 +484,7 @@ pub(crate) fn user_perms(cache: impl AsRef<Cache>, channel_id: ChannelId) -> Res
 #[must_use]
 pub fn shard_id(guild_id: GuildId, shard_count: u16) -> u16 {
     let shard_count = check_shard_total(shard_count);
-    ((guild_id.get() >> 22) % (shard_count.get() as u64)) as u16
+    ((guild_id.get() >> 22) % u64::from(shard_count.get())) as u16
 }
 
 pub(crate) fn check_shard_total(total_shards: u16) -> NonZeroU16 {


### PR DESCRIPTION
Also, removed the impls of `From<{i32,u64}> for Colour`, as it only makes sense to convert infallibly from `u32`.