### PR TITLE
Remove `InternalEventHandler`

### DIFF
--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -1,7 +1,6 @@
 use std::collections::VecDeque;
 #[cfg(feature = "cache")]
 use std::num::NonZeroU16;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use strum::{EnumCount, IntoStaticStr, VariantNames};
@@ -534,11 +533,4 @@ pub trait RawEventHandler: Send + Sync {
         drop((context, event));
         true
     }
-}
-
-#[derive(Clone)]
-pub enum InternalEventHandler {
-    Raw(Arc<dyn RawEventHandler>),
-    Normal(Arc<dyn EventHandler>),
-    Both { raw: Arc<dyn RawEventHandler>, normal: Arc<dyn EventHandler> },
 }

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -38,7 +38,7 @@ use futures::StreamExt as _;
 use tracing::debug;
 
 pub use self::context::Context;
-pub use self::event_handler::{EventHandler, FullEvent, InternalEventHandler, RawEventHandler};
+pub use self::event_handler::{EventHandler, FullEvent, RawEventHandler};
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
@@ -289,18 +289,8 @@ impl IntoFuture for ClientBuilder {
         let presence = self.presence;
         let http = self.http;
 
-        let event_handler = match (self.event_handler, self.raw_event_handler) {
-            (Some(normal), Some(raw)) => Some(InternalEventHandler::Both {
-                normal,
-                raw,
-            }),
-            (Some(h), None) => Some(InternalEventHandler::Normal(h)),
-            (None, Some(h)) => Some(InternalEventHandler::Raw(h)),
-            (None, None) => None,
-        };
-
         if let Some(ratelimiter) = &http.ratelimiter {
-            if let Some(InternalEventHandler::Normal(event_handler)) = &event_handler {
+            if let Some(event_handler) = &self.event_handler {
                 let event_handler = Arc::clone(event_handler);
                 ratelimiter.set_ratelimit_callback(Box::new(move |info| {
                     let event_handler = Arc::clone(&event_handler);
@@ -334,7 +324,8 @@ impl IntoFuture for ClientBuilder {
             let framework_cell = Arc::new(OnceLock::new());
             let (shard_manager, shard_manager_ret_value) = ShardManager::new(ShardManagerOptions {
                 data: Arc::clone(&data),
-                event_handler,
+                event_handler: self.event_handler,
+                raw_event_handler: self.raw_event_handler,
                 #[cfg(feature = "framework")]
                 framework: Arc::clone(&framework_cell),
                 #[cfg(feature = "voice")]

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -16,7 +16,7 @@ use super::{ShardId, ShardQueue, ShardQueuer, ShardQueuerMessage, ShardRunnerInf
 use crate::cache::Cache;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
-use crate::gateway::client::InternalEventHandler;
+use crate::gateway::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "voice")]
 use crate::gateway::VoiceGatewayManager;
 use crate::gateway::{ConnectionStage, GatewayError, PresenceData};
@@ -49,7 +49,7 @@ use crate::model::gateway::GatewayIntents;
 /// use std::env;
 /// use std::sync::{Arc, OnceLock};
 ///
-/// use serenity::gateway::client::{EventHandler, InternalEventHandler, RawEventHandler};
+/// use serenity::gateway::client::EventHandler;
 /// use serenity::gateway::{ShardManager, ShardManagerOptions};
 /// use serenity::http::Http;
 /// use serenity::model::gateway::GatewayIntents;
@@ -66,12 +66,13 @@ use crate::model::gateway::GatewayIntents;
 /// let data = Arc::new(());
 /// let shard_total = gateway_info.shards;
 /// let ws_url = Arc::from(gateway_info.url);
-/// let event_handler = Arc::new(Handler) as Arc<dyn EventHandler>;
+/// let event_handler = Arc::new(Handler);
 /// let max_concurrency = std::num::NonZeroU16::MIN;
 ///
 /// ShardManager::new(ShardManagerOptions {
 ///     data,
-///     event_handler: Some(InternalEventHandler::Normal(event_handler)),
+///     event_handler: Some(event_handler),
+///     raw_event_handler: None,
 ///     framework: Arc::new(OnceLock::new()),
 ///     # #[cfg(feature = "voice")]
 ///     # voice_manager: None,
@@ -128,6 +129,7 @@ impl ShardManager {
         let mut shard_queuer = ShardQueuer {
             data: opt.data,
             event_handler: opt.event_handler,
+            raw_event_handler: opt.raw_event_handler,
             #[cfg(feature = "framework")]
             framework: opt.framework,
             last_start: None,
@@ -356,7 +358,8 @@ impl Drop for ShardManager {
 
 pub struct ShardManagerOptions {
     pub data: Arc<dyn std::any::Any + Send + Sync>,
-    pub event_handler: Option<InternalEventHandler>,
+    pub event_handler: Option<Arc<dyn EventHandler>>,
+    pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     #[cfg(feature = "framework")]
     pub framework: Arc<OnceLock<Arc<dyn Framework>>>,
     #[cfg(feature = "voice")]

--- a/src/gateway/sharding/shard_queuer.rs
+++ b/src/gateway/sharding/shard_queuer.rs
@@ -22,7 +22,7 @@ use super::{
 use crate::cache::Cache;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
-use crate::gateway::client::InternalEventHandler;
+use crate::gateway::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "voice")]
 use crate::gateway::VoiceGatewayManager;
 use crate::gateway::{ConnectionStage, PresenceData, Shard, ShardRunnerMessage};
@@ -42,11 +42,10 @@ pub struct ShardQueuer {
     ///
     /// [`Client::data`]: crate::Client::data
     pub data: Arc<dyn std::any::Any + Send + Sync>,
-    /// A reference to [`EventHandler`] or [`RawEventHandler`].
-    ///
-    /// [`EventHandler`]: crate::gateway::client::EventHandler
-    /// [`RawEventHandler`]: crate::gateway::client::RawEventHandler
-    pub event_handler: Option<InternalEventHandler>,
+    /// A reference to an [`EventHandler`].
+    pub event_handler: Option<Arc<dyn EventHandler>>,
+    /// A reference to a [`RawEventHandler`].
+    pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     /// A copy of the framework
     #[cfg(feature = "framework")]
     pub framework: Arc<OnceLock<Arc<dyn Framework>>>,
@@ -223,6 +222,7 @@ impl ShardQueuer {
         let mut runner = ShardRunner::new(ShardRunnerOptions {
             data: Arc::clone(&self.data),
             event_handler: self.event_handler.clone(),
+            raw_event_handler: self.raw_event_handler.clone(),
             #[cfg(feature = "framework")]
             framework: self.framework.get().cloned(),
             manager: Arc::clone(&self.manager),


### PR DESCRIPTION
Since having both a regular event handler and a raw handler at the same time is now supported, the `InternalEventHandler` enum is no longer needed to ensure mutual exclusivity. Additionally, there was a subtle bug introduced when the `Both` variant was added: ratelimit events and shard stage update events would not be dispatched because the conditionals to dispatch those events only checked for the `Normal` variant. Inlining the regular/raw event handler fields improves ergonomics and fixes said bug.