### PR TITLE
Bump MSRV to Rust 1.79

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
 
 ## MSRV Policy
 
-Serenity's minimum supported Rust version (MSRV) is Rust 1.74.
+Serenity's minimum supported Rust version (MSRV) is Rust 1.79.
 
 We opt to keep MSRV stable on the `current` branch. This means it will remain
 unchanged between minor releases. Occasionally, dependencies may violate SemVer
@@ -244,5 +244,5 @@ a Rust-native cloud development platform that allows deploying Serenity bots for
 [repo:andesite]: https://github.com/natanbc/andesite
 [repo:lavaplayer]: https://github.com/sedmelluq/lavaplayer
 [logo]: https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png
-[rust-version-badge]: https://img.shields.io/badge/rust-1.74.0+-93450a.svg?style=flat-square
-[rust-version-link]: https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
+[rust-version-badge]: https://img.shields.io/badge/rust-1.79.0+-93450a.svg?style=flat-square
+[rust-version-link]: https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html


### PR DESCRIPTION
The actual version change was made in #2902, but left README.md unchanged.