### PR TITLE
 Add support for the bulk ban endpoint 

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -286,6 +286,8 @@ impl Http {
         delete_message_days: u8,
         reason: Option<&str>,
     ) -> Result<()> {
+        let delete_message_seconds = u32::from(delete_message_days) * 86400;
+
         self.wind(204, Request {
             body: None,
             multipart: None,
@@ -295,7 +297,7 @@ impl Http {
                 guild_id,
                 user_id,
             },
-            params: Some(vec![("delete_message_days", delete_message_days.to_string())]),
+            params: Some(vec![("delete_message_seconds", delete_message_seconds.to_string())]),
         })
         .await
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -302,6 +302,28 @@ impl Http {
         .await
     }
 
+    /// Bans multiple users from a [`Guild`], optionally removing their messages.
+    ///
+    /// See the [Discord Docs](https://github.com/discord/discord-api-docs/pull/6720) for more information.
+    pub async fn bulk_ban_users(
+        &self,
+        guild_id: GuildId,
+        map: &impl serde::Serialize,
+        reason: Option<&str>,
+    ) -> Result<BulkBanResponse> {
+        self.fire(Request {
+            body: Some(to_vec(map)?),
+            multipart: None,
+            headers: reason.map(reason_into_header),
+            method: LightMethod::Post,
+            route: Route::GuildBulkBan {
+                guild_id,
+            },
+            params: None,
+        })
+        .await
+    }
+
     /// Broadcasts that the current user is typing in the given [`Channel`].
     ///
     /// This lasts for about 10 seconds, and will then need to be renewed to indicate that the

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -210,6 +210,10 @@ routes! ('a, {
     api!("/guilds/{}/bans/{}", guild_id, user_id),
     Some(RatelimitingKind::PathAndId(guild_id.into()));
 
+    GuildBulkBan { guild_id: GuildId },
+    api!("/guilds/{}/bulk-ban", guild_id),
+    Some(RatelimitingKind::PathAndId(guild_id.into()));
+
     GuildBans { guild_id: GuildId },
     api!("/guilds/{}/bans", guild_id),
     Some(RatelimitingKind::PathAndId(guild_id.into()));


### PR DESCRIPTION
This also fixes up the usage of the deprecated delete_message_days by replacing it with delete_message_seconds internally.