### PR TITLE
Take Arc<Http> in ClientBuilder::new_with_http

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ framework = ["client", "model", "utils"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["flate2"]
 # Enables HTTP, which enables bots to execute actions on Discord.
-http = ["dashmap", "mime_guess", "percent-encoding"]
+http = ["dashmap", "parking_lot", "mime_guess", "percent-encoding"]
 # Enables wrapper methods around HTTP requests on model types.
 # Requires "builder" to configure the requests and "http" to execute them.
 # Note: the model type definitions themselves are always active, regardless of this feature.


### PR DESCRIPTION
This allows the user to make a http, pass it off to a background task, then use it in serenity, instead of having to initialize two.