### PR TITLE
Convert enum number into wrapper struct to save type sizes

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -40,7 +40,6 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum Opcode {
         /// Dispatches an event.

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -212,7 +212,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum CommandType {
         ChatInput = 1,
@@ -288,7 +287,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum CommandOptionType {
         SubCommand = 1,
@@ -361,7 +359,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum CommandPermissionType {
         Role = 1,

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -567,7 +567,7 @@ fn option_from_raw(raw: RawCommandDataOption) -> Result<CommandDataOption> {
         CommandOptionType::Mentionable => CommandDataOptionValue::Mentionable(value!()),
         CommandOptionType::Role => CommandDataOptionValue::Role(value!()),
         CommandOptionType::User => CommandDataOptionValue::User(value!()),
-        CommandOptionType::Unknown(unknown) => CommandDataOptionValue::Unknown(unknown),
+        CommandOptionType(unknown) => CommandDataOptionValue::Unknown(unknown),
     };
 
     Ok(CommandDataOption {

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -10,7 +10,6 @@ enum_number! {
     /// The type of a component
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ComponentType {
         ActionRow = 1,
@@ -70,7 +69,7 @@ impl<'de> Deserialize<'de> for ActionRowComponent {
             ComponentType::ActionRow => {
                 return Err(DeError::custom("Invalid component type ActionRow"))
             },
-            ComponentType::Unknown(i) => {
+            ComponentType(i) => {
                 return Err(DeError::custom(format_args!("Unknown component type {i}")))
             },
         }
@@ -134,7 +133,7 @@ impl Serialize for ButtonKind {
                 custom_id,
                 style,
             } => Helper {
-                style: (*style).into(),
+                style: style.0,
                 url: None,
                 custom_id: Some(custom_id),
             },
@@ -171,7 +170,6 @@ enum_number! {
     /// The style of a button.
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ButtonStyle {
         Primary = 1,
@@ -285,7 +283,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-styles).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum InputTextStyle {
         Short = 1,

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -280,12 +280,12 @@ impl<'de> Deserialize<'de> for ComponentInteractionDataKind {
             ComponentType::ChannelSelect => Self::ChannelSelect {
                 values: parse_values!(),
             },
-            ComponentType::Unknown(x) => Self::Unknown(x),
             x @ (ComponentType::ActionRow | ComponentType::InputText) => {
                 return Err(D::Error::custom(format_args!(
                     "invalid message component type in this context: {x:?}",
                 )));
             },
+            ComponentType(x) => Self::Unknown(x),
         })
     }
 }

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -237,7 +237,7 @@ impl<'de> Deserialize<'de> for Interaction {
             InteractionType::Autocomplete => from_value(value).map(Interaction::Autocomplete),
             InteractionType::Modal => from_value(value).map(Interaction::Modal),
             InteractionType::Ping => from_value(value).map(Interaction::Ping),
-            InteractionType::Unknown(_) => return Err(DeError::custom("Unknown interaction type")),
+            InteractionType(_) => return Err(DeError::custom("Unknown interaction type")),
         }
         .map_err(DeError::custom)
     }
@@ -260,7 +260,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum InteractionType {
         Ping = 1,

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -118,7 +118,6 @@ pub struct TeamMember {
 enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MembershipState {
         Invited = 1,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -180,11 +180,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-forum-layout-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ForumLayoutType {
         /// No default has been set for forum channel.
-        #[default]
         NotSet = 0,
         /// Display posts as a list.
         ListView = 1,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -855,11 +855,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MessageType {
         /// A regular message.
-        #[default]
         Regular = 0,
         /// An indicator that a recipient was added by the author.
         GroupRecipientAddition = 1,
@@ -922,7 +920,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-activity-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MessageActivityKind {
         Join = 1,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -212,11 +212,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ChannelType {
         /// An indicator that the channel is a text [`GuildChannel`].
-        #[default]
         Text = 0,
         /// An indicator that the channel is a [`PrivateChannel`].
         Private = 1,
@@ -250,8 +248,8 @@ enum_number! {
 
 impl ChannelType {
     #[must_use]
-    pub const fn name(&self) -> &str {
-        match *self {
+    pub const fn name(self) -> &'static str {
+        match self {
             Self::Private => "private",
             Self::Text => "text",
             Self::Voice => "voice",
@@ -264,7 +262,7 @@ impl ChannelType {
             Self::Stage => "stage",
             Self::Directory => "directory",
             Self::Forum => "forum",
-            Self::Unknown(_) => "unknown",
+            Self(_) => "unknown",
         }
     }
 }
@@ -357,7 +355,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-video-quality-modes).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum VideoQualityMode {
         /// An indicator that the video quality is chosen by Discord for optimal
@@ -373,15 +370,14 @@ enum_number! {
     /// See [`StageInstance::privacy_level`].
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level).
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
+    #[<default> = 2]
     pub enum StageInstancePrivacyLevel {
         /// The Stage instance is visible publicly. (deprecated)
         Public = 1,
         /// The Stage instance is visible to only guild members.
-        #[default]
         GuildOnly = 2,
         _ => Unknown(u8),
     }
@@ -393,7 +389,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object)
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u16", into = "u16")]
     #[non_exhaustive]
     pub enum AutoArchiveDuration {
         None = 0,
@@ -590,7 +585,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-sort-order-types).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum SortOrder {
         /// Sort forum posts by activity.

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -42,7 +42,6 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-visibility-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ConnectionVisibility {
         /// Invisible to everyone except the user themselves

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -187,11 +187,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ActivityType {
         /// An indicator that the user is playing a game.
-        #[default]
         Playing = 0,
         /// An indicator that the user is streaming to a service.
         Streaming = 1,

--- a/src/model/guild/automod.rs
+++ b/src/model/guild/automod.rs
@@ -438,7 +438,7 @@ impl<'de> Deserialize<'de> for Action {
                     .duration_seconds
                     .ok_or_else(|| Error::missing_field("duration_seconds"))?,
             )),
-            ActionType::Unknown(unknown) => Action::Unknown(unknown),
+            ActionType(unknown) => Action::Unknown(unknown),
         })
     }
 }
@@ -497,7 +497,6 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ActionType {
         BlockMessage = 1,

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -41,7 +41,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum IntegrationExpireBehaviour {
         RemoveRole = 0,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2426,11 +2426,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum DefaultMessageNotificationLevel {
         /// Receive notifications for everything.
-        #[default]
         All = 0,
         /// Receive only mentions.
         Mentions = 1,
@@ -2444,11 +2442,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ExplicitContentFilter {
         /// Don't scan any messages.
-        #[default]
         None = 0,
         /// Scan messages from members without a role.
         WithoutRole = 1,
@@ -2464,11 +2460,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-mfa-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum MfaLevel {
         /// MFA is disabled.
-        #[default]
         None = 0,
         /// MFA is enabled.
         Elevated = 1,
@@ -2483,11 +2477,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-verification-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum VerificationLevel {
         /// Does not require any verification.
-        #[default]
         None = 0,
         /// Must have a verified email on the user's Discord account.
         Low = 1,
@@ -2507,11 +2499,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum NsfwLevel {
         /// The nsfw level is not specified.
-        #[default]
         Default = 0,
         /// The guild is considered as explicit.
         Explicit = 1,
@@ -2529,7 +2519,6 @@ enum_number! {
     /// See [AfkMetadata::afk_timeout].
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u16", into = "u16")]
     #[non_exhaustive]
     pub enum AfkTimeout {
         OneMinute = 60,

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -4,11 +4,9 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-premium-tier).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum PremiumTier {
         /// Guild has not unlocked any Server Boost perks
-        #[default]
         Tier0 = 0,
         /// Guild has unlocked Server Boost level 1 perks
         Tier1 = 1,

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -60,7 +60,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ScheduledEventStatus {
         Scheduled = 1,
@@ -75,7 +74,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ScheduledEventType {
         StageInstance = 1,
@@ -111,7 +109,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum ScheduledEventPrivacyLevel {
         GuildOnly = 2,

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -405,7 +405,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum InviteTargetType {
         Stream = 1,

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -25,7 +25,6 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object-sku-types).
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum SkuKind {
         /// Represents a recurring subscription.
@@ -88,7 +87,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-types).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Debug, Serialize, Deserialize)]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum EntitlementKind {
         /// Entitlement was purchased as an app subscription.

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -216,7 +216,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum StickerType {
         /// An official sticker in a pack, part of Nitro or in a removed purchasable pack.
@@ -233,7 +232,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum StickerFormatType {
         /// A PNG format sticker.
@@ -254,7 +252,7 @@ fn sticker_url(sticker_id: StickerId, sticker_format_type: StickerFormatType) ->
         StickerFormatType::Png | StickerFormatType::Apng => "png",
         StickerFormatType::Lottie => "json",
         StickerFormatType::Gif => "gif",
-        StickerFormatType::Unknown(_) => return None,
+        StickerFormatType(_) => return None,
     };
 
     Some(cdn!("/stickers/{}.{}", sticker_id, ext))

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -297,10 +297,8 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-premium-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum PremiumType {
-        #[default]
         None = 0,
         NitroClassic = 1,
         Nitro = 2,

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -26,7 +26,6 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum WebhookType {
         /// An indicator that the webhook can post messages to channels with a token.
@@ -42,12 +41,12 @@ enum_number! {
 
 impl WebhookType {
     #[must_use]
-    pub fn name(&self) -> &str {
+    pub fn name(self) -> &'static str {
         match self {
             Self::Incoming => "incoming",
             Self::ChannelFollower => "channel follower",
             Self::Application => "application",
-            Self::Unknown(_) => "unknown",
+            _ => "unknown",
         }
     }
 }


### PR DESCRIPTION
Saves a couple bytes in each model by replacing the enums with a simpler and more accurate representation, a newtype with named statics. https://www.diffchecker.com/ohzayL9Z/