### PR TITLE
Remove `PartialEq` implementations from all builders

### DIFF
--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -61,7 +61,7 @@ enum ParseValue {
 /// ```
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#allowed-mentions-object).
-#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateAllowedMentions<'a> {
     parse: HashSet<ParseValue>,

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -16,7 +16,7 @@ use crate::model::id::AttachmentId;
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure).
 ///
 /// [`send_files`]: crate::model::id::ChannelId::send_files
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 #[must_use]
 pub struct CreateAttachment<'a> {
@@ -112,12 +112,12 @@ impl<'a> CreateAttachment<'a> {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize)]
 struct ExistingAttachment {
     id: AttachmentId,
 }
 
-#[derive(Debug, Clone, serde::Serialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize)]
 #[serde(untagged)]
 enum NewOrExisting<'a> {
     New(CreateAttachment<'a>),
@@ -179,7 +179,7 @@ enum NewOrExisting<'a> {
 ///
 /// Internally, this type is used not just for message editing endpoints, but also for message
 /// creation endpoints.
-#[derive(Default, Debug, Clone, serde::Serialize, PartialEq)]
+#[derive(Default, Debug, Clone, serde::Serialize)]
 #[serde(transparent)]
 #[must_use]
 pub struct EditAttachments<'a> {

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 /// A builder for creating a components action row in a message.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#component-object).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 #[must_use]
 pub enum CreateActionRow<'a> {
     Buttons(Vec<CreateButton<'a>>),
@@ -34,7 +34,7 @@ impl<'a> serde::Serialize for CreateActionRow<'a> {
 }
 
 /// A builder for creating a button component in a message
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateButton<'a> {
     style: ButtonStyle,
@@ -139,7 +139,7 @@ impl Serialize for CreateSelectMenuDefault {
 }
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum CreateSelectMenuKind<'a> {
     String {
         options: Cow<'a, [CreateSelectMenuOption<'a>]>,
@@ -226,7 +226,7 @@ impl<'a> Serialize for CreateSelectMenuKind<'a> {
 /// A builder for creating a select menu component in a message
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure).
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateSelectMenu<'a> {
     custom_id: Cow<'a, str>,
@@ -292,7 +292,7 @@ impl<'a> CreateSelectMenu<'a> {
 /// A builder for creating an option of a select menu component in a message
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure)
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateSelectMenuOption<'a> {
     label: Cow<'a, str>,
@@ -352,7 +352,7 @@ impl<'a> CreateSelectMenuOption<'a> {
 /// A builder for creating an input text component in a modal
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure).
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateInputText<'a> {
     #[serde(rename = "type")]

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -23,7 +23,7 @@ use crate::model::prelude::*;
 /// A builder to create an embed in a message
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object)
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateEmbed<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -258,7 +258,7 @@ impl<'a> From<Embed> for CreateEmbed<'a> {
 }
 
 /// A builder to create the author data of an emebd. See [`CreateEmbed::author`]
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateEmbedAuthor<'a> {
     name: Cow<'a, str>,
@@ -306,7 +306,7 @@ impl<'a> From<EmbedAuthor> for CreateEmbedAuthor<'a> {
 }
 
 /// A builder to create the footer data for an embed. See [`CreateEmbed::footer`]
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateEmbedFooter<'a> {
     text: Cow<'a, str>,
@@ -344,7 +344,7 @@ impl<'a> From<EmbedFooter> for CreateEmbedFooter<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct CreateEmbedField<'a> {
     name: Cow<'a, str>,
     value: Cow<'a, str>,
@@ -371,7 +371,7 @@ impl<'a> From<EmbedField> for CreateEmbedField<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct CreateEmbedImage<'a> {
     url: Cow<'a, str>,
 }

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -15,7 +15,7 @@ use crate::model::{Colour, Timestamp};
 ///
 /// [slack's attachments]: https://api.slack.com/docs/message-attachments
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Embed {
     /// The title of the embed.
@@ -76,7 +76,7 @@ pub struct Embed {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedAuthor {
     /// The name of the author.
@@ -98,7 +98,7 @@ pub struct EmbedAuthor {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedField {
     /// The name of the field.
@@ -144,7 +144,7 @@ impl EmbedField {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedFooter {
     /// The associated text with the footer.
@@ -163,7 +163,7 @@ pub struct EmbedFooter {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-image-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedImage {
     /// Source URL of the image.
@@ -182,7 +182,7 @@ pub struct EmbedImage {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedProvider {
     /// The name of the provider.
@@ -195,7 +195,7 @@ pub struct EmbedProvider {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedThumbnail {
     /// The source URL of the thumbnail.
@@ -214,7 +214,7 @@ pub struct EmbedThumbnail {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct EmbedVideo {
     /// The source URL of the video.


### PR DESCRIPTION
Because builder fields are all private, it doesn't make sense to compare them directly. From a user's perspective, they have no idea what the builder might contain. This also lets us change their internals easier, without worrying about equality.