### PR TITLE
Fix transport compression feature & add CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
             features: unstable
             dont-test: true
           - name: zlib compression
-            features: transport_compression_zlib
+            features: default transport_compression_zlib
           - name: zstd compression
-            features: transport_compression_zstd
+            features: default transport_compression_zstd
           - name: zlib and zstd compression
-            features: transport_compression_zlib transport_compression_zstd
+            features: default transport_compression_zlib transport_compression_zstd
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           - no cache
           - no gateway
           - unstable Discord API features
+          - zlib compression
+          - zstd compression
+          - zlib and zstd compression
 
         include:
           - name: beta
@@ -51,6 +54,12 @@ jobs:
           - name: unstable Discord API (no default features)
             features: unstable
             dont-test: true
+          - name: zlib compression
+            features: transport_compression_zlib
+          - name: zstd compression
+            features: transport_compression_zstd
+          - name: zlib and zstd compression
+            features: transport_compression_zlib transport_compression_zstd
 
     steps:
       - name: Checkout sources

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -44,7 +44,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration as StdDuration, Instant};
 
-#[cfg(feature = "transport_compression_zlib")]
+#[cfg(any(feature = "transport_compression_zlib", feature = "transport_compression_zstd"))]
 use aformat::aformat_into;
 use aformat::{aformat, ArrayString, CapStr};
 use serde::Deserialize;


### PR DESCRIPTION
- fixes an incorrect feature gate on an `aformat_into` import introduced with #3036
- adds new CI tests to check combinations of the transport compression feature flags introduced with #3036 