### PR TITLE
Restore match arm for `Error::Gateway` variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -138,11 +138,12 @@ impl StdError for Error {
             Self::Model(inner) => Some(inner),
             #[cfg(feature = "client")]
             Self::Client(inner) => Some(inner),
+            #[cfg(feature = "gateway")]
+            Self::Gateway(inner) => Some(inner),
             #[cfg(feature = "http")]
             Self::Http(inner) => Some(inner),
             #[cfg(feature = "gateway")]
             Self::Tungstenite(inner) => Some(inner),
-            _ => None,
         }
     }
 }


### PR DESCRIPTION
This was mistakenly removed in #2278 and wasn't caught because of the wildcard pattern in the match.