### PR TITLE
Adds "unstable-exhaustive-types" as new feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,10 @@ native_tls_backend = [
     "bytes",
 ]
 
+# Disables all "#[non_exhaustive]" macros, to ensure that all enum variants or struct fields are required when pattern matching.
+unstable_exhaustive_types = ["serenity-voice-model/unstable_exhaustive_types"]
+
+
 
 [package.metadata.docs.rs]
 features = ["full"]

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -17,7 +17,7 @@ use crate::model::id::AttachmentId;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure).
 #[derive(Clone, Debug, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[must_use]
 pub struct CreateAttachment {
     pub(crate) id: u64, // Placeholder ID will be filled in when sending the request

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -152,7 +152,7 @@ pub(crate) struct CachedShardData {
 /// [`http`]: crate::http
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Cache {
     // Temp cache:
     // ---

--- a/src/cache/settings.rs
+++ b/src/cache/settings.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 /// ```
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Settings {
     /// The maximum number of messages to store in a channel's message cache.
     ///

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -8,7 +8,7 @@ use std::fmt;
 /// [`Client`]: super::Client
 /// [`Error::Client`]: crate::Error::Client
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Error {
     /// When a shard has completely failed to reboot after resume and/or reconnect attempts.
     ShardBootFailure,

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -27,7 +27,7 @@ macro_rules! event_handler {
         }
 
         /// This enum stores every possible event that an [`EventHandler`] can receive.
-        #[non_exhaustive]
+        #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
         #[allow(clippy::large_enum_variant)] // TODO: do some boxing to fix this
         #[derive(Clone, Debug)]
         pub enum FullEvent {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -35,8 +35,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum Opcode {
         /// Dispatches an event.
         Dispatch = 0,

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ pub type Result<T, E = Error> = StdResult<T, E>;
 /// The most common error types, the [`ClientError`] and [`GatewayError`] enums, are both wrapped
 /// around this in the form of the [`Self::Client`] and [`Self::Gateway`] variants.
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Error {
     /// An error while decoding a payload.
     Decode(&'static str, Value),

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -8,7 +8,7 @@ use uwl::Stream;
 
 /// Defines how an operation on an [`Args`] method failed.
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Error<E> {
     /// "END-OF-STRING". We reached the end. There's nothing to parse anymore.
     Eos,

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -120,7 +120,7 @@ pub struct SuggestedCommandName {
 
 /// A single command containing all related pieces of information.
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Command<'a> {
     pub name: &'static str,
     pub group_name: &'static str,
@@ -172,7 +172,7 @@ impl Suggestions {
 /// Covers possible outcomes of a help-request and yields relevant data in customised textual
 /// representation.
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum CustomisedHelpData<'a> {
     /// To display suggested commands.
     SuggestedCommands { help_description: String, suggestions: Suggestions },

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -45,7 +45,7 @@ use crate::model::{guild::Role, id::RoleId};
 
 /// An enum representing all possible fail conditions under which a command won't be executed.
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum DispatchError {
     /// When a custom function check has failed.
     CheckFailed(&'static str, Reason),

--- a/src/framework/standard/structures/check.rs
+++ b/src/framework/standard/structures/check.rs
@@ -13,7 +13,7 @@ use crate::model::channel::Message;
 /// solely serves as a way to inform a user about why a check has failed and for the developer to
 /// log given failure (e.g. bugs or statistics) occurring in [`Check`]s.
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Reason {
     /// No information on the failure.
     Unknown,

--- a/src/framework/standard/structures/mod.rs
+++ b/src/framework/standard/structures/mod.rs
@@ -17,7 +17,7 @@ mod check;
 pub use self::check::*;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum OnlyIn {
     Dm,
     Guild,
@@ -129,7 +129,7 @@ impl PartialEq for HelpCommand {
 /// - Lacking required roles to execute the command.
 /// - The command can't be used in the current channel (as in `DM only` or `guild only`).
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum HelpBehaviour {
     /// The command will be displayed, hence nothing will be done.
     Nothing,

--- a/src/gateway/error.rs
+++ b/src/gateway/error.rs
@@ -8,7 +8,7 @@ use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 /// Note that - from a user standpoint - there should be no situation in which you manually handle
 /// these.
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Error {
     /// There was an error building a URL.
     BuildingUrl,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -172,7 +172,7 @@ impl From<Activity> for ActivityData {
 ///
 /// This can be useful for knowing which shards are currently "down"/"up".
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ConnectionStage {
     /// Indicator that the [`Shard`] is normally connected and is not in, e.g., a resume phase.
     Connected,
@@ -237,7 +237,7 @@ impl fmt::Display for ConnectionStage {
 }
 
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ShardAction {
     Heartbeat,
     Identify,
@@ -246,7 +246,7 @@ pub enum ShardAction {
 
 /// The type of reconnection that should be performed.
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ReconnectType {
     /// Indicator that a new connection should be made by sending an IDENTIFY.
     Reidentify,

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -10,7 +10,7 @@ use crate::internal::prelude::*;
 use crate::json::*;
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct DiscordJsonError {
     /// The error code.
     pub code: isize,
@@ -32,7 +32,7 @@ pub struct DiscordJsonSingleError {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ErrorResponse {
     pub status_code: StatusCode,
     pub url: String,
@@ -57,7 +57,7 @@ impl ErrorResponse {
 }
 
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum HttpError {
     /// When a non-successful status code was received for a request.
     UnsuccessfulRequest(ErrorResponse),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -166,7 +166,7 @@ impl LightMethod {
 }
 
 /// Representation of the method of a query to send for the [`Http::get_guilds`] function.
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum GuildPagination {
     /// The Id to get the guilds after.
     After(GuildId),
@@ -176,7 +176,7 @@ pub enum GuildPagination {
 
 /// Representation of the method of a query to send for the [`Http::get_scheduled_event_users`] and
 /// [`Http::get_bans`] functions.
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum UserPagination {
     /// The Id to get the users after.
     After(UserId),
@@ -185,7 +185,7 @@ pub enum UserPagination {
 }
 
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum MessagePagination {
     After(MessageId),
     Around(MessageId),

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -55,7 +55,7 @@ use crate::internal::prelude::*;
 /// Passed to the [`Ratelimiter::set_ratelimit_callback`] callback. If using Client, that callback
 /// is initialized to call the `EventHandler::ratelimit()` method.
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct RatelimitInfo {
     pub timeout: std::time::Duration,
     pub limit: i64,

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -25,7 +25,7 @@ use crate::model::Permissions;
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Command {
     /// The command Id.
     pub id: CommandId,
@@ -240,8 +240,7 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum CommandType {
         ChatInput = 1,
         User = 2,
@@ -258,8 +257,7 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-entry-point-command-handler-types)
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum EntryPointHandlerType {
         AppHandler = 1,
         DiscordLaunchActivity = 2,
@@ -272,7 +270,7 @@ enum_number! {
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandOption {
     /// The option type.
     #[serde(rename = "type")]
@@ -333,8 +331,7 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum CommandOptionType {
         SubCommand = 1,
         SubCommandGroup = 2,
@@ -356,7 +353,7 @@ enum_number! {
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-choice-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandOptionChoice {
     /// The choice name.
     pub name: String,
@@ -372,7 +369,7 @@ pub struct CommandOptionChoice {
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandPermissions {
     /// The id of the command.
     pub id: CommandId,
@@ -389,7 +386,7 @@ pub struct CommandPermissions {
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandPermission {
     /// The [`RoleId`] or [`UserId`], depends on `kind` value.
     pub id: CommandPermissionId,
@@ -406,8 +403,7 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum CommandPermissionType {
         Role = 1,
         User = 2,

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -47,7 +47,7 @@ use crate::utils::{CreateQuickModal, QuickModalResponse};
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandInteraction {
     /// Id of the interaction.
     pub id: InteractionId,
@@ -278,7 +278,7 @@ impl Serialize for CommandInteraction {
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandData {
     /// The Id of the invoked command.
     pub id: CommandId,
@@ -431,7 +431,7 @@ impl CommandData {
 
 /// The focused option for autocomplete interactions return by [`CommandData::autocomplete`].
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct AutocompleteOption<'a> {
     pub name: &'a str,
     pub kind: CommandOptionType,
@@ -439,7 +439,7 @@ pub struct AutocompleteOption<'a> {
 }
 
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ResolvedOption<'a> {
     pub name: &'a str,
     pub value: ResolvedValue<'a>,
@@ -447,7 +447,7 @@ pub struct ResolvedOption<'a> {
 
 /// The resolved value of a [`CommandDataOption`].
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ResolvedValue<'a> {
     Autocomplete { kind: CommandOptionType, value: &'a str },
     Boolean(bool),
@@ -465,7 +465,7 @@ pub enum ResolvedValue<'a> {
 
 /// Option value variants that couldn't be resolved by `CommandData::options()`.
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Unresolved {
     Attachment(AttachmentId),
     Channel(ChannelId),
@@ -478,7 +478,7 @@ pub enum Unresolved {
 
 /// The resolved value of a [`CommandData::target_id`].
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ResolvedTarget<'a> {
     User(&'a User, Option<&'a PartialMember>),
     Message(&'a Message),
@@ -490,7 +490,7 @@ pub enum ResolvedTarget<'a> {
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandDataResolved {
     /// The resolved users.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -523,7 +523,7 @@ pub struct CommandDataResolved {
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-interaction-data-option-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandDataOption {
     /// The name of the parameter.
     pub name: String,
@@ -648,7 +648,7 @@ impl Serialize for CommandDataOption {
 /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum CommandDataOptionValue {
     Autocomplete { kind: CommandOptionType, value: String },
     Boolean(bool),

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -10,8 +10,7 @@ enum_number! {
     /// The type of a component
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ComponentType {
         ActionRow = 1,
         Button = 2,
@@ -30,7 +29,7 @@ enum_number! {
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#action-rows).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ActionRow {
     /// Always [`ComponentType::ActionRow`]
     #[serde(rename = "type")]
@@ -45,7 +44,7 @@ pub struct ActionRow {
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#component-object-component-types).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ActionRowComponent {
     Button(Button),
     SelectMenu(SelectMenu),
@@ -161,7 +160,7 @@ impl Serialize for ButtonKind {
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Button {
     /// The component type, it will always be [`ComponentType::Button`].
     #[serde(rename = "type")]
@@ -184,8 +183,7 @@ enum_number! {
     /// The style of a button.
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ButtonStyle {
         Primary = 1,
         Secondary = 2,
@@ -201,7 +199,7 @@ enum_number! {
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct SelectMenu {
     /// The component type, which may either be [`ComponentType::StringSelect`],
     /// [`ComponentType::UserSelect`], [`ComponentType::RoleSelect`],
@@ -234,7 +232,7 @@ pub struct SelectMenu {
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct SelectMenuOption {
     /// The text displayed on this option.
     pub label: String,
@@ -254,7 +252,7 @@ pub struct SelectMenuOption {
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct InputText {
     /// The component type, it will always be [`ComponentType::InputText`].
     #[serde(rename = "type")]
@@ -298,8 +296,7 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-styles).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum InputTextStyle {
         Short = 1,
         Paragraph = 2,

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -25,7 +25,7 @@ use crate::utils::{CreateQuickModal, QuickModalResponse};
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ComponentInteraction {
     /// Id of the interaction.
     pub id: InteractionId,
@@ -336,7 +336,7 @@ impl Serialize for ComponentInteractionDataKind {
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-message-component-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ComponentInteractionData {
     /// The custom id of the component.
     pub custom_id: String,

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -20,7 +20,7 @@ use crate::model::Permissions;
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Interaction {
     Ping(PingInteraction),
     Command(CommandInteraction),
@@ -278,7 +278,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum InteractionType {
         Ping = 1,
         Command = 2,
@@ -311,7 +311,7 @@ bitflags! {
 /// [Discord Docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-authorizing-integration-owners-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum AuthorizingIntegrationOwner {
     /// The [`Application`] was installed to a guild, containing the id if invoked in said guild.
     ///
@@ -408,7 +408,7 @@ impl serde::Serialize for AuthorizingIntegrationOwners {
 )]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageInteraction {
     /// The id of the interaction.
     pub id: InteractionId,
@@ -428,7 +428,7 @@ pub struct MessageInteraction {
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageCommandInteractionMetadata {
     /// The ID of the interaction
     pub id: InteractionId,
@@ -447,7 +447,7 @@ pub struct MessageCommandInteractionMetadata {
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageComponentInteractionMetadata {
     /// The ID of the interaction
     pub id: InteractionId,
@@ -463,7 +463,7 @@ pub struct MessageComponentInteractionMetadata {
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageModalSubmitInteractionMetadata {
     /// The ID of the interaction
     pub id: InteractionId,
@@ -481,7 +481,7 @@ pub struct MessageModalSubmitInteractionMetadata {
 /// user IDs.
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum MessageInteractionMetadata {
     Command(MessageCommandInteractionMetadata),
     Component(MessageComponentInteractionMetadata),

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -30,7 +30,7 @@ use super::Permissions;
 /// Discord docs: [application field of Ready](https://discord.com/developers/docs/topics/gateway-events#ready-ready-event-fields)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PartialCurrentApplicationInfo {
     /// The unique Id of the user.
     pub id: ApplicationId,
@@ -42,7 +42,7 @@ pub struct PartialCurrentApplicationInfo {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/application#application-object-application-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CurrentApplicationInfo {
     pub id: ApplicationId,
     pub name: String,
@@ -106,7 +106,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum InstallationContext {
         Guild = 0,
         User = 1,
@@ -121,7 +121,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum InteractionContext {
         /// Interaction can be used within servers
         Guild = 0,
@@ -145,7 +145,7 @@ pub struct InstallationContextConfig {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-team-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Team {
     /// The icon of the team.
     pub icon: Option<ImageHash>,
@@ -163,7 +163,7 @@ pub struct Team {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-team-member-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct TeamMember {
     /// The member's membership state.
     pub membership_state: MembershipState,
@@ -184,7 +184,7 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum MembershipState {
         Invited = 1,
         Accepted = 2,
@@ -194,7 +194,7 @@ enum_number! {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum TeamMemberRole {
     Admin,
     Developer,
@@ -274,7 +274,7 @@ bitflags! {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/application#install-params-object-install-params-structure).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct InstallParams {
     pub scopes: Vec<Scope>,
     pub permissions: Permissions,

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -19,7 +19,7 @@ use crate::model::prelude::*;
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ModalInteraction {
     /// Id of the interaction.
     pub id: InteractionId,
@@ -216,7 +216,7 @@ impl Serialize for ModalInteraction {
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ModalInteractionData {
     /// The custom id of the modal
     pub custom_id: String,

--- a/src/model/application/oauth.rs
+++ b/src/model/application/oauth.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// [Discord docs](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Scope {
     /// For oauth2 bots, this puts the bot in the user's selected guild by default.
     #[serde(rename = "bot")]

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -7,7 +7,7 @@ use crate::model::id::{ApplicationId, InteractionId};
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PingInteraction {
     /// Id of the interaction.
     pub id: InteractionId,

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -31,7 +31,7 @@ where
 /// [`Embed`]: super::Embed
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Attachment {
     /// The unique ID given to this attachment.
     pub id: AttachmentId,

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -13,7 +13,7 @@ use crate::model::{Colour, Timestamp};
 /// [slack's attachments]: https://api.slack.com/docs/message-attachments
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Embed {
     /// The title of the embed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,7 +74,7 @@ pub struct Embed {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EmbedAuthor {
     /// The name of the author.
     pub name: String,
@@ -96,7 +96,7 @@ pub struct EmbedAuthor {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EmbedField {
     /// The name of the field.
     ///
@@ -138,7 +138,7 @@ impl EmbedField {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EmbedFooter {
     /// The associated text with the footer.
     pub text: String,
@@ -157,7 +157,7 @@ pub struct EmbedFooter {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-image-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EmbedImage {
     /// Source URL of the image.
     ///
@@ -176,7 +176,7 @@ pub struct EmbedImage {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EmbedProvider {
     /// The name of the provider.
     pub name: Option<String>,
@@ -189,7 +189,7 @@ pub struct EmbedProvider {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EmbedThumbnail {
     /// The source URL of the thumbnail.
     ///
@@ -208,7 +208,7 @@ pub struct EmbedThumbnail {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EmbedVideo {
     /// The source URL of the video.
     pub url: String,

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -40,7 +40,7 @@ use crate::model::prelude::*;
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildChannel {
     /// The unique Id of the channel.
     pub id: ChannelId,
@@ -182,7 +182,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ForumLayoutType {
         /// No default has been set for forum channel.
         #[default]
@@ -1208,7 +1208,7 @@ impl fmt::Display for GuildChannel {
 /// [subset description](https://discord.com/developers/docs/topics/gateway#thread-delete)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PartialGuildChannel {
     /// The channel Id.
     pub id: ChannelId,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -32,7 +32,7 @@ use crate::utils;
 /// [extra fields](https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Message {
     /// The unique Id of the message. Can be used to calculate the creation date of the message.
     pub id: MessageId,
@@ -932,7 +932,7 @@ impl From<&Message> for MessageId {
 /// [reaction type]: ReactionType
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageReaction {
     /// The amount of the type of reaction that have been sent for the associated message
     /// including super reactions.
@@ -956,7 +956,7 @@ pub struct MessageReaction {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#reaction-count-details-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CountDetails {
     pub burst: u64,
     pub normal: u64,
@@ -969,7 +969,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum MessageType {
         /// A regular message.
         #[default]
@@ -1040,7 +1040,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum MessageActivityKind {
         Join = 1,
         Spectate = 2,
@@ -1056,7 +1056,7 @@ enum_number! {
 /// [subset undocumented](https://discord.com/developers/docs/resources/channel#message-object-message-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageApplication {
     /// ID of the application.
     pub id: ApplicationId,
@@ -1075,7 +1075,7 @@ pub struct MessageApplication {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-activity-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageActivity {
     /// Kind of message activity.
     #[serde(rename = "type")]
@@ -1091,7 +1091,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum MessageReferenceKind {
         #[default]
         Default = 0,
@@ -1105,7 +1105,7 @@ enum_number! {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageReference {
     /// The Type of Message Reference
     #[serde(rename = "type", default = "MessageReferenceKind::default")]
@@ -1180,7 +1180,7 @@ impl From<(ChannelId, MessageId)> for MessageReference {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-mention-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ChannelMention {
     /// ID of the channel.
     pub id: ChannelId,
@@ -1198,7 +1198,7 @@ pub struct ChannelMention {
 /// For field documentation, see [`Message`].
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageSnapshot {
     pub content: String,
     pub timestamp: Timestamp,
@@ -1345,7 +1345,7 @@ pub struct RoleSubscriptionData {
 /// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Poll {
     pub question: PollMedia,
     pub answers: Vec<PollAnswer>,
@@ -1366,7 +1366,7 @@ pub struct Poll {
 /// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-media-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PollMedia {
     pub text: Option<String>,
     pub emoji: Option<PollMediaEmoji>,
@@ -1419,7 +1419,7 @@ impl From<EmojiId> for PollMediaEmoji {
 /// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-answer-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PollAnswer {
     pub answer_id: AnswerId,
     pub poll_media: PollMedia,
@@ -1434,7 +1434,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum PollLayoutType {
         #[default]
         Default = 1,
@@ -1449,7 +1449,7 @@ enum_number! {
 /// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-results-object-poll-results-object-structure)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PollResults {
     pub is_finalized: bool,
     pub answer_counts: Vec<PollAnswerCount>,
@@ -1460,7 +1460,7 @@ pub struct PollResults {
 /// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-results-object-poll-answer-count-object-structure)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PollAnswerCount {
     pub id: AnswerId,
     pub count: u64,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -36,7 +36,7 @@ pub type AttachmentType<'a> = crate::builder::CreateAttachment;
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[allow(clippy::large_enum_variant)] // https://github.com/rust-lang/rust-clippy/issues/9798
 pub enum Channel {
     /// A channel within a [`Guild`].
@@ -222,7 +222,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ChannelType {
         /// An indicator that the channel is a text [`GuildChannel`].
         #[default]
@@ -353,7 +353,7 @@ pub struct PermissionOverwrite {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object-overwrite-structure) (field `type`).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum PermissionOverwriteType {
     /// A member which is having its permission overwrites edited.
     Member(UserId),
@@ -368,7 +368,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum VideoQualityMode {
         /// An indicator that the video quality is chosen by Discord for optimal
         /// performance.
@@ -386,7 +386,7 @@ enum_number! {
     #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum StageInstancePrivacyLevel {
         /// The Stage instance is visible publicly. (deprecated)
         Public = 1,
@@ -404,7 +404,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u16", into = "u16")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum AutoArchiveDuration {
         None = 0,
         OneHour = 60,
@@ -418,7 +418,7 @@ enum_number! {
 /// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct StageInstance {
     /// The Id of the stage instance.
     pub id: StageInstanceId,
@@ -441,7 +441,7 @@ pub struct StageInstance {
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadMetadata {
     /// Whether the thread is archived.
     pub archived: bool,
@@ -473,7 +473,7 @@ pub struct ThreadMetadata {
 /// [4](https://discord.com/developers/docs/resources/channel#list-private-archived-threads-response-body)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadsData {
     /// The threads channels.
     pub threads: Vec<GuildChannel>,
@@ -490,7 +490,7 @@ pub struct ThreadsData {
 /// [docs]()
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ForumEmoji {
     /// The id of a guild's custom emoji.
     Id(EmojiId),
@@ -543,7 +543,7 @@ impl<'de> serde::Deserialize<'de> for ForumEmoji {
 /// See [Discord docs](https://discord.com/developers/docs/resources/channel#forum-tag-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ForumTag {
     /// The id of the tag.
     pub id: ForumTagId,
@@ -564,7 +564,7 @@ enum_number! {
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum SortOrder {
         /// Sort forum posts by activity.
         LatestActivity = 0,

--- a/src/model/channel/partial_channel.rs
+++ b/src/model/channel/partial_channel.rs
@@ -8,7 +8,7 @@ use crate::model::Permissions;
 /// [subset specification](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PartialChannel {
     /// The channel Id.
     pub id: ChannelId,
@@ -33,7 +33,7 @@ pub struct PartialChannel {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#followed-channel-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct FollowedChannel {
     /// The source news channel
     pub channel_id: ChannelId,

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -16,7 +16,7 @@ use crate::model::utils::single_recipient;
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PrivateChannel {
     /// The unique Id of the private channel.
     ///

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -23,7 +23,7 @@ use crate::model::utils::discord_colours_opt;
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Reaction {
     /// The Id of the [`User`] that sent the reaction.
     ///
@@ -63,7 +63,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ReactionTypes {
         Normal = 0,
         Burst = 1,
@@ -285,7 +285,7 @@ impl Reaction {
 /// The type of a [`Reaction`] sent.
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ReactionType {
     /// A reaction with a [`Guild`]s custom [`Emoji`], which is unique to the guild.
     Custom {

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -6,7 +6,7 @@ use super::prelude::*;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-connection-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Connection {
     /// The ID of the account on the other side of this connection.
     pub id: String,
@@ -40,8 +40,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-visibility-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ConnectionVisibility {
         /// Invisible to everyone except the user themselves
         None = 0,

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -46,7 +46,7 @@ use super::Permissions;
 /// [`GuildId::ban`]: super::id::GuildId::ban
 /// [`model`]: crate::model
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Error {
     /// When attempting to delete below or above the minimum or maximum allowed number of messages.
     BulkDeleteAmount,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -26,7 +26,7 @@ use crate::model::utils::{
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct CommandPermissionsUpdateEvent {
     pub permission: CommandPermissions,
 }
@@ -37,7 +37,7 @@ pub struct CommandPermissionsUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct AutoModRuleCreateEvent {
     pub rule: Rule,
 }
@@ -48,7 +48,7 @@ pub struct AutoModRuleCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct AutoModRuleUpdateEvent {
     pub rule: Rule,
 }
@@ -59,7 +59,7 @@ pub struct AutoModRuleUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct AutoModRuleDeleteEvent {
     pub rule: Rule,
 }
@@ -70,7 +70,7 @@ pub struct AutoModRuleDeleteEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct AutoModActionExecutionEvent {
     pub execution: ActionExecution,
 }
@@ -86,7 +86,7 @@ pub struct AutoModActionExecutionEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ChannelCreateEvent {
     /// The channel that was created.
     pub channel: GuildChannel,
@@ -98,7 +98,7 @@ pub struct ChannelCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ChannelDeleteEvent {
     pub channel: GuildChannel,
 }
@@ -108,7 +108,7 @@ pub struct ChannelDeleteEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-pins-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ChannelPinsUpdateEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
@@ -121,7 +121,7 @@ pub struct ChannelPinsUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ChannelUpdateEvent {
     pub channel: GuildChannel,
 }
@@ -131,7 +131,7 @@ pub struct ChannelUpdateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildAuditLogEntryCreateEvent {
     pub guild_id: GuildId,
     #[serde(flatten)]
@@ -143,7 +143,7 @@ pub struct GuildAuditLogEntryCreateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-ban-add).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildBanAddEvent {
     pub guild_id: GuildId,
     pub user: User,
@@ -154,7 +154,7 @@ pub struct GuildBanAddEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildBanRemoveEvent {
     pub guild_id: GuildId,
     pub user: User,
@@ -166,7 +166,7 @@ pub struct GuildBanRemoveEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildCreateEvent {
     pub guild: Guild,
 }
@@ -190,7 +190,7 @@ impl<'de> Deserialize<'de> for GuildCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildDeleteEvent {
     pub guild: UnavailableGuild,
 }
@@ -200,7 +200,7 @@ pub struct GuildDeleteEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildEmojisUpdateEvent {
     #[serde(with = "emojis")]
     pub emojis: HashMap<EmojiId, Emoji>,
@@ -212,7 +212,7 @@ pub struct GuildEmojisUpdateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildIntegrationsUpdateEvent {
     pub guild_id: GuildId,
 }
@@ -223,7 +223,7 @@ pub struct GuildIntegrationsUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildMemberAddEvent {
     pub member: Member,
 }
@@ -233,7 +233,7 @@ pub struct GuildMemberAddEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-remove).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildMemberRemoveEvent {
     pub guild_id: GuildId,
     pub user: User,
@@ -244,7 +244,7 @@ pub struct GuildMemberRemoveEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildMemberUpdateEvent {
     pub guild_id: GuildId,
     pub nick: Option<String>,
@@ -269,7 +269,7 @@ pub struct GuildMemberUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildMembersChunkEvent {
     /// ID of the guild.
     pub guild_id: GuildId,
@@ -319,7 +319,7 @@ struct RoleEventHelper {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildRoleCreateEvent {
     pub role: Role,
 }
@@ -340,7 +340,7 @@ impl<'de> Deserialize<'de> for GuildRoleCreateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildRoleDeleteEvent {
     pub guild_id: GuildId,
     pub role_id: RoleId,
@@ -351,7 +351,7 @@ pub struct GuildRoleDeleteEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildRoleUpdateEvent {
     pub role: Role,
 }
@@ -372,7 +372,7 @@ impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildStickersUpdateEvent {
     #[serde(with = "stickers")]
     pub stickers: HashMap<StickerId, Sticker>,
@@ -384,7 +384,7 @@ pub struct GuildStickersUpdateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#invite-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct InviteCreateEvent {
     /// Whether or not the invite is temporary (invited users will be kicked on disconnect unless
     /// Channel the invite is for.
@@ -418,7 +418,7 @@ pub struct InviteCreateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#invite-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct InviteDeleteEvent {
     pub channel_id: ChannelId,
     pub guild_id: Option<GuildId>,
@@ -431,7 +431,7 @@ pub struct InviteDeleteEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildUpdateEvent {
     /// GuildUpdateEvent doesn't have GuildCreate's extra fields, so this is a partial guild
     pub guild: PartialGuild,
@@ -443,7 +443,7 @@ pub struct GuildUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageCreateEvent {
     pub message: Message,
 }
@@ -453,7 +453,7 @@ pub struct MessageCreateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-delete-bulk).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageDeleteBulkEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
@@ -465,7 +465,7 @@ pub struct MessageDeleteBulkEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageDeleteEvent {
     pub guild_id: Option<GuildId>,
     pub channel_id: ChannelId,
@@ -493,7 +493,7 @@ where
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessageUpdateEvent {
     pub id: MessageId,
     pub channel_id: ChannelId,
@@ -627,7 +627,7 @@ impl MessageUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PresenceUpdateEvent {
     pub presence: Presence,
 }
@@ -637,7 +637,7 @@ pub struct PresenceUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PresencesReplaceEvent {
     pub presences: Vec<Presence>,
 }
@@ -649,7 +649,7 @@ pub struct PresencesReplaceEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ReactionAddEvent {
     pub reaction: Reaction,
 }
@@ -661,7 +661,7 @@ pub struct ReactionAddEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ReactionRemoveEvent {
     // The Discord API doesn't share the same schema for Reaction Remove Event and Reaction Add
     // Event (which [`Reaction`] is), but the two currently match up well enough, so re-using the
@@ -675,7 +675,7 @@ pub struct ReactionRemoveEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-all).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ReactionRemoveAllEvent {
     pub channel_id: ChannelId,
     pub message_id: MessageId,
@@ -689,7 +689,7 @@ pub struct ReactionRemoveAllEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ReactionRemoveEmojiEvent {
     pub reaction: Reaction,
 }
@@ -702,7 +702,7 @@ pub struct ReactionRemoveEmojiEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ReadyEvent {
     pub ready: Ready,
 }
@@ -712,7 +712,7 @@ pub struct ReadyEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#resumed).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ResumedEvent {}
 
 /// Requires [`GatewayIntents::GUILD_MESSAGE_TYPING`] or [`GatewayIntents::DIRECT_MESSAGE_TYPING`].
@@ -720,7 +720,7 @@ pub struct ResumedEvent {}
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#typing-start).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct TypingStartEvent {
     /// ID of the channel.
     pub channel_id: ChannelId,
@@ -736,7 +736,7 @@ pub struct TypingStartEvent {
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct UnknownEvent {
     #[serde(rename = "t")]
     pub kind: String,
@@ -752,7 +752,7 @@ pub struct UnknownEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct UserUpdateEvent {
     pub current_user: CurrentUser,
 }
@@ -762,7 +762,7 @@ pub struct UserUpdateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#voice-server-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct VoiceServerUpdateEvent {
     pub token: String,
     pub guild_id: Option<GuildId>,
@@ -775,7 +775,7 @@ pub struct VoiceServerUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct VoiceStateUpdateEvent {
     pub voice_state: VoiceState,
 }
@@ -785,7 +785,7 @@ pub struct VoiceStateUpdateEvent {
 /// [Incomplete documentation](https://github.com/discord/discord-api-docs/pull/6398)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct VoiceChannelStatusUpdateEvent {
     pub status: Option<String>,
     pub id: ChannelId,
@@ -797,7 +797,7 @@ pub struct VoiceChannelStatusUpdateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#webhooks-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct WebhookUpdateEvent {
     pub channel_id: ChannelId,
     pub guild_id: GuildId,
@@ -809,7 +809,7 @@ pub struct WebhookUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct InteractionCreateEvent {
     pub interaction: Interaction,
 }
@@ -820,7 +820,7 @@ pub struct InteractionCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct IntegrationCreateEvent {
     pub integration: Integration,
 }
@@ -831,7 +831,7 @@ pub struct IntegrationCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct IntegrationUpdateEvent {
     pub integration: Integration,
 }
@@ -841,7 +841,7 @@ pub struct IntegrationUpdateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#integration-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct IntegrationDeleteEvent {
     pub id: IntegrationId,
     pub guild_id: GuildId,
@@ -854,7 +854,7 @@ pub struct IntegrationDeleteEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct StageInstanceCreateEvent {
     pub stage_instance: StageInstance,
 }
@@ -865,7 +865,7 @@ pub struct StageInstanceCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct StageInstanceUpdateEvent {
     pub stage_instance: StageInstance,
 }
@@ -876,7 +876,7 @@ pub struct StageInstanceUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct StageInstanceDeleteEvent {
     pub stage_instance: StageInstance,
 }
@@ -887,7 +887,7 @@ pub struct StageInstanceDeleteEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadCreateEvent {
     pub thread: GuildChannel,
 }
@@ -898,7 +898,7 @@ pub struct ThreadCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadUpdateEvent {
     pub thread: GuildChannel,
 }
@@ -909,7 +909,7 @@ pub struct ThreadUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadDeleteEvent {
     pub thread: PartialGuildChannel,
 }
@@ -919,7 +919,7 @@ pub struct ThreadDeleteEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-list-sync).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadListSyncEvent {
     /// The guild Id.
     pub guild_id: GuildId,
@@ -941,7 +941,7 @@ pub struct ThreadListSyncEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadMemberUpdateEvent {
     pub member: ThreadMember,
 }
@@ -951,7 +951,7 @@ pub struct ThreadMemberUpdateEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-members-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadMembersUpdateEvent {
     /// The id of the thread.
     pub id: ChannelId,
@@ -976,7 +976,7 @@ pub struct ThreadMembersUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildScheduledEventCreateEvent {
     pub event: ScheduledEvent,
 }
@@ -987,7 +987,7 @@ pub struct GuildScheduledEventCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildScheduledEventUpdateEvent {
     pub event: ScheduledEvent,
 }
@@ -998,7 +998,7 @@ pub struct GuildScheduledEventUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildScheduledEventDeleteEvent {
     pub event: ScheduledEvent,
 }
@@ -1008,7 +1008,7 @@ pub struct GuildScheduledEventDeleteEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildScheduledEventUserAddEvent {
     #[serde(rename = "guild_scheduled_event_id")]
     pub scheduled_event_id: ScheduledEventId,
@@ -1021,7 +1021,7 @@ pub struct GuildScheduledEventUserAddEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildScheduledEventUserRemoveEvent {
     #[serde(rename = "guild_scheduled_event_id")]
     pub scheduled_event_id: ScheduledEventId,
@@ -1035,7 +1035,7 @@ pub struct GuildScheduledEventUserRemoveEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EntitlementCreateEvent {
     pub entitlement: Entitlement,
 }
@@ -1046,7 +1046,7 @@ pub struct EntitlementCreateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EntitlementUpdateEvent {
     pub entitlement: Entitlement,
 }
@@ -1057,7 +1057,7 @@ pub struct EntitlementUpdateEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EntitlementDeleteEvent {
     pub entitlement: Entitlement,
 }
@@ -1067,7 +1067,7 @@ pub struct EntitlementDeleteEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-poll-vote-add)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessagePollVoteAddEvent {
     pub user_id: UserId,
     pub channel_id: ChannelId,
@@ -1081,7 +1081,7 @@ pub struct MessagePollVoteAddEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-poll-vote-remove)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct MessagePollVoteRemoveEvent {
     pub user_id: UserId,
     pub channel_id: ChannelId,
@@ -1094,7 +1094,7 @@ pub struct MessagePollVoteRemoveEvent {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[serde(untagged)]
 pub enum GatewayEvent {
     Dispatch(u64, Event),
@@ -1149,7 +1149,7 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[serde(tag = "t", content = "d")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Event {
     /// The permissions of an [`Command`] was changed.
     ///

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -17,7 +17,7 @@ use super::utils::*;
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#get-gateway-bot-json-response).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct BotGateway {
     /// The gateway to connect to.
     pub url: String,
@@ -33,7 +33,7 @@ pub struct BotGateway {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Activity {
     /// The ID of the application for the activity.
     #[serde(deserialize_with = "deserialize_buggy_id")]
@@ -84,7 +84,7 @@ pub struct Activity {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-buttons).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ActivityButton {
     /// The text shown on the button.
     pub label: String,
@@ -100,7 +100,7 @@ pub struct ActivityButton {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-assets).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ActivityAssets {
     /// The ID for a large asset of the activity, usually a snowflake.
     pub large_image: Option<String>,
@@ -145,7 +145,7 @@ bitflags! {
 /// [Discord docs](https://discord.com/developers/docs/game-sdk/activities#data-models-activityparty-struct).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ActivityParty {
     /// The ID of the party.
     pub id: Option<String>,
@@ -158,7 +158,7 @@ pub struct ActivityParty {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-secrets).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ActivitySecrets {
     /// The secret for joining a party.
     pub join: Option<String>,
@@ -174,7 +174,7 @@ pub struct ActivitySecrets {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-emoji).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ActivityEmoji {
     /// The name of the emoji.
     pub name: String,
@@ -189,7 +189,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ActivityType {
         /// An indicator that the user is playing a game.
         #[default]
@@ -214,7 +214,7 @@ enum_number! {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#get-gateway-example-response).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Gateway {
     /// The gateway to connect to.
     pub url: String,
@@ -225,7 +225,7 @@ pub struct Gateway {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#client-status-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ClientStatus {
     pub desktop: Option<OnlineStatus>,
     pub mobile: Option<OnlineStatus>,
@@ -241,7 +241,7 @@ pub struct ClientStatus {
 /// [modification description](https://discord.com/developers/docs/topics/gateway-events#presence-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PresenceUser {
     pub id: UserId,
     pub avatar: Option<ImageHash>,
@@ -313,7 +313,7 @@ impl PresenceUser {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#presence-update-presence-update-event-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Presence {
     /// Data about the associated user.
     pub user: PresenceUser,
@@ -333,7 +333,7 @@ pub struct Presence {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#ready-ready-event-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Ready {
     /// API version
     #[serde(rename = "v")]
@@ -356,7 +356,7 @@ pub struct Ready {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#session-start-limit-object-session-start-limit-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct SessionStartLimit {
     /// The number of sessions that you can still initiate within the current ratelimit period.
     pub remaining: u64,
@@ -408,7 +408,7 @@ impl serde::Serialize for ShardInfo {
 /// [Discord docs](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytimestamps-struct).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ActivityTimestamps {
     pub end: Option<u64>,
     pub start: Option<u64>,

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -17,7 +17,7 @@ use crate::model::{Permissions, Timestamp};
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct AffectedRole {
     pub id: RoleId,
     pub name: String,
@@ -26,7 +26,7 @@ pub struct AffectedRole {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, PartialEq, Eq, Serialize, Clone)]
 #[serde(untagged)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum EntityType {
     Int(u64),
     Str(String),
@@ -48,7 +48,7 @@ macro_rules! generate_change {
         #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
         // serde_json's Value impls Eq, simd-json's Value doesn't
         #[cfg_attr(not(feature = "simd_json"), derive(Eq))]
-        #[non_exhaustive]
+        #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
         #[serde(tag = "key")]
         #[serde(rename_all = "snake_case")]
         pub enum Change {

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -17,7 +17,7 @@ use crate::model::prelude::*;
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Action {
     GuildUpdate,
     Channel(ChannelAction),
@@ -107,7 +107,7 @@ impl Serialize for Action {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum ChannelAction {
     Create = 10,
@@ -118,7 +118,7 @@ pub enum ChannelAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum ChannelOverwriteAction {
     Create = 13,
@@ -129,7 +129,7 @@ pub enum ChannelOverwriteAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum MemberAction {
     Kick = 20,
@@ -146,7 +146,7 @@ pub enum MemberAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum RoleAction {
     Create = 30,
@@ -157,7 +157,7 @@ pub enum RoleAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum InviteAction {
     Create = 40,
@@ -168,7 +168,7 @@ pub enum InviteAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum WebhookAction {
     Create = 50,
@@ -179,7 +179,7 @@ pub enum WebhookAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum EmojiAction {
     Create = 60,
@@ -190,7 +190,7 @@ pub enum EmojiAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum MessageAction {
     Delete = 72,
@@ -202,7 +202,7 @@ pub enum MessageAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum IntegrationAction {
     Create = 80,
@@ -213,7 +213,7 @@ pub enum IntegrationAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum StageInstanceAction {
     Create = 83,
@@ -224,7 +224,7 @@ pub enum StageInstanceAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum StickerAction {
     Create = 90,
@@ -235,7 +235,7 @@ pub enum StickerAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum ScheduledEventAction {
     Create = 100,
@@ -246,7 +246,7 @@ pub enum ScheduledEventAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum ThreadAction {
     Create = 110,
@@ -257,7 +257,7 @@ pub enum ThreadAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum AutoModAction {
     RuleCreate = 140,
@@ -271,7 +271,7 @@ pub enum AutoModAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum CreatorMonetizationAction {
     RequestCreated = 150,
@@ -281,7 +281,7 @@ pub enum CreatorMonetizationAction {
 /// [Incomplete documentation](https://github.com/discord/discord-api-docs/pull/6398)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum VoiceChannelStatusAction {
     StatusUpdate = 192,
@@ -291,7 +291,7 @@ pub enum VoiceChannelStatusAction {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct AuditLogs {
     /// List of audit log entries, sorted from most to least recent.
     #[serde(rename = "audit_log_entries")]
@@ -322,7 +322,7 @@ pub struct AuditLogs {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-object-example-partial-integration-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PartialIntegration {
     pub id: IntegrationId,
     pub name: String,
@@ -335,7 +335,7 @@ pub struct PartialIntegration {
 /// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct AuditLogEntry {
     /// Determines to what entity an [`Self::action`] was used on.
     pub target_id: Option<GenericId>,
@@ -358,7 +358,7 @@ pub struct AuditLogEntry {
 // TODO: should be renamed to a less ambiguous name
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Options {
     /// Name of the Auto Moderation rule that was triggered.
     pub auto_moderation_rule_name: Option<String>,

--- a/src/model/guild/automod.rs
+++ b/src/model/guild/automod.rs
@@ -16,7 +16,7 @@ use crate::model::id::*;
 // TODO: should be renamed to a less ambiguous name
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Rule {
     /// ID of the rule.
     pub id: RuleId,
@@ -51,7 +51,7 @@ pub struct Rule {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum EventType {
     MessageSend,
     Unknown(u8),
@@ -82,7 +82,7 @@ impl From<EventType> for u8 {
 /// [metadata](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Trigger {
     Keyword {
         /// Substrings which will be searched for in content (Maximum of 1000)
@@ -222,7 +222,7 @@ impl Trigger {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum TriggerType {
     Keyword,
     Spam,
@@ -265,7 +265,7 @@ impl From<TriggerType> for u8 {
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct TriggerMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keyword_filter: Option<Vec<String>>,
@@ -285,7 +285,7 @@ pub struct TriggerMetadata {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum KeywordPresetType {
     /// Words that may be considered forms of swearing or cursing
     Profanity,
@@ -323,7 +323,7 @@ impl From<KeywordPresetType> for u8 {
 /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Action {
     /// Blocks the content of a message according to the rule.
     BlockMessage {
@@ -353,7 +353,7 @@ pub enum Action {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ActionExecution {
     /// ID of the guild in which the action was executed.
     pub guild_id: GuildId,
@@ -496,8 +496,7 @@ enum_number! {
     ///
     /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-    #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ActionType {
         BlockMessage = 1,
         Alert = 2,

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -20,7 +20,7 @@ use crate::model::ModelError;
 /// [Discord docs](https://discord.com/developers/docs/resources/emoji#emoji-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Emoji {
     /// Whether the emoji is animated.
     #[serde(default)]

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1855,7 +1855,7 @@ impl<H: AsRef<Http>> MembersIter<H> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum GuildWidgetStyle {
     Shield,
     Banner1,

--- a/src/model/guild/guild_preview.rs
+++ b/src/model/guild/guild_preview.rs
@@ -9,7 +9,7 @@ use crate::model::sticker::Sticker;
 ///
 /// [`Guild`]: super::Guild
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildPreview {
     /// The guild Id.
     pub id: GuildId,

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -7,7 +7,7 @@ use crate::model::prelude::*;
 /// [extra fields 2](https://discord.com/developers/docs/topics/gateway-events#integration-update),
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Integration {
     pub id: IntegrationId,
     pub name: String,
@@ -38,7 +38,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum IntegrationExpireBehaviour {
         RemoveRole = 0,
         Kick = 1,
@@ -58,7 +58,7 @@ impl From<Integration> for IntegrationId {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-account-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct IntegrationAccount {
     pub id: String,
     pub name: String,
@@ -69,7 +69,7 @@ pub struct IntegrationAccount {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-application-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct IntegrationApplication {
     pub id: ApplicationId,
     pub name: String,

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -20,7 +20,7 @@ use crate::model::utils::avatar_url;
 /// [extra fields](https://discord.com/developers/docs/topics/gateway-events#guild-member-add-guild-member-add-extra-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Member {
     /// Attached User struct.
     pub user: User,
@@ -564,7 +564,7 @@ impl fmt::Display for Member {
 /// [link](https://discord.com/developers/docs/interactions/receiving-and-responding#message-interaction-object))
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PartialMember {
     /// Indicator of whether the member can hear in voice channels.
     #[serde(default)]
@@ -645,7 +645,7 @@ impl From<Member> for PartialMember {
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PartialThreadMember {
     /// The time the current user last joined the thread.
     pub join_timestamp: Timestamp,
@@ -659,7 +659,7 @@ pub struct PartialThreadMember {
 /// [extra fields](https://discord.com/developers/docs/topics/gateway-events#thread-member-update-thread-member-update-event-extra-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ThreadMember {
     #[serde(flatten)]
     pub inner: PartialThreadMember,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -67,7 +67,7 @@ use crate::model::utils::*;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#ban-object).
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Ban {
     /// The reason given for this ban.
     pub reason: Option<String>,
@@ -80,7 +80,7 @@ pub struct Ban {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#bulk-guild-ban).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct BulkBanResponse {
     /// The users that were successfully banned.
     pub banned_users: Vec<UserId>,
@@ -104,7 +104,7 @@ pub struct AfkMetadata {
 /// [extension](https://discord.com/developers/docs/topics/gateway-events#guild-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Guild {
     /// The unique Id identifying the guild.
     ///
@@ -2662,7 +2662,7 @@ fn closest_to_origin(origin: &str, word_a: &str, word_b: &str) -> std::cmp::Orde
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-widget-settings-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildWidget {
     /// Whether the widget is enabled.
     pub enabled: bool,
@@ -2675,7 +2675,7 @@ pub struct GuildWidget {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#get-guild-prune-count).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildPrune {
     /// The number of members that would be pruned by the operation.
     pub pruned: u64,
@@ -2687,7 +2687,7 @@ pub struct GuildPrune {
 /// [subset example](https://discord.com/developers/docs/resources/user#get-current-user-guilds-example-partial-guild).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildInfo {
     /// The unique Id of the guild.
     ///
@@ -2732,7 +2732,7 @@ impl InviteGuild {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#unavailable-guild-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct UnavailableGuild {
     /// The Id of the [`Guild`] that may be unavailable.
     pub id: GuildId,
@@ -2748,7 +2748,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum DefaultMessageNotificationLevel {
         /// Receive notifications for everything.
         #[default]
@@ -2766,7 +2766,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ExplicitContentFilter {
         /// Don't scan any messages.
         #[default]
@@ -2786,7 +2786,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum MfaLevel {
         /// MFA is disabled.
         #[default]
@@ -2805,7 +2805,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum VerificationLevel {
         /// Does not require any verification.
         #[default]
@@ -2829,7 +2829,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum NsfwLevel {
         /// The nsfw level is not specified.
         #[default]
@@ -2851,7 +2851,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u16", into = "u16")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum AfkTimeout {
         OneMinute = 60,
         FiveMinutes = 300,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -33,7 +33,7 @@ use crate::model::utils::{emojis, roles, stickers};
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct PartialGuild {
     // ======
     // These fields are copy-pasted from the top part of Guild, and the omitted fields filled in

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -5,7 +5,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum PremiumTier {
         /// Guild has not unlocked any Server Boost perks
         #[default]

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -26,7 +26,7 @@ fn minus1_as_0<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<u16,
 /// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Role {
     /// The Id of the role. Can be used to calculate the role's creation date.
     pub id: RoleId,
@@ -218,7 +218,7 @@ impl From<&Role> for RoleId {
 /// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure).
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct RoleTags {
     /// The Id of the bot the [`Role`] belongs to.
     pub bot_id: Option<UserId>,

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ScheduledEvent {
     /// The Id of the scheduled event.
     pub id: ScheduledEventId,
@@ -58,7 +58,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ScheduledEventStatus {
         Scheduled = 1,
         Active = 2,
@@ -73,7 +73,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ScheduledEventType {
         StageInstance = 1,
         Voice = 2,
@@ -85,7 +85,7 @@ enum_number! {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ScheduledEventMetadata {
     #[serde(default)]
     pub location: Option<String>,
@@ -94,7 +94,7 @@ pub struct ScheduledEventMetadata {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-user-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct ScheduledEventUser {
     #[serde(rename = "guild_scheduled_event_id")]
     pub event_id: ScheduledEventId,
@@ -109,7 +109,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum ScheduledEventPrivacyLevel {
         GuildOnly = 2,
         _ => Unknown(u8),

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -7,7 +7,7 @@ use crate::model::id::{ChannelId, EmojiId};
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildWelcomeScreen {
     /// The server description shown in the welcome screen.
     pub description: Option<String>,
@@ -22,7 +22,7 @@ pub struct GuildWelcomeScreen {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct GuildWelcomeChannel {
     /// The channel Id.
     pub channel_id: ChannelId,
@@ -92,7 +92,7 @@ impl Serialize for GuildWelcomeChannel {
 /// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum GuildWelcomeChannelEmoji {
     /// A custom emoji.
     Custom { id: EmojiId, name: String },

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -16,7 +16,7 @@ use crate::internal::prelude::*;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Invite {
     /// The approximate number of [`Member`]s in the related [`Guild`].
     pub approximate_member_count: Option<u64>,
@@ -195,7 +195,7 @@ impl Invite {
 /// A minimal amount of information about the channel an invite points to.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-example-invite-object).
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InviteChannel {
     pub id: ChannelId,
@@ -208,7 +208,7 @@ pub struct InviteChannel {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-example-invite-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct InviteGuild {
     pub id: GuildId,
     pub name: String,
@@ -275,7 +275,7 @@ impl InviteGuild {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-metadata-object) (extends [`Invite`] fields).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct RichInvite {
     /// A representation of the minimal amount of information needed about the channel being
     /// invited to.
@@ -390,7 +390,7 @@ impl RichInvite {
 
 /// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-stage-instance-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct InviteStageInstance {
     /// The members speaking in the Stage
     pub members: Vec<PartialMember>,
@@ -409,7 +409,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum InviteTargetType {
         Stream = 1,
         EmbeddedApplication = 2,

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -162,7 +162,7 @@ impl std::str::FromStr for ImageHash {
 ///
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-emoji).
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct EmojiIdentifier {
     /// Whether the emoji is animated
     pub animated: bool,
@@ -234,7 +234,7 @@ impl FromStr for EmojiIdentifier {
 ///
 /// [Discord docs](https://discordstatus.com/api) (see "Unresolved incident" example)
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Incident {
     pub created_at: String,
     pub id: String,
@@ -255,7 +255,7 @@ pub struct Incident {
 ///
 /// [Discord docs](https://discordstatus.com/api) (see "Unresolved incident" example)
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct IncidentUpdate {
     pub body: String,
     pub created_at: String,
@@ -271,7 +271,7 @@ pub struct IncidentUpdate {
 ///
 /// [Discord docs](https://discordstatus.com/api) (see "scheduled maintenances" examples)
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Maintenance {
     pub created_at: String,
     pub id: String,

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -44,7 +44,7 @@ enum_number! {
     /// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object-sku-types).
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum SkuKind {
         /// Represents a recurring subscription.
         Subscription = 5,
@@ -131,7 +131,7 @@ enum_number! {
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum EntitlementKind {
         /// Entitlement was purchased as an app subscription.
         ApplicationSubscription = 8,

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -77,7 +77,7 @@ impl StickerId {
 /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-item-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct StickerItem {
     /// The unique ID given to this sticker.
     pub id: StickerId,
@@ -116,7 +116,7 @@ impl StickerItem {
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-pack-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct StickerPack {
     /// The unique ID given to this sticker sticker pack.
     pub id: StickerPackId,
@@ -158,7 +158,7 @@ fn banner_url(banner_asset_id: StickerPackBannerId) -> String {
 /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Sticker {
     /// The unique ID given to this sticker.
     pub id: StickerId,
@@ -277,7 +277,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum StickerType {
         /// An official sticker in a pack, part of Nitro or in a removed purchasable pack.
         Standard = 1,
@@ -294,7 +294,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum StickerFormatType {
         /// A PNG format sticker.
         Png = 1,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -192,7 +192,7 @@ impl CurrentUser {
 #[derive(
     Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
 )]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum OnlineStatus {
     #[serde(rename = "dnd")]
     DoNotDisturb,
@@ -226,7 +226,7 @@ impl OnlineStatus {
 /// additional partial member field documented [here](https://discord.com/developers/docs/topics/gateway-events#message-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct User {
     /// The unique Id of the user. Can be used to calculate the account's creation date.
     pub id: UserId,
@@ -299,7 +299,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum PremiumType {
         #[default]
         None = 0,

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -11,7 +11,7 @@ use crate::model::Timestamp;
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/voice#voice-region-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct VoiceRegion {
     /// Whether it is a custom voice region, which is used for events.
     pub custom: bool,
@@ -31,7 +31,7 @@ pub struct VoiceRegion {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct VoiceState {
     pub channel_id: Option<ChannelId>,
     pub deaf: bool,

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -22,7 +22,7 @@ enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
-    #[non_exhaustive]
+    #[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
     pub enum WebhookType {
         /// An indicator that the webhook can post messages to channels with a token.
         Incoming = 1,
@@ -54,7 +54,7 @@ impl WebhookType {
 /// [Discord docs](https://discord.com/developers/docs/resources/webhook#webhook-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct Webhook {
     /// The unique Id.
     ///
@@ -98,7 +98,7 @@ pub struct Webhook {
 /// The guild object returned by a [`Webhook`], of type [`WebhookType::ChannelFollower`].
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct WebhookGuild {
     /// The unique Id identifying the guild.
     pub id: GuildId,
@@ -160,7 +160,7 @@ impl WebhookGuild {
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct WebhookChannel {
     /// The unique Id of the channel.
     pub id: ChannelId,

--- a/src/utils/argument_convert/_template.rs
+++ b/src/utils/argument_convert/_template.rs
@@ -3,7 +3,7 @@ use super::ArgumentConvert;
 use crate::{model::prelude::*, prelude::*};
 
 /// Error that can be returned from [`PLACEHOLDER::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum PLACEHOLDERParseError {
 }

--- a/src/utils/argument_convert/channel.rs
+++ b/src/utils/argument_convert/channel.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 use crate::prelude::*;
 
 /// Error that can be returned from [`Channel::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Debug)]
 pub enum ChannelParseError {
     /// When channel retrieval via HTTP failed
@@ -105,7 +105,7 @@ impl ArgumentConvert for Channel {
 }
 
 /// Error that can be returned from [`GuildChannel::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Debug)]
 pub enum GuildChannelParseError {
     /// When channel retrieval via HTTP failed

--- a/src/utils/argument_convert/emoji.rs
+++ b/src/utils/argument_convert/emoji.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 use crate::prelude::*;
 
 /// Error that can be returned from [`Emoji::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum EmojiParseError {
     /// Parser was invoked outside a guild.

--- a/src/utils/argument_convert/guild.rs
+++ b/src/utils/argument_convert/guild.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 use crate::prelude::*;
 
 /// Error that can be returned from [`Guild::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum GuildParseError {
     /// The provided guild string failed to parse, or the parsed result cannot be found in the

--- a/src/utils/argument_convert/member.rs
+++ b/src/utils/argument_convert/member.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 use crate::prelude::*;
 
 /// Error that can be returned from [`Member::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum MemberParseError {
     /// Parser was invoked outside a guild.

--- a/src/utils/argument_convert/message.rs
+++ b/src/utils/argument_convert/message.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 use crate::prelude::*;
 
 /// Error that can be returned from [`Message::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Debug)]
 pub enum MessageParseError {
     /// When the provided string does not adhere to any known guild message format

--- a/src/utils/argument_convert/role.rs
+++ b/src/utils/argument_convert/role.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 use crate::prelude::*;
 
 /// Error that can be returned from [`Role::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Debug)]
 pub enum RoleParseError {
     /// When the operation was invoked outside a guild.

--- a/src/utils/argument_convert/user.rs
+++ b/src/utils/argument_convert/user.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 use crate::prelude::*;
 
 /// Error that can be returned from [`User::convert`].
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum UserParseError {
     /// The provided user string failed to parse, or the parsed result cannot be found in the guild

--- a/src/utils/formatted_timestamp.rs
+++ b/src/utils/formatted_timestamp.rs
@@ -107,7 +107,7 @@ impl fmt::Display for FormattedTimestampStyle {
 
 /// An error that can occur when parsing a [`FormattedTimestamp`] from a string.
 #[derive(Debug, Clone)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub struct FormattedTimestampParseError {
     string: String,
 }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -973,7 +973,7 @@ impl EmbedMessageBuilding for MessageBuilder {
 /// use serenity::utils::ContentModifier::{Bold, Italic};
 /// let content: Content = Bold + Italic + "text";
 /// ```
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum ContentModifier {
     Italic,
     Bold,

--- a/voice-model/Cargo.toml
+++ b/voice-model/Cargo.toml
@@ -35,3 +35,7 @@ serde_test = "1"
 name = "deserialisation"
 path = "benches/de.rs"
 harness = false
+
+[features]
+# Disables all "#[non_exhaustive]" macros to ensure, that all enum variants or struct fields are required when pattern matching.
+unstable_exhaustive_types = []

--- a/voice-model/src/event/mod.rs
+++ b/voice-model/src/event/mod.rs
@@ -13,7 +13,7 @@ use crate::payload::*;
 
 /// A representation of data received for voice gateway events.
 #[derive(Clone, Debug)]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 pub enum Event {
     /// Used to begin a voice websocket connection.
     Identify(Identify),

--- a/voice-model/src/opcode.rs
+++ b/voice-model/src/opcode.rs
@@ -6,7 +6,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 #[derive(
     Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize_repr, Serialize_repr,
 )]
-#[non_exhaustive]
+#[cfg_attr(any(not(feature = "unstable_exhaustive_types"), doc), non_exhaustive)]
 #[repr(u8)]
 pub enum Opcode {
     /// Used to begin a voice websocket connection.


### PR DESCRIPTION
This feature deactivates all "#[non_exhaustive]" added into the code. This can be used by developers to ensure, that they match all enum variants or struct fields during pattern matching.

This should not break any existing code.