### PR TITLE
Fix deserializing snowflakes from non-self-describing formats

### DIFF
--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -343,7 +343,8 @@ mod snowflake {
     use serde::{Deserializer, Serializer};
 
     pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<NonZeroU64, D::Error> {
-        deserializer.deserialize_any(SnowflakeVisitor)
+        // Deserialize_str also works on integers, so we can use it here to allow for deserializing the various forms snowflakes can take
+        deserializer.deserialize_str(SnowflakeVisitor)
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]


### PR DESCRIPTION
Previously snowflakes were deserialized using `deserialize_any` which is [recommended against](https://serde.rs/impl-deserialize.html) because it prevents usage with non-self-describing formats such as Bincode (which was my use-case which caused me to run up against this issue).

I simply replaced `deserialize_any` with `deserialize_str`. Although this causes the deserializer to expect to read a `str`, the bytes representation of `1234` and `"1234"` are the same so it works perfectly. All tests pass.