### PR TITLE
Fixed unused warnings when compiling without certain features

### DIFF
--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -250,6 +250,7 @@ impl<'a> EditAttachments<'a> {
     /// Clones all new attachments into a new Vec, keeping only data and filename, because those
     /// are needed for the multipart form data. The data is taken out of `self` in the process, so
     /// this method can only be called once.
+    #[cfg(feature = "http")]
     pub(crate) fn take_files(&mut self) -> Vec<CreateAttachment<'a>> {
         let mut files = Vec::new();
         for attachment in &mut self.new_and_existing_attachments {

--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 #[cfg(feature = "http")]
 use crate::http::Http;

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use serde_json::json;
 

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -201,6 +201,7 @@ impl<'a> EditMessage<'a> {
         self
     }
 
+    #[cfg(feature = "cache")]
     fn is_only_suppress_embeds(&self) -> bool {
         self.flags == Some(MessageFlags::SUPPRESS_EMBEDS)
             && self.content.is_none()
@@ -234,6 +235,7 @@ impl<'a> EditMessage<'a> {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     /// [`From<Embed>`]: CreateEmbed#impl-From<Embed>
     #[cfg(feature = "http")]
+    #[cfg_attr(not(feature = "cache"), allow(unused_variables))]
     pub async fn execute(
         mut self,
         cache_http: impl CacheHttp,

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to create or edit a [`Role`] for use via a number of model methods.

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -121,6 +121,7 @@ impl GetMessages {
     }
 }
 
+#[cfg_attr(not(feature = "http"), allow(dead_code))]
 #[derive(Clone, Copy, Debug)]
 enum SearchFilter {
     After(MessageId),

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashSet, VecDeque};
-use std::num::NonZeroU16;
 
 use super::{Cache, CacheUpdate};
 use crate::internal::prelude::*;
@@ -32,9 +31,8 @@ use crate::model::event::{
     VoiceChannelStatusUpdateEvent,
     VoiceStateUpdateEvent,
 };
-use crate::model::gateway::{Presence, ShardInfo};
+use crate::model::gateway::Presence;
 use crate::model::guild::{Guild, GuildMemberFlags, Member, MemberGeneratedFlags, Role};
-use crate::model::id::ShardId;
 use crate::model::user::{CurrentUser, OnlineStatus};
 use crate::model::voice::VoiceState;
 
@@ -449,8 +447,7 @@ impl CacheUpdate for ReadyEvent {
         let mut guilds_to_remove = vec![];
         let ready_guilds_hashset =
             self.ready.guilds.iter().map(|status| status.id).collect::<HashSet<_>>();
-        let shard_data =
-            self.ready.shard.unwrap_or_else(|| ShardInfo::new(ShardId(1), NonZeroU16::MIN));
+        let shard_data = self.ready.shard.unwrap_or_default();
 
         for guild_entry in cache.guilds.iter() {
             let guild = guild_entry.key();

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -35,7 +35,7 @@ use std::sync::OnceLock;
 use futures::channel::mpsc::UnboundedReceiver as Receiver;
 use futures::future::BoxFuture;
 use futures::StreamExt as _;
-use tracing::debug;
+use tracing::{debug, warn};
 
 pub use self::context::Context;
 pub use self::event_handler::{EventHandler, FullEvent, RawEventHandler};
@@ -55,7 +55,6 @@ use crate::model::gateway::GatewayIntents;
 #[cfg(feature = "voice")]
 use crate::model::id::UserId;
 use crate::model::user::OnlineStatus;
-use crate::utils::check_shard_total;
 
 /// A builder implementing [`IntoFuture`] building a [`Client`] to interact with Discord.
 #[must_use = "Builders do nothing unless they are awaited"]
@@ -761,4 +760,11 @@ impl Client {
 
         Ok(())
     }
+}
+
+fn check_shard_total(total_shards: u16) -> NonZeroU16 {
+    NonZeroU16::new(total_shards).unwrap_or_else(|| {
+        warn!("Invalid shard total provided ({total_shards}), defaulting to 1");
+        NonZeroU16::MIN
+    })
 }

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -42,6 +42,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration as StdDuration, Instant};
 
+use aformat::{aformat, CapStr};
 use secrecy::{ExposeSecret as _, Secret};
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;

--- a/src/gateway/sharding/shard_queuer.rs
+++ b/src/gateway/sharding/shard_queuer.rs
@@ -207,10 +207,14 @@ impl ShardQueuer {
 
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     async fn start(&mut self, shard_id: ShardId) -> Result<()> {
+        let shard_info = ShardInfo {
+            id: shard_id,
+            total: self.shard_total,
+        };
         let mut shard = Shard::new(
             Arc::clone(&self.ws_url),
             Arc::clone(self.http.token()),
-            ShardInfo::new(shard_id, self.shard_total),
+            shard_info,
             self.intents,
             self.presence.clone(),
         )

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -42,10 +42,6 @@ impl Token {
     pub fn new(inner: Arc<str>) -> Secret<Self> {
         Secret::new(Self(inner))
     }
-
-    pub fn get_inner(&self) -> &Arc<str> {
-        &self.0
-    }
 }
 
 impl std::ops::Deref for Token {
@@ -297,8 +293,9 @@ impl Http {
         self.application_id.store(application_id.get(), Ordering::Relaxed);
     }
 
+    #[cfg(feature = "gateway")]
     pub(crate) fn token(&self) -> &Arc<str> {
-        self.token.expose_secret().get_inner()
+        &self.token.expose_secret().0
     }
 
     /// Adds a [`User`] to a [`Guild`] with a valid OAuth2 access token.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -5,6 +5,7 @@ use std::cell::Cell;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use aformat::{aformat, CapStr};
 use arrayvec::ArrayVec;
 use nonmax::{NonMaxU16, NonMaxU8};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};

--- a/src/internal/prelude.rs
+++ b/src/internal/prelude.rs
@@ -4,13 +4,14 @@
 
 pub use std::result::Result as StdResult;
 
-pub use aformat::{aformat, aformat_into, ArrayString, CapStr};
 pub use extract_map::{ExtractKey, ExtractMap, LendingIterator};
 pub use serde_json::Value;
 pub use small_fixed_array::{FixedArray, FixedString, TruncatingInto};
 pub use to_arraystring::ToArrayString;
 
-pub(crate) use super::utils::join_to_string;
-pub use crate::error::{Error, Result};
+pub use super::utils::join_to_string;
+#[cfg(feature = "http")]
+pub use crate::error::Error;
+pub use crate::error::Result;
 
 pub type JsonMap = serde_json::Map<String, Value>;

--- a/src/internal/utils.rs
+++ b/src/internal/utils.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-pub(crate) fn join_to_string(
+pub fn join_to_string(
     sep: impl std::fmt::Display,
     iter: impl IntoIterator<Item = impl std::fmt::Display>,
 ) -> String {

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -8,18 +8,7 @@ use super::{InstallationContext, InteractionContext};
 use crate::builder::CreateCommand;
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
-use crate::model::channel::ChannelType;
-use crate::model::id::{
-    ApplicationId,
-    CommandId,
-    CommandPermissionId,
-    CommandVersionId,
-    GuildId,
-    RoleId,
-    UserId,
-};
-use crate::model::Permissions;
+use crate::model::prelude::*;
 
 /// The base command model that belongs to an application.
 ///

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -17,27 +17,8 @@ use crate::builder::{
 use crate::gateway::client::Context;
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 use crate::internal::utils::lending_for_each;
-use crate::model::application::{CommandOptionType, CommandType};
-use crate::model::channel::{Attachment, Message, PartialChannel};
-use crate::model::guild::{Member, PartialMember, Role};
-use crate::model::id::{
-    ApplicationId,
-    AttachmentId,
-    ChannelId,
-    CommandId,
-    GenericId,
-    GuildId,
-    InteractionId,
-    MessageId,
-    RoleId,
-    TargetId,
-    UserId,
-};
-use crate::model::monetization::Entitlement;
-use crate::model::user::User;
-use crate::model::Permissions;
+use crate::model::prelude::*;
 #[cfg(all(feature = "collector", feature = "utils"))]
 use crate::utils::{CreateQuickModal, QuickModalResponse};
 

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -2,7 +2,6 @@ use serde::de::Error as DeError;
 use serde::ser::{Serialize, Serializer};
 use serde_json::from_value;
 
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::{default_true, deserialize_val};
 

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -13,7 +13,6 @@ use crate::builder::{
 use crate::gateway::client::Context;
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 #[cfg(all(feature = "collector", feature = "utils"))]
 use crate::utils::{CreateQuickModal, QuickModalResponse};

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -17,11 +17,7 @@ pub use oauth::*;
 mod ping_interaction;
 pub use ping_interaction::*;
 
-use super::id::{ApplicationId, GenericId, GuildId, SkuId, UserId};
-use super::misc::ImageHash;
-use super::user::User;
-use super::Permissions;
-use crate::internal::prelude::*;
+use super::prelude::*;
 
 /// Partial information about the given application.
 ///

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -9,7 +9,6 @@ use crate::builder::{
 };
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// An interaction triggered by a modal submit.

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::internal::prelude::*;
-use crate::model::id::{ApplicationId, InteractionId};
+use crate::model::prelude::*;
 
 /// A ping interaction, which can only be received through an endpoint url.
 ///

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -3,7 +3,6 @@ use nonmax::NonMaxU32;
 use reqwest::Client as ReqwestClient;
 use serde_cow::CowStr;
 
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "model")]
 use std::borrow::Cow;
 #[cfg(feature = "model")]
 use std::sync::Arc;
@@ -28,7 +29,6 @@ use crate::collector::{MessageCollector, ReactionCollector};
 use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 #[cfg(feature = "model")]

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -365,6 +365,7 @@ impl ChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the channel retrieval request failed.
+    #[cfg_attr(not(feature = "cache"), allow(unused_variables))]
     pub async fn to_channel(
         self,
         cache_http: impl CacheHttp,

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -1,7 +1,6 @@
 use nonmax::NonMaxU32;
 
-use crate::internal::prelude::*;
-use crate::model::{Colour, Timestamp};
+use crate::model::prelude::*;
 
 /// Represents a rich embed which allows using richer markdown, multiple fields and more. This was
 /// heavily inspired by [slack's attachments].

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -30,7 +30,6 @@ use crate::collector::{MessageCollector, ReactionCollector};
 use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, Typing};
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Represents a guild's text, news, or voice channel. Some methods are available only for voice

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "model")]
 use std::borrow::Cow;
 use std::fmt;
 #[cfg(feature = "model")]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1,5 +1,6 @@
 //! Models relating to Discord channels.
 
+#[cfg(feature = "model")]
 use std::borrow::Cow;
 
 use nonmax::NonMaxU64;

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -21,7 +21,6 @@ use crate::constants;
 use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::{discord_colours, StrOrInt};
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -15,6 +15,7 @@ use serde::de::{Error as DeError, Unexpected};
 use serde_json::from_value;
 
 pub use self::attachment::*;
+#[cfg(feature = "model")]
 pub use self::channel_id::*;
 pub use self::embed::*;
 pub use self::guild_channel::*;

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -25,7 +25,6 @@ pub use self::private_channel::*;
 pub use self::reaction::*;
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
 

--- a/src/model/channel/partial_channel.rs
+++ b/src/model/channel/partial_channel.rs
@@ -1,7 +1,4 @@
-use crate::internal::prelude::*;
-use crate::model::channel::{ChannelType, ThreadMetadata};
-use crate::model::id::{ChannelId, WebhookId};
-use crate::model::Permissions;
+use crate::model::prelude::*;
 
 /// A container for any partial channel.
 ///

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "model")]
 use std::borrow::Cow;
 use std::fmt;
 #[cfg(feature = "model")]
@@ -9,7 +10,6 @@ use crate::builder::{CreateAttachment, CreateMessage, EditMessage, GetMessages};
 use crate::http::CacheHttp;
 #[cfg(feature = "model")]
 use crate::http::{Http, Typing};
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::single_recipient;
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -15,7 +15,6 @@ use tracing::warn;
 
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::discord_colours_opt;
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -4,6 +4,7 @@ use std::fmt::Display as _;
 use std::fmt::{self, Write as _};
 use std::str::FromStr;
 
+#[cfg(feature = "model")]
 use nonmax::NonMaxU8;
 #[cfg(feature = "http")]
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -1,7 +1,6 @@
 //! Models for user connections.
 
 use super::prelude::*;
-use crate::internal::prelude::*;
 
 /// Information about a connection between the current user and a third party service.
 ///

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -16,6 +16,7 @@ pub enum Maximum {
     BulkDeleteAmount,
 }
 
+#[cfg(feature = "http")]
 impl Maximum {
     pub(crate) fn check_overflow(self, value: usize) -> Result<(), Error> {
         let max = self.value();
@@ -64,6 +65,7 @@ pub enum Minimum {
     BulkDeleteAmount,
 }
 
+#[cfg(feature = "http")]
 impl Minimum {
     pub(crate) fn check_underflow(self, value: usize) -> Result<(), Error> {
         let min = self.value();

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -13,7 +13,6 @@ use strum::{EnumCount, IntoStaticStr, VariantNames};
 use tracing::{debug, warn};
 
 use crate::constants::Opcode;
-use crate::internal::prelude::*;
 use crate::internal::utils::lending_for_each;
 use crate::model::prelude::*;
 use crate::model::utils::deserialize_val;

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -7,16 +7,16 @@
 #![allow(clippy::option_option)]
 
 use nonmax::NonMaxU64;
-use serde::de::Error as DeError;
 use serde::Serialize;
 use strum::{EnumCount, IntoStaticStr, VariantNames};
+#[cfg(feature = "gateway")]
 use tracing::{debug, warn};
 
 use crate::constants::Opcode;
 use crate::internal::prelude::*;
 use crate::internal::utils::lending_for_each;
 use crate::model::prelude::*;
-use crate::model::utils::{deserialize_val, remove_from_map, remove_from_map_opt};
+use crate::model::utils::deserialize_val;
 
 /// Requires no gateway intents.
 ///
@@ -1094,19 +1094,29 @@ pub enum GatewayEvent {
 // Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for GatewayEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
+        use serde::de::{DeserializeOwned, Error};
+
+        fn remove_from_map<T: DeserializeOwned, E: Error>(
+            map: &mut JsonMap,
+            key: &'static str,
+        ) -> StdResult<T, E> {
+            map.remove(key)
+                .ok_or_else(|| serde::de::Error::missing_field(key))
+                .and_then(deserialize_val)
+        }
+
         let mut map = JsonMap::deserialize(deserializer)?;
-        let seq = remove_from_map_opt(&mut map, "s")?.flatten();
 
         Ok(match remove_from_map(&mut map, "op")? {
             Opcode::Dispatch => {
                 Self::Dispatch {
-                    seq: seq.ok_or_else(|| DeError::missing_field("s"))?,
+                    seq: remove_from_map(&mut map, "s")?,
                     // Filled in in recv_event
                     original_str: FixedString::new(),
                     data: map,
                 }
             },
-            Opcode::Heartbeat => Self::Heartbeat(seq.ok_or_else(|| DeError::missing_field("s"))?),
+            Opcode::Heartbeat => Self::Heartbeat(remove_from_map(&mut map, "s")?),
             Opcode::InvalidSession => Self::InvalidateSession(remove_from_map(&mut map, "d")?),
             Opcode::Hello => {
                 #[derive(Deserialize)]
@@ -1119,7 +1129,7 @@ impl<'de> Deserialize<'de> for GatewayEvent {
             },
             Opcode::Reconnect => Self::Reconnect,
             Opcode::HeartbeatAck => Self::HeartbeatAck,
-            _ => return Err(DeError::custom("invalid opcode")),
+            _ => return Err(Error::custom("invalid opcode")),
         })
     }
 }
@@ -1338,30 +1348,19 @@ impl Event {
         self.into()
     }
 
+    #[cfg(feature = "gateway")]
     pub(crate) fn deserialize_and_log(map: JsonMap, original_str: &str) -> Result<Self> {
-        deserialize_val(Value::Object(map))
-            .map_err(|err| log_deserialisation_err(original_str, err))
+        deserialize_val(Value::Object(map)).map_err(|err| {
+            let err_dbg = format!("{err:?}");
+            if let Some((variant_name, _)) =
+                err_dbg.strip_prefix(r#"Error("unknown variant `"#).and_then(|s| s.split_once('`'))
+            {
+                debug!("Unknown event: {variant_name}");
+            } else {
+                warn!("Err deserializing text: {err_dbg}");
+            }
+            debug!("Failing text: {original_str}");
+            Error::Json(err)
+        })
     }
-}
-
-fn filter_unknown_variant(json_err_dbg: &str) -> bool {
-    if let Some(msg) = json_err_dbg.strip_prefix("Error(\"unknown variant `") {
-        if let Some((variant_name, _)) = msg.split_once('`') {
-            debug!("Unknown event: {variant_name}");
-            return true;
-        }
-    }
-
-    false
-}
-
-#[cold]
-fn log_deserialisation_err(json_str: &str, err: serde_json::Error) -> Error {
-    let json_err_dbg = format!("{err:?}");
-    if !filter_unknown_variant(&json_err_dbg) {
-        warn!("Err deserializing text: {json_err_dbg}");
-    }
-
-    debug!("Failing text: {json_str}");
-    Error::Json(err)
 }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -372,12 +372,11 @@ pub struct ShardInfo {
     pub total: NonZeroU16,
 }
 
-impl ShardInfo {
-    #[must_use]
-    pub(crate) fn new(id: ShardId, total: NonZeroU16) -> Self {
+impl Default for ShardInfo {
+    fn default() -> Self {
         Self {
-            id,
-            total,
+            id: ShardId(1),
+            total: NonZeroU16::MIN,
         }
     }
 }

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -7,7 +7,6 @@ use url::Url;
 
 use super::prelude::*;
 use super::utils::*;
-use crate::internal::prelude::*;
 
 /// A representation of the data retrieved from the bot gateway endpoint.
 ///

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -1,21 +1,7 @@
 use nonmax::NonMaxU16;
 
-use crate::internal::prelude::*;
-use crate::model::channel::PermissionOverwrite;
-use crate::model::guild::automod::{Action, EventType, TriggerMetadata, TriggerType};
-use crate::model::guild::{
-    AfkTimeout,
-    DefaultMessageNotificationLevel,
-    ExplicitContentFilter,
-    MfaLevel,
-    SystemChannelFlags,
-    VerificationLevel,
-};
-use crate::model::id::{ApplicationId, ChannelId, GenericId, GuildId, RoleId, UserId};
-use crate::model::misc::ImageHash;
-use crate::model::sticker::StickerFormatType;
+use crate::model::prelude::*;
 use crate::model::utils::StrOrInt;
-use crate::model::{Permissions, Timestamp};
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
@@ -165,7 +151,7 @@ generate_change! {
     "enable_emoticons" => EnableEmoticons(bool),
     /// Entity type of guild scheduled event was changed.
     "entity_type" => EntityType(u64),
-    "event_type" => EventType(EventType),
+    "event_type" => EventType(AutomodEventType),
     "exempt_channels" => ExemptChannels(FixedArray<ChannelId>),
     "exempt_roles" => ExemptRoles(FixedArray<RoleId>),
     /// Behavior of the expiration of an integration was changed.

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -9,7 +9,6 @@ mod utils;
 pub use change::{AffectedRole, Change, EntityType};
 use utils::optional_string;
 
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Determines the action that was done on a target.

--- a/src/model/guild/automod.rs
+++ b/src/model/guild/automod.rs
@@ -8,8 +8,7 @@ use serde::de::{Deserializer, Error};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 
-use crate::internal::prelude::*;
-use crate::model::id::*;
+use crate::model::prelude::*;
 
 /// Configured auto moderation rule.
 ///

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -1,8 +1,6 @@
 use std::fmt;
 
-use crate::internal::prelude::*;
-use crate::model::id::{EmojiId, RoleId};
-use crate::model::user::User;
+use crate::model::prelude::*;
 use crate::model::utils::default_true;
 
 /// Represents a custom guild emoji, which can either be created using the API, or via an

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -31,8 +31,6 @@ use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, UserPagination};
 #[cfg(feature = "model")]
-use crate::internal::prelude::*;
-#[cfg(feature = "model")]
 use crate::model::error::Maximum;
 use crate::model::prelude::*;
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 #[cfg(feature = "model")]
 use futures::stream::Stream;
+#[cfg(feature = "model")]
 use nonmax::{NonMaxU16, NonMaxU8};
 
 #[cfg(feature = "model")]
@@ -31,6 +32,7 @@ use crate::gateway::ShardMessenger;
 use crate::http::{CacheHttp, Http, UserPagination};
 #[cfg(feature = "model")]
 use crate::internal::prelude::*;
+#[cfg(feature = "model")]
 use crate::model::error::Maximum;
 use crate::model::prelude::*;
 

--- a/src/model/guild/guild_preview.rs
+++ b/src/model/guild/guild_preview.rs
@@ -1,8 +1,4 @@
-use crate::internal::prelude::*;
-use crate::model::guild::Emoji;
-use crate::model::id::GuildId;
-use crate::model::misc::ImageHash;
-use crate::model::sticker::Sticker;
+use crate::model::prelude::*;
 
 /// Preview [`Guild`] information.
 ///

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -8,7 +8,6 @@ use crate::builder::EditMember;
 use crate::cache::Cache;
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::avatar_url;

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -17,7 +17,9 @@ mod welcome_screen;
 #[cfg(feature = "model")]
 use std::borrow::Cow;
 
-use nonmax::{NonMaxU16, NonMaxU64, NonMaxU8};
+use nonmax::NonMaxU64;
+#[cfg(feature = "model")]
+use nonmax::{NonMaxU16, NonMaxU8};
 #[cfg(feature = "model")]
 use tracing::{error, warn};
 
@@ -59,6 +61,7 @@ use crate::gateway::ShardMessenger;
 use crate::http::{CacheHttp, Http, UserPagination};
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
+#[cfg(feature = "model")]
 use crate::model::utils::*;
 
 /// A representation of a banning of a user.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -59,7 +59,6 @@ use crate::constants::LARGE_THRESHOLD;
 use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, UserPagination};
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::*;

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -23,7 +23,6 @@ use crate::collector::{MessageCollector, ReactionCollector};
 use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http, UserPagination};
-use crate::internal::prelude::*;
 use crate::internal::utils::lending_for_each;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,4 +1,6 @@
-use nonmax::{NonMaxU16, NonMaxU64, NonMaxU8};
+use nonmax::NonMaxU64;
+#[cfg(feature = "model")]
+use nonmax::{NonMaxU16, NonMaxU8};
 use serde::Serialize;
 
 #[cfg(feature = "model")]

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -5,7 +5,6 @@ use std::fmt;
 use crate::builder::EditRole;
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::is_false;
 

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -1,6 +1,5 @@
 use nonmax::NonMaxU64;
 
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Information about a guild scheduled event.

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::internal::prelude::*;
-use crate::model::id::{ChannelId, EmojiId};
+use crate::model::prelude::*;
 
 /// Information relating to a guild's welcome screen.
 ///

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -4,8 +4,7 @@ use std::fmt;
 
 use nonmax::NonMaxU64;
 
-use super::Timestamp;
-use crate::internal::prelude::*;
+use super::prelude::*;
 
 macro_rules! newtype_display_impl {
     ($name:ident) => {

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -340,7 +340,7 @@ id_u64! {
 /// This identifier is special, it simply models internal IDs for type safety,
 /// and therefore cannot be [`Serialize`]d or [`Deserialize`]d.
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct ShardId(pub u16);
 
 impl ShardId {

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -7,7 +7,6 @@ use super::prelude::*;
 use crate::builder::CreateInvite;
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 
 /// Information about an invite code.
 ///

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -4,8 +4,9 @@ use std::fmt;
 #[cfg(all(feature = "model", feature = "utils"))]
 use std::str::FromStr;
 
+use aformat::{aformat_into, ArrayString, ToArrayString};
+
 use super::prelude::*;
-use crate::internal::prelude::*;
 #[cfg(all(feature = "model", feature = "utils"))]
 use crate::utils;
 
@@ -113,7 +114,7 @@ impl fmt::Display for Mention {
 
 impl ToArrayString for Mention {
     const MAX_LENGTH: usize = 20 + 4;
-    type ArrayString = ArrayString<{ 20 + 4 }>;
+    type ArrayString = ArrayString<{ Self::MAX_LENGTH }>;
 
     fn to_arraystring(self) -> Self::ArrayString {
         let mut out = Self::ArrayString::new();

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -8,8 +8,9 @@ use std::fmt::Write;
 use std::result::Result as StdResult;
 use std::str::FromStr;
 
+use aformat::ArrayString;
+
 use super::prelude::*;
-use crate::internal::prelude::*;
 #[cfg(all(feature = "model", any(feature = "cache", feature = "utils")))]
 use crate::utils;
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -62,8 +62,6 @@ pub use self::timestamp::Timestamp;
 /// use serenity::model::prelude::*;
 /// ```
 pub mod prelude {
-    pub(crate) use std::collections::HashMap;
-
     pub(crate) use serde::{Deserialize, Deserializer};
 
     pub use super::guild::automod::EventType as AutomodEventType;

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -2,7 +2,6 @@
 use crate::builder::EditSticker;
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 use crate::model::utils::comma_separated_string;
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -17,7 +17,6 @@ use crate::collector::{MessageCollector, ReactionCollector};
 use crate::gateway::ShardMessenger;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::avatar_url;
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -6,7 +6,6 @@ use serde_cow::CowStr;
 use small_fixed_array::FixedString;
 
 use super::prelude::*;
-use crate::internal::prelude::*;
 
 pub fn default_true() -> bool {
     true

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -52,22 +52,6 @@ where
     T::deserialize(val).map_err(serde::de::Error::custom)
 }
 
-pub fn remove_from_map_opt<T, E>(map: &mut JsonMap, key: &str) -> StdResult<Option<T>, E>
-where
-    T: serde::de::DeserializeOwned,
-    E: serde::de::Error,
-{
-    map.remove(key).map(deserialize_val).transpose()
-}
-
-pub fn remove_from_map<T, E>(map: &mut JsonMap, key: &'static str) -> StdResult<T, E>
-where
-    T: serde::de::DeserializeOwned,
-    E: serde::de::Error,
-{
-    remove_from_map_opt(map, key)?.ok_or_else(|| serde::de::Error::missing_field(key))
-}
-
 pub(super) enum StrOrInt<'de> {
     String(String),
     Str(&'de str),

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -3,10 +3,7 @@
 use serde::de::{Deserialize, Deserializer};
 use serde::Serialize;
 
-use crate::internal::prelude::*;
-use crate::model::guild::Member;
-use crate::model::id::{ChannelId, GuildId, UserId};
-use crate::model::Timestamp;
+use crate::model::prelude::*;
 
 /// Information about an available voice region.
 ///

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -11,7 +11,6 @@ use crate::builder::{EditWebhook, EditWebhookMessage, ExecuteWebhook};
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 enum_number! {

--- a/src/utils/argument_convert/mod.rs
+++ b/src/utils/argument_convert/mod.rs
@@ -22,7 +22,7 @@ pub use role::*;
 mod emoji;
 pub use emoji::*;
 
-use super::{DOMAINS, MAX_DOMAIN_LEN};
+use super::DOMAINS;
 use crate::model::prelude::*;
 use crate::prelude::*;
 
@@ -139,3 +139,19 @@ pub fn parse_message_url(s: &str) -> Option<(GuildId, ChannelId, MessageId)> {
     }
     None
 }
+
+const MAX_DOMAIN_LEN: usize = {
+    let mut max_len = 0;
+    let mut i = 0;
+
+    while i < DOMAINS.len() {
+        let cur_len = DOMAINS[i].len();
+        if cur_len > max_len {
+            max_len = cur_len;
+        }
+
+        i += 1;
+    }
+
+    max_len
+};

--- a/src/utils/formatted_timestamp.rs
+++ b/src/utils/formatted_timestamp.rs
@@ -2,10 +2,9 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::str::FromStr;
 
-use aformat::{ArrayString, ToArrayString};
+use aformat::{aformat_into, ArrayString, ToArrayString};
 
-use crate::all::Timestamp;
-use crate::internal::prelude::*;
+use crate::model::Timestamp;
 
 /// Represents a combination of a timestamp and a style for formatting time in messages.
 ///
@@ -195,6 +194,8 @@ impl FromStr for FormattedTimestampStyle {
 
 #[cfg(test)]
 mod tests {
+    use aformat::aformat;
+
     use super::*;
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -22,7 +22,6 @@ pub use content_safe::*;
 pub use formatted_timestamp::*;
 #[cfg(feature = "collector")]
 pub use quick_modal::*;
-use tracing::warn;
 use url::Url;
 
 pub use self::custom_message::CustomMessage;
@@ -376,22 +375,6 @@ const DOMAINS: [&str; 6] = [
     "ptb.discordapp.com",
 ];
 
-const MAX_DOMAIN_LEN: usize = {
-    let mut max_len = 0;
-    let mut i = 0;
-
-    while i < DOMAINS.len() {
-        let cur_len = DOMAINS[i].len();
-        if cur_len > max_len {
-            max_len = cur_len;
-        }
-
-        i += 1;
-    }
-
-    max_len
-};
-
 /// Parses the id and token from a webhook url. Expects a [`url::Url`] rather than a [`&str`].
 ///
 /// # Examples
@@ -438,13 +421,6 @@ pub fn parse_webhook(url: &Url) -> Option<(WebhookId, &str)> {
 #[must_use]
 pub fn shard_id(guild_id: GuildId, shard_count: NonZeroU16) -> u16 {
     ((guild_id.get() >> 22) % u64::from(shard_count.get())) as u16
-}
-
-pub(crate) fn check_shard_total(total_shards: u16) -> NonZeroU16 {
-    NonZeroU16::new(total_shards).unwrap_or_else(|| {
-        warn!("Invalid shard total provided ({total_shards}), defaulting to 1");
-        NonZeroU16::MIN
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is mostly just clean up, moving things around and gating things behind features so that unused warnings in CI go away.