### PR TITLE
Deprecate Channel::is_nsfw

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -664,13 +664,11 @@ impl GuildChannel {
     }
 
     /// Determines if the channel is NSFW.
-    ///
-    /// Only [text channels][`ChannelType::Text`] are taken into consideration as being NSFW.
-    /// [voice channels][`ChannelType::Voice`] are never NSFW.
     #[inline]
     #[must_use]
+    #[deprecated = "Use the GuildChannel::nsfw field"]
     pub fn is_nsfw(&self) -> bool {
-        self.kind == ChannelType::Text && self.nsfw
+        self.nsfw
     }
 
     /// Gets a message from the channel.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -142,8 +142,10 @@ impl Channel {
     #[inline]
     #[must_use]
     #[cfg(feature = "model")]
+    #[deprecated = "Use the GuildChannel::nsfw field, as PrivateChannel is never NSFW"]
     pub fn is_nsfw(&self) -> bool {
         match self {
+            #[allow(deprecated)]
             Self::Guild(channel) => channel.is_nsfw(),
             Self::Private(_) => false,
         }
@@ -479,44 +481,6 @@ pub struct ThreadsData {
     /// Whether there are potentially more threads that could be returned on a subsequent call.
     #[serde(default)]
     pub has_more: bool,
-}
-
-#[cfg(test)]
-mod test {
-    #[cfg(all(feature = "model", feature = "utils"))]
-    mod model_utils {
-        use crate::model::prelude::*;
-
-        #[test]
-        fn nsfw_checks() {
-            let mut channel = GuildChannel::default();
-            assert!(!channel.is_nsfw());
-            channel.kind = ChannelType::Voice;
-            assert!(!channel.is_nsfw());
-
-            channel.kind = ChannelType::Text;
-            channel.name = "nsfw-".to_string();
-            assert!(!channel.is_nsfw());
-
-            channel.name = "nsfw".to_string();
-            assert!(!channel.is_nsfw());
-            channel.kind = ChannelType::Voice;
-            assert!(!channel.is_nsfw());
-            channel.kind = ChannelType::Text;
-
-            channel.name = "nsf".to_string();
-            channel.nsfw = true;
-            assert!(channel.is_nsfw());
-            channel.nsfw = false;
-            assert!(!channel.is_nsfw());
-
-            let channel = Channel::Guild(channel);
-            assert!(!channel.is_nsfw());
-
-            let private_channel = PrivateChannel::default();
-            assert!(!private_channel.is_nsfw());
-        }
-    }
 }
 
 /// An object that specifies the emoji to use for Forum related emoji parameters.

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -156,12 +156,10 @@ impl PrivateChannel {
     }
 
     /// Determines if the channel is NSFW.
-    ///
-    /// **Note**: This method is for consistency. This will always return `false`, due to DMs not
-    /// being considered NSFW.
     #[inline]
     #[must_use]
     #[allow(clippy::unused_self)]
+    #[deprecated = "This always returns false"]
     pub fn is_nsfw(&self) -> bool {
         false
     }


### PR DESCRIPTION
Similar to #2787, GuildChannel::is_nsfw was the only method doing anything and that logic was wrong, as voice channels can be nsfw. Once this is merged, I'll rebase next on current and open a PR to remove the methods.