### PR TITLE
Gate deprecated markers with no stable replacement under unstable flag

### DIFF
--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -75,7 +75,10 @@ pub struct Command {
     /// Indicates whether the command is available in DMs with the app, only for globally-scoped
     /// commands. By default, commands are visible.
     #[serde(default)]
-    #[deprecated = "Use Command::contexts"]
+    #[cfg_attr(
+        all(not(ignore_serenity_deprecated), feature = "unstable_discord_api"),
+        deprecated = "Use Command::contexts"
+    )]
     pub dm_permission: Option<bool>,
     /// Indicates whether the command is [age-restricted](https://discord.com/developers/docs/interactions/application-commands#agerestricted-commands),
     /// defaults to false.

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -395,7 +395,10 @@ impl serde::Serialize for AuthorizingIntegrationOwners {
 /// [`Message`]: crate::model::channel::Message
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#message-interaction-object).
-#[cfg_attr(not(ignore_serenity_deprecated), deprecated = "Use Message::interaction_metadata")]
+#[cfg_attr(
+    all(not(ignore_serenity_deprecated), feature = "unstable_discord_api"),
+    deprecated = "Use Message::interaction_metadata"
+)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -106,8 +106,10 @@ pub struct Message {
     pub flags: Option<MessageFlags>,
     /// The message that was replied to using this message.
     pub referenced_message: Option<Box<Message>>, // Boxed to avoid recursion
-    #[cfg_attr(not(ignore_serenity_deprecated), deprecated = "Use interaction_metadata")]
-    #[allow(deprecated)]
+    #[cfg_attr(
+        all(not(ignore_serenity_deprecated), feature = "unstable_discord_api"),
+        deprecated = "Use interaction_metadata"
+    )]
     pub interaction: Option<Box<MessageInteraction>>,
     /// Sent if the message is a response to an [`Interaction`].
     ///

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -525,9 +525,11 @@ pub struct MessageUpdateEvent {
     pub flags: Option<Option<MessageFlags>>,
     #[serde(default, deserialize_with = "deserialize_some")]
     pub referenced_message: Option<Option<Box<Message>>>,
-    #[cfg_attr(not(ignore_serenity_deprecated), deprecated = "Use interaction_metadata")]
+    #[cfg_attr(
+        all(not(ignore_serenity_deprecated), feature = "unstable_discord_api"),
+        deprecated = "Use interaction_metadata"
+    )]
     #[serde(default, deserialize_with = "deserialize_some")]
-    #[allow(deprecated)]
     pub interaction: Option<Option<Box<MessageInteraction>>>,
     #[cfg(feature = "unstable_discord_api")]
     pub interaction_metadata: Option<Option<Box<MessageInteractionMetadata>>>,


### PR DESCRIPTION
This fixes poise@serenity-next once rebased onto next by only deprecating (and therefore removing) fields when unstable is being used when said fields only have a replacement when unstable is being used.