### PR TITLE
Use ToArrayString for int -> str 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ small-fixed-array = { version = "0.4", features = ["serde"] }
 bool_to_bitflags = { version = "0.1.0" }
 nonmax = { version = "0.5.5", features = ["serde"] }
 strum = { version = "0.26", features = ["derive"] }
+to-arraystring = "0.1.0"
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"], optional = true }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -14,6 +14,7 @@ use reqwest::{Client, ClientBuilder, Response as ReqwestResponse, StatusCode};
 use secrecy::{ExposeSecret as _, Secret};
 use serde::de::DeserializeOwned;
 use serde_json::{from_value, json, to_string, to_vec};
+use to_arraystring::ToArrayString as _;
 use tracing::{debug, trace};
 
 use super::multipart::{Multipart, MultipartUpload};
@@ -345,7 +346,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: Some(&[("delete_message_days", delete_message_days.to_string())]),
+            params: Some(&[("delete_message_days", &delete_message_days.to_arraystring())]),
         })
         .await
     }
@@ -2495,11 +2496,14 @@ impl Http {
         files: Vec<CreateAttachment<'_>>,
         map: &impl serde::Serialize,
     ) -> Result<Option<Message>> {
+        let thread_id_str;
+        let wait_str = wait.to_arraystring();
         let mut params = ArrayVec::<_, 2>::new();
 
-        params.push(("wait", wait.to_string()));
+        params.push(("wait", wait_str.as_str()));
         if let Some(thread_id) = thread_id {
-            params.push(("thread_id", thread_id.to_string()));
+            thread_id_str = thread_id.to_arraystring();
+            params.push(("thread_id", &thread_id_str));
         }
 
         let mut request = Request {
@@ -2537,6 +2541,14 @@ impl Http {
         token: &str,
         message_id: MessageId,
     ) -> Result<Message> {
+        let thread_id_str;
+        let mut params = None;
+
+        if let Some(thread_id) = thread_id {
+            thread_id_str = thread_id.to_arraystring();
+            params = Some([("thread_id", thread_id_str.as_str())]);
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2547,10 +2559,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params: thread_id
-                .map(|thread_id| [("thread_id", thread_id.to_string())])
-                .as_ref()
-                .map(<[_; 1]>::as_slice),
+            params: params.as_ref().map(<[_; 1]>::as_slice),
         })
         .await
     }
@@ -2565,7 +2574,13 @@ impl Http {
         map: &impl serde::Serialize,
         new_attachments: Vec<CreateAttachment<'_>>,
     ) -> Result<Message> {
-        let params = thread_id.map(|thread_id| [("thread_id", thread_id.to_string())]);
+        let thread_id_str;
+        let mut params = None;
+
+        if let Some(thread_id) = thread_id {
+            thread_id_str = thread_id.to_arraystring();
+            params = Some([("thread_id", thread_id_str.as_str())]);
+        }
 
         let mut request = Request {
             body: None,
@@ -2601,6 +2616,14 @@ impl Http {
         token: &str,
         message_id: MessageId,
     ) -> Result<()> {
+        let thread_id_str;
+        let mut params = None;
+
+        if let Some(thread_id) = thread_id {
+            thread_id_str = thread_id.to_arraystring();
+            params = Some([("thread_id", thread_id_str.as_str())]);
+        }
+
         self.wind(204, Request {
             body: None,
             multipart: None,
@@ -2611,10 +2634,7 @@ impl Http {
                 token,
                 message_id,
             },
-            params: thread_id
-                .map(|thread_id| [("thread_id", thread_id.to_string())])
-                .as_ref()
-                .map(<[_; 1]>::as_slice),
+            params: params.as_ref().map(<[_; 1]>::as_slice),
         })
         .await
     }
@@ -2659,17 +2679,23 @@ impl Http {
         target: Option<UserPagination>,
         limit: Option<u8>,
     ) -> Result<Vec<Ban>> {
+        let id_str;
+        let limit_str;
         let mut params = ArrayVec::<_, 2>::new();
 
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", limit_str.as_str()));
         }
 
         if let Some(target) = target {
-            match target {
-                UserPagination::After(id) => params.push(("after", id.to_string())),
-                UserPagination::Before(id) => params.push(("before", id.to_string())),
-            }
+            let (name, id) = match target {
+                UserPagination::After(id) => ("after", id),
+                UserPagination::Before(id) => ("before", id),
+            };
+
+            id_str = id.to_arraystring();
+            params.push((name, &id_str));
         }
 
         self.fire(Request {
@@ -2694,18 +2720,23 @@ impl Http {
         before: Option<AuditLogEntryId>,
         limit: Option<u8>,
     ) -> Result<AuditLogs> {
+        let (action_type_str, before_str, limit_str, user_id_str);
         let mut params = ArrayVec::<_, 4>::new();
         if let Some(action_type) = action_type {
-            params.push(("action_type", action_type.num().to_string()));
+            action_type_str = action_type.num().to_arraystring();
+            params.push(("action_type", action_type_str.as_str()));
         }
         if let Some(before) = before {
-            params.push(("before", before.to_string()));
+            before_str = before.to_arraystring();
+            params.push(("before", &before_str));
         }
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", &limit_str));
         }
         if let Some(user_id) = user_id {
-            params.push(("user_id", user_id.to_string()));
+            user_id_str = user_id.to_arraystring();
+            params.push(("user_id", &user_id_str));
         }
 
         self.fire(Request {
@@ -2897,12 +2928,15 @@ impl Http {
         before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
+        let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
-            params.push(("before", before.to_string()));
+            before_str = before.to_string();
+            params.push(("before", before_str.as_str()));
         }
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", &limit_str));
         }
 
         self.fire(Request {
@@ -2925,12 +2959,15 @@ impl Http {
         before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
+        let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
-            params.push(("before", before.to_string()));
+            before_str = before.to_string();
+            params.push(("before", before_str.as_str()));
         }
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", &limit_str));
         }
 
         self.fire(Request {
@@ -2953,12 +2990,15 @@ impl Http {
         before: Option<ChannelId>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
+        let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
-            params.push(("before", before.to_string()));
+            before_str = before.to_arraystring();
+            params.push(("before", before_str.as_str()));
         }
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", &limit_str));
         }
 
         self.fire(Request {
@@ -3194,28 +3234,36 @@ impl Http {
         guild_id: Option<GuildId>,
         exclude_ended: Option<bool>,
     ) -> Result<Vec<Entitlement>> {
+        let (user_id_str, sku_ids_str, before_str, after_str, limit_str, guild_id_str, exclude_str);
         let mut params = ArrayVec::<_, 7>::new();
 
         if let Some(user_id) = user_id {
-            params.push(("user_id", user_id.to_string()));
+            user_id_str = user_id.to_arraystring();
+            params.push(("user_id", user_id_str.as_str()));
         }
         if let Some(sku_ids) = sku_ids {
-            params.push(("sku_ids", join_to_string(',', sku_ids)));
+            sku_ids_str = join_to_string(',', sku_ids);
+            params.push(("sku_ids", &sku_ids_str));
         }
         if let Some(before) = before {
-            params.push(("before", before.to_string()));
+            before_str = before.to_arraystring();
+            params.push(("before", &before_str));
         }
         if let Some(after) = after {
-            params.push(("after", after.to_string()));
+            after_str = after.to_arraystring();
+            params.push(("after", &after_str));
         }
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", &limit_str));
         }
         if let Some(guild_id) = guild_id {
-            params.push(("guild_id", guild_id.to_string()));
+            guild_id_str = guild_id.to_arraystring();
+            params.push(("guild_id", &guild_id_str));
         }
         if let Some(exclude_ended) = exclude_ended {
-            params.push(("exclude_ended", exclude_ended.to_string()));
+            exclude_str = exclude_ended.to_arraystring();
+            params.push(("exclude_ended", &exclude_str));
         }
 
         self.fire(Request {
@@ -3269,7 +3317,7 @@ impl Http {
             route: Route::Commands {
                 application_id: self.try_application_id()?,
             },
-            params: Some(&[("with_localizations", String::from("true"))]),
+            params: Some(&[("with_localizations", "true")]),
         })
         .await
     }
@@ -3315,7 +3363,7 @@ impl Http {
             route: Route::Guild {
                 guild_id,
             },
-            params: Some(&[("with_counts", String::from("true"))]),
+            params: Some(&[("with_counts", "true")]),
         })
         .await
     }
@@ -3351,7 +3399,7 @@ impl Http {
                 application_id: self.try_application_id()?,
                 guild_id,
             },
-            params: Some(&[("with_localizations", String::from("true"))]),
+            params: Some(&[("with_localizations", "true")]),
         })
         .await
     }
@@ -3523,10 +3571,15 @@ impl Http {
         limit: Option<NonMaxU16>,
         after: Option<UserId>,
     ) -> Result<Vec<Member>> {
+        let (limit_str, after_str);
         let mut params = ArrayVec::<_, 2>::new();
-        params.push(("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string()));
+
+        limit_str = limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).get().to_arraystring();
+        params.push(("limit", limit_str.as_str()));
+
         if let Some(after) = after {
-            params.push(("after", after.to_string()));
+            after_str = after.to_arraystring();
+            params.push(("after", &after_str));
         }
 
         let mut value: Value = self
@@ -3555,6 +3608,7 @@ impl Http {
 
     /// Gets the amount of users that can be pruned.
     pub async fn get_guild_prune_count(&self, guild_id: GuildId, days: u8) -> Result<GuildPrune> {
+        let days_str = days.to_arraystring();
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3563,7 +3617,7 @@ impl Http {
             route: Route::GuildPrune {
                 guild_id,
             },
-            params: Some(&[("days", days.to_string())]),
+            params: Some(&[("days", &days_str)]),
         })
         .await
     }
@@ -3621,6 +3675,7 @@ impl Http {
         event_id: ScheduledEventId,
         with_user_count: bool,
     ) -> Result<ScheduledEvent> {
+        let with_user_count_str = with_user_count.to_arraystring();
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3630,7 +3685,7 @@ impl Http {
                 guild_id,
                 event_id,
             },
-            params: Some(&[("with_user_count", with_user_count.to_string())]),
+            params: Some(&[("with_user_count", &with_user_count_str)]),
         })
         .await
     }
@@ -3645,6 +3700,7 @@ impl Http {
         guild_id: GuildId,
         with_user_count: bool,
     ) -> Result<Vec<ScheduledEvent>> {
+        let with_user_count_str = with_user_count.to_arraystring();
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3653,7 +3709,7 @@ impl Http {
             route: Route::GuildScheduledEvents {
                 guild_id,
             },
-            params: Some(&[("with_user_count", with_user_count.to_string())]),
+            params: Some(&[("with_user_count", &with_user_count_str)]),
         })
         .await
     }
@@ -3682,18 +3738,24 @@ impl Http {
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
+        let (limit_str, with_member_str, id_str);
         let mut params = ArrayVec::<_, 3>::new();
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", limit_str.as_str()));
         }
         if let Some(with_member) = with_member {
-            params.push(("with_member", with_member.to_string()));
+            with_member_str = with_member.to_arraystring();
+            params.push(("with_member", &with_member_str));
         }
         if let Some(target) = target {
-            match target {
-                UserPagination::After(id) => params.push(("after", id.to_string())),
-                UserPagination::Before(id) => params.push(("before", id.to_string())),
-            }
+            let (name, id) = match target {
+                UserPagination::After(id) => ("after", id),
+                UserPagination::Before(id) => ("before", id),
+            };
+
+            id_str = id.to_arraystring();
+            params.push((name, &id_str));
         }
 
         self.fire(Request {
@@ -3828,15 +3890,20 @@ impl Http {
         target: Option<GuildPagination>,
         limit: Option<u64>,
     ) -> Result<Vec<GuildInfo>> {
+        let (limit_str, id_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", limit_str.as_str()));
         }
         if let Some(target) = target {
-            match target {
-                GuildPagination::After(id) => params.push(("after", id.to_string())),
-                GuildPagination::Before(id) => params.push(("before", id.to_string())),
-            }
+            let (name, id) = match target {
+                GuildPagination::After(id) => ("after", id),
+                GuildPagination::Before(id) => ("before", id),
+            };
+
+            id_str = id.to_arraystring();
+            params.push((name, &id_str));
         }
 
         self.fire(Request {
@@ -3918,14 +3985,21 @@ impl Http {
         expiration: bool,
         event_id: Option<ScheduledEventId>,
     ) -> Result<Invite> {
+        let (member_counts_str, expiration_str, event_id_str);
         #[cfg(feature = "utils")]
         let code = crate::utils::parse_invite(code);
 
         let mut params = ArrayVec::<_, 3>::new();
-        params.push(("member_counts", member_counts.to_string()));
-        params.push(("expiration", expiration.to_string()));
+
+        member_counts_str = member_counts.to_arraystring();
+        params.push(("member_counts", member_counts_str.as_str()));
+
+        expiration_str = expiration.to_arraystring();
+        params.push(("expiration", &expiration_str));
+
         if let Some(event_id) = event_id {
-            params.push(("event_id", event_id.to_string()));
+            event_id_str = event_id.to_arraystring();
+            params.push(("event_id", &event_id_str));
         }
 
         self.fire(Request {
@@ -3991,16 +4065,23 @@ impl Http {
         target: Option<MessagePagination>,
         limit: Option<u8>,
     ) -> Result<Vec<Message>> {
+        let (limit_str, id_str);
         let mut params = ArrayVec::<_, 2>::new();
+
         if let Some(limit) = limit {
-            params.push(("limit", limit.to_string()));
+            limit_str = limit.to_arraystring();
+            params.push(("limit", limit_str.as_str()));
         }
+
         if let Some(target) = target {
-            match target {
-                MessagePagination::After(id) => params.push(("after", id.to_string())),
-                MessagePagination::Around(id) => params.push(("around", id.to_string())),
-                MessagePagination::Before(id) => params.push(("before", id.to_string())),
-            }
+            let (name, id) = match target {
+                MessagePagination::After(id) => ("after", id),
+                MessagePagination::Around(id) => ("around", id),
+                MessagePagination::Before(id) => ("before", id),
+            };
+
+            id_str = id.to_arraystring();
+            params.push((name, &id_str));
         }
 
         self.fire(Request {
@@ -4059,11 +4140,17 @@ impl Http {
         limit: u8,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
+        let (limit_str, after_str);
         let mut params = ArrayVec::<_, 2>::new();
-        params.push(("limit", limit.to_string()));
+
+        limit_str = limit.to_arraystring();
+        params.push(("limit", limit_str.as_str()));
+
         if let Some(after) = after {
-            params.push(("after", after.to_string()));
+            after_str = after.to_arraystring();
+            params.push(("after", &after_str));
         }
+
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4474,6 +4561,7 @@ impl Http {
         query: &str,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
+        let limit_str = limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).get().to_arraystring();
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -4483,10 +4571,7 @@ impl Http {
                 route: Route::GuildMembersSearch {
                     guild_id,
                 },
-                params: Some(&[
-                    ("query", query.to_string()),
-                    ("limit", limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).to_string()),
-                ]),
+                params: Some(&[("query", query), ("limit", &limit_str)]),
             })
             .await?;
 
@@ -4508,6 +4593,7 @@ impl Http {
         days: u8,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildPrune> {
+        let days_str = days.to_arraystring();
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4516,7 +4602,7 @@ impl Http {
             route: Route::GuildPrune {
                 guild_id,
             },
-            params: Some(&[("days", days.to_string())]),
+            params: Some(&[("days", &days_str)]),
         })
         .await
     }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -24,7 +24,7 @@ pub struct Request<'a> {
     pub(super) headers: Option<Headers>,
     pub(super) method: LightMethod,
     pub(super) route: Route<'a>,
-    pub(super) params: Option<&'a [(&'static str, String)]>,
+    pub(super) params: Option<&'a [(&'a str, &'a str)]>,
 }
 
 impl<'a> Request<'a> {
@@ -54,7 +54,7 @@ impl<'a> Request<'a> {
         self
     }
 
-    pub fn params(mut self, params: &'a [(&'static str, String)]) -> Self {
+    pub fn params(mut self, params: &'a [(&'a str, &'a str)]) -> Self {
         if params.is_empty() {
             self.params = None;
         } else {
@@ -73,7 +73,7 @@ impl<'a> Request<'a> {
         token: &str,
         proxy: Option<&str>,
     ) -> Result<ReqwestRequestBuilder> {
-        let mut path = self.route.path().to_string();
+        let mut path = self.route.path().into_owned();
 
         if let Some(proxy) = proxy {
             // trim_end_matches to prevent double slashes after the domain
@@ -139,7 +139,7 @@ impl<'a> Request<'a> {
     }
 
     #[must_use]
-    pub fn params_ref(&self) -> Option<&'a [(&'static str, String)]> {
+    pub fn params_ref(&self) -> Option<&'a [(&'a str, &'a str)]> {
         self.params
     }
 }

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 
 use nonmax::NonMaxU64;
+use to_arraystring::ToArrayString;
 
 use super::Timestamp;
 
@@ -99,6 +100,13 @@ macro_rules! id_u64 {
 
                 fn from_str(s: &str) -> Result<Self, Self::Err> {
                     s.parse().map(Self).map_err(ParseIdError)
+                }
+            }
+
+            impl ToArrayString for $name {
+                type ArrayString = <u64 as ToArrayString>::ArrayString;
+                fn to_arraystring(self) -> Self::ArrayString {
+                    self.get().to_arraystring()
                 }
             }
 


### PR DESCRIPTION
This replaces the slow heap allocations with stack allocations at the cost of complicating the code because of lifetime shenanigans.

It also makes ToArrayString a public trait implementation for Ids, which shouldn't be a problem, but I can remove if wanted.