### PR TITLE
Add `OAuth2Token`, `OAuth2TokenRevocation`, and `OAuth2AuthorizationCurrent` to `Route`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2944,7 +2944,7 @@ impl Http {
             multipart: None,
             headers: None,
             method: LightMethod::Get,
-            route: Route::Oauth2ApplicationCurrent,
+            route: Route::OAuth2ApplicationCurrent,
             params: None,
         })
         .await

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -361,8 +361,20 @@ routes! ('a, {
     api!("/invites/{}", code),
     Some(RatelimitingKind::Path);
 
-    Oauth2ApplicationCurrent,
+    OAuth2Token,
+    api!("/oauth2/token"),
+    None;
+
+    OAuth2TokenRevocation,
+    api!("/oauth2/token/revoke"),
+    None;
+
+    OAuth2ApplicationCurrent,
     api!("/oauth2/applications/@me"),
+    None;
+
+    OAuth2AuthorizationCurrent,
+    api!("/oauth2/@me"),
     None;
 
     StatusIncidentsUnresolved,


### PR DESCRIPTION
Adds routes to `Route` which are related to OAuth2 and token exchanges. This is a step towards resolving #762 and #2475.