### PR TITLE
Add missing fields to CurrentApplicationInfo

### DIFF
--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -16,7 +16,7 @@ mod oauth;
 pub use oauth::*;
 mod ping_interaction;
 pub use ping_interaction::*;
-use crate::model::guild::PartialGuild;
+use super::guild::PartialGuild;
 use super::id::{ApplicationId, GenericId, GuildId, SkuId, UserId};
 use super::misc::ImageHash;
 use super::user::User;

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -16,6 +16,7 @@ mod oauth;
 pub use oauth::*;
 mod ping_interaction;
 pub use ping_interaction::*;
+
 use super::guild::PartialGuild;
 use super::id::{ApplicationId, GenericId, GuildId, SkuId, UserId};
 use super::misc::ImageHash;

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -80,6 +80,8 @@ pub struct CurrentApplicationInfo {
     #[serde(default)]
     pub integration_types_config:
         std::collections::HashMap<InstallationContext, InstallationContextConfig>,
+    pub approximate_guild_count: Option<u64>,
+    pub approximate_user_install_count: Option<u64>,
 }
 
 impl CurrentApplicationInfo {

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -80,8 +80,8 @@ pub struct CurrentApplicationInfo {
     #[serde(default)]
     pub integration_types_config:
         std::collections::HashMap<InstallationContext, InstallationContextConfig>,
-    pub approximate_guild_count: Option<u64>,
-    pub approximate_user_install_count: Option<u64>,
+    pub approximate_guild_count: Option<u32>,
+    pub approximate_user_install_count: Option<u32>,
 }
 
 impl CurrentApplicationInfo {

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -16,7 +16,7 @@ mod oauth;
 pub use oauth::*;
 mod ping_interaction;
 pub use ping_interaction::*;
-
+use crate::model::guild::PartialGuild;
 use super::id::{ApplicationId, GenericId, GuildId, SkuId, UserId};
 use super::misc::ImageHash;
 use super::user::User;
@@ -82,6 +82,9 @@ pub struct CurrentApplicationInfo {
         std::collections::HashMap<InstallationContext, InstallationContextConfig>,
     pub approximate_guild_count: Option<u32>,
     pub approximate_user_install_count: Option<u32>,
+    pub guild: Option<PartialGuild>,
+    pub redirect_uris: Option<Vec<String>>,
+    pub interactions_endpoint_url: Option<String>,
 }
 
 impl CurrentApplicationInfo {


### PR DESCRIPTION
As per the discord docs [https://discord.com/developers/docs/resources/application#application-object-application-structure](https://discord.com/developers/docs/resources/application#application-object-application-structure) application contain approximate_guild_count and approximate_user_install_count.

approximate_user_install_count was recently added [https://github.com/discord/discord-api-docs/commit/9c45aa73fb353cba97e71257a8e5374ba53876f7](https://github.com/discord/discord-api-docs/commit/9c45aa73fb353cba97e71257a8e5374ba53876f7)

but approximate_guild_count seem to have been missed.

there's also guild, redirect_uris, interactions_endpoint_url which according to the doc are in the application but not given by serenity, I didn't add them because I didn't need them and they seem to be older and either ignored on purpose or forgotten.
