### PR TITLE
Add Token to serenity::all

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,8 @@ pub mod all {
     #[cfg(feature = "interactions_endpoint")]
     #[doc(no_inline)]
     pub use crate::interactions_endpoint::*;
+    #[doc(no_inline)]
+    pub use crate::secrets::*;
     #[cfg(feature = "utils")]
     #[doc(no_inline)]
     pub use crate::utils::*;


### PR DESCRIPTION
This allows it to imported via `poise::serenity_prelude` which is often `use`'d as `serenity`.