### PR TITLE
Add polls to interaction responses

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -1,3 +1,4 @@
+use super::create_poll::Ready;
 #[cfg(feature = "http")]
 use super::{check_overflow, Builder};
 use super::{
@@ -5,6 +6,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
+    CreatePoll,
     EditAttachments,
 };
 #[cfg(feature = "http")]
@@ -179,6 +181,8 @@ pub struct CreateInteractionResponseMessage {
     flags: Option<InteractionResponseFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     components: Option<Vec<CreateActionRow>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    poll: Option<CreatePoll<Ready>>,
     attachments: EditAttachments,
 }
 
@@ -294,6 +298,15 @@ impl CreateInteractionResponseMessage {
         self.components = Some(components);
         self
     }
+
+    /// Adds a poll to the message. Only one poll can be added per message.
+    ///
+    /// See [`CreatePoll`] for more information on creating and configuring a poll.
+    pub fn poll(mut self, poll: CreatePoll<Ready>) -> Self {
+        self.poll = Some(poll);
+        self
+    }
+
     super::button_and_select_menu_convenience_methods!(self.components);
 }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -1,3 +1,4 @@
+use super::create_poll::Ready;
 #[cfg(feature = "http")]
 use super::{check_overflow, Builder};
 use super::{
@@ -5,6 +6,7 @@ use super::{
     CreateAllowedMentions,
     CreateAttachment,
     CreateEmbed,
+    CreatePoll,
     EditAttachments,
 };
 #[cfg(feature = "http")]
@@ -32,6 +34,8 @@ pub struct CreateInteractionResponseFollowup {
     components: Option<Vec<CreateActionRow>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    poll: Option<CreatePoll<Ready>>,
     attachments: EditAttachments,
 }
 
@@ -151,6 +155,14 @@ impl CreateInteractionResponseFollowup {
         };
 
         self.flags = Some(flags);
+        self
+    }
+
+    /// Adds a poll to the message. Only one poll can be added per message.
+    ///
+    /// See [`CreatePoll`] for more information on creating and configuring a poll.
+    pub fn poll(mut self, poll: CreatePoll<Ready>) -> Self {
+        self.poll = Some(poll);
         self
     }
 


### PR DESCRIPTION
This was not added when poll support was added to serenity. I have not tested this, but it is modeled after existing support for `CreateMessage`.