### PR TITLE
Add method to retrieve the Role icon url

### DIFF
--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -126,6 +126,17 @@ impl Role {
             self.permissions.contains(permissions)
         }
     }
+
+    #[inline]
+    #[must_use]
+    /// Generates a URL to the Role icon's image.
+    pub fn icon_url(&self) -> Option<String> {
+        self.icon.map(|icon| {
+            let ext = if icon.is_animated() { "gif" } else { "webp" };
+
+            cdn!("/role-icons/{}/{}.{}", self.id, icon, ext)
+        })
+    }
 }
 
 impl fmt::Display for Role {


### PR DESCRIPTION
Example link:
https://cdn.discordapp.com/role-icons/1199033047501242439/08077e7ef70f08bc4bb452b737ced15c.webp