### PR TITLE
Use FxHash everywhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ arrayvec = { version = "0.7.4", features = ["serde"] }
 small-fixed-array = { version = "0.2", features = ["serde"] }
 bool_to_bitflags = { version = "0.1.0" }
 nonmax = { version = "0.5.5", features = ["serde"] }
+rustc-hash = { version = "1.1.0" }
 # Optional dependencies
-fxhash = { version = "0.2.1", optional = true }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.28", optional = true }
 reqwest = { version = "0.11.22", default-features = false, features = ["multipart", "stream", "json"], optional = true }
@@ -79,7 +79,7 @@ default_no_backend = [
 builder = []
 # Enables the cache, which stores the data received from Discord gateway to provide access to
 # complete guild data, channels, users and more without needing HTTP requests.
-cache = ["fxhash", "dashmap", "parking_lot"]
+cache = ["dashmap", "parking_lot"]
 # Enables collectors, a utility feature that lets you await interaction events in code with
 # zero setup, without needing to setup an InteractionCreate event listener.
 collector = ["gateway", "model"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,3 @@
-cognitive-complexity-threshold = 20
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "Use utils::hasher::HashMap" },
+]

--- a/examples/e05_sample_bot_structure/src/commands/welcome.rs
+++ b/examples/e05_sample_bot_structure/src/commands/welcome.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 
 use serenity::builder::{CreateCommand, CreateCommandOption};
+use serenity::hasher::{BuildHasher, HashMap};
 use serenity::model::application::CommandOptionType;
 
 fn new_map<'a>(key: &'a str, value: &'a str) -> HashMap<Cow<'a, str>, Cow<'a, str>> {
-    let mut map = HashMap::with_capacity(1);
+    let mut map = HashMap::with_capacity_and_hasher(1, BuildHasher::default());
     map.insert(Cow::Borrowed(key), Cow::Borrowed(value));
     map
 }

