### PR TITLE
Add `CreateAttachmentStream` type

### DIFF
--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -99,7 +99,7 @@ impl<'a> CreateForumPost<'a> {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     #[cfg(feature = "http")]
     pub async fn execute(mut self, http: &Http, channel_id: ChannelId) -> Result<GuildChannel> {
-        let files = self.message.attachments.take_files();
+        let files = self.message.attachments.take_files().await?;
         http.create_forum_post_with_attachments(channel_id, &self, files, self.audit_log_reason)
             .await
     }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -130,7 +130,7 @@ impl CreateInteractionResponse<'_> {
         let files = match &mut self {
             CreateInteractionResponse::Message(msg)
             | CreateInteractionResponse::Defer(msg)
-            | CreateInteractionResponse::UpdateMessage(msg) => msg.attachments.take_files(),
+            | CreateInteractionResponse::UpdateMessage(msg) => msg.attachments.take_files().await?,
             _ => Vec::new(),
         };
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -167,7 +167,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.take_files();
+        let files = self.attachments.take_files().await?;
 
         match message_id {
             Some(id) => http.edit_followup_message(interaction_token, id, &self, files).await,

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -288,7 +288,7 @@ impl<'a> CreateMessage<'a> {
 
         let http = cache_http.http();
 
-        let files = self.attachments.take_files();
+        let files = self.attachments.take_files().await?;
 
         #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut message = http.send_message(channel_id, files, &self).await?;

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -114,7 +114,10 @@ impl<'a> EditInteractionResponse<'a> {
     pub async fn execute(mut self, http: &Http, interaction_token: &str) -> Result<Message> {
         self.0.check_length()?;
 
-        let files = self.0.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
+        let files = match self.0.attachments.as_mut() {
+            Some(attachments) => attachments.take_files().await?,
+            None => Vec::new(),
+        };
 
         http.edit_original_interaction_response(interaction_token, &self, files).await
     }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -252,7 +252,10 @@ impl<'a> EditMessage<'a> {
             }
         }
 
-        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
+        let files = match self.attachments.as_mut() {
+            Some(attachments) => attachments.take_files().await?,
+            None => Vec::new(),
+        };
 
         cache_http.http().edit_message(channel_id, message_id, &self, files).await
     }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -164,7 +164,10 @@ impl<'a> EditWebhookMessage<'a> {
     ) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
+        let files = match self.attachments.as_mut() {
+            Some(attachments) => attachments.take_files().await?,
+            None => Vec::new(),
+        };
 
         http.edit_webhook_message(
             webhook_id,

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -342,7 +342,7 @@ impl<'a> ExecuteWebhook<'a> {
     ) -> Result<Option<Message>> {
         self.check_length()?;
 
-        let files = self.attachments.take_files();
+        let files = self.attachments.take_files().await?;
 
         http.execute_webhook(webhook_id, self.thread_id, webhook_token, wait, files, &self).await
     }


### PR DESCRIPTION
Addresses #2690 by adding a type which allows lazily creating attachments which only get resolved at request time. The `Clone` requirement means that we can't store the `Reader` types directly, which is unfortunate but not too bad.

Draft for now because I don't know how to concisely add support to the `create_*` builders. Adding support to the `edit_*` builders was easy by just adding an `EditAttachments::add_stream` method. However, the `create_*` builders have three separate methods for adding attachments: `add_file`, `add_files`, and `files`. Duplicating all three to accommodate the streaming variant seems quite noisy.