### PR TITLE
Use join_to_string throughout serenity

### DIFF
--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::fmt::Write;
 
 use arrayvec::ArrayVec;
 use url::Url;
@@ -9,16 +8,6 @@ use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
-
-fn join_to_string(sep: char, iter: impl Iterator<Item = impl std::fmt::Display>) -> String {
-    let mut buf = String::new();
-    for item in iter {
-        write!(buf, "{item}{sep}").unwrap();
-    }
-
-    buf.truncate(buf.len() - 1);
-    buf
-}
 
 /// A builder for constructing an invite link with custom OAuth2 scopes.
 #[derive(Debug, Clone, Default)]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3200,10 +3200,7 @@ impl Http {
             params.push(("user_id", user_id.to_string()));
         }
         if let Some(sku_ids) = sku_ids {
-            params.push((
-                "sku_ids",
-                sku_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(","),
-            ));
+            params.push(("sku_ids", join_to_string(',', sku_ids)));
         }
         if let Some(before) = before {
             params.push(("before", before.to_string()));

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -4,3 +4,5 @@ pub mod macros;
 pub mod prelude;
 
 pub mod tokio;
+
+pub mod utils;

--- a/src/internal/prelude.rs
+++ b/src/internal/prelude.rs
@@ -7,6 +7,7 @@ pub use std::result::Result as StdResult;
 pub use serde_json::Value;
 pub use small_fixed_array::{FixedArray, FixedString, TruncatingInto};
 
+pub(crate) use super::utils::join_to_string;
 pub use crate::error::{Error, Result};
 
 pub type JsonMap = serde_json::Map<String, Value>;

--- a/src/internal/utils.rs
+++ b/src/internal/utils.rs
@@ -1,0 +1,14 @@
+use std::fmt::Write;
+
+pub(crate) fn join_to_string(
+    sep: impl std::fmt::Display,
+    iter: impl IntoIterator<Item = impl std::fmt::Display>,
+) -> String {
+    let mut buf = String::new();
+    for item in iter {
+        write!(buf, "{item}{sep}").unwrap();
+    }
+
+    buf.truncate(buf.len() - 1);
+    buf
+}

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -350,8 +350,7 @@ pub mod comma_separated_string {
         vec: &FixedArray<FixedString>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        let vec: Vec<String> = vec.iter().cloned().map(String::from).collect();
-        serializer.serialize_str(&vec.join(", "))
+        serializer.serialize_str(&join_to_string(", ", vec))
     }
 }
 


### PR DESCRIPTION
This helper was already added to bot_auth_parameters, but is useful in other places, so I made a new internal utils module and used it to reduce allocations.