### PR TITLE
Remove methods on `ClientBulder` that don't serve a purpose

### DIFF
--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -52,7 +52,6 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
 use crate::model::gateway::GatewayIntents;
-use crate::model::id::ApplicationId;
 #[cfg(feature = "voice")]
 use crate::model::id::UserId;
 use crate::model::user::OnlineStatus;
@@ -107,26 +106,6 @@ impl ClientBuilder {
             raw_event_handler: None,
             presence: PresenceData::default(),
         }
-    }
-
-    /// Gets the current token used for the [`Http`] client.
-    #[must_use]
-    pub fn get_token(&self) -> &str {
-        self.http.token()
-    }
-
-    /// Sets the application id.
-    pub fn application_id(self, application_id: ApplicationId) -> Self {
-        self.http.set_application_id(application_id);
-
-        self
-    }
-
-    /// Gets the application ID, if already initialized. See [`Self::application_id`] for more
-    /// info.
-    #[must_use]
-    pub fn get_application_id(&self) -> Option<ApplicationId> {
-        self.http.application_id()
     }
 
     /// Sets the global data type that can be accessed from [`Context::data`].


### PR DESCRIPTION
The `ClientBuilder` struct is gated behind the `gateway` feature, which means that the client will receive the current application ID over the gateway when first authenticating. Therefore it doesn't make sense to set the application ID through the `ClientBuilder` as it will get overrided anyway.

Also, the `get_token` method is pretty useless because the only source of the token would be whatever the user would have passed to `ClientBuilder::new`, meaning they would already have a way to read out its value.