### PR TITLE
Remove Channel::name

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -492,23 +492,6 @@ impl ChannelId {
         MessagesIter::stream(cache_http, self)
     }
 
-    /// Returns the name of whatever channel this id holds.
-    ///
-    /// DM channels don't have a name, so a name is generated according to
-    /// [`PrivateChannel::name()`].
-    ///
-    /// # Errors
-    ///
-    /// Same as [`Self::to_channel()`].
-    pub async fn name(self, cache_http: impl CacheHttp) -> Result<String> {
-        let channel = self.to_channel(cache_http).await?;
-
-        Ok(match channel {
-            Channel::Guild(channel) => channel.name.into(),
-            Channel::Private(channel) => channel.name(),
-        })
-    }
-
     /// Pins a [`Message`] to the channel.
     ///
     /// **Note**: Requires the [Manage Messages] permission.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -674,12 +674,6 @@ impl GuildChannel {
         self.id.messages(http, builder).await
     }
 
-    /// Returns the name of the guild channel.
-    #[must_use]
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
     /// Calculates the permissions of a member.
     ///
     /// The Id of the argument must be a [`Member`] of the [`Guild`] that the channel is in.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -183,12 +183,6 @@ impl PrivateChannel {
         self.id.messages(http, builder).await
     }
 
-    /// Returns "DM with $username#discriminator".
-    #[must_use]
-    pub fn name(&self) -> String {
-        format!("DM with {}", self.recipient.tag())
-    }
-
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a certain [`Emoji`].
     ///
     /// The default `limit` is `50` - specify otherwise to receive a different maximum number of

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -206,8 +206,8 @@ pub enum OnlineStatus {
 
 impl OnlineStatus {
     #[must_use]
-    pub fn name(&self) -> &str {
-        match *self {
+    pub fn name(self) -> &'static str {
+        match self {
             OnlineStatus::DoNotDisturb => "dnd",
             OnlineStatus::Idle => "idle",
             OnlineStatus::Invisible => "invisible",


### PR DESCRIPTION
`Channel::name` just called to_channel (cloning the entire Channel!) and `PrivateChannel::name` or `GuildChannel::name`
`GuildChannel::name` just returned the field of the same name, for consistency with `PrivateChannel::name`
`PrivateChannel::name` returned a non-standard format string that would be very easy to replicate in user code.

I also tweaked the signature of `OnlineStatus::name` to stop passing an 8 byte reference to a 1 byte struct, and return `&'static str`. 