### PR TITLE
switch to strum for fullevent and event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ arrayvec = { version = "0.7.4", features = ["serde"] }
 small-fixed-array = { version = "0.4", features = ["serde"] }
 bool_to_bitflags = { version = "0.1.0" }
 nonmax = { version = "0.5.5", features = ["serde"] }
+strum = { version = "0.26", features = ["derive"] }
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"], optional = true }

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 use std::num::NonZeroU16;
 
 use async_trait::async_trait;
+use strum::{EnumCount, IntoStaticStr, VariantNames};
 
 use super::context::Context;
 use crate::gateway::ShardStageUpdateEvent;
@@ -31,7 +32,7 @@ macro_rules! event_handler {
 
         /// This enum stores every possible event that an [`EventHandler`] can receive.
         #[non_exhaustive]
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug, VariantNames, IntoStaticStr, EnumCount)]
         pub enum FullEvent {
             $(
                 $( #[doc = $doc] )*

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -241,15 +241,11 @@ impl fmt::Display for Error {
             Self::TooSmall {
                 minimum,
                 value,
-            } => {
-                write!(f, "The {minimum} minimum has been missed by {value}")
-            },
+            } => write!(f, "The {minimum} minimum has been missed by {value}"),
             Self::TooLarge {
                 maximum,
                 value,
-            } => {
-                write!(f, "The {maximum} maximum has been overflowed by {value}")
-            },
+            } => write!(f, "The {maximum} maximum has been overflowed by {value}"),
             Self::GuildNotFound => f.write_str("Guild not found in the cache."),
             Self::RoleNotFound => f.write_str("Role not found in the cache."),
             Self::MemberNotFound => f.write_str("Member not found in the cache."),

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -241,11 +241,15 @@ impl fmt::Display for Error {
             Self::TooSmall {
                 minimum,
                 value,
-            } => write!(f, "The {minimum} minimum has been missed by {value}"),
+            } => {
+                write!(f, "The {minimum} minimum has been missed by {value}")
+            },
             Self::TooLarge {
                 maximum,
                 value,
-            } => write!(f, "The {maximum} maximum has been overflowed by {value}"),
+            } => {
+                write!(f, "The {maximum} maximum has been overflowed by {value}")
+            },
             Self::GuildNotFound => f.write_str("Guild not found in the cache."),
             Self::RoleNotFound => f.write_str("Role not found in the cache."),
             Self::MemberNotFound => f.write_str("Member not found in the cache."),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -9,6 +9,7 @@
 use nonmax::NonMaxU64;
 use serde::de::Error as DeError;
 use serde::Serialize;
+use strum::{EnumCount, IntoStaticStr, VariantNames};
 use tracing::{debug, warn};
 
 use crate::constants::Opcode;
@@ -1107,7 +1108,8 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#receive-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, EnumCount, VariantNames, IntoStaticStr)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[serde(tag = "t", content = "d")]
 #[non_exhaustive]
@@ -1305,9 +1307,8 @@ pub enum Event {
 impl Event {
     /// Returns the event name of this event.
     #[must_use]
-    pub fn name(&self) -> Option<String> {
-        let map = serde_json::to_value(self).ok()?;
-        Some(map.get("t")?.as_str()?.to_string())
+    pub fn name(&self) -> &'static str {
+        self.into()
     }
 
     pub(crate) fn deserialize_and_log(map: JsonMap, original_str: &str) -> Result<Self> {


### PR DESCRIPTION
Add Strum for getting variant names and list of all variants for large enums such as FullEvent and Event. Also removes a hack (``Event::name``) where serde is used to get the variant name