### PR TITLE
Remove the builder trait and only take required arguments

### DIFF
--- a/examples/e14_slash_commands/src/commands/modal.rs
+++ b/examples/e14_slash_commands/src/commands/modal.rs
@@ -17,7 +17,7 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) -> Result<(), 
     response
         .interaction
         .create_response(
-            ctx,
+            &ctx.http,
             CreateInteractionResponse::Message(CreateInteractionResponseMessage::new().content(
                 format!("**Name**: {first_name} {last_name}\n\nHobbies and interests: {hobbies}"),
             )),

--- a/examples/e16_message_components/src/main.rs
+++ b/examples/e16_message_components/src/main.rs
@@ -83,7 +83,7 @@ impl EventHandler for Handler {
         // Acknowledge the interaction and edit the message
         interaction
             .create_response(
-                &ctx,
+                &ctx.http,
                 CreateInteractionResponse::UpdateMessage(
                     CreateInteractionResponseMessage::default()
                         .content(format!("You chose: **{animal}**\nNow choose a sound!"))
@@ -117,7 +117,7 @@ impl EventHandler for Handler {
             // Acknowledge the interaction and send a reply
             interaction
                 .create_response(
-                    &ctx,
+                    &ctx.http,
                     // This time we dont edit the message but reply to it
                     CreateInteractionResponse::Message(
                         CreateInteractionResponseMessage::default()

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -16,29 +16,35 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         println!("command message: {msg:#?}");
     } else if msg.content == "register" {
         guild_id
-            .create_command(&ctx, CreateCommand::new("editattachments").description("test command"))
+            .create_command(
+                &ctx.http,
+                CreateCommand::new("editattachments").description("test command"),
+            )
             .await?;
         guild_id
             .create_command(
-                &ctx,
+                &ctx.http,
                 CreateCommand::new("unifiedattachments1").description("test command"),
             )
             .await?;
         guild_id
             .create_command(
-                &ctx,
+                &ctx.http,
                 CreateCommand::new("unifiedattachments2").description("test command"),
             )
             .await?;
         guild_id
-            .create_command(&ctx, CreateCommand::new("editembeds").description("test command"))
-            .await?;
-        guild_id
-            .create_command(&ctx, CreateCommand::new("newselectmenu").description("test command"))
+            .create_command(&ctx.http, CreateCommand::new("editembeds").description("test command"))
             .await?;
         guild_id
             .create_command(
-                &ctx,
+                &ctx.http,
+                CreateCommand::new("newselectmenu").description("test command"),
+            )
+            .await?;
+        guild_id
+            .create_command(
+                &ctx.http,
                 CreateCommand::new("autocomplete").description("test command").add_option(
                     CreateCommandOption::new(CommandOptionType::String, "foo", "foo")
                         .set_autocomplete(true),
@@ -117,7 +123,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
                 .timeout(std::time::Duration::from_secs(10))
                 .await;
             match button_press {
-                Some(x) => x.defer(ctx).await?,
+                Some(x) => x.defer(&ctx.http).await?,
                 None => break,
             }
 
@@ -130,7 +136,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
     } else if msg.content == "testautomodregex" {
         guild_id
             .create_automod_rule(
-                ctx,
+                &ctx.http,
                 EditAutoModRule::new().trigger(Trigger::Keyword {
                     strings: vec!["badword".into()],
                     regex_patterns: vec!["b[o0]{2,}b(ie)?s?".into()],
@@ -158,7 +164,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         let forum = forum_id.to_channel(ctx).await?.guild().unwrap();
         channel_id
             .edit_thread(
-                &ctx,
+                &ctx.http,
                 EditThread::new()
                     .applied_tags(forum.available_tags.iter().map(|t| t.id).collect::<Vec<_>>()),
             )
@@ -212,7 +218,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
             .parse::<ChannelId>()
             .unwrap()
             .create_forum_post(
-                ctx,
+                &ctx.http,
                 CreateForumPost::new(
                     "a",
                     CreateMessage::new()
@@ -242,7 +248,7 @@ async fn interaction(
         // Respond with an image
         interaction
             .create_response(
-                &ctx,
+                &ctx.http,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new().add_file(
                         CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?,
@@ -257,7 +263,7 @@ async fn interaction(
         // Add another image
         let msg = interaction
             .edit_response(
-                &ctx,
+                &ctx.http,
                 EditInteractionResponse::new().attachments(
                     EditAttachments::keep_all(&msg)
                         .add(CreateAttachment::url(&ctx.http, IMAGE_URL_2, "testing1.png").await?),
@@ -270,7 +276,7 @@ async fn interaction(
         // Only keep the new image, removing the first image
         let _msg = interaction
             .edit_response(
-                &ctx,
+                &ctx.http,
                 EditInteractionResponse::new()
                     .attachments(EditAttachments::new().keep(msg.attachments[1].id)),
             )
@@ -278,7 +284,7 @@ async fn interaction(
     } else if interaction.data.name == "unifiedattachments1" {
         interaction
             .create_response(
-                ctx,
+                &ctx.http,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new().content("works"),
                 ),
@@ -286,19 +292,19 @@ async fn interaction(
             .await?;
 
         interaction
-            .edit_response(ctx, EditInteractionResponse::new().content("works still"))
+            .edit_response(&ctx.http, EditInteractionResponse::new().content("works still"))
             .await?;
 
         interaction
             .create_followup(
-                ctx,
+                &ctx.http,
                 CreateInteractionResponseFollowup::new().content("still works still"),
             )
             .await?;
     } else if interaction.data.name == "unifiedattachments2" {
         interaction
             .create_response(
-                ctx,
+                &ctx.http,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new().add_file(
                         CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?,
@@ -309,7 +315,7 @@ async fn interaction(
 
         interaction
             .edit_response(
-                ctx,
+                &ctx.http,
                 EditInteractionResponse::new().new_attachment(
                     CreateAttachment::url(&ctx.http, IMAGE_URL_2, "testing1.png").await?,
                 ),
@@ -318,7 +324,7 @@ async fn interaction(
 
         interaction
             .create_followup(
-                ctx,
+                &ctx.http,
                 CreateInteractionResponseFollowup::new()
                     .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
@@ -326,7 +332,7 @@ async fn interaction(
     } else if interaction.data.name == "editembeds" {
         interaction
             .create_response(
-                &ctx,
+                &ctx.http,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
                         .content("hi")
@@ -336,11 +342,11 @@ async fn interaction(
             .await?;
 
         // Pre-PR, this falsely deleted the embed
-        interaction.edit_response(&ctx, EditInteractionResponse::new()).await?;
+        interaction.edit_response(&ctx.http, EditInteractionResponse::new()).await?;
     } else if interaction.data.name == "newselectmenu" {
         interaction
             .create_response(
-                &ctx,
+                &ctx.http,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
                         .select_menu(CreateSelectMenu::new("0", CreateSelectMenuKind::String {
@@ -387,7 +393,7 @@ impl EventHandler for Handler {
             Interaction::Component(i) => println!("{:#?}", i.data),
             Interaction::Autocomplete(i) => {
                 i.create_response(
-                    &ctx,
+                    &ctx.http,
                     CreateInteractionResponse::Autocomplete(
                         CreateAutocompleteResponse::new()
                             .add_string_choice("suggestion", "suggestion"),

--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -84,13 +82,6 @@ impl<'a> AddMember<'a> {
         self.deaf = Some(deafen);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for AddMember<'_> {
-    type Context<'ctx> = (GuildId, UserId);
-    type Built = Option<Member>;
 
     /// Adds a [`User`] to this guild with a valid OAuth2 access token.
     ///
@@ -100,11 +91,13 @@ impl Builder for AddMember<'_> {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().add_guild_member(ctx.0, ctx.1, &self).await
+        http: &Http,
+        guild_id: GuildId,
+        user_id: UserId,
+    ) -> Result<Option<Member>> {
+        http.add_guild_member(guild_id, user_id, &self).await
     }
 }

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -3,8 +3,6 @@ use std::borrow::Cow;
 use nonmax::NonMaxU16;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
@@ -256,13 +254,6 @@ impl<'a> CreateChannel<'a> {
         self.default_sort_order = Some(default_sort_order);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for CreateChannel<'a> {
-    type Context<'ctx> = GuildId;
-    type Built = GuildChannel;
 
     /// Creates a new [`Channel`] in the guild.
     ///
@@ -274,14 +265,15 @@ impl<'a> Builder for CreateChannel<'a> {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+        guild_id: GuildId,
+    ) -> Result<GuildChannel> {
         #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::MANAGE_CHANNELS)?;
+        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_CHANNELS)?;
 
-        cache_http.http().create_channel(ctx, &self, self.audit_log_reason).await
+        cache_http.http().create_channel(guild_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -2,9 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
@@ -459,13 +457,6 @@ impl<'a> CreateCommand<'a> {
         self.nsfw = nsfw;
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for CreateCommand<'_> {
-    type Context<'ctx> = (Option<GuildId>, Option<CommandId>);
-    type Built = Command;
 
     /// Create a [`Command`], overriding an existing one with the same name if it exists.
     ///
@@ -481,13 +472,14 @@ impl Builder for CreateCommand<'_> {
     /// May also return [`Error::Json`] if there is an error in deserializing the API response.
     ///
     /// [Discord's docs]: https://discord.com/developers/docs/interactions/slash-commands
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        let http = cache_http.http();
-        match ctx {
+        http: &Http,
+        guild_id: Option<GuildId>,
+        command_id: Option<CommandId>,
+    ) -> Result<Command> {
+        match (guild_id, command_id) {
             (Some(guild_id), Some(cmd_id)) => {
                 http.edit_guild_command(guild_id, cmd_id, &self).await
             },

--- a/src/builder/create_command_permission.rs
+++ b/src/builder/create_command_permission.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -26,13 +24,6 @@ impl<'a> EditCommandPermissions<'a> {
             permissions: permissions.into(),
         }
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for EditCommandPermissions<'_> {
-    type Context<'ctx> = (GuildId, CommandId);
-    type Built = CommandPermissions;
 
     /// Create permissions for a guild application command. These will overwrite any existing
     /// permissions for that command.
@@ -47,12 +38,13 @@ impl Builder for EditCommandPermissions<'_> {
     ///
     /// [Discord's docs]: https://discord.com/developers/docs/interactions/slash-commands
     #[cfg(feature = "http")]
-    async fn execute(
+    pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().edit_guild_command_permissions(ctx.0, ctx.1, &self).await
+        http: &Http,
+        guild_id: GuildId,
+        command_id: CommandId,
+    ) -> Result<CommandPermissions> {
+        http.edit_guild_command_permissions(guild_id, command_id, &self).await
     }
 }
 

--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -2,11 +2,9 @@ use std::borrow::Cow;
 
 use nonmax::NonMaxU16;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::CreateMessage;
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -93,28 +91,16 @@ impl<'a> CreateForumPost<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for CreateForumPost<'a> {
-    type Context<'ctx> = ChannelId;
-    type Built = GuildChannel;
 
     /// Creates a forum post in the given channel.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    async fn execute(
-        mut self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+    #[cfg(feature = "http")]
+    pub async fn execute(mut self, http: &Http, channel_id: ChannelId) -> Result<GuildChannel> {
         let files = self.message.attachments.take_files();
-        cache_http
-            .http()
-            .create_forum_post_with_attachments(ctx, &self, files, self.audit_log_reason)
+        http.create_forum_post_with_attachments(channel_id, &self, files, self.audit_log_reason)
             .await
     }
 }

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -10,7 +8,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -148,13 +146,6 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         self
     }
     super::button_and_select_menu_convenience_methods!(self.components);
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for CreateInteractionResponseFollowup<'_> {
-    type Context<'ctx> = (Option<MessageId>, &'ctx str);
-    type Built = Message;
 
     /// Creates or edits a followup response to the response sent. If a [`MessageId`] is provided,
     /// then the corresponding message will be edited. Otherwise, a new message will be created.
@@ -167,19 +158,20 @@ impl Builder for CreateInteractionResponseFollowup<'_> {
     /// Returns [`Error::Model`] if the content is too long. May also return [`Error::Http`] if the
     /// API returns an error, or [`Error::Json`] if there is an error in deserializing the
     /// response.
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         mut self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+        http: &Http,
+        message_id: Option<MessageId>,
+        interaction_token: &str,
+    ) -> Result<Message> {
         self.check_length()?;
 
         let files = self.attachments.take_files();
 
-        let http = cache_http.http();
-        match ctx.0 {
-            Some(id) => http.edit_followup_message(ctx.1, id, &self, files).await,
-            None => http.create_followup_message(ctx.1, &self, files).await,
+        match message_id {
+            Some(id) => http.edit_followup_message(interaction_token, id, &self, files).await,
+            None => http.create_followup_message(interaction_token, &self, files).await,
         }
     }
 }

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
@@ -194,13 +192,6 @@ impl<'a> CreateInvite<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for CreateInvite<'a> {
-    type Context<'ctx> = ChannelId;
-    type Built = RichInvite;
 
     /// Creates an invite for the given channel.
     ///
@@ -212,18 +203,23 @@ impl<'a> Builder for CreateInvite<'a> {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
+        channel_id: ChannelId,
     ) -> Result<RichInvite> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(cache, ctx, Permissions::CREATE_INSTANT_INVITE)?;
+                crate::utils::user_has_perms_cache(
+                    cache,
+                    channel_id,
+                    Permissions::CREATE_INSTANT_INVITE,
+                )?;
             }
         }
 
-        cache_http.http().create_invite(ctx, &self, self.audit_log_reason).await
+        cache_http.http().create_invite(channel_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -250,16 +248,6 @@ impl<'a> CreateMessage<'a> {
         self.nonce = Some(nonce);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for CreateMessage<'_> {
-    #[cfg(feature = "cache")]
-    type Context<'ctx> = (ChannelId, Option<GuildId>);
-    #[cfg(not(feature = "cache"))]
-    type Context<'ctx> = (ChannelId,);
-    type Built = Message;
 
     /// Send a message to the channel.
     ///
@@ -278,15 +266,13 @@ impl Builder for CreateMessage<'_> {
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES
     /// [Attach Files]: Permissions::ATTACH_FILES
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         mut self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        let channel_id = ctx.0;
-        #[cfg(feature = "cache")]
-        let guild_id = ctx.1;
-
+        channel_id: ChannelId,
+        #[cfg(feature = "cache")] guild_id: Option<GuildId>,
+    ) -> Result<Message> {
         #[cfg(feature = "cache")]
         {
             let mut req = Permissions::SEND_MESSAGES;

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -122,13 +120,6 @@ impl<'a> CreateScheduledEvent<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for CreateScheduledEvent<'a> {
-    type Context<'ctx> = GuildId;
-    type Built = ScheduledEvent;
 
     /// Creates a new scheduled event in the guild with the data set, if any.
     ///
@@ -140,15 +131,16 @@ impl<'a> Builder for CreateScheduledEvent<'a> {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Create Events]: Permissions::CREATE_EVENTS
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+        channel_id: GuildId,
+    ) -> Result<ScheduledEvent> {
         #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::CREATE_EVENTS)?;
+        crate::utils::user_has_guild_perms(&cache_http, channel_id, Permissions::CREATE_EVENTS)?;
 
-        cache_http.http().create_scheduled_event(ctx, &self, self.audit_log_reason).await
+        cache_http.http().create_scheduled_event(channel_id, &self, self.audit_log_reason).await
     }
 }
 

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -72,13 +70,6 @@ impl<'a> CreateSticker<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for CreateSticker<'a> {
-    type Context<'ctx> = GuildId;
-    type Built = Sticker;
 
     /// Creates a new sticker in the guild with the data set, if any.
     ///
@@ -90,15 +81,12 @@ impl<'a> Builder for CreateSticker<'a> {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+    #[cfg(feature = "http")]
+    pub async fn execute(self, cache_http: impl CacheHttp, guild_id: GuildId) -> Result<Sticker> {
         #[cfg(feature = "cache")]
         crate::utils::user_has_guild_perms(
             &cache_http,
-            ctx,
+            guild_id,
             Permissions::CREATE_GUILD_EXPRESSIONS,
         )?;
 
@@ -108,6 +96,6 @@ impl<'a> Builder for CreateSticker<'a> {
             ("description".into(), self.description),
         ];
 
-        cache_http.http().create_sticker(ctx, map, self.file, self.audit_log_reason).await
+        cache_http.http().create_sticker(guild_id, map, self.file, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -3,9 +3,7 @@ use std::borrow::Cow;
 use nonmax::NonMaxU16;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -96,13 +94,6 @@ impl<'a> CreateThread<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for CreateThread<'a> {
-    type Context<'ctx> = (ChannelId, Option<MessageId>);
-    type Built = GuildChannel;
 
     /// Creates a thread, either private or public. Public threads require a message to connect the
     /// thread to.
@@ -110,17 +101,18 @@ impl<'a> Builder for CreateThread<'a> {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
+        http: &Http,
+        channel_id: ChannelId,
+        message_id: Option<MessageId>,
     ) -> Result<GuildChannel> {
-        let http = cache_http.http();
-        match ctx.1 {
+        match message_id {
             Some(id) => {
-                http.create_thread_from_message(ctx.0, id, &self, self.audit_log_reason).await
+                http.create_thread_from_message(channel_id, id, &self, self.audit_log_reason).await
             },
-            None => http.create_thread(ctx.0, &self, self.audit_log_reason).await,
+            None => http.create_thread(channel_id, &self, self.audit_log_reason).await,
         }
     }
 }

--- a/src/builder/edit_automod_rule.rs
+++ b/src/builder/edit_automod_rule.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
@@ -98,6 +96,31 @@ impl<'a> EditAutoModRule<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
+
+    /// Creates or edits an AutoMod [`Rule`] in a guild. Providing a [`RuleId`] will edit that
+    /// corresponding rule, otherwise a new rule will be created.
+    ///
+    /// **Note**: Requires the [Manage Guild] permission.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
+    ///
+    /// [Manage Guild]: Permissions::MANAGE_GUILD
+    #[cfg(feature = "http")]
+    pub async fn execute(
+        self,
+        http: &Http,
+        guild_id: GuildId,
+        rule_id: Option<RuleId>,
+    ) -> Result<Rule> {
+        match rule_id {
+            Some(id) => http.edit_automod_rule(guild_id, id, &self, self.audit_log_reason).await,
+            // Automod Rule creation has required fields, whereas modifying a rule does not.
+            // TODO: Enforce these fields (maybe with a separate CreateAutoModRule builder).
+            None => http.create_automod_rule(guild_id, &self, self.audit_log_reason).await,
+        }
+    }
 }
 
 impl<'a> Default for EditAutoModRule<'a> {
@@ -111,37 +134,6 @@ impl<'a> Default for EditAutoModRule<'a> {
             exempt_channels: None,
             event_type: EventType::MessageSend,
             audit_log_reason: None,
-        }
-    }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditAutoModRule<'a> {
-    type Context<'ctx> = (GuildId, Option<RuleId>);
-    type Built = Rule;
-
-    /// Creates or edits an AutoMod [`Rule`] in a guild. Providing a [`RuleId`] will edit that
-    /// corresponding rule, otherwise a new rule will be created.
-    ///
-    /// **Note**: Requires the [Manage Guild] permission.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    ///
-    /// [Manage Guild]: Permissions::MANAGE_GUILD
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        let http = cache_http.http();
-        match ctx.1 {
-            Some(id) => http.edit_automod_rule(ctx.0, id, &self, self.audit_log_reason).await,
-            // Automod Rule creation has required fields, whereas modifying a rule does not.
-            // TODO: Enforce these fields (maybe with a separate CreateAutoModRule builder).
-            None => http.create_automod_rule(ctx.0, &self, self.audit_log_reason).await,
         }
     }
 }

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -306,18 +306,26 @@ impl<'a> EditChannel<'a> {
     pub async fn execute(
         self,
         cache_http: impl CacheHttp,
-        chan_id: ChannelId,
+        channel_id: ChannelId,
     ) -> Result<GuildChannel> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(cache, chan_id, Permissions::MANAGE_CHANNELS)?;
+                crate::utils::user_has_perms_cache(
+                    cache,
+                    channel_id,
+                    Permissions::MANAGE_CHANNELS,
+                )?;
                 if self.permission_overwrites.is_some() {
-                    crate::utils::user_has_perms_cache(cache, chan_id, Permissions::MANAGE_ROLES)?;
+                    crate::utils::user_has_perms_cache(
+                        cache,
+                        channel_id,
+                        Permissions::MANAGE_ROLES,
+                    )?;
                 }
             }
         }
 
-        cache_http.http().edit_channel(chan_id, &self, self.audit_log_reason).await
+        cache_http.http().edit_channel(channel_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 use nonmax::NonMaxU16;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::CreateForumTag;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -291,13 +289,6 @@ impl<'a> EditChannel<'a> {
         self.default_forum_layout = Some(default_forum_layout);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditChannel<'a> {
-    type Context<'ctx> = ChannelId;
-    type Built = GuildChannel;
 
     /// Edits the channel's settings.
     ///
@@ -311,21 +302,22 @@ impl<'a> Builder for EditChannel<'a> {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+        chan_id: ChannelId,
+    ) -> Result<GuildChannel> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(cache, ctx, Permissions::MANAGE_CHANNELS)?;
+                crate::utils::user_has_perms_cache(cache, chan_id, Permissions::MANAGE_CHANNELS)?;
                 if self.permission_overwrites.is_some() {
-                    crate::utils::user_has_perms_cache(cache, ctx, Permissions::MANAGE_ROLES)?;
+                    crate::utils::user_has_perms_cache(cache, chan_id, Permissions::MANAGE_ROLES)?;
                 }
             }
         }
 
-        cache_http.http().edit_channel(ctx, &self, self.audit_log_reason).await
+        cache_http.http().edit_channel(chan_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -309,13 +307,6 @@ impl<'a> EditGuild<'a> {
         self.premium_progress_bar_enabled = Some(premium_progress_bar_enabled);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditGuild<'a> {
-    type Context<'ctx> = GuildId;
-    type Built = PartialGuild;
 
     /// Edits the given guild.
     ///
@@ -327,14 +318,15 @@ impl<'a> Builder for EditGuild<'a> {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+        guild_id: GuildId,
+    ) -> Result<PartialGuild> {
         #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, ctx, Permissions::MANAGE_GUILD)?;
+        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_GUILD)?;
 
-        cache_http.http().edit_guild(ctx, &self, self.audit_log_reason).await
+        cache_http.http().edit_guild(guild_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -62,13 +60,6 @@ impl<'a> EditGuildWelcomeScreen<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditGuildWelcomeScreen<'a> {
-    type Context<'ctx> = GuildId;
-    type Built = GuildWelcomeScreen;
 
     /// Edits the guild's welcome screen.
     ///
@@ -79,12 +70,9 @@ impl<'a> Builder for EditGuildWelcomeScreen<'a> {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().edit_guild_welcome_screen(ctx, &self, self.audit_log_reason).await
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<GuildWelcomeScreen> {
+        http.edit_guild_welcome_screen(guild_id, &self, self.audit_log_reason).await
     }
 }
 

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -44,13 +42,6 @@ impl<'a> EditGuildWidget<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditGuildWidget<'a> {
-    type Context<'ctx> = GuildId;
-    type Built = GuildWidget;
 
     /// Edits the guild's widget.
     ///
@@ -61,11 +52,8 @@ impl<'a> Builder for EditGuildWidget<'a> {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().edit_guild_widget(ctx, &self, self.audit_log_reason).await
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<GuildWidget> {
+        http.edit_guild_widget(guild_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -135,13 +133,6 @@ impl<'a> EditMember<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditMember<'a> {
-    type Context<'ctx> = (GuildId, UserId);
-    type Built = Member;
 
     /// Edits the properties of the guild member.
     ///
@@ -150,11 +141,8 @@ impl<'a> Builder for EditMember<'a> {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().edit_member(ctx.0, ctx.1, &self, self.audit_log_reason).await
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: &Http, guild_id: GuildId, user_id: UserId) -> Result<Member> {
+        http.edit_member(guild_id, user_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -202,9 +200,7 @@ impl<'a> EditMessage<'a> {
         self.attachments = Some(EditAttachments::new());
         self
     }
-}
 
-impl EditMessage<'_> {
     fn is_only_suppress_embeds(&self) -> bool {
         self.flags == Some(MessageFlags::SUPPRESS_EMBEDS)
             && self.content.is_none()
@@ -213,13 +209,6 @@ impl EditMessage<'_> {
             && self.components.is_none()
             && self.attachments.is_none()
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for EditMessage<'_> {
-    type Context<'ctx> = (ChannelId, MessageId, Option<UserId>);
-    type Built = Message;
 
     /// Edits a message in the channel.
     ///
@@ -244,15 +233,18 @@ impl Builder for EditMessage<'_> {
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     /// [`From<Embed>`]: CreateEmbed#impl-From<Embed>
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         mut self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+        channel_id: ChannelId,
+        message_id: MessageId,
+        user_id: Option<UserId>,
+    ) -> Result<Message> {
         self.check_length()?;
 
         #[cfg(feature = "cache")]
-        if let Some(user_id) = ctx.2 {
+        if let Some(user_id) = user_id {
             if let Some(cache) = cache_http.cache() {
                 if user_id != cache.current_user().id && !self.is_only_suppress_embeds() {
                     return Err(Error::Model(ModelError::InvalidUser));
@@ -262,6 +254,6 @@ impl Builder for EditMessage<'_> {
 
         let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
 
-        cache_http.http().edit_message(ctx.0, ctx.1, &self, files).await
+        cache_http.http().edit_message(channel_id, message_id, &self, files).await
     }
 }

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -1,10 +1,8 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
@@ -66,13 +64,6 @@ impl<'a> EditProfile<'a> {
         self.username = Some(username.into());
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for EditProfile<'_> {
-    type Context<'ctx> = ();
-    type Built = CurrentUser;
 
     /// Edit the current user's profile with the fields set.
     ///
@@ -80,11 +71,8 @@ impl Builder for EditProfile<'_> {
     ///
     /// Returns an [`Error::Http`] if an invalid value is set. May also return an [`Error::Json`]
     /// if there is an error in deserializing the API response.
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        _ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().edit_profile(&self).await
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: &Http) -> Result<CurrentUser> {
+        http.edit_profile(&self).await
     }
 }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::CacheHttp;
@@ -149,13 +147,6 @@ impl<'a> EditRole<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditRole<'a> {
-    type Context<'ctx> = (GuildId, Option<RoleId>);
-    type Built = Role;
 
     /// Edits the role.
     ///
@@ -167,13 +158,13 @@ impl<'a> Builder for EditRole<'a> {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        let (guild_id, role_id) = ctx;
-
+        guild_id: GuildId,
+        role_id: Option<RoleId>,
+    ) -> Result<Role> {
         #[cfg(feature = "cache")]
         crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_ROLES)?;
 

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -1,10 +1,8 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::{CreateAttachment, CreateScheduledEventMetadata};
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -164,13 +162,6 @@ impl<'a> EditScheduledEvent<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditScheduledEvent<'a> {
-    type Context<'ctx> = (GuildId, ScheduledEventId);
-    type Built = ScheduledEvent;
 
     /// Modifies a scheduled event in the guild with the data set, if any.
     ///
@@ -184,11 +175,13 @@ impl<'a> Builder for EditScheduledEvent<'a> {
     ///
     /// [Create Events]: Permissions::CREATE_EVENTS
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().edit_scheduled_event(ctx.0, ctx.1, &self, self.audit_log_reason).await
+        http: &Http,
+        guild_id: GuildId,
+        event_id: ScheduledEventId,
+    ) -> Result<ScheduledEvent> {
+        http.edit_scheduled_event(guild_id, event_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_sticker.rs
+++ b/src/builder/edit_sticker.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(any(feature = "http", doc))]
@@ -68,13 +66,6 @@ impl<'a> EditSticker<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditSticker<'a> {
-    type Context<'ctx> = (GuildId, StickerId);
-    type Built = Sticker;
 
     /// Edits the sticker.
     ///
@@ -88,11 +79,13 @@ impl<'a> Builder for EditSticker<'a> {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().edit_sticker(ctx.0, ctx.1, &self, self.audit_log_reason).await
+        http: &Http,
+        guild_id: GuildId,
+        sticker_id: StickerId,
+    ) -> Result<Sticker> {
+        http.edit_sticker(guild_id, sticker_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -3,9 +3,7 @@ use std::borrow::Cow;
 use nonmax::NonMaxU16;
 
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -104,24 +102,14 @@ impl<'a> EditThread<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditThread<'a> {
-    type Context<'ctx> = ChannelId;
-    type Built = GuildChannel;
 
     /// Edits the thread.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().edit_thread(ctx, &self, self.audit_log_reason).await
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: &Http, channel_id: ChannelId) -> Result<GuildChannel> {
+        http.edit_thread(channel_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
 use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
@@ -60,13 +58,6 @@ impl EditVoiceState {
         self.request_to_speak_timestamp = Some(Some(timestamp.into()));
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for EditVoiceState {
-    type Context<'ctx> = (GuildId, ChannelId, Option<UserId>);
-    type Built = ();
 
     /// Edits the given user's voice state in a stage channel. Providing a [`UserId`] will edit
     /// that user's voice state, otherwise the current user's voice state will be edited.
@@ -84,12 +75,14 @@ impl Builder for EditVoiceState {
     ///
     /// [Request to Speak]: Permissions::REQUEST_TO_SPEAK
     /// [Mute Members]: Permissions::MUTE_MEMBERS
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         mut self,
         cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        let (guild_id, channel_id, user_id) = ctx;
+        guild_id: GuildId,
+        channel_id: ChannelId,
+        user_id: Option<UserId>,
+    ) -> Result<()> {
         #[cfg(feature = "cache")]
         {
             if let Some(cache) = cache_http.cache() {

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -1,10 +1,8 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -61,13 +59,6 @@ impl<'a> EditWebhook<'a> {
         self.audit_log_reason = Some(reason);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl<'a> Builder for EditWebhook<'a> {
-    type Context<'ctx> = (WebhookId, Option<&'ctx str>);
-    type Built = Webhook;
 
     /// Edits the webhook corresponding to the provided [`WebhookId`] and token, and returns the
     /// resulting new [`Webhook`].
@@ -77,19 +68,18 @@ impl<'a> Builder for EditWebhook<'a> {
     /// Returns [`Error::Http`] if the content is malformed, or if the token is invalid.
     ///
     /// Returns [`Error::Json`] if there is an error in deserialising Discord's response.
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        match ctx.1 {
+        http: &Http,
+        webhook_id: WebhookId,
+        webhook_token: Option<&str>,
+    ) -> Result<Webhook> {
+        match webhook_token {
             Some(token) => {
-                cache_http
-                    .http()
-                    .edit_webhook_with_token(ctx.0, token, &self, self.audit_log_reason)
-                    .await
+                http.edit_webhook_with_token(webhook_id, token, &self, self.audit_log_reason).await
             },
-            None => cache_http.http().edit_webhook(ctx.0, &self, self.audit_log_reason).await,
+            None => http.edit_webhook(webhook_id, &self, self.audit_log_reason).await,
         }
     }
 }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -10,7 +8,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -142,13 +140,6 @@ impl<'a> EditWebhookMessage<'a> {
         self.attachments = Some(EditAttachments::new());
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for EditWebhookMessage<'_> {
-    type Context<'ctx> = (WebhookId, &'ctx str, MessageId);
-    type Built = Message;
 
     /// Edits the webhook's message.
     ///
@@ -163,18 +154,26 @@ impl Builder for EditWebhookMessage<'_> {
     /// invalid, or the given message Id does not belong to the webhook.
     ///
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         mut self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+        http: &Http,
+        webhook_id: WebhookId,
+        webhook_token: &str,
+        message_id: MessageId,
+    ) -> Result<Message> {
         self.check_length()?;
 
         let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
 
-        cache_http
-            .http()
-            .edit_webhook_message(ctx.0, self.thread_id, ctx.1, ctx.2, &self, files)
-            .await
+        http.edit_webhook_message(
+            webhook_id,
+            self.thread_id,
+            webhook_token,
+            message_id,
+            &self,
+            files,
+        )
+        .await
     }
 }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use super::Builder;
 use super::{
     CreateActionRow,
     CreateAllowedMentions,
@@ -10,7 +8,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -326,14 +324,6 @@ impl<'a> ExecuteWebhook<'a> {
         self.thread_name = Some(thread_name);
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for ExecuteWebhook<'_> {
-    type Context<'ctx> = (WebhookId, &'ctx str, bool);
-    type Built = Option<Message>;
-
     /// Executes the webhook with the given content.
     ///
     /// # Errors
@@ -342,15 +332,18 @@ impl Builder for ExecuteWebhook<'_> {
     /// execution is attempted in a thread not belonging to the webhook's [`Channel`].
     ///
     /// Returns [`Error::Json`] if there is an error in deserialising Discord's response.
-    async fn execute(
+    #[cfg(feature = "http")]
+    pub async fn execute(
         mut self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
+        http: &Http,
+        webhook_id: WebhookId,
+        webhook_token: &str,
+        wait: bool,
+    ) -> Result<Option<Message>> {
         self.check_length()?;
 
         let files = self.attachments.take_files();
 
-        cache_http.http().execute_webhook(ctx.0, self.thread_id, ctx.1, ctx.2, files, &self).await
+        http.execute_webhook(webhook_id, self.thread_id, webhook_token, wait, files, &self).await
     }
 }

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "http")]
-use super::Builder;
-#[cfg(feature = "http")]
-use crate::http::{CacheHttp, MessagePagination};
+use crate::http::{Http, MessagePagination};
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -88,13 +86,6 @@ impl GetMessages {
         self.limit = Some(limit.min(100));
         self
     }
-}
-
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-impl Builder for GetMessages {
-    type Context<'ctx> = ChannelId;
-    type Built = Vec<Message>;
 
     /// Gets messages from the channel.
     ///
@@ -106,12 +97,9 @@ impl Builder for GetMessages {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built> {
-        cache_http.http().get_messages(ctx, self.search_filter.map(Into::into), self.limit).await
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: &Http, channel_id: ChannelId) -> Result<Vec<Message>> {
+        http.get_messages(channel_id, self.search_filter.map(Into::into), self.limit).await
     }
 }
 

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -8,26 +8,9 @@
 #![allow(clippy::option_option)]
 
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
-#[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::ModelError;
-
-/// Common trait for all HTTP request builders in this module.
-#[cfg(feature = "http")]
-#[async_trait::async_trait]
-pub trait Builder {
-    /// Additional data that's only required when sending a request off to the API.
-    type Context<'ctx>;
-    type Built;
-    /// Serializes a builder's fields and sends the request off the API, returning the response.
-    async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        ctx: Self::Context<'_>,
-    ) -> Result<Self::Built>;
-}
 
 #[cfg(feature = "http")]
 pub(crate) fn check_lengths(

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "model")]
-use crate::builder::{Builder, CreateCommand};
+use crate::builder::CreateCommand;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::channel::ChannelType;
 use crate::model::id::{
@@ -140,11 +140,8 @@ impl Command {
     /// See [`CreateCommand::execute`] for a list of possible errors.
     ///
     /// [`InteractionCreate`]: crate::client::EventHandler::interaction_create
-    pub async fn create_global_command(
-        cache_http: impl CacheHttp,
-        builder: CreateCommand<'_>,
-    ) -> Result<Command> {
-        builder.execute(cache_http, (None, None)).await
+    pub async fn create_global_command(http: &Http, builder: CreateCommand<'_>) -> Result<Command> {
+        builder.execute(http, None, None).await
     }
 
     /// Override all global application commands.
@@ -165,11 +162,11 @@ impl Command {
     ///
     /// See [`CreateCommand::execute`] for a list of possible errors.
     pub async fn edit_global_command(
-        cache_http: impl CacheHttp,
+        http: &Http,
         command_id: CommandId,
         builder: CreateCommand<'_>,
     ) -> Result<Command> {
-        builder.execute(cache_http, (None, Some(command_id))).await
+        builder.execute(http, None, Some(command_id)).await
     }
 
     /// Gets all global commands.

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "model")]
 use crate::builder::{
-    Builder,
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     CreateInteractionResponseMessage,
@@ -15,7 +14,7 @@ use crate::builder::{
 #[cfg(feature = "collector")]
 use crate::client::Context;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::application::{CommandOptionType, CommandType};
 use crate::model::channel::{Attachment, Message, PartialChannel};
@@ -104,10 +103,10 @@ impl CommandInteraction {
     /// deserializing the API response.
     pub async fn create_response(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateInteractionResponse<'_>,
     ) -> Result<()> {
-        builder.execute(cache_http, (self.id, &self.token)).await
+        builder.execute(http, self.id, &self.token).await
     }
 
     /// Edits the initial interaction response.
@@ -121,10 +120,10 @@ impl CommandInteraction {
     /// deserializing the API response.
     pub async fn edit_response(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditInteractionResponse<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, &self.token).await
+        builder.execute(http, &self.token).await
     }
 
     /// Deletes the initial interaction response.
@@ -150,10 +149,10 @@ impl CommandInteraction {
     /// response.
     pub async fn create_followup(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (None, &self.token)).await
+        builder.execute(http, None, &self.token).await
     }
 
     /// Edits a followup response to the response sent.
@@ -167,11 +166,11 @@ impl CommandInteraction {
     /// response.
     pub async fn edit_followup(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (Some(message_id), &self.token)).await
+        builder.execute(http, Some(message_id), &self.token).await
     }
 
     /// Deletes a followup message.
@@ -200,9 +199,9 @@ impl CommandInteraction {
     ///
     /// Returns an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is
     /// an error in deserializing the API response.
-    pub async fn defer(&self, cache_http: impl CacheHttp) -> Result<()> {
+    pub async fn defer(&self, http: &Http) -> Result<()> {
         let builder = CreateInteractionResponse::Defer(CreateInteractionResponseMessage::default());
-        self.create_response(cache_http, builder).await
+        self.create_response(http, builder).await
     }
 
     /// Helper function to defer an interaction ephemerally
@@ -211,11 +210,11 @@ impl CommandInteraction {
     ///
     /// May also return an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if
     /// there is an error in deserializing the API response.
-    pub async fn defer_ephemeral(&self, cache_http: impl CacheHttp) -> Result<()> {
+    pub async fn defer_ephemeral(&self, http: &Http) -> Result<()> {
         let builder = CreateInteractionResponse::Defer(
             CreateInteractionResponseMessage::new().ephemeral(true),
         );
-        self.create_response(cache_http, builder).await
+        self.create_response(http, builder).await
     }
 
     /// See [`CreateQuickModal`].

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -4,7 +4,6 @@ use serde_json::{from_value, json};
 
 #[cfg(feature = "model")]
 use crate::builder::{
-    Builder,
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     CreateInteractionResponseMessage,
@@ -13,7 +12,7 @@ use crate::builder::{
 #[cfg(feature = "collector")]
 use crate::client::Context;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 #[cfg(all(feature = "collector", feature = "utils"))]
@@ -86,10 +85,10 @@ impl ComponentInteraction {
     /// deserializing the API response.
     pub async fn create_response(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateInteractionResponse<'_>,
     ) -> Result<()> {
-        builder.execute(cache_http, (self.id, &self.token)).await
+        builder.execute(http, self.id, &self.token).await
     }
 
     /// Edits the initial interaction response.
@@ -103,10 +102,10 @@ impl ComponentInteraction {
     /// deserializing the API response.
     pub async fn edit_response(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditInteractionResponse<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, &self.token).await
+        builder.execute(http, &self.token).await
     }
 
     /// Deletes the initial interaction response.
@@ -132,10 +131,10 @@ impl ComponentInteraction {
     /// response.
     pub async fn create_followup(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (None, &self.token)).await
+        builder.execute(http, None, &self.token).await
     }
 
     /// Edits a followup response to the response sent.
@@ -149,11 +148,11 @@ impl ComponentInteraction {
     /// response.
     pub async fn edit_followup(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (Some(message_id), &self.token)).await
+        builder.execute(http, Some(message_id), &self.token).await
     }
 
     /// Deletes a followup message.
@@ -182,8 +181,8 @@ impl ComponentInteraction {
     ///
     /// Returns an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is
     /// an error in deserializing the API response.
-    pub async fn defer(&self, cache_http: impl CacheHttp) -> Result<()> {
-        self.create_response(cache_http, CreateInteractionResponse::Acknowledge).await
+    pub async fn defer(&self, http: &Http) -> Result<()> {
+        self.create_response(http, CreateInteractionResponse::Acknowledge).await
     }
 
     /// Helper function to defer an interaction ephemerally
@@ -192,11 +191,11 @@ impl ComponentInteraction {
     ///
     /// May also return an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if
     /// there is an error in deserializing the API response.
-    pub async fn defer_ephemeral(&self, cache_http: impl CacheHttp) -> Result<()> {
+    pub async fn defer_ephemeral(&self, http: &Http) -> Result<()> {
         let builder = CreateInteractionResponse::Defer(
             CreateInteractionResponseMessage::new().ephemeral(true),
         );
-        self.create_response(cache_http, builder).await
+        self.create_response(http, builder).await
     }
 
     /// See [`CreateQuickModal`].

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -3,14 +3,13 @@ use serde::Serialize;
 
 #[cfg(feature = "model")]
 use crate::builder::{
-    Builder,
     CreateInteractionResponse,
     CreateInteractionResponseFollowup,
     CreateInteractionResponseMessage,
     EditInteractionResponse,
 };
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
@@ -85,10 +84,10 @@ impl ModalInteraction {
     /// deserializing the API response.
     pub async fn create_response(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateInteractionResponse<'_>,
     ) -> Result<()> {
-        builder.execute(cache_http, (self.id, &self.token)).await
+        builder.execute(http, self.id, &self.token).await
     }
 
     /// Edits the initial interaction response.
@@ -102,10 +101,10 @@ impl ModalInteraction {
     /// deserializing the API response.
     pub async fn edit_response(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditInteractionResponse<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, &self.token).await
+        builder.execute(http, &self.token).await
     }
 
     /// Deletes the initial interaction response.
@@ -131,10 +130,10 @@ impl ModalInteraction {
     /// response.
     pub async fn create_followup(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (None, &self.token)).await
+        builder.execute(http, None, &self.token).await
     }
 
     /// Edits a followup response to the response sent.
@@ -148,11 +147,11 @@ impl ModalInteraction {
     /// response.
     pub async fn edit_followup(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (Some(message_id), &self.token)).await
+        builder.execute(http, Some(message_id), &self.token).await
     }
 
     /// Deletes a followup message.
@@ -171,8 +170,8 @@ impl ModalInteraction {
     ///
     /// Returns an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is
     /// an error in deserializing the API response.
-    pub async fn defer(&self, cache_http: impl CacheHttp) -> Result<()> {
-        self.create_response(cache_http, CreateInteractionResponse::Acknowledge).await
+    pub async fn defer(&self, http: &Http) -> Result<()> {
+        self.create_response(http, CreateInteractionResponse::Acknowledge).await
     }
 
     /// Helper function to defer an interaction ephemerally
@@ -181,11 +180,11 @@ impl ModalInteraction {
     ///
     /// May also return an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if
     /// there is an error in deserializing the API response.
-    pub async fn defer_ephemeral(&self, cache_http: impl CacheHttp) -> Result<()> {
+    pub async fn defer_ephemeral(&self, http: &Http) -> Result<()> {
         let builder = CreateInteractionResponse::Defer(
             CreateInteractionResponseMessage::new().ephemeral(true),
         );
-        self.create_response(cache_http, builder).await
+        self.create_response(http, builder).await
     }
 }
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -7,7 +7,6 @@ use futures::stream::Stream;
 
 #[cfg(feature = "model")]
 use crate::builder::{
-    Builder,
     CreateAttachment,
     CreateForumPost,
     CreateInvite,
@@ -325,7 +324,7 @@ impl ChannelId {
         message_id: MessageId,
         builder: EditMessage<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, (self, message_id, None)).await
+        builder.execute(cache_http, self, message_id, None).await
     }
 
     /// Follows the News Channel
@@ -450,12 +449,8 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-    pub async fn messages(
-        self,
-        cache_http: impl CacheHttp,
-        builder: GetMessages,
-    ) -> Result<Vec<Message>> {
-        builder.execute(cache_http, self).await
+    pub async fn messages(self, http: &Http, builder: GetMessages) -> Result<Vec<Message>> {
+        builder.execute(http, self).await
     }
 
     /// Streams over all the messages in a channel.
@@ -693,9 +688,9 @@ impl ChannelId {
         builder: CreateMessage<'_>,
     ) -> Result<Message> {
         #[cfg(feature = "cache")]
-        let msg = builder.execute(cache_http, (self, None)).await;
+        let msg = builder.execute(cache_http, self, None).await;
         #[cfg(not(feature = "cache"))]
-        let msg = builder.execute(cache_http, (self,)).await;
+        let msg = builder.execute(cache_http, self).await;
         msg
     }
 
@@ -852,12 +847,8 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn edit_thread(
-        self,
-        cache_http: impl CacheHttp,
-        builder: EditThread<'_>,
-    ) -> Result<GuildChannel> {
-        builder.execute(cache_http, self).await
+    pub async fn edit_thread(self, http: &Http, builder: EditThread<'_>) -> Result<GuildChannel> {
+        builder.execute(http, self).await
     }
 
     /// Deletes a stage instance.
@@ -878,11 +869,11 @@ impl ChannelId {
     #[doc(alias = "create_public_thread")]
     pub async fn create_thread_from_message(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        builder.execute(cache_http, (self, Some(message_id))).await
+        builder.execute(http, self, Some(message_id)).await
     }
 
     /// Creates a thread that is not connected to a message.
@@ -893,10 +884,10 @@ impl ChannelId {
     #[doc(alias = "create_public_thread", alias = "create_private_thread")]
     pub async fn create_thread(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        builder.execute(cache_http, (self, None)).await
+        builder.execute(http, self, None).await
     }
 
     /// Creates a post in a forum channel.
@@ -906,10 +897,10 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn create_forum_post(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateForumPost<'_>,
     ) -> Result<GuildChannel> {
-        builder.execute(cache_http, self).await
+        builder.execute(http, self).await
     }
 
     /// Gets the thread members, if this channel is a thread.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -7,7 +7,6 @@ use nonmax::{NonMaxU16, NonMaxU32, NonMaxU8};
 
 #[cfg(feature = "model")]
 use crate::builder::{
-    Builder,
     CreateAttachment,
     CreateForumPost,
     CreateInvite,
@@ -494,12 +493,8 @@ impl GuildChannel {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
-    pub async fn edit_thread(
-        &mut self,
-        cache_http: impl CacheHttp,
-        builder: EditThread<'_>,
-    ) -> Result<()> {
-        *self = self.id.edit_thread(cache_http, builder).await?;
+    pub async fn edit_thread(&mut self, http: &Http, builder: EditThread<'_>) -> Result<()> {
+        *self = self.id.edit_thread(http, builder).await?;
         Ok(())
     }
 
@@ -549,7 +544,7 @@ impl GuildChannel {
         user_id: UserId,
         builder: EditVoiceState,
     ) -> Result<()> {
-        builder.execute(cache_http, (self.guild_id, self.id, Some(user_id))).await
+        builder.execute(cache_http, self.guild_id, self.id, Some(user_id)).await
     }
 
     /// Edits the current user's voice state in a stage channel.
@@ -601,7 +596,7 @@ impl GuildChannel {
         cache_http: impl CacheHttp,
         builder: EditVoiceState,
     ) -> Result<()> {
-        builder.execute(cache_http, (self.guild_id, self.id, None)).await
+        builder.execute(cache_http, self.guild_id, self.id, None).await
     }
 
     /// Follows the News Channel
@@ -678,12 +673,8 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-    pub async fn messages(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: GetMessages,
-    ) -> Result<Vec<Message>> {
-        self.id.messages(cache_http, builder).await
+    pub async fn messages(&self, http: &Http, builder: GetMessages) -> Result<Vec<Message>> {
+        self.id.messages(http, builder).await
     }
 
     /// Returns the name of the guild channel.
@@ -841,9 +832,9 @@ impl GuildChannel {
         builder: CreateMessage<'_>,
     ) -> Result<Message> {
         #[cfg(feature = "cache")]
-        let msg = builder.execute(cache_http, (self.id, Some(self.guild_id))).await;
+        let msg = builder.execute(cache_http, self.id, Some(self.guild_id)).await;
         #[cfg(not(feature = "cache"))]
-        let msg = builder.execute(cache_http, (self.id,)).await;
+        let msg = builder.execute(cache_http, self.id).await;
         msg
     }
 
@@ -1064,11 +1055,11 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn create_thread_from_message(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_thread_from_message(cache_http, message_id, builder).await
+        self.id.create_thread_from_message(http, message_id, builder).await
     }
 
     /// Creates a thread that is not connected to a message.
@@ -1078,10 +1069,10 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn create_thread(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateThread<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_thread(cache_http, builder).await
+        self.id.create_thread(http, builder).await
     }
 
     /// Creates a post in a forum channel.
@@ -1091,10 +1082,10 @@ impl GuildChannel {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn create_forum_post(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateForumPost<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_forum_post(cache_http, builder).await
+        self.id.create_forum_post(http, builder).await
     }
 }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -9,7 +9,7 @@ use std::fmt::Write;
 use nonmax::NonMaxU64;
 
 #[cfg(all(feature = "model", feature = "utils"))]
-use crate::builder::{Builder, CreateAllowedMentions, CreateMessage, EditMessage};
+use crate::builder::{CreateAllowedMentions, CreateMessage, EditMessage};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "collector")]
@@ -359,8 +359,7 @@ impl Message {
             }
         }
 
-        *self =
-            builder.execute(cache_http, (self.channel_id, self.id, Some(self.author.id))).await?;
+        *self = builder.execute(cache_http, self.channel_id, self.id, Some(self.author.id)).await?;
         Ok(())
     }
 

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -180,12 +180,8 @@ impl PrivateChannel {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-    pub async fn messages(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: GetMessages,
-    ) -> Result<Vec<Message>> {
-        self.id.messages(cache_http, builder).await
+    pub async fn messages(&self, http: &Http, builder: GetMessages) -> Result<Vec<Message>> {
+        self.id.messages(http, builder).await
     }
 
     /// Returns "DM with $username#discriminator".

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -8,7 +8,6 @@ use serde_json::json;
 #[cfg(feature = "model")]
 use crate::builder::{
     AddMember,
-    Builder,
     CreateChannel,
     CreateCommand,
     CreateScheduledEvent,
@@ -110,10 +109,10 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn create_automod_rule(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        builder.execute(cache_http, (self, None)).await
+        builder.execute(http, self, None).await
     }
 
     /// Edit an auto moderation [`Rule`], given its Id.
@@ -127,11 +126,11 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_automod_rule(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         rule_id: RuleId,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        builder.execute(cache_http, (self, Some(rule_id))).await
+        builder.execute(http, self, Some(rule_id)).await
     }
 
     /// Deletes an auto moderation [`Rule`] from the guild.
@@ -158,11 +157,11 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn add_member(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user_id: UserId,
         builder: AddMember<'_>,
     ) -> Result<Option<Member>> {
-        builder.execute(cache_http, (self, user_id)).await
+        builder.execute(http, self, user_id).await
     }
 
     /// Ban a [`User`] from the guild, deleting a number of days' worth of messages (`dmd`) between
@@ -381,12 +380,8 @@ impl GuildId {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn create_role(
-        self,
-        cache_http: impl CacheHttp,
-        builder: EditRole<'_>,
-    ) -> Result<Role> {
-        builder.execute(cache_http, (self, None)).await
+    pub async fn create_role(self, http: &Http, builder: EditRole<'_>) -> Result<Role> {
+        builder.execute(http, self, None).await
     }
 
     /// Creates a new scheduled event in the guild with the data set, if any.
@@ -595,11 +590,11 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn edit_member(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user_id: UserId,
         builder: EditMember<'_>,
     ) -> Result<Member> {
-        builder.execute(cache_http, (self, user_id)).await
+        builder.execute(http, self, user_id).await
     }
 
     /// Edits the guild's MFA level. Returns the new level on success.
@@ -674,7 +669,7 @@ impl GuildId {
         role_id: RoleId,
         builder: EditRole<'_>,
     ) -> Result<Role> {
-        builder.execute(cache_http, (self, Some(role_id))).await
+        builder.execute(cache_http, self, Some(role_id)).await
     }
 
     /// Modifies a scheduled event in the guild with the data set, if any.
@@ -691,11 +686,11 @@ impl GuildId {
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn edit_scheduled_event(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         event_id: ScheduledEventId,
         builder: EditScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
-        builder.execute(cache_http, (self, event_id)).await
+        builder.execute(http, self, event_id).await
     }
 
     /// Edits a sticker.
@@ -729,11 +724,11 @@ impl GuildId {
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
     pub async fn edit_sticker(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         sticker_id: StickerId,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
-        builder.execute(cache_http, (self, sticker_id)).await
+        builder.execute(http, self, sticker_id).await
     }
 
     /// Edit the position of a [`Role`] relative to all others in the [`Guild`].
@@ -772,10 +767,10 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_welcome_screen(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
-        builder.execute(cache_http, self).await
+        builder.execute(http, self).await
     }
 
     /// Edits the guild's widget.
@@ -789,10 +784,10 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_widget(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
-        builder.execute(cache_http, self).await
+        builder.execute(http, self).await
     }
 
     /// Gets all of the guild's roles over the REST API.
@@ -1044,12 +1039,12 @@ impl GuildId {
     /// [Move Members]: Permissions::MOVE_MEMBERS
     pub async fn move_member(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user_id: UserId,
         channel_id: ChannelId,
     ) -> Result<Member> {
         let builder = EditMember::new().voice_channel(channel_id);
-        self.edit_member(cache_http, user_id, builder).await
+        self.edit_member(http, user_id, builder).await
     }
 
     /// Returns the name of whatever guild this id holds.
@@ -1069,12 +1064,8 @@ impl GuildId {
     /// currently in a voice channel for this [`Guild`].
     ///
     /// [Move Members]: Permissions::MOVE_MEMBERS
-    pub async fn disconnect_member(
-        self,
-        cache_http: impl CacheHttp,
-        user_id: UserId,
-    ) -> Result<Member> {
-        self.edit_member(cache_http, user_id, EditMember::new().disconnect_member()).await
+    pub async fn disconnect_member(self, http: &Http, user_id: UserId) -> Result<Member> {
+        self.edit_member(http, user_id, EditMember::new().disconnect_member()).await
     }
 
     /// Gets the number of [`Member`]s that would be pruned with the given number of days.
@@ -1368,12 +1359,8 @@ impl GuildId {
     /// # Errors
     ///
     /// See [`CreateCommand::execute`] for a list of possible errors.
-    pub async fn create_command(
-        self,
-        cache_http: impl CacheHttp,
-        builder: CreateCommand<'_>,
-    ) -> Result<Command> {
-        builder.execute(cache_http, (Some(self), None)).await
+    pub async fn create_command(self, http: &Http, builder: CreateCommand<'_>) -> Result<Command> {
+        builder.execute(http, Some(self), None).await
     }
 
     /// Override all guild application commands.
@@ -1398,11 +1385,11 @@ impl GuildId {
     /// See [`EditCommandPermissions::execute`] for a list of possible errors.
     pub async fn edit_command_permissions(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         command_id: CommandId,
         builder: EditCommandPermissions<'_>,
     ) -> Result<CommandPermissions> {
-        builder.execute(cache_http, (self, command_id)).await
+        builder.execute(http, self, command_id).await
     }
 
     /// Get all guild application commands.
@@ -1439,11 +1426,11 @@ impl GuildId {
     /// See [`CreateCommand::execute`] for a list of possible errors.
     pub async fn edit_command(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         command_id: CommandId,
         builder: CreateCommand<'_>,
     ) -> Result<Command> {
-        builder.execute(cache_http, (Some(self), Some(command_id))).await
+        builder.execute(http, Some(self), Some(command_id)).await
     }
 
     /// Delete guild application command by its Id.

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -198,11 +198,11 @@ impl Member {
     #[doc(alias = "timeout")]
     pub async fn disable_communication_until(
         &mut self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         time: Timestamp,
     ) -> Result<()> {
         let builder = EditMember::new().disable_communication_until(time);
-        match self.guild_id.edit_member(cache_http, self.user.id, builder).await {
+        match self.guild_id.edit_member(http, self.user.id, builder).await {
             Ok(_) => {
                 self.communication_disabled_until = Some(time);
                 Ok(())
@@ -241,12 +241,8 @@ impl Member {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks necessary permissions.
-    pub async fn edit(
-        &mut self,
-        cache_http: impl CacheHttp,
-        builder: EditMember<'_>,
-    ) -> Result<()> {
-        *self = self.guild_id.edit_member(cache_http, self.user.id, builder).await?;
+    pub async fn edit(&mut self, http: &Http, builder: EditMember<'_>) -> Result<()> {
+        *self = self.guild_id.edit_member(http, self.user.id, builder).await?;
         Ok(())
     }
 
@@ -260,9 +256,9 @@ impl Member {
     ///
     /// [Moderate Members]: Permissions::MODERATE_MEMBERS
     #[doc(alias = "timeout")]
-    pub async fn enable_communication(&mut self, cache_http: impl CacheHttp) -> Result<()> {
+    pub async fn enable_communication(&mut self, http: &Http) -> Result<()> {
         let builder = EditMember::new().enable_communication();
-        *self = self.guild_id.edit_member(cache_http, self.user.id, builder).await?;
+        *self = self.guild_id.edit_member(http, self.user.id, builder).await?;
         Ok(())
     }
 
@@ -388,12 +384,8 @@ impl Member {
     /// current user lacks permission.
     ///
     /// [Move Members]: Permissions::MOVE_MEMBERS
-    pub async fn move_to_voice_channel(
-        &self,
-        cache_http: impl CacheHttp,
-        channel: ChannelId,
-    ) -> Result<Member> {
-        self.guild_id.move_member(cache_http, self.user.id, channel).await
+    pub async fn move_to_voice_channel(&self, http: &Http, channel: ChannelId) -> Result<Member> {
+        self.guild_id.move_member(http, self.user.id, channel).await
     }
 
     /// Disconnects the member from their voice channel if any.
@@ -406,8 +398,8 @@ impl Member {
     /// current user lacks permission.
     ///
     /// [Move Members]: Permissions::MOVE_MEMBERS
-    pub async fn disconnect_from_voice(&self, cache_http: impl CacheHttp) -> Result<Member> {
-        self.guild_id.disconnect_member(cache_http, self.user.id).await
+    pub async fn disconnect_from_voice(&self, http: &Http) -> Result<Member> {
+        self.guild_id.disconnect_member(http, self.user.id).await
     }
 
     /// Returns the guild-level permissions for the member.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -322,10 +322,10 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn create_automod_rule(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        self.id.create_automod_rule(cache_http, builder).await
+        self.id.create_automod_rule(http, builder).await
     }
 
     /// Edit an auto moderation [`Rule`], given its Id.
@@ -339,11 +339,11 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_automod_rule(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         rule_id: RuleId,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        self.id.edit_automod_rule(cache_http, rule_id, builder).await
+        self.id.edit_automod_rule(http, rule_id, builder).await
     }
 
     /// Deletes an auto moderation [`Rule`] from the guild.
@@ -533,11 +533,11 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn add_member(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user_id: UserId,
         builder: AddMember<'_>,
     ) -> Result<Option<Member>> {
-        self.id.add_member(cache_http, user_id, builder).await
+        self.id.add_member(http, user_id, builder).await
     }
 
     /// Retrieves a list of [`AuditLogs`] for the guild.
@@ -695,12 +695,8 @@ impl Guild {
     /// See [`CreateCommand::execute`] for a list of possible errors.
     ///
     /// [`CreateCommand::execute`]: ../../builder/struct.CreateCommand.html#method.execute
-    pub async fn create_command(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: CreateCommand<'_>,
-    ) -> Result<Command> {
-        self.id.create_command(cache_http, builder).await
+    pub async fn create_command(&self, http: &Http, builder: CreateCommand<'_>) -> Result<Command> {
+        self.id.create_command(http, builder).await
     }
 
     /// Override all guild application commands.
@@ -727,11 +723,11 @@ impl Guild {
     /// [`CreateCommandPermissionsData::execute`]: ../../builder/struct.CreateCommandPermissionsData.html#method.execute
     pub async fn edit_command_permissions(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         command_id: CommandId,
         builder: EditCommandPermissions<'_>,
     ) -> Result<CommandPermissions> {
-        self.id.edit_command_permissions(cache_http, command_id, builder).await
+        self.id.edit_command_permissions(http, command_id, builder).await
     }
 
     /// Get all guild application commands.
@@ -770,11 +766,11 @@ impl Guild {
     /// [`CreateCommand::execute`]: ../../builder/struct.CreateCommand.html#method.execute
     pub async fn edit_command(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         command_id: CommandId,
         builder: CreateCommand<'_>,
     ) -> Result<Command> {
-        self.id.edit_command(cache_http, command_id, builder).await
+        self.id.edit_command(http, command_id, builder).await
     }
 
     /// Delete guild application command by its Id.
@@ -822,12 +818,8 @@ impl Guild {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn create_role(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: EditRole<'_>,
-    ) -> Result<Role> {
-        self.id.create_role(cache_http, builder).await
+    pub async fn create_role(&self, http: &Http, builder: EditRole<'_>) -> Result<Role> {
+        self.id.create_role(http, builder).await
     }
 
     /// Creates a new scheduled event in the guild with the data set, if any.
@@ -1056,11 +1048,11 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn edit_member(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user_id: UserId,
         builder: EditMember<'_>,
     ) -> Result<Member> {
-        self.id.edit_member(cache_http, user_id, builder).await
+        self.id.edit_member(http, user_id, builder).await
     }
 
     /// Edits the guild's MFA level. Returns the new level on success.
@@ -1170,11 +1162,11 @@ impl Guild {
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn edit_scheduled_event(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         event_id: ScheduledEventId,
         builder: EditScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
-        self.id.edit_scheduled_event(cache_http, event_id, builder).await
+        self.id.edit_scheduled_event(http, event_id, builder).await
     }
 
     /// Edits a sticker.
@@ -1211,11 +1203,11 @@ impl Guild {
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
     pub async fn edit_sticker(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         sticker_id: StickerId,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
-        self.id.edit_sticker(cache_http, sticker_id, builder).await
+        self.id.edit_sticker(http, sticker_id, builder).await
     }
 
     /// Edits the guild's welcome screen.
@@ -1229,10 +1221,10 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_welcome_screen(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
-        self.id.edit_welcome_screen(cache_http, builder).await
+        self.id.edit_welcome_screen(http, builder).await
     }
 
     /// Edits the guild's widget.
@@ -1246,10 +1238,10 @@ impl Guild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_widget(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
-        self.id.edit_widget(cache_http, builder).await
+        self.id.edit_widget(http, builder).await
     }
 
     /// Gets a partial amount of guild data by its Id.
@@ -1782,11 +1774,11 @@ impl Guild {
     /// [Move Members]: Permissions::MOVE_MEMBERS
     pub async fn move_member(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user_id: UserId,
         channel_id: ChannelId,
     ) -> Result<Member> {
-        self.id.move_member(cache_http, user_id, channel_id).await
+        self.id.move_member(http, user_id, channel_id).await
     }
 
     /// Calculate a [`Member`]'s permissions in a given channel in the guild.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -226,10 +226,10 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn create_automod_rule(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        self.id.create_automod_rule(cache_http, builder).await
+        self.id.create_automod_rule(http, builder).await
     }
 
     /// Edit an auto moderation [`Rule`], given its Id.
@@ -243,11 +243,11 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_automod_rule(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         rule_id: RuleId,
         builder: EditAutoModRule<'_>,
     ) -> Result<Rule> {
-        self.id.edit_automod_rule(cache_http, rule_id, builder).await
+        self.id.edit_automod_rule(http, rule_id, builder).await
     }
 
     /// Deletes an auto moderation [`Rule`] from the guild.
@@ -463,12 +463,8 @@ impl PartialGuild {
     /// See [`CreateCommand::execute`] for a list of possible errors.
     ///
     /// [`CreateCommand::execute`]: ../../builder/struct.CreateCommand.html#method.execute
-    pub async fn create_command(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: CreateCommand<'_>,
-    ) -> Result<Command> {
-        self.id.create_command(cache_http, builder).await
+    pub async fn create_command(&self, http: &Http, builder: CreateCommand<'_>) -> Result<Command> {
+        self.id.create_command(http, builder).await
     }
 
     /// Override all guild application commands.
@@ -495,11 +491,11 @@ impl PartialGuild {
     /// [`CreateCommandPermissionsData::execute`]: ../../builder/struct.CreateCommandPermissionsData.html#method.execute
     pub async fn edit_command_permissions(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         command_id: CommandId,
         builder: EditCommandPermissions<'_>,
     ) -> Result<CommandPermissions> {
-        self.id.edit_command_permissions(cache_http, command_id, builder).await
+        self.id.edit_command_permissions(http, command_id, builder).await
     }
 
     /// Get all guild application commands.
@@ -538,11 +534,11 @@ impl PartialGuild {
     /// [`CreateCommand::execute`]: ../../builder/struct.CreateCommand.html#method.execute
     pub async fn edit_command(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         command_id: CommandId,
         builder: CreateCommand<'_>,
     ) -> Result<Command> {
-        self.id.edit_command(cache_http, command_id, builder).await
+        self.id.edit_command(http, command_id, builder).await
     }
 
     /// Delete guild application command by its Id.
@@ -588,12 +584,8 @@ impl PartialGuild {
     /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn create_role(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: EditRole<'_>,
-    ) -> Result<Role> {
-        self.id.create_role(cache_http, builder).await
+    pub async fn create_role(&self, http: &Http, builder: EditRole<'_>) -> Result<Role> {
+        self.id.create_role(http, builder).await
     }
 
     /// Creates a new sticker in the guild with the data set, if any.
@@ -755,11 +747,11 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     pub async fn edit_member(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user_id: UserId,
         builder: EditMember<'_>,
     ) -> Result<Member> {
-        self.id.edit_member(cache_http, user_id, builder).await
+        self.id.edit_member(http, user_id, builder).await
     }
 
     /// Edits the guild's MFA level. Returns the new level on success.
@@ -875,11 +867,11 @@ impl PartialGuild {
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
     pub async fn edit_sticker(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         sticker_id: StickerId,
         builder: EditSticker<'_>,
     ) -> Result<Sticker> {
-        self.id.edit_sticker(cache_http, sticker_id, builder).await
+        self.id.edit_sticker(http, sticker_id, builder).await
     }
 
     /// Edits the guild's welcome screen.
@@ -893,10 +885,10 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_welcome_screen(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditGuildWelcomeScreen<'_>,
     ) -> Result<GuildWelcomeScreen> {
-        self.id.edit_welcome_screen(cache_http, builder).await
+        self.id.edit_welcome_screen(http, builder).await
     }
 
     /// Edits the guild's widget.
@@ -910,10 +902,10 @@ impl PartialGuild {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_widget(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: EditGuildWidget<'_>,
     ) -> Result<GuildWidget> {
-        self.id.edit_widget(cache_http, builder).await
+        self.id.edit_widget(http, builder).await
     }
 
     /// Gets a partial amount of guild data by its Id.
@@ -1219,11 +1211,11 @@ impl PartialGuild {
     /// [Move Members]: Permissions::MOVE_MEMBERS
     pub async fn move_member(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user_id: UserId,
         channel_id: ChannelId,
     ) -> Result<Member> {
-        self.id.move_member(cache_http, user_id, channel_id).await
+        self.id.move_member(http, user_id, channel_id).await
     }
 
     /// Calculate a [`Member`]'s permissions in a given channel in the guild.

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "model")]
 use crate::builder::EditSticker;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::comma_separated_string;
@@ -192,13 +192,9 @@ impl Sticker {
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     /// [Manage Guild Expressions]: Permissions::MANAGE_GUILD_EXPRESSIONS
-    pub async fn edit(
-        &mut self,
-        cache_http: impl CacheHttp,
-        builder: EditSticker<'_>,
-    ) -> Result<()> {
+    pub async fn edit(&mut self, http: &Http, builder: EditSticker<'_>) -> Result<()> {
         if let Some(guild_id) = self.guild_id {
-            *self = guild_id.edit_sticker(cache_http, self.id, builder).await?;
+            *self = guild_id.edit_sticker(http, self.id, builder).await?;
             Ok(())
         } else {
             Err(Error::Model(ModelError::DeleteNitroSticker))

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -12,13 +12,13 @@ use serde_json::json;
 
 use super::prelude::*;
 #[cfg(feature = "model")]
-use crate::builder::{Builder, CreateMessage, EditProfile};
+use crate::builder::{CreateMessage, EditProfile};
 #[cfg(feature = "collector")]
 use crate::collector::{MessageCollector, ReactionCollector};
 #[cfg(feature = "collector")]
 use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
-use crate::http::CacheHttp;
+use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 use crate::model::mention::Mentionable;
 #[cfg(feature = "model")]
@@ -177,12 +177,8 @@ impl CurrentUser {
     ///
     /// Returns an [`Error::Http`] if an invalid value is set. May also return an [`Error::Json`]
     /// if there is an error in deserializing the API response.
-    pub async fn edit(
-        &mut self,
-        cache_http: impl CacheHttp,
-        builder: EditProfile<'_>,
-    ) -> Result<()> {
-        *self = builder.execute(cache_http, ()).await?;
+    pub async fn edit(&mut self, http: &Http, builder: EditProfile<'_>) -> Result<()> {
+        *self = builder.execute(http).await?;
         Ok(())
     }
 }

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -10,7 +10,7 @@ use super::id::{ChannelId, GuildId, WebhookId};
 use super::user::User;
 use super::utils::secret;
 #[cfg(feature = "model")]
-use crate::builder::{Builder, EditWebhook, EditWebhookMessage, ExecuteWebhook};
+use crate::builder::{EditWebhook, EditWebhookMessage, ExecuteWebhook};
 #[cfg(feature = "cache")]
 use crate::cache::{Cache, GuildChannelRef, GuildRef};
 #[cfg(feature = "model")]
@@ -361,13 +361,9 @@ impl Webhook {
     /// May also return an [`Error::Http`] if the content is malformed, or if the token is invalid.
     ///
     /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
-    pub async fn edit(
-        &mut self,
-        cache_http: impl CacheHttp,
-        builder: EditWebhook<'_>,
-    ) -> Result<()> {
+    pub async fn edit(&mut self, http: &Http, builder: EditWebhook<'_>) -> Result<()> {
         let token = self.token.as_ref().map(ExposeSecret::expose_secret).map(String::as_str);
-        *self = builder.execute(cache_http, (self.id, token)).await?;
+        *self = builder.execute(http, self.id, token).await?;
         Ok(())
     }
 
@@ -431,12 +427,12 @@ impl Webhook {
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     pub async fn execute(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         wait: bool,
         builder: ExecuteWebhook<'_>,
     ) -> Result<Option<Message>> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        builder.execute(cache_http, (self.id, token, wait)).await
+        builder.execute(http, self.id, token, wait).await
     }
 
     /// Gets a previously sent message from the webhook.
@@ -474,12 +470,12 @@ impl Webhook {
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     pub async fn edit_message(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: EditWebhookMessage<'_>,
     ) -> Result<Message> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        builder.execute(cache_http, (self.id, token, message_id)).await
+        builder.execute(http, self.id, token, message_id).await
     }
 
     /// Deletes a webhook message.

--- a/src/utils/quick_modal.rs
+++ b/src/utils/quick_modal.rs
@@ -1,12 +1,6 @@
 use std::borrow::Cow;
 
-use crate::builder::{
-    Builder as _,
-    CreateActionRow,
-    CreateInputText,
-    CreateInteractionResponse,
-    CreateModal,
-};
+use crate::builder::{CreateActionRow, CreateInputText, CreateInteractionResponse, CreateModal};
 use crate::client::Context;
 use crate::collector::ModalInteractionCollector;
 use crate::internal::prelude::*;
@@ -105,7 +99,7 @@ impl<'a> CreateQuickModal<'a> {
                     .collect::<Vec<_>>(),
             ),
         );
-        builder.execute(ctx, (interaction_id, token)).await?;
+        builder.execute(&ctx.http, interaction_id, token).await?;
 
         let collector = ModalInteractionCollector::new(ctx.shard.clone())
             .custom_ids(vec![modal_custom_id.trunc_into()]);


### PR DESCRIPTION
Removes unnecessary trait, which only limited the signatures to always take `CacheHttp` and required the async_trait boxing and compile time cost. This also makes a lot less methods generic, improving compile times. 