### PR TITLE
Use u64 serialization of Snowflake for non human-readable serializers

### DIFF
--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -343,12 +343,20 @@ mod snowflake {
     use serde::{Deserializer, Serializer};
 
     pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<NonZeroU64, D::Error> {
-        deserializer.deserialize_any(SnowflakeVisitor)
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_any(SnowflakeVisitor)
+        } else {
+            deserializer.deserialize_u64(SnowflakeVisitor)
+        }
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn serialize<S: Serializer>(id: &NonZeroU64, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.collect_str(&id.get())
+        if serializer.is_human_readable() {
+            serializer.collect_str(&id.get())
+        } else {
+            serializer.serialize_u64(id.get())
+        }
     }
 
     struct SnowflakeVisitor;


### PR DESCRIPTION
Snowflake deserialization uses [`serde::de::Deserializer deserialize_any`](https://docs.rs/serde/latest/serde/de/trait.Deserializer.html#tymethod.deserialize_any) method, which may not be provided by some formats and according the documentation should not be relied on. This for example causes `UserID` fail to serialize with `bincode`, effectively preventing storing it in `native_db`.

Currently `serde` seems not to support easy way to determinate if `deserialize_any` is supported or not. Although [`is_human_readable`](https://docs.rs/serde/latest/serde/de/trait.Deserializer.html#method.is_human_readable) is provided for both `Serializer` and `Deserializer` traits.

This PR bypasses requirement of having `deserialize_any` available, by serializing and deserializing Snowflake values as `u64` for non human-readable formats. This additionally optimizes its storage size for such formats.