### PR TITLE
Add Consume Entitlement endpoint and missing fields for SKUs and Entitlements

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3445,6 +3445,28 @@ impl Http {
         .await
     }
 
+    /// For a one-time purchase consumable SKU (of kind [`Consumable`]), marks the entitlement as
+    /// consumed.
+    ///
+    /// The entitlement will have its `consumed` field set to `true` when fetched using
+    /// [`Self::get_entitlements`].
+    ///
+    /// [`Consumable`]: SkuKind::Consumable
+    pub async fn consume_entitlement(&self, entitlement_id: EntitlementId) -> Result<()> {
+        self.wind(204, Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Post,
+            route: Route::ConsumeEntitlement {
+                application_id: self.try_application_id()?,
+                entitlement_id,
+            },
+            params: None,
+        })
+        .await
+    }
+
     #[allow(clippy::too_many_arguments)]
     /// Gets all entitlements for the current app, active and expired.
     pub async fn get_entitlements(

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -510,6 +510,10 @@ routes! ('a, {
     api!("/applications/{}/entitlements/{}", application_id, entitlement_id),
     Some(RatelimitingKind::PathAndId(application_id.into()));
 
+    ConsumeEntitlement { application_id: ApplicationId, entitlement_id: EntitlementId },
+    api!("/applications/{}/entitlements/{}/consume", application_id, entitlement_id),
+    Some(RatelimitingKind::PathAndId(application_id.into()));
+
     Entitlements { application_id: ApplicationId },
     api!("/applications/{}/entitlements", application_id),
     Some(RatelimitingKind::PathAndId(application_id.into()));

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "model")]
 use crate::builder::{Builder as _, GetEntitlements};
 #[cfg(feature = "model")]
-use crate::http::CacheHttp;
+use crate::http::{CacheHttp, Http};
 use crate::model::prelude::*;
 
 /// A premium offering that can be made available to an application's users and guilds.
@@ -46,6 +46,10 @@ enum_number! {
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum SkuKind {
+        /// A durable one-time purchase.
+        Durable = 2,
+        /// A consumable one-time purchase.
+        Consumable = 3,
         /// Represents a recurring subscription.
         Subscription = 5,
         /// A system-generated group for each SKU created of type [`SkuKind::Subscription`].
@@ -98,6 +102,8 @@ pub struct Entitlement {
     pub ends_at: Option<Timestamp>,
     /// The ID of the guild that is granted access to the SKU.
     pub guild_id: Option<GuildId>,
+    /// For consumable items, whether or not the entitlement has been consumed.
+    pub consumed: Option<bool>,
 }
 
 impl Entitlement {
@@ -108,6 +114,22 @@ impl Entitlement {
             "https://discord.com/application-directory/{}/store/{}",
             self.application_id, self.sku_id
         )
+    }
+
+    /// For a one-time purchase consumable SKU (of kind [`Consumable`]), marks the entitlement as
+    /// consumed. On success, the [`consumed`] field will be set to `Some(true)`.
+    ///
+    /// # Errors
+    ///
+    /// Will fail if the corresponding SKU is not of kind [`Consumable`].
+    ///
+    /// [`Consumable`]: SkuKind::Consumable
+    /// [`consumed`]: Entitlement::consumed
+    #[cfg(feature = "model")]
+    pub async fn consume(&mut self, http: &Http) -> Result<()> {
+        http.consume_entitlement(self.id).await?;
+        self.consumed = Some(true);
+        Ok(())
     }
 
     /// Returns all entitlements for the current application, active and expired.
@@ -133,6 +155,20 @@ enum_number! {
     #[serde(from = "u8", into = "u8")]
     #[non_exhaustive]
     pub enum EntitlementKind {
+        /// Entitlement was purchased by a user.
+        Purchase = 1,
+        /// Entitlement for a Discord Nitro subscription.
+        PremiumSubscription = 2,
+        /// Entitlement was gifted by an app developer.
+        DeveloperGift = 3,
+        /// Entitlement was purchased by a developer in application test mode.
+        TestModePurchase = 4,
+        /// Entitlement was granted when the corresponding SKU was free.
+        FreePurchase = 5,
+        /// Entitlement was gifted by another user.
+        UserGift = 6,
+        /// Entitlement was claimed by user for free as a Nitro Subscriber.
+        PremiumPurchase = 7,
         /// Entitlement was purchased as an app subscription.
         ApplicationSubscription = 8,
         _ => Unknown(u8),


### PR DESCRIPTION
I have not tested this endpoint so I'm not completely sure of the failure condition, but I think it's a reasonable assumption.