### PR TITLE
Bump the discriminant of audit_log::Action to u16

### DIFF
--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -35,36 +35,36 @@ pub enum Action {
     AutoMod(AutoModAction),
     CreatorMonetization(CreatorMonetizationAction),
     VoiceChannelStatus(VoiceChannelStatusAction),
-    Unknown(u8),
+    Unknown(u16),
 }
 
 impl Action {
     #[must_use]
-    pub const fn num(self) -> u8 {
+    pub const fn num(self) -> u16 {
         match self {
             Self::GuildUpdate => 1,
-            Self::Channel(x) => x as u8,
-            Self::ChannelOverwrite(x) => x as u8,
-            Self::Member(x) => x as u8,
-            Self::Role(x) => x as u8,
-            Self::Invite(x) => x as u8,
-            Self::Webhook(x) => x as u8,
-            Self::Emoji(x) => x as u8,
-            Self::Message(x) => x as u8,
-            Self::Integration(x) => x as u8,
-            Self::StageInstance(x) => x as u8,
-            Self::Sticker(x) => x as u8,
-            Self::ScheduledEvent(x) => x as u8,
-            Self::Thread(x) => x as u8,
-            Self::AutoMod(x) => x as u8,
-            Self::CreatorMonetization(x) => x as u8,
-            Self::VoiceChannelStatus(x) => x as u8,
+            Self::Channel(x) => x as u16,
+            Self::ChannelOverwrite(x) => x as u16,
+            Self::Member(x) => x as u16,
+            Self::Role(x) => x as u16,
+            Self::Invite(x) => x as u16,
+            Self::Webhook(x) => x as u16,
+            Self::Emoji(x) => x as u16,
+            Self::Message(x) => x as u16,
+            Self::Integration(x) => x as u16,
+            Self::StageInstance(x) => x as u16,
+            Self::Sticker(x) => x as u16,
+            Self::ScheduledEvent(x) => x as u16,
+            Self::Thread(x) => x as u16,
+            Self::AutoMod(x) => x as u16,
+            Self::CreatorMonetization(x) => x as u16,
+            Self::VoiceChannelStatus(x) => x as u16,
             Self::Unknown(x) => x,
         }
     }
 
     #[must_use]
-    pub fn from_value(value: u8) -> Action {
+    pub fn from_value(value: u16) -> Action {
         match value {
             1 => Action::GuildUpdate,
             10 => Action::Channel(ChannelAction::Create),
@@ -131,14 +131,14 @@ impl Action {
 // Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for Action {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let value = u8::deserialize(deserializer)?;
+        let value = u16::deserialize(deserializer)?;
         Ok(Action::from_value(value))
     }
 }
 
 impl Serialize for Action {
     fn serialize<S: Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
-        serializer.serialize_u8(self.num())
+        serializer.serialize_u16(self.num())
     }
 }
 
@@ -146,7 +146,6 @@ impl Serialize for Action {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum ChannelAction {
     Create = 10,
     Update = 11,
@@ -157,7 +156,6 @@ pub enum ChannelAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum ChannelOverwriteAction {
     Create = 13,
     Update = 14,
@@ -168,7 +166,6 @@ pub enum ChannelOverwriteAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum MemberAction {
     Kick = 20,
     Prune = 21,
@@ -185,7 +182,6 @@ pub enum MemberAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum RoleAction {
     Create = 30,
     Update = 31,
@@ -196,7 +192,6 @@ pub enum RoleAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum InviteAction {
     Create = 40,
     Update = 41,
@@ -207,7 +202,6 @@ pub enum InviteAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum WebhookAction {
     Create = 50,
     Update = 51,
@@ -218,7 +212,6 @@ pub enum WebhookAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum EmojiAction {
     Create = 60,
     Update = 61,
@@ -229,7 +222,6 @@ pub enum EmojiAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum MessageAction {
     Delete = 72,
     BulkDelete = 73,
@@ -241,7 +233,6 @@ pub enum MessageAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum IntegrationAction {
     Create = 80,
     Update = 81,
@@ -252,7 +243,6 @@ pub enum IntegrationAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum StageInstanceAction {
     Create = 83,
     Update = 84,
@@ -263,7 +253,6 @@ pub enum StageInstanceAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum StickerAction {
     Create = 90,
     Update = 91,
@@ -274,7 +263,6 @@ pub enum StickerAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum ScheduledEventAction {
     Create = 100,
     Update = 101,
@@ -285,7 +273,6 @@ pub enum ScheduledEventAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum ThreadAction {
     Create = 110,
     Update = 111,
@@ -296,7 +283,6 @@ pub enum ThreadAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum AutoModAction {
     RuleCreate = 140,
     RuleUpdate = 141,
@@ -310,7 +296,6 @@ pub enum AutoModAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum CreatorMonetizationAction {
     RequestCreated = 150,
     TermsAccepted = 151,
@@ -320,7 +305,6 @@ pub enum CreatorMonetizationAction {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
-#[repr(u8)]
 pub enum VoiceChannelStatusAction {
     StatusUpdate = 192,
     StatusDelete = 193,


### PR DESCRIPTION
Values are getting quite close to the u8 limit (193), so let's preemptively bump this to avoid future breaking changes.