### PR TITLE
Avoid cloning FullEvent in dispatch code

### DIFF
--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -14,7 +14,7 @@ impl EventHandler for Handler {
     //
     // Event handlers are dispatched through a threadpool, and so multiple events can be dispatched
     // simultaneously.
-    async fn message(&self, ctx: Context, msg: Message) {
+    async fn message(&self, ctx: &Context, msg: &Message) {
         if msg.content == "!ping" {
             // Sending a message can fail, due to a network error, an authentication error, or lack
             // of permissions to post in the channel, so log to stdout when some error happens,
@@ -30,7 +30,7 @@ impl EventHandler for Handler {
     // Ids, current user data, private channels, and more.
     //
     // In this case, just print what the current user's username is.
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -24,7 +24,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
+    async fn message(&self, ctx: &Context, msg: &Message) {
         if msg.content == "!ping" {
             println!("Shard {}", ctx.shard_id);
 
@@ -34,7 +34,7 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -10,7 +10,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, context: Context, msg: Message) {
+    async fn message(&self, context: &Context, msg: &Message) {
         if msg.content == "!messageme" {
             // If the `utils`-feature is enabled, then model structs will have a lot of useful
             // methods implemented, to avoid using an often otherwise bulky Context, or even much
@@ -27,7 +27,7 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -10,7 +10,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, context: Context, msg: Message) {
+    async fn message(&self, context: &Context, msg: &Message) {
         if msg.content == "!ping" {
             let channel = match msg.channel_id.to_channel(&context).await {
                 Ok(channel) => channel,
@@ -26,7 +26,7 @@ impl EventHandler for Handler {
             // emojis, and more.
             let response = MessageBuilder::new()
                 .push("User ")
-                .push_bold_safe(msg.author.name.into_string())
+                .push_bold_safe(msg.author.name.as_str())
                 .push(" used the 'ping' command in the ")
                 .mention(&channel)
                 .push(" channel")
@@ -38,7 +38,7 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -52,7 +52,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e06_sample_bot_structure/src/main.rs
+++ b/examples/e06_sample_bot_structure/src/main.rs
@@ -37,11 +37,11 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         info!("Connected as {}", ready.user.name);
     }
 
-    async fn resume(&self, _: Context, _: ResumedEvent) {
+    async fn resume(&self, _: &Context, _: &ResumedEvent) {
         info!("Resumed");
     }
 }

--- a/examples/e07_env_logging/src/main.rs
+++ b/examples/e07_env_logging/src/main.rs
@@ -15,7 +15,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         // Log at the INFO level. This is a macro from the `tracing` crate.
         info!("{} is connected!", ready.user.name);
     }
@@ -25,7 +25,7 @@ impl EventHandler for Handler {
     // Handler doesn't implement Debug here, so we specify to skip that argument.
     // Context doesn't implement Debug either, so it is also skipped.
     #[instrument(skip(self, _ctx))]
-    async fn resume(&self, _ctx: Context, _resume: ResumedEvent) {
+    async fn resume(&self, _ctx: &Context, _resume: &ResumedEvent) {
         // Log at the DEBUG level.
         //
         // In this example, this will not show up in the logs because DEBUG is

--- a/examples/e08_shard_manager/src/main.rs
+++ b/examples/e08_shard_manager/src/main.rs
@@ -31,7 +31,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         if let Some(shard) = ready.shard {
             // Note that array index 0 is 0-indexed, while index 1 is 1-indexed.
             //

--- a/examples/e09_create_message_builder/src/main.rs
+++ b/examples/e09_create_message_builder/src/main.rs
@@ -11,7 +11,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
+    async fn message(&self, ctx: &Context, msg: &Message) {
         if msg.content == "!hello" {
             // The create message builder allows you to easily create embeds and messages using a
             // builder syntax.
@@ -43,7 +43,7 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -44,7 +44,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e11_gateway_intents/src/main.rs
+++ b/examples/e11_gateway_intents/src/main.rs
@@ -10,17 +10,17 @@ struct Handler;
 #[async_trait]
 impl EventHandler for Handler {
     // This event will be dispatched for guilds, but not for direct messages.
-    async fn message(&self, _ctx: Context, msg: Message) {
+    async fn message(&self, _ctx: &Context, msg: &Message) {
         println!("Received message: {}", msg.content);
     }
 
     // As the intents set in this example, this event shall never be dispatched.
     // Try it by changing your status.
-    async fn presence_update(&self, _ctx: Context, _new_data: Presence) {
+    async fn presence_update(&self, _ctx: &Context, _new_data: &Presence) {
         println!("Presence Update");
     }
 
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e12_global_data/src/main.rs
+++ b/examples/e12_global_data/src/main.rs
@@ -50,7 +50,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
+    async fn message(&self, ctx: &Context, msg: &Message) {
         // We are verifying if the bot id is the same as the message author id.
         if msg.author.id != ctx.cache.current_user().id
             && msg.content.to_lowercase().contains("owo")
@@ -68,7 +68,7 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, _: Context, ready: Ready) {
+    async fn ready(&self, _: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
     }
 }

--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -13,7 +13,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
+    async fn interaction_create(&self, ctx: &Context, interaction: &Interaction) {
         if let Interaction::Command(command) = interaction {
             println!("Received command interaction: {command:#?}");
 
@@ -22,7 +22,7 @@ impl EventHandler for Handler {
                 "id" => Some(commands::id::run(&command.data.options())),
                 "attachmentinput" => Some(commands::attachmentinput::run(&command.data.options())),
                 "modal" => {
-                    commands::modal::run(&ctx, &command).await.unwrap();
+                    commands::modal::run(ctx, command).await.unwrap();
                     None
                 },
                 _ => Some("not implemented :(".to_string()),
@@ -38,7 +38,7 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, ctx: Context, ready: Ready) {
+    async fn ready(&self, ctx: &Context, ready: &Ready) {
         println!("{} is connected!", ready.user.name);
 
         let guild_id = GuildId::new(

--- a/examples/e15_sqlite_database/src/main.rs
+++ b/examples/e15_sqlite_database/src/main.rs
@@ -12,7 +12,7 @@ struct Bot {
 
 #[async_trait]
 impl EventHandler for Bot {
-    async fn message(&self, ctx: Context, msg: Message) {
+    async fn message(&self, ctx: &Context, msg: &Message) {
         let user_id = msg.author.id.get() as i64;
 
         if let Some(task_description) = msg.content.strip_prefix("~todo add") {

--- a/examples/e16_message_components/src/main.rs
+++ b/examples/e16_message_components/src/main.rs
@@ -29,7 +29,7 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
+    async fn message(&self, ctx: &Context, msg: &Message) {
         if msg.content != "animal" {
             return;
         }

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -9,7 +9,7 @@ mod model_type_sizes;
 const IMAGE_URL: &str = "https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png";
 const IMAGE_URL_2: &str = "https://rustacean.net/assets/rustlogo.png";
 
-async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
+async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
     let channel_id = msg.channel_id;
     let guild_id = msg.guild_id.unwrap();
     if let Some(_args) = msg.content.strip_prefix("testmessage ") {
@@ -236,7 +236,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
 
 async fn interaction(
     ctx: &Context,
-    interaction: CommandInteraction,
+    interaction: &CommandInteraction,
 ) -> Result<(), serenity::Error> {
     if interaction.data.name == "editattachments" {
         // Respond with an image
@@ -377,13 +377,13 @@ async fn interaction(
 struct Handler;
 #[serenity::async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
-        message(&ctx, msg).await.unwrap();
+    async fn message(&self, ctx: &Context, msg: &Message) {
+        message(ctx, msg).await.unwrap();
     }
 
-    async fn interaction_create(&self, ctx: Context, i: Interaction) {
+    async fn interaction_create(&self, ctx: &Context, i: &Interaction) {
         match i {
-            Interaction::Command(i) => interaction(&ctx, i).await.unwrap(),
+            Interaction::Command(i) => interaction(ctx, i).await.unwrap(),
             Interaction::Component(i) => println!("{:#?}", i.data),
             Interaction::Autocomplete(i) => {
                 i.create_response(
@@ -400,7 +400,7 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn reaction_remove_emoji(&self, _ctx: Context, removed_reactions: Reaction) {
+    async fn reaction_remove_emoji(&self, _ctx: &Context, removed_reactions: &Reaction) {
         println!("Got ReactionRemoveEmoji event: {removed_reactions:?}");
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -288,7 +288,7 @@ impl Cache {
     /// #[serenity::async_trait]
     /// # #[cfg(feature = "client")]
     /// impl EventHandler for Handler {
-    ///     async fn cache_ready(&self, ctx: Context, _: Vec<GuildId>) {
+    ///     async fn cache_ready(&self, ctx: &Context, _: &Vec<GuildId>) {
     ///         println!("{} unknown members", ctx.cache.unknown_members());
     ///     }
     /// }
@@ -329,7 +329,7 @@ impl Cache {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, context: Context, _: Ready) {
+    ///     async fn ready(&self, context: &Context, _: &Ready) {
     ///         let guilds = context.cache.guilds().len();
     ///
     ///         println!("Guilds in the Cache: {}", guilds);

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -114,7 +114,7 @@ impl Context {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         if msg.content == "!online" {
     ///             ctx.online();
     ///         }
@@ -142,7 +142,7 @@ impl Context {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         if msg.content == "!idle" {
     ///             ctx.idle();
     ///         }
@@ -170,7 +170,7 @@ impl Context {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         if msg.content == "!dnd" {
     ///             ctx.dnd();
     ///         }
@@ -198,7 +198,7 @@ impl Context {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         if msg.content == "!invisible" {
     ///             ctx.invisible();
     ///         }
@@ -229,7 +229,7 @@ impl Context {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         if msg.content == "!reset_presence" {
     ///             ctx.reset_presence();
     ///         }
@@ -259,7 +259,7 @@ impl Context {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         let mut args = msg.content.splitn(2, ' ');
     ///
     ///         if let (Some("~setgame"), Some(game)) = (args.next(), args.next()) {
@@ -286,7 +286,7 @@ impl Context {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, ctx: Context, _: Ready) {
+    ///     async fn ready(&self, ctx: &Context, _: &Ready) {
     ///         use serenity::model::user::OnlineStatus;
     ///
     ///         ctx.set_presence(None, OnlineStatus::Idle);
@@ -303,7 +303,7 @@ impl Context {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, context: Context, _: Ready) {
+    ///     async fn ready(&self, context: &Context, _: &Ready) {
     ///         use serenity::gateway::ActivityData;
     ///         use serenity::model::user::OnlineStatus;
     ///

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -24,8 +24,9 @@ macro_rules! event_handler {
             $(
                 $( #[doc = $doc] )*
                 $( #[cfg(feature = $feature)] )?
-                async fn $method_name(&self, $($context: Context,)? $( $arg_name: $arg_type ),*) {
+                async fn $method_name(&self, $($context: &Context,)? $( $arg_name: &$arg_type ),*) {
                     // Suppress unused argument warnings
+                    #[allow(dropping_references, dropping_copy_types)]
                     drop(( $($context,)? $($arg_name),* ))
                 }
             )*
@@ -66,7 +67,7 @@ macro_rules! event_handler {
             }
 
             /// Runs the given [`EventHandler`]'s code for this event.
-            pub async fn dispatch(self, ctx: Context, handler: &dyn EventHandler) {
+            pub async fn dispatch(&self, ctx: &Context, handler: &dyn EventHandler) {
                 match self {
                     $(
                         $( #[cfg(feature = $feature)] )?

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -300,7 +300,7 @@ impl IntoFuture for ClientBuilder {
                 for event_handler in &event_handlers_clone {
                     let info = info.clone();
                     let event_handler = Arc::clone(event_handler);
-                    tokio::spawn(async move { event_handler.ratelimit(info).await });
+                    tokio::spawn(async move { event_handler.ratelimit(&info).await });
                 }
             }));
         }
@@ -395,7 +395,7 @@ impl IntoFuture for ClientBuilder {
 ///
 /// #[serenity::async_trait]
 /// impl EventHandler for Handler {
-///     async fn message(&self, context: Context, msg: Message) {
+///     async fn message(&self, context: &Context, msg: &Message) {
 ///         if msg.content == "!ping" {
 ///             let _ = msg.channel_id.say(&context, "Pong!");
 ///         }

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -102,7 +102,7 @@ pub trait Framework: Send + Sync {
         let _: &Client = client;
     }
     /// Called on every incoming event.
-    async fn dispatch(&self, ctx: Context, event: FullEvent);
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent);
 }
 
 #[async_trait]
@@ -113,7 +113,7 @@ where
     async fn init(&mut self, client: &Client) {
         (**self).init(client).await;
     }
-    async fn dispatch(&self, ctx: Context, event: FullEvent) {
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
         (**self).dispatch(ctx, event).await;
     }
 }
@@ -126,7 +126,7 @@ where
     async fn init(&mut self, client: &Client) {
         (**self).init(client).await;
     }
-    async fn dispatch(&self, ctx: Context, event: FullEvent) {
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
         (**self).dispatch(ctx, event).await;
     }
 }

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -605,7 +605,7 @@ impl StandardFramework {
 #[async_trait]
 impl Framework for StandardFramework {
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self, event)))]
-    async fn dispatch(&self, mut ctx: Context, event: FullEvent) {
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
         let FullEvent::Message {
             new_message: msg,
         } = event
@@ -613,7 +613,7 @@ impl Framework for StandardFramework {
             return;
         };
 
-        if self.should_ignore(&msg) {
+        if self.should_ignore(msg) {
             return;
         }
 
@@ -623,11 +623,11 @@ impl Framework for StandardFramework {
 
         let config = self.config.read().clone();
 
-        let prefix = parse::prefix(&ctx, &msg, &mut stream, &config).await;
+        let prefix = parse::prefix(ctx, msg, &mut stream, &config).await;
 
         if prefix.is_some() && stream.rest().is_empty() {
             if let Some(prefix_only) = &self.prefix_only {
-                prefix_only(&mut ctx, &msg).await;
+                prefix_only(ctx, msg).await;
             }
 
             return;
@@ -635,15 +635,15 @@ impl Framework for StandardFramework {
 
         if prefix.is_none() && !(config.get_no_dm_prefix() && msg.is_private()) {
             if let Some(normal) = &self.normal_message {
-                normal(&mut ctx, &msg).await;
+                normal(ctx, msg).await;
             }
 
             return;
         }
 
         let invocation = parse::command(
-            &ctx,
-            &msg,
+            ctx,
+            msg,
             &mut stream,
             &self.groups,
             &config,
@@ -656,12 +656,12 @@ impl Framework for StandardFramework {
             Err(ParseError::UnrecognisedCommand(unreg)) => {
                 if let Some(unreg) = unreg {
                     if let Some(unrecognised_command) = &self.unrecognised_command {
-                        unrecognised_command(&mut ctx, &msg, &unreg).await;
+                        unrecognised_command(ctx, msg, &unreg).await;
                     }
                 }
 
                 if let Some(normal) = &self.normal_message {
-                    normal(&mut ctx, &msg).await;
+                    normal(ctx, msg).await;
                 }
 
                 return;
@@ -671,7 +671,7 @@ impl Framework for StandardFramework {
                 command_name,
             }) => {
                 if let Some(dispatch) = &self.dispatch {
-                    dispatch(&mut ctx, &msg, error, &command_name).await;
+                    dispatch(ctx, msg, error, &command_name).await;
                 }
 
                 return;
@@ -694,16 +694,15 @@ impl Framework for StandardFramework {
                 let help = self.help.unwrap();
 
                 if let Some(before) = &self.before {
-                    if !before(&mut ctx, &msg, name).await {
+                    if !before(ctx, msg, name).await {
                         return;
                     }
                 }
 
-                let res =
-                    (help.fun)(&mut ctx, &msg, args, help.options, &groups, config.owners).await;
+                let res = (help.fun)(ctx, msg, args, help.options, &groups, config.owners).await;
 
                 if let Some(after) = &self.after {
-                    after(&mut ctx, &msg, name, res).await;
+                    after(ctx, msg, name, res).await;
                 }
             },
             Invoke::Command {
@@ -738,11 +737,11 @@ impl Framework for StandardFramework {
                 };
 
                 if let Some(error) =
-                    self.should_fail(&ctx, &msg, &mut args, command.options, group.options).await
+                    self.should_fail(ctx, msg, &mut args, command.options, group.options).await
                 {
                     if let Some(dispatch) = &self.dispatch {
                         let command_name = command.options.names[0];
-                        dispatch(&mut ctx, &msg, error, command_name).await;
+                        dispatch(ctx, msg, error, command_name).await;
                     }
 
                     return;
@@ -751,24 +750,24 @@ impl Framework for StandardFramework {
                 let name = command.options.names[0];
 
                 if let Some(before) = &self.before {
-                    if !before(&mut ctx, &msg, name).await {
+                    if !before(ctx, msg, name).await {
                         return;
                     }
                 }
 
-                let res = (command.fun)(&mut ctx, &msg, args).await;
+                let res = (command.fun)(ctx, msg, args).await;
 
                 // Check if the command wants to revert the bucket by giving back a ticket.
                 if matches!(&res, Err(e) if e.is::<RevertBucket>()) {
                     let mut buckets = self.buckets.lock().await;
 
                     if let Some(bucket) = command.options.bucket.and_then(|b| buckets.get_mut(b)) {
-                        bucket.give(&ctx, &msg).await;
+                        bucket.give(ctx, msg).await;
                     }
                 }
 
                 if let Some(after) = &self.after {
-                    after(&mut ctx, &msg, name, res).await;
+                    after(ctx, msg, name, res).await;
                 }
             },
         }

--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -128,7 +128,7 @@ impl ShardRunner {
                         shard_id: self.shard.shard_info().id,
                     };
                     spawn_named("dispatch::event_handler::shard_stage_update", async move {
-                        event_handler.shard_stage_update(context, event).await;
+                        event_handler.shard_stage_update(&context, &event).await;
                     });
                 }
             }
@@ -175,11 +175,11 @@ impl ShardRunner {
 
                 dispatch_model(
                     event,
-                    &self.make_context(),
+                    self.make_context(),
                     #[cfg(feature = "framework")]
                     self.framework.clone(),
-                    self.event_handlers.clone(),
-                    self.raw_event_handlers.clone(),
+                    &self.event_handlers,
+                    &self.raw_event_handlers,
                 );
             }
 

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -104,8 +104,8 @@ impl Attachment {
     /// #[serenity::async_trait]
     /// # #[cfg(feature = "client")]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, context: Context, mut message: Message) {
-    ///         for attachment in message.attachments {
+    ///     async fn message(&self, context: &Context, message: &Message) {
+    ///         for attachment in &message.attachments {
     ///             let content = match attachment.download().await {
     ///                 Ok(content) => content,
     ///                 Err(why) => {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -707,7 +707,7 @@ impl GuildChannel {
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, context: Context, msg: Message) {
+    ///     async fn message(&self, context: &Context, msg: &Message) {
     ///         let channel = match context.cache.channel(msg.channel_id) {
     ///             Some(channel) => channel,
     ///             None => return,

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -116,7 +116,7 @@ impl fmt::Display for Minimum {
 /// #[serenity::async_trait]
 /// #[cfg(feature = "client")]
 /// impl EventHandler for Handler {
-///     async fn guild_ban_removal(&self, ctx: Context, guild_id: GuildId, user: User) {
+///     async fn guild_ban_removal(&self, ctx: &Context, guild_id: &GuildId, user: &User) {
 ///         match guild_id.ban(&ctx.http, user.id, 8).await {
 ///             Ok(()) => {
 ///                 // Ban successful.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2177,7 +2177,7 @@ impl Guild {
     /// #[serenity::async_trait]
     /// #[cfg(all(feature = "cache", feature = "client"))]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         if let Some(guild_id) = msg.guild_id {
     ///             if let Some(guild) = guild_id.to_guild_cached(&ctx.cache) {
     ///                 if let Some(role) = guild.role_by_name("role_name") {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1372,7 +1372,7 @@ impl PartialGuild {
     /// #[serenity::async_trait]
     /// #[cfg(all(feature = "cache", feature = "client"))]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         if let Some(guild_id) = msg.guild_id {
     ///             if let Some(guild) = guild_id.to_guild_cached(&ctx.cache) {
     ///                 if let Some(role) = guild.role_by_name("role_name") {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -438,7 +438,7 @@ impl User {
     /// #[serenity::async_trait]
     /// # #[cfg(feature = "client")]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
+    ///     async fn message(&self, ctx: &Context, msg: &Message) {
     ///         if msg.content == "~help" {
     ///             let builder = CreateMessage::new().content("Helpful info here.");
     ///
@@ -561,7 +561,7 @@ impl User {
     /// #[serenity::async_trait]
     /// # #[cfg(feature = "client")]
     /// impl EventHandler for Handler {
-    ///     async fn message(&self, context: Context, msg: Message) {
+    ///     async fn message(&self, context: &Context, msg: &Message) {
     ///         if msg.content == "!mytag" {
     ///             let content = format!("Your tag is: {}", msg.author.tag());
     ///             let _ = msg.channel_id.say(&context.http, &content).await;


### PR DESCRIPTION
Avoids cloning entire event structs when dispatching. To reduce code size and allocations all the state is bundled up into a temporary struct called DispatchContext, but this isn't user facing at all. This regresses code size a bit, but is worth it for runtime performance, and probably reduces actual code sizes as `FullEvent` doesn't have to be moved around as much.