### PR TITLE
Add support for super reactions

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -815,12 +815,12 @@ impl Http {
         .await
     }
 
-    /// Reacts to a message.
-    pub async fn create_reaction(
+    async fn _create_reaction(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
         reaction_type: &ReactionType,
+        burst: bool,
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
@@ -832,9 +832,29 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: None,
+            params: Some(vec![("burst", burst.to_string())]),
         })
         .await
+    }
+
+    /// Reacts to a message.
+    pub async fn create_reaction(
+        &self,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        reaction_type: &ReactionType,
+    ) -> Result<()> {
+        self._create_reaction(channel_id, message_id, reaction_type, false).await
+    }
+
+    /// Super reacts to a message.
+    pub async fn create_super_reaction(
+        &self,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        reaction_type: &ReactionType,
+    ) -> Result<()> {
+        self._create_reaction(channel_id, message_id, reaction_type, true).await
     }
 
     /// Creates a role.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeMap, Serializer};
+use serde_cow::CowStr;
 #[cfg(feature = "model")]
 use tracing::warn;
 
@@ -91,7 +92,7 @@ fn discord_colours<'de, D>(deserializer: D) -> Result<Option<Vec<Colour>>, D::Er
 where
     D: Deserializer<'de>,
 {
-    let vec_str: Option<Vec<String>> = Deserialize::deserialize(deserializer)?;
+    let vec_str: Option<Vec<CowStr<'_>>> = Deserialize::deserialize(deserializer)?;
 
     let Some(vec_str) = vec_str else { return Ok(None) };
 
@@ -102,7 +103,7 @@ where
     let colours: Result<Vec<_>, _> = vec_str
         .iter()
         .map(|s| {
-            let s = s.strip_prefix('#').ok_or_else(|| DeError::custom("Invalid colour data"))?;
+            let s = s.0.strip_prefix('#').ok_or_else(|| DeError::custom("Invalid colour data"))?;
 
             if s.len() != 6 {
                 return Err(DeError::custom("Invalid colour data length"));

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -50,7 +50,7 @@ pub struct Reaction {
     /// Colours used for the super reaction animation.
     ///
     /// Only present on the ReactionAdd gateway event.
-    #[serde(rename = "burst_colors")]
+    #[serde(rename = "burst_colors", default, deserialize_with = "discord_colours")]
     pub burst_colours: Option<Vec<Colour>>,
     /// The type of reaction.
     #[serde(rename = "type")]
@@ -84,6 +84,40 @@ impl<'de> Deserialize<'de> for Reaction {
 impl Serialize for Reaction {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
         Self::serialize(self, serializer) // calls #[serde(remote)]-generated inherent method
+    }
+}
+
+fn discord_colours<'de, D>(deserializer: D) -> Result<Option<Vec<Colour>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let vec_str: Option<Vec<String>> = Deserialize::deserialize(deserializer)?;
+
+    let Some(vec_str) = vec_str else { return Ok(None) };
+
+    if vec_str.is_empty() {
+        return Ok(None);
+    }
+
+    let colours: Result<Vec<_>, _> = vec_str
+        .iter()
+        .map(|s| {
+            let s = s.strip_prefix('#').ok_or_else(|| DeError::custom("Invalid colour data"))?;
+
+            if s.len() != 6 {
+                return Err(DeError::custom("Invalid colour data length"));
+            }
+
+            match u32::from_str_radix(s, 16) {
+                Ok(c) => Ok(Colour::new(c)),
+                Err(_) => Err(DeError::custom("Invalid colour data")),
+            }
+        })
+        .collect();
+
+    match colours {
+        Ok(colours) => Ok(Some(colours)),
+        Err(err) => Err(err),
     }
 }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -36,9 +36,38 @@ pub struct Reaction {
     /// The optional Id of the [`Guild`] where the reaction was sent.
     pub guild_id: Option<GuildId>,
     /// The optional object of the member which added the reaction.
+    ///
+    /// Not present on the ReactionRemove gateway event.
     pub member: Option<Member>,
     /// The reactive emoji used.
     pub emoji: ReactionType,
+    /// The Id of the user who sent the message which this reacted to.
+    ///
+    /// Only present on the ReactionAdd gateway event.
+    pub message_author_id: Option<UserId>,
+    /// Indicates if this was a super reaction.
+    pub burst: bool,
+    /// Colours used for the super reaction animation.
+    ///
+    /// Only present on the ReactionAdd gateway event.
+    #[serde(rename = "burst_colors")]
+    pub burst_colours: Option<Vec<Colour>>,
+    /// The type of reaction.
+    #[serde(rename = "type")]
+    pub reaction_type: ReactionTypes,
+}
+
+enum_number! {
+    /// A list of types a reaction can be.
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum ReactionTypes {
+        Normal = 0,
+        Burst = 1,
+        _ => Unknown(u8),
+    }
 }
 
 // Manual impl needed to insert guild_id into PartialMember


### PR DESCRIPTION
Rough, very quick addition of super reactions.

Fixes #2866.

Also seems like bots have a currency system identical to when super reactions first rolled out, I'm not sure if it *ever* gets replenished for bots or you get 5 a week, bots have some features of nitro for free but *now* users with nitro have unlimited super reactions, so I won't be sure for a week whats the verdict.