### PR TITLE
Allow setting both normal and raw event handlers

### DIFF
--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -513,7 +513,7 @@ event_handler! {
 #[async_trait]
 pub trait RawEventHandler: Send + Sync {
     /// Dispatched when any event occurs
-    async fn raw_event(&self, _ctx: Context, _ev: Event) {}
+    async fn raw_event(&self, _ctx: Context, _ev: &Event) {}
 
     /// Checks if the `event` should be dispatched (`true`) or ignored (`false`).
     ///
@@ -540,4 +540,5 @@ pub trait RawEventHandler: Send + Sync {
 pub enum InternalEventHandler {
     Raw(Arc<dyn RawEventHandler>),
     Normal(Arc<dyn EventHandler>),
+    Both { raw: Arc<dyn RawEventHandler>, normal: Arc<dyn EventHandler> },
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -296,7 +296,10 @@ impl IntoFuture for ClientBuilder {
         let http = self.http;
 
         let event_handler = match (self.event_handler, self.raw_event_handler) {
-            (Some(_), Some(_)) => panic!("Cannot provide both a normal and raw event handlers"),
+            (Some(normal), Some(raw)) => Some(InternalEventHandler::Both {
+                normal,
+                raw,
+            }),
             (Some(h), None) => Some(InternalEventHandler::Normal(h)),
             (None, Some(h)) => Some(InternalEventHandler::Raw(h)),
             (None, None) => None,

--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -178,6 +178,12 @@ impl ShardRunner {
                     Some(InternalEventHandler::Raw(handler)) => {
                         handler.filter_event(&context, &event)
                     },
+                    Some(InternalEventHandler::Both {
+                        raw,
+                        normal,
+                    }) => {
+                        raw.filter_event(&context, &event) && normal.filter_event(&context, &event)
+                    },
                     None => true,
                 };
 


### PR DESCRIPTION
Changes the raw event handler to take `&Event` instead of `Event`. Realistically I can't think of a real-world use case where owned data is needed here, and it's likely much more usable now than it was before anyways.