### PR TITLE
Remove `Result` from `ShardRunner::recv`'s return type

### DIFF
--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -100,7 +100,7 @@ impl ShardRunner {
 
         loop {
             trace!("[ShardRunner {:?}] loop iteration started.", self.shard.shard_info());
-            if !self.recv().await? {
+            if !self.recv().await {
                 return Ok(());
             }
 
@@ -352,12 +352,12 @@ impl ShardRunner {
     // happen, as the sending half is kept on the runner.
     // Returns whether the shard runner is in a state that can continue.
     #[instrument(skip(self))]
-    async fn recv(&mut self) -> Result<bool> {
+    async fn recv(&mut self) -> bool {
         loop {
             match self.runner_rx.try_next() {
                 Ok(Some(value)) => {
                     if !self.handle_rx_value(value).await {
-                        return Ok(false);
+                        return false;
                     }
                 },
                 Ok(None) => {
@@ -367,7 +367,7 @@ impl ShardRunner {
                     );
 
                     self.request_restart().await;
-                    return Ok(false);
+                    return false;
                 },
                 Err(_) => break,
             }
@@ -375,7 +375,7 @@ impl ShardRunner {
 
         // There are no longer any values available.
 
-        Ok(true)
+        true
     }
 
     /// Returns a received event, as well as whether reading the potentially present event was


### PR DESCRIPTION
With [the change of `ShardRunner::request_restart`'s return type to remove the `Result`](https://github.com/serenity-rs/serenity/commit/8ff5965b0f8e6019392d759684811123116cce49) since it didn't return an `Err(...)` case ever, the `Result` in the return type of `ShardRunner::recv` can be similarly removed.