### PR TITLE
Replace outdated secrecy library with own impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,12 @@ bitflags = "2.4.2"
 serde_json = "1.0.108"
 async-trait = "0.1.74"
 tracing = { version = "0.1.40", features = ["log"] }
-serde = { version = "1.0.192", features = ["derive"] }
+serde = { version = "1.0.192", features = ["derive", "rc"] }
 url = { version = "2.4.1", features = ["serde"] }
 tokio = { version = "1.34.0", features = ["macros", "rt", "sync", "time", "io-util"] }
 futures = { version = "0.3.29", default-features = false, features = ["std"] }
 dep_time = { version = "0.3.36", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
 base64 = { version = "0.22.0" }
-secrecy = { version = "0.8.0", features = ["serde"] }
 zeroize = { version = "1.7" } # Not used in serenity, but bumps the minimal version from secrecy
 arrayvec = { version = "0.7.4", features = ["serde"] }
 serde_cow = { version = "0.1.0" }

--- a/src/gateway/sharding/shard_queuer.rs
+++ b/src/gateway/sharding/shard_queuer.rs
@@ -213,7 +213,7 @@ impl ShardQueuer {
         };
         let mut shard = Shard::new(
             Arc::clone(&self.ws_url),
-            Arc::clone(self.http.token()),
+            self.http.token(),
             shard_info,
             self.intents,
             self.presence.clone(),

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -44,13 +44,12 @@ use std::time::SystemTime;
 use dashmap::DashMap;
 use reqwest::header::HeaderMap;
 use reqwest::{Client, Response, StatusCode};
-use secrecy::{ExposeSecret as _, Secret};
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 use tracing::debug;
 
 pub use super::routing::RatelimitingBucket;
-use super::{HttpError, LightMethod, Request, Token};
+use super::{HttpError, LightMethod, Request};
 use crate::internal::prelude::*;
 
 /// Passed to the [`Ratelimiter::set_ratelimit_callback`] callback. If using Client, that callback
@@ -86,7 +85,7 @@ pub struct Ratelimiter {
     client: Client,
     global: Mutex<()>,
     routes: DashMap<RatelimitingBucket, Ratelimit>,
-    token: Secret<Token>,
+    token: SecretString,
     absolute_ratelimits: bool,
     ratelimit_callback: parking_lot::RwLock<Box<dyn Fn(RatelimitInfo) + Send + Sync>>,
 }
@@ -112,7 +111,7 @@ impl Ratelimiter {
     pub fn new(client: Client, token: Arc<str>) -> Self {
         Self {
             client,
-            token: Token::new(token),
+            token: SecretString::new(token),
             global: Mutex::default(),
             routes: DashMap::new(),
             absolute_ratelimits: false,

--- a/src/internal/prelude.rs
+++ b/src/internal/prelude.rs
@@ -13,5 +13,6 @@ pub use super::utils::join_to_string;
 #[cfg(feature = "http")]
 pub use crate::error::Error;
 pub use crate::error::Result;
+pub use crate::secret_string::SecretString;
 
 pub type JsonMap = serde_json::Map<String, Value>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod gateway;
 pub mod http;
 #[cfg(feature = "interactions_endpoint")]
 pub mod interactions_endpoint;
+pub mod secret_string;
 #[cfg(feature = "utils")]
 pub mod utils;
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -203,25 +203,6 @@ pub mod single_recipient {
     }
 }
 
-pub mod secret {
-    use secrecy::{ExposeSecret, Secret, Zeroize};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn deserialize<'de, S: Deserialize<'de> + Zeroize, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Option<Secret<S>>, D::Error> {
-        Option::<S>::deserialize(deserializer).map(|s| s.map(Secret::new))
-    }
-
-    #[allow(clippy::ref_option)]
-    pub fn serialize<S: Serialize + Zeroize, Sr: Serializer>(
-        secret: &Option<Secret<S>>,
-        serializer: Sr,
-    ) -> Result<Sr::Ok, Sr::Error> {
-        secret.as_ref().map(ExposeSecret::expose_secret).serialize(serializer)
-    }
-}
-
 pub fn discord_colours_opt<'de, D>(deserializer: D) -> Result<Option<Vec<Colour>>, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -1,11 +1,6 @@
 //! Webhook model and implementations.
 
 #[cfg(feature = "model")]
-use secrecy::ExposeSecret;
-use secrecy::SecretString;
-
-use super::utils::secret;
-#[cfg(feature = "model")]
 use crate::builder::{EditWebhook, EditWebhookMessage, ExecuteWebhook};
 #[cfg(feature = "cache")]
 use crate::cache::{Cache, GuildRef};
@@ -76,7 +71,6 @@ pub struct Webhook {
     /// This can be temporarily overridden via [`ExecuteWebhook::avatar_url`].
     pub avatar: Option<ImageHash>,
     /// The webhook's secure token.
-    #[serde(with = "secret", default)]
     pub token: Option<SecretString>,
     /// The bot/OAuth2 application that created this webhook.
     pub application_id: Option<ApplicationId>,
@@ -87,7 +81,6 @@ pub struct Webhook {
     /// [`WebhookType::ChannelFollower`]).
     pub source_channel: Option<WebhookChannel>,
     /// The url used for executing the webhook (returned by the webhooks OAuth2 flow).
-    #[serde(with = "secret", default)]
     pub url: Option<SecretString>,
 }
 
@@ -314,7 +307,7 @@ impl Webhook {
     ///
     /// Or may return an [`Error::Json`] if there is an error in deserialising Discord's response.
     pub async fn edit(&mut self, http: &Http, builder: EditWebhook<'_>) -> Result<()> {
-        let token = self.token.as_ref().map(ExposeSecret::expose_secret).map(String::as_str);
+        let token = self.token.as_ref().map(SecretString::expose_secret);
         *self = builder.execute(http, self.id, token).await?;
         Ok(())
     }

--- a/src/secret_string.rs
+++ b/src/secret_string.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+/// A cheaply clonable, zeroed on drop, String.
+///
+/// This is a simple newtype of `Arc<str>` that uses [`zeroize::Zeroize`] on on last drop to avoid
+/// keeping it around in memory.
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+pub struct SecretString(Arc<str>);
+
+impl SecretString {
+    #[must_use]
+    pub fn new(inner: Arc<str>) -> Self {
+        Self(inner)
+    }
+
+    #[must_use]
+    pub fn expose_secret(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SecretString {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_tuple(std::any::type_name::<Self>()).field(&"<secret>").finish()
+    }
+}
+
+impl zeroize::Zeroize for SecretString {
+    fn zeroize(&mut self) {
+        if let Some(string) = Arc::get_mut(&mut self.0) {
+            string.zeroize();
+        }
+    }
+}
+
+#[cfg(feature = "typesize")]
+impl typesize::TypeSize for SecretString {
+    fn extra_size(&self) -> usize {
+        self.0.len() + (size_of::<usize>() * 2)
+    }
+}

--- a/src/secret_string.rs
+++ b/src/secret_string.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 /// A cheaply clonable, zeroed on drop, String.
 ///
-/// This is a simple newtype of `Arc<str>` that uses [`zeroize::Zeroize`] on on last drop to avoid
+/// This is a simple newtype of `Arc<str>` that uses [`zeroize::Zeroize`] on last drop to avoid
 /// keeping it around in memory.
 #[derive(Clone, serde::Deserialize, serde::Serialize)]
 pub struct SecretString(Arc<str>);


### PR DESCRIPTION
`secrecy` has had major changes in it's transition from `0.8` -> `0.10` that would make it even less useful than it is now.

This just brings the basic implementation in-house and exposes it publicly, which is somehow less lines of code that trying to use the `0.8` API, let alone `0.10`. 