### PR TITLE
Re-add Secret to bot token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ futures = { version = "0.3.29", default-features = false, features = ["std"] }
 dep_time = { version = "0.3.30", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
 base64 = { version = "0.21.5" }
 secrecy = { version = "0.8.0", features = ["serde"] }
+zeroize = { version = "1.7" } # Not used in serenity, but bumps the minimal version from secrecy
 arrayvec = { version = "0.7.4", features = ["serde"] }
 small-fixed-array = { version = "0.2", features = ["serde"] }
 bool_to_bitflags = { version = "0.1.0" }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::{Duration as StdDuration, Instant};
 
+use secrecy::{ExposeSecret as _, Secret};
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 use tracing::{debug, error, info, trace, warn};
@@ -17,6 +18,7 @@ use super::{
     WsClient,
 };
 use crate::constants::{self, close_codes};
+use crate::http::Token;
 use crate::internal::prelude::*;
 use crate::model::event::{Event, GatewayEvent};
 use crate::model::gateway::{GatewayIntents, ShardInfo};
@@ -71,7 +73,7 @@ pub struct Shard {
     // This acts as a timeout to determine if the shard has - for some reason - not started within
     // a decent amount of time.
     pub started: Instant,
-    pub token: Arc<str>,
+    token: Secret<Token>,
     ws_url: Arc<str>,
     pub intents: GatewayIntents,
 }
@@ -147,7 +149,7 @@ impl Shard {
             seq,
             stage,
             started: Instant::now(),
-            token,
+            token: Token::new(token),
             session_id,
             shard_info,
             ws_url,
@@ -656,7 +658,12 @@ impl Shard {
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     pub async fn identify(&mut self) -> Result<()> {
         self.client
-            .send_identify(&self.shard_info, &self.token, self.intents, &self.presence)
+            .send_identify(
+                &self.shard_info,
+                self.token.expose_secret(),
+                self.intents,
+                &self.presence,
+            )
             .await?;
 
         self.last_heartbeat_sent = Some(Instant::now());
@@ -713,7 +720,9 @@ impl Shard {
 
         match &self.session_id {
             Some(session_id) => {
-                self.client.send_resume(&self.shard_info, session_id, self.seq, &self.token).await
+                self.client
+                    .send_resume(&self.shard_info, session_id, self.seq, self.token.expose_secret())
+                    .await
             },
             None => Err(Error::Gateway(GatewayError::NoSessionId)),
         }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -11,6 +11,7 @@ use reqwest::header::{HeaderMap as Headers, HeaderValue};
 #[cfg(feature = "utils")]
 use reqwest::Url;
 use reqwest::{Client, ClientBuilder, Response as ReqwestResponse, StatusCode};
+use secrecy::{ExposeSecret as _, Secret};
 use serde::de::DeserializeOwned;
 use serde_json::{from_value, json, to_string, to_vec};
 use tracing::{debug, trace};
@@ -34,6 +35,38 @@ use crate::internal::prelude::*;
 use crate::model::application::{Command, CommandPermissions};
 use crate::model::guild::automod::Rule;
 use crate::model::prelude::*;
+
+#[derive(Clone)]
+pub(crate) struct Token(Arc<str>);
+
+impl Token {
+    pub fn new(inner: Arc<str>) -> Secret<Self> {
+        Secret::new(Self(inner))
+    }
+
+    pub fn get_inner(&self) -> &Arc<str> {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Token {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl secrecy::Zeroize for Token {
+    fn zeroize(&mut self) {
+        if let Some(string) = Arc::get_mut(&mut self.0) {
+            string.zeroize();
+        }
+    }
+}
+
+impl secrecy::CloneableSecret for Token {}
+impl secrecy::DebugSecret for Token {}
 
 /// A builder for the underlying [`Http`] client that performs requests to Discord's HTTP API. If
 /// you do not need to use a proxy or do not need to disable the rate limiter, you can use
@@ -163,7 +196,7 @@ impl HttpBuilder {
             client,
             ratelimiter,
             proxy: self.proxy,
-            token: self.token,
+            token: Token::new(self.token),
             application_id,
         }
     }
@@ -201,7 +234,7 @@ pub struct Http {
     pub(crate) client: Client,
     pub ratelimiter: Option<Ratelimiter>,
     pub proxy: Option<FixedString<u16>>,
-    token: Arc<str>,
+    token: Secret<Token>,
     application_id: AtomicU64,
 }
 
@@ -229,7 +262,7 @@ impl Http {
     }
 
     pub(crate) fn token(&self) -> &Arc<str> {
-        &self.token
+        self.token.expose_secret().get_inner()
     }
 
     /// Adds a [`User`] to a [`Guild`] with a valid OAuth2 access token.
@@ -4656,7 +4689,9 @@ impl Http {
         let response = if let Some(ratelimiter) = &self.ratelimiter {
             ratelimiter.perform(req).await?
         } else {
-            let request = req.build(&self.client, &self.token, self.proxy.as_deref())?.build()?;
+            let request = req
+                .build(&self.client, self.token.expose_secret(), self.proxy.as_deref())?
+                .build()?;
             self.client.execute(request).await?
         };
 


### PR DESCRIPTION
This re-adds Secret to the bot token, without losing the `Arc<str>` opt. This works by using a newtype to Zeroise on last drop, using `Arc::get_mut`.