### PR TITLE
Add into_inner for CreateEmbed's wrapped Embed field

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -198,6 +198,13 @@ impl CreateEmbed {
         super::check_overflow(length, crate::constants::EMBED_MAX_LENGTH)
             .map_err(|overflow| Error::Model(ModelError::EmbedTooLarge(overflow)))
     }
+
+    /// Consumes the [`CreateEmbed`], returning the wrapped [`Embed`].
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> Embed {
+        self.0
+    }
 }
 
 impl Default for CreateEmbed {


### PR DESCRIPTION
Admittedly, it's an incredibly niche change, but it annoyed me so here we are.