### PR TITLE
Fix and make `edit_role_position` plural

### DIFF
--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -172,7 +172,9 @@ impl<'a> EditRole<'a> {
         };
 
         if let Some(position) = self.position {
-            guild_id.edit_role_position(http, role.id, position, self.audit_log_reason).await?;
+            guild_id
+                .edit_role_positions(http, [(role.id, position)], self.audit_log_reason)
+                .await?;
         }
         Ok(role)
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2006,8 +2006,8 @@ impl Http {
         from_value(value).map_err(From::from)
     }
 
-    /// Changes the position of a role in a guild.
-    pub async fn edit_role_position(
+    /// Changes the positions of roles in a guild.
+    pub async fn edit_role_positions(
         &self,
         guild_id: GuildId,
         map: &impl serde::Serialize,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -794,15 +794,28 @@ impl GuildId {
         builder.execute(http, self, sticker_id).await
     }
 
-    /// Edit the position of a [`Role`] relative to all others in the [`Guild`].
+    /// Edits the position of [`Role`]s relative to all others in the [`Guild`].
     ///
     /// **Note**: Requires the [Manage Roles] permission.
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
-    /// use serenity::model::{GuildId, RoleId};
-    /// GuildId::new(7).edit_role_position(&context, RoleId::new(8), 2);
+    /// ```rust,no_run
+    /// # use std::collections::HashMap;
+    /// # use serenity::http::Http;
+    /// use serenity::model::id::{GuildId, RoleId};
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let http: Http = unimplemented!();
+    /// let roles = HashMap::from([
+    ///     (RoleId::new(8), 2),
+    ///     (RoleId::new(10), 3),
+    ///     (RoleId::new(11), 4),
+    ///     (RoleId::new(25), 7),
+    /// ]);
+    /// GuildId::new(7).edit_role_positions(&http, roles, None);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -810,11 +823,10 @@ impl GuildId {
     /// Returns an [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn edit_role_position(
+    pub async fn edit_role_positions(
         self,
         http: &Http,
-        role_id: RoleId,
-        position: i16,
+        roles: impl IntoIterator<Item = (RoleId, i16)>,
         reason: Option<&str>,
     ) -> Result<Vec<Role>> {
         #[derive(serde::Serialize)]
@@ -827,12 +839,15 @@ impl GuildId {
             Maximum::AuditLogReason.check_overflow(reason.len())?;
         }
 
-        let map = EditRole {
-            id: role_id,
-            position,
-        };
+        let map = roles
+            .into_iter()
+            .map(|(id, position)| EditRole {
+                id,
+                position,
+            })
+            .collect::<Vec<_>>();
 
-        http.edit_role_position(self, &map, reason).await
+        http.edit_role_positions(self, &map, reason).await
     }
 
     /// Edits the guild's welcome screen.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -839,15 +839,12 @@ impl GuildId {
             Maximum::AuditLogReason.check_overflow(reason.len())?;
         }
 
-        let map = roles
-            .into_iter()
-            .map(|(id, position)| EditRole {
-                id,
-                position,
-            })
-            .collect::<Vec<_>>();
+        let iter = roles.into_iter().map(|(id, position)| EditRole {
+            id,
+            position,
+        });
 
-        http.edit_role_positions(self, &map, reason).await
+        http.edit_role_positions(self, &SerializeIter::new(iter), reason).await
     }
 
     /// Edits the guild's welcome screen.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1090,9 +1090,24 @@ impl Guild {
     ///
     /// Change the order of a role:
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use std::collections::HashMap;
+    /// # use serenity::http::Http;
+    /// # use serenity::model::guild::Guild;
     /// use serenity::model::id::RoleId;
-    /// guild.edit_role_position(&context, RoleId::new(8), 2);
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let http: Http = unimplemented!();
+    /// # let guild: Guild = unimplemented!();
+    /// let roles = HashMap::from([
+    ///     (RoleId::new(8), 2),
+    ///     (RoleId::new(10), 3),
+    ///     (RoleId::new(11), 4),
+    ///     (RoleId::new(25), 7),
+    /// ]);
+    /// guild.edit_role_positions(&http, roles, None);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -1100,14 +1115,13 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn edit_role_position(
+    pub async fn edit_role_positions(
         &self,
         http: &Http,
-        role_id: RoleId,
-        position: i16,
+        roles: impl IntoIterator<Item = (RoleId, i16)>,
         audit_log_reason: Option<&str>,
     ) -> Result<Vec<Role>> {
-        self.id.edit_role_position(http, role_id, position, audit_log_reason).await
+        self.id.edit_role_positions(http, roles, audit_log_reason).await
     }
 
     /// Modifies a scheduled event in the guild with the data set, if any.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -815,9 +815,24 @@ impl PartialGuild {
     ///
     /// Change the order of a role:
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use std::collections::HashMap;
+    /// # use serenity::http::Http;
+    /// # use serenity::model::guild::PartialGuild;
     /// use serenity::model::id::RoleId;
-    /// partial_guild.edit_role_position(&context, RoleId::new(8), 2);
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let http: Http = unimplemented!();
+    /// # let partial_guild: PartialGuild = unimplemented!();
+    /// let roles = HashMap::from([
+    ///     (RoleId::new(8), 2),
+    ///     (RoleId::new(10), 3),
+    ///     (RoleId::new(11), 4),
+    ///     (RoleId::new(25), 7),
+    /// ]);
+    /// partial_guild.edit_role_positions(&http, roles, None);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -825,14 +840,13 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
-    pub async fn edit_role_position(
+    pub async fn edit_role_positions(
         &self,
         http: &Http,
-        role_id: RoleId,
-        position: i16,
+        roles: impl IntoIterator<Item = (RoleId, i16)>,
         audit_log_reason: Option<&str>,
     ) -> Result<Vec<Role>> {
-        self.id.edit_role_position(http, role_id, position, audit_log_reason).await
+        self.id.edit_role_positions(http, roles, audit_log_reason).await
     }
 
     /// Edits a sticker.


### PR DESCRIPTION
There was a regression introduced to the `edit_role_position` endpoint in #2806 - this endpoint expects an array of json objects but a single object was being sent to the API, not inside of an array. This means the response would always error due to invalid format.

This PR fixes said bug by pluralizing the endpoint to take a list of roles to edit. The list will be serialized as a JSON array.