--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 
+use crate::hasher::{BuildHasher, HashMap};
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::internal::prelude::*;
@@ -353,9 +353,9 @@ impl<'a> CreateCommand<'a> {
             kind: None,
 
             name: name.into(),
-            name_localizations: HashMap::new(),
+            name_localizations: HashMap::with_hasher(BuildHasher::default()),
             description: None,
-            description_localizations: HashMap::new(),
+            description_localizations: HashMap::with_hasher(BuildHasher::default()),
             default_member_permissions: None,
             dm_permission: None,
 

--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -10,6 +10,8 @@ use dashmap::DashMap;
 #[cfg(feature = "typesize")]
 use typesize::TypeSize;
 
+use crate::hasher::BuildHasher;
+
 #[derive(Debug)]
 /// A wrapper around Option<DashMap<K, V>> to ease disabling specific cache fields.
 pub(crate) struct MaybeMap<K: Eq + Hash, V>(pub(super) Option<DashMap<K, V, BuildHasher>>);
@@ -79,25 +81,6 @@ impl<'a, K: Eq + Hash, V> ReadOnlyMapRef<'a, K, V> {
 
     pub fn len(&self) -> usize {
         self.0.map_or(0, DashMap::len)
-    }
-}
-pub struct Hasher(fxhash::FxHasher);
-impl std::hash::Hasher for Hasher {
-    fn finish(&self) -> u64 {
-        self.0.finish()
-    }
-
-    fn write(&mut self, bytes: &[u8]) {
-        self.0.write(bytes);
-    }
-}
-#[derive(Clone, Default)]
-pub struct BuildHasher(fxhash::FxBuildHasher);
-impl std::hash::BuildHasher for BuildHasher {
-    type Hasher = Hasher;
-
-    fn build_hasher(&self) -> Self::Hasher {
-        Hasher(self.0.build_hasher())
     }
 }
 

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 #[cfg(feature = "cache")]
 use std::num::NonZeroU16;
 
@@ -6,6 +5,7 @@ use async_trait::async_trait;
 
 use super::context::Context;
 use crate::gateway::ShardStageUpdateEvent;
+use crate::hasher::HashMap;
 use crate::http::RatelimitInfo;
 use crate::model::application::{CommandPermissions, Interaction};
 use crate::model::guild::audit_log::AuditLogEntry;

--- a/src/gateway/bridge/shard_manager.rs
+++ b/src/gateway/bridge/shard_manager.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::num::NonZeroU16;
 use std::sync::Arc;
 #[cfg(feature = "framework")]
@@ -20,6 +19,7 @@ use crate::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
 use crate::gateway::{ConnectionStage, GatewayError, PresenceData};
+use crate::hasher::{BuildHasher, HashMap};
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
@@ -115,7 +115,7 @@ impl ShardManager {
         let (return_value_tx, return_value_rx) = mpsc::unbounded();
         let (shard_queue_tx, shard_queue_rx) = mpsc::unbounded();
 
-        let runners = Arc::new(Mutex::new(HashMap::new()));
+        let runners = Arc::new(Mutex::new(HashMap::with_hasher(BuildHasher::default())));
         let (shutdown_send, shutdown_recv) = mpsc::unbounded();
 
         let manager = Arc::new(Self {

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::num::NonZeroU16;
 use std::sync::Arc;
 #[cfg(feature = "framework")]
@@ -27,6 +27,7 @@ use crate::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
 use crate::gateway::{ConnectionStage, PresenceData, Shard, ShardRunnerMessage};
+use crate::hasher::{BuildHasher, HashMap};
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
@@ -308,7 +309,10 @@ pub struct ShardQueue {
 impl ShardQueue {
     pub fn new(max_concurrency: NonZeroU16) -> Self {
         Self {
-            buckets: HashMap::with_capacity(max_concurrency.get() as usize),
+            buckets: HashMap::with_capacity_and_hasher(
+                max_concurrency.get() as usize,
+                BuildHasher::default(),
+            ),
             max_concurrency,
         }
     }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,0 +1,23 @@
+pub struct Hasher(rustc_hash::FxHasher);
+impl std::hash::Hasher for Hasher {
+    fn finish(&self) -> u64 {
+        self.0.finish()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes);
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct BuildHasher();
+impl std::hash::BuildHasher for BuildHasher {
+    type Hasher = Hasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        Hasher(rustc_hash::FxHasher::default())
+    }
+}
+
+#[allow(clippy::disallowed_types)]
+pub type HashMap<K, V> = std::collections::HashMap<K, V, BuildHasher>;

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::sync::Arc;
@@ -8,6 +7,7 @@ use reqwest::{Error as ReqwestError, Method, Response, StatusCode};
 use serde::de::{Deserialize, Deserializer, Error as _};
 use url::ParseError as UrlError;
 
+use crate::hasher::HashMap;
 use crate::internal::prelude::*;
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ extern crate serde;
 mod internal;
 
 pub mod constants;
+pub mod hasher;
 pub mod model;
 pub mod prelude;
 

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "model")]
 use crate::builder::CreateCommand;
+use crate::hasher::HashMap;
 #[cfg(feature = "model")]
 use crate::http::Http;
 use crate::internal::prelude::*;

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::de::{Deserializer, Error as DeError};
 use serde::ser::{Error as _, Serializer};
 use serde::{Deserialize, Serialize};
@@ -13,6 +11,7 @@ use crate::builder::{
 };
 #[cfg(feature = "collector")]
 use crate::client::Context;
+use crate::hasher::HashMap;
 #[cfg(feature = "model")]
 use crate::http::Http;
 use crate::internal::prelude::*;

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -6,8 +6,6 @@
 // Just for MessageUpdateEvent (for some reason the #[allow] doesn't work when placed directly)
 #![allow(clippy::option_option)]
 
-use std::collections::HashMap;
-
 use nonmax::NonMaxU64;
 use serde::de::Error as DeError;
 use serde::Serialize;
@@ -23,6 +21,7 @@ use super::utils::{
     stickers,
 };
 use crate::constants::Opcode;
+use crate::hasher::HashMap;
 use crate::internal::prelude::*;
 use crate::model::application::{CommandPermissions, Interaction};
 use crate::model::guild::audit_log::AuditLogEntry;

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -1,10 +1,10 @@
 //! Audit log types for administrative actions within guilds.
 
-use std::collections::HashMap;
-
 use nonmax::{NonMaxU32, NonMaxU64};
 use serde::de::Deserializer;
 use serde::ser::{Serialize, Serializer};
+
+use crate::hasher::HashMap;
 
 mod change;
 mod utils;

--- a/src/model/guild/audit_log/utils.rs
+++ b/src/model/guild/audit_log/utils.rs
@@ -1,9 +1,8 @@
 /// Used with `#[serde(with = "users")]`
 pub mod users {
-    use std::collections::HashMap;
-
     use serde::Deserializer;
 
+    use crate::hasher::HashMap;
     use crate::model::id::UserId;
     use crate::model::user::User;
     use crate::model::utils::SequenceToMapVisitor;
@@ -19,10 +18,9 @@ pub mod users {
 
 /// Used with `#[serde(with = "webhooks")]`
 pub mod webhooks {
-    use std::collections::HashMap;
-
     use serde::Deserializer;
 
+    use crate::hasher::HashMap;
     use crate::model::id::WebhookId;
     use crate::model::utils::SequenceToMapVisitor;
     use crate::model::webhook::Webhook;

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2534,9 +2534,9 @@ enum_number! {
 mod test {
     #[cfg(feature = "model")]
     mod model {
-        use std::collections::*;
         use std::num::NonZeroU16;
 
+        use crate::hasher::BuildHasher;
         use crate::model::prelude::*;
 
         fn gen_member() -> Member {
@@ -2553,9 +2553,11 @@ mod test {
 
         fn gen() -> Guild {
             let m = gen_member();
+            let mut members = HashMap::with_capacity_and_hasher(1, BuildHasher::default());
+            members.insert(m.user.id, m);
 
             Guild {
-                members: HashMap::from([(m.user.id, m)]),
+                members,
                 ..Default::default()
             }
         }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -62,8 +62,6 @@ pub use self::timestamp::Timestamp;
 /// use serenity::model::prelude::*;
 /// ```
 pub mod prelude {
-    pub(crate) use std::collections::HashMap;
-
     pub(crate) use serde::de::Visitor;
     pub(crate) use serde::{Deserialize, Deserializer};
 
@@ -102,5 +100,6 @@ pub mod prelude {
         ModelError,
         Timestamp,
     };
+    pub(crate) use crate::hasher::HashMap;
     pub(crate) use crate::internal::prelude::*;
 }


### PR DESCRIPTION
Swaps the HashMap uses throughout serenity to use FxHash, this should be checked to avoid hashdos first.