### PR TITLE
Add Clone to Interactions Endpoint Verifier

### DIFF
--- a/src/interactions_endpoint.rs
+++ b/src/interactions_endpoint.rs
@@ -53,6 +53,7 @@ impl std::error::Error for InvalidKey {
 ///     // Send HTTP 401 Unauthorized response
 /// }
 /// ```
+#[derive(Clone)]
 pub struct Verifier {
     public_key: ed25519_dalek::VerifyingKey,
 }


### PR DESCRIPTION
Add Clone trait to Verifier. This makes it easier to use in things like Axum stateful middleware. 

For example:
```rust
async fn discord_verifier(
    State(verifier): State<Verifier>,
    request: Request,
    next: Next,
) -> Response {
...
```