### PR TITLE
Add GuildId param to ChannelId::to_channel 

### DIFF
--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -12,7 +12,7 @@ struct Handler;
 impl EventHandler for Handler {
     async fn message(&self, context: Context, msg: Message) {
         if msg.content == "!ping" {
-            let channel = match msg.channel_id.to_channel(&context).await {
+            let channel = match msg.channel(&context).await {
                 Ok(channel) => channel,
                 Err(why) => {
                     println!("Error getting channel: {why:?}");

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -360,22 +360,29 @@ impl ChannelId {
         http.follow_news_channel(self, &map).await
     }
 
-    /// First attempts to retrieve the channel from the `temp_cache` if enabled, otherwise performs
-    /// a HTTP request.
-    ///
-    /// It is recommended to first check if the channel is accessible via `Cache::guild` and
-    /// `Guild::members`, although this requires a `GuildId`.
+    /// Attempts to retrieve the channel from the guild cache, otherwise from HTTP/temp cache.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the channel retrieval request failed.
-    pub async fn to_channel(self, cache_http: impl CacheHttp) -> Result<Channel> {
-        #[cfg(feature = "temp_cache")]
-        {
-            if let Some(cache) = cache_http.cache() {
-                if let Some(channel) = cache.temp_channels.get(&self) {
-                    return Ok(Channel::Guild(GuildChannel::clone(&*channel)));
+    pub async fn to_channel(
+        self,
+        cache_http: impl CacheHttp,
+        guild_id: Option<GuildId>,
+    ) -> Result<Channel> {
+        #[cfg(feature = "cache")]
+        if let Some(cache) = cache_http.cache() {
+            if let Some(guild_id) = guild_id {
+                if let Some(guild) = cache.guild(guild_id) {
+                    if let Some(channel) = guild.channels.get(&self) {
+                        return Ok(Channel::Guild(channel.clone()));
+                    }
                 }
+            }
+
+            #[cfg(feature = "temp_cache")]
+            if let Some(channel) = cache.temp_channels.get(&self) {
+                return Ok(Channel::Guild(GuildChannel::clone(&*channel)));
             }
         }
 
@@ -394,6 +401,29 @@ impl ChannelId {
         }
 
         Ok(channel)
+    }
+
+    /// Fetches a channel from the cache, falling back to HTTP/temp cache.
+    ///
+    /// It is highly recommended to pass the `guild_id` parameter as otherwise this may perform many
+    /// HTTP requests.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the HTTP fallback fails, or if the channel does not come from the guild passed.
+    pub async fn to_guild_channel(
+        self,
+        cache_http: impl CacheHttp,
+        guild_id: Option<GuildId>,
+    ) -> Result<GuildChannel> {
+        let channel = self.to_channel(cache_http, guild_id).await?;
+        let guild_channel = channel.guild().ok_or(ModelError::InvalidChannelType)?;
+
+        if guild_id.is_some_and(|id| guild_channel.guild_id != id) {
+            return Err(Error::Model(ModelError::ChannelNotFound));
+        }
+
+        Ok(guild_channel)
     }
 
     /// Gets all of the channel's invites.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -104,7 +104,7 @@ impl Reaction {
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
     pub async fn channel(&self, cache_http: impl CacheHttp) -> Result<Channel> {
-        self.channel_id.to_channel(cache_http).await
+        self.channel_id.to_channel(cache_http, self.guild_id).await
     }
 
     /// Deletes the reaction, but only if the current user is the user who made the reaction or has

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -166,23 +166,6 @@ pub struct WebhookChannel {
 }
 
 #[cfg(feature = "model")]
-impl WebhookChannel {
-    /// First attempts to retrieve the channel from the `temp_cache` if enabled, otherwise performs
-    /// a HTTP request.
-    ///
-    /// It is recommended to first check if the channel is accessible via `Cache::guild` and
-    /// `Guild::members`, although this requires a `GuildId`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Http`] if the channel retrieval request failed.
-    pub async fn to_channel(self, cache_http: impl CacheHttp) -> Result<GuildChannel> {
-        let channel = self.id.to_channel(cache_http).await?;
-        channel.guild().ok_or(Error::Model(ModelError::InvalidChannelType))
-    }
-}
-
-#[cfg(feature = "model")]
 impl Webhook {
     /// Retrieves a webhook given its Id.
     ///

--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -46,7 +46,7 @@ async fn lookup_channel_global(
     s: &str,
 ) -> Result<Channel, ChannelParseError> {
     if let Some(channel_id) = s.parse().ok().or_else(|| crate::utils::parse_channel_mention(s)) {
-        return channel_id.to_channel(&ctx).await.map_err(ChannelParseError::Http);
+        return channel_id.to_channel(ctx, guild_id).await.map_err(ChannelParseError::Http);
     }
 
     let guild_id = guild_id.ok_or(ChannelParseError::NotFoundOrMalformed)?;


### PR DESCRIPTION
This mitigates the `Cache::channels` removal by allowing the user to provide the GuildId to lookup from cache, instead of always fetching from HTTP (or temp cache).