### PR TITLE
Clean up references on format! macros

### DIFF
--- a/examples/e05_command_framework/src/main.rs
+++ b/examples/e05_command_framework/src/main.rs
@@ -182,7 +182,7 @@ async fn dispatch_error(ctx: &Context, msg: &Message, error: DispatchError, _com
         if info.is_first_try {
             let _ = msg
                 .channel_id
-                .say(&ctx.http, &format!("Try this again in {} seconds.", info.as_secs()))
+                .say(&ctx.http, format!("Try this again in {} seconds.", info.as_secs()))
                 .await;
         }
     }
@@ -203,7 +203,7 @@ fn _dispatch_error_no_macro<'fut>(
             if info.is_first_try {
                 let _ = msg
                     .channel_id
-                    .say(&ctx.http, &format!("Try this again in {} seconds.", info.as_secs()))
+                    .say(&ctx.http, format!("Try this again in {} seconds.", info.as_secs()))
                     .await;
             }
         };
@@ -405,7 +405,7 @@ async fn owner_check(
 
 #[command]
 async fn some_long_command(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
-    msg.channel_id.say(&ctx.http, &format!("Arguments: {:?}", args.rest())).await?;
+    msg.channel_id.say(&ctx.http, format!("Arguments: {:?}", args.rest())).await?;
 
     Ok(())
 }
@@ -476,7 +476,7 @@ async fn latency(ctx: &Context, msg: &Message) -> CommandResult {
         },
     };
 
-    msg.reply(ctx, &format!("The shard latency is {:?}", runner.latency)).await?;
+    msg.reply(ctx, format!("The shard latency is {:?}", runner.latency)).await?;
 
     Ok(())
 }

--- a/examples/e10_collectors/src/main.rs
+++ b/examples/e10_collectors/src/main.rs
@@ -189,12 +189,11 @@ async fn challenge(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
         score += 1;
         let _ = msg.reply(ctx, "Great! You edited 5 out of 5").await;
     } else {
-        let _ = msg.reply(ctx, &format!("You only edited {} out of 5", edited.len())).await;
+        let _ = msg.reply(ctx, format!("You only edited {} out of 5", edited.len())).await;
     }
 
-    let _ = msg
-        .reply(ctx, &format!("TIME'S UP! You completed {score} out of 4 tasks correctly!"))
-        .await;
+    let _ =
+        msg.reply(ctx, format!("TIME'S UP! You completed {score} out of 4 tasks correctly!")).await;
 
     Ok(())
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -926,7 +926,7 @@ fn flatten_group_to_string(
         writeln!(group_text)?;
     }
 
-    let mut joined_commands = group.command_names.join(&format!("\n{}", &repeated_indent_str));
+    let mut joined_commands = group.command_names.join(&format!("\n{repeated_indent_str}"));
 
     if !group.command_names.is_empty() {
         joined_commands.insert_str(0, &repeated_indent_str);

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -136,7 +136,7 @@ impl Attachment {
     ///
     ///             let _ = message
     ///                 .channel_id
-    ///                 .say(&context, &format!("Saved {:?}", attachment.filename))
+    ///                 .say(&context, format!("Saved {:?}", attachment.filename))
     ///                 .await;
     ///         }
     ///     }


### PR DESCRIPTION
formatting a String, dereffencing it, before its turned back into a String is wasteful. (`impl Into<String>`)

And then theres that one usage in standard framework where it is behind a double reference and cannot be inlined out (thanks rustc for not optimizing that out)