### PR TITLE
Truncate cache if `max_messages` is set to a lower value at runtime

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -439,6 +439,18 @@ impl Cache {
     ///
     /// By default, no messages will be cached.
     pub fn set_max_messages(&self, max: usize) {
+        // Check to see if cache has to be truncated
+        if max < self.settings.read().max_messages {
+            for mut entry in self.messages.iter_mut() {
+                let message_queue = entry.value_mut();
+                let queue_len = message_queue.len();
+
+                if queue_len > max {
+                    message_queue.drain(..queue_len - max);
+                }
+            }
+        }
+
         self.settings.write().max_messages = max;
     }
 


### PR DESCRIPTION
Just a small commit that removes excess messages from cache if `Settings::max_messages` is changed at runtime through `set_max_messages`. Lot of iteration, but I couldn't think of a faster way to do it.

Address #2884.