### PR TITLE
Add support for Entry Point commands

### DIFF
--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -320,6 +320,8 @@ pub struct CreateCommand {
     #[serde(skip_serializing_if = "Option::is_none")]
     contexts: Option<Vec<InteractionContext>>,
     nsfw: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    handler: Option<EntryPointHandlerType>,
 }
 
 impl CreateCommand {
@@ -342,6 +344,7 @@ impl CreateCommand {
 
             options: Vec::new(),
             nsfw: false,
+            handler: None,
         }
     }
 
@@ -461,6 +464,15 @@ impl CreateCommand {
     /// Whether this command is marked NSFW (age-restricted)
     pub fn nsfw(mut self, nsfw: bool) -> Self {
         self.nsfw = nsfw;
+        self
+    }
+
+    /// Sets the command's entry point handler type. Only valid for commands of type
+    /// [`PrimaryEntryPoint`].
+    ///
+    /// [`PrimaryEntryPoint`]: CommandType::PrimaryEntryPoint
+    pub fn handler(mut self, handler: EntryPointHandlerType) -> Self {
+        self.handler = Some(handler);
         self
     }
 }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -64,6 +64,13 @@ pub enum CreateInteractionResponse {
     /// Corresponds to Discord's `PREMIUM_REQUIRED'.
     #[deprecated = "use premium button components via `CreateButton::new_premium` instead"]
     PremiumRequired,
+    /// Not valid for autocomplete and Ping interactions. Only available for applications with
+    /// Activities enabled.
+    ///
+    /// Responds to the interaction by launching the Activity associated with the app.
+    ///
+    /// Corresponds to Discord's `LAUNCH_ACTIVITY`.
+    LaunchActivity,
 }
 
 impl serde::Serialize for CreateInteractionResponse {
@@ -81,6 +88,7 @@ impl serde::Serialize for CreateInteractionResponse {
             Self::Autocomplete(_) => 8,
             Self::Modal(_) => 9,
             Self::PremiumRequired => 10,
+            Self::LaunchActivity => 12,
         })?;
 
         match self {
@@ -92,6 +100,7 @@ impl serde::Serialize for CreateInteractionResponse {
             Self::Autocomplete(x) => map.serialize_entry("data", &x)?,
             Self::Modal(x) => map.serialize_entry("data", &x)?,
             Self::PremiumRequired => map.serialize_entry("data", &None::<()>)?,
+            Self::LaunchActivity => map.serialize_entry("data", &None::<()>)?,
         }
 
         map.end()

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -97,6 +97,10 @@ pub struct Command {
     pub contexts: Option<Vec<InteractionContext>>,
     /// An autoincremented version identifier updated during substantial record changes.
     pub version: CommandVersionId,
+    /// Only present for commands of type [`PrimaryEntryPoint`].
+    ///
+    /// [`PrimaryEntryPoint`]: CommandType::PrimaryEntryPoint
+    pub handler: Option<EntryPointHandlerType>,
 }
 
 #[cfg(feature = "model")]
@@ -245,6 +249,23 @@ enum_number! {
         ChatInput = 1,
         User = 2,
         Message = 3,
+        PrimaryEntryPoint = 4,
+        _ => Unknown(u8),
+    }
+}
+
+enum_number! {
+    /// Signifies how the invocation of a command of type [`PrimaryEntryPoint`] should be handled.
+    ///
+    /// [`PrimaryEntryPoint`]: CommandType::PrimaryEntryPoint
+    /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-entry-point-command-handler-types)
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum EntryPointHandlerType {
+        AppHandler = 1,
+        DiscordLaunchActivity = 2,
         _ => Unknown(u8),
     }
 }


### PR DESCRIPTION
The discord docs are a little confusing for this feature, but I think it's basically pretty simple. Applications with activities enabled can define a global command of type `PrimaryEntryPoint` - based on the value of the `handler` field, this command can be treated essentially like normal, allowing the application to respond with a followup message when called; or, the behavior of the command can be automatically handled by Discord.