### PR TITLE
Remove comment about bots not being able to send stickers

### DIFF
--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -142,8 +142,6 @@ fn banner_url(banner_asset_id: StickerPackBannerId) -> String {
 
 /// A sticker sent with a message.
 ///
-/// Bots cannot send stickers.
-///
 /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
The builders support this already, but for whatever reason this comment still is here saying that bots cannot send them.

![image](https://github.com/serenity-rs/serenity/assets/22662856/12932331-488b-4fae-9759-ef3f2834ed32)
