### PR TITLE
Correct docs in various places

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -8,10 +8,10 @@
 //! Most models of Discord objects, such as the [`Message`], [`GuildChannel`], or [`Emoji`], have
 //! methods for interacting with that single instance. This feature is only compiled if the `model`
 //! feature is enabled. An example of this is [`Guild::edit`], which performs a check to ensure that
-//! the current user is the owner of the guild, prior to actually performing the HTTP request.
-//! The cache is involved due to the function's use of unlocking the cache and retrieving
-//! the Id of the current user, and comparing it to the Id of the user that owns the guild. This is
-//! an inexpensive method of being able to access data required by these sugary methods.
+//! the current user has the [Manage Guild] permission prior to actually performing the HTTP
+//! request. The cache is involved due to the function's use of unlocking the cache and retrieving
+//! the permissions of the current user. This is an inexpensive method of being able to access data
+//! required by these sugary methods.
 //!
 //! # Do I need the Cache?
 //!
@@ -22,6 +22,7 @@
 //!
 //! [`Shard`]: crate::gateway::Shard
 //! [`http`]: crate::http
+//! [Manage Guild]: Permissions::MANAGE_GUILD
 
 use std::collections::{HashSet, VecDeque};
 use std::hash::Hash;

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -19,8 +19,7 @@
 //!
 //! See [Discord's documentation][docs] for more information.
 //!
-//! If you are not using a bot account or do not require sharding - such as for a small bot - then
-//! use [`Client::start`].
+//! If you do not require sharding - such as for a small bot - then use [`Client::start`].
 //!
 //! There are a few methods of sharding available:
 //! - [`Client::start_autosharded`]: retrieves the number of shards Discord recommends using from

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -62,7 +62,7 @@ pub struct Member {
     /// If the member is currently flagged for sending excessive DMs to non-friend server members
     /// in the last 24 hours.
     ///
-    /// Will be None or a time in the past if the user is not timed out.
+    /// Will be None or a time in the past if the user is not flagged.
     pub unusual_dm_activity_until: Option<Timestamp>,
 }
 
@@ -585,7 +585,7 @@ pub struct PartialMember {
     /// If the member is currently flagged for sending excessive DMs to non-friend server members
     /// in the last 24 hours.
     ///
-    /// Will be None or a time in the past if the user is not timed out.
+    /// Will be None or a time in the past if the user is not flagged.
     pub unusual_dm_activity_until: Option<Timestamp>,
 }
 


### PR DESCRIPTION
When using `Guild::edit` we don't check if the current user owns the guild, but instead if the current user has MANAGE_GUILD permissions.

On `next`, all the permission checks have been removed, and it is up to the responsibility of the user to check, so almost the entire paragraph can be removed on `next`.

We have never supported user accounts, so mentioning user accounts in the gateway documentation doesn't make sense.