### PR TITLE
Remove inaccurate doc comment on GuildChannel::nsfw

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -90,8 +90,7 @@ pub struct GuildChannel {
     ///
     /// **Note**: This is only available for voice channels.
     pub user_limit: Option<u32>,
-    /// Used to tell if the channel is not safe for work. Note however, it's recommended to use
-    /// [`Self::is_nsfw`] as it's gonna be more accurate.
+    /// Used to tell if the channel is not safe for work.
     // This field can or can not be present sometimes, but if it isn't default to `false`.
     #[serde(default)]
     pub nsfw: bool,


### PR DESCRIPTION
`GuildChannel::is_nsfw` is deprecated and just calls `self.nsfw` internally, it cannot be more accurate.