### PR TITLE
Fill message cache with ChannelId::messages and ChannelId::pins

### DIFF
--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -89,6 +89,9 @@ impl GetMessages {
 
     /// Gets messages from the channel.
     ///
+    /// If the cache is enabled, this method will fill up the message cache for the channel, if the
+    /// messages returned are newer than the existing cached messages or the cache is not full yet.
+    ///
     /// **Note**: If the user does not have the [Read Message History] permission, returns an empty
     /// [`Vec`].
     ///

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -638,7 +638,8 @@ impl Cache {
         // Make sure the cache stays sorted to messages
         channel_messages.make_contiguous().sort_unstable_by_key(|m| m.id);
         // Get rid of the overflow at the front of the queue.
-        channel_messages.drain(..max_messages);
+        let truncate_end_index = channel_messages.len().saturating_sub(max_messages);
+        channel_messages.drain(..truncate_end_index);
     }
 
     /// Updates the cache with the update implementation for an event or other custom update

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -616,6 +616,31 @@ impl Cache {
         )
     }
 
+    /// Inserts new messages into the message cache for a channel manually.
+    ///
+    /// This will keep the ordering of the message cache consistent, even if the message iterator
+    /// contains randomly ordered messages, and respects the [`Settings::max_messages`] setting.
+    pub(crate) fn fill_message_cache(
+        &self,
+        channel_id: ChannelId,
+        new_messages: impl Iterator<Item = Message>,
+    ) {
+        let max_messages = self.settings().max_messages;
+        if max_messages == 0 {
+            // Early exit for common case of message cache being disabled.
+            return;
+        }
+
+        let mut channel_messages = self.messages.entry(channel_id).or_default();
+
+        // Fill up the existing cache
+        channel_messages.extend(new_messages.take(max_messages));
+        // Make sure the cache stays sorted to messages
+        channel_messages.make_contiguous().sort_unstable_by_key(|m| m.id);
+        // Get rid of the overflow at the front of the queue.
+        channel_messages.drain(..max_messages);
+    }
+
     /// Updates the cache with the update implementation for an event or other custom update
     /// implementation.
     ///

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -106,10 +106,11 @@ impl CacheHttp for Context {
 }
 
 #[cfg(feature = "cache")]
-impl CacheHttp for (&Arc<Cache>, &Http) {
+impl CacheHttp for (Option<&Arc<Cache>>, &Http) {
     fn cache(&self) -> Option<&Arc<Cache>> {
-        Some(self.0)
+        self.0
     }
+
     fn http(&self) -> &Http {
         self.1
     }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -535,6 +535,9 @@ impl ChannelId {
 
     /// Gets the list of [`Message`]s which are pinned to the channel.
     ///
+    /// If the cache is enabled, this method will fill up the message cache for the channel, if the
+    /// messages returned are newer than the existing cached messages or the cache is not full yet.
+    ///
     /// **Note**: Returns an empty [`Vec`] if the current user does not have the [Read Message
     /// History] permission.
     ///


### PR DESCRIPTION
Fills the (non temp) message cache with messages from `ChannelId::messages`/`pins`. This doesn't need to be temporary as they will stay consistent with events and will be thrown out when new messages are received anyway.