### PR TITLE
Switch to a generic type argument for `ClientBuilder::data`

### DIFF
--- a/examples/e11_global_data/src/main.rs
+++ b/examples/e11_global_data/src/main.rs
@@ -73,8 +73,10 @@ async fn main() {
         | GatewayIntents::DIRECT_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
     let mut client = Client::builder(&token, intents)
-        // We have to use `as` to turn our UserData into `dyn Any`.
-        .data(Arc::new(data) as _)
+        // Specifying the data type as a type argument here is optional, but if done, you can
+        // guarantee that Context::data will not panic if the same type is given, as providing the
+        // incorrect type will lead to a compiler error, rather than a runtime panic.
+        .data::<UserData>(Arc::new(data))
         .event_handler(Handler)
         .await
         .expect("Err creating client");

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -134,7 +134,7 @@ impl ClientBuilder {
     }
 
     /// Sets the global data type that can be accessed from [`Context::data`].
-    pub fn data(mut self, data: Arc<dyn std::any::Any + Send + Sync>) -> Self {
+    pub fn data<D: std::any::Any + Send + Sync>(mut self, data: Arc<D>) -> Self {
         self.data = Some(data);
         self
     }


### PR DESCRIPTION
A small change to how the user data is initially provided to the Client that improves the usability of the Client and Context data.

This change replaces the requirement to use `as _` when providing a data type, with an optionally provided type argument, that if provided, will check if the type is equal to the data, and will throw a compiler error if they do not match. This can help the user identify the data type that is given to the builder, so they can more easily provide it to the required type argument in `Client::data` and `Context::data`.

There are two very small drawbacks with this new implementation:
- It's marginally slower to compile if multiple clients are built.
- If the data type provided is a `dyn Any`, the user would be required to downcast the type after being requested via `Client::data` or `Context::data`. With the previous implementation, the downcast could be skipped by providing the original type to either method.

I personally see both of these as a very niche use cases, which are not worth the hassle to optimize when this change will improve the usability of the library for the vast majority of users.