### PR TITLE
Deprecate `GuildChannel::permissions_for_user` and add `Message::author_permissions`

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -196,12 +196,7 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
         channel.edit(ctx, EditChannel::new().category(None)).await?;
         channel.edit(ctx, EditChannel::new().category(Some(parent_id))).await?;
     } else if msg.content == "channelperms" {
-        let guild = guild_id.to_guild_cached(ctx).unwrap().clone();
-        let perms = guild.user_permissions_in(
-            &channel_id.to_channel(ctx).await?.guild().unwrap(),
-            &*guild.member(ctx, msg.author.id).await?,
-        );
-        channel_id.say(ctx, format!("{:?}", perms)).await?;
+        channel_id.say(ctx, format!("{:?}", msg.author_permissions(ctx))).await?;
     } else if let Some(forum_channel_id) = msg.content.strip_prefix("createforumpostin ") {
         forum_channel_id
             .parse::<ChannelId>()

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -857,13 +857,10 @@ pub(crate) fn has_correct_permissions(
 ) -> bool {
     if options.required_permissions().is_empty() {
         true
+    } else if let Some(permissions) = message.author_permissions(cache) {
+        permissions.contains(*options.required_permissions())
     } else {
-        message.guild(cache.as_ref()).is_some_and(|guild| {
-            let Some(channel) = guild.channels.get(&message.channel_id) else { return false };
-            let Some(member) = guild.members.get(&message.author.id) else { return false };
-
-            guild.user_permissions_in(channel, member).contains(*options.required_permissions())
-        })
+        false
     }
 }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -761,6 +761,7 @@ impl GuildChannel {
     /// [Attach Files]: Permissions::ATTACH_FILES
     /// [Send Messages]: Permissions::SEND_MESSAGES
     #[cfg(feature = "cache")]
+    #[deprecated = "Use `Guild::user_permissions_in`"]
     #[inline]
     pub fn permissions_for_user(
         &self,
@@ -1022,13 +1023,11 @@ impl GuildChannel {
                 .collect()),
             ChannelType::News | ChannelType::Text => Ok(guild
                 .members
-                .iter()
-                .filter(|e| {
-                    self.permissions_for_user(cache, e.0)
-                        .map(|p| p.contains(Permissions::VIEW_CHANNEL))
-                        .unwrap_or(false)
+                .values()
+                .filter(|member| {
+                    guild.user_permissions_in(self, member).contains(Permissions::VIEW_CHANNEL)
                 })
-                .map(|e| e.1.clone())
+                .cloned()
                 .collect::<Vec<Member>>()),
             _ => Err(Error::from(ModelError::InvalidChannelType)),
         }

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -420,6 +420,28 @@ generate_get_permission_names! {
 /// TODO: use a macro to shorten this entire file lol
 #[cfg(feature = "model")]
 impl Permissions {
+    #[must_use]
+    pub fn dm_permissions() -> Self {
+        Self::ADD_REACTIONS
+            | Self::STREAM
+            | Self::VIEW_CHANNEL
+            | Self::SEND_MESSAGES
+            | Self::SEND_TTS_MESSAGES
+            | Self::EMBED_LINKS
+            | Self::ATTACH_FILES
+            | Self::READ_MESSAGE_HISTORY
+            | Self::MENTION_EVERYONE
+            | Self::USE_EXTERNAL_EMOJIS
+            | Self::CONNECT
+            | Self::SPEAK
+            | Self::USE_VAD
+            | Self::USE_APPLICATION_COMMANDS
+            | Self::USE_EXTERNAL_STICKERS
+            | Self::SEND_VOICE_MESSAGES
+            | Self::SEND_POLLS
+            | Self::USE_EXTERNAL_APPS
+    }
+
     /// Shorthand for checking that the set of permissions contains the [Add Reactions] permission.
     ///
     /// [Add Reactions]: Self::ADD_REACTIONS


### PR DESCRIPTION
This deprecates `GuildChannel::permissions_for_user` as:
- It is unnecessary API surface
- Performs a cache lookup when most users will have `Guild` if they have `GuildChannel`

It also adds `Message::author_permissions` to match `Interaction::permissions` and hopefully be a replacement for a lot of the usage of `GuildChannel::permissions_for_user`. This also takes advantage of the lesser known `Message::member` field to not require member intents for calculating the permissions from a message create event.

For `Message::author_permissions`, this also adds `Permissions::dm_permissions`, which returns the permissions that are implicitly enabled in a DM. 