### PR TITLE
Remove even more impl CacheHttp

### DIFF
--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -19,7 +19,7 @@ impl EventHandler for Handler {
             // In this case, you can direct message a User directly by simply calling a method on
             // its instance, with the content of the message.
             let builder = CreateMessage::new().content("Hello!");
-            let dm = msg.author.dm(&context, builder).await;
+            let dm = msg.author.dm(&context.http, builder).await;
 
             if let Err(why) = dm {
                 println!("Error when direct messaging user: {why:?}");

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -190,7 +190,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
         // As of 2023-04-20, bots are still not allowed to sending voice messages
         msg.author
             .id
-            .create_dm_channel(ctx)
+            .create_dm_channel(&ctx.http)
             .await?
             .id
             .send_message(

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -835,7 +835,7 @@ impl Guild {
         cache_http: impl CacheHttp,
         builder: CreateSticker<'a>,
     ) -> Result<Sticker> {
-        self.id.create_sticker(cache_http.http(), builder).await
+        self.id.create_sticker(cache_http, builder).await
     }
 
     /// Deletes the current guild if the current user is the owner of the

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1025,11 +1025,11 @@ impl PartialGuild {
     /// [`Error::Json`]: crate::error::Error::Json
     pub async fn start_prune(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         days: u8,
         reason: Option<&str>,
     ) -> Result<GuildPrune> {
-        self.id.start_prune(cache_http.http(), days, reason).await
+        self.id.start_prune(http, days, reason).await
     }
 
     /// Kicks a [`Member`] from the guild.


### PR DESCRIPTION
These were found by auditing .http() calls, instead of just manually looking at `impl CacheHttp`.