### PR TITLE
Transport compression support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ default_no_backend = [
     "cache",
     "chrono",
     "framework",
+    "transport_compression_zlib",
 ]
 
 # Enables builder structs to configure Discord HTTP requests. Without this feature, you have to
@@ -93,6 +94,8 @@ http = ["dashmap", "mime_guess", "percent-encoding"]
 # TODO: remove dependeny on utils feature
 model = ["builder", "http", "utils"]
 voice_model = ["serenity-voice-model"]
+# Enables zlib-stream transport compression of incoming gateway events.
+transport_compression_zlib = ["flate2", "gateway"]
 # Enables support for Discord API functionality that's not stable yet, as well as serenity APIs that
 # are allowed to change even in semver non-breaking updates.
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bytes = "1.5.0"
 fxhash = { version = "0.2.1", optional = true }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.28", optional = true }
+zstd-safe = { version = "7.2.1", optional = true }
 reqwest = { version = "0.12.2", default-features = false, features = ["multipart", "stream", "json"], optional = true }
 tokio-tungstenite = { version = "0.21.0", optional = true }
 percent-encoding = { version = "2.3.0", optional = true }
@@ -71,6 +72,7 @@ default_no_backend = [
     "chrono",
     "framework",
     "transport_compression_zlib",
+    "transport_compression_zstd",
 ]
 
 # Enables builder structs to configure Discord HTTP requests. Without this feature, you have to
@@ -96,6 +98,8 @@ model = ["builder", "http", "utils"]
 voice_model = ["serenity-voice-model"]
 # Enables zlib-stream transport compression of incoming gateway events.
 transport_compression_zlib = ["flate2", "gateway"]
+# Enables zstd-stream transport compression of incoming gateway events.
+transport_compression_zstd = ["zstd-safe", "gateway"]
 # Enables support for Discord API functionality that's not stable yet, as well as serenity APIs that
 # are allowed to change even in semver non-breaking updates.
 unstable = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
     /// An error from the `tungstenite` crate.
     #[cfg(feature = "gateway")]
     Tungstenite(Box<TungsteniteError>),
+    #[cfg(feature = "transport_compression_zlib")]
+    /// A decompression error from the `flate2` crate.
+    DecompressZlib(flate2::DecompressError),
 }
 
 #[cfg(feature = "gateway")]
@@ -101,6 +104,13 @@ impl From<ReqwestError> for Error {
     }
 }
 
+#[cfg(feature = "transport_compression_zlib")]
+impl From<flate2::DecompressError> for Error {
+    fn from(e: flate2::DecompressError) -> Error {
+        Error::DecompressZlib(e)
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -113,6 +123,8 @@ impl fmt::Display for Error {
             Self::Http(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "gateway")]
             Self::Tungstenite(inner) => fmt::Display::fmt(&inner, f),
+            #[cfg(feature = "transport_compression_zlib")]
+            Self::DecompressZlib(inner) => fmt::Display::fmt(&inner, f),
         }
     }
 }
@@ -130,6 +142,8 @@ impl StdError for Error {
             Self::Http(inner) => Some(inner),
             #[cfg(feature = "gateway")]
             Self::Tungstenite(inner) => Some(inner),
+            #[cfg(feature = "transport_compression_zlib")]
+            Self::DecompressZlib(inner) => Some(inner),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,9 +46,6 @@ pub enum Error {
     /// An error from the `tungstenite` crate.
     #[cfg(feature = "gateway")]
     Tungstenite(Box<TungsteniteError>),
-    #[cfg(feature = "transport_compression_zlib")]
-    /// A decompression error from the `flate2` crate.
-    DecompressZlib(flate2::DecompressError),
 }
 
 #[cfg(feature = "gateway")]
@@ -104,13 +101,6 @@ impl From<ReqwestError> for Error {
     }
 }
 
-#[cfg(feature = "transport_compression_zlib")]
-impl From<flate2::DecompressError> for Error {
-    fn from(e: flate2::DecompressError) -> Error {
-        Error::DecompressZlib(e)
-    }
-}
-
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -123,8 +113,6 @@ impl fmt::Display for Error {
             Self::Http(inner) => fmt::Display::fmt(&inner, f),
             #[cfg(feature = "gateway")]
             Self::Tungstenite(inner) => fmt::Display::fmt(&inner, f),
-            #[cfg(feature = "transport_compression_zlib")]
-            Self::DecompressZlib(inner) => fmt::Display::fmt(&inner, f),
         }
     }
 }
