### PR TITLE
Fix null error in InstallationContextConfig

### DIFF
--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -124,7 +124,8 @@ enum_number! {
 #[cfg(feature = "unstable_discord_api")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InstallationContextConfig {
-    pub oauth2_install_params: InstallParams,
+    #[serde(default)]
+    pub oauth2_install_params: InstallParams, // TODO: Replace with an option instead of #[serde(default)]
 }
 
 /// Information about the Team group of the application.
@@ -265,7 +266,14 @@ pub struct InstallParams {
     pub scopes: Vec<Scope>,
     pub permissions: Permissions,
 }
-
+impl Default for InstallParams {
+    fn default() -> Self {
+        Self {
+            scopes: Vec::new(),
+            permissions: Permissions::empty(),
+        }
+    }
+}
 #[cfg(test)]
 mod team_role_ordering {
     use super::TeamMemberRole;

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -124,8 +124,7 @@ enum_number! {
 #[cfg(feature = "unstable_discord_api")]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InstallationContextConfig {
-    #[serde(default)]
-    pub oauth2_install_params: InstallParams, // TODO: Replace with an option instead of #[serde(default)]
+    pub oauth2_install_params: Option<InstallParams>,
 }
 
 /// Information about the Team group of the application.
@@ -266,14 +265,7 @@ pub struct InstallParams {
     pub scopes: Vec<Scope>,
     pub permissions: Permissions,
 }
-impl Default for InstallParams {
-    fn default() -> Self {
-        Self {
-            scopes: Vec::new(),
-            permissions: Permissions::empty(),
-        }
-    }
-}
+
 #[cfg(test)]
 mod team_role_ordering {
     use super::TeamMemberRole;


### PR DESCRIPTION
Added #[serde(default)] to oauth2_install_params in InstallationContextConfig and added a Default implementation to InstallParams #2883 and https://discord.com/developers/docs/resources/application#application-object-application-structure.