### PR TITLE
Remove impl AsRef

### DIFF
--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -22,7 +22,7 @@ impl EventHandler for Handler {
                 .title("This is a title")
                 .description("This is a description")
                 .image("attachment://ferris_eyes.png")
-                .fields(vec![
+                .fields([
                     ("This is the first field", "This is a field body", true),
                     ("This is the second field", "Both fields are inline", true),
                 ])

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -95,7 +95,7 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
 
     // There is a method implemented for some models to conveniently collect replies. They return a
     // builder that can be turned into a Stream, or here, where we can await a single reply
-    let collector = msg.author.await_reply(&ctx.shard).timeout(Duration::from_secs(10));
+    let collector = msg.author.await_reply(ctx.shard.clone()).timeout(Duration::from_secs(10));
     if let Some(answer) = collector.await {
         if answer.content.to_lowercase() == "ferris" {
             let _ = answer.reply(ctx, "That's correct!").await;
@@ -114,7 +114,7 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
 
     // The message model can also be turned into a Collector to collect reactions on it.
     let collector = react_msg
-        .await_reaction(&ctx.shard)
+        .await_reaction(ctx.shard.clone())
         .timeout(Duration::from_secs(10))
         .author_id(msg.author.id);
 
@@ -132,7 +132,7 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
     let _ = msg.reply(ctx, "Write 5 messages in 10 seconds").await;
 
     // We can create a collector from scratch too using this builder future.
-    let collector = MessageCollector::new(&ctx.shard)
+    let collector = MessageCollector::new(ctx.shard.clone())
     // Only collect messages by this user.
         .author_id(msg.author.id)
         .channel_id(msg.channel_id)

--- a/examples/e16_message_components/src/main.rs
+++ b/examples/e16_message_components/src/main.rs
@@ -60,7 +60,7 @@ impl EventHandler for Handler {
         // This uses a collector to wait for an incoming event without needing to listen for it
         // manually in the EventHandler.
         let interaction = match m
-            .await_component_interaction(&ctx.shard)
+            .await_component_interaction(ctx.shard.clone())
             .timeout(Duration::from_secs(60 * 3))
             .await
         {
@@ -107,8 +107,10 @@ impl EventHandler for Handler {
             .unwrap();
 
         // Wait for multiple interactions
-        let mut interaction_stream =
-            m.await_component_interaction(&ctx.shard).timeout(Duration::from_secs(60 * 3)).stream();
+        let mut interaction_stream = m
+            .await_component_interaction(ctx.shard.clone())
+            .timeout(Duration::from_secs(60 * 3))
+            .stream();
 
         while let Some(interaction) = interaction_stream.next().await {
             let sound = &interaction.data.custom_id;

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -209,7 +209,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         channel.edit(ctx, EditChannel::new().category(None)).await?;
         channel.edit(ctx, EditChannel::new().category(Some(parent_id))).await?;
     } else if msg.content == "channelperms" {
-        let guild = guild_id.to_guild_cached(ctx).unwrap().clone();
+        let guild = guild_id.to_guild_cached(&ctx.cache).unwrap().clone();
         let perms = guild.user_permissions_in(
             &channel_id.to_channel(ctx).await?.guild().unwrap(),
             &*guild.member(ctx, msg.author.id).await?,

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -58,7 +58,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             .send_message(
                 &ctx,
                 CreateMessage::new()
-                    .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
+                    .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
             .await?;
         // Pre-PR, this falsely triggered a MODEL_TYPE_CONVERT Discord error
@@ -71,14 +71,14 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             .send_message(
                 ctx,
                 CreateMessage::new()
-                    .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
+                    .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
             .await?;
         msg.edit(
             ctx,
             EditMessage::new().attachments(
                 EditAttachments::keep_all(&msg)
-                    .add(CreateAttachment::url(ctx, IMAGE_URL_2, "testing1.png").await?),
+                    .add(CreateAttachment::url(&ctx.http, IMAGE_URL_2, "testing1.png").await?),
             ),
         )
         .await?;
@@ -146,11 +146,11 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
                 }),
             )
             .await?;
-        println!("new automod rules: {:?}", guild_id.automod_rules(ctx).await?);
+        println!("new automod rules: {:?}", guild_id.automod_rules(&ctx.http).await?);
     } else if let Some(user_id) = msg.content.strip_prefix("ban ") {
         // Test if banning without a reason actually works
         let user_id: UserId = user_id.trim().parse().unwrap();
-        guild_id.ban(ctx, user_id, 0).await?;
+        guild_id.ban(&ctx.http, user_id, 0).await?;
     } else if msg.content == "createtags" {
         channel_id
             .edit(
@@ -199,7 +199,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
                 ctx,
                 CreateMessage::new()
                     .flags(MessageFlags::IS_VOICE_MESSAGE)
-                    .add_file(CreateAttachment::url(ctx, audio_url, "testing.ogg").await?),
+                    .add_file(CreateAttachment::url(&ctx.http, audio_url, "testing.ogg").await?),
             )
             .await?;
     } else if let Some(channel) = msg.content.strip_prefix("movetorootandback") {
@@ -233,7 +233,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             serenity::utils::parse_message_url(forum_post_url).unwrap();
         msg.channel_id.say(ctx, format!("Deleting <#{}> in 10 seconds...", channel_id)).await?;
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-        channel_id.delete(ctx).await?;
+        channel_id.delete(&ctx.http).await?;
     } else {
         return Ok(());
     }
@@ -252,14 +252,15 @@ async fn interaction(
             .create_response(
                 &ctx,
                 CreateInteractionResponse::Message(
-                    CreateInteractionResponseMessage::new()
-                        .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
+                    CreateInteractionResponseMessage::new().add_file(
+                        CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?,
+                    ),
                 ),
             )
             .await?;
 
         // We need to know the attachments' IDs in order to not lose them in the subsequent edit
-        let msg = interaction.get_response(ctx).await?;
+        let msg = interaction.get_response(&ctx.http).await?;
 
         // Add another image
         let msg = interaction
@@ -267,7 +268,7 @@ async fn interaction(
                 &ctx,
                 EditInteractionResponse::new().attachments(
                     EditAttachments::keep_all(&msg)
-                        .add(CreateAttachment::url(ctx, IMAGE_URL_2, "testing1.png").await?),
+                        .add(CreateAttachment::url(&ctx.http, IMAGE_URL_2, "testing1.png").await?),
                 ),
             )
             .await?;
@@ -307,8 +308,9 @@ async fn interaction(
             .create_response(
                 ctx,
                 CreateInteractionResponse::Message(
-                    CreateInteractionResponseMessage::new()
-                        .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
+                    CreateInteractionResponseMessage::new().add_file(
+                        CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?,
+                    ),
                 ),
             )
             .await?;
@@ -316,8 +318,9 @@ async fn interaction(
         interaction
             .edit_response(
                 ctx,
-                EditInteractionResponse::new()
-                    .new_attachment(CreateAttachment::url(ctx, IMAGE_URL_2, "testing1.png").await?),
+                EditInteractionResponse::new().new_attachment(
+                    CreateAttachment::url(&ctx.http, IMAGE_URL_2, "testing1.png").await?,
+                ),
             )
             .await?;
 
@@ -325,7 +328,7 @@ async fn interaction(
             .create_followup(
                 ctx,
                 CreateInteractionResponseFollowup::new()
-                    .add_file(CreateAttachment::url(ctx, IMAGE_URL, "testing.png").await?),
+                    .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
             .await?;
     } else if interaction.data.name == "editembeds" {

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -121,7 +121,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
                 )
                 .await?;
             let button_press = msg
-                .await_component_interaction(&ctx.shard)
+                .await_component_interaction(ctx.shard.clone())
                 .timeout(std::time::Duration::from_secs(10))
                 .await;
             match button_press {

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -85,8 +85,8 @@ impl<'a> CreateBotAuthParameters<'a> {
     ///
     /// [`HttpError::UnsuccessfulRequest`]: crate::http::HttpError::UnsuccessfulRequest
     #[cfg(feature = "http")]
-    pub async fn auto_client_id(mut self, http: impl AsRef<Http>) -> Result<Self> {
-        self.client_id = http.as_ref().get_current_application_info().await.map(|v| Some(v.id))?;
+    pub async fn auto_client_id(mut self, http: &Http) -> Result<Self> {
+        self.client_id = http.get_current_application_info().await.map(|v| Some(v.id))?;
         Ok(self)
     }
 

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -81,11 +81,11 @@ impl<'a> CreateAttachment<'a> {
     /// Returns [`Error::Http`] if downloading the data fails.
     #[cfg(feature = "http")]
     pub async fn url(
-        http: impl AsRef<Http>,
+        http: &Http,
         url: impl reqwest::IntoUrl,
         filename: impl Into<Cow<'static, str>>,
     ) -> Result<Self> {
-        let response = http.as_ref().client.get(url).send().await?;
+        let response = http.client.get(url).send().await?;
         let data = response.bytes().await?.to_vec();
 
         Ok(CreateAttachment::bytes(data, filename))

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -178,8 +178,8 @@ impl Builder for CreateInteractionResponseFollowup<'_> {
 
         let http = cache_http.http();
         match ctx.0 {
-            Some(id) => http.as_ref().edit_followup_message(ctx.1, id, &self, files).await,
-            None => http.as_ref().create_followup_message(ctx.1, &self, files).await,
+            Some(id) => http.edit_followup_message(ctx.1, id, &self, files).await,
+            None => http.create_followup_message(ctx.1, &self, files).await,
         }
     }
 }

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -323,40 +323,6 @@ impl Context {
     }
 }
 
-impl AsRef<Arc<Http>> for Context {
-    fn as_ref(&self) -> &Arc<Http> {
-        &self.http
-    }
-}
-
-#[cfg(feature = "cache")]
-impl AsRef<Cache> for Context {
-    fn as_ref(&self) -> &Cache {
-        &self.cache
-    }
-}
-
-#[cfg(feature = "cache")]
-impl AsRef<Cache> for Arc<Context> {
-    fn as_ref(&self) -> &Cache {
-        &self.cache
-    }
-}
-
-#[cfg(feature = "cache")]
-impl AsRef<Arc<Cache>> for Context {
-    fn as_ref(&self) -> &Arc<Cache> {
-        &self.cache
-    }
-}
-
-#[cfg(feature = "cache")]
-impl AsRef<Cache> for Cache {
-    fn as_ref(&self) -> &Cache {
-        self
-    }
-}
-
 #[cfg(feature = "gateway")]
 impl AsRef<ShardMessenger> for Context {
     fn as_ref(&self) -> &ShardMessenger {

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -322,10 +322,3 @@ impl Context {
         self.shard.set_presence(activity, status);
     }
 }
-
-#[cfg(feature = "gateway")]
-impl AsRef<ShardMessenger> for Context {
-    fn as_ref(&self) -> &ShardMessenger {
-        &self.shard
-    }
-}

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -323,18 +323,6 @@ impl Context {
     }
 }
 
-impl AsRef<Http> for Context {
-    fn as_ref(&self) -> &Http {
-        &self.http
-    }
-}
-
-impl AsRef<Http> for Arc<Context> {
-    fn as_ref(&self) -> &Http {
-        &self.http
-    }
-}
-
 impl AsRef<Arc<Http>> for Context {
     fn as_ref(&self) -> &Arc<Http> {
         &self.http

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -64,9 +64,9 @@ macro_rules! make_specific_collector {
 
         impl $collector_type {
             /// Creates a new collector without any filters configured.
-            pub fn new(shard: impl AsRef<ShardMessenger>) -> Self {
+            pub fn new(shard: ShardMessenger) -> Self {
                 Self {
-                    shard: shard.as_ref().clone(),
+                    shard,
                     duration: None,
                     filter: None,
                     $( $filter_name: None, )*

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -847,14 +847,14 @@ impl CommonOptions for &CommandOptions {
 
 #[cfg(feature = "cache")]
 pub(crate) fn has_correct_permissions(
-    cache: impl AsRef<Cache>,
+    cache: &Cache,
     options: &impl CommonOptions,
     message: &Message,
 ) -> bool {
     if options.required_permissions().is_empty() {
         true
     } else {
-        message.guild(cache.as_ref()).is_some_and(|guild| {
+        message.guild(cache).is_some_and(|guild| {
             let Some(channel) = guild.channels.get(&message.channel_id) else { return false };
             let Some(member) = guild.members.get(&message.author.id) else { return false };
 

--- a/src/gateway/bridge/mod.rs
+++ b/src/gateway/bridge/mod.rs
@@ -94,12 +94,6 @@ pub struct ShardRunnerInfo {
     pub stage: ConnectionStage,
 }
 
-impl AsRef<ShardMessenger> for ShardRunnerInfo {
-    fn as_ref(&self) -> &ShardMessenger {
-        &self.runner_tx
-    }
-}
-
 /// Newtype around a callback that will be called on every incoming request. As long as this
 /// collector should still receive events, it should return `true`. Once it returns `false`, it is
 /// removed.

--- a/src/gateway/bridge/shard_messenger.rs
+++ b/src/gateway/bridge/shard_messenger.rs
@@ -214,9 +214,3 @@ impl ShardMessenger {
         self.collectors.lock().expect("poison").push(collector);
     }
 }
-
-impl AsRef<ShardMessenger> for ShardMessenger {
-    fn as_ref(&self) -> &ShardMessenger {
-        self
-    }
-}

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4690,9 +4690,3 @@ fn configure_client_backend(builder: ClientBuilder) -> ClientBuilder {
 fn configure_client_backend(builder: ClientBuilder) -> ClientBuilder {
     builder.use_native_tls()
 }
-
-impl AsRef<Http> for Http {
-    fn as_ref(&self) -> &Http {
-        self
-    }
-}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -128,13 +128,6 @@ impl AsRef<Cache> for (&Arc<Cache>, &Http) {
     }
 }
 
-#[cfg(feature = "cache")]
-impl AsRef<Http> for (&Arc<Cache>, &Http) {
-    fn as_ref(&self) -> &Http {
-        self.1
-    }
-}
-
 /// An method used for ratelimiting special routes.
 ///
 /// This is needed because [`reqwest`]'s [`Method`] enum does not derive Copy.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -121,13 +121,6 @@ impl CacheHttp for Http {
     }
 }
 
-#[cfg(feature = "cache")]
-impl AsRef<Cache> for (&Arc<Cache>, &Http) {
-    fn as_ref(&self) -> &Cache {
-        self.0
-    }
-}
-
 /// An method used for ratelimiting special routes.
 ///
 /// This is needed because [`reqwest`]'s [`Method`] enum does not derive Copy.

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -154,10 +154,10 @@ impl Command {
     ///
     /// Returns the same errors as [`Self::create_global_command`].
     pub async fn set_global_commands(
-        http: impl AsRef<Http>,
+        http: &Http,
         commands: &[CreateCommand<'_>],
     ) -> Result<Vec<Command>> {
-        http.as_ref().create_global_commands(&commands).await
+        http.create_global_commands(&commands).await
     }
 
     /// Edit a global command, given its Id.
@@ -178,8 +178,8 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_global_commands(http: impl AsRef<Http>) -> Result<Vec<Command>> {
-        http.as_ref().get_global_commands().await
+    pub async fn get_global_commands(http: &Http) -> Result<Vec<Command>> {
+        http.get_global_commands().await
     }
 
     /// Gets all global commands with localizations.
@@ -187,10 +187,8 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_global_commands_with_localizations(
-        http: impl AsRef<Http>,
-    ) -> Result<Vec<Command>> {
-        http.as_ref().get_global_commands_with_localizations().await
+    pub async fn get_global_commands_with_localizations(http: &Http) -> Result<Vec<Command>> {
+        http.get_global_commands_with_localizations().await
     }
 
     /// Gets a global command by its Id.
@@ -198,11 +196,8 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_global_command(
-        http: impl AsRef<Http>,
-        command_id: CommandId,
-    ) -> Result<Command> {
-        http.as_ref().get_global_command(command_id).await
+    pub async fn get_global_command(http: &Http, command_id: CommandId) -> Result<Command> {
+        http.get_global_command(command_id).await
     }
 
     /// Deletes a global command by its Id.
@@ -210,11 +205,8 @@ impl Command {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn delete_global_command(
-        http: impl AsRef<Http>,
-        command_id: CommandId,
-    ) -> Result<()> {
-        http.as_ref().delete_global_command(command_id).await
+    pub async fn delete_global_command(http: &Http, command_id: CommandId) -> Result<()> {
+        http.delete_global_command(command_id).await
     }
 }
 

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -90,8 +90,8 @@ impl CommandInteraction {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if there is no interaction response.
-    pub async fn get_response(&self, http: impl AsRef<Http>) -> Result<Message> {
-        http.as_ref().get_original_interaction_response(&self.token).await
+    pub async fn get_response(&self, http: &Http) -> Result<Message> {
+        http.get_original_interaction_response(&self.token).await
     }
 
     /// Creates a response to the interaction received.
@@ -136,8 +136,8 @@ impl CommandInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_response(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_original_interaction_response(&self.token).await
+    pub async fn delete_response(&self, http: &Http) -> Result<()> {
+        http.delete_original_interaction_response(&self.token).await
     }
 
     /// Creates a followup response to the response sent.
@@ -181,12 +181,8 @@ impl CommandInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_followup(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: MessageId,
-    ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id).await
+    pub async fn delete_followup(&self, http: &Http, message_id: MessageId) -> Result<()> {
+        http.delete_followup_message(&self.token, message_id).await
     }
 
     /// Gets a followup message.
@@ -195,12 +191,8 @@ impl CommandInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was
     /// deleted.
-    pub async fn get_followup(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: MessageId,
-    ) -> Result<Message> {
-        http.as_ref().get_followup_message(&self.token, message_id).await
+    pub async fn get_followup(&self, http: &Http, message_id: MessageId) -> Result<Message> {
+        http.get_followup_message(&self.token, message_id).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -71,8 +71,8 @@ impl ComponentInteraction {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if there is no interaction response.
-    pub async fn get_response(&self, http: impl AsRef<Http>) -> Result<Message> {
-        http.as_ref().get_original_interaction_response(&self.token).await
+    pub async fn get_response(&self, http: &Http) -> Result<Message> {
+        http.get_original_interaction_response(&self.token).await
     }
 
     /// Creates a response to the interaction received.
@@ -117,8 +117,8 @@ impl ComponentInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_response(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_original_interaction_response(&self.token).await
+    pub async fn delete_response(&self, http: &Http) -> Result<()> {
+        http.delete_original_interaction_response(&self.token).await
     }
 
     /// Creates a followup response to the response sent.
@@ -162,12 +162,8 @@ impl ComponentInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_followup(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: MessageId,
-    ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id).await
+    pub async fn delete_followup(&self, http: &Http, message_id: MessageId) -> Result<()> {
+        http.delete_followup_message(&self.token, message_id).await
     }
 
     /// Gets a followup message.
@@ -176,12 +172,8 @@ impl ComponentInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was
     /// deleted.
-    pub async fn get_followup(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: MessageId,
-    ) -> Result<Message> {
-        http.as_ref().get_followup_message(&self.token, message_id).await
+    pub async fn get_followup(&self, http: &Http, message_id: MessageId) -> Result<Message> {
+        http.get_followup_message(&self.token, message_id).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -70,8 +70,8 @@ impl ModalInteraction {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if there is no interaction response.
-    pub async fn get_response(&self, http: impl AsRef<Http>) -> Result<Message> {
-        http.as_ref().get_original_interaction_response(&self.token).await
+    pub async fn get_response(&self, http: &Http) -> Result<Message> {
+        http.get_original_interaction_response(&self.token).await
     }
 
     /// Creates a response to the interaction received.
@@ -116,8 +116,8 @@ impl ModalInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_response(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_original_interaction_response(&self.token).await
+    pub async fn delete_response(&self, http: &Http) -> Result<()> {
+        http.delete_original_interaction_response(&self.token).await
     }
 
     /// Creates a followup response to the response sent.
@@ -161,12 +161,8 @@ impl ModalInteraction {
     ///
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
-    pub async fn delete_followup(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: MessageId,
-    ) -> Result<()> {
-        http.as_ref().delete_followup_message(&self.token, message_id).await
+    pub async fn delete_followup(&self, http: &Http, message_id: MessageId) -> Result<()> {
+        http.delete_followup_message(&self.token, message_id).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -783,29 +783,26 @@ impl ChannelId {
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this
     /// channel.
     #[cfg(feature = "collector")]
-    pub fn await_reply(self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_reply(self, shard_messenger: ShardMessenger) -> MessageCollector {
         MessageCollector::new(shard_messenger).channel_id(self)
     }
 
     /// Same as [`Self::await_reply`].
     #[cfg(feature = "collector")]
-    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_replies(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent in
     /// this channel.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+    pub fn await_reaction(self, shard_messenger: ShardMessenger) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).channel_id(self)
     }
 
     /// Same as [`Self::await_reaction`].
     #[cfg(feature = "collector")]
-    pub fn await_reactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollector {
+    pub fn await_reactions(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         self.await_reaction(shard_messenger)
     }
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -61,8 +61,8 @@ impl ChannelId {
     /// channel.
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES
-    pub async fn broadcast_typing(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().broadcast_typing(self).await
+    pub async fn broadcast_typing(self, http: &Http) -> Result<()> {
+        http.broadcast_typing(self).await
     }
 
     /// Creates an invite for the given channel.
@@ -96,13 +96,9 @@ impl ChannelId {
     /// set.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    pub async fn create_permission(
-        self,
-        http: impl AsRef<Http>,
-        target: PermissionOverwrite,
-    ) -> Result<()> {
+    pub async fn create_permission(self, http: &Http, target: PermissionOverwrite) -> Result<()> {
         let data: PermissionOverwriteData = target.into();
-        http.as_ref().create_permission(self, data.id, &data, None).await
+        http.create_permission(self, data.id, &data, None).await
     }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
@@ -119,11 +115,11 @@ impl ChannelId {
     /// [Add Reactions]: Permissions::ADD_REACTIONS
     pub async fn create_reaction(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.as_ref().create_reaction(self, message_id, &reaction_type.into()).await
+        http.create_reaction(self, message_id, &reaction_type.into()).await
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
@@ -135,8 +131,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    pub async fn delete(self, http: impl AsRef<Http>) -> Result<Channel> {
-        http.as_ref().delete_channel(self, None).await
+    pub async fn delete(self, http: &Http) -> Result<Channel> {
+        http.delete_channel(self, None).await
     }
 
     /// Deletes a [`Message`] given its Id.
@@ -151,8 +147,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission to delete the message.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_message(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
-        http.as_ref().delete_message(self, message_id, None).await
+    pub async fn delete_message(self, http: &Http, message_id: MessageId) -> Result<()> {
+        http.delete_message(self, message_id, None).await
     }
 
     /// Deletes all messages by Ids from the given vector in the given channel.
@@ -171,11 +167,7 @@ impl ChannelId {
     /// Also will return [`Error::Http`] if the current user lacks permission to delete messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_messages(
-        self,
-        http: impl AsRef<Http>,
-        message_ids: &[MessageId],
-    ) -> Result<()> {
+    pub async fn delete_messages(self, http: &Http, message_ids: &[MessageId]) -> Result<()> {
         use crate::model::error::{Maximum, Minimum};
 
         #[derive(serde::Serialize)]
@@ -193,7 +185,7 @@ impl ChannelId {
                 messages: message_ids,
             };
 
-            http.as_ref().delete_messages(self, &req, None).await
+            http.delete_messages(self, &req, None).await
         }
     }
 
@@ -208,14 +200,14 @@ impl ChannelId {
     /// [Manage Channel]: Permissions::MANAGE_CHANNELS
     pub async fn delete_permission(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         permission_type: PermissionOverwriteType,
     ) -> Result<()> {
         let id = match permission_type {
             PermissionOverwriteType::Member(id) => id.into(),
             PermissionOverwriteType::Role(id) => id.get().into(),
         };
-        http.as_ref().delete_permission(self, id, None).await
+        http.delete_permission(self, id, None).await
     }
 
     /// Deletes the given [`Reaction`] from the channel.
@@ -231,12 +223,11 @@ impl ChannelId {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn delete_reaction(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        let http = http.as_ref();
         let reaction_type = reaction_type.into();
         match user_id {
             Some(user_id) => http.delete_reaction(self, message_id, user_id, &reaction_type).await,
@@ -254,12 +245,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_reactions(
-        self,
-        http: impl AsRef<Http>,
-        message_id: MessageId,
-    ) -> Result<()> {
-        http.as_ref().delete_message_reactions(self, message_id).await
+    pub async fn delete_reactions(self, http: &Http, message_id: MessageId) -> Result<()> {
+        http.delete_message_reactions(self, message_id).await
     }
 
     /// Deletes all [`Reaction`]s of the given emoji to a message within the channel.
@@ -273,11 +260,11 @@ impl ChannelId {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn delete_reaction_emoji(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.as_ref().delete_message_reaction_emoji(self, message_id, &reaction_type.into()).await
+        http.delete_message_reaction_emoji(self, message_id, &reaction_type.into()).await
     }
 
     /// Edits a channel's settings.
@@ -353,10 +340,10 @@ impl ChannelId {
     /// Permissions::MANAGE_WEBHOOKS
     pub async fn follow(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         target_channel_id: ChannelId,
     ) -> Result<FollowedChannel> {
-        http.as_ref().follow_news_channel(self, target_channel_id).await
+        http.follow_news_channel(self, target_channel_id).await
     }
 
     /// Attempts to find a [`GuildChannel`] by its Id in the cache.
@@ -412,8 +399,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    pub async fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
-        http.as_ref().get_channel_invites(self).await
+    pub async fn invites(self, http: &Http) -> Result<Vec<RichInvite>> {
+        http.get_channel_invites(self).await
     }
 
     /// Gets a message from the channel.
@@ -499,8 +486,8 @@ impl ChannelId {
     /// }
     /// # }
     /// ```
-    pub fn messages_iter<H: AsRef<Http>>(self, http: H) -> impl Stream<Item = Result<Message>> {
-        MessagesIter::<H>::stream(http, self)
+    pub fn messages_iter(self, http: &Http) -> impl Stream<Item = Result<Message>> + '_ {
+        MessagesIter::stream(http, self)
     }
 
     /// Returns the name of whatever channel this id holds.
@@ -530,8 +517,8 @@ impl ChannelId {
     /// many pinned messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn pin(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
-        http.as_ref().pin_message(self, message_id, None).await
+    pub async fn pin(self, http: &Http, message_id: MessageId) -> Result<()> {
+        http.pin_message(self, message_id, None).await
     }
 
     /// Crossposts a [`Message`].
@@ -547,8 +534,8 @@ impl ChannelId {
     /// author of the message.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn crosspost(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<Message> {
-        http.as_ref().crosspost_message(self, message_id).await
+    pub async fn crosspost(self, http: &Http, message_id: MessageId) -> Result<Message> {
+        http.crosspost_message(self, message_id).await
     }
 
     /// Gets the list of [`Message`]s which are pinned to the channel.
@@ -561,8 +548,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission to view the channel.
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-    pub async fn pins(self, http: impl AsRef<Http>) -> Result<Vec<Message>> {
-        http.as_ref().get_pins(self).await
+    pub async fn pins(self, http: &Http) -> Result<Vec<Message>> {
+        http.get_pins(self).await
     }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a certain [`Emoji`].
@@ -588,7 +575,7 @@ impl ChannelId {
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     pub async fn reaction_users(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
@@ -596,9 +583,7 @@ impl ChannelId {
     ) -> Result<Vec<User>> {
         let limit = limit.map_or(50, |x| if x > 100 { 100 } else { x });
 
-        http.as_ref()
-            .get_reaction_users(self, message_id, &reaction_type.into(), limit, after)
-            .await
+        http.get_reaction_users(self, message_id, &reaction_type.into(), limit, after).await
     }
 
     /// Sends a message with just the given message content in the channel.
@@ -765,8 +750,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn unpin(self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
-        http.as_ref().unpin_message(self, message_id, None).await
+    pub async fn unpin(self, http: &Http, message_id: MessageId) -> Result<()> {
+        http.unpin_message(self, message_id, None).await
     }
 
     /// Retrieves the channel's webhooks.
@@ -778,8 +763,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
-    pub async fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
-        http.as_ref().get_channel_webhooks(self).await
+    pub async fn webhooks(self, http: &Http) -> Result<Vec<Webhook>> {
+        http.get_channel_webhooks(self).await
     }
 
     /// Creates a webhook in the channel.
@@ -830,8 +815,8 @@ impl ChannelId {
     ///
     /// Returns [`Error::Http`] if the channel is not a stage channel, or if there is no stage
     /// instance currently.
-    pub async fn get_stage_instance(self, http: impl AsRef<Http>) -> Result<StageInstance> {
-        http.as_ref().get_stage_instance(self).await
+    pub async fn get_stage_instance(self, http: &Http) -> Result<StageInstance> {
+        http.get_stage_instance(self).await
     }
 
     /// Creates a stage instance.
@@ -884,8 +869,8 @@ impl ChannelId {
     ///
     /// Returns [`Error::Http`] if the channel is not a stage channel, or if there is no stage
     /// instance currently.
-    pub async fn delete_stage_instance(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_stage_instance(self, None).await
+    pub async fn delete_stage_instance(self, http: &Http) -> Result<()> {
+        http.delete_stage_instance(self, None).await
     }
 
     /// Creates a public thread that is connected to a message.
@@ -935,8 +920,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn get_thread_members(self, http: impl AsRef<Http>) -> Result<Vec<ThreadMember>> {
-        http.as_ref().get_channel_thread_members(self).await
+    pub async fn get_thread_members(self, http: &Http) -> Result<Vec<ThreadMember>> {
+        http.get_channel_thread_members(self).await
     }
 
     /// Joins the thread, if this channel is a thread.
@@ -944,8 +929,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn join_thread(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().join_thread_channel(self).await
+    pub async fn join_thread(self, http: &Http) -> Result<()> {
+        http.join_thread_channel(self).await
     }
 
     /// Leaves the thread, if this channel is a thread.
@@ -953,8 +938,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn leave_thread(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().leave_thread_channel(self).await
+    pub async fn leave_thread(self, http: &Http) -> Result<()> {
+        http.leave_thread_channel(self).await
     }
 
     /// Adds a thread member, if this channel is a thread.
@@ -962,8 +947,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn add_thread_member(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
-        http.as_ref().add_thread_channel_member(self, user_id).await
+    pub async fn add_thread_member(self, http: &Http, user_id: UserId) -> Result<()> {
+        http.add_thread_channel_member(self, user_id).await
     }
 
     /// Removes a thread member, if this channel is a thread.
@@ -971,8 +956,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
-    pub async fn remove_thread_member(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
-        http.as_ref().remove_thread_channel_member(self, user_id).await
+    pub async fn remove_thread_member(self, http: &Http, user_id: UserId) -> Result<()> {
+        http.remove_thread_channel_member(self, user_id).await
     }
 
     /// Gets private archived threads of a channel.
@@ -982,11 +967,11 @@ impl ChannelId {
     /// It may return an [`Error::Http`] if the bot doesn't have the permission to get it.
     pub async fn get_archived_private_threads(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.as_ref().get_channel_archived_private_threads(self, before, limit).await
+        http.get_channel_archived_private_threads(self, before, limit).await
     }
 
     /// Gets public archived threads of a channel.
@@ -996,11 +981,11 @@ impl ChannelId {
     /// It may return an [`Error::Http`] if the bot doesn't have the permission to get it.
     pub async fn get_archived_public_threads(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.as_ref().get_channel_archived_public_threads(self, before, limit).await
+        http.get_channel_archived_public_threads(self, before, limit).await
     }
 
     /// Gets private archived threads joined by the current user of a channel.
@@ -1010,11 +995,11 @@ impl ChannelId {
     /// It may return an [`Error::Http`] if the bot doesn't have the permission to get it.
     pub async fn get_joined_archived_private_threads(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         before: Option<ChannelId>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.as_ref().get_channel_joined_archived_private_threads(self, before, limit).await
+        http.get_channel_joined_archived_private_threads(self, before, limit).await
     }
 }
 
@@ -1079,8 +1064,8 @@ impl<'a> From<&'a WebhookChannel> for ChannelId {
 /// A helper class returned by [`ChannelId::messages_iter`]
 #[derive(Clone, Debug)]
 #[cfg(feature = "model")]
-pub struct MessagesIter<H: AsRef<Http>> {
-    http: H,
+pub struct MessagesIter<'a> {
+    http: &'a Http,
     channel_id: ChannelId,
     buffer: Vec<Message>,
     before: Option<MessageId>,
@@ -1088,8 +1073,8 @@ pub struct MessagesIter<H: AsRef<Http>> {
 }
 
 #[cfg(feature = "model")]
-impl<H: AsRef<Http>> MessagesIter<H> {
-    fn new(http: H, channel_id: ChannelId) -> MessagesIter<H> {
+impl<'a> MessagesIter<'a> {
+    fn new(http: &'a Http, channel_id: ChannelId) -> MessagesIter<'a> {
         MessagesIter {
             http,
             channel_id,
@@ -1125,7 +1110,7 @@ impl<H: AsRef<Http>> MessagesIter<H> {
         if let Some(before) = self.before {
             builder = builder.before(before);
         }
-        self.buffer = self.channel_id.messages(self.http.as_ref(), builder).await?;
+        self.buffer = self.channel_id.messages(self.http, builder).await?;
 
         self.buffer.reverse();
 
@@ -1165,9 +1150,9 @@ impl<H: AsRef<Http>> MessagesIter<H> {
     /// # }
     /// ```
     pub fn stream(
-        http: impl AsRef<Http>,
+        http: &'a Http,
         channel_id: ChannelId,
-    ) -> impl Stream<Item = Result<Message>> {
+    ) -> impl Stream<Item = Result<Message>> + 'a {
         let init_state = MessagesIter::new(http, channel_id);
 
         futures::stream::unfold(init_state, |mut state| async {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -349,7 +349,7 @@ impl ChannelId {
     /// Attempts to find a [`GuildChannel`] by its Id in the cache.
     #[cfg(feature = "cache")]
     pub fn to_channel_cached(self, cache: &Cache) -> Option<GuildChannelRef<'_>> {
-        cache.as_ref().channel(self)
+        cache.channel(self)
     }
 
     /// First attempts to find a [`Channel`] by its Id in the cache, upon failure requests it via

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1133,11 +1133,11 @@ impl<'a> MessagesIter<'a> {
     /// #
     /// # async fn run() {
     /// # let channel_id = ChannelId::new(1);
-    /// # let ctx: Http = unimplemented!();
+    /// # let http: Http = unimplemented!();
     /// use serenity::futures::StreamExt;
     /// use serenity::model::channel::MessagesIter;
     ///
-    /// let mut messages = MessagesIter::<Http>::stream(&ctx, channel_id).boxed();
+    /// let mut messages = MessagesIter::stream(&http, channel_id).boxed();
     /// while let Some(message_result) = messages.next().await {
     ///     match message_result {
     ///         Ok(message) => println!("{} said \"{}\"", message.author.name, message.content,),

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -217,7 +217,7 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user does not have the required permissions.
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES
-    pub async fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> {
+    pub async fn broadcast_typing(&self, http: &Http) -> Result<()> {
         self.id.broadcast_typing(http).await
     }
 
@@ -329,11 +329,7 @@ impl GuildChannel {
     /// [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
     /// [Send Messages]: Permissions::SEND_MESSAGES
     /// [Send TTS Messages]: Permissions::SEND_TTS_MESSAGES
-    pub async fn create_permission(
-        &self,
-        http: impl AsRef<Http>,
-        target: PermissionOverwrite,
-    ) -> Result<()> {
+    pub async fn create_permission(&self, http: &Http, target: PermissionOverwrite) -> Result<()> {
         self.id.create_permission(http, target).await
     }
 
@@ -375,11 +371,7 @@ impl GuildChannel {
     /// delete either 0 or more than 100 messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_messages(
-        &self,
-        http: impl AsRef<Http>,
-        message_ids: &[MessageId],
-    ) -> Result<()> {
+    pub async fn delete_messages(&self, http: &Http, message_ids: &[MessageId]) -> Result<()> {
         self.id.delete_messages(http, message_ids).await
     }
 
@@ -394,7 +386,7 @@ impl GuildChannel {
     /// [Manage Channel]: Permissions::MANAGE_CHANNELS
     pub async fn delete_permission(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         permission_type: PermissionOverwriteType,
     ) -> Result<()> {
         self.id.delete_permission(http, permission_type).await
@@ -411,7 +403,7 @@ impl GuildChannel {
     /// Permissions::MANAGE_MESSAGES
     pub async fn delete_reaction(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
@@ -430,11 +422,7 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_reactions(
-        &self,
-        http: impl AsRef<Http>,
-        message_id: MessageId,
-    ) -> Result<()> {
+    pub async fn delete_reactions(&self, http: &Http, message_id: MessageId) -> Result<()> {
         self.id.delete_reactions(http, message_id).await
     }
 
@@ -628,7 +616,7 @@ impl GuildChannel {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn follow(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         target_channel_id: ChannelId,
     ) -> Result<FollowedChannel> {
         self.id.follow(http, target_channel_id).await
@@ -649,7 +637,7 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    pub async fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
+    pub async fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> {
         self.id.invites(http).await
     }
 
@@ -760,7 +748,7 @@ impl GuildChannel {
     /// too many pinned messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn pin(&self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+    pub async fn pin(&self, http: &Http, message_id: MessageId) -> Result<()> {
         self.id.pin(http, message_id).await
     }
 
@@ -774,7 +762,7 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission to view the channel.
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-    pub async fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> {
+    pub async fn pins(&self, http: &Http) -> Result<Vec<Message>> {
         self.id.pins(http).await
     }
 
@@ -800,7 +788,7 @@ impl GuildChannel {
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     pub async fn reaction_users(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
@@ -913,7 +901,7 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn unpin(&self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+    pub async fn unpin(&self, http: &Http, message_id: MessageId) -> Result<()> {
         self.id.unpin(http, message_id).await
     }
 
@@ -926,7 +914,7 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
-    pub async fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
+    pub async fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> {
         self.id.webhooks(http).await
     }
 
@@ -1023,7 +1011,7 @@ impl GuildChannel {
     /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
     ///
     /// Returns [`Error::Http`] if there is no stage instance currently.
-    pub async fn get_stage_instance(&self, http: impl AsRef<Http>) -> Result<StageInstance> {
+    pub async fn get_stage_instance(&self, http: &Http) -> Result<StageInstance> {
         if self.kind != ChannelType::Stage {
             return Err(Error::Model(ModelError::InvalidChannelType));
         }
@@ -1069,7 +1057,7 @@ impl GuildChannel {
     /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
     ///
     /// Returns [`Error::Http`] if there is no stage instance currently.
-    pub async fn delete_stage_instance(&self, http: impl AsRef<Http>) -> Result<()> {
+    pub async fn delete_stage_instance(&self, http: &Http) -> Result<()> {
         if self.kind != ChannelType::Stage {
             return Err(Error::Model(ModelError::InvalidChannelType));
         }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -624,8 +624,8 @@ impl GuildChannel {
 
     /// Attempts to find this channel's guild in the Cache.
     #[cfg(feature = "cache")]
-    pub fn guild<'a>(&self, cache: &'a impl AsRef<Cache>) -> Option<cache::GuildRef<'a>> {
-        cache.as_ref().guild(self.guild_id)
+    pub fn guild<'a>(&self, cache: &'a Cache) -> Option<cache::GuildRef<'a>> {
+        cache.guild(self.guild_id)
     }
 
     /// Gets all of the channel's invites.
@@ -728,12 +728,8 @@ impl GuildChannel {
     /// [Attach Files]: Permissions::ATTACH_FILES
     /// [Send Messages]: Permissions::SEND_MESSAGES
     #[cfg(feature = "cache")]
-    pub fn permissions_for_user(
-        &self,
-        cache: impl AsRef<Cache>,
-        user_id: UserId,
-    ) -> Result<Permissions> {
-        let guild = self.guild(&cache).ok_or(Error::Model(ModelError::GuildNotFound))?;
+    pub fn permissions_for_user(&self, cache: &Cache, user_id: UserId) -> Result<Permissions> {
+        let guild = self.guild(cache).ok_or(Error::Model(ModelError::GuildNotFound))?;
         let member = guild.members.get(&user_id).ok_or(Error::Model(ModelError::MemberNotFound))?;
         Ok(guild.user_permissions_in(self, member))
     }
@@ -930,8 +926,7 @@ impl GuildChannel {
     /// Other [`ChannelType`]s lack the concept of [`Member`]s and will return:
     /// [`ModelError::InvalidChannelType`].
     #[cfg(feature = "cache")]
-    pub fn members(&self, cache: impl AsRef<Cache>) -> Result<Vec<Member>> {
-        let cache = cache.as_ref();
+    pub fn members(&self, cache: &Cache) -> Result<Vec<Member>> {
         let guild = cache.guild(self.guild_id).ok_or(ModelError::GuildNotFound)?;
 
         match self.kind {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -960,29 +960,26 @@ impl GuildChannel {
     /// Returns a builder which can be awaited to obtain a message or stream of messages sent in
     /// this guild channel.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_reply(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         MessageCollector::new(shard_messenger).channel_id(self.id)
     }
 
     /// Same as [`Self::await_reply`].
     #[cfg(feature = "collector")]
-    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_replies(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         self.await_reply(shard_messenger)
     }
 
     /// Returns a stream builder which can be awaited to obtain a reaction or stream of reactions
     /// sent by this guild channel.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).channel_id(self.id)
     }
 
     /// Same as [`Self::await_reaction`].
     #[cfg(feature = "collector")]
-    pub fn await_reactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollector {
+    pub fn await_reactions(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         self.await_reaction(shard_messenger)
     }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -761,16 +761,13 @@ impl Message {
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions on this
     /// message.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).message_id(self.id)
     }
 
     /// Same as [`Self::await_reaction`].
     #[cfg(feature = "collector")]
-    pub fn await_reactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollector {
+    pub fn await_reactions(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         self.await_reaction(shard_messenger)
     }
 
@@ -779,7 +776,7 @@ impl Message {
     #[cfg(feature = "collector")]
     pub fn await_component_interaction(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
+        shard_messenger: ShardMessenger,
     ) -> ComponentInteractionCollector {
         ComponentInteractionCollector::new(shard_messenger).message_id(self.id)
     }
@@ -788,7 +785,7 @@ impl Message {
     #[cfg(feature = "collector")]
     pub fn await_component_interactions(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
+        shard_messenger: ShardMessenger,
     ) -> ComponentInteractionCollector {
         self.await_component_interaction(shard_messenger)
     }
@@ -798,7 +795,7 @@ impl Message {
     #[cfg(feature = "collector")]
     pub fn await_modal_interaction(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
+        shard_messenger: ShardMessenger,
     ) -> ModalInteractionCollector {
         ModalInteractionCollector::new(shard_messenger).message_id(self.id)
     }
@@ -807,7 +804,7 @@ impl Message {
     #[cfg(feature = "collector")]
     pub fn await_modal_interactions(
         &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
+        shard_messenger: ShardMessenger,
     ) -> ModalInteractionCollector {
         self.await_modal_interaction(shard_messenger)
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -815,12 +815,6 @@ impl Message {
     }
 }
 
-impl AsRef<MessageId> for Message {
-    fn as_ref(&self) -> &MessageId {
-        &self.id
-    }
-}
-
 impl From<Message> for MessageId {
     /// Gets the Id of a [`Message`].
     fn from(message: Message) -> MessageId {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -274,7 +274,7 @@ impl Message {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn delete_reaction(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
@@ -305,7 +305,6 @@ impl Message {
 
         cache_http
             .http()
-            .as_ref()
             .delete_message_reaction_emoji(self.channel_id, self.id, &reaction_type.into())
             .await
     }
@@ -434,7 +433,7 @@ impl Message {
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     pub async fn reaction_users(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
         after: Option<UserId>,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -208,8 +208,8 @@ impl Message {
 
     /// A util function for determining whether this message was sent by someone else, or the bot.
     #[cfg(feature = "cache")]
-    pub fn is_own(&self, cache: impl AsRef<Cache>) -> bool {
-        self.author.id == cache.as_ref().current_user().id
+    pub fn is_own(&self, cache: &Cache) -> bool {
+        self.author.id == cache.current_user().id
     }
 
     /// Deletes the message.
@@ -367,7 +367,7 @@ impl Message {
     /// Returns message content, but with user and role mentions replaced with
     /// names and everyone/here mentions cancelled.
     #[cfg(feature = "cache")]
-    pub fn content_safe(&self, cache: impl AsRef<Cache>) -> String {
+    pub fn content_safe(&self, cache: &Cache) -> String {
         let mut result = self.content.to_string();
 
         // First replace all user mentions.
@@ -396,7 +396,7 @@ impl Message {
             for id in &self.mention_roles {
                 let mention = id.mention().to_string();
 
-                if let Some(guild) = cache.as_ref().guild(guild_id) {
+                if let Some(guild) = cache.guild(guild_id) {
                     if let Some(role) = guild.roles.get(id) {
                         result = result.replace(&mention, &format!("@{}", role.name));
                         continue;

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -45,7 +45,7 @@ impl PrivateChannel {
     ///
     /// See [ChannelId::broadcast_typing] for more details.
     #[allow(clippy::missing_errors_doc)]
-    pub async fn broadcast_typing(&self, http: impl AsRef<Http>) -> Result<()> {
+    pub async fn broadcast_typing(&self, http: &Http) -> Result<()> {
         self.id.broadcast_typing(http).await
     }
 
@@ -59,7 +59,7 @@ impl PrivateChannel {
     /// not exist.
     pub async fn create_reaction(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
@@ -69,7 +69,7 @@ impl PrivateChannel {
     /// Deletes the channel. This does not delete the contents of the channel, and is equivalent to
     /// closing a private channel on the client, which can be re-opened.
     #[allow(clippy::missing_errors_doc)]
-    pub async fn delete(&self, http: impl AsRef<Http>) -> Result<PrivateChannel> {
+    pub async fn delete(&self, http: &Http) -> Result<PrivateChannel> {
         self.id.delete(http).await?.private().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 
@@ -87,11 +87,7 @@ impl PrivateChannel {
     /// delete either 0 or more than 100 messages.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_messages(
-        &self,
-        http: impl AsRef<Http>,
-        message_ids: &[MessageId],
-    ) -> Result<()> {
+    pub async fn delete_messages(&self, http: &Http, message_ids: &[MessageId]) -> Result<()> {
         self.id.delete_messages(http, message_ids).await
     }
 
@@ -103,7 +99,7 @@ impl PrivateChannel {
     #[allow(clippy::missing_errors_doc)]
     pub async fn delete_permission(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         permission_type: PermissionOverwriteType,
     ) -> Result<()> {
         self.id.delete_permission(http, permission_type).await
@@ -118,7 +114,7 @@ impl PrivateChannel {
     /// Returns [`Error::Http`] if the reaction is not from the current user.
     pub async fn delete_reaction(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         user_id: Option<UserId>,
         reaction_type: impl Into<ReactionType>,
@@ -212,7 +208,7 @@ impl PrivateChannel {
     /// Returns [`Error::Http`] if a message with the given Id does not exist in the channel.
     pub async fn reaction_users(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
         limit: Option<u8>,
@@ -226,13 +222,13 @@ impl PrivateChannel {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the number of pinned messages would exceed the 50 message limit.
-    pub async fn pin(&self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+    pub async fn pin(&self, http: &Http, message_id: MessageId) -> Result<()> {
         self.id.pin(http, message_id).await
     }
 
     /// Retrieves the list of messages that have been pinned in the private channel.
     #[allow(clippy::missing_errors_doc)]
-    pub async fn pins(&self, http: impl AsRef<Http>) -> Result<Vec<Message>> {
+    pub async fn pins(&self, http: &Http) -> Result<Vec<Message>> {
         self.id.pins(http).await
     }
 
@@ -342,7 +338,7 @@ impl PrivateChannel {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, if the message was deleted,
     /// or if the channel already has the limit of 50 pinned messages.
-    pub async fn unpin(&self, http: impl AsRef<Http>, message_id: MessageId) -> Result<()> {
+    pub async fn unpin(&self, http: &Http, message_id: MessageId) -> Result<()> {
         self.id.unpin(http, message_id).await
     }
 }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -145,7 +145,6 @@ impl Reaction {
         }
         cache_http
             .http()
-            .as_ref()
             .delete_message_reaction_emoji(self.channel_id, self.message_id, &self.emoji)
             .await
     }
@@ -212,7 +211,7 @@ impl Reaction {
     /// [permissions]: crate::model::permissions
     pub async fn users(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         reaction_type: impl Into<ReactionType>,
         limit: Option<NonMaxU8>,
         after: Option<UserId>,
@@ -222,7 +221,7 @@ impl Reaction {
 
     async fn _users(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         reaction_type: &ReactionType,
         limit: Option<NonMaxU8>,
         after: Option<UserId>,
@@ -234,9 +233,7 @@ impl Reaction {
             warn!("Reaction users limit clamped to 100! (API Restriction)");
         }
 
-        http.as_ref()
-            .get_reaction_users(self.channel_id, self.message_id, reaction_type, limit, after)
-            .await
+        http.get_reaction_users(self.channel_id, self.message_id, reaction_type, limit, after).await
     }
 }
 

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -116,8 +116,8 @@ impl fmt::Display for Minimum {
 /// #[serenity::async_trait]
 /// #[cfg(feature = "client")]
 /// impl EventHandler for Handler {
-///     async fn guild_ban_removal(&self, context: Context, guild_id: GuildId, user: User) {
-///         match guild_id.ban(&context, user.id, 8).await {
+///     async fn guild_ban_removal(&self, ctx: Context, guild_id: GuildId, user: User) {
+///         match guild_id.ban(&ctx.http, user.id, 8).await {
 ///             Ok(()) => {
 ///                 // Ban successful.
 ///             },

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1654,11 +1654,11 @@ impl<'a> MembersIter<'a> {
     /// #
     /// # async fn run() {
     /// # let guild_id = GuildId::new(1);
-    /// # let ctx: Http = unimplemented!();
+    /// # let http: Http = unimplemented!();
     /// use serenity::futures::StreamExt;
     /// use serenity::model::guild::MembersIter;
     ///
-    /// let mut members = MembersIter::<Http>::stream(&ctx, guild_id).boxed();
+    /// let mut members = MembersIter::stream(&http, guild_id).boxed();
     /// while let Some(member_result) = members.next().await {
     ///     match member_result {
     ///         Ok(member) => println!("{} is {}", member, member.display_name(),),

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -52,8 +52,8 @@ impl GuildId {
     /// Returns an [`Error::Http`] if the guild is unavailable.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rules(self, http: impl AsRef<Http>) -> Result<Vec<Rule>> {
-        http.as_ref().get_automod_rules(self).await
+    pub async fn automod_rules(self, http: &Http) -> Result<Vec<Rule>> {
+        http.get_automod_rules(self).await
     }
 
     /// Gets an auto moderation [`Rule`] of this guild by its ID via HTTP.
@@ -65,8 +65,8 @@ impl GuildId {
     /// Returns an [`Error::Http`] if a rule with the given ID does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rule(self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<Rule> {
-        http.as_ref().get_automod_rule(self, rule_id).await
+    pub async fn automod_rule(self, http: &Http, rule_id: RuleId) -> Result<Rule> {
+        http.get_automod_rule(self, rule_id).await
     }
 
     /// Creates an auto moderation [`Rule`] in the guild.
@@ -145,8 +145,8 @@ impl GuildId {
     /// does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn delete_automod_rule(self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<()> {
-        http.as_ref().delete_automod_rule(self, rule_id, None).await
+    pub async fn delete_automod_rule(self, http: &Http, rule_id: RuleId) -> Result<()> {
+        http.delete_automod_rule(self, rule_id, None).await
     }
 
     /// Adds a [`User`] to this guild with a valid OAuth2 access token.
@@ -198,7 +198,7 @@ impl GuildId {
     /// Also can return [`Error::Http`] if the current user lacks permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn ban(self, http: impl AsRef<Http>, user: UserId, dmd: u8) -> Result<()> {
+    pub async fn ban(self, http: &Http, user: UserId, dmd: u8) -> Result<()> {
         self._ban(http, user, dmd, None).await
     }
 
@@ -211,7 +211,7 @@ impl GuildId {
     /// [`ModelError::TooLarge`] if `reason` is too long.
     pub async fn ban_with_reason(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         user: UserId,
         dmd: u8,
         reason: &str,
@@ -219,13 +219,7 @@ impl GuildId {
         self._ban(http, user, dmd, Some(reason)).await
     }
 
-    async fn _ban(
-        self,
-        http: impl AsRef<Http>,
-        user: UserId,
-        dmd: u8,
-        reason: Option<&str>,
-    ) -> Result<()> {
+    async fn _ban(self, http: &Http, user: UserId, dmd: u8, reason: Option<&str>) -> Result<()> {
         use crate::model::error::Maximum;
 
         Maximum::DeleteMessageDays.check_overflow(dmd.into())?;
@@ -233,7 +227,7 @@ impl GuildId {
             Maximum::AuditLogReason.check_overflow(reason.len())?;
         }
 
-        http.as_ref().ban_user(self, user, dmd, reason).await
+        http.ban_user(self, user, dmd, reason).await
     }
 
     /// Gets a list of the guild's bans, with additional options and filtering. See
@@ -248,11 +242,11 @@ impl GuildId {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     pub async fn bans(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         target: Option<UserPagination>,
         limit: Option<u8>,
     ) -> Result<Vec<Ban>> {
-        http.as_ref().get_bans(self, target, limit).await
+        http.get_bans(self, target, limit).await
     }
 
     /// Gets a list of the guild's audit log entries
@@ -267,13 +261,13 @@ impl GuildId {
     /// [View Audit Log]: Permissions::VIEW_AUDIT_LOG
     pub async fn audit_logs(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         action_type: Option<audit_log::Action>,
         user_id: Option<UserId>,
         before: Option<AuditLogEntryId>,
         limit: Option<u8>,
     ) -> Result<AuditLogs> {
-        http.as_ref().get_audit_logs(self, action_type, user_id, before, limit).await
+        http.get_audit_logs(self, action_type, user_id, before, limit).await
     }
 
     /// Gets all of the guild's channels over the REST API.
@@ -281,11 +275,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user is not in the guild.
-    pub async fn channels(
-        self,
-        http: impl AsRef<Http>,
-    ) -> Result<HashMap<ChannelId, GuildChannel>> {
-        let channels = http.as_ref().get_channels(self).await?;
+    pub async fn channels(self, http: &Http) -> Result<HashMap<ChannelId, GuildChannel>> {
+        let channels = http.get_channels(self).await?;
 
         Ok(channels.into_iter().map(|c| (c.id, c)).collect())
     }
@@ -347,18 +338,13 @@ impl GuildId {
     ///
     /// [`EditProfile::avatar`]: crate::builder::EditProfile::avatar
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
-    pub async fn create_emoji(
-        self,
-        http: impl AsRef<Http>,
-        name: &str,
-        image: &str,
-    ) -> Result<Emoji> {
+    pub async fn create_emoji(self, http: &Http, name: &str, image: &str) -> Result<Emoji> {
         let map = json!({
             "name": name,
             "image": image,
         });
 
-        http.as_ref().create_emoji(self, &map, None).await
+        http.create_emoji(self, &map, None).await
     }
 
     /// Creates an integration for the guild.
@@ -372,7 +358,7 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn create_integration(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
         kind: &str,
     ) -> Result<()> {
@@ -381,7 +367,7 @@ impl GuildId {
             "type": kind,
         });
 
-        http.as_ref().create_guild_integration(self, integration_id, &map, None).await
+        http.create_guild_integration(self, integration_id, &map, None).await
     }
 
     /// Creates a new role in the guild with the data set, if any.
@@ -450,8 +436,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user is not the owner of the guild.
-    pub async fn delete(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_guild(self).await
+    pub async fn delete(self, http: &Http) -> Result<()> {
+        http.delete_guild(self).await
     }
 
     /// Deletes an [`Emoji`] from the guild.
@@ -467,8 +453,8 @@ impl GuildId {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_emoji(self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<()> {
-        http.as_ref().delete_emoji(self, emoji_id, None).await
+    pub async fn delete_emoji(self, http: &Http, emoji_id: EmojiId) -> Result<()> {
+        http.delete_emoji(self, emoji_id, None).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -483,10 +469,10 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn delete_integration(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
     ) -> Result<()> {
-        http.as_ref().delete_guild_integration(self, integration_id, None).await
+        http.delete_guild_integration(self, integration_id, None).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -501,8 +487,8 @@ impl GuildId {
     /// does not exist.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn delete_role(self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
-        http.as_ref().delete_role(self, role_id, None).await
+    pub async fn delete_role(self, http: &Http, role_id: RoleId) -> Result<()> {
+        http.delete_role(self, role_id, None).await
     }
 
     /// Deletes a specified scheduled event in the guild.
@@ -518,10 +504,10 @@ impl GuildId {
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn delete_scheduled_event(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         event_id: ScheduledEventId,
     ) -> Result<()> {
-        http.as_ref().delete_scheduled_event(self, event_id).await
+        http.delete_scheduled_event(self, event_id).await
     }
 
     /// Deletes a [`Sticker`] by id from the guild.
@@ -537,8 +523,8 @@ impl GuildId {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_sticker(self, http: impl AsRef<Http>, sticker_id: StickerId) -> Result<()> {
-        http.as_ref().delete_sticker(self, sticker_id, None).await
+    pub async fn delete_sticker(self, http: &Http, sticker_id: StickerId) -> Result<()> {
+        http.delete_sticker(self, sticker_id, None).await
     }
 
     /// Edits the current guild with new data where specified.
@@ -572,17 +558,12 @@ impl GuildId {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn edit_emoji(
-        self,
-        http: impl AsRef<Http>,
-        emoji_id: EmojiId,
-        name: &str,
-    ) -> Result<Emoji> {
+    pub async fn edit_emoji(self, http: &Http, emoji_id: EmojiId, name: &str) -> Result<Emoji> {
         let map = json!({
             "name": name,
         });
 
-        http.as_ref().edit_emoji(self, emoji_id, &map, None).await
+        http.edit_emoji(self, emoji_id, &map, None).await
     }
 
     /// Edits the properties a guild member, such as muting or nicknaming them. Returns the new
@@ -631,14 +612,14 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     pub async fn edit_mfa_level(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         mfa_level: MfaLevel,
         audit_log_reason: Option<&str>,
     ) -> Result<MfaLevel> {
         let value = json!({
             "level": mfa_level,
         });
-        http.as_ref().edit_guild_mfa_level(self, &value, audit_log_reason).await
+        http.edit_guild_mfa_level(self, &value, audit_log_reason).await
     }
 
     /// Edits the current user's nickname for the guild.
@@ -652,12 +633,8 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Change Nickname]: Permissions::CHANGE_NICKNAME
-    pub async fn edit_nickname(
-        self,
-        http: impl AsRef<Http>,
-        new_nickname: Option<&str>,
-    ) -> Result<()> {
-        http.as_ref().edit_nickname(self, new_nickname, None).await
+    pub async fn edit_nickname(self, http: &Http, new_nickname: Option<&str>) -> Result<()> {
+        http.edit_nickname(self, new_nickname, None).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.
@@ -778,11 +755,11 @@ impl GuildId {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn edit_role_position(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         role_id: RoleId,
         position: i16,
     ) -> Result<Vec<Role>> {
-        http.as_ref().edit_role_position(self, role_id, position, None).await
+        http.edit_role_position(self, role_id, position, None).await
     }
 
     /// Edits the guild's welcome screen.
@@ -825,8 +802,8 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user is not in
     /// the guild.
-    pub async fn roles(self, http: impl AsRef<Http>) -> Result<HashMap<RoleId, Role>> {
-        let roles = http.as_ref().get_guild_roles(self).await?;
+    pub async fn roles(self, http: &Http) -> Result<HashMap<RoleId, Role>> {
+        let roles = http.get_guild_roles(self).await?;
 
         Ok(roles.into_iter().map(|r| (r.id, r)).collect())
     }
@@ -872,11 +849,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild.
-    pub async fn to_partial_guild_with_counts(
-        self,
-        http: impl AsRef<Http>,
-    ) -> Result<PartialGuild> {
-        http.as_ref().get_guild_with_counts(self).await
+    pub async fn to_partial_guild_with_counts(self, http: &Http) -> Result<PartialGuild> {
+        http.get_guild_with_counts(self).await
     }
 
     /// Gets all [`Emoji`]s of this guild via HTTP.
@@ -884,8 +858,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the guild is unavailable.
-    pub async fn emojis(self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
-        http.as_ref().get_emojis(self).await
+    pub async fn emojis(self, http: &Http) -> Result<Vec<Emoji>> {
+        http.get_emojis(self).await
     }
 
     /// Gets an [`Emoji`] of this guild by its ID via HTTP.
@@ -893,8 +867,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if an emoji with that id does not exist.
-    pub async fn emoji(self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
-        http.as_ref().get_emoji(self, emoji_id).await
+    pub async fn emoji(self, http: &Http, emoji_id: EmojiId) -> Result<Emoji> {
+        http.get_emoji(self, emoji_id).await
     }
 
     /// Gets all [`Sticker`]s of this guild via HTTP.
@@ -902,8 +876,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the guild is unavailable.
-    pub async fn stickers(self, http: impl AsRef<Http>) -> Result<Vec<Sticker>> {
-        http.as_ref().get_guild_stickers(self).await
+    pub async fn stickers(self, http: &Http) -> Result<Vec<Sticker>> {
+        http.get_guild_stickers(self).await
     }
 
     /// Gets an [`Sticker`] of this guild by its ID via HTTP.
@@ -911,8 +885,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if an sticker with that Id does not exist.
-    pub async fn sticker(self, http: impl AsRef<Http>, sticker_id: StickerId) -> Result<Sticker> {
-        http.as_ref().get_guild_sticker(self, sticker_id).await
+    pub async fn sticker(self, http: &Http, sticker_id: StickerId) -> Result<Sticker> {
+        http.get_guild_sticker(self, sticker_id).await
     }
 
     /// Gets all integration of the guild.
@@ -925,8 +899,8 @@ impl GuildId {
     /// [`Error::Json`] if there is an error in deserializing the API response.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn integrations(self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {
-        http.as_ref().get_guild_integrations(self).await
+    pub async fn integrations(self, http: &Http) -> Result<Vec<Integration>> {
+        http.get_guild_integrations(self).await
     }
 
     /// Gets all of the guild's invites.
@@ -939,8 +913,8 @@ impl GuildId {
     /// [`Error::Json`] if there is an error in deserializing the API response.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn invites(self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
-        http.as_ref().get_guild_invites(self).await
+    pub async fn invites(self, http: &Http) -> Result<Vec<RichInvite>> {
+        http.get_guild_invites(self).await
     }
 
     /// Kicks a [`Member`] from the guild.
@@ -952,21 +926,16 @@ impl GuildId {
     /// Returns [`Error::Http`] if the member cannot be kicked by the current user.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    pub async fn kick(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
-        http.as_ref().kick_member(self, user_id, None).await
+    pub async fn kick(self, http: &Http, user_id: UserId) -> Result<()> {
+        http.kick_member(self, user_id, None).await
     }
 
     /// # Errors
     ///
     /// In addition to the reasons [`Self::kick`] may return an error, may also return an error if
     /// the reason is too long.
-    pub async fn kick_with_reason(
-        self,
-        http: impl AsRef<Http>,
-        user_id: UserId,
-        reason: &str,
-    ) -> Result<()> {
-        http.as_ref().kick_member(self, user_id, Some(reason)).await
+    pub async fn kick_with_reason(self, http: &Http, user_id: UserId, reason: &str) -> Result<()> {
+        http.kick_member(self, user_id, Some(reason)).await
     }
 
     /// Returns a guild [`Member`] object for the current user.
@@ -977,8 +946,8 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild or the access token
     /// lacks the necessary scope.
-    pub async fn current_user_member(self, http: impl AsRef<Http>) -> Result<Member> {
-        http.as_ref().get_current_user_guild_member(self).await
+    pub async fn current_user_member(self, http: &Http) -> Result<Member> {
+        http.get_current_user_guild_member(self).await
     }
 
     /// Leaves the guild.
@@ -987,8 +956,8 @@ impl GuildId {
     ///
     /// May return an [`Error::Http`] if the current user cannot leave the guild, or currently is
     /// not in the guild.
-    pub async fn leave(self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().leave_guild(self).await
+    pub async fn leave(self, http: &Http) -> Result<()> {
+        http.leave_guild(self).await
     }
 
     /// Gets a user's [`Member`] for the guild by Id.
@@ -1028,11 +997,11 @@ impl GuildId {
     /// [`User`]: crate::model::user::User
     pub async fn members(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         limit: Option<NonMaxU16>,
         after: Option<UserId>,
     ) -> Result<Vec<Member>> {
-        http.as_ref().get_guild_members(self, limit, after).await
+        http.get_guild_members(self, limit, after).await
     }
 
     /// Streams over all the members in a guild.
@@ -1060,8 +1029,8 @@ impl GuildId {
     /// }
     /// # }
     /// ```
-    pub fn members_iter<H: AsRef<Http>>(self, http: H) -> impl Stream<Item = Result<Member>> {
-        MembersIter::<H>::stream(http, self)
+    pub fn members_iter(self, http: &Http) -> impl Stream<Item = Result<Member>> + '_ {
+        MembersIter::stream(http, self)
     }
 
     /// Moves a member to a specific voice channel.
@@ -1118,8 +1087,8 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user does not have permission.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    pub async fn prune_count(self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
-        http.as_ref().get_guild_prune_count(self, days).await
+    pub async fn prune_count(self, http: &Http, days: u8) -> Result<GuildPrune> {
+        http.get_guild_prune_count(self, days).await
     }
 
     /// Re-orders the channels of the guild.
@@ -1138,7 +1107,7 @@ impl GuildId {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn reorder_channels(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         channels: impl IntoIterator<Item = (ChannelId, u64)>,
     ) -> Result<()> {
         #[derive(serde::Serialize)]
@@ -1152,7 +1121,7 @@ impl GuildId {
             position,
         });
 
-        http.as_ref().edit_guild_channel_positions(self, &SerializeIter::new(iter)).await
+        http.edit_guild_channel_positions(self, &SerializeIter::new(iter)).await
     }
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname starts with a
@@ -1166,11 +1135,11 @@ impl GuildId {
     /// Returns an [`Error::Http`] if the API returns an error.
     pub async fn search_members(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         query: &str,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
-        http.as_ref().search_guild_members(self, query, limit).await
+        http.search_guild_members(self, query, limit).await
     }
 
     /// Fetches a specified scheduled event in the guild, by Id. If `with_user_count` is set to
@@ -1187,11 +1156,11 @@ impl GuildId {
     /// [View Channel]: Permissions::VIEW_CHANNEL
     pub async fn scheduled_event(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         event_id: ScheduledEventId,
         with_user_count: bool,
     ) -> Result<ScheduledEvent> {
-        http.as_ref().get_scheduled_event(self, event_id, with_user_count).await
+        http.get_scheduled_event(self, event_id, with_user_count).await
     }
 
     /// Fetches a list of all scheduled events in the guild. If `with_user_count` is set to `true`,
@@ -1206,10 +1175,10 @@ impl GuildId {
     /// [View Channel]: Permissions::VIEW_CHANNEL
     pub async fn scheduled_events(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         with_user_count: bool,
     ) -> Result<Vec<ScheduledEvent>> {
-        http.as_ref().get_scheduled_events(self, with_user_count).await
+        http.get_scheduled_events(self, with_user_count).await
     }
 
     /// Fetches a list of interested users for the specified event.
@@ -1226,11 +1195,11 @@ impl GuildId {
     /// [View Channel]: Permissions::VIEW_CHANNEL
     pub async fn scheduled_event_users(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         event_id: ScheduledEventId,
         limit: Option<u64>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        http.as_ref().get_scheduled_event_users(self, event_id, limit, None, None).await
+        http.get_scheduled_event_users(self, event_id, limit, None, None).await
     }
 
     /// Fetches a list of interested users for the specified event, with additional options and
@@ -1246,13 +1215,13 @@ impl GuildId {
     /// [View Channel]: Permissions::VIEW_CHANNEL
     pub async fn scheduled_event_users_optioned(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         event_id: ScheduledEventId,
         limit: Option<u64>,
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        http.as_ref().get_scheduled_event_users(self, event_id, limit, target, with_member).await
+        http.get_scheduled_event_users(self, event_id, limit, target, with_member).await
     }
 
     /// Returns the Id of the shard associated with the guild.
@@ -1306,10 +1275,10 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn start_integration_sync(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
     ) -> Result<()> {
-        http.as_ref().start_integration_sync(self, integration_id).await
+        http.start_integration_sync(self, integration_id).await
     }
 
     /// Starts a prune of [`Member`]s.
@@ -1323,8 +1292,8 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    pub async fn start_prune(self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
-        http.as_ref().start_guild_prune(self, days, None).await
+    pub async fn start_prune(self, http: &Http, days: u8) -> Result<GuildPrune> {
+        http.start_guild_prune(self, days, None).await
     }
 
     /// Unbans a [`User`] from the guild.
@@ -1336,8 +1305,8 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user does not have permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn unban(self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
-        http.as_ref().remove_ban(self, user_id, None).await
+    pub async fn unban(self, http: &Http, user_id: UserId) -> Result<()> {
+        http.remove_ban(self, user_id, None).await
     }
 
     /// Retrieve's the guild's vanity URL.
@@ -1350,8 +1319,8 @@ impl GuildId {
     /// [`Error::Json`] if there is an error deserializing the API response.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn vanity_url(self, http: impl AsRef<Http>) -> Result<String> {
-        http.as_ref().get_guild_vanity_url(self).await
+    pub async fn vanity_url(self, http: &Http) -> Result<String> {
+        http.get_guild_vanity_url(self).await
     }
 
     /// Retrieves the guild's webhooks.
@@ -1364,8 +1333,8 @@ impl GuildId {
     ///
     /// Will return an [`Error::Http`] if the bot is lacking permissions. Can also return an
     /// [`Error::Json`] if there is an error deserializing the API response.
-    pub async fn webhooks(self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
-        http.as_ref().get_guild_webhooks(self).await
+    pub async fn webhooks(self, http: &Http) -> Result<Vec<Webhook>> {
+        http.get_guild_webhooks(self).await
     }
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this
     /// guild.
@@ -1418,10 +1387,10 @@ impl GuildId {
     /// Returns the same errors as [`Self::create_command`].
     pub async fn set_commands(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         commands: &[CreateCommand<'_>],
     ) -> Result<Vec<Command>> {
-        http.as_ref().create_guild_commands(self, &commands).await
+        http.create_guild_commands(self, &commands).await
     }
 
     /// Overwrites permissions for a specific command.
@@ -1445,8 +1414,8 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands(self, http: impl AsRef<Http>) -> Result<Vec<Command>> {
-        http.as_ref().get_guild_commands(self).await
+    pub async fn get_commands(self, http: &Http) -> Result<Vec<Command>> {
+        http.get_guild_commands(self).await
     }
 
     /// Get all guild application commands with localizations.
@@ -1454,11 +1423,8 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands_with_localizations(
-        self,
-        http: impl AsRef<Http>,
-    ) -> Result<Vec<Command>> {
-        http.as_ref().get_guild_commands_with_localizations(self).await
+    pub async fn get_commands_with_localizations(self, http: &Http) -> Result<Vec<Command>> {
+        http.get_guild_commands_with_localizations(self).await
     }
 
     /// Get a specific guild application command by its Id.
@@ -1466,12 +1432,8 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_command(
-        self,
-        http: impl AsRef<Http>,
-        command_id: CommandId,
-    ) -> Result<Command> {
-        http.as_ref().get_guild_command(self, command_id).await
+    pub async fn get_command(self, http: &Http, command_id: CommandId) -> Result<Command> {
+        http.get_guild_command(self, command_id).await
     }
 
     /// Edit a guild application command, given its Id.
@@ -1493,8 +1455,8 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn delete_command(self, http: impl AsRef<Http>, command_id: CommandId) -> Result<()> {
-        http.as_ref().delete_guild_command(self, command_id).await
+    pub async fn delete_command(self, http: &Http, command_id: CommandId) -> Result<()> {
+        http.delete_guild_command(self, command_id).await
     }
 
     /// Get all guild application commands permissions only.
@@ -1502,11 +1464,8 @@ impl GuildId {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands_permissions(
-        self,
-        http: impl AsRef<Http>,
-    ) -> Result<Vec<CommandPermissions>> {
-        http.as_ref().get_guild_commands_permissions(self).await
+    pub async fn get_commands_permissions(self, http: &Http) -> Result<Vec<CommandPermissions>> {
+        http.get_guild_commands_permissions(self).await
     }
 
     /// Get permissions for specific guild application command by its Id.
@@ -1516,10 +1475,10 @@ impl GuildId {
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_command_permissions(
         self,
-        http: impl AsRef<Http>,
+        http: &Http,
         command_id: CommandId,
     ) -> Result<CommandPermissions> {
-        http.as_ref().get_guild_command_permissions(self, command_id).await
+        http.get_guild_command_permissions(self, command_id).await
     }
 
     /// Get the guild welcome screen.
@@ -1527,8 +1486,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the guild does not have a welcome screen.
-    pub async fn get_welcome_screen(self, http: impl AsRef<Http>) -> Result<GuildWelcomeScreen> {
-        http.as_ref().get_guild_welcome_screen(self).await
+    pub async fn get_welcome_screen(self, http: &Http) -> Result<GuildWelcomeScreen> {
+        http.get_guild_welcome_screen(self).await
     }
 
     /// Get the guild preview.
@@ -1539,8 +1498,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the bot cannot see the guild preview, see the note.
-    pub async fn get_preview(self, http: impl AsRef<Http>) -> Result<GuildPreview> {
-        http.as_ref().get_guild_preview(self).await
+    pub async fn get_preview(self, http: &Http) -> Result<GuildPreview> {
+        http.get_guild_preview(self).await
     }
 
     /// Get the guild widget.
@@ -1548,8 +1507,8 @@ impl GuildId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the bot does not have `MANAGE_MESSAGES` permission.
-    pub async fn get_widget(self, http: impl AsRef<Http>) -> Result<GuildWidget> {
-        http.as_ref().get_guild_widget(self).await
+    pub async fn get_widget(self, http: &Http) -> Result<GuildWidget> {
+        http.get_guild_widget(self).await
     }
 
     /// Get the widget image URL.
@@ -1564,8 +1523,8 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if there is an error in the deserialization, or if the bot issuing
     /// the request is not in the guild.
-    pub async fn get_active_threads(self, http: impl AsRef<Http>) -> Result<ThreadsData> {
-        http.as_ref().get_guild_active_threads(self).await
+    pub async fn get_active_threads(self, http: &Http) -> Result<ThreadsData> {
+        http.get_guild_active_threads(self).await
     }
 }
 
@@ -1642,18 +1601,18 @@ impl<'a> From<&'a WebhookGuild> for GuildId {
 /// A helper class returned by [`GuildId::members_iter`]
 #[derive(Clone, Debug)]
 #[cfg(feature = "model")]
-pub struct MembersIter<H: AsRef<Http>> {
+pub struct MembersIter<'a> {
     guild_id: GuildId,
-    http: H,
+    http: &'a Http,
     buffer: Vec<Member>,
     after: Option<UserId>,
     tried_fetch: bool,
 }
 
 #[cfg(feature = "model")]
-impl<H: AsRef<Http>> MembersIter<H> {
-    fn new(guild_id: GuildId, http: H) -> MembersIter<H> {
-        MembersIter {
+impl<'a> MembersIter<'a> {
+    fn new(guild_id: GuildId, http: &'a Http) -> Self {
+        Self {
             guild_id,
             http,
             buffer: Vec::new(),
@@ -1672,7 +1631,7 @@ impl<H: AsRef<Http>> MembersIter<H> {
         let grab_size = crate::constants::MEMBER_FETCH_LIMIT;
 
         // Number of profiles to fetch
-        self.buffer = self.guild_id.members(&self.http, Some(grab_size), self.after).await?;
+        self.buffer = self.guild_id.members(self.http, Some(grab_size), self.after).await?;
 
         // Get the last member.  If shorter than 1000, there are no more results anyway
         self.after = self.buffer.get(grab_size.get() as usize - 1).map(|member| member.user.id);
@@ -1711,7 +1670,7 @@ impl<H: AsRef<Http>> MembersIter<H> {
     /// }
     /// # }
     /// ```
-    pub fn stream(http: impl AsRef<Http>, guild_id: GuildId) -> impl Stream<Item = Result<Member>> {
+    pub fn stream(http: &Http, guild_id: GuildId) -> impl Stream<Item = Result<Member>> + '_ {
         let init_state = MembersIter::new(guild_id, http);
 
         futures::stream::unfold(init_state, |mut state| async {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -816,8 +816,8 @@ impl GuildId {
 
     /// Tries to find the [`Guild`] by its Id in the cache.
     #[cfg(feature = "cache")]
-    pub fn to_guild_cached(self, cache: &impl AsRef<Cache>) -> Option<GuildRef<'_>> {
-        cache.as_ref().guild(self)
+    pub fn to_guild_cached(self, cache: &Cache) -> Option<GuildRef<'_>> {
+        cache.guild(self)
     }
 
     /// Requests [`PartialGuild`] over REST API.
@@ -1056,8 +1056,8 @@ impl GuildId {
     /// Returns the name of whatever guild this id holds.
     #[cfg(feature = "cache")]
     #[must_use]
-    pub fn name(self, cache: impl AsRef<Cache>) -> Option<String> {
-        self.to_guild_cached(cache.as_ref()).map(|g| g.name.to_string())
+    pub fn name(self, cache: &Cache) -> Option<String> {
+        self.to_guild_cached(cache).map(|g| g.name.to_string())
     }
 
     /// Disconnects a member from a voice channel in the guild.
@@ -1234,8 +1234,8 @@ impl GuildId {
     /// [`utils::shard_id`]: crate::utils::shard_id
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[must_use]
-    pub fn shard_id(self, cache: impl AsRef<Cache>) -> u16 {
-        crate::utils::shard_id(self, cache.as_ref().shard_count().get())
+    pub fn shard_id(self, cache: &Cache) -> u16 {
+        crate::utils::shard_id(self, cache.shard_count().get())
     }
 
     /// Returns the Id of the shard associated with the guild.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1339,29 +1339,26 @@ impl GuildId {
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this
     /// guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply(self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_reply(self, shard_messenger: ShardMessenger) -> MessageCollector {
         MessageCollector::new(shard_messenger).guild_id(self)
     }
 
     /// Same as [`Self::await_reply`].
     #[cfg(feature = "collector")]
-    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_replies(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in
     /// this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+    pub fn await_reaction(self, shard_messenger: ShardMessenger) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).guild_id(self)
     }
 
     /// Same as [`Self::await_reaction`].
     #[cfg(feature = "collector")]
-    pub fn await_reactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollector {
+    pub fn await_reactions(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         self.await_reaction(shard_messenger)
     }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -98,8 +98,8 @@ impl Member {
     /// Id does not exist.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn add_role(&self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
-        http.as_ref().add_member_role(self.guild_id, self.user.id, role_id, None).await
+    pub async fn add_role(&self, http: &Http, role_id: RoleId) -> Result<()> {
+        http.add_member_role(self.guild_id, self.user.id, role_id, None).await
     }
 
     /// Adds one or multiple [`Role`]s to the member.
@@ -112,9 +112,9 @@ impl Member {
     /// does not exist.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn add_roles(&self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
+    pub async fn add_roles(&self, http: &Http, role_ids: &[RoleId]) -> Result<()> {
         for &role_id in role_ids {
-            self.add_role(http.as_ref(), role_id).await?;
+            self.add_role(http, role_id).await?;
         }
 
         Ok(())
@@ -131,7 +131,7 @@ impl Member {
     /// return [`Error::Http`] if the current user lacks permission to ban this member.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn ban(&self, http: impl AsRef<Http>, dmd: u8) -> Result<()> {
+    pub async fn ban(&self, http: &Http, dmd: u8) -> Result<()> {
         self.ban_with_reason(http, dmd, "").await
     }
 
@@ -142,12 +142,7 @@ impl Member {
     ///
     /// In addition to the errors [`Self::ban`] may return, can also return
     /// [`ModelError::TooLarge`] if the length of the reason is greater than 512.
-    pub async fn ban_with_reason(
-        &self,
-        http: impl AsRef<Http>,
-        dmd: u8,
-        reason: &str,
-    ) -> Result<()> {
+    pub async fn ban_with_reason(&self, http: &Http, dmd: u8, reason: &str) -> Result<()> {
         self.guild_id.ban_with_reason(http, self.user.id, dmd, reason).await
     }
 
@@ -448,8 +443,8 @@ impl Member {
     /// lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn remove_role(&self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
-        http.as_ref().remove_member_role(self.guild_id, self.user.id, role_id, None).await
+    pub async fn remove_role(&self, http: &Http, role_id: RoleId) -> Result<()> {
+        http.remove_member_role(self.guild_id, self.user.id, role_id, None).await
     }
 
     /// Removes one or multiple [`Role`]s from the member.
@@ -462,9 +457,9 @@ impl Member {
     /// lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn remove_roles(&self, http: impl AsRef<Http>, role_ids: &[RoleId]) -> Result<()> {
+    pub async fn remove_roles(&self, http: &Http, role_ids: &[RoleId]) -> Result<()> {
         for &role_id in role_ids {
-            self.remove_role(http.as_ref(), role_id).await?;
+            self.remove_role(http, role_id).await?;
         }
 
         Ok(())
@@ -499,8 +494,8 @@ impl Member {
     /// does not have permission to perform bans.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn unban(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().remove_ban(self.guild_id, self.user.id, None).await
+    pub async fn unban(&self, http: &Http) -> Result<()> {
+        http.remove_ban(self.guild_id, self.user.id, None).await
     }
 
     /// Returns the formatted URL of the member's per guild avatar, if one exists.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -148,8 +148,8 @@ impl Member {
 
     /// Determines the member's colour.
     #[cfg(feature = "cache")]
-    pub fn colour(&self, cache: impl AsRef<Cache>) -> Option<Colour> {
-        let guild = cache.as_ref().guild(self.guild_id)?;
+    pub fn colour(&self, cache: &Cache) -> Option<Colour> {
+        let guild = cache.guild(self.guild_id)?;
 
         let mut roles = self
             .roles
@@ -167,8 +167,8 @@ impl Member {
     /// Returns the "default channel" of the guild for the member. (This returns the first channel
     /// that can be read by the member, if there isn't one returns [`None`])
     #[cfg(feature = "cache")]
-    pub fn default_channel(&self, cache: impl AsRef<Cache>) -> Option<GuildChannel> {
-        let guild = self.guild_id.to_guild_cached(&cache)?;
+    pub fn default_channel(&self, cache: &Cache) -> Option<GuildChannel> {
+        let guild = self.guild_id.to_guild_cached(cache)?;
 
         let member = guild.members.get(&self.user.id)?;
 
@@ -275,8 +275,8 @@ impl Member {
     /// The "highest role in hierarchy" is defined as the role with the highest position. If two or
     /// more roles have the same highest position, then the role with the lowest ID is the highest.
     #[cfg(feature = "cache")]
-    pub fn highest_role_info(&self, cache: impl AsRef<Cache>) -> Option<(RoleId, i16)> {
-        let guild = cache.as_ref().guild(self.guild_id)?;
+    pub fn highest_role_info(&self, cache: &Cache) -> Option<(RoleId, i16)> {
+        let guild = cache.guild(self.guild_id)?;
 
         let mut highest = None;
 
@@ -428,8 +428,8 @@ impl Member {
     /// And/or returns [`ModelError::ItemMissing`] if the "default channel" of the guild is not
     /// found.
     #[cfg(feature = "cache")]
-    pub fn permissions(&self, cache: impl AsRef<Cache>) -> Result<Permissions> {
-        let guild = cache.as_ref().guild(self.guild_id).ok_or(ModelError::GuildNotFound)?;
+    pub fn permissions(&self, cache: &Cache) -> Result<Permissions> {
+        let guild = cache.guild(self.guild_id).ok_or(ModelError::GuildNotFound)?;
         Ok(guild.member_permissions(self))
     }
 
@@ -471,10 +471,9 @@ impl Member {
     ///
     /// If role data can not be found for the member, then [`None`] is returned.
     #[cfg(feature = "cache")]
-    pub fn roles(&self, cache: impl AsRef<Cache>) -> Option<Vec<Role>> {
+    pub fn roles(&self, cache: &Cache) -> Option<Vec<Role>> {
         Some(
             cache
-                .as_ref()
                 .guild(self.guild_id)?
                 .roles
                 .iter()

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2198,29 +2198,26 @@ impl Guild {
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this
     /// guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_reply(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         MessageCollector::new(shard_messenger).guild_id(self.id)
     }
 
     /// Same as [`Self::await_reply`].
     #[cfg(feature = "collector")]
-    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_replies(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in
     /// this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).guild_id(self.id)
     }
 
     /// Same as [`Self::await_reaction`].
     #[cfg(feature = "collector")]
-    pub fn await_reactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollector {
+    pub fn await_reactions(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         self.await_reaction(shard_messenger)
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -292,7 +292,7 @@ impl Guild {
     /// Returns an [`Error::Http`] if the guild is unavailable.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rules(&self, http: impl AsRef<Http>) -> Result<Vec<Rule>> {
+    pub async fn automod_rules(&self, http: &Http) -> Result<Vec<Rule>> {
         self.id.automod_rules(http).await
     }
 
@@ -305,7 +305,7 @@ impl Guild {
     /// Returns an [`Error::Http`] if a rule with the given ID does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rule(&self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<Rule> {
+    pub async fn automod_rule(&self, http: &Http, rule_id: RuleId) -> Result<Rule> {
         self.id.automod_rule(http, rule_id).await
     }
 
@@ -358,7 +358,7 @@ impl Guild {
     /// does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn delete_automod_rule(&self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<()> {
+    pub async fn delete_automod_rule(&self, http: &Http, rule_id: RuleId) -> Result<()> {
         self.id.delete_automod_rule(http, rule_id).await
     }
 
@@ -554,7 +554,7 @@ impl Guild {
     /// [View Audit Log]: Permissions::VIEW_AUDIT_LOG
     pub async fn audit_logs(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         action_type: Option<audit_log::Action>,
         user_id: Option<UserId>,
         before: Option<AuditLogEntryId>,
@@ -568,10 +568,7 @@ impl Guild {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the guild is currently unavailable.
-    pub async fn channels(
-        &self,
-        http: impl AsRef<Http>,
-    ) -> Result<HashMap<ChannelId, GuildChannel>> {
+    pub async fn channels(&self, http: &Http) -> Result<HashMap<ChannelId, GuildChannel>> {
         self.id.channels(http).await
     }
 
@@ -600,17 +597,13 @@ impl Guild {
     ///
     /// [`Shard`]: crate::gateway::Shard
     /// [whitelist]: https://discord.com/developers/docs/resources/guild#create-guild
-    pub async fn create(
-        http: impl AsRef<Http>,
-        name: &str,
-        icon: Option<ImageHash>,
-    ) -> Result<PartialGuild> {
+    pub async fn create(http: &Http, name: &str, icon: Option<ImageHash>) -> Result<PartialGuild> {
         let map = json!({
             "icon": icon,
             "name": name,
         });
 
-        http.as_ref().create_guild(&map).await
+        http.create_guild(&map).await
     }
 
     /// Creates a new [`Channel`] in the guild.
@@ -673,12 +666,7 @@ impl Guild {
     /// [`EditProfile::avatar`]: crate::builder::EditProfile::avatar
     /// [`CreateAttachment`]: crate::builder::CreateAttachment
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
-    pub async fn create_emoji(
-        &self,
-        http: impl AsRef<Http>,
-        name: &str,
-        image: &str,
-    ) -> Result<Emoji> {
+    pub async fn create_emoji(&self, http: &Http, name: &str, image: &str) -> Result<Emoji> {
         self.id.create_emoji(http, name, image).await
     }
 
@@ -693,7 +681,7 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn create_integration(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
         kind: &str,
     ) -> Result<()> {
@@ -724,7 +712,7 @@ impl Guild {
     /// Returns the same errors as [`Self::create_command`].
     pub async fn set_commands(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         commands: &[CreateCommand<'_>],
     ) -> Result<Vec<Command>> {
         self.id.set_commands(http, commands).await
@@ -753,7 +741,7 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands(&self, http: impl AsRef<Http>) -> Result<Vec<Command>> {
+    pub async fn get_commands(&self, http: &Http) -> Result<Vec<Command>> {
         self.id.get_commands(http).await
     }
 
@@ -762,10 +750,7 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands_with_localizations(
-        &self,
-        http: impl AsRef<Http>,
-    ) -> Result<Vec<Command>> {
+    pub async fn get_commands_with_localizations(&self, http: &Http) -> Result<Vec<Command>> {
         self.id.get_commands_with_localizations(http).await
     }
 
@@ -774,11 +759,7 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_command(
-        &self,
-        http: impl AsRef<Http>,
-        command_id: CommandId,
-    ) -> Result<Command> {
+    pub async fn get_command(&self, http: &Http, command_id: CommandId) -> Result<Command> {
         self.id.get_command(http, command_id).await
     }
 
@@ -803,11 +784,7 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn delete_command(
-        &self,
-        http: impl AsRef<Http>,
-        command_id: CommandId,
-    ) -> Result<()> {
+    pub async fn delete_command(&self, http: &Http, command_id: CommandId) -> Result<()> {
         self.id.delete_command(http, command_id).await
     }
 
@@ -816,10 +793,7 @@ impl Guild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands_permissions(
-        &self,
-        http: impl AsRef<Http>,
-    ) -> Result<Vec<CommandPermissions>> {
+    pub async fn get_commands_permissions(&self, http: &Http) -> Result<Vec<CommandPermissions>> {
         self.id.get_commands_permissions(http).await
     }
 
@@ -830,7 +804,7 @@ impl Guild {
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_command_permissions(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         command_id: CommandId,
     ) -> Result<CommandPermissions> {
         self.id.get_command_permissions(http, command_id).await
@@ -931,7 +905,7 @@ impl Guild {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<()> {
+    pub async fn delete_emoji(&self, http: &Http, emoji_id: EmojiId) -> Result<()> {
         self.id.delete_emoji(http, emoji_id).await
     }
 
@@ -947,7 +921,7 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn delete_integration(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
     ) -> Result<()> {
         self.id.delete_integration(http, integration_id).await
@@ -964,7 +938,7 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user lacks permission to delete the role.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn delete_role(&self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
+    pub async fn delete_role(&self, http: &Http, role_id: RoleId) -> Result<()> {
         self.id.delete_role(http, role_id).await
     }
 
@@ -981,7 +955,7 @@ impl Guild {
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn delete_scheduled_event(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         event_id: ScheduledEventId,
     ) -> Result<()> {
         self.id.delete_scheduled_event(http, event_id).await
@@ -1000,11 +974,7 @@ impl Guild {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_sticker(
-        &self,
-        http: impl AsRef<Http>,
-        sticker_id: StickerId,
-    ) -> Result<()> {
+    pub async fn delete_sticker(&self, http: &Http, sticker_id: StickerId) -> Result<()> {
         self.id.delete_sticker(http, sticker_id).await
     }
 
@@ -1069,12 +1039,7 @@ impl Guild {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn edit_emoji(
-        &self,
-        http: impl AsRef<Http>,
-        emoji_id: EmojiId,
-        name: &str,
-    ) -> Result<Emoji> {
+    pub async fn edit_emoji(&self, http: &Http, emoji_id: EmojiId, name: &str) -> Result<Emoji> {
         self.id.edit_emoji(http, emoji_id, name).await
     }
 
@@ -1109,7 +1074,7 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     pub async fn edit_mfa_level(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         mfa_level: MfaLevel,
         audit_log_reason: Option<&str>,
     ) -> Result<MfaLevel> {
@@ -1186,7 +1151,7 @@ impl Guild {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn edit_role_position(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         role_id: RoleId,
         position: i16,
     ) -> Result<Vec<Role>> {
@@ -1386,7 +1351,7 @@ impl Guild {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the guild is unavailable
-    pub async fn emojis(&self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
+    pub async fn emojis(&self, http: &Http) -> Result<Vec<Emoji>> {
         self.id.emojis(http).await
     }
 
@@ -1398,7 +1363,7 @@ impl Guild {
     /// guild is unavailable.
     ///
     /// May also return [`Error::Json`] if there is an error in deserializing the API response.
-    pub async fn emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
+    pub async fn emoji(&self, http: &Http, emoji_id: EmojiId) -> Result<Emoji> {
         self.id.emoji(http, emoji_id).await
     }
 
@@ -1413,7 +1378,7 @@ impl Guild {
     /// May also return [`Error::Json`] if there is an error in deserializing the API response.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {
+    pub async fn integrations(&self, http: &Http) -> Result<Vec<Integration>> {
         self.id.integrations(http).await
     }
 
@@ -1456,7 +1421,7 @@ impl Guild {
     /// Returns [`Error::Http`] if the member cannot be kicked by the current user.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    pub async fn kick(&self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+    pub async fn kick(&self, http: &Http, user_id: UserId) -> Result<()> {
         self.id.kick(http, user_id).await
     }
 
@@ -1464,12 +1429,7 @@ impl Guild {
     ///
     /// In addition to the reasons [`Self::kick`] may return an error, may also return an error if
     /// the reason is too long.
-    pub async fn kick_with_reason(
-        &self,
-        http: impl AsRef<Http>,
-        user_id: UserId,
-        reason: &str,
-    ) -> Result<()> {
+    pub async fn kick_with_reason(&self, http: &Http, user_id: UserId, reason: &str) -> Result<()> {
         self.id.kick_with_reason(http, user_id, reason).await
     }
 
@@ -1481,7 +1441,7 @@ impl Guild {
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild or the access token
     /// lacks the necessary scope.
-    pub async fn current_user_member(&self, http: impl AsRef<Http>) -> Result<Member> {
+    pub async fn current_user_member(&self, http: &Http) -> Result<Member> {
         self.id.current_user_member(http).await
     }
 
@@ -1491,7 +1451,7 @@ impl Guild {
     ///
     /// May return an [`Error::Http`] if the current user cannot leave the guild, or currently is
     /// not in the guild.
-    pub async fn leave(&self, http: impl AsRef<Http>) -> Result<()> {
+    pub async fn leave(&self, http: &Http) -> Result<()> {
         self.id.leave(http).await
     }
 
@@ -1531,7 +1491,7 @@ impl Guild {
     /// [`User`]: crate::model::user::User
     pub async fn members(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         limit: Option<NonMaxU16>,
         after: Option<UserId>,
     ) -> Result<Vec<Member>> {
@@ -1954,7 +1914,7 @@ impl Guild {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn reorder_channels(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         channels: impl IntoIterator<Item = (ChannelId, u64)>,
     ) -> Result<()> {
         self.id.reorder_channels(http, channels).await
@@ -1973,7 +1933,7 @@ impl Guild {
     /// Returns an [`Error::Http`] if the API returns an error.
     pub async fn search_members(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         query: &str,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
@@ -1994,7 +1954,7 @@ impl Guild {
     /// [View Channel]: Permissions::VIEW_CHANNEL
     pub async fn scheduled_event(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         event_id: ScheduledEventId,
         with_user_count: bool,
     ) -> Result<ScheduledEvent> {
@@ -2013,7 +1973,7 @@ impl Guild {
     /// [View Channel]: Permissions::VIEW_CHANNEL
     pub async fn scheduled_events(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         with_user_count: bool,
     ) -> Result<Vec<ScheduledEvent>> {
         self.id.scheduled_events(http, with_user_count).await
@@ -2033,7 +1993,7 @@ impl Guild {
     /// [View Channel]: Permissions::VIEW_CHANNEL
     pub async fn scheduled_event_users(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         event_id: ScheduledEventId,
         limit: Option<u64>,
     ) -> Result<Vec<ScheduledEventUser>> {
@@ -2053,7 +2013,7 @@ impl Guild {
     /// [View Channel]: Permissions::VIEW_CHANNEL
     pub async fn scheduled_event_users_optioned(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         event_id: ScheduledEventId,
         limit: Option<u64>,
         target: Option<UserPagination>,
@@ -2117,7 +2077,7 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn start_integration_sync(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
     ) -> Result<()> {
         self.id.start_integration_sync(http, integration_id).await
@@ -2185,7 +2145,7 @@ impl Guild {
     ///
     /// Will return [`Error::Http`] if the current user is lacking permissions. Can also return an
     /// [`Error::Json`] if there is an error deserializing the API response.
-    pub async fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
+    pub async fn vanity_url(&self, http: &Http) -> Result<String> {
         self.id.vanity_url(http).await
     }
 
@@ -2199,7 +2159,7 @@ impl Guild {
     ///
     /// Will return an [`Error::Http`] if the current user is lacking permissions. Can also return
     /// an [`Error::Json`] if there is an error deserializing the API response.
-    pub async fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
+    pub async fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> {
         self.id.webhooks(http).await
     }
 
@@ -2270,7 +2230,7 @@ impl Guild {
     ///
     /// Returns [`Error::Http`] if there is an error in the deserialization, or if the bot issuing
     /// the request is not in the guild.
-    pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
+    pub async fn get_active_threads(&self, http: &Http) -> Result<ThreadsData> {
         self.id.get_active_threads(http).await
     }
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -364,7 +364,7 @@ impl Guild {
 
     #[cfg(feature = "cache")]
     fn check_hierarchy(&self, cache: &Cache, other_user: UserId) -> Result<()> {
-        let current_id = cache.as_ref().current_user().id;
+        let current_id = cache.current_user().id;
 
         if let Some(higher) = self.greater_member_hierarchy(cache, other_user, current_id) {
             if higher != current_id {
@@ -422,8 +422,8 @@ impl Guild {
     }
 
     #[cfg(feature = "cache")]
-    pub fn channel_id_from_name(&self, cache: impl AsRef<Cache>, name: &str) -> Option<ChannelId> {
-        let guild_channels = cache.as_ref().guild_channels(self.id)?;
+    pub fn channel_id_from_name(&self, cache: &Cache, name: &str) -> Option<ChannelId> {
+        let guild_channels = cache.guild_channels(self.id)?;
 
         for (id, channel) in guild_channels.iter() {
             if &*channel.name == name {
@@ -1281,17 +1281,17 @@ impl Guild {
     #[cfg(feature = "cache")]
     pub fn greater_member_hierarchy(
         &self,
-        cache: impl AsRef<Cache>,
+        cache: &Cache,
         lhs_id: UserId,
         rhs_id: UserId,
     ) -> Option<UserId> {
-        self._greater_member_hierarchy(&cache, lhs_id, rhs_id)
+        self._greater_member_hierarchy(cache, lhs_id, rhs_id)
     }
 
     #[cfg(feature = "cache")]
     fn _greater_member_hierarchy(
         &self,
-        cache: impl AsRef<Cache>,
+        cache: &Cache,
         lhs_id: UserId,
         rhs_id: UserId,
     ) -> Option<UserId> {
@@ -1308,9 +1308,9 @@ impl Guild {
         }
 
         let lhs =
-            self.members.get(&lhs_id)?.highest_role_info(&cache).unwrap_or((RoleId::new(1), 0));
+            self.members.get(&lhs_id)?.highest_role_info(cache).unwrap_or((RoleId::new(1), 0));
         let rhs =
-            self.members.get(&rhs_id)?.highest_role_info(&cache).unwrap_or((RoleId::new(1), 0));
+            self.members.get(&rhs_id)?.highest_role_info(cache).unwrap_or((RoleId::new(1), 0));
 
         // If LHS and RHS both have no top position or have the same role ID, then no one wins.
         if (lhs.1 == 0 && rhs.1 == 0) || (lhs.0 == rhs.0) {
@@ -2031,8 +2031,8 @@ impl Guild {
     ///
     /// [`utils::shard_id`]: crate::utils::shard_id
     #[cfg(all(feature = "cache", feature = "utils"))]
-    pub fn shard_id(&self, cache: impl AsRef<Cache>) -> u16 {
-        self.id.shard_id(&cache)
+    pub fn shard_id(&self, cache: &Cache) -> u16 {
+        self.id.shard_id(cache)
     }
 
     /// Returns the Id of the shard associated with the guild.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2181,7 +2181,7 @@ impl Guild {
     /// impl EventHandler for Handler {
     ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if let Some(guild_id) = msg.guild_id {
-    ///             if let Some(guild) = guild_id.to_guild_cached(&ctx) {
+    ///             if let Some(guild) = guild_id.to_guild_cached(&ctx.cache) {
     ///                 if let Some(role) = guild.role_by_name("role_name") {
     ///                     println!("{:?}", role);
     ///                 }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -194,7 +194,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the guild is unavailable.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rules(self, http: impl AsRef<Http>) -> Result<Vec<Rule>> {
+    pub async fn automod_rules(self, http: &Http) -> Result<Vec<Rule>> {
         self.id.automod_rules(http).await
     }
 
@@ -207,7 +207,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if a rule with the given ID does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn automod_rule(&self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<Rule> {
+    pub async fn automod_rule(&self, http: &Http, rule_id: RuleId) -> Result<Rule> {
         self.id.automod_rule(http, rule_id).await
     }
 
@@ -260,7 +260,7 @@ impl PartialGuild {
     /// does not exist.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn delete_automod_rule(&self, http: impl AsRef<Http>, rule_id: RuleId) -> Result<()> {
+    pub async fn delete_automod_rule(&self, http: &Http, rule_id: RuleId) -> Result<()> {
         self.id.delete_automod_rule(http, rule_id).await
     }
 
@@ -286,7 +286,7 @@ impl PartialGuild {
     /// Also may return [`Error::Http`] if the current user lacks permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn ban(&self, http: impl AsRef<Http>, user: UserId, dmd: u8) -> Result<()> {
+    pub async fn ban(&self, http: &Http, user: UserId, dmd: u8) -> Result<()> {
         self.ban_with_reason(http, user, dmd, "").await
     }
 
@@ -299,7 +299,7 @@ impl PartialGuild {
     /// the reason is too long.
     pub async fn ban_with_reason(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         user: UserId,
         dmd: u8,
         reason: &str,
@@ -319,7 +319,7 @@ impl PartialGuild {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     pub async fn bans(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         target: Option<UserPagination>,
         limit: Option<u8>,
     ) -> Result<Vec<Ban>> {
@@ -338,7 +338,7 @@ impl PartialGuild {
     /// [View Audit Log]: Permissions::VIEW_AUDIT_LOG
     pub async fn audit_logs(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         action_type: Option<audit_log::Action>,
         user_id: Option<UserId>,
         before: Option<AuditLogEntryId>,
@@ -353,10 +353,7 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Http`] if the current user is not in the guild or if the guild is
     /// otherwise unavailable.
-    pub async fn channels(
-        &self,
-        http: impl AsRef<Http>,
-    ) -> Result<HashMap<ChannelId, GuildChannel>> {
+    pub async fn channels(&self, http: &Http) -> Result<HashMap<ChannelId, GuildChannel>> {
         self.id.channels(http).await
     }
 
@@ -435,12 +432,7 @@ impl PartialGuild {
     /// [`EditProfile::avatar`]: crate::builder::EditProfile::avatar
     /// [`utils::read_image`]: crate::utils::read_image
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
-    pub async fn create_emoji(
-        &self,
-        http: impl AsRef<Http>,
-        name: &str,
-        image: &str,
-    ) -> Result<Emoji> {
+    pub async fn create_emoji(&self, http: &Http, name: &str, image: &str) -> Result<Emoji> {
         self.id.create_emoji(http, name, image).await
     }
 
@@ -455,7 +447,7 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn create_integration(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
         kind: &str,
     ) -> Result<()> {
@@ -486,7 +478,7 @@ impl PartialGuild {
     /// Returns the same errors as [`Self::create_command`].
     pub async fn set_commands(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         commands: &[CreateCommand<'_>],
     ) -> Result<Vec<Command>> {
         self.id.set_commands(http, commands).await
@@ -515,7 +507,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands(&self, http: impl AsRef<Http>) -> Result<Vec<Command>> {
+    pub async fn get_commands(&self, http: &Http) -> Result<Vec<Command>> {
         self.id.get_commands(http).await
     }
 
@@ -524,10 +516,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands_with_localizations(
-        &self,
-        http: impl AsRef<Http>,
-    ) -> Result<Vec<Command>> {
+    pub async fn get_commands_with_localizations(&self, http: &Http) -> Result<Vec<Command>> {
         self.id.get_commands_with_localizations(http).await
     }
 
@@ -536,11 +525,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_command(
-        &self,
-        http: impl AsRef<Http>,
-        command_id: CommandId,
-    ) -> Result<Command> {
+    pub async fn get_command(&self, http: &Http, command_id: CommandId) -> Result<Command> {
         self.id.get_command(http, command_id).await
     }
 
@@ -565,11 +550,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn delete_command(
-        &self,
-        http: impl AsRef<Http>,
-        command_id: CommandId,
-    ) -> Result<()> {
+    pub async fn delete_command(&self, http: &Http, command_id: CommandId) -> Result<()> {
         self.id.delete_command(http, command_id).await
     }
 
@@ -578,10 +559,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
-    pub async fn get_commands_permissions(
-        &self,
-        http: impl AsRef<Http>,
-    ) -> Result<Vec<CommandPermissions>> {
+    pub async fn get_commands_permissions(&self, http: &Http) -> Result<Vec<CommandPermissions>> {
         self.id.get_commands_permissions(http).await
     }
 
@@ -592,7 +570,7 @@ impl PartialGuild {
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_command_permissions(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         command_id: CommandId,
     ) -> Result<CommandPermissions> {
         self.id.get_command_permissions(http, command_id).await
@@ -645,7 +623,7 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Http`] if the current user is not the owner of
     /// the guild.
-    pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
+    pub async fn delete(&self, http: &Http) -> Result<()> {
         self.id.delete(http).await
     }
 
@@ -662,7 +640,7 @@ impl PartialGuild {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<()> {
+    pub async fn delete_emoji(&self, http: &Http, emoji_id: EmojiId) -> Result<()> {
         self.id.delete_emoji(http, emoji_id).await
     }
 
@@ -678,7 +656,7 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn delete_integration(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
     ) -> Result<()> {
         self.id.delete_integration(http, integration_id).await
@@ -696,7 +674,7 @@ impl PartialGuild {
     /// does not exist in the Guild.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn delete_role(&self, http: impl AsRef<Http>, role_id: RoleId) -> Result<()> {
+    pub async fn delete_role(&self, http: &Http, role_id: RoleId) -> Result<()> {
         self.id.delete_role(http, role_id).await
     }
 
@@ -713,11 +691,7 @@ impl PartialGuild {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete_sticker(
-        &self,
-        http: impl AsRef<Http>,
-        sticker_id: StickerId,
-    ) -> Result<()> {
+    pub async fn delete_sticker(&self, http: &Http, sticker_id: StickerId) -> Result<()> {
         self.id.delete_sticker(http, sticker_id).await
     }
 
@@ -762,12 +736,7 @@ impl PartialGuild {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn edit_emoji(
-        &self,
-        http: impl AsRef<Http>,
-        emoji_id: EmojiId,
-        name: &str,
-    ) -> Result<Emoji> {
+    pub async fn edit_emoji(&self, http: &Http, emoji_id: EmojiId, name: &str) -> Result<Emoji> {
         self.id.edit_emoji(http, emoji_id, name).await
     }
 
@@ -802,7 +771,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     pub async fn edit_mfa_level(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         mfa_level: MfaLevel,
         audit_log_reason: Option<&str>,
     ) -> Result<MfaLevel> {
@@ -820,11 +789,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user lacks permission to change their nickname.
     ///
     /// [Change Nickname]: Permissions::CHANGE_NICKNAME
-    pub async fn edit_nickname(
-        &self,
-        http: impl AsRef<Http>,
-        new_nickname: Option<&str>,
-    ) -> Result<()> {
+    pub async fn edit_nickname(&self, http: &Http, new_nickname: Option<&str>) -> Result<()> {
         self.id.edit_nickname(http, new_nickname).await
     }
 
@@ -869,7 +834,7 @@ impl PartialGuild {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn edit_role_position(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         role_id: RoleId,
         position: i16,
     ) -> Result<Vec<Role>> {
@@ -1074,7 +1039,7 @@ impl PartialGuild {
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn reorder_channels(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         channels: impl IntoIterator<Item = (ChannelId, u64)>,
     ) -> Result<()> {
         self.id.reorder_channels(http, channels).await
@@ -1093,7 +1058,7 @@ impl PartialGuild {
     /// Returns an [`Error::Http`] if the API returns an error.
     pub async fn search_members(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         query: &str,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
@@ -1131,7 +1096,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the member cannot be kicked by the current user.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
-    pub async fn kick(&self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+    pub async fn kick(&self, http: &Http, user_id: UserId) -> Result<()> {
         self.id.kick(http, user_id).await
     }
 
@@ -1139,12 +1104,7 @@ impl PartialGuild {
     ///
     /// In addition to the reasons [`Self::kick`] may return an error, can also return an error if
     /// the reason is too long.
-    pub async fn kick_with_reason(
-        &self,
-        http: impl AsRef<Http>,
-        user_id: UserId,
-        reason: &str,
-    ) -> Result<()> {
+    pub async fn kick_with_reason(&self, http: &Http, user_id: UserId, reason: &str) -> Result<()> {
         self.id.kick_with_reason(http, user_id, reason).await
     }
 
@@ -1165,7 +1125,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the guild is unavailable.
-    pub async fn emojis(&self, http: impl AsRef<Http>) -> Result<Vec<Emoji>> {
+    pub async fn emojis(&self, http: &Http) -> Result<Vec<Emoji>> {
         self.id.emojis(http).await
     }
 
@@ -1174,7 +1134,7 @@ impl PartialGuild {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if an [`Emoji`] with the given Id does not exist for the guild.
-    pub async fn emoji(&self, http: impl AsRef<Http>, emoji_id: EmojiId) -> Result<Emoji> {
+    pub async fn emoji(&self, http: &Http, emoji_id: EmojiId) -> Result<Emoji> {
         self.id.emoji(http, emoji_id).await
     }
 
@@ -1187,7 +1147,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn integrations(&self, http: impl AsRef<Http>) -> Result<Vec<Integration>> {
+    pub async fn integrations(&self, http: &Http) -> Result<Vec<Integration>> {
         self.id.integrations(http).await
     }
 
@@ -1200,7 +1160,7 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn invites(&self, http: impl AsRef<Http>) -> Result<Vec<RichInvite>> {
+    pub async fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> {
         self.id.invites(http).await
     }
 
@@ -1212,7 +1172,7 @@ impl PartialGuild {
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild or the access token
     /// lacks the necessary scope.
-    pub async fn current_user_member(&self, http: impl AsRef<Http>) -> Result<Member> {
+    pub async fn current_user_member(&self, http: &Http) -> Result<Member> {
         self.id.current_user_member(http).await
     }
 
@@ -1222,7 +1182,7 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Http`] if the current user is unable to leave the Guild, or currently is
     /// not in the guild.
-    pub async fn leave(&self, http: impl AsRef<Http>) -> Result<()> {
+    pub async fn leave(&self, http: &Http) -> Result<()> {
         self.id.leave(http).await
     }
 
@@ -1251,7 +1211,7 @@ impl PartialGuild {
     /// [`User`]: crate::model::user::User
     pub async fn members(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         limit: Option<NonMaxU16>,
         after: Option<UserId>,
     ) -> Result<Vec<Member>> {
@@ -1299,7 +1259,7 @@ impl PartialGuild {
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
     /// [`Guild::prune_count`]: crate::model::guild::Guild::prune_count
-    pub async fn prune_count(&self, http: impl AsRef<Http>, days: u8) -> Result<GuildPrune> {
+    pub async fn prune_count(&self, http: &Http, days: u8) -> Result<GuildPrune> {
         self.id.prune_count(http, days).await
     }
 
@@ -1359,7 +1319,7 @@ impl PartialGuild {
     /// [`Guild::start_integration_sync`]: crate::model::guild::Guild::start_integration_sync
     pub async fn start_integration_sync(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         integration_id: IntegrationId,
     ) -> Result<()> {
         self.id.start_integration_sync(http, integration_id).await
@@ -1375,7 +1335,7 @@ impl PartialGuild {
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
     /// [`Guild::unban`]: crate::model::guild::Guild::unban
-    pub async fn unban(&self, http: impl AsRef<Http>, user_id: UserId) -> Result<()> {
+    pub async fn unban(&self, http: &Http, user_id: UserId) -> Result<()> {
         self.id.unban(http, user_id).await
     }
 
@@ -1389,7 +1349,7 @@ impl PartialGuild {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     /// [`Guild::vanity_url`]: crate::model::guild::Guild::vanity_url
-    pub async fn vanity_url(&self, http: impl AsRef<Http>) -> Result<String> {
+    pub async fn vanity_url(&self, http: &Http) -> Result<String> {
         self.id.vanity_url(http).await
     }
 
@@ -1403,7 +1363,7 @@ impl PartialGuild {
     ///
     /// [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
     /// [`Guild::webhooks`]: crate::model::guild::Guild::webhooks
-    pub async fn webhooks(&self, http: impl AsRef<Http>) -> Result<Vec<Webhook>> {
+    pub async fn webhooks(&self, http: &Http) -> Result<Vec<Webhook>> {
         self.id.webhooks(http).await
     }
 
@@ -1474,7 +1434,7 @@ impl PartialGuild {
     ///
     /// Returns [`Error::Http`] if there is an error in the deserialization, or if the bot issuing
     /// the request is not in the guild.
-    pub async fn get_active_threads(&self, http: impl AsRef<Http>) -> Result<ThreadsData> {
+    pub async fn get_active_threads(&self, http: &Http) -> Result<ThreadsData> {
         self.id.get_active_threads(http).await
     }
 }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1372,9 +1372,9 @@ impl PartialGuild {
     /// #[serenity::async_trait]
     /// #[cfg(all(feature = "cache", feature = "client"))]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, context: Context, msg: Message) {
+    ///     async fn message(&self, ctx: Context, msg: Message) {
     ///         if let Some(guild_id) = msg.guild_id {
-    ///             if let Some(guild) = guild_id.to_guild_cached(&context) {
+    ///             if let Some(guild) = guild_id.to_guild_cached(&ctx.cache) {
     ///                 if let Some(role) = guild.role_by_name("role_name") {
     ///                     println!("Obtained role's reference: {:?}", role);
     ///                 }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1391,29 +1391,26 @@ impl PartialGuild {
     /// Returns a builder which can be awaited to obtain a message or stream of messages in this
     /// guild.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_reply(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         MessageCollector::new(shard_messenger).guild_id(self.id)
     }
 
     /// Same as [`Self::await_reply`].
     #[cfg(feature = "collector")]
-    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_replies(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a message or stream of reactions sent in
     /// this guild.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).guild_id(self.id)
     }
 
     /// Same as [`Self::await_reaction`].
     #[cfg(feature = "collector")]
-    pub fn await_reactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollector {
+    pub fn await_reactions(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         self.await_reaction(shard_messenger)
     }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -358,8 +358,8 @@ impl PartialGuild {
     }
 
     #[cfg(feature = "cache")]
-    pub fn channel_id_from_name(&self, cache: impl AsRef<Cache>, name: &str) -> Option<ChannelId> {
-        let guild_channels = cache.as_ref().guild_channels(self.id)?;
+    pub fn channel_id_from_name(&self, cache: &Cache, name: &str) -> Option<ChannelId> {
+        let guild_channels = cache.guild_channels(self.id)?;
 
         for (id, channel) in guild_channels.iter() {
             if &*channel.name == name {
@@ -941,17 +941,7 @@ impl PartialGuild {
     #[cfg(feature = "cache")]
     pub fn greater_member_hierarchy(
         &self,
-        cache: impl AsRef<Cache>,
-        lhs_id: UserId,
-        rhs_id: UserId,
-    ) -> Option<UserId> {
-        self._greater_member_hierarchy(&cache, lhs_id, rhs_id)
-    }
-
-    #[cfg(feature = "cache")]
-    fn _greater_member_hierarchy(
-        &self,
-        cache: impl AsRef<Cache>,
+        cache: &Cache,
         lhs_id: UserId,
         rhs_id: UserId,
     ) -> Option<UserId> {
@@ -968,7 +958,6 @@ impl PartialGuild {
         }
 
         let (lhs, rhs) = {
-            let cache = cache.as_ref();
             let default = (RoleId::new(1), 0);
 
             // Clone is necessary, highest_role_info goes into cache.
@@ -1273,7 +1262,7 @@ impl PartialGuild {
     /// [`utils::shard_id`]: crate::utils::shard_id
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[must_use]
-    pub fn shard_id(&self, cache: impl AsRef<Cache>) -> u16 {
+    pub fn shard_id(&self, cache: &Cache) -> u16 {
         self.id.shard_id(cache)
     }
 

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -79,8 +79,8 @@ impl Role {
     /// Returns [`Error::Http`] if the current user lacks permission to delete this role.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn delete(&mut self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_role(self.guild_id, self.id, None).await
+    pub async fn delete(&mut self, http: &Http) -> Result<()> {
+        http.delete_role(self.guild_id, self.id, None).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.
@@ -96,8 +96,8 @@ impl Role {
     /// Returns [`Error::Http`] if the current user does not have permission to Manage Roles.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn edit(&mut self, http: impl AsRef<Http>, builder: EditRole<'_>) -> Result<()> {
-        *self = self.guild_id.edit_role(http.as_ref(), self.id, builder).await?;
+    pub async fn edit(&mut self, http: &Http, builder: EditRole<'_>) -> Result<()> {
+        *self = self.guild_id.edit_role(http, self.id, builder).await?;
         Ok(())
     }
 

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -108,7 +108,7 @@ impl Invite {
             }
         }
 
-        cache_http.http().as_ref().delete_invite(&self.code, None).await
+        cache_http.http().delete_invite(&self.code, None).await
     }
 
     /// Gets information about an invite.
@@ -128,7 +128,7 @@ impl Invite {
     /// May return an [`Error::Http`] if the invite is invalid. Can also return an [`Error::Json`]
     /// if there is an error deserializing the API response.
     pub async fn get(
-        http: impl AsRef<Http>,
+        http: &Http,
         code: &str,
         member_counts: bool,
         expiration: bool,
@@ -141,7 +141,7 @@ impl Invite {
             invite = crate::utils::parse_invite(invite);
         }
 
-        http.as_ref().get_invite(invite, member_counts, expiration, event_id).await
+        http.get_invite(invite, member_counts, expiration, event_id).await
     }
 
     /// Returns a URL to use for the invite.
@@ -329,7 +329,7 @@ impl RichInvite {
             }
         }
 
-        cache_http.http().as_ref().delete_invite(&self.code, None).await
+        cache_http.http().delete_invite(&self.code, None).await
     }
 
     /// Returns a URL to use for the invite.

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -235,8 +235,8 @@ impl InviteGuild {
     /// [`utils::shard_id`]: crate::utils::shard_id
     #[cfg(all(feature = "cache", feature = "utils"))]
     #[must_use]
-    pub fn shard_id(&self, cache: impl AsRef<Cache>) -> u16 {
-        self.id.shard_id(&cache)
+    pub fn shard_id(&self, cache: &Cache) -> u16 {
+        self.id.shard_id(cache)
     }
 
     /// Returns the Id of the shard associated with the guild.

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -14,8 +14,8 @@ impl StickerId {
     ///
     /// Returns [`Error::Http`] if a [`Sticker`] with that [`StickerId`] does not exist, or is
     /// otherwise unavailable.
-    pub async fn to_sticker(self, http: impl AsRef<Http>) -> Result<Sticker> {
-        http.as_ref().get_sticker(self).await
+    pub async fn to_sticker(self, http: &Http) -> Result<Sticker> {
+        http.get_sticker(self).await
     }
 }
 
@@ -42,7 +42,7 @@ impl StickerItem {
     ///
     /// Returns [`Error::Http`] if a [`Sticker`] with that [`StickerId`] does
     /// not exist, or is otherwise unavailable.
-    pub async fn to_sticker(&self, http: impl AsRef<Http>) -> Result<Sticker> {
+    pub async fn to_sticker(&self, http: &Http) -> Result<Sticker> {
         self.id.to_sticker(http).await
     }
 
@@ -153,7 +153,7 @@ impl Sticker {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
+    pub async fn delete(&self, http: &Http) -> Result<()> {
         if let Some(guild_id) = self.guild_id {
             guild_id.delete_sticker(http, self.id).await
         } else {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -603,29 +603,26 @@ impl User {
     /// Returns a builder which can be awaited to obtain a message or stream of messages sent by
     /// this user.
     #[cfg(feature = "collector")]
-    pub fn await_reply(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_reply(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         MessageCollector::new(shard_messenger).author_id(self.id)
     }
 
     /// Same as [`Self::await_reply`].
     #[cfg(feature = "collector")]
-    pub fn await_replies(&self, shard_messenger: impl AsRef<ShardMessenger>) -> MessageCollector {
+    pub fn await_replies(&self, shard_messenger: ShardMessenger) -> MessageCollector {
         self.await_reply(shard_messenger)
     }
 
     /// Returns a builder which can be awaited to obtain a reaction or stream of reactions sent by
     /// this user.
     #[cfg(feature = "collector")]
-    pub fn await_reaction(&self, shard_messenger: impl AsRef<ShardMessenger>) -> ReactionCollector {
+    pub fn await_reaction(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         ReactionCollector::new(shard_messenger).author_id(self.id)
     }
 
     /// Same as [`Self::await_reaction`].
     #[cfg(feature = "collector")]
-    pub fn await_reactions(
-        &self,
-        shard_messenger: impl AsRef<ShardMessenger>,
-    ) -> ReactionCollector {
+    pub fn await_reactions(&self, shard_messenger: ShardMessenger) -> ReactionCollector {
         self.await_reaction(shard_messenger)
     }
 }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -151,11 +151,8 @@ impl WebhookGuild {
     /// # Errors
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild.
-    pub async fn to_partial_guild_with_counts(
-        self,
-        http: impl AsRef<Http>,
-    ) -> Result<PartialGuild> {
-        http.as_ref().get_guild_with_counts(self.id).await
+    pub async fn to_partial_guild_with_counts(self, http: &Http) -> Result<PartialGuild> {
+        http.get_guild_with_counts(self.id).await
     }
 }
 
@@ -245,8 +242,8 @@ impl Webhook {
     ///
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's
     /// response.
-    pub async fn from_id(http: impl AsRef<Http>, webhook_id: WebhookId) -> Result<Self> {
-        http.as_ref().get_webhook(webhook_id).await
+    pub async fn from_id(http: &Http, webhook_id: WebhookId) -> Result<Self> {
+        http.get_webhook(webhook_id).await
     }
 
     /// Retrieves a webhook given its Id and unique token.
@@ -278,11 +275,11 @@ impl Webhook {
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's
     /// response.
     pub async fn from_id_with_token(
-        http: impl AsRef<Http>,
+        http: &Http,
         webhook_id: WebhookId,
         token: &str,
     ) -> Result<Self> {
-        http.as_ref().get_webhook_with_token(webhook_id, token).await
+        http.get_webhook_with_token(webhook_id, token).await
     }
 
     /// Retrieves a webhook given its url.
@@ -312,8 +309,8 @@ impl Webhook {
     ///
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's
     /// response.
-    pub async fn from_url(http: impl AsRef<Http>, url: &str) -> Result<Self> {
-        http.as_ref().get_webhook_from_url(url).await
+    pub async fn from_url(http: &Http, url: &str) -> Result<Self> {
+        http.get_webhook_from_url(url).await
     }
 
     /// Deletes the webhook.
@@ -325,8 +322,7 @@ impl Webhook {
     ///
     /// Returns [`Error::Http`] if the webhook does not exist, the token is invalid, or if the
     /// webhook could not otherwise be deleted.
-    pub async fn delete(&self, http: impl AsRef<Http>) -> Result<()> {
-        let http = http.as_ref();
+    pub async fn delete(&self, http: &Http) -> Result<()> {
         match &self.token {
             Some(token) => {
                 http.delete_webhook_with_token(self.id, token.expose_secret(), None).await
@@ -455,12 +451,12 @@ impl Webhook {
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     pub async fn get_message(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         thread_id: Option<ChannelId>,
         message_id: MessageId,
     ) -> Result<Message> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        http.as_ref().get_webhook_message(self.id, thread_id, token, message_id).await
+        http.get_webhook_message(self.id, thread_id, token, message_id).await
     }
 
     /// Edits a webhook message with the fields set via the given builder.
@@ -496,12 +492,12 @@ impl Webhook {
     /// Id does not belong to the current webhook.
     pub async fn delete_message(
         &self,
-        http: impl AsRef<Http>,
+        http: &Http,
         thread_id: Option<ChannelId>,
         message_id: MessageId,
     ) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        http.as_ref().delete_webhook_message(self.id, thread_id, token, message_id).await
+        http.delete_webhook_message(self.id, thread_id, token, message_id).await
     }
 
     /// Retrieves the latest information about the webhook, editing the webhook in-place.
@@ -517,9 +513,9 @@ impl Webhook {
     /// error. Such as if the [`Webhook`] was deleted.
     ///
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
-    pub async fn refresh(&mut self, http: impl AsRef<Http>) -> Result<()> {
+    pub async fn refresh(&mut self, http: &Http) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        http.as_ref().get_webhook_with_token(self.id, token).await.map(|replacement| {
+        http.get_webhook_with_token(self.id, token).await.map(|replacement| {
             *self = replacement;
         })
     }
@@ -553,7 +549,7 @@ impl WebhookId {
     /// May also return an [`Error::Json`] if there is an error in deserialising the response.
     ///
     /// [Manage Webhooks]: super::permissions::Permissions::MANAGE_WEBHOOKS
-    pub async fn to_webhook(self, http: impl AsRef<Http>) -> Result<Webhook> {
-        http.as_ref().get_webhook(self).await
+    pub async fn to_webhook(self, http: &Http) -> Result<Webhook> {
+        http.get_webhook(self).await
     }
 }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -118,8 +118,8 @@ pub struct WebhookGuild {
 impl WebhookGuild {
     /// Tries to find the [`Guild`] by its Id in the cache.
     #[cfg(feature = "cache")]
-    pub fn to_guild_cached(self, cache: &impl AsRef<Cache>) -> Option<GuildRef<'_>> {
-        cache.as_ref().guild(self.id)
+    pub fn to_guild_cached<'a>(&self, cache: &'a Cache) -> Option<GuildRef<'a>> {
+        cache.guild(self.id)
     }
 
     /// Requests [`PartialGuild`] over REST API.
@@ -171,7 +171,7 @@ impl WebhookChannel {
     /// Attempts to find a [`GuildChannel`] by its Id in the cache.
     #[cfg(feature = "cache")]
     pub fn to_channel_cached(self, cache: &Cache) -> Option<GuildChannelRef<'_>> {
-        cache.as_ref().channel(self.id)
+        cache.channel(self.id)
     }
 
     /// First attempts to find a [`Channel`] by its Id in the cache, upon failure requests it via

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -425,7 +425,7 @@ pub(crate) fn user_has_guild_perms(
 /// will return `true` even when the permissions are not in the cache.
 #[cfg(all(feature = "cache", feature = "model"))]
 pub(crate) fn user_has_perms_cache(
-    cache: impl AsRef<Cache>,
+    cache: &Cache,
     channel_id: ChannelId,
     required_permissions: Permissions,
 ) -> Result<()> {
@@ -446,9 +446,7 @@ pub(crate) fn user_has_perms_cache(
 }
 
 #[cfg(all(feature = "cache", feature = "model"))]
-pub(crate) fn user_perms(cache: impl AsRef<Cache>, channel_id: ChannelId) -> Result<Permissions> {
-    let cache = cache.as_ref();
-
+pub(crate) fn user_perms(cache: &Cache, channel_id: ChannelId) -> Result<Permissions> {
     let Some(guild_id) = cache.channels.get(&channel_id).map(|c| *c) else {
         return Err(Error::Model(ModelError::ChannelNotFound));
     };

--- a/src/utils/quick_modal.rs
+++ b/src/utils/quick_modal.rs
@@ -107,7 +107,7 @@ impl<'a> CreateQuickModal<'a> {
         );
         builder.execute(ctx, (interaction_id, token)).await?;
 
-        let collector = ModalInteractionCollector::new(&ctx.shard)
+        let collector = ModalInteractionCollector::new(ctx.shard.clone())
             .custom_ids(vec![modal_custom_id.trunc_into()]);
 
         let collector = match self.timeout {


### PR DESCRIPTION
This should improve compile times even more, by compiling a lot more methods in serenity, instead of in the bot/poise code.