### PR TITLE
Use NonMax in HTTP function signatures

### DIFF
--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -1,3 +1,5 @@
+use nonmax::NonMaxU8;
+
 #[cfg(feature = "http")]
 use crate::http::{CacheHttp, MessagePagination};
 #[cfg(feature = "http")]
@@ -48,7 +50,7 @@ use crate::model::prelude::*;
 #[must_use]
 pub struct GetMessages {
     search_filter: Option<SearchFilter>,
-    limit: Option<u8>,
+    limit: Option<NonMaxU8>,
 }
 
 impl GetMessages {
@@ -83,7 +85,7 @@ impl GetMessages {
     /// **Note**: This field is capped to 100 messages due to a Discord limitation. If an amount
     /// larger than 100 is supplied, it will be truncated.
     pub fn limit(mut self, limit: u8) -> Self {
-        self.limit = Some(limit.min(100));
+        self.limit = NonMaxU8::new(limit.min(100));
         self
     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use arrayvec::ArrayVec;
-use nonmax::NonMaxU16;
+use nonmax::{NonMaxU16, NonMaxU8};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::{HeaderMap as Headers, HeaderValue};
 #[cfg(feature = "utils")]
@@ -2284,14 +2284,14 @@ impl Http {
         &self,
         guild_id: GuildId,
         target: Option<UserPagination>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU16>,
     ) -> Result<Vec<Ban>> {
         let id_str;
         let limit_str;
         let mut params = ArrayVec::<_, 2>::new();
 
         if let Some(limit) = limit {
-            limit_str = limit.to_arraystring();
+            limit_str = limit.get().to_arraystring();
             params.push(("limit", limit_str.as_str()));
         }
 
@@ -2325,7 +2325,7 @@ impl Http {
         action_type: Option<audit_log::Action>,
         user_id: Option<UserId>,
         before: Option<AuditLogEntryId>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
     ) -> Result<AuditLogs> {
         let (action_type_str, before_str, limit_str, user_id_str);
         let mut params = ArrayVec::<_, 4>::new();
@@ -2338,7 +2338,7 @@ impl Http {
             params.push(("before", &before_str));
         }
         if let Some(limit) = limit {
-            limit_str = limit.to_arraystring();
+            limit_str = limit.get().to_arraystring();
             params.push(("limit", &limit_str));
         }
         if let Some(user_id) = user_id {
@@ -2811,7 +2811,7 @@ impl Http {
         sku_ids: Option<Vec<SkuId>>,
         before: Option<EntitlementId>,
         after: Option<EntitlementId>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
         guild_id: Option<GuildId>,
         exclude_ended: Option<bool>,
     ) -> Result<Vec<Entitlement>> {
@@ -2835,7 +2835,7 @@ impl Http {
             params.push(("after", &after_str));
         }
         if let Some(limit) = limit {
-            limit_str = limit.to_arraystring();
+            limit_str = limit.get().to_arraystring();
             params.push(("limit", &limit_str));
         }
         if let Some(guild_id) = guild_id {
@@ -3293,14 +3293,14 @@ impl Http {
         &self,
         guild_id: GuildId,
         event_id: ScheduledEventId,
-        limit: Option<u64>,
+        limit: Option<NonMaxU8>,
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
         let (limit_str, with_member_str, id_str);
         let mut params = ArrayVec::<_, 3>::new();
         if let Some(limit) = limit {
-            limit_str = limit.to_arraystring();
+            limit_str = limit.get().to_arraystring();
             params.push(("limit", limit_str.as_str()));
         }
         if let Some(with_member) = with_member {
@@ -3403,12 +3403,12 @@ impl Http {
     pub async fn get_guilds(
         &self,
         target: Option<GuildPagination>,
-        limit: Option<u64>,
+        limit: Option<NonMaxU8>,
     ) -> Result<Vec<GuildInfo>> {
         let (limit_str, id_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(limit) = limit {
-            limit_str = limit.to_arraystring();
+            limit_str = limit.get().to_arraystring();
             params.push(("limit", limit_str.as_str()));
         }
         if let Some(target) = target {
@@ -3544,13 +3544,13 @@ impl Http {
         &self,
         channel_id: ChannelId,
         target: Option<MessagePagination>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
     ) -> Result<Vec<Message>> {
         let (limit_str, id_str);
         let mut params = ArrayVec::<_, 2>::new();
 
         if let Some(limit) = limit {
-            limit_str = limit.to_arraystring();
+            limit_str = limit.get().to_arraystring();
             params.push(("limit", limit_str.as_str()));
         }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 #[cfg(feature = "model")]
 use futures::stream::Stream;
-use nonmax::NonMaxU16;
+use nonmax::{NonMaxU16, NonMaxU8};
 use serde_json::json;
 
 #[cfg(feature = "model")]
@@ -238,7 +238,7 @@ impl GuildId {
         self,
         http: &Http,
         target: Option<UserPagination>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU16>,
     ) -> Result<Vec<Ban>> {
         http.get_bans(self, target, limit).await
     }
@@ -259,7 +259,7 @@ impl GuildId {
         action_type: Option<audit_log::Action>,
         user_id: Option<UserId>,
         before: Option<AuditLogEntryId>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
     ) -> Result<AuditLogs> {
         http.get_audit_logs(self, action_type, user_id, before, limit).await
     }
@@ -1170,7 +1170,7 @@ impl GuildId {
         self,
         http: &Http,
         event_id: ScheduledEventId,
-        limit: Option<u64>,
+        limit: Option<NonMaxU8>,
     ) -> Result<Vec<ScheduledEventUser>> {
         http.get_scheduled_event_users(self, event_id, limit, None, None).await
     }
@@ -1190,7 +1190,7 @@ impl GuildId {
         self,
         http: &Http,
         event_id: ScheduledEventId,
-        limit: Option<u64>,
+        limit: Option<NonMaxU8>,
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -17,7 +17,7 @@ mod welcome_screen;
 #[cfg(feature = "model")]
 use std::borrow::Cow;
 
-use nonmax::{NonMaxU16, NonMaxU64};
+use nonmax::{NonMaxU16, NonMaxU64, NonMaxU8};
 #[cfg(feature = "model")]
 use tracing::{error, warn};
 
@@ -484,7 +484,7 @@ impl Guild {
         &self,
         cache_http: impl CacheHttp,
         target: Option<UserPagination>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU16>,
     ) -> Result<Vec<Ban>> {
         #[cfg(feature = "cache")]
         {
@@ -529,7 +529,7 @@ impl Guild {
         action_type: Option<audit_log::Action>,
         user_id: Option<UserId>,
         before: Option<AuditLogEntryId>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
     ) -> Result<AuditLogs> {
         self.id.audit_logs(http, action_type, user_id, before, limit).await
     }
@@ -1947,7 +1947,7 @@ impl Guild {
         &self,
         http: &Http,
         event_id: ScheduledEventId,
-        limit: Option<u64>,
+        limit: Option<NonMaxU8>,
     ) -> Result<Vec<ScheduledEventUser>> {
         self.id.scheduled_event_users(http, event_id, limit).await
     }
@@ -1967,7 +1967,7 @@ impl Guild {
         &self,
         http: &Http,
         event_id: ScheduledEventId,
-        limit: Option<u64>,
+        limit: Option<NonMaxU8>,
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,4 +1,4 @@
-use nonmax::{NonMaxU16, NonMaxU64};
+use nonmax::{NonMaxU16, NonMaxU64, NonMaxU8};
 use serde::Serialize;
 
 #[cfg(feature = "model")]
@@ -314,7 +314,7 @@ impl PartialGuild {
         &self,
         http: &Http,
         target: Option<UserPagination>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU16>,
     ) -> Result<Vec<Ban>> {
         self.id.bans(http, target, limit).await
     }
@@ -335,7 +335,7 @@ impl PartialGuild {
         action_type: Option<audit_log::Action>,
         user_id: Option<UserId>,
         before: Option<AuditLogEntryId>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
     ) -> Result<AuditLogs> {
         self.id.audit_logs(http, action_type, user_id, before, limit).await
     }


### PR DESCRIPTION
Saves having to pass the extra bool, encodes the limits similar to the builder methods.