### PR TITLE
Get rid of redundant status argument in Http::wind

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1878,16 +1878,14 @@ impl Http {
         .await
     }
 
-    /// Edits the current user's nickname for the provided [`Guild`] via its Id.
-    ///
-    /// Pass [`None`] to reset the nickname.
-    pub async fn edit_nickname(
+    /// Edits the current member for the provided [`Guild`] via its Id.
+    pub async fn edit_current_member(
         &self,
         guild_id: GuildId,
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<()> {
-        self.wind(200, Request {
+    ) -> Result<Member> {
+        self.fire(Request {
             body: Some(to_vec(&map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -314,7 +314,7 @@ impl Http {
         role_id: RoleId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -343,7 +343,7 @@ impl Http {
     ) -> Result<()> {
         let delete_message_seconds = u32::from(delete_message_days) * 86400;
 
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: reason.map(reason_into_header),
@@ -382,7 +382,7 @@ impl Http {
 
     /// Broadcasts that the current user is typing in the given [`Channel`].
     pub async fn broadcast_typing(&self, channel_id: ChannelId) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -679,7 +679,7 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -723,7 +723,7 @@ impl Http {
             });
         }
 
-        self.wind(204, request).await
+        self.wind(request).await
     }
 
     /// Creates a [`RichInvite`] for the given [channel][`GuildChannel`].
@@ -758,7 +758,7 @@ impl Http {
     ) -> Result<()> {
         let body = to_vec(map)?;
 
-        self.wind(204, Request {
+        self.wind(Request {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -797,7 +797,7 @@ impl Http {
         reaction_type: &ReactionType,
         burst: bool,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -991,7 +991,7 @@ impl Http {
         channel_id: ChannelId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1011,7 +1011,7 @@ impl Http {
         emoji_id: EmojiId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1027,7 +1027,7 @@ impl Http {
 
     /// Deletes an application emoji.
     pub async fn delete_application_emoji(&self, emoji_id: EmojiId) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1047,7 +1047,7 @@ impl Http {
         interaction_token: &str,
         message_id: MessageId,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1064,7 +1064,7 @@ impl Http {
 
     /// Deletes a global command.
     pub async fn delete_global_command(&self, command_id: CommandId) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1080,7 +1080,7 @@ impl Http {
 
     /// Deletes a guild, only if connected account owns it.
     pub async fn delete_guild(&self, guild_id: GuildId) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1099,7 +1099,7 @@ impl Http {
         guild_id: GuildId,
         command_id: CommandId,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1121,7 +1121,7 @@ impl Http {
         integration_id: IntegrationId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1161,7 +1161,7 @@ impl Http {
         message_id: MessageId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1182,7 +1182,7 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1201,7 +1201,7 @@ impl Http {
         channel_id: ChannelId,
         message_id: MessageId,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1222,7 +1222,7 @@ impl Http {
         message_id: MessageId,
         reaction_type: &ReactionType,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1242,7 +1242,7 @@ impl Http {
         &self,
         interaction_token: &str,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1263,7 +1263,7 @@ impl Http {
         target_id: TargetId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1285,7 +1285,7 @@ impl Http {
         user_id: UserId,
         reaction_type: &ReactionType,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1308,7 +1308,7 @@ impl Http {
         message_id: MessageId,
         reaction_type: &ReactionType,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1330,7 +1330,7 @@ impl Http {
         role_id: RoleId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1350,7 +1350,7 @@ impl Http {
         guild_id: GuildId,
         event_id: ScheduledEventId,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1371,7 +1371,7 @@ impl Http {
         sticker_id: StickerId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1388,7 +1388,7 @@ impl Http {
     /// Deletes a currently active test entitlement. Discord will act as though the corresponding
     /// user/guild *no longer has* an entitlement to the corresponding SKU.
     pub async fn delete_test_entitlement(&self, entitlement_id: EntitlementId) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -1408,7 +1408,7 @@ impl Http {
         webhook_id: WebhookId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1430,7 +1430,7 @@ impl Http {
         token: &str,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -1683,7 +1683,7 @@ impl Http {
     ) -> Result<()> {
         let body = to_vec(&SerializeIter::new(value))?;
 
-        self.wind(204, Request {
+        self.wind(Request {
             body: Some(body),
             multipart: None,
             headers: None,
@@ -2132,7 +2132,7 @@ impl Http {
         user_id: UserId,
         map: &impl serde::Serialize,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
@@ -2152,7 +2152,7 @@ impl Http {
         guild_id: GuildId,
         map: &impl serde::Serialize,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
@@ -2174,7 +2174,7 @@ impl Http {
     ) -> Result<()> {
         let body = to_vec(map)?;
 
-        self.wind(204, Request {
+        self.wind(Request {
             body: Some(body),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -2369,7 +2369,7 @@ impl Http {
             params = Some([("thread_id", thread_id_str.as_str())]);
         }
 
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -2581,7 +2581,7 @@ impl Http {
         rule_id: RuleId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -2751,7 +2751,7 @@ impl Http {
 
     /// Joins a thread channel.
     pub async fn join_thread_channel(&self, channel_id: ChannelId) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -2766,7 +2766,7 @@ impl Http {
 
     /// Leaves a thread channel.
     pub async fn leave_thread_channel(&self, channel_id: ChannelId) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -2785,7 +2785,7 @@ impl Http {
         channel_id: ChannelId,
         user_id: UserId,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -2805,7 +2805,7 @@ impl Http {
         channel_id: ChannelId,
         user_id: UserId,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -4150,7 +4150,7 @@ impl Http {
         user_id: UserId,
         reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: reason.map(reason_into_header),
@@ -4166,7 +4166,7 @@ impl Http {
 
     /// Leaves a guild.
     pub async fn leave_guild(&self, guild_id: GuildId) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -4217,7 +4217,7 @@ impl Http {
         message_id: MessageId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -4238,7 +4238,7 @@ impl Http {
         user_id: UserId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -4260,7 +4260,7 @@ impl Http {
         role_id: RoleId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -4335,7 +4335,7 @@ impl Http {
         guild_id: GuildId,
         integration_id: IntegrationId,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: None,
@@ -4356,7 +4356,7 @@ impl Http {
         message_id: MessageId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        self.wind(204, Request {
+        self.wind(Request {
             body: None,
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
@@ -4409,21 +4409,20 @@ impl Http {
         }
     }
 
-    /// Performs a request and then verifies that the response status code is equal to the expected
-    /// value.
+    /// Performs a request and verifies that Discord responds with [`StatusCode::NO_CONTENT`].
     ///
-    /// This is a function that performs a light amount of work and returns an empty tuple, so it's
+    /// This is a function that performs a light amount of work and returns the unit type, so it's
     /// called "self.wind" to denote that it's lightweight.
-    pub(super) async fn wind(&self, expected: u16, req: Request<'_>) -> Result<()> {
+    pub(super) async fn wind(&self, req: Request<'_>) -> Result<()> {
         let route = req.route;
         let method = req.method.reqwest_method();
         let response = self.request(req).await?;
 
-        if response.status().is_success() {
-            let response_status = response.status().as_u16();
-            if response_status != expected {
+        let status = response.status();
+        if status.is_success() {
+            if status != StatusCode::NO_CONTENT {
                 let route = route.path();
-                warn!("Mismatched successful response status from {route}! Expected {expected} but got {response_status}");
+                warn!("Mismatched successful response status from {route}! Expected 'No Content' but got {status}");
             }
 
             return Ok(());

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -666,7 +666,7 @@ impl GuildId {
         http.edit_guild_mfa_level(self, &map, reason).await
     }
 
-    /// Edits the current user's nickname for the guild.
+    /// Edits the current member's nickname for the guild.
     ///
     /// Pass [`None`] to reset the nickname.
     ///
@@ -682,17 +682,17 @@ impl GuildId {
         http: &Http,
         new_nickname: Option<&str>,
         reason: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<Member> {
         #[derive(serde::Serialize)]
-        struct EditNickname<'a> {
+        struct EditMember<'a> {
             nick: Option<&'a str>,
         }
 
-        let map = EditNickname {
+        let map = EditMember {
             nick: new_nickname,
         };
 
-        http.edit_nickname(self, &map, reason).await
+        http.edit_current_member(self, &map, reason).await
     }
 
     /// Edits a [`Role`], optionally setting its new fields.


### PR DESCRIPTION
Turns out this was always being passed 204, except one case where it should have been deserialising the `Member` return type anyway. This fixes both issues.