### PR TITLE
Make FullEvent fields non exhaustive

### DIFF
--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -57,6 +57,7 @@ macro_rules! event_handler {
                 $( #[doc = $doc] )*
                 $( #[cfg(feature = $feature)] )?
                 $( #[deprecated = $deprecated] )?
+                #[cfg_attr(not(feature = "unstable"), non_exhaustive)]
                 $variant_name {
                     $( $arg_name: $arg_type ),*
                 },


### PR DESCRIPTION
Right now we can't add fields to events without it being a breaking change, unless I'm missing anything this should let us do that.