### PR TITLE
`GuildChannel#is_text_based` returns `true` for thread channel

### DIFF
--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -202,7 +202,13 @@ impl GuildChannel {
     pub fn is_text_based(&self) -> bool {
         matches!(
             self.kind,
-            ChannelType::Text | ChannelType::News | ChannelType::Voice | ChannelType::Stage
+            ChannelType::Text
+                | ChannelType::News
+                | ChannelType::Voice
+                | ChannelType::Stage
+                | ChannelType::PublicThread
+                | ChannelType::PrivateThread
+                | ChannelType::NewsThread
         )
     }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -254,7 +254,7 @@ enum_number! {
         /// An indicator that the channel is a forum [`GuildChannel`].
         Forum = 15,
         _ => Unknown(u8),
-    }
+    } // Make sure to update [`GuildChannel::is_text_based`].
 }
 
 impl ChannelType {


### PR DESCRIPTION
Make `GuildChannel#is_text_based` return `true` for public and private threads.

ref: https://canary.discord.com/channels/381880193251409931/673965002805477386/1305494065613111366 (Serenity Discord)