### PR TITLE
Fix new clippy warnings

### DIFF
--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::mem::Discriminant;
 use std::num::NonZeroU64;
 
 use crate::model::id::*;
@@ -59,10 +60,13 @@ macro_rules! routes {
                     )+
                 };
 
-                // To avoid adding a lifetime on RatelimitingBucket and causing lifetime infection,
-                // we transmute the Discriminant<Route<'a>> to Discriminant<Route<'static>>.
+                // This avoids adding a lifetime on RatelimitingBucket and causing lifetime infection
                 // SAFETY: std::mem::discriminant erases lifetimes.
-                let discriminant = unsafe { std::mem::transmute(std::mem::discriminant(self)) };
+                let discriminant = unsafe {
+                    std::mem::transmute::<Discriminant<Route<'a>>, Discriminant<Route<'static>>>(
+                        std::mem::discriminant(self),
+                    )
+                };
 
                 RatelimitingBucket(ratelimiting_kind.map(|r| {
                     let id = match r {

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -402,8 +402,6 @@ pub mod colours {
 
 #[cfg(test)]
 mod test {
-    use std::u32;
-
     use super::Colour;
 
     #[test]

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -65,6 +65,7 @@ impl Action {
     }
 
     #[must_use]
+    #[allow(unknown_lints, clippy::missing_transmute_annotations)]
     pub fn from_value(value: u8) -> Action {
         match value {
             1 => Action::GuildUpdate,


### PR DESCRIPTION
A fix and an ignore for missing_transmute_annotations, which is already fixed on next with the `forbid(unsafe_code)`, and a relic showing how old serenity's codebase is lol.