### PR TITLE
Remove cache from most builders

### DIFF
--- a/examples/e09_collectors/src/main.rs
+++ b/examples/e09_collectors/src/main.rs
@@ -21,7 +21,8 @@ impl EventHandler for Handler {
 
     async fn message(&self, ctx: Context, msg: Message) {
         let mut score = 0u32;
-        let _ = msg.reply(&ctx, "How was that crusty crab called again? 10 seconds time!").await;
+        let _ =
+            msg.reply(&ctx.http, "How was that crusty crab called again? 10 seconds time!").await;
 
         // There is a method implemented for some models to conveniently collect replies. They
         // return a builder that can be turned into a Stream, or here, where we can await a
@@ -29,17 +30,17 @@ impl EventHandler for Handler {
         let collector = msg.author.await_reply(ctx.shard.clone()).timeout(Duration::from_secs(10));
         if let Some(answer) = collector.await {
             if answer.content.to_lowercase() == "ferris" {
-                let _ = answer.reply(&ctx, "That's correct!").await;
+                let _ = answer.reply(&ctx.http, "That's correct!").await;
                 score += 1;
             } else {
-                let _ = answer.reply(&ctx, "Wrong, it's Ferris!").await;
+                let _ = answer.reply(&ctx.http, "Wrong, it's Ferris!").await;
             }
         } else {
-            let _ = msg.reply(&ctx, "No answer within 10 seconds.").await;
+            let _ = msg.reply(&ctx.http, "No answer within 10 seconds.").await;
         };
 
         let react_msg = msg
-            .reply(&ctx, "React with the reaction representing 1, you got 10 seconds!")
+            .reply(&ctx.http, "React with the reaction representing 1, you got 10 seconds!")
             .await
             .unwrap();
 
@@ -52,15 +53,15 @@ impl EventHandler for Handler {
         if let Some(reaction) = collector.await {
             let _ = if reaction.emoji.as_data() == "1️⃣" {
                 score += 1;
-                msg.reply(&ctx, "That's correct!").await
+                msg.reply(&ctx.http, "That's correct!").await
             } else {
-                msg.reply(&ctx, "Wrong!").await
+                msg.reply(&ctx.http, "Wrong!").await
             };
         } else {
-            let _ = msg.reply(&ctx, "No reaction within 10 seconds.").await;
+            let _ = msg.reply(&ctx.http, "No reaction within 10 seconds.").await;
         };
 
-        let _ = msg.reply(&ctx, "Write 5 messages in 10 seconds").await;
+        let _ = msg.reply(&ctx.http, "Write 5 messages in 10 seconds").await;
 
         // We can create a collector from scratch too using this builder future.
         let collector = MessageCollector::new(ctx.shard.clone())
@@ -107,7 +108,7 @@ impl EventHandler for Handler {
         })
         .take_until(Box::pin(tokio::time::sleep(Duration::from_secs(20))));
 
-        let _ = msg.reply(&ctx, "Edit each of those 5 messages in 20 seconds").await;
+        let _ = msg.reply(&ctx.http, "Edit each of those 5 messages in 20 seconds").await;
         let mut edited = HashSet::new();
         while let Some(edited_message_id) = collector.next().await {
             edited.insert(edited_message_id);
@@ -118,13 +119,17 @@ impl EventHandler for Handler {
 
         if edited.len() >= 5 {
             score += 1;
-            let _ = msg.reply(&ctx, "Great! You edited 5 out of 5").await;
+            let _ = msg.reply(&ctx.http, "Great! You edited 5 out of 5").await;
         } else {
-            let _ = msg.reply(&ctx, &format!("You only edited {} out of 5", edited.len())).await;
+            let _ =
+                msg.reply(&ctx.http, &format!("You only edited {} out of 5", edited.len())).await;
         }
 
         let _ = msg
-            .reply(ctx, &format!("TIME'S UP! You completed {score} out of 4 tasks correctly!"))
+            .reply(
+                &ctx.http,
+                &format!("TIME'S UP! You completed {score} out of 4 tasks correctly!"),
+            )
             .await;
     }
 }

--- a/examples/e11_global_data/src/main.rs
+++ b/examples/e11_global_data/src/main.rs
@@ -48,7 +48,7 @@ impl EventHandler for Handler {
                 Cow::Owned(format!("OWO Has been said {owo_count} times!"))
             };
 
-            if let Err(err) = msg.reply(ctx, response).await {
+            if let Err(err) = msg.reply(&ctx.http, response).await {
                 eprintln!("Error sending response: {err:?}")
             };
         }

--- a/examples/e12_parallel_loops/src/main.rs
+++ b/examples/e12_parallel_loops/src/main.rs
@@ -85,7 +85,7 @@ async fn log_system_load(ctx: &Context) {
             false,
         );
     let builder = CreateMessage::new().embed(embed);
-    let message = ChannelId::new(381926291785383946).send_message(&ctx, builder).await;
+    let message = ChannelId::new(381926291785383946).send_message(&ctx.http, builder).await;
     if let Err(why) = message {
         eprintln!("Error sending message: {why:?}");
     };

--- a/examples/e13_sqlite_database/src/main.rs
+++ b/examples/e13_sqlite_database/src/main.rs
@@ -30,7 +30,7 @@ impl EventHandler for Bot {
             .unwrap();
 
             let response = format!("Successfully added `{task_description}` to your todo list");
-            msg.channel_id.say(&ctx, response).await.unwrap();
+            msg.channel_id.say(&ctx.http, response).await.unwrap();
         } else if let Some(task_index) = msg.content.strip_prefix("~todo remove") {
             let task_index = task_index.trim().parse::<i64>().unwrap() - 1;
 
@@ -51,7 +51,7 @@ impl EventHandler for Bot {
                 .unwrap();
 
             let response = format!("Successfully completed `{}`!", entry.task);
-            msg.channel_id.say(&ctx, response).await.unwrap();
+            msg.channel_id.say(&ctx.http, response).await.unwrap();
         } else if msg.content.trim() == "~todo list" {
             // "SELECT" will return the task of all rows where user_Id column = user_id in todo.
             let todos = sqlx::query!("SELECT task FROM todo WHERE user_id = ? ORDER BY rowid", user_id)
@@ -64,7 +64,7 @@ impl EventHandler for Bot {
                 writeln!(response, "{}. {}", i + 1, todo.task).unwrap();
             }
 
-            msg.channel_id.say(&ctx, response).await.unwrap();
+            msg.channel_id.say(&ctx.http, response).await.unwrap();
         }
     }
 }

--- a/examples/e14_message_components/src/main.rs
+++ b/examples/e14_message_components/src/main.rs
@@ -37,7 +37,7 @@ impl EventHandler for Handler {
         let m = msg
             .channel_id
             .send_message(
-                &ctx,
+                &ctx.http,
                 CreateMessage::new().content("Please select your favorite animal").select_menu(
                     CreateSelectMenu::new("animal_select", CreateSelectMenuKind::String {
                         options: Cow::Borrowed(&[
@@ -65,7 +65,7 @@ impl EventHandler for Handler {
         {
             Some(x) => x,
             None => {
-                m.reply(&ctx, "Timed out").await.unwrap();
+                m.reply(&ctx.http, "Timed out").await.unwrap();
                 return;
             },
         };

--- a/examples/e14_message_components/src/main.rs
+++ b/examples/e14_message_components/src/main.rs
@@ -131,7 +131,7 @@ impl EventHandler for Handler {
 
         // Delete the orig message or there will be dangling components (components that still
         // exist, but no collector is running so any user who presses them sees an error)
-        m.delete(&ctx, None).await.unwrap()
+        m.delete(&ctx.http, None).await.unwrap()
     }
 }
 

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -133,7 +133,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
     } else if msg.content == "reactionremoveemoji" {
         // Test new ReactionRemoveEmoji gateway event: https://github.com/serenity-rs/serenity/issues/2248
         msg.react(&ctx.http, '👍').await?;
-        msg.delete_reaction_emoji(ctx, '👍').await?;
+        msg.delete_reaction_emoji(&ctx.http, '👍').await?;
     } else if msg.content == "testautomodregex" {
         guild_id
             .create_automod_rule(

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -54,7 +54,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
     } else if msg.content == "edit" {
         let mut msg = channel_id
             .send_message(
-                &ctx,
+                &ctx.http,
                 CreateMessage::new()
                     .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
@@ -62,12 +62,13 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         // Pre-PR, this falsely triggered a MODEL_TYPE_CONVERT Discord error
         msg.edit(&ctx, EditMessage::new().attachments(EditAttachments::keep_all(&msg))).await?;
     } else if msg.content == "unifiedattachments" {
-        let mut msg = channel_id.send_message(ctx, CreateMessage::new().content("works")).await?;
+        let mut msg =
+            channel_id.send_message(&ctx.http, CreateMessage::new().content("works")).await?;
         msg.edit(ctx, EditMessage::new().content("works still")).await?;
 
         let mut msg = channel_id
             .send_message(
-                ctx,
+                &ctx.http,
                 CreateMessage::new()
                     .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
@@ -86,14 +87,14 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         // Test special characters in audit log reason
         msg.channel_id
             .edit(
-                ctx,
+                &ctx.http,
                 EditChannel::new().name("new-channel-name").audit_log_reason("hello\nworld\n🙂"),
             )
             .await?;
     } else if msg.content == "actionrow" {
         channel_id
             .send_message(
-                ctx,
+                &ctx.http,
                 CreateMessage::new()
                     .button(CreateButton::new("0").label("Foo"))
                     .button(CreateButton::new("1").emoji('🤗').style(ButtonStyle::Secondary))
@@ -113,7 +114,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         loop {
             let msg = channel_id
                 .send_message(
-                    ctx,
+                    &ctx.http,
                     CreateMessage::new()
                         .button(CreateButton::new(custom_id.clone()).label(custom_id)),
                 )
@@ -131,7 +132,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         }
     } else if msg.content == "reactionremoveemoji" {
         // Test new ReactionRemoveEmoji gateway event: https://github.com/serenity-rs/serenity/issues/2248
-        msg.react(ctx, '👍').await?;
+        msg.react(&ctx.http, '👍').await?;
         msg.delete_reaction_emoji(ctx, '👍').await?;
     } else if msg.content == "testautomodregex" {
         guild_id
@@ -152,7 +153,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
     } else if msg.content == "createtags" {
         channel_id
             .edit(
-                &ctx,
+                &ctx.http,
                 EditChannel::new().available_tags(vec![
                     CreateForumTag::new("tag1 :)").emoji('👍'),
                     CreateForumTag::new("tag2 (:").moderated(true),
@@ -174,7 +175,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         use tokio::time::Duration;
 
         let mut msg = channel_id
-            .say(ctx, format!("https://codereview.stackexchange.com/questions/260653/very-slow-discord-bot-to-play-music{}", msg.id))
+            .say(&ctx.http, format!("https://codereview.stackexchange.com/questions/260653/very-slow-discord-bot-to-play-music{}", msg.id))
             .await?;
 
         let msg_id = msg.id;
@@ -197,15 +198,15 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         let mut channel =
             channel.trim().parse::<ChannelId>().unwrap().to_channel(ctx).await?.guild().unwrap();
         let parent_id = channel.parent_id.unwrap();
-        channel.edit(ctx, EditChannel::new().category(None)).await?;
-        channel.edit(ctx, EditChannel::new().category(Some(parent_id))).await?;
+        channel.edit(&ctx.http, EditChannel::new().category(None)).await?;
+        channel.edit(&ctx.http, EditChannel::new().category(Some(parent_id))).await?;
     } else if msg.content == "channelperms" {
         let guild = guild_id.to_guild_cached(&ctx.cache).unwrap().clone();
         let perms = guild.user_permissions_in(
             &channel_id.to_channel(ctx).await?.guild().unwrap(),
             &*guild.member(&ctx.http, msg.author.id).await?,
         );
-        channel_id.say(ctx, format!("{:?}", perms)).await?;
+        channel_id.say(&ctx.http, format!("{:?}", perms)).await?;
     } else if let Some(forum_channel_id) = msg.content.strip_prefix("createforumpostin ") {
         forum_channel_id
             .parse::<ChannelId>()
@@ -222,14 +223,16 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
     } else if let Some(forum_post_url) = msg.content.strip_prefix("deleteforumpost ") {
         let (_guild_id, channel_id, _message_id) =
             serenity::utils::parse_message_url(forum_post_url).unwrap();
-        msg.channel_id.say(ctx, format!("Deleting <#{}> in 10 seconds...", channel_id)).await?;
+        msg.channel_id
+            .say(&ctx.http, format!("Deleting <#{}> in 10 seconds...", channel_id))
+            .await?;
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         channel_id.delete(&ctx.http, None).await?;
     } else {
         return Ok(());
     }
 
-    msg.react(&ctx, '✅').await?;
+    msg.react(&ctx.http, '✅').await?;
     Ok(())
 }
 

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -266,11 +266,6 @@ impl<'a> EditAttachments<'a> {
         }
         files
     }
-
-    #[cfg(feature = "cache")]
-    pub(crate) fn is_empty(&self) -> bool {
-        self.new_and_existing_attachments.is_empty()
-    }
 }
 
 impl<'a> Serialize for EditAttachments<'a> {

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use nonmax::NonMaxU16;
 
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -261,19 +261,11 @@ impl<'a> CreateChannel<'a> {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     #[cfg(feature = "http")]
-    pub async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        guild_id: GuildId,
-    ) -> Result<GuildChannel> {
-        #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_CHANNELS)?;
-
-        cache_http.http().create_channel(guild_id, &self, self.audit_log_reason).await
+    pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<GuildChannel> {
+        http.create_channel(guild_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -15,9 +15,10 @@ use crate::model::prelude::*;
 /// ```rust,no_run
 /// # use serenity::{prelude::*, model::prelude::*};
 /// use serenity::builder::CreateInvite;
-/// # async fn run(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
+/// use serenity::http::Http;
+/// # async fn run(http: &Http, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
 /// let builder = CreateInvite::new().max_age(3600).max_uses(10);
-/// let creation = channel.create_invite(&context, builder).await?;
+/// let creation = channel.create_invite(http, builder).await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -64,11 +65,11 @@ impl<'a> CreateInvite<'a> {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::builder::CreateInvite;
-    /// # use serenity::http::CacheHttp;
+    /// # use serenity::http::Http;
     /// #
-    /// # async fn example(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn example(http: &Http, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = CreateInvite::new().max_age(3600);
-    /// let invite = channel.create_invite(context, builder).await?;
+    /// let invite = channel.create_invite(http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -92,11 +93,11 @@ impl<'a> CreateInvite<'a> {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::builder::CreateInvite;
-    /// # use serenity::http::CacheHttp;
+    /// # use serenity::http::Http;
     /// #
-    /// # async fn example(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn example(http:  &Http, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = CreateInvite::new().max_uses(5);
-    /// let invite = channel.create_invite(context, builder).await?;
+    /// let invite = channel.create_invite(http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -116,11 +117,11 @@ impl<'a> CreateInvite<'a> {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::builder::CreateInvite;
-    /// # use serenity::http::CacheHttp;
+    /// # use serenity::http::Http;
     /// #
-    /// # async fn example(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn example(http: &Http, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = CreateInvite::new().temporary(true);
-    /// let invite = channel.create_invite(context, builder).await?;
+    /// let invite = channel.create_invite(http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -140,11 +141,11 @@ impl<'a> CreateInvite<'a> {
     /// ```rust,no_run
     /// # use serenity::model::prelude::*;
     /// # use serenity::builder::CreateInvite;
-    /// # use serenity::http::CacheHttp;
+    /// # use serenity::http::Http;
     /// #
-    /// # async fn example(context: impl CacheHttp, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn example(http: &Http, channel: GuildChannel) -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = CreateInvite::new().unique(true);
-    /// let invite = channel.create_invite(context, builder).await?;
+    /// let invite = channel.create_invite(&http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -199,29 +200,12 @@ impl<'a> CreateInvite<'a> {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is
+    /// given.
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     #[cfg(feature = "http")]
-    pub async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        channel_id: ChannelId,
-        guild_id: Option<GuildId>,
-    ) -> Result<RichInvite> {
-        #[cfg(feature = "cache")]
-        {
-            if let (Some(cache), Some(guild_id)) = (cache_http.cache(), guild_id) {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    guild_id,
-                    channel_id,
-                    Permissions::CREATE_INSTANT_INVITE,
-                )?;
-            }
-        }
-
-        cache_http.http().create_invite(channel_id, &self, self.audit_log_reason).await
+    pub async fn execute(self, http: &Http, channel_id: ChannelId) -> Result<RichInvite> {
+        http.create_invite(channel_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -8,7 +8,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -272,36 +272,21 @@ impl<'a> CreateMessage<'a> {
     ///
     /// Returns a [`ModelError::TooLarge`] if the message contents are over the above limits.
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES
     /// [Attach Files]: Permissions::ATTACH_FILES
     #[cfg(feature = "http")]
     pub async fn execute(
         mut self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         channel_id: ChannelId,
         guild_id: Option<GuildId>,
     ) -> Result<Message> {
-        #[cfg(feature = "cache")]
-        {
-            let mut req = Permissions::SEND_MESSAGES;
-            if !self.attachments.is_empty() {
-                req |= Permissions::ATTACH_FILES;
-            }
-            if let (Some(cache), Some(guild_id)) = (cache_http.cache(), guild_id) {
-                crate::utils::user_has_perms_cache(cache, guild_id, channel_id, req)?;
-            }
-        }
-
         self.check_length()?;
-
-        let http = cache_http.http();
 
         let files = self.attachments.take_files();
 
-        #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
         let mut message = http.send_message(channel_id, files, &self).await?;
 
         for reaction in self.reactions.iter() {

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use super::CreateAttachment;
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -127,20 +127,12 @@ impl<'a> CreateScheduledEvent<'a> {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Events]: Permissions::CREATE_EVENTS
     #[cfg(feature = "http")]
-    pub async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        channel_id: GuildId,
-    ) -> Result<ScheduledEvent> {
-        #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, channel_id, Permissions::CREATE_EVENTS)?;
-
-        cache_http.http().create_scheduled_event(channel_id, &self, self.audit_log_reason).await
+    pub async fn execute(self, http: &Http, channel_id: GuildId) -> Result<ScheduledEvent> {
+        http.create_scheduled_event(channel_id, &self, self.audit_log_reason).await
     }
 }
 

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use super::CreateAttachment;
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
@@ -77,25 +77,17 @@ impl<'a> CreateSticker<'a> {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     #[cfg(feature = "http")]
-    pub async fn execute(self, cache_http: impl CacheHttp, guild_id: GuildId) -> Result<Sticker> {
-        #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(
-            &cache_http,
-            guild_id,
-            Permissions::CREATE_GUILD_EXPRESSIONS,
-        )?;
-
+    pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<Sticker> {
         let map = vec![
             ("name".into(), self.name),
             ("tags".into(), self.tags),
             ("description".into(), self.description),
         ];
 
-        cache_http.http().create_sticker(guild_id, map, self.file, self.audit_log_reason).await
+        http.create_sticker(guild_id, map, self.file, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use super::CreateAttachment;
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -314,19 +314,11 @@ impl<'a> EditGuild<'a> {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[cfg(feature = "http")]
-    pub async fn execute(
-        self,
-        cache_http: impl CacheHttp,
-        guild_id: GuildId,
-    ) -> Result<PartialGuild> {
-        #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_GUILD)?;
-
-        cache_http.http().edit_guild(guild_id, &self, self.audit_log_reason).await
+    pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<PartialGuild> {
+        http.edit_guild(guild_id, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -23,11 +23,11 @@ use crate::model::prelude::*;
 /// # use serenity::builder::EditMessage;
 /// # use serenity::model::channel::Message;
 /// # use serenity::model::id::ChannelId;
-/// # use serenity::http::CacheHttp;
+/// # use serenity::http::Http;
 ///
-/// # async fn example(ctx: impl CacheHttp, mut message: Message) -> Result<(), Box<dyn std::error::Error>> {
+/// # async fn example(http: &Http, mut message: Message) -> Result<(), Box<dyn std::error::Error>> {
 /// let builder = EditMessage::new().content("hello");
-/// message.edit(ctx, builder).await?;
+/// message.edit(http, builder).await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -120,7 +120,7 @@ impl<'a> EditMessage<'a> {
     ///
     /// use futures::StreamExt;
     ///
-    /// let mut msg = channel_id.say(ctx, "<link that spawns an embed>").await?;
+    /// let mut msg = channel_id.say(&ctx.http, "<link that spawns an embed>").await?;
     ///
     /// // When the embed appears, a MessageUpdate event is sent and we suppress the embed.
     /// // No MessageUpdate event is sent if the message contains no embeddable link or if the link

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use super::CreateAttachment;
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
@@ -154,21 +154,16 @@ impl<'a> EditRole<'a> {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[cfg(feature = "http")]
     pub async fn execute(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         guild_id: GuildId,
         role_id: Option<RoleId>,
     ) -> Result<Role> {
-        #[cfg(feature = "cache")]
-        crate::utils::user_has_guild_perms(&cache_http, guild_id, Permissions::MANAGE_ROLES)?;
-
-        let http = cache_http.http();
         let role = match role_id {
             Some(role_id) => {
                 http.edit_role(guild_id, role_id, &self, self.audit_log_reason).await?

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -170,8 +170,7 @@ impl<'a> EditScheduledEvent<'a> {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     ///
     /// [Create Events]: Permissions::CREATE_EVENTS
     /// [Manage Events]: Permissions::MANAGE_EVENTS

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -403,7 +403,7 @@ impl IntoFuture for ClientBuilder {
 /// impl EventHandler for Handler {
 ///     async fn message(&self, context: Context, msg: Message) {
 ///         if msg.content == "!ping" {
-///             let _ = msg.channel_id.say(&context, "Pong!");
+///             let _ = msg.channel_id.say(&context.http, "Pong!");
 ///         }
 ///     }
 /// }

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -111,8 +111,10 @@ impl Attachment {
     ///                 Ok(content) => content,
     ///                 Err(why) => {
     ///                     println!("Error downloading attachment: {:?}", why);
-    ///                     let _ =
-    ///                         message.channel_id.say(&context, "Error downloading attachment").await;
+    ///                     let _ = message
+    ///                         .channel_id
+    ///                         .say(&context.http, "Error downloading attachment")
+    ///                         .await;
     ///
     ///                     return;
     ///                 },
@@ -122,7 +124,7 @@ impl Attachment {
     ///                 Ok(file) => file,
     ///                 Err(why) => {
     ///                     println!("Error creating file: {:?}", why);
-    ///                     let _ = message.channel_id.say(&context, "Error creating file").await;
+    ///                     let _ = message.channel_id.say(&context.http, "Error creating file").await;
     ///
     ///                     return;
     ///                 },
@@ -136,7 +138,7 @@ impl Attachment {
     ///
     ///             let _ = message
     ///                 .channel_id
-    ///                 .say(&context, &format!("Saved {:?}", attachment.filename))
+    ///                 .say(&context.http, &format!("Saved {:?}", attachment.filename))
     ///                 .await;
     ///         }
     ///     }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -70,16 +70,11 @@ impl ChannelId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
-    pub async fn create_invite(
-        self,
-        cache_http: impl CacheHttp,
-        builder: CreateInvite<'_>,
-    ) -> Result<RichInvite> {
-        builder.execute(cache_http, self, None).await
+    pub async fn create_invite(self, http: &Http, builder: CreateInvite<'_>) -> Result<RichInvite> {
+        builder.execute(http, self).await
     }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a single [`Member`] or
@@ -307,17 +302,12 @@ impl ChannelId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn edit(
-        self,
-        cache_http: impl CacheHttp,
-        builder: EditChannel<'_>,
-    ) -> Result<GuildChannel> {
-        builder.execute(cache_http, self, None).await
+    pub async fn edit(self, http: &Http, builder: EditChannel<'_>) -> Result<GuildChannel> {
+        builder.execute(http, self).await
     }
 
     /// Edits a [`Message`] in the channel given its Id.
@@ -336,11 +326,11 @@ impl ChannelId {
     /// reasons.
     pub async fn edit_message(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: EditMessage<'_>,
     ) -> Result<Message> {
-        builder.execute(cache_http, self, message_id, None).await
+        builder.execute(http, self, message_id, None).await
     }
 
     /// Follows the News Channel
@@ -606,13 +596,9 @@ impl ChannelId {
     ///
     /// Returns a [`ModelError::TooLarge`] if the content length is over the above limit. See
     /// [`CreateMessage::execute`] for more details.
-    pub async fn say(
-        self,
-        cache_http: impl CacheHttp,
-        content: impl Into<Cow<'_, str>>,
-    ) -> Result<Message> {
+    pub async fn say(self, http: &Http, content: impl Into<Cow<'_, str>>) -> Result<Message> {
         let builder = CreateMessage::new().content(content);
-        self.send_message(cache_http, builder).await
+        self.send_message(http, builder).await
     }
 
     /// Sends file(s) along with optional message contents. The filename _must_ be specified.
@@ -683,11 +669,11 @@ impl ChannelId {
     /// [`File`]: tokio::fs::File
     pub async fn send_files<'a>(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         files: impl IntoIterator<Item = CreateAttachment<'a>>,
         builder: CreateMessage<'a>,
     ) -> Result<Message> {
-        self.send_message(cache_http, builder.files(files)).await
+        self.send_message(http, builder.files(files)).await
     }
 
     /// Sends a message to the channel.
@@ -699,12 +685,8 @@ impl ChannelId {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
-    pub async fn send_message(
-        self,
-        cache_http: impl CacheHttp,
-        builder: CreateMessage<'_>,
-    ) -> Result<Message> {
-        builder.execute(cache_http, self, None).await
+    pub async fn send_message(self, http: &Http, builder: CreateMessage<'_>) -> Result<Message> {
+        builder.execute(http, self, None).await
     }
 
     /// Starts typing in the channel for an indefinite period of time.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -230,17 +230,16 @@ impl GuildChannel {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     #[cfg(feature = "utils")]
     pub async fn create_invite(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateInvite<'_>,
     ) -> Result<RichInvite> {
-        builder.execute(cache_http, self.id, None).await
+        builder.execute(http, self.id).await
     }
 
     /// Creates a [permission overwrite][`PermissionOverwrite`] for either a single [`Member`] or
@@ -266,30 +265,11 @@ impl GuildChannel {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission.
-    ///
-    /// Otherwise returns [`Error::Http`] if the current user lacks permission.
+    /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
-    pub async fn delete(
-        &self,
-        cache_http: impl CacheHttp,
-        reason: Option<&str>,
-    ) -> Result<GuildChannel> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    self.guild_id,
-                    self.id,
-                    Permissions::MANAGE_CHANNELS,
-                )?;
-            }
-        }
-
-        let channel = self.id.delete(cache_http.http(), reason).await?;
+    pub async fn delete(&self, http: &Http, reason: Option<&str>) -> Result<GuildChannel> {
+        let channel = self.id.delete(http, reason).await?;
         channel.guild().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 
@@ -393,17 +373,12 @@ impl GuildChannel {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn edit(
-        &mut self,
-        cache_http: impl CacheHttp,
-        builder: EditChannel<'_>,
-    ) -> Result<()> {
-        let channel = builder.execute(cache_http, self.id, Some(self.guild_id)).await?;
+    pub async fn edit(&mut self, http: &Http, builder: EditChannel<'_>) -> Result<()> {
+        let channel = builder.execute(http, self.id).await?;
         *self = channel;
         Ok(())
     }
@@ -424,11 +399,11 @@ impl GuildChannel {
     /// reasons.
     pub async fn edit_message(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: EditMessage<'_>,
     ) -> Result<Message> {
-        self.id.edit_message(cache_http, message_id, builder).await
+        self.id.edit_message(http, message_id, builder).await
     }
 
     /// Edits a thread.
@@ -731,12 +706,8 @@ impl GuildChannel {
     ///
     /// Returns a [`ModelError::TooLarge`] if the content length is over the above limit. See
     /// [`CreateMessage::execute`] for more details.
-    pub async fn say(
-        &self,
-        cache_http: impl CacheHttp,
-        content: impl Into<Cow<'_, str>>,
-    ) -> Result<Message> {
-        self.id.say(cache_http, content).await
+    pub async fn say(&self, http: &Http, content: impl Into<Cow<'_, str>>) -> Result<Message> {
+        self.id.say(http, content).await
     }
 
     /// Sends file(s) along with optional message contents.
@@ -749,11 +720,11 @@ impl GuildChannel {
     /// reasons.
     pub async fn send_files<'a>(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         files: impl IntoIterator<Item = CreateAttachment<'a>>,
         builder: CreateMessage<'a>,
     ) -> Result<Message> {
-        self.send_message(cache_http, builder.files(files)).await
+        self.send_message(http, builder.files(files)).await
     }
 
     /// Sends a message to the channel.
@@ -765,12 +736,8 @@ impl GuildChannel {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
-    pub async fn send_message(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: CreateMessage<'_>,
-    ) -> Result<Message> {
-        builder.execute(cache_http, self.id, Some(self.guild_id)).await
+    pub async fn send_message(&self, http: &Http, builder: CreateMessage<'_>) -> Result<Message> {
+        builder.execute(http, self.id, Some(self.guild_id)).await
     }
 
     /// Starts typing in the channel for an indefinite period of time.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -432,12 +432,7 @@ impl Message {
     /// [Add Reactions]: Permissions::ADD_REACTIONS
     /// [permissions]: crate::model::permissions
     pub async fn react(&self, http: &Http, reaction_type: impl Into<ReactionType>) -> Result<()> {
-        self._react(http, reaction_type.into()).await
-    }
-
-    async fn _react(&self, http: &Http, reaction_type: ReactionType) -> Result<()> {
-        http.create_reaction(self.channel_id, self.id, &reaction_type).await?;
-        Ok(())
+        http.create_reaction(self.channel_id, self.id, &reaction_type.into()).await
     }
 
     /// Uses Discord's inline reply to a user without pinging them.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -158,7 +158,7 @@ impl Message {
     /// Returns a [`ModelError::CannotCrosspostMessage`] if the message cannot be crossposted.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn crosspost(&self, cache_http: impl CacheHttp) -> Result<Message> {
+    pub async fn crosspost(&self, http: &Http) -> Result<Message> {
         if let Some(flags) = self.flags {
             if flags.contains(MessageFlags::CROSSPOSTED) {
                 return Err(Error::Model(ModelError::MessageAlreadyCrossposted));
@@ -169,7 +169,7 @@ impl Message {
             }
         }
 
-        self.channel_id.crosspost(cache_http.http(), self.id).await
+        self.channel_id.crosspost(http, self.id).await
     }
 
     /// First attempts to find a [`Channel`] by its Id in the cache, upon failure requests it via
@@ -202,8 +202,8 @@ impl Message {
     /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete(&self, cache_http: impl CacheHttp, reason: Option<&str>) -> Result<()> {
-        self.channel_id.delete_message(cache_http.http(), self.id, reason).await
+    pub async fn delete(&self, http: &Http, reason: Option<&str>) -> Result<()> {
+        self.channel_id.delete_message(http, self.id, reason).await
     }
 
     /// Deletes all of the [`Reaction`]s associated with the message.
@@ -215,8 +215,8 @@ impl Message {
     /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn delete_reactions(&self, cache_http: impl CacheHttp) -> Result<()> {
-        self.channel_id.delete_reactions(cache_http.http(), self.id).await
+    pub async fn delete_reactions(&self, http: &Http) -> Result<()> {
+        self.channel_id.delete_reactions(http, self.id).await
     }
 
     /// Deletes the given [`Reaction`] from the message.
@@ -250,13 +250,10 @@ impl Message {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn delete_reaction_emoji(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        cache_http
-            .http()
-            .delete_message_reaction_emoji(self.channel_id, self.id, &reaction_type.into())
-            .await
+        http.delete_message_reaction_emoji(self.channel_id, self.id, &reaction_type.into()).await
     }
 
     /// Edits this message, replacing the original content with new content.
@@ -417,8 +414,8 @@ impl Message {
     /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub async fn pin(&self, cache_http: impl CacheHttp, reason: Option<&str>) -> Result<()> {
-        self.channel_id.pin(cache_http.http(), self.id, reason).await
+    pub async fn pin(&self, http: &Http, reason: Option<&str>) -> Result<()> {
+        self.channel_id.pin(http, self.id, reason).await
     }
 
     /// React to the message with a custom [`Emoji`] or unicode character.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -23,7 +23,7 @@ pub use self::partial_channel::*;
 pub use self::private_channel::*;
 pub use self::reaction::*;
 #[cfg(feature = "model")]
-use crate::http::CacheHttp;
+use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
@@ -117,17 +117,14 @@ impl Channel {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`], if the current user
-    /// lacks permission.
-    ///
-    /// Otherwise will return [`Error::Http`] if the current user does not have permission.
-    pub async fn delete(&self, cache_http: impl CacheHttp, reason: Option<&str>) -> Result<()> {
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    pub async fn delete(&self, http: &Http, reason: Option<&str>) -> Result<()> {
         match self {
             Self::Guild(public_channel) => {
-                public_channel.delete(cache_http, reason).await?;
+                public_channel.delete(http, reason).await?;
             },
             Self::Private(private_channel) => {
-                private_channel.delete(cache_http.http()).await?;
+                private_channel.delete(http).await?;
             },
         }
 

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -140,11 +140,11 @@ impl PrivateChannel {
     /// [`EditMessage::execute`]: ../../builder/struct.EditMessage.html#method.execute
     pub async fn edit_message(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         message_id: MessageId,
         builder: EditMessage<'_>,
     ) -> Result<Message> {
-        self.id.edit_message(cache_http, message_id, builder).await
+        self.id.edit_message(http, message_id, builder).await
     }
 
     /// Gets a message from the channel.
@@ -222,12 +222,8 @@ impl PrivateChannel {
     /// [`CreateMessage::execute`] for more details.
     ///
     /// [`CreateMessage::execute`]: ../../builder/struct.CreateMessage.html#method.execute
-    pub async fn say(
-        &self,
-        cache_http: impl CacheHttp,
-        content: impl Into<Cow<'_, str>>,
-    ) -> Result<Message> {
-        self.id.say(cache_http, content).await
+    pub async fn say(&self, http: &Http, content: impl Into<Cow<'_, str>>) -> Result<Message> {
+        self.id.say(http, content).await
     }
 
     /// Sends file(s) along with optional message contents.
@@ -242,11 +238,11 @@ impl PrivateChannel {
     /// [`CreateMessage::execute`]: ../../builder/struct.CreateMessage.html#method.execute
     pub async fn send_files<'a>(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         files: impl IntoIterator<Item = CreateAttachment<'a>>,
         builder: CreateMessage<'a>,
     ) -> Result<Message> {
-        self.id.send_files(cache_http, files, builder).await
+        self.id.send_files(http, files, builder).await
     }
 
     /// Sends a message to the channel.
@@ -260,12 +256,8 @@ impl PrivateChannel {
     /// reasons.
     ///
     /// [`CreateMessage::execute`]: ../../builder/struct.CreateMessage.html#method.execute
-    pub async fn send_message(
-        &self,
-        cache_http: impl CacheHttp,
-        builder: CreateMessage<'_>,
-    ) -> Result<Message> {
-        self.id.send_message(cache_http, builder).await
+    pub async fn send_message(&self, http: &Http, builder: CreateMessage<'_>) -> Result<Message> {
+        self.id.send_message(http, builder).await
     }
 
     /// Starts typing in the channel for an indefinite period of time.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -86,37 +86,13 @@ impl Reaction {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, then returns a [`ModelError::InvalidPermissions`] if the current
-    /// user does not have the required [permissions].
-    ///
-    /// Otherwise returns [`Error::Http`] if the current user lacks permission.
+    /// Returns [`Error::Http`] if the current user lacks the required [permissions].
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     /// [permissions]: crate::model::permissions
-    pub async fn delete(&self, cache_http: impl CacheHttp) -> Result<()> {
-        #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
-        let mut user_id = self.user_id;
-
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if self.user_id == Some(cache.current_user().id) {
-                    user_id = None;
-                }
-
-                if let (Some(_), Some(guild_id)) = (user_id, self.guild_id) {
-                    crate::utils::user_has_perms_cache(
-                        cache,
-                        guild_id,
-                        self.channel_id,
-                        Permissions::MANAGE_MESSAGES,
-                    )?;
-                }
-            }
-        }
-
+    pub async fn delete(&self, http: &Http) -> Result<()> {
         self.channel_id
-            .delete_reaction(cache_http.http(), self.message_id, user_id, self.emoji.clone())
+            .delete_reaction(http, self.message_id, self.user_id, self.emoji.clone())
             .await
     }
 
@@ -126,29 +102,12 @@ impl Reaction {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, then returns a [`ModelError::InvalidPermissions`] if the current
-    /// user does not have the required [permissions].
-    ///
-    /// Otherwise returns [`Error::Http`] if the current user lacks permission.
+    /// Returns [`Error::Http`] if the current user lacks [permissions].
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     /// [permissions]: crate::model::permissions
-    pub async fn delete_all(&self, cache_http: impl CacheHttp) -> Result<()> {
-        #[cfg(feature = "cache")]
-        {
-            if let (Some(cache), Some(guild_id)) = (cache_http.cache(), self.guild_id) {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    guild_id,
-                    self.channel_id,
-                    Permissions::MANAGE_MESSAGES,
-                )?;
-            }
-        }
-        cache_http
-            .http()
-            .delete_message_reaction_emoji(self.channel_id, self.message_id, &self.emoji)
-            .await
+    pub async fn delete_all(&self, http: &Http) -> Result<()> {
+        http.delete_message_reaction_emoji(self.channel_id, self.message_id, &self.emoji).await
     }
 
     /// Retrieves the [`Message`] associated with this reaction.
@@ -206,8 +165,7 @@ impl Reaction {
     ///
     /// # Errors
     ///
-    /// Returns a [`ModelError::InvalidPermissions`] if the current user does not have the required
-    /// [permissions].
+    /// Returns [`Error::Http`] if the current user lacks the required [permissions].
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     /// [permissions]: crate::model::permissions
@@ -368,13 +326,13 @@ impl From<char> for ReactionType {
     ///
     /// ```rust,no_run
     /// # #[cfg(feature = "http")]
-    /// # use serenity::http::CacheHttp;
+    /// # use serenity::http::Http;
     /// # use serenity::model::channel::Message;
     /// # use serenity::model::id::ChannelId;
     /// #
     /// # #[cfg(feature = "http")]
-    /// # async fn example(ctx: impl CacheHttp, message: Message) -> Result<(), Box<dyn std::error::Error>> {
-    /// message.react(ctx, '🍎').await?;
+    /// # async fn example(http: &Http, message: Message) -> Result<(), Box<dyn std::error::Error>> {
+    /// message.react(http, '🍎').await?;
     /// # Ok(())
     /// # }
     /// #

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -3,8 +3,6 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use super::Permissions;
-
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Maximum {
@@ -189,13 +187,6 @@ pub enum Error {
     /// When editing a role, if the role is higher in position than the current user's highest
     /// role, then the role can not be edited.
     Hierarchy,
-    /// Indicates that you do not have the required permissions to perform an operation.
-    InvalidPermissions {
-        /// Which permissions were required for the operation
-        required: Permissions,
-        /// Which permissions the bot had
-        present: Permissions,
-    },
     /// An indicator that the [current user] cannot perform an action.
     ///
     /// [current user]: super::user::CurrentUser
@@ -252,9 +243,6 @@ impl fmt::Display for Error {
             Self::ChannelNotFound => f.write_str("Channel not found in the cache."),
             Self::Hierarchy => f.write_str("Role hierarchy prevents this action."),
             Self::InvalidChannelType => f.write_str("The channel cannot perform the action."),
-            Self::InvalidPermissions {
-                ..
-            } => f.write_str("Invalid permissions."),
             Self::InvalidUser => f.write_str("The current user cannot perform the action."),
             Self::ItemMissing => f.write_str("The required item is missing from the cache."),
             Self::MessageAlreadyCrossposted => f.write_str("Message already crossposted."),

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -281,16 +281,15 @@ impl GuildId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn create_channel(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateChannel<'_>,
     ) -> Result<GuildChannel> {
-        builder.execute(cache_http, self).await
+        builder.execute(http, self).await
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.
@@ -372,8 +371,7 @@ impl GuildId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn create_role(self, http: &Http, builder: EditRole<'_>) -> Result<Role> {
@@ -386,16 +384,15 @@ impl GuildId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Events]: Permissions::CREATE_EVENTS
     pub async fn create_scheduled_event(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
-        builder.execute(cache_http, self).await
+        builder.execute(http, self).await
     }
 
     /// Creates a new sticker in the guild with the data set, if any.
@@ -404,16 +401,11 @@ impl GuildId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
-    pub async fn create_sticker(
-        self,
-        cache_http: impl CacheHttp,
-        builder: CreateSticker<'_>,
-    ) -> Result<Sticker> {
-        builder.execute(cache_http, self).await
+    pub async fn create_sticker(self, http: &Http, builder: CreateSticker<'_>) -> Result<Sticker> {
+        builder.execute(http, self).await
     }
 
     /// Deletes the current guild if the current account is the owner of the
@@ -539,16 +531,11 @@ impl GuildId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit(
-        self,
-        cache_http: impl CacheHttp,
-        builder: EditGuild<'_>,
-    ) -> Result<PartialGuild> {
-        builder.execute(cache_http, self).await
+    pub async fn edit(self, http: &Http, builder: EditGuild<'_>) -> Result<PartialGuild> {
+        builder.execute(http, self).await
     }
 
     /// Edits an [`Emoji`]'s name in the guild.
@@ -706,17 +693,16 @@ impl GuildId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn edit_role(
         self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         role_id: RoleId,
         builder: EditRole<'_>,
     ) -> Result<Role> {
-        builder.execute(cache_http, self, Some(role_id)).await
+        builder.execute(http, self, Some(role_id)).await
     }
 
     /// Modifies a scheduled event in the guild with the data set, if any.
@@ -726,8 +712,7 @@ impl GuildId {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Events]: Permissions::CREATE_EVENTS
     /// [Manage Events]: Permissions::MANAGE_EVENTS

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -49,8 +49,6 @@ use crate::builder::{
     EditScheduledEvent,
     EditSticker,
 };
-#[cfg(all(feature = "cache", feature = "model"))]
-use crate::cache::Cache;
 #[cfg(feature = "collector")]
 use crate::collector::{MessageCollector, ReactionCollector};
 #[cfg(feature = "model")]
@@ -351,19 +349,6 @@ impl Guild {
         self.id.delete_automod_rule(http, rule_id, reason).await
     }
 
-    #[cfg(feature = "cache")]
-    fn check_hierarchy(&self, cache: &Cache, other_user: UserId) -> Result<()> {
-        let current_id = cache.current_user().id;
-
-        if let Some(higher) = self.greater_member_hierarchy(other_user, current_id) {
-            if higher != current_id {
-                return Err(Error::Model(ModelError::Hierarchy));
-            }
-        }
-
-        Ok(())
-    }
-
     /// Returns the "default" channel of the guild for the passed user id. (This returns the first
     /// channel that can be read by the user, if there isn't one, returns [`None`])
     #[must_use]
@@ -391,25 +376,6 @@ impl Guild {
         })
     }
 
-    /// Intentionally not async. Retrieving anything from HTTP here is overkill/undesired
-    #[cfg(feature = "cache")]
-    pub(crate) fn require_perms(
-        &self,
-        cache: &Cache,
-        required_permissions: Permissions,
-    ) -> Result<(), Error> {
-        if let Some(member) = self.members.get(&cache.current_user().id) {
-            let bot_permissions = self.member_permissions(member);
-            if !bot_permissions.contains(required_permissions) {
-                return Err(Error::Model(ModelError::InvalidPermissions {
-                    required: required_permissions,
-                    present: bot_permissions,
-                }));
-            }
-        }
-        Ok(())
-    }
-
     /// Ban a [`User`] from the guild, deleting a number of days' worth of messages (`dmd`) between
     /// the range 0 and 7.
     ///
@@ -431,30 +397,17 @@ impl Guild {
     /// Returns a [`ModelError::TooLarge`] if the number of days' worth of messages
     /// to delete is over the maximum.
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to perform bans, or may return a [`ModelError::Hierarchy`] if the
-    /// member to be banned has a higher role than the current user.
-    ///
-    /// Otherwise returns [`Error::Http`] if the member cannot be banned.
+    /// Returns [`Error::Http`] if the current user lacks permission to ban the member.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
     pub async fn ban(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         user: UserId,
         dmd: u8,
         reason: Option<&str>,
     ) -> Result<()> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                self.require_perms(cache, Permissions::BAN_MEMBERS)?;
-
-                self.check_hierarchy(cache, user)?;
-            }
-        }
-
-        self.id.ban(cache_http.http(), user, dmd, reason).await
+        self.id.ban(http, user, dmd, reason).await
     }
 
     /// Returns the formatted URL of the guild's banner image, if one exists.
@@ -470,24 +423,16 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to perform bans.
+    /// Returns [`Error::Http`] if the current user lacks permission to perform bans.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
     pub async fn bans(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         target: Option<UserPagination>,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<Ban>> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                self.require_perms(cache, Permissions::BAN_MEMBERS)?;
-            }
-        }
-
-        self.id.bans(cache_http.http(), target, limit).await
+        self.id.bans(http, target, limit).await
     }
 
     /// Adds a [`User`] to this guild with a valid OAuth2 access token.
@@ -603,16 +548,15 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn create_channel(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateChannel<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_channel(cache_http, builder).await
+        self.id.create_channel(http, builder).await
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image. The
@@ -794,8 +738,7 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn create_role(&self, http: &Http, builder: EditRole<'_>) -> Result<Role> {
@@ -808,16 +751,15 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Events]: Permissions::CREATE_EVENTS
     pub async fn create_scheduled_event(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateScheduledEvent<'_>,
     ) -> Result<ScheduledEvent> {
-        self.id.create_scheduled_event(cache_http, builder).await
+        self.id.create_scheduled_event(http, builder).await
     }
 
     /// Creates a new sticker in the guild with the data set, if any.
@@ -826,16 +768,15 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     pub async fn create_sticker<'a>(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateSticker<'a>,
     ) -> Result<Sticker> {
-        self.id.create_sticker(cache_http, builder).await
+        self.id.create_sticker(http, builder).await
     }
 
     /// Deletes the current guild if the current user is the owner of the
@@ -990,12 +931,11 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditGuild<'_>) -> Result<()> {
-        let guild = self.id.edit(cache_http, builder).await?;
+    pub async fn edit(&mut self, http: &Http, builder: EditGuild<'_>) -> Result<()> {
+        let guild = self.id.edit(http, builder).await?;
 
         self.afk_metadata = guild.afk_metadata;
         self.default_message_notifications = guild.default_message_notifications;
@@ -1081,8 +1021,7 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to change their own nickname.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// Otherwise will return [`Error::Http`] if the current user lacks permission.
     ///
@@ -1093,13 +1032,6 @@ impl Guild {
         new_nickname: Option<&str>,
         reason: Option<&str>,
     ) -> Result<()> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                self.require_perms(cache, Permissions::CHANGE_NICKNAME)?;
-            }
-        }
-
         self.id.edit_nickname(cache_http.http(), new_nickname, reason).await
     }
 
@@ -1113,17 +1045,16 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn edit_role(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         role_id: RoleId,
         builder: EditRole<'_>,
     ) -> Result<Role> {
-        self.id.edit_role(cache_http, role_id, builder).await
+        self.id.edit_role(http, role_id, builder).await
     }
 
     /// Edits the order of [`Role`]s. Requires the [Manage Roles] permission.
@@ -1159,8 +1090,7 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Events]: Permissions::CREATE_EVENTS
     /// [Manage Events]: Permissions::MANAGE_EVENTS
@@ -1397,21 +1327,11 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to see invites.
-    ///
-    /// Otherwise will return [`Error::Http`] if the current user does not have permission.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn invites(&self, cache_http: impl CacheHttp) -> Result<Vec<RichInvite>> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                self.require_perms(cache, Permissions::MANAGE_GUILD)?;
-            }
-        }
-
-        self.id.invites(cache_http.http()).await
+    pub async fn invites(&self, http: &Http) -> Result<Vec<RichInvite>> {
+        self.id.invites(http).await
     }
 
     /// Checks if the guild is 'large'.
@@ -1901,28 +1821,19 @@ impl Guild {
     ///
     /// See the documentation on [`GuildPrune`] for more information.
     ///
-    /// **Note**: Requires the [Kick Members] permission.
+    /// **Note**: Requires [Manage Guild] and [Kick Members] permission.
     ///
     /// # Errors
-    ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to kick members.
     ///
     /// Otherwise may return [`Error::Http`] if the current user does not have permission. Can also
     /// return [`Error::Json`] if there is an error in deserializing the API response.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
+    /// [Manage Guild]: Permissions::MANAGE_GUILD
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
-    pub async fn prune_count(&self, cache_http: impl CacheHttp, days: u8) -> Result<GuildPrune> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                self.require_perms(cache, Permissions::KICK_MEMBERS)?;
-            }
-        }
-
-        self.id.prune_count(cache_http.http(), days).await
+    pub async fn prune_count(&self, http: &Http, days: u8) -> Result<GuildPrune> {
+        self.id.prune_count(http, days).await
     }
 
     /// Re-orders the channels of the guild.
@@ -2084,18 +1995,16 @@ impl Guild {
     ///
     /// See the documentation on [`GuildPrune`] for more information.
     ///
-    /// **Note**: Requires the [Kick Members] permission.
+    /// **Note**: Requires [Manage Guild] and [Kick Members] permissions.
     ///
     /// # Errors
-    ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to kick members.
     ///
     /// Otherwise will return [`Error::Http`] if the current user does not have permission.
     ///
     /// Can also return an [`Error::Json`] if there is an error deserializing the API response.
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
+    /// [Manage Guild]: Permissions::MANAGE_GUILD
     /// [`Error::Http`]: crate::error::Error::Http
     /// [`Error::Json`]: crate::error::Error::Json
     pub async fn start_prune(
@@ -2104,13 +2013,6 @@ impl Guild {
         days: u8,
         reason: Option<&str>,
     ) -> Result<GuildPrune> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                self.require_perms(cache, Permissions::KICK_MEMBERS)?;
-            }
-        }
-
         self.id.start_prune(cache_http.http(), days, reason).await
     }
 
@@ -2120,10 +2022,7 @@ impl Guild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to perform bans.
-    ///
-    /// Otherwise will return an [`Error::Http`] if the current user does not have permission.
+    /// Returns [`Error::Http`] if the current user does not have permission to perform bans.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
     pub async fn unban(
@@ -2132,13 +2031,6 @@ impl Guild {
         user_id: UserId,
         reason: Option<&str>,
     ) -> Result<()> {
-        #[cfg(feature = "cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                self.require_perms(cache, Permissions::BAN_MEMBERS)?;
-            }
-        }
-
         self.id.unban(cache_http.http(), user_id, reason).await
     }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -372,16 +372,15 @@ impl PartialGuild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn create_channel(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateChannel<'_>,
     ) -> Result<GuildChannel> {
-        self.id.create_channel(cache_http, builder).await
+        self.id.create_channel(http, builder).await
     }
 
     /// Creates an emoji in the guild with a name and base64-encoded image.
@@ -559,8 +558,7 @@ impl PartialGuild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn create_role(&self, http: &Http, builder: EditRole<'_>) -> Result<Role> {
@@ -573,16 +571,15 @@ impl PartialGuild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Guild Expressions]: Permissions::CREATE_GUILD_EXPRESSIONS
     pub async fn create_sticker<'a>(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         builder: CreateSticker<'a>,
     ) -> Result<Sticker> {
-        self.id.create_sticker(cache_http, builder).await
+        self.id.create_sticker(http, builder).await
     }
 
     /// Deletes the current guild if the current user is the owner of the
@@ -688,12 +685,11 @@ impl PartialGuild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit(&mut self, cache_http: impl CacheHttp, builder: EditGuild<'_>) -> Result<()> {
-        let guild = self.id.edit(cache_http, builder).await?;
+    pub async fn edit(&mut self, http: &Http, builder: EditGuild<'_>) -> Result<()> {
+        let guild = self.id.edit(http, builder).await?;
 
         self.afk_metadata = guild.afk_metadata;
         self.default_message_notifications = guild.default_message_notifications;
@@ -801,17 +797,16 @@ impl PartialGuild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn edit_role(
         &self,
-        cache_http: impl CacheHttp,
+        http: &Http,
         role_id: RoleId,
         builder: EditRole<'_>,
     ) -> Result<Role> {
-        self.id.edit_role(cache_http, role_id, builder).await
+        self.id.edit_role(http, role_id, builder).await
     }
 
     /// Edits the order of [`Role`]s. Requires the [Manage Roles] permission.
@@ -1013,10 +1008,8 @@ impl PartialGuild {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have permission to kick members.
     ///
-    /// Otherwise will return [`Error::Http`] if the current user does not have permission.
+    /// Returns [`Error::Http`] if the current user does not have permission.
     ///
     /// Can also return an [`Error::Json`] if there is an error deserializing the API response.
     ///

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -68,16 +68,15 @@ impl Invite {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns [`ModelError::InvalidPermissions`] if the current user
-    /// lacks permission. Otherwise returns [`Error::Http`], as well as if invalid data is given.
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     pub async fn create(
-        cache_http: impl CacheHttp,
+        http: &Http,
         channel_id: ChannelId,
         builder: CreateInvite<'_>,
     ) -> Result<RichInvite> {
-        channel_id.create_invite(cache_http, builder).await
+        channel_id.create_invite(http, builder).await
     }
 
     /// Deletes the invite.
@@ -86,28 +85,13 @@ impl Invite {
     ///
     /// # Errors
     ///
-    /// If the `cache` is enabled, returns a [`ModelError::InvalidPermissions`] if the current user
-    /// does not have the required [permission].
-    ///
-    /// Otherwise may return [`Error::Http`] if permissions are lacking, or if the invite is
+    /// Returns [`Error::Http`] if the current user lacks permission or if the invite is
     /// invalid.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     /// [permission]: super::permissions
-    pub async fn delete(&self, cache_http: impl CacheHttp, reason: Option<&str>) -> Result<Invite> {
-        #[cfg(feature = "cache")]
-        {
-            if let (Some(cache), Some(guild)) = (cache_http.cache(), &self.guild) {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    guild.id,
-                    self.channel.id,
-                    Permissions::MANAGE_GUILD,
-                )?;
-            }
-        }
-
-        cache_http.http().delete_invite(&self.code, reason).await
+    pub async fn delete(&self, http: &Http, reason: Option<&str>) -> Result<Invite> {
+        http.delete_invite(&self.code, reason).await
     }
 
     /// Gets information about an invite.
@@ -282,24 +266,11 @@ impl RichInvite {
     ///
     /// # Errors
     ///
-    /// If the `cache` feature is enabled, then this returns a [`ModelError::InvalidPermissions`]
-    /// if the current user does not have the required [permission].
+    /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     /// [permission]: super::permissions
     pub async fn delete(&self, cache_http: impl CacheHttp, reason: Option<&str>) -> Result<Invite> {
-        #[cfg(feature = "cache")]
-        {
-            if let (Some(cache), Some(guild)) = (cache_http.cache(), &self.guild) {
-                crate::utils::user_has_perms_cache(
-                    cache,
-                    guild.id,
-                    self.channel.id,
-                    Permissions::MANAGE_GUILD,
-                )?;
-            }
-        }
-
         cache_http.http().delete_invite(&self.code, reason).await
     }
 

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -6,7 +6,7 @@ use super::prelude::*;
 #[cfg(feature = "model")]
 use crate::builder::CreateInvite;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::internal::prelude::*;
 
 /// Information about an invite code.
@@ -270,8 +270,8 @@ impl RichInvite {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     /// [permission]: super::permissions
-    pub async fn delete(&self, cache_http: impl CacheHttp, reason: Option<&str>) -> Result<Invite> {
-        cache_http.http().delete_invite(&self.code, reason).await
+    pub async fn delete(&self, http: &Http, reason: Option<&str>) -> Result<Invite> {
+        http.delete_invite(&self.code, reason).await
     }
 
     /// Returns a URL to use for the invite.

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -41,7 +41,7 @@ pub trait Mentionable {
     ///         member = member.mention(),
     ///         rules = rules_channel.mention(),
     ///     ));
-    ///     to_channel.id.send_message(ctx, builder).await?;
+    ///     to_channel.id.send_message(&ctx.http, builder).await?;
     ///     Ok(())
     /// }
     /// # }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -634,7 +634,7 @@ impl UserId {
     ///
     ///             if let Err(why) = msg.author.id.direct_message(&ctx.http, builder).await {
     ///                 println!("Err sending help: {why:?}");
-    ///                 let _ = msg.reply(&ctx, "There was an error DMing you help.").await;
+    ///                 let _ = msg.reply(&ctx.http, "There was an error DMing you help.").await;
     ///             };
     ///         }
     ///     }


### PR DESCRIPTION
Users should realistically be checking the permissions themselves, or handling the http error from Discord.

This removes any cases where permission checking inside the library is broken because discord changes or just over oversights.

Also changes the documentation on the prune functionality, this was recently changed to also require `MANAGE_GUILDS` as well as `KICK_MEMBERS`.

Please check for any `impl CacheHttp`'s being replaced with `Http`, they should be replaced with `&Http` or places where i may have skewed the docs.