### PR TITLE
Backport: Fix model functions using SerializeIter

### DIFF
--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -33,7 +33,6 @@ use crate::http::{CacheHttp, Http, UserPagination};
 use crate::internal::prelude::*;
 #[cfg(feature = "model")]
 use crate::json::json;
-use crate::model::guild::SerializeIter;
 use crate::model::prelude::*;
 
 #[cfg(feature = "model")]
@@ -263,18 +262,18 @@ impl GuildId {
     pub async fn bulk_ban(
         self,
         http: &Http,
-        users: impl IntoIterator<Item = UserId>,
+        user_ids: &[UserId],
         delete_message_seconds: u32,
         reason: Option<&str>,
     ) -> Result<BulkBanResponse> {
         #[derive(serde::Serialize)]
-        struct BulkBan<I> {
-            user_ids: I,
+        struct BulkBan<'a> {
+            user_ids: &'a [UserId],
             delete_message_seconds: u32,
         }
 
         let map = BulkBan {
-            user_ids: SerializeIter::new(users.into_iter()),
+            user_ids,
             delete_message_seconds,
         };
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -534,7 +534,7 @@ impl Guild {
     pub async fn bulk_ban(
         &self,
         cache_http: impl CacheHttp,
-        users: impl IntoIterator<Item = UserId>,
+        user_ids: &[UserId],
         delete_message_seconds: u32,
         reason: Option<&str>,
     ) -> Result<BulkBanResponse> {
@@ -545,7 +545,7 @@ impl Guild {
             }
         }
 
-        self.id.bulk_ban(cache_http.http(), users, delete_message_seconds, reason).await
+        self.id.bulk_ban(cache_http.http(), user_ids, delete_message_seconds, reason).await
     }
 
     /// Returns the formatted URL of the guild's banner image, if one exists.

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -1,4 +1,3 @@
-use std::cell::Cell;
 use std::fmt;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -82,28 +81,6 @@ where
         Ok(NonZeroU64::new(val).map(Id::from))
     } else {
         Ok(None)
-    }
-}
-
-pub(super) struct SerializeIter<I>(Cell<Option<I>>);
-
-impl<I> SerializeIter<I> {
-    pub fn new(iter: I) -> Self {
-        Self(Cell::new(Some(iter)))
-    }
-}
-
-impl<Iter, Item> serde::Serialize for SerializeIter<Iter>
-where
-    Iter: Iterator<Item = Item>,
-    Item: serde::Serialize,
-{
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let Some(iter) = self.0.take() else {
-            return serializer.serialize_seq(Some(0))?.end();
-        };
-
-        serializer.collect_seq(iter)
     }
 }
 


### PR DESCRIPTION
This is a backport of #2955 to current, currently bulk_ban is uncallable so this "breaking" change doesn't actually break anyone.