### PR TITLE
Update `tokio-tungstenite` dependency to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ fxhash = { version = "0.2.1", optional = true }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.28", optional = true }
 reqwest = { version = "0.12.2", default-features = false, features = ["multipart", "stream", "json"], optional = true }
-tokio-tungstenite = { version = "0.21.0", optional = true }
+tokio-tungstenite = { version = "0.24.0", features = ["url"], optional = true }
 percent-encoding = { version = "2.3.0", optional = true }
 mini-moka = { version = "0.10.2", optional = true }
 mime_guess = { version = "2.0.4", optional = true }


### PR DESCRIPTION
Updates the `tokio-tungstenite` dependency to 0.24. Also enables its "url" feature to continue using the `url` crate in combination with it.

This avoids indirectly pulling in multiple versions of `rustls`.