### PR TITLE
Fix RoleTags deserialisation after removal of simd-json

### DIFF
--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -221,6 +221,10 @@ mod bool_as_option_unit {
         fn visit_none<E: Error>(self) -> Result<Self::Value, E> {
             Ok(true)
         }
+
+        fn visit_unit<E: Error>(self) -> Result<Self::Value, E> {
+            Ok(true)
+        }
     }
 }
 


### PR DESCRIPTION
There was a comment here that said it was called by simd-json, so I removed the function, but it turns out that serde_json also calls it.