### PR TITLE
Document rule for attachment names for proper functioning in embeds

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -101,6 +101,9 @@ impl CreateEmbed {
     }
 
     /// Set the image associated with the embed. This only supports HTTP(S).
+    ///
+    /// Refer [Discord Documentation](https://discord.com/developers/docs/reference#uploading-files)
+    /// for rules on naming local attachments.
     #[inline]
     pub fn image(mut self, url: impl Into<String>) -> Self {
         self.0.image = Some(EmbedImage {
@@ -162,6 +165,8 @@ impl CreateEmbed {
     ///
     /// Note however, you have to be sure you set an attachment (with [`ChannelId::send_files`])
     /// with the provided filename. Or else this won't work.
+    ///
+    /// Refer [`Self::image`] for rules on naming local attachments.
     ///
     /// [`ChannelId::send_files`]: crate::model::id::ChannelId::send_files
     #[inline]
@@ -300,6 +305,8 @@ impl CreateEmbedFooter {
     }
 
     /// Set the icon URL's value. This only supports HTTP(S).
+    ///
+    /// Refer [`CreateEmbed::image`] for rules on naming local attachments.
     pub fn icon_url(mut self, icon_url: impl Into<String>) -> Self {
         self.0.icon_url = Some(icon_url.into());
         self

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -100,7 +100,7 @@ impl CreateEmbed {
         self
     }
 
-    /// Set the image associated with the embed. This only supports HTTP(S).
+    /// Set the image associated with the embed.
     ///
     /// Refer [Discord Documentation](https://discord.com/developers/docs/reference#uploading-files)
     /// for rules on naming local attachments.
@@ -115,7 +115,7 @@ impl CreateEmbed {
         self
     }
 
-    /// Set the thumbnail of the embed. This only supports HTTP(S).
+    /// Set the thumbnail of the embed.
     #[inline]
     pub fn thumbnail(mut self, url: impl Into<String>) -> Self {
         self.0.thumbnail = Some(EmbedThumbnail {
@@ -304,7 +304,7 @@ impl CreateEmbedFooter {
         self
     }
 
-    /// Set the icon URL's value. This only supports HTTP(S).
+    /// Set the icon URL's value.
     ///
     /// Refer [`CreateEmbed::image`] for rules on naming local attachments.
     pub fn icon_url(mut self, icon_url: impl Into<String>) -> Self {


### PR DESCRIPTION
Address #2635 by documenting [Discord's rules](https://discord.com/developers/docs/reference#uploading-files) for attachment URLS in the `attachment` and `image` methods of `CreateEmbed`.

It is worth noting that these rules apply to all attachment URLs. I chose to document only in `CreateEmbed` as this is, as far as I know, the only case where unexpected behaviour occurs when the name contains invalid characters. In other cases, Discord handles it by stripping or replacing the invalid characters with underscores and no error is thrown.