### PR TITLE
Remove broken Message::super_react

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -836,7 +836,8 @@ impl Http {
         .await
     }
 
-    async fn create_reaction_(
+    /// Reacts to a message.
+    pub async fn create_reaction(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
@@ -855,16 +856,6 @@ impl Http {
             params: None,
         })
         .await
-    }
-
-    /// Reacts to a message.
-    pub async fn create_reaction(
-        &self,
-        channel_id: ChannelId,
-        message_id: MessageId,
-        reaction_type: &ReactionType,
-    ) -> Result<()> {
-        self.create_reaction_(channel_id, message_id, reaction_type).await
     }
     /// Creates a role.
     pub async fn create_role(

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -841,7 +841,6 @@ impl Http {
         channel_id: ChannelId,
         message_id: MessageId,
         reaction_type: &ReactionType,
-        burst: bool,
     ) -> Result<()> {
         self.wind(204, Request {
             body: None,
@@ -853,7 +852,7 @@ impl Http {
                 message_id,
                 reaction: &reaction_type.as_data(),
             },
-            params: Some(vec![("burst", burst.to_string())]),
+            params: None,
         })
         .await
     }
@@ -865,19 +864,8 @@ impl Http {
         message_id: MessageId,
         reaction_type: &ReactionType,
     ) -> Result<()> {
-        self.create_reaction_(channel_id, message_id, reaction_type, false).await
+        self.create_reaction_(channel_id, message_id, reaction_type).await
     }
-
-    /// Super reacts to a message.
-    pub async fn create_super_reaction(
-        &self,
-        channel_id: ChannelId,
-        message_id: MessageId,
-        reaction_type: &ReactionType,
-    ) -> Result<()> {
-        self.create_reaction_(channel_id, message_id, reaction_type, true).await
-    }
-
     /// Creates a role.
     pub async fn create_role(
         &self,


### PR DESCRIPTION
Turns out you can't send these anymore, and they weren't documented to begin with, I don't know how I ended up implementing it.

This is on current despite it removing a public method because the method does not work.