### PR TITLE
Add guild_id to ReactionRemoveAll

### DIFF
--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -325,6 +325,7 @@ fn update_cache_with_event(
             removed_reaction: event.reaction,
         },
         Event::ReactionRemoveAll(event) => FullEvent::ReactionRemoveAll {
+            guild_id: event.guild_id,
             channel_id: event.channel_id,
             removed_from_message_id: event.message_id,
         },

--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -315,7 +315,7 @@ event_handler! {
 
     /// Dispatched when all reactions of a message are detached from a message.
     ///
-    /// Provides the channel's id, the message's id, and guild's id if in a guild.
+    /// Provides the channel's id, message's id, and guild's id if in a guild.
     ReactionRemoveAll { guild_id: Option<GuildId>, channel_id: ChannelId, removed_from_message_id: MessageId } => async fn reaction_remove_all(&self, ctx: Context);
 
     /// Dispatched when all reactions of a message are detached from a message.

--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -315,8 +315,8 @@ event_handler! {
 
     /// Dispatched when all reactions of a message are detached from a message.
     ///
-    /// Provides the channel's id and the message's id.
-    ReactionRemoveAll { channel_id: ChannelId, removed_from_message_id: MessageId } => async fn reaction_remove_all(&self, ctx: Context);
+    /// Provides the channel's id, the message's id, and guild's id if in a guild.
+    ReactionRemoveAll { guild_id: Option<GuildId>, channel_id: ChannelId, removed_from_message_id: MessageId } => async fn reaction_remove_all(&self, ctx: Context);
 
     /// Dispatched when all reactions of a message are detached from a message.
     ///


### PR DESCRIPTION
This was missing on FullEvent but was present within the event itself.