### PR TITLE
refactor!: remove `fs` feature for `tokio` by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1.74"
 tracing = { version = "0.1.40", features = ["log"] }
 serde = { version = "1.0.192", features = ["derive"] }
 url = { version = "2.4.1", features = ["serde"] }
-tokio = { version = "1.34.0", features = ["fs", "macros", "rt", "sync", "time", "io-util"] }
+tokio = { version = "1.34.0", features = ["macros", "rt", "sync", "time", "io-util"] }
 futures = { version = "0.3.29", default-features = false, features = ["std"] }
 dep_time = { version = "0.3.30", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
 base64 = { version = "0.21.5" }
@@ -80,7 +80,7 @@ default_no_backend = [
 
 # Enables builder structs to configure Discord HTTP requests. Without this feature, you have to
 # construct JSON manually at some places.
-builder = []
+builder = ["tokio/fs"]
 # Enables the cache, which stores the data received from Discord gateway to provide access to
 # complete guild data, channels, users and more without needing HTTP requests.
 cache = ["fxhash", "dashmap", "parking_lot"]


### PR DESCRIPTION
I currently working with wasm on one of my personal projects. I'm would like to use `serenity` to get access to the discord API response models, but currently the library can not the compiled to wasm, because the `tokio/fs` feature is not supported in that target.

I went ahead and removed the need to include that feature by default. By the looks of it, it only was used with the `builder` and `model` features, so I conditionally added `tokio/fs` back when those features are being used (the `model` feature already depends on `builder` so that doesn't need to be changed).