### PR TITLE
No longer update topic on VoiceChannelStatusUpdate

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -609,8 +609,6 @@ impl CacheUpdate for VoiceChannelStatusUpdateEvent {
 
         let old = channel.status.clone();
         channel.status.clone_from(&self.status);
-        // Discord updates topic but doesn't fire ChannelUpdate.
-        channel.topic.clone_from(&self.status);
         old
     }
 }


### PR DESCRIPTION
In my original PR I was updating topic because the event was changing the topic of the VC because it was changing server side but without firing `ChannelUpdate`.

This doesn't seem to be the case anymore, I guess they are still stabilizing things considering the documentation for this feature isn't even merged yet.

This change targets next because it messes with stuff users could access, if this doesn't count as breaking I'll change the base target.