### PR TITLE
Remove Option around Interaction::app_permissions

### DIFF
--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -55,8 +55,7 @@ pub struct CommandInteraction {
     /// Always `1`.
     pub version: u8,
     /// Permissions the app or bot has within the channel the interaction was sent from.
-    // TODO(next): This is now always serialized.
-    pub app_permissions: Option<Permissions>,
+    pub app_permissions: Permissions,
     /// The selected language of the invoking user.
     pub locale: FixedString,
     /// The guild's preferred locale.

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -53,7 +53,7 @@ pub struct ComponentInteraction {
     /// The message this interaction was triggered by, if it is a component.
     pub message: Box<Message>,
     /// Permissions the app or bot has within the channel the interaction was sent from.
-    pub app_permissions: Option<Permissions>,
+    pub app_permissions: Permissions,
     /// The selected language of the invoking user.
     pub locale: FixedString,
     /// The guild's preferred locale.

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -56,9 +56,9 @@ impl Interaction {
 
     /// Permissions the app or bot has within the channel the interaction was sent from.
     #[must_use]
-    pub fn app_permissions(&self) -> Option<Permissions> {
+    pub fn app_permissions(&self) -> Permissions {
         match self {
-            Self::Ping(_) => None,
+            Self::Ping(i) => i.app_permissions,
             Self::Command(i) | Self::Autocomplete(i) => i.app_permissions,
             Self::Component(i) => i.app_permissions,
             Self::Modal(i) => i.app_permissions,

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -51,7 +51,7 @@ pub struct ModalInteraction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<Box<Message>>,
     /// Permissions the app or bot has within the channel the interaction was sent from.
-    pub app_permissions: Option<Permissions>,
+    pub app_permissions: Permissions,
     /// The selected language of the invoking user.
     pub locale: FixedString,
     /// The guild's preferred locale.

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -17,4 +17,6 @@ pub struct PingInteraction {
     pub token: FixedString,
     /// Always `1`.
     pub version: u8,
+    /// Permissions the app or bot has within the channel the interaction was sent from.
+    pub app_permissions: Permissions,
 }


### PR DESCRIPTION
Discord documents this as always present, even with Ping interactions.