### PR TITLE
disable non_exhaustive if unstable_discord_api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,13 @@ jobs:
           - name: chrono
             features: chrono
           - name: unstable API + typesize
-            features: default unstable_discord_api typesize
+            features: default unstable typesize
             dont-test: true
           - name: builder without model
             features: builder
             dont-test: true
           - name: unstable Discord API (no default features)
-            features: unstable_discord_api
+            features: unstable
             dont-test: true
 
     steps:
@@ -207,7 +207,7 @@ jobs:
 
       - name: Build docs
         run: |
-          cargo doc --no-deps --features collector,voice,unstable_discord_api
+          cargo doc --no-deps --features collector,voice,unstable
         env:
           RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ model = ["builder", "http", "utils"]
 voice_model = ["serenity-voice-model"]
 # Enables support for Discord API functionality that's not stable yet, as well as serenity APIs that
 # are allowed to change even in semver non-breaking updates.
-unstable_discord_api = []
+unstable = []
 # Enables some utility functions that can be useful for bot creators.
 utils = []
 voice = ["client", "model"]
@@ -113,7 +113,9 @@ chrono = ["dep:chrono", "typesize?/chrono"]
 
 # This enables all parts of the serenity codebase
 # (Note: all feature-gated APIs to be documented should have their features listed here!)
-full = ["default", "collector", "unstable_discord_api", "voice", "voice_model", "interactions_endpoint"]
+# 
+# Unstable functionality should be gated under the `unstable` feature.
+full = ["default", "collector", "voice", "voice_model", "interactions_endpoint"]
 
 # Enables temporary caching in functions that retrieve data via the HTTP API.
 temp_cache = ["cache", "mini-moka", "typesize?/mini_moka"]

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ the HTTP functions.
 - **default_native_tls**: Default features but using `native_tls_backend`
 instead of `rustls_backend`.
 - **tokio_task_builder**: Enables tokio's `tracing` feature and uses `tokio::task::Builder` to spawn tasks with names if `RUSTFLAGS="--cfg tokio_unstable"` is set.
-- **unstable_discord_api**: Enables features of the Discord API that do not have a stable interface. The features might not have official documentation or are subject to change.
+- **unstable**: Enables features of the Discord API that do not have a stable interface. The features might not have official documentation or are subject to change.
 - **temp_cache**: Enables temporary caching in functions that retrieve data via the HTTP API.
 - **chrono**: Uses the `chrono` crate to represent timestamps. If disabled, the `time` crate is used instead.
 - **interactions_endpoint**: Enables tools related to Discord's Interactions Endpoint URL feature

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ the HTTP functions.
 - **default_native_tls**: Default features but using `native_tls_backend`
 instead of `rustls_backend`.
 - **tokio_task_builder**: Enables tokio's `tracing` feature and uses `tokio::task::Builder` to spawn tasks with names if `RUSTFLAGS="--cfg tokio_unstable"` is set.
-- **unstable**: Enables features of the Discord API that do not have a stable interface. The features might not have official documentation or are subject to change.
+- **unstable**: Enables features of the Serenity and Discord API that do not have a stable interface. The features might not have official documentation and are subject to change without a breaking version bump.
 - **temp_cache**: Enables temporary caching in functions that retrieve data via the HTTP API.
 - **chrono**: Uses the `chrono` crate to represent timestamps. If disabled, the `time` crate is used instead.
 - **interactions_endpoint**: Enables tools related to Discord's Interactions Endpoint URL feature

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -31,8 +31,9 @@ macro_rules! event_handler {
         }
 
         /// This enum stores every possible event that an [`EventHandler`] can receive.
-        #[non_exhaustive]
+        #[cfg_attr(not(feature = "unstable_discord_api"), non_exhaustive)]
         #[derive(Clone, Debug, VariantNames, IntoStaticStr, EnumCount)]
+        #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
         pub enum FullEvent {
             $(
                 $( #[doc = $doc] )*

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -31,7 +31,7 @@ macro_rules! event_handler {
         }
 
         /// This enum stores every possible event that an [`EventHandler`] can receive.
-        #[cfg_attr(not(feature = "unstable_discord_api"), non_exhaustive)]
+        #[cfg_attr(not(feature = "unstable"), non_exhaustive)]
         #[derive(Clone, Debug, VariantNames, IntoStaticStr, EnumCount)]
         #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
         pub enum FullEvent {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -63,11 +63,11 @@ pub struct Activity {
     pub timestamps: Option<ActivityTimestamps>,
     /// The sync ID of the activity. Mainly used by the Spotify activity type which uses this
     /// parameter to store the track ID.
-    #[cfg(feature = "unstable_discord_api")]
+    #[cfg(feature = "unstable")]
     pub sync_id: Option<FixedString>,
     /// The session ID of the activity. Reserved for specific activity types, such as the Activity
     /// that is transmitted when a user is listening to Spotify.
-    #[cfg(feature = "unstable_discord_api")]
+    #[cfg(feature = "unstable")]
     pub session_id: Option<FixedString>,
     /// The Stream URL if [`Self::kind`] is [`ActivityType::Streaming`].
     pub url: Option<Url>,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -344,7 +344,7 @@ bitflags! {
         /// Bot's running with HTTP interactions
         const BOT_HTTP_INTERACTIONS = 1 << 19;
         /// User's flag for suspected spam activity.
-        #[cfg(feature = "unstable_discord_api")]
+        #[cfg(feature = "unstable")]
         const SPAMMER = 1 << 20;
         /// User's flag as active developer
         const ACTIVE_DEVELOPER = 1 << 22;


### PR DESCRIPTION
Disables the ``non_exhaustive`` attribute in FullEvent if ``unstable_discord_api`` is enabled as a feature. It is already expected that any change to serenity with ``unstable_discord_api`` enabled may or may not break code using this feature and making this enum exhaustive allows for use cases such as fine-grained audit logging etc. where new variants should be a compiler error