### PR TITLE
Add missing TeamMember::role

### DIFF
--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -107,11 +107,14 @@ pub struct TeamMember {
     /// The list of permissions of the member on the team.
     ///
     /// NOTE: Will always be "*" for now.
+    #[deprecated = "This field is not sent by the API anymore"]
     pub permissions: Vec<String>,
     /// The ID of the team they are a member of.
     pub team_id: GenericId,
     /// The user type of the team member.
     pub user: User,
+    /// The [`TeamMemberRole`] of the team member.
+    pub role: TeamMemberRole,
 }
 
 enum_number! {
@@ -124,6 +127,17 @@ enum_number! {
         Accepted = 2,
         _ => Unknown(u8),
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TeamMemberRole {
+    Admin,
+    Developer,
+    ReadOnly,
+    #[serde(untagged)]
+    Other(String),
 }
 
 bitflags! {


### PR DESCRIPTION
Tested locally with my team, deserialised owner as Admin with `owner_user_id` set to themselves which is a curious way of doing things. Closes #2859.