### PR TITLE
Reduce unknown events to debug level... again

### DIFF
--- a/examples/testing/src/model_type_sizes.rs
+++ b/examples/testing/src/model_type_sizes.rs
@@ -195,7 +195,6 @@ pub fn print_ranking() {
         ("TriggerMetadata", std::mem::size_of::<TriggerMetadata>()),
         ("TypingStartEvent", std::mem::size_of::<TypingStartEvent>()),
         ("UnavailableGuild", std::mem::size_of::<UnavailableGuild>()),
-        ("UnknownEvent", std::mem::size_of::<UnknownEvent>()),
         ("User", std::mem::size_of::<User>()),
         ("UserId", std::mem::size_of::<UserId>()),
         ("UserPublicFlags", std::mem::size_of::<UserPublicFlags>()),

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -120,7 +120,8 @@ impl WsClient {
             Ok(None) | Err(_) => return Ok(None),
         };
 
-        let value = match message {
+        let json_str = match message {
+            Message::Text(payload) => payload,
             Message::Binary(bytes) => {
                 let mut decompressed =
                     String::with_capacity(bytes.len() * DECOMPRESSION_MULTIPLIER);
@@ -132,26 +133,15 @@ impl WsClient {
                     why
                 })?;
 
-                from_str(&decompressed).map_err(|why| {
-                    warn!("Err deserializing bytes: {why:?}");
-                    debug!("Failing text: {decompressed}");
-
-                    why
-                })?
+                decompressed
             },
-            Message::Text(payload) => from_str(&payload).map_err(|why| {
-                warn!("Err deserializing text: {why:?}");
-                debug!("Failing text: {payload}");
-
-                why
-            })?,
             Message::Close(Some(frame)) => {
                 return Err(Error::Gateway(GatewayError::Closed(Some(frame))));
             },
             _ => return Ok(None),
         };
 
-        Ok(Some(value))
+        from_str(&json_str).map(Some).map_err(|err| log_deserialisation_err(&json_str, err))
     }
 
     pub(crate) async fn send_json(&mut self, value: &impl serde::Serialize) -> Result<()> {
@@ -317,4 +307,25 @@ impl WsClient {
         })
         .await
     }
+}
+
+fn filter_unknown_variant(json_err_dbg: &str) -> bool {
+    if let Some(msg) = json_err_dbg.strip_prefix("Error(\"unknown variant `") {
+        if let Some((variant_name, _)) = msg.split_once('`') {
+            tracing::debug!("Unknown event: {variant_name}");
+            return true;
+        }
+    }
+
+    false
+}
+
+fn log_deserialisation_err(json_str: &str, err: serde_json::Error) -> Error {
+    let json_err_dbg = format!("{err:?}");
+    if !filter_unknown_variant(&json_err_dbg) {
+        warn!("Err deserializing text: {json_err_dbg}");
+    }
+
+    debug!("Failing text: {json_str}");
+    Error::Json(err)
 }

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -29,7 +29,7 @@ use crate::constants::{self, Opcode};
 use crate::gateway::GatewayError;
 #[cfg(feature = "client")]
 use crate::json::from_str;
-use crate::json::to_string;
+use crate::json::{to_string, JsonError};
 #[cfg(feature = "client")]
 use crate::model::event::GatewayEvent;
 use crate::model::gateway::{GatewayIntents, ShardInfo};
@@ -309,6 +309,12 @@ impl WsClient {
     }
 }
 
+#[cfg(feature = "simd_json")]
+fn filter_unknown_variant(_: &str) -> bool {
+    false
+}
+
+#[cfg(not(feature = "simd_json"))]
 fn filter_unknown_variant(json_err_dbg: &str) -> bool {
     if let Some(msg) = json_err_dbg.strip_prefix("Error(\"unknown variant `") {
         if let Some((variant_name, _)) = msg.split_once('`') {
@@ -320,7 +326,7 @@ fn filter_unknown_variant(json_err_dbg: &str) -> bool {
     false
 }
 
-fn log_deserialisation_err(json_str: &str, err: serde_json::Error) -> Error {
+fn log_deserialisation_err(json_str: &str, err: JsonError) -> Error {
     let json_err_dbg = format!("{err:?}");
     if !filter_unknown_variant(&json_err_dbg) {
         warn!("Err deserializing text: {json_err_dbg}");

--- a/src/json.rs
+++ b/src/json.rs
@@ -94,7 +94,7 @@ where
 /// If the `simd_json` feature is enabled, this function turns its argument into `Cow::Owned`
 /// before deserializing from it. In other words, passing in a `&str` will result in a clone.
 #[allow(clippy::missing_errors_doc)]
-pub fn from_str<'a, T>(s: impl Into<Cow<'a, str>>) -> Result<T>
+pub fn from_str<'a, T>(s: impl Into<Cow<'a, str>>) -> Result<T, JsonError>
 where
     T: DeserializeOwned,
 {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -737,16 +737,6 @@ pub struct TypingStartEvent {
     pub member: Option<Member>,
 }
 
-#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
-pub struct UnknownEvent {
-    #[serde(rename = "t")]
-    pub kind: FixedString,
-    #[serde(rename = "d")]
-    pub value: Value,
-}
-
 /// Sent when properties about the current bot's user change.
 ///
 /// Requires no gateway intents.


### PR DESCRIPTION
This implementation sucks, but that's all error introspection with boxed errors. This is a repeat of #2064, specifically my bot is currently firing a massive warning for every time someone... uses a soundboard sound, so my logs are entirely useless without this.