### PR TITLE
Fix AuditLogEntry::user_id

### DIFF
--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -382,9 +382,10 @@ pub struct AuditLogEntry {
     /// What was the reasoning by doing an action on a target? If there was one.
     pub reason: Option<FixedString>,
     /// The user that did this action on a target.
-    pub user_id: UserId,
+    pub user_id: Option<UserId>,
     /// What changes were made.
-    pub changes: Option<Vec<Change>>,
+    #[serde(default)]
+    pub changes: Vec<Change>,
     /// The id of this entry.
     pub id: AuditLogEntryId,
     /// Some optional data associated with this entry.


### PR DESCRIPTION
This field is documented as nullable but that isn't reflected in the model. I also took the opportunity to replace the Option<Vec> with a default Vec.