### PR TITLE
feat(ci): move rustflags to specific targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,23 @@
-[build]
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "target-cpu=haswell"]
+
+[target.x86_64-pc-windows-gnu]
+rustflags = ["-C", "target-cpu=haswell"]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-cpu=haswell"]
+
+[target.x86_64-unknown-freebsd]
+rustflags = ["-C", "target-cpu=haswell"]
+
+[target.x86_64-unknown-illumos]
+rustflags = ["-C", "target-cpu=haswell"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=haswell"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-cpu=haswell"]
+
+[target.x86_64-unknown-netbsd]
 rustflags = ["-C", "target-cpu=haswell"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,9 +131,6 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Remove cargo build config
-        run: rm .cargo/config.toml
-
       - name: Build
         run: cargo build
 


### PR DESCRIPTION
This would cause a cascade of failures if you developed on anything,
but x86_64.

This is mostly to ease the development on non-x86_64 machines.