### PR TITLE
Add Http::default_allowed_mentions

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -151,7 +151,14 @@ impl Builder for CreateInteractionResponse {
             _ => Vec::new(),
         };
 
-        cache_http.http().create_interaction_response(ctx.0, ctx.1, &self, files).await
+        let http = cache_http.http();
+        if let Self::Message(msg) | Self::Defer(msg) | Self::UpdateMessage(msg) = &mut self {
+            if msg.allowed_mentions.is_none() {
+                msg.allowed_mentions.clone_from(&http.default_allowed_mentions);
+            }
+        };
+
+        http.create_interaction_response(ctx.0, ctx.1, &self, files).await
     }
 }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -189,6 +189,10 @@ impl Builder for CreateInteractionResponseFollowup {
         let files = self.attachments.take_files();
 
         let http = cache_http.http();
+        if self.allowed_mentions.is_none() {
+            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+        }
+
         match ctx.0 {
             Some(id) => http.as_ref().edit_followup_message(ctx.1, id, &self, files).await,
             None => http.as_ref().create_followup_message(ctx.1, &self, files).await,

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -334,6 +334,9 @@ impl Builder for CreateMessage {
         let http = cache_http.http();
 
         let files = self.attachments.take_files();
+        if self.allowed_mentions.is_none() {
+            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+        }
 
         #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut message = http.send_message(channel_id, files, &self).await?;

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -267,6 +267,11 @@ impl Builder for EditMessage {
 
         let files = self.attachments.as_mut().map_or(Vec::new(), |a| a.take_files());
 
-        cache_http.http().edit_message(ctx.0, ctx.1, &self, files).await
+        let http = cache_http.http();
+        if self.allowed_mentions.is_none() {
+            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+        }
+
+        http.edit_message(ctx.0, ctx.1, &self, files).await
     }
 }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -188,9 +188,11 @@ impl Builder for EditWebhookMessage {
 
         let files = self.attachments.as_mut().map_or(Vec::new(), |a| a.take_files());
 
-        cache_http
-            .http()
-            .edit_webhook_message(ctx.0, self.thread_id, ctx.1, ctx.2, &self, files)
-            .await
+        let http = cache_http.http();
+        if self.allowed_mentions.is_none() {
+            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+        }
+
+        http.edit_webhook_message(ctx.0, self.thread_id, ctx.1, ctx.2, &self, files).await
     }
 }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -362,6 +362,11 @@ impl Builder for ExecuteWebhook {
 
         let files = self.attachments.take_files();
 
-        cache_http.http().execute_webhook(ctx.0, self.thread_id, ctx.1, ctx.2, files, &self).await
+        let http = cache_http.http();
+        if self.allowed_mentions.is_none() {
+            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+        }
+
+        http.execute_webhook(ctx.0, self.thread_id, ctx.1, ctx.2, files, &self).await
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -27,7 +27,7 @@ use super::{
     MessagePagination,
     UserPagination,
 };
-use crate::builder::CreateAttachment;
+use crate::builder::{CreateAllowedMentions, CreateAttachment};
 use crate::constants;
 use crate::internal::prelude::*;
 use crate::json::*;
@@ -56,6 +56,7 @@ pub struct HttpBuilder {
     token: SecretString,
     proxy: Option<String>,
     application_id: Option<ApplicationId>,
+    default_allowed_mentions: Option<CreateAllowedMentions>,
 }
 
 impl HttpBuilder {
@@ -69,6 +70,7 @@ impl HttpBuilder {
             token: SecretString::new(parse_token(token)),
             proxy: None,
             application_id: None,
+            default_allowed_mentions: None,
         }
     }
 
@@ -127,6 +129,15 @@ impl HttpBuilder {
         self
     }
 
+    /// Sets the [`CreateAllowedMentions`] used by default for each request that would use it.
+    ///
+    /// This only takes effect if you are calling through the model or builder methods, not directly
+    /// calling [`Http`] methods, as [`Http`] is simply used as a convenient storage for these.
+    pub fn default_allowed_mentions(mut self, allowed_mentions: CreateAllowedMentions) -> Self {
+        self.default_allowed_mentions = Some(allowed_mentions);
+        self
+    }
+
     /// Use the given configuration to build the `Http` client.
     #[must_use]
     pub fn build(self) -> Http {
@@ -148,6 +159,7 @@ impl HttpBuilder {
             proxy: self.proxy,
             token: self.token,
             application_id,
+            default_allowed_mentions: self.default_allowed_mentions,
         }
     }
 }
@@ -186,6 +198,7 @@ pub struct Http {
     pub proxy: Option<String>,
     token: SecretString,
     application_id: AtomicU64,
+    pub default_allowed_mentions: Option<CreateAllowedMentions>,
 }
 
 impl Http {


### PR DESCRIPTION
Closes #2630. `ClientBuilder` cannot have a method that mutates Http as next is taking Http as Arc<Http> and shouldn't duplicate Http's configuration anyway, so this can only be used with `ClientBuilder::new_with_http`.