### PR TITLE
Remove deprecated Channel::is_nsfw methods

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -633,13 +633,6 @@ impl GuildChannel {
         self.id.invites(http).await
     }
 
-    /// Determines if the channel is NSFW.
-    #[must_use]
-    #[deprecated = "Use the GuildChannel::nsfw field"]
-    pub fn is_nsfw(&self) -> bool {
-        self.nsfw
-    }
-
     /// Gets a message from the channel.
     ///
     /// Requires the [Read Message History] permission.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -91,9 +91,7 @@ pub struct GuildChannel {
     ///
     /// This is max 99 for voice channels and 10,000 for stage channels (0 refers to no limit).
     pub user_limit: Option<NonMaxU16>,
-    /// Used to tell if the channel is not safe for work. Note however, it's recommended to use
-    /// [`Self::is_nsfw`] as it's gonna be more accurate.
-    // This field can or can not be present sometimes, but if it isn't default to `false`.
+    /// Used to tell if the channel is not safe for work.
     #[serde(default)]
     pub nsfw: bool,
     /// A rate limit that applies per user and excludes bots.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -134,18 +134,6 @@ impl Channel {
         Ok(())
     }
 
-    /// Determines if the channel is NSFW.
-    #[must_use]
-    #[cfg(feature = "model")]
-    #[deprecated = "Use the GuildChannel::nsfw field, as PrivateChannel is never NSFW"]
-    pub fn is_nsfw(&self) -> bool {
-        match self {
-            #[allow(deprecated)]
-            Self::Guild(channel) => channel.is_nsfw(),
-            Self::Private(_) => false,
-        }
-    }
-
     /// Retrieves the Id of the inner [`GuildChannel`], or [`PrivateChannel`].
     #[must_use]
     pub const fn id(&self) -> ChannelId {

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -146,14 +146,6 @@ impl PrivateChannel {
         self.id.edit_message(cache_http, message_id, builder).await
     }
 
-    /// Determines if the channel is NSFW.
-    #[must_use]
-    #[allow(clippy::unused_self)]
-    #[deprecated = "This always returns false"]
-    pub fn is_nsfw(&self) -> bool {
-        false
-    }
-
     /// Gets a message from the channel.
     ///
     /// # Errors


### PR DESCRIPTION
Followup to #2791.