@@ -142,8 +130,6 @@ impl StdError for Error {
             Self::Http(inner) => Some(inner),
             #[cfg(feature = "gateway")]
             Self::Tungstenite(inner) => Some(inner),
-            #[cfg(feature = "transport_compression_zlib")]
-            Self::DecompressZlib(inner) => Some(inner),
         }
     }
 }

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -42,6 +42,7 @@ use tracing::{debug, warn};
 
 pub use self::context::Context;
 pub use self::event_handler::{EventHandler, FullEvent, RawEventHandler};
+use super::TransportCompression;
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
@@ -82,6 +83,7 @@ pub struct ClientBuilder {
     raw_event_handler: Option<Arc<dyn RawEventHandler>>,
     presence: PresenceData,
     wait_time_between_shard_start: Duration,
+    compression: TransportCompression,
 }
 
 impl ClientBuilder {
@@ -116,6 +118,7 @@ impl ClientBuilder {
             raw_event_handler: None,
             presence: PresenceData::default(),
             wait_time_between_shard_start: DEFAULT_WAIT_BETWEEN_SHARD_START,
+            compression: TransportCompression::None,
         }
     }
 
@@ -173,6 +176,12 @@ impl ClientBuilder {
     /// [Twilight Gateway Proxy]: https://github.com/Gelbpunkt/gateway-proxy
     pub fn wait_time_between_shard_start(mut self, wait_time: Duration) -> Self {
         self.wait_time_between_shard_start = wait_time;
+        self
+    }
+
+    /// Sets the compression method to be used when receiving data from the gateway.
+    pub fn compression(mut self, compression: TransportCompression) -> Self {
+        self.compression = compression;
         self
     }
 
@@ -342,6 +351,7 @@ impl IntoFuture for ClientBuilder {
                 presence: Some(presence),
                 max_concurrency,
                 wait_time_between_shard_start: self.wait_time_between_shard_start,
+                compression: self.compression,
             });
 
             let client = Client {

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -53,6 +53,12 @@ pub enum Error {
     #[cfg(feature = "transport_compression_zlib")]
     /// A decompression error from the `flate2` crate.
     DecompressZlib(flate2::DecompressError),
+    #[cfg(feature = "transport_compression_zstd")]
+    /// A decompression error from zstd.
+    DecompressZstd(usize),
+    /// When zstd decompression fails due to corrupted data.
+    #[cfg(feature = "transport_compression_zstd")]
+    DecompressZstdCorrupted,
     /// When decompressed gateway data is not valid UTF-8.
     DecompressUtf8(std::string::FromUtf8Error),
 }
@@ -77,6 +83,12 @@ impl fmt::Display for Error {
             },
             #[cfg(feature = "transport_compression_zlib")]
             Self::DecompressZlib(inner) => fmt::Display::fmt(&inner, f),
+            #[cfg(feature = "transport_compression_zstd")]
+            Self::DecompressZstd(code) => write!(f, "Zstd decompression error: {code}"),
+            #[cfg(feature = "transport_compression_zstd")]
+            Self::DecompressZstdCorrupted => {
+                f.write_str("Zstd decompression error: corrupted data")
+            },
             Self::DecompressUtf8(inner) => fmt::Display::fmt(&inner, f),
         }
     }

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -53,6 +53,8 @@ pub enum Error {
     #[cfg(feature = "transport_compression_zlib")]
     /// A decompression error from the `flate2` crate.
     DecompressZlib(flate2::DecompressError),
+    /// When decompressed gateway data is not valid UTF-8.
+    DecompressUtf8(std::string::FromUtf8Error),
 }
 
 impl fmt::Display for Error {
@@ -75,6 +77,7 @@ impl fmt::Display for Error {
             },
             #[cfg(feature = "transport_compression_zlib")]
             Self::DecompressZlib(inner) => fmt::Display::fmt(&inner, f),
+            Self::DecompressUtf8(inner) => fmt::Display::fmt(&inner, f),
         }
     }
 }

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -7,7 +7,7 @@ use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 ///
 /// Note that - from a user standpoint - there should be no situation in which you manually handle
 /// these.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// There was an error building a URL.
@@ -50,6 +50,9 @@ pub enum Error {
     /// If an connection has been established but privileged gateway intents were provided without
     /// enabling them prior.
     DisallowedGatewayIntents,
+    #[cfg(feature = "transport_compression_zlib")]
+    /// A decompression error from the `flate2` crate.
+    DecompressZlib(flate2::DecompressError),
 }
 
 impl fmt::Display for Error {
@@ -70,6 +73,8 @@ impl fmt::Display for Error {
             Self::DisallowedGatewayIntents => {
                 f.write_str("Disallowed gateway intents were provided")
             },
+            #[cfg(feature = "transport_compression_zlib")]
+            Self::DecompressZlib(inner) => fmt::Display::fmt(&inner, f),
         }
     }
 }

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -130,7 +130,7 @@ impl Shard {
     /// use std::num::NonZeroU16;
     /// use std::sync::Arc;
     ///
-    /// use serenity::gateway::Shard;
+    /// use serenity::gateway::{Shard, TransportCompression};
     /// use serenity::model::gateway::{GatewayIntents, ShardInfo};
     /// use serenity::model::id::ShardId;
     /// use serenity::secret_string::SecretString;
@@ -148,7 +148,15 @@ impl Shard {
     ///
     /// // retrieve the gateway response, which contains the URL to connect to
     /// let gateway = Arc::from(http.get_gateway().await?.url);
-    /// let shard = Shard::new(gateway, token, shard_info, GatewayIntents::all(), None).await?;
+    /// let shard = Shard::new(
+    ///     gateway,
+    ///     token,
+    ///     shard_info,
+    ///     GatewayIntents::all(),
+    ///     None,
+    ///     TransportCompression::None,
+    /// )
+    /// .await?;
     ///
     /// // at this point, you can create a `loop`, and receive events and match
     /// // their variants

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -983,16 +983,28 @@ pub enum TransportCompression {
     #[cfg(feature = "transport_compression_zlib")]
     /// Use zlib-stream transport compression.
     Zlib,
+
+    #[cfg(feature = "transport_compression_zstd")]
+    /// Use zstd-stream transport compression.
+    Zstd,
 }
 
 impl TransportCompression {
     fn query_param(self) -> ArrayString<21> {
-        #[cfg_attr(not(feature = "transport_compression_zlib"), expect(unused_mut))]
+        #[cfg_attr(
+            not(any(
+                feature = "transport_compression_zlib",
+                feature = "transport_compression_zstd"
+            )),
+            expect(unused_mut)
+        )]
         let mut res = ArrayString::new();
         match self {
             Self::None => {},
             #[cfg(feature = "transport_compression_zlib")]
             Self::Zlib => aformat_into!(res, "&compress=zlib-stream"),
+            #[cfg(feature = "transport_compression_zstd")]
+            Self::Zstd => aformat_into!(res, "&compress=zstd-stream"),
         }
 
         res

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -44,7 +44,9 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration as StdDuration, Instant};
 
-use aformat::{aformat, aformat_into, ArrayString, CapStr};
+#[cfg(feature = "transport_compression_zlib")]
+use aformat::aformat_into;
+use aformat::{aformat, ArrayString, CapStr};
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 use tracing::{debug, error, info, trace, warn};
@@ -985,6 +987,7 @@ pub enum TransportCompression {
 
 impl TransportCompression {
     fn query_param(self) -> ArrayString<21> {
+        #[cfg_attr(not(feature = "transport_compression_zlib"), expect(unused_mut))]
         let mut res = ArrayString::new();
         match self {
             Self::None => {},

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -60,7 +60,12 @@ pub const DEFAULT_WAIT_BETWEEN_SHARD_START: Duration = Duration::from_secs(5);
 /// use std::sync::{Arc, OnceLock};
 ///
 /// use serenity::gateway::client::EventHandler;
-/// use serenity::gateway::{ShardManager, ShardManagerOptions, DEFAULT_WAIT_BETWEEN_SHARD_START};
+/// use serenity::gateway::{
+///     ShardManager,
+///     ShardManagerOptions,
+///     TransportCompression,
+///     DEFAULT_WAIT_BETWEEN_SHARD_START,
+/// };
 /// use serenity::http::Http;
 /// use serenity::model::gateway::GatewayIntents;
 /// use serenity::prelude::*;
@@ -95,6 +100,7 @@ pub const DEFAULT_WAIT_BETWEEN_SHARD_START: Duration = Duration::from_secs(5);
 ///     presence: None,
 ///     max_concurrency,
 ///     wait_time_between_shard_start: DEFAULT_WAIT_BETWEEN_SHARD_START,
+///     compression: TransportCompression::None,
 /// });
 /// # Ok(())
 /// # }

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -11,7 +11,14 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-use super::{ShardId, ShardQueue, ShardQueuer, ShardQueuerMessage, ShardRunnerInfo};
+use super::{
+    ShardId,
+    ShardQueue,
+    ShardQueuer,
+    ShardQueuerMessage,
+    ShardRunnerInfo,
+    TransportCompression,
+};
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
 #[cfg(feature = "framework")]
@@ -144,6 +151,7 @@ impl ShardManager {
             #[cfg(feature = "voice")]
             voice_manager: opt.voice_manager,
             ws_url: opt.ws_url,
+            compression: opt.compression,
             shard_total: opt.shard_total,
             #[cfg(feature = "cache")]
             cache: opt.cache,
@@ -379,4 +387,5 @@ pub struct ShardManagerOptions {
     pub max_concurrency: NonZeroU16,
     /// Number of seconds to wait between starting each shard/set of shards start
     pub wait_time_between_shard_start: Duration,
+    pub compression: TransportCompression,
 }

--- a/src/gateway/sharding/shard_queuer.rs
+++ b/src/gateway/sharding/shard_queuer.rs
@@ -17,6 +17,7 @@ use super::{
     ShardRunner,
     ShardRunnerInfo,
     ShardRunnerOptions,
+    TransportCompression,
 };
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
@@ -64,6 +65,8 @@ pub struct ShardQueuer {
     pub voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
     /// A copy of the URL to use to connect to the gateway.
     pub ws_url: Arc<str>,
+    /// The compression method to use for the WebSocket connection.
+    pub compression: TransportCompression,
     /// The total amount of shards to start.
     pub shard_total: NonZeroU16,
     /// Number of seconds to wait between each start
@@ -216,6 +219,7 @@ impl ShardQueuer {
             shard_info,
             self.intents,
             self.presence.clone(),
+            self.compression,
         )
         .await?;
 

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -451,7 +451,16 @@ impl ShardRunner {
             )) => {
                 error!("Shard handler received fatal err: {why:?}");
 
-                self.manager.return_with_value(Err(why.clone())).await;
+                let why_clone = match why {
+                    GatewayError::InvalidAuthentication => GatewayError::InvalidAuthentication,
+                    GatewayError::InvalidGatewayIntents => GatewayError::InvalidGatewayIntents,
+                    GatewayError::DisallowedGatewayIntents => {
+                        GatewayError::DisallowedGatewayIntents
+                    },
+                    _ => unreachable!(),
+                };
+
+                self.manager.return_with_value(Err(why_clone)).await;
                 return Err(Error::Gateway(why));
             },
             Err(Error::Json(_)) => return Ok((None, None, true)),

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -128,7 +128,9 @@ impl Compression {
 
                 let pre_out = inflater.total_out();
                 decompressed.clear();
-                inflater.decompress_vec(compressed, decompressed, flate2::FlushDecompress::Sync)?;
+                inflater
+                    .decompress_vec(compressed, decompressed, flate2::FlushDecompress::Sync)
+                    .map_err(GatewayError::DecompressZlib)?;
 
                 let size = inflater.total_out() - pre_out;
                 Ok(Some(&decompressed[..size as usize]))

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -90,18 +90,14 @@ enum Compression {
     },
 }
 
-const DECOMPRESSION_MULTIPLIER: usize = 3;
-#[cfg(feature = "transport_compression_zlib")]
-const ZLIB_SUFFIX: [u8; 4] = [0x00, 0x00, 0xFF, 0xFF];
-#[cfg(feature = "transport_compression_zlib")]
-const ZLIB_BUFFER_SIZE: usize = 32 * 1024;
-
 impl Compression {
     fn inflate(&mut self, slice: &[u8]) -> Result<Option<&[u8]>> {
         match self {
             Compression::Payload {
                 decompressed,
             } => {
+                const DECOMPRESSION_MULTIPLIER: usize = 3;
+
                 decompressed.clear();
                 decompressed.reserve(slice.len() * DECOMPRESSION_MULTIPLIER);
 
@@ -121,6 +117,8 @@ impl Compression {
                 compressed,
                 decompressed,
             } => {
+                const ZLIB_SUFFIX: [u8; 4] = [0x00, 0x00, 0xFF, 0xFF];
+
                 compressed.extend_from_slice(slice);
                 let length = compressed.len();
 
@@ -150,7 +148,7 @@ impl From<TransportCompression> for Compression {
             TransportCompression::Zlib => Compression::Zlib {
                 inflater: Decompress::new(true),
                 compressed: Vec::new(),
-                decompressed: Vec::with_capacity(ZLIB_BUFFER_SIZE),
+                decompressed: Vec::with_capacity(32 * 1024),
             },
         }
     }


### PR DESCRIPTION
Reworks how the current payload compression is handled and adds support for transport compression.

- [x] implement `zlib-stream` decompression
- [x] implement `zstd-stream` decompression

Should close #693.
_And unlike #1508 it concats the WS query params with `&` instead of [`?`](https://github.com/serenity-rs/serenity/pull/1508/files?diff=split&w=0#diff-d1e3faa80a031e801cfb6cfac377a10139019f0133cf7fedb5cc33cc9c3b4d45R826-R831)._

#1508 had some logic to periodically resize/shrink buffers (even tho it seems like it was not hooked up to be called anywhere?) which this PR does not ~_yet_~ have.