### PR TITLE
Upgrade to small-fixed-array 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ base64 = { version = "0.21.5" }
 secrecy = { version = "0.8.0", features = ["serde"] }
 zeroize = { version = "1.7" } # Not used in serenity, but bumps the minimal version from secrecy
 arrayvec = { version = "0.7.4", features = ["serde"] }
-small-fixed-array = { version = "0.2", features = ["serde"] }
+small-fixed-array = { version = "0.4", features = ["serde"] }
 bool_to_bitflags = { version = "0.1.0" }
 nonmax = { version = "0.5.5", features = ["serde"] }
 # Optional dependencies

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -467,7 +467,7 @@ impl CacheUpdate for ThreadCreateEvent {
 
         cache.guilds.get_mut(&guild_id).and_then(|mut g| {
             if let Some(i) = g.threads.iter().position(|e| e.id == thread_id) {
-                Some(std::mem::replace(&mut g.threads[i], self.thread.clone()))
+                Some(std::mem::replace(&mut g.threads[i as u32], self.thread.clone()))
             } else {
                 // This is a rare enough occurence to realloc.
                 let mut threads = std::mem::take(&mut g.threads).into_vec();
@@ -490,7 +490,7 @@ impl CacheUpdate for ThreadUpdateEvent {
 
         cache.guilds.get_mut(&guild_id).and_then(|mut g| {
             if let Some(i) = g.threads.iter().position(|e| e.id == thread_id) {
-                Some(std::mem::replace(&mut g.threads[i], self.thread.clone()))
+                Some(std::mem::replace(&mut g.threads[i as u32], self.thread.clone()))
             } else {
                 // This is a rare enough occurence to realloc.
                 let mut threads = std::mem::take(&mut g.threads).into_vec();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -149,7 +149,7 @@ impl ActivityData {
         Self {
             // discord seems to require a name for custom activities
             // even though it's not displayed
-            name: FixedString::from_str_trunc("~"),
+            name: FixedString::from_static_trunc("~"),
             kind: ActivityType::Custom,
             state: Some(state.into().trunc_into()),
             url: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -163,16 +163,14 @@ impl HttpBuilder {
     /// [`HTTP CONNECT`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
     pub fn proxy<'a>(mut self, proxy: impl Into<Cow<'a, str>>) -> Self {
         let proxy = proxy.into();
-        let len = proxy.len();
+        u16::try_from(proxy.len()).expect("Proxy URL should be less than u16::MAX characters");
 
         let proxy = match proxy {
             Cow::Owned(proxy) => FixedString::from_string_trunc(proxy),
             Cow::Borrowed(proxy) => FixedString::from_str_trunc(proxy),
         };
 
-        assert_eq!(len as u32, proxy.len(), "Proxy URL should not be larger than u16::MAX chars");
         self.proxy = Some(proxy);
-
         self
     }
 

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -254,7 +254,7 @@ mod test {
         let error = DiscordJsonError {
             code: 43121215,
             errors: FixedArray::empty(),
-            message: FixedString::from_str_trunc("This is a Ferris error"),
+            message: FixedString::from_static_trunc("This is a Ferris error"),
         };
 
         let mut builder = Builder::new();
@@ -268,7 +268,7 @@ mod test {
 
         let known = ErrorResponse {
             status_code: reqwest::StatusCode::from_u16(403).unwrap(),
-            url: FixedString::from_str_trunc("https://ferris.crab/"),
+            url: FixedString::from_static_trunc("https://ferris.crab/"),
             method: Method::POST,
             error,
         };

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -801,13 +801,13 @@ mod tests {
     #[test]
     fn nested_options() {
         let value = CommandDataOption {
-            name: FixedString::from_str_trunc("subcommand_group"),
+            name: FixedString::from_static_trunc("subcommand_group"),
             value: CommandDataOptionValue::SubCommandGroup(
                 vec![CommandDataOption {
-                    name: FixedString::from_str_trunc("subcommand"),
+                    name: FixedString::from_static_trunc("subcommand"),
                     value: CommandDataOptionValue::SubCommand(
                         vec![CommandDataOption {
-                            name: FixedString::from_str_trunc("channel"),
+                            name: FixedString::from_static_trunc("channel"),
                             value: CommandDataOptionValue::Channel(ChannelId::new(3)),
                         }]
                         .trunc_into(),
@@ -835,30 +835,30 @@ mod tests {
     fn mixed_options() {
         let value = vec![
             CommandDataOption {
-                name: FixedString::from_str_trunc("boolean"),
+                name: FixedString::from_static_trunc("boolean"),
                 value: CommandDataOptionValue::Boolean(true),
             },
             CommandDataOption {
-                name: FixedString::from_str_trunc("integer"),
+                name: FixedString::from_static_trunc("integer"),
                 value: CommandDataOptionValue::Integer(1),
             },
             CommandDataOption {
-                name: FixedString::from_str_trunc("number"),
+                name: FixedString::from_static_trunc("number"),
                 value: CommandDataOptionValue::Number(2.0),
             },
             CommandDataOption {
-                name: FixedString::from_str_trunc("string"),
-                value: CommandDataOptionValue::String(FixedString::from_str_trunc("foobar")),
+                name: FixedString::from_static_trunc("string"),
+                value: CommandDataOptionValue::String(FixedString::from_static_trunc("foobar")),
             },
             CommandDataOption {
-                name: FixedString::from_str_trunc("empty_subcommand"),
+                name: FixedString::from_static_trunc("empty_subcommand"),
                 value: CommandDataOptionValue::SubCommand(FixedArray::default()),
             },
             CommandDataOption {
-                name: FixedString::from_str_trunc("autocomplete"),
+                name: FixedString::from_static_trunc("autocomplete"),
                 value: CommandDataOptionValue::Autocomplete {
                     kind: CommandOptionType::Integer,
-                    value: FixedString::from_str_trunc("not an integer"),
+                    value: FixedString::from_static_trunc("not an integer"),
                 },
             },
         ];

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -303,10 +303,10 @@ mod tests {
         let mut button = Button {
             kind: ComponentType::Button,
             data: ButtonKind::NonLink {
-                custom_id: FixedString::from_str_trunc("hello"),
+                custom_id: FixedString::from_static_trunc("hello"),
                 style: ButtonStyle::Danger,
             },
-            label: Some(FixedString::from_str_trunc("a")),
+            label: Some(FixedString::from_static_trunc("a")),
             emoji: None,
             disabled: false,
         };
@@ -316,7 +316,7 @@ mod tests {
         );
 
         button.data = ButtonKind::Link {
-            url: FixedString::from_str_trunc("https://google.com"),
+            url: FixedString::from_static_trunc("https://google.com"),
         };
         assert_json(
             &button,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -484,16 +484,16 @@ mod test {
             assert!(!channel.is_nsfw());
 
             channel.kind = ChannelType::Text;
-            channel.name = FixedString::from_str_trunc("nsfw-");
+            channel.name = FixedString::from_static_trunc("nsfw-");
             assert!(!channel.is_nsfw());
 
-            channel.name = FixedString::from_str_trunc("nsfw");
+            channel.name = FixedString::from_static_trunc("nsfw");
             assert!(!channel.is_nsfw());
             channel.kind = ChannelType::Voice;
             assert!(!channel.is_nsfw());
             channel.kind = ChannelType::Text;
 
-            channel.name = FixedString::from_str_trunc("nsf");
+            channel.name = FixedString::from_static_trunc("nsf");
             channel.nsfw = true;
             assert!(channel.is_nsfw());
             channel.nsfw = false;

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -474,7 +474,7 @@ impl<'a> TryFrom<&'a str> for ReactionType {
     /// let reaction2 = ReactionType::Custom {
     ///     animated: false,
     ///     id: EmojiId::new(600404340292059257),
-    ///     name: Some(FixedString::from_str_trunc("customemoji")),
+    ///     name: Some(FixedString::from_static_trunc("customemoji")),
     /// };
     ///
     /// assert_eq!(reaction, reaction2);

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -299,7 +299,7 @@ mod tests {
     fn entity_type_variant() {
         let value = Change::Type {
             old: Some(EntityType::Int(123)),
-            new: Some(EntityType::Str(FixedString::from_str_trunc("discord"))),
+            new: Some(EntityType::Str(FixedString::from_static_trunc("discord"))),
         };
         assert_json(&value, json!({"key": "type", "old_value": 123, "new_value": "discord"}));
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2541,9 +2541,9 @@ mod test {
 
         fn gen_member() -> Member {
             Member {
-                nick: Some(FixedString::from_str_trunc("aaaa")),
+                nick: Some(FixedString::from_static_trunc("aaaa")),
                 user: User {
-                    name: FixedString::from_str_trunc("test"),
+                    name: FixedString::from_static_trunc("test"),
                     discriminator: NonZeroU16::new(1432),
                     ..User::default()
                 },

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -803,7 +803,7 @@ mod test {
                 id: UserId::new(210),
                 avatar: Some(ImageHash::from_str("fb211703bcc04ee612c88d494df0272f").unwrap()),
                 discriminator: NonZeroU16::new(1432),
-                name: FixedString::from_str_trunc("test"),
+                name: FixedString::from_static_trunc("test"),
                 ..Default::default()
             };
 

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -208,7 +208,7 @@ mod tests {
     fn test_content_safe() {
         let user = User {
             id: UserId::new(100000000000000000),
-            name: FixedString::from_str_trunc("Crab"),
+            name: FixedString::from_static_trunc("Crab"),
             ..Default::default()
         };
 
@@ -220,19 +220,19 @@ mod tests {
         let mut guild = no_member_guild.clone();
 
         let member = Member {
-            nick: Some(FixedString::from_str_trunc("Ferris")),
+            nick: Some(FixedString::from_static_trunc("Ferris")),
             ..Default::default()
         };
 
         let role = Role {
             id: RoleId::new(333333333333333333),
-            name: FixedString::from_str_trunc("ferris-club-member"),
+            name: FixedString::from_static_trunc("ferris-club-member"),
             ..Default::default()
         };
 
         let channel = GuildChannel {
             id: ChannelId::new(111880193700067777),
-            name: FixedString::from_str_trunc("general"),
+            name: FixedString::from_static_trunc("general"),
             ..Default::default()
         };
 

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1185,7 +1185,7 @@ mod test {
     fn mentions() {
         let mut emoji = Emoji {
             id: EmojiId::new(32),
-            name: FixedString::from_str_trunc("Rohrkatze"),
+            name: FixedString::from_static_trunc("Rohrkatze"),
             roles: FixedArray::empty(),
             user: None,
             __generated_flags: EmojiGeneratedFlags::empty(),

--- a/src/utils/quick_modal.rs
+++ b/src/utils/quick_modal.rs
@@ -24,7 +24,7 @@ pub struct QuickModalResponse {
 ///     .paragraph_field("Hobbies and interests");
 /// let response = interaction.quick_modal(ctx, modal).await?;
 /// let inputs = response.unwrap().inputs;
-/// let (first_name, last_name, hobbies) = (&inputs[0_usize], &inputs[1_usize], &inputs[2_usize]);
+/// let (first_name, last_name, hobbies) = (&inputs[0], &inputs[1], &inputs[2]);
 /// # Ok(())
 /// # }
 /// ```

--- a/tests/test_reaction.rs
+++ b/tests/test_reaction.rs
@@ -11,7 +11,7 @@ fn str_to_reaction_type() {
     let reaction2 = ReactionType::Custom {
         animated: false,
         id: EmojiId::new(600404340292059257),
-        name: Some(FixedString::from_str_trunc("customemoji")),
+        name: Some(FixedString::from_static_trunc("customemoji")),
     };
     assert_eq!(reaction, reaction2);
 }
@@ -23,7 +23,7 @@ fn str_to_reaction_type_animated() {
     let reaction2 = ReactionType::Custom {
         animated: true,
         id: EmojiId::new(600409340292059257),
-        name: Some(FixedString::from_str_trunc("customemoji2")),
+        name: Some(FixedString::from_static_trunc("customemoji2")),
     };
     assert_eq!(reaction, reaction2);
 }
@@ -35,7 +35,7 @@ fn string_to_reaction_type() {
     let reaction2 = ReactionType::Custom {
         animated: false,
         id: EmojiId::new(600404340292059257),
-        name: Some(FixedString::from_str_trunc("customemoji")),
+        name: Some(FixedString::from_static_trunc("customemoji")),
     };
     assert_eq!(reaction, reaction2);
 }


### PR DESCRIPTION
small-fixed-array 0.3 adds LenT indexing and `len` returns `LenT`
small-fixed-array 0.4 removes the usize indexing, as having two index impls causes issues, as well as adding a `&'static str` variant to `FixedString` for no memory cost.