### PR TITLE
implement serialize/deserialize for fullevent

### DIFF
--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -4,6 +4,7 @@ use std::num::NonZeroU16;
 
 use async_trait::async_trait;
 use strum::{EnumCount, IntoStaticStr, VariantNames};
+use serde::{Serialize, Deserialize};
 
 use super::context::Context;
 use crate::gateway::ShardStageUpdateEvent;
@@ -32,7 +33,7 @@ macro_rules! event_handler {
 
         /// This enum stores every possible event that an [`EventHandler`] can receive.
         #[cfg_attr(not(feature = "unstable"), non_exhaustive)]
-        #[derive(Clone, Debug, VariantNames, IntoStaticStr, EnumCount)]
+        #[derive(Clone, Debug, Serialize, Deserialize, VariantNames, IntoStaticStr, EnumCount)]
         #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
         pub enum FullEvent {
             $(


### PR DESCRIPTION
Use cases:

- Dispatching events programmatically
- Knowing the keys of an event easily
- Easier unt testing/debugging

Could be in `unstable` to if desired