### PR TITLE
Swap CreateAttachment::data to Bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,13 +38,13 @@ strum = { version = "0.26", features = ["derive"] }
 to-arraystring = "0.2.0"
 extract_map = { version = "0.1.0", features = ["serde", "iter_mut"] }
 aformat = "0.1.3"
+bytes = "1.5.0"
 # Optional dependencies
 fxhash = { version = "0.2.1", optional = true }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.28", optional = true }
 reqwest = { version = "0.12.2", default-features = false, features = ["multipart", "stream", "json"], optional = true }
 tokio-tungstenite = { version = "0.21.0", optional = true }
-bytes = { version = "1.5.0", optional = true }
 percent-encoding = { version = "2.3.0", optional = true }
 mini-moka = { version = "0.10.2", optional = true }
 mime_guess = { version = "2.0.4", optional = true }
@@ -124,14 +124,12 @@ tracing_instrument = ["tracing/attributes"]
 rustls_backend = [
     "reqwest/rustls-tls",
     "tokio-tungstenite/rustls-tls-webpki-roots",
-    "bytes",
 ]
 
 # - Native TLS Backends
 native_tls_backend = [
     "reqwest/native-tls",
     "tokio-tungstenite/native-tls",
-    "bytes",
 ]
 
 

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::path::Path;
 
+use bytes::Bytes;
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
@@ -21,15 +22,12 @@ use crate::model::id::AttachmentId;
 pub struct CreateAttachment<'a> {
     pub filename: Cow<'static, str>,
     pub description: Option<Cow<'a, str>>,
-    pub data: Cow<'static, [u8]>,
+    pub data: Bytes,
 }
 
 impl<'a> CreateAttachment<'a> {
     /// Builds an [`CreateAttachment`] from the raw attachment data.
-    pub fn bytes(
-        data: impl Into<Cow<'static, [u8]>>,
-        filename: impl Into<Cow<'static, str>>,
-    ) -> Self {
+    pub fn bytes(data: impl Into<Bytes>, filename: impl Into<Cow<'static, str>>) -> Self {
         CreateAttachment {
             data: data.into(),
             filename: filename.into(),
@@ -85,7 +83,7 @@ impl<'a> CreateAttachment<'a> {
         filename: impl Into<Cow<'static, str>>,
     ) -> Result<Self> {
         let response = http.client.get(url).send().await?;
-        let data = response.bytes().await?.to_vec();
+        let data = response.bytes().await?;
 
         Ok(CreateAttachment::bytes(data, filename))
     }

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -7,7 +7,7 @@ use crate::internal::prelude::*;
 
 impl CreateAttachment<'_> {
     fn into_part(self) -> Result<Part> {
-        let mut part = Part::bytes(self.data);
+        let mut part = Part::stream(self.data);
         part = guess_mime_str(part, &self.filename)?;
         part = part.file_name(self.filename);
         Ok(part)


### PR DESCRIPTION
This exposes the `bytes` dependency but in turn allows for people to pass responses directly from reqwest to discord without cloning the data, as well as allowing reuploading cached data without cloning or leaking to get a static reference.

The bytes dependency also has to be made non-optional, but this is fine as it was already due to `aformat` depending on it via `bytestring`.