### PR TITLE
Fix VoiceServerUpdate::guild_id being wrapped in Option

### DIFF
--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -341,11 +341,9 @@ impl ShardRunner {
                         .await;
                 },
                 Event::VoiceServerUpdate(event) => {
-                    if let Some(guild_id) = event.guild_id {
-                        voice_manager
-                            .server_update(guild_id, event.endpoint.as_deref(), &event.token)
-                            .await;
-                    }
+                    voice_manager
+                        .server_update(event.guild_id, event.endpoint.as_deref(), &event.token)
+                        .await;
                 },
                 Event::VoiceStateUpdate(event) => {
                     if let Some(guild_id) = event.voice_state.guild_id {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -758,7 +758,7 @@ pub struct UserUpdateEvent {
 #[non_exhaustive]
 pub struct VoiceServerUpdateEvent {
     pub token: FixedString,
-    pub guild_id: Option<GuildId>,
+    pub guild_id: GuildId,
     pub endpoint: Option<FixedString>,
 }
 


### PR DESCRIPTION
Noticed by @vicky5124, this does not need to be optional.
https://discord.com/developers/docs/topics/gateway-events#voice-server-update
