### PR TITLE
Remove useless method wrappers

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -454,19 +454,11 @@ impl Cache {
     /// [`EventHandler::message`]: crate::client::EventHandler::message
     /// [`members`]: crate::model::guild::Guild::members
     pub fn member(&self, guild_id: GuildId, user_id: UserId) -> Option<MemberRef<'_>> {
-        self._member(guild_id, user_id)
-    }
-
-    fn _member(&self, guild_id: GuildId, user_id: UserId) -> Option<MemberRef<'_>> {
         let member = self.guilds.get(&guild_id)?.try_map(|g| g.members.get(&user_id)).ok()?;
         Some(CacheRef::from_mapped_ref(member))
     }
 
     pub fn guild_roles(&self, guild_id: GuildId) -> Option<GuildRolesRef<'_>> {
-        self._guild_roles(guild_id)
-    }
-
-    fn _guild_roles(&self, guild_id: GuildId) -> Option<GuildRolesRef<'_>> {
         let roles = self.guilds.get(&guild_id)?.map(|g| &g.roles);
         Some(CacheRef::from_mapped_ref(roles))
     }
@@ -478,10 +470,6 @@ impl Cache {
 
     /// This method returns all channels from a guild of with the given `guild_id`.
     pub fn guild_channels(&self, guild_id: GuildId) -> Option<GuildChannelsRef<'_>> {
-        self._guild_channels(guild_id)
-    }
-
-    fn _guild_channels(&self, guild_id: GuildId) -> Option<GuildChannelsRef<'_>> {
         let channels = self.guilds.get(&guild_id)?.map(|g| &g.channels);
         Some(CacheRef::from_mapped_ref(channels))
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1270,16 +1270,6 @@ impl Guild {
         lhs_id: UserId,
         rhs_id: UserId,
     ) -> Option<UserId> {
-        self._greater_member_hierarchy(cache, lhs_id, rhs_id)
-    }
-
-    #[cfg(feature = "cache")]
-    fn _greater_member_hierarchy(
-        &self,
-        cache: &Cache,
-        lhs_id: UserId,
-        rhs_id: UserId,
-    ) -> Option<UserId> {
         // Check that the IDs are the same. If they are, neither is greater.
         if lhs_id == rhs_id {
             return None;


### PR DESCRIPTION
These used to be a monomorphisation barrier, but since the AsRef/Into/CacheHttp purge they are no longer needed.