### PR TITLE
Deprecate Cache methods returning mapped references

### DIFF
--- a/src/builder/create_stage_instance.rs
+++ b/src/builder/create_stage_instance.rs
@@ -64,25 +64,12 @@ impl<'a> Builder for CreateStageInstance<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
-    ///
     /// Returns [`Error::Http`] if there is already a stage instance currently.
     async fn execute(
         mut self,
         cache_http: impl CacheHttp,
         ctx: Self::Context<'_>,
     ) -> Result<StageInstance> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.channel(ctx) {
-                    if channel.kind != ChannelType::Stage {
-                        return Err(Error::Model(ModelError::InvalidChannelType));
-                    }
-                }
-            }
-        }
-
         self.channel_id = Some(ctx);
         cache_http.http().create_stage_instance(&self, self.audit_log_reason).await
     }

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -61,9 +61,6 @@ impl<'a> Builder for CreateWebhook<'a> {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidChannelType`] if the corresponding
-    /// channel is not of type [`Text`] or [`News`].
-    ///
     /// If the provided name is less than 2 characters, returns [`ModelError::NameTooShort`]. If it
     /// is more than 100 characters, returns [`ModelError::NameTooLong`].
     ///
@@ -77,19 +74,6 @@ impl<'a> Builder for CreateWebhook<'a> {
         cache_http: impl CacheHttp,
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.channel(ctx) {
-                    // forum channels are not text-based, but webhooks can be created in them
-                    // and used to send messages in their posts
-                    if !channel.is_text_based() && channel.kind != ChannelType::Forum {
-                        return Err(Error::Model(ModelError::InvalidChannelType));
-                    }
-                }
-            }
-        }
-
         if self.name.len() < 2 {
             return Err(Error::Model(ModelError::NameTooShort));
         } else if self.name.len() > 100 {

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -56,8 +56,6 @@ impl<'a> Builder for EditStageInstance<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError::InvalidChannelType`] if the channel is not a stage channel.
-    ///
     /// Returns [`Error::Http`] if the channel is not a stage channel, or there is no stage
     /// instance currently.
     async fn execute(
@@ -65,17 +63,6 @@ impl<'a> Builder for EditStageInstance<'a> {
         cache_http: impl CacheHttp,
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.channel(ctx) {
-                    if channel.kind != ChannelType::Stage {
-                        return Err(Error::Model(ModelError::InvalidChannelType));
-                    }
-                }
-            }
-        }
-
         cache_http.http().edit_stage_instance(ctx, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -77,9 +77,6 @@ impl Builder for EditVoiceState {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidChannelType`] if the channel is
-    /// not a stage channel.
-    ///
     /// Returns [`Error::Http`] if the user lacks permission, or if invalid data is given.
     ///
     /// [Request to Speak]: Permissions::REQUEST_TO_SPEAK
@@ -90,16 +87,6 @@ impl Builder for EditVoiceState {
         ctx: Self::Context<'_>,
     ) -> Result<Self::Built> {
         let (guild_id, channel_id, user_id) = ctx;
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.channel(channel_id) {
-                    if channel.kind != ChannelType::Stage {
-                        return Err(Error::from(ModelError::InvalidChannelType));
-                    }
-                }
-            }
-        }
 
         self.channel_id = Some(channel_id);
         if let Some(user_id) = user_id {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::mapref::entry::Entry;
-use dashmap::mapref::one::{MappedRef, MappedRefMut, Ref};
+use dashmap::mapref::one::{MappedRef, Ref};
 use dashmap::DashMap;
 #[cfg(feature = "temp_cache")]
 use mini_moka::sync::Cache as MokaCache;
@@ -368,6 +368,7 @@ impl Cache {
 
     /// Retrieves a [`GuildChannel`] from the cache based on the given Id.
     #[inline]
+    #[deprecated = "Use Cache::guild and Guild::channels instead"]
     pub fn channel<C: Into<ChannelId>>(&self, id: C) -> Option<GuildChannelRef<'_>> {
         self._channel(id.into())
     }
@@ -388,15 +389,6 @@ impl Cache {
         }
 
         None
-    }
-
-    pub(super) fn channel_mut(
-        &self,
-        id: ChannelId,
-    ) -> Option<MappedRefMut<'_, GuildId, Guild, GuildChannel, BuildHasher>> {
-        let guild_id = *self.channels.get(&id)?;
-        let guild_ref = self.guilds.get_mut(&guild_id)?;
-        guild_ref.try_map(|g| g.channels.get_mut(&id)).ok()
     }
 
     /// Get a reference to the cached messages for a channel based on the given `Id`.
@@ -492,6 +484,7 @@ impl Cache {
     /// [`EventHandler::message`]: crate::client::EventHandler::message
     /// [`members`]: crate::model::guild::Guild::members
     #[inline]
+    #[deprecated = "Use Cache::guild and Guild::members instead"]
     pub fn member(
         &self,
         guild_id: impl Into<GuildId>,
@@ -506,6 +499,7 @@ impl Cache {
     }
 
     #[inline]
+    #[deprecated = "Use Cache::guild and Guild::roles instead"]
     pub fn guild_roles(&self, guild_id: impl Into<GuildId>) -> Option<GuildRolesRef<'_>> {
         self._guild_roles(guild_id.into())
     }
@@ -523,6 +517,7 @@ impl Cache {
 
     /// This method returns all channels from a guild of with the given `guild_id`.
     #[inline]
+    #[deprecated = "Use Cache::guild and Guild::channels instead"]
     pub fn guild_channels(&self, guild_id: impl Into<GuildId>) -> Option<GuildChannelsRef<'_>> {
         self._guild_channels(guild_id.into())
     }
@@ -608,6 +603,7 @@ impl Cache {
     /// [`Guild`]: crate::model::guild::Guild
     /// [`roles`]: crate::model::guild::Guild::roles
     #[inline]
+    #[deprecated = "Use Cache::guild and Guild::roles instead"]
     pub fn role<G, R>(&self, guild_id: G, role_id: R) -> Option<GuildRoleRef<'_>>
     where
         G: Into<GuildId>,
@@ -703,7 +699,9 @@ impl Cache {
     }
 
     /// Returns a channel category matching the given ID
+    #[deprecated = "Use Cache::guild, Guild::channels, and GuildChannel::kind"]
     pub fn category(&self, channel_id: ChannelId) -> Option<GuildChannelRef<'_>> {
+        #[allow(deprecated)]
         let channel = self.channel(channel_id)?;
         if channel.kind == ChannelType::Category {
             Some(channel)
@@ -713,7 +711,9 @@ impl Cache {
     }
 
     /// Returns the parent category of the given channel ID.
+    #[deprecated = "Use Cache::guild, Guild::channels, and GuildChannel::parent_id"]
     pub fn channel_category_id(&self, channel_id: ChannelId) -> Option<ChannelId> {
+        #[allow(deprecated)]
         self.channel(channel_id)?.parent_id
     }
 

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -226,8 +226,10 @@ fn update_cache_with_event(
         },
         Event::GuildMemberUpdate(mut event) => {
             let before = if_cache!(event.update(cache));
-            let after: Option<Member> =
-                if_cache!(cache.member(event.guild_id, event.user.id).map(|m| m.clone()));
+            let after: Option<Member> = if_cache!({
+                let guild = cache.guild(event.guild_id);
+                guild.and_then(|g| g.members.get(&event.user.id).cloned())
+            });
 
             FullEvent::GuildMemberUpdate {
                 old_if_available: before,

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -2,6 +2,7 @@
     not(ignore_serenity_deprecated),
     deprecated = "The standard framework is deprecated, and will be removed in 0.13. Please migrate to `poise` for command handling"
 )]
+#![allow(deprecated)] // Entire framework is deprecated anyway.
 
 pub mod help_commands;
 pub mod macros {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1068,18 +1068,7 @@ impl GuildId {
         cache_http: impl CacheHttp,
         user_id: impl Into<UserId>,
     ) -> Result<Member> {
-        let user_id = user_id.into();
-
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(member) = cache.member(self, user_id) {
-                    return Ok(member.clone());
-                }
-            }
-        }
-
-        cache_http.http().get_member(self, user_id).await
+        cache_http.http().get_member(self, user_id.into()).await
     }
 
     /// Gets a list of the guild's members.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -427,21 +427,15 @@ impl Guild {
     }
 
     #[cfg(feature = "cache")]
+    #[deprecated = "Iterate through Guild::channels and use Iterator::find"]
     pub fn channel_id_from_name(
         &self,
-        cache: impl AsRef<Cache>,
+        #[allow(unused_variables)] cache: impl AsRef<Cache>,
         name: impl AsRef<str>,
     ) -> Option<ChannelId> {
         let name = name.as_ref();
-        let guild_channels = cache.as_ref().guild_channels(self.id)?;
 
-        for (id, channel) in guild_channels.iter() {
-            if channel.name == name {
-                return Some(*id);
-            }
-        }
-
-        None
+        self.channels.values().find(|c| c.name == name).map(|c| c.id)
     }
 
     /// Ban a [`User`] from the guild, deleting a number of days' worth of messages (`dmd`) between

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -377,21 +377,16 @@ impl PartialGuild {
     }
 
     #[cfg(feature = "cache")]
+    #[deprecated = "Use Cache::guild and Guild::channels"]
     pub fn channel_id_from_name(
         &self,
         cache: impl AsRef<Cache>,
         name: impl AsRef<str>,
     ) -> Option<ChannelId> {
-        let name = name.as_ref();
-        let guild_channels = cache.as_ref().guild_channels(self.id)?;
-
-        for (id, channel) in guild_channels.iter() {
-            if channel.name == name {
-                return Some(*id);
-            }
-        }
-
-        None
+        let cache = cache.as_ref();
+        let guild = cache.guild(self.id)?;
+        #[allow(deprecated)]
+        guild.channel_id_from_name(cache, name)
     }
 
     /// Creates a [`GuildChannel`] in the guild.

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -60,8 +60,15 @@ impl ArgumentConvert for Role {
         let guild_id = guild_id.ok_or(RoleParseError::NotInGuild)?;
 
         #[cfg(feature = "cache")]
-        let roles =
-            ctx.cache().and_then(|c| c.guild_roles(guild_id)).ok_or(RoleParseError::NotInCache)?;
+        let guild;
+
+        #[cfg(feature = "cache")]
+        let roles = {
+            let cache = ctx.cache().ok_or(RoleParseError::NotInCache)?;
+            guild = cache.guild(guild_id).ok_or(RoleParseError::NotInCache)?;
+            &guild.roles
+        };
+
         #[cfg(not(feature = "cache"))]
         let roles = ctx.http().get_guild_roles(guild_id).await.map_err(RoleParseError::Http)?;
 

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -222,6 +222,7 @@ fn clean_mention(
     let cache = cache.as_ref();
     match mention {
         Mention::Channel(id) => {
+            #[allow(deprecated)] // This is reworked on next already.
             if let Some(channel) = id.to_channel_cached(cache) {
                 format!("#{}", channel.name).into()
             } else {


### PR DESCRIPTION
These mapped references confuse beginners to the simplicity of the cache, and can lead to performance hits for users who accidentally fetch guilds multiple times in one function. It also leads to extra caching when absolutely optional, such as the `Cache::channels` cache which simply stores `ChannelId: GuildId` for the methods which need a `GuildId` but don't take it. This PR deprecates the methods and removes the usage when possible, and if not deprecates the methods it was used on. 

I have had to remove some of the preemptive error checks or move them to the model versions instead of the ID versions, but I don't exactly like these preemptive checks anyway.