### PR TITLE
Fix deserialisation failure of audit logs when the user ID is absent

### DIFF
--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -344,6 +344,8 @@ pub struct AuditLogEntry {
     pub action: Action,
     /// What was the reasoning by doing an action on a target? If there was one.
     pub reason: Option<String>,
+    // FIXME: Remove this attribute and change the type to `Option<UserId>` on `next`.
+    #[serde(default)]
     /// The user that did this action on a target.
     pub user_id: UserId,
     /// What changes were made.


### PR DESCRIPTION
Kind of fixes #2929.

Real fix would be to account for this at the type level with `Option<T>`, but this change cannot be committed to `current` as it is a breaking change.