### PR TITLE
Make fields of BulkBanResponse public

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -318,7 +318,8 @@ impl Http {
 
     /// Bans multiple users from a [`Guild`], optionally removing their messages.
     ///
-    /// See the [Discord Docs](https://github.com/discord/discord-api-docs/pull/6720) for more information.
+    /// See the [Discord docs](https://discord.com/developers/docs/resources/guild#bulk-guild-ban)
+    /// for more information.
     pub async fn bulk_ban_users(
         &self,
         guild_id: GuildId,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -77,7 +77,7 @@ pub struct Ban {
 
 /// The response from [`GuildId::bulk_ban`].
 ///
-/// [Discord docs](https://github.com/discord/discord-api-docs/pull/6720).
+/// [Discord docs](https://discord.com/developers/docs/resources/guild#bulk-guild-ban).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct BulkBanResponse {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -82,9 +82,9 @@ pub struct Ban {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct BulkBanResponse {
     /// The users that were successfully banned.
-    banned_users: Vec<UserId>,
+    pub banned_users: Vec<UserId>,
     /// The users that were not successfully banned.
-    failed_users: Vec<UserId>,
+    pub failed_users: Vec<UserId>,
 }
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -80,6 +80,7 @@ pub struct Ban {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#bulk-guild-ban).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct BulkBanResponse {
     /// The users that were successfully banned.
     pub banned_users: Vec<UserId>,


### PR DESCRIPTION
How are we supposed to use them if they're private?