### PR TITLE
Specify shared crate metadata at the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,30 @@
 [package]
+name = "serenity"
+version = "0.12.4"
 authors = ["Alex M. M. <acdenissk69@gmail.com>"]
 description = "A Rust library for the Discord API."
-documentation = "https://docs.rs/serenity"
-homepage = "https://github.com/serenity-rs/serenity"
-keywords = ["discord", "api"]
-license = "ISC"
-name = "serenity"
 readme = "README.md"
-repository = "https://github.com/serenity-rs/serenity.git"
-version = "0.12.4"
-edition = "2021"
-rust-version = "1.74"
 include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md", "build.rs"]
+
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [workspace]
 members = ["examples/*"]
+
+[workspace.package]
+documentation = "https://docs.rs/serenity"
+homepage = "https://github.com/serenity-rs/serenity"
+repository = "https://github.com/serenity-rs/serenity.git"
+keywords = ["discord", "api"]
+license = "ISC"
+edition = "2021"
+rust-version = "1.74"
 
 [dependencies]
 # Required dependencies

--- a/command_attr/Cargo.toml
+++ b/command_attr/Cargo.toml
@@ -2,9 +2,15 @@
 name = "command_attr"
 version = "0.5.3"
 authors = ["Alex M. M. <acdenissk69@gmail.com>"]
-edition = "2021"
 description = "Procedural macros for command creation for the Serenity library."
-license = "ISC"
+
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/voice-model/Cargo.toml
+++ b/voice-model/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
+name = "serenity-voice-model"
+version = "0.2.0"
 authors = ["Alex M. M. <acdenissk69@gmail.com>"]
 description = "A Rust library for (de)serializing Discord Voice API gateway messages."
-documentation = "https://docs.rs/serenity"
-homepage = "https://github.com/serenity-rs/serenity"
-include = ["src/**/*.rs", "Cargo.toml"]
-keywords = ["discord", "api"]
-license = "ISC"
-name = "serenity-voice-model"
 # readme = "README.md"
-repository = "https://github.com/serenity-rs/serenity.git"
-version = "0.2.0"
-edition = "2018"
+include = ["src/**/*.rs", "Cargo.toml"]
+
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bitflags = "2.4"


### PR DESCRIPTION
This keeps crate metadata in sync across the whole workspace, including MSRV and edition, plus adds some missing metadata fields to serenity's subcrates.

Feedback wanted: should the `authors` field also be applied to the whole workspace? Note that workspace fields are opt-in via `field.workspace = true` and can be overridden by simply providing a `field = ...` value.