### PR TITLE
Deprecate Guild::is_large and Message::is_own/private

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -203,6 +203,7 @@ impl Message {
 
     /// A util function for determining whether this message was sent by someone else, or the bot.
     #[cfg(feature = "cache")]
+    #[deprecated = "Check Message::author is equal to Cache::current_user"]
     pub fn is_own(&self, cache: impl AsRef<Cache>) -> bool {
         self.author.id == cache.as_ref().current_user().id
     }
@@ -453,6 +454,7 @@ impl Message {
     /// never set for those, which this method relies on.
     #[inline]
     #[must_use]
+    #[deprecated = "Check if guild_id is None if the message is recieved from the gateway."]
     pub fn is_private(&self) -> bool {
         self.guild_id.is_none()
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -454,7 +454,7 @@ impl Message {
     /// never set for those, which this method relies on.
     #[inline]
     #[must_use]
-    #[deprecated = "Check if guild_id is None if the message is recieved from the gateway."]
+    #[deprecated = "Check if guild_id is None if the message is received from the gateway."]
     pub fn is_private(&self) -> bool {
         self.guild_id.is_none()
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1520,12 +1520,14 @@ impl Guild {
         self.id.invites(cache_http.http()).await
     }
 
-    /// Checks if the guild is 'large'. A guild is considered large if it has more than 250
-    /// members.
+    /// Checks if the guild is 'large'.
+    ///
+    /// A guild is considered large if it has more than 250 members.
     #[inline]
     #[must_use]
+    #[deprecated = "Use Guild::large"]
     pub fn is_large(&self) -> bool {
-        self.members.len() > LARGE_THRESHOLD as usize
+        self.member_count > u64::from(LARGE_THRESHOLD)
     }
 
     /// Kicks a [`Member`] from the guild.


### PR DESCRIPTION
These methods are all wrong and/or easily performed without serenity doing it.