### PR TITLE
Add support for incident actions

### DIFF
--- a/src/builder/edit_guild_incident_actions.rs
+++ b/src/builder/edit_guild_incident_actions.rs
@@ -1,0 +1,49 @@
+#[cfg(feature = "http")]
+use crate::http::Http;
+#[cfg(feature = "http")]
+use crate::internal::prelude::*;
+use crate::model::prelude::*;
+
+/// A builder for editing guild incident actions.
+///
+/// [Discord's docs]: https://github.com/discord/discord-api-docs/pull/6396
+#[must_use]
+pub struct EditGuildIncidentActions {
+    invites_disabled_until: Option<Timestamp>,
+    dms_disabled_until: Option<Timestamp>,
+}
+
+impl EditGuildIncidentActions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the time invites to the guild will be disabled until. Must be no further than 1 day in
+    /// the future.
+    pub fn invites_disabled_until(mut self, timestamp: Timestamp) -> Self {
+        self.invites_disabled_until = Some(timestamp);
+        self
+    }
+
+    /// Sets the time dms for users within the guild will be disabled until. Must be no further
+    /// than 1 day in the future.
+    pub fn dms_disabled_until(mut self, timestamp: Timestamp) -> Self {
+        self.dms_disabled_until = Some(timestamp);
+        self
+    }
+
+    /// Modifies the guild's incident actions.
+    ///
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if invalid data is given. See [Discord's docs] for more details.
+    ///
+    /// May also return [`Error::Json`] if there is an error in deserializing the API response.
+    ///
+    /// [Discord's docs]: https://github.com/discord/discord-api-docs/pull/6396
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<IncidentsData> {
+        http.edit_guild_incident_actions(guild_id, &self).await
+    }
+}

--- a/src/builder/edit_guild_incident_actions.rs
+++ b/src/builder/edit_guild_incident_actions.rs
@@ -7,6 +7,7 @@ use crate::model::prelude::*;
 /// A builder for editing guild incident actions.
 ///
 /// [Discord's docs]: https://github.com/discord/discord-api-docs/pull/6396
+#[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditGuildIncidentActions {
     invites_disabled_until: Option<Timestamp>,

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -60,6 +60,8 @@ mod create_webhook;
 mod edit_automod_rule;
 mod edit_channel;
 mod edit_guild;
+#[cfg(feature = "unstable_discord_api")]
+mod edit_guild_incident_actions;
 mod edit_guild_welcome_screen;
 mod edit_guild_widget;
 mod edit_interaction_response;
@@ -102,6 +104,8 @@ pub use create_webhook::*;
 pub use edit_automod_rule::*;
 pub use edit_channel::*;
 pub use edit_guild::*;
+#[cfg(feature = "unstable_discord_api")]
+pub use edit_guild_incident_actions::*;
 pub use edit_guild_welcome_screen::*;
 pub use edit_guild_widget::*;
 pub use edit_interaction_response::*;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4779,6 +4779,26 @@ impl Http {
         .await
     }
 
+    /// Modify the guild's incident actions.
+    #[cfg(feature = "unstable_discord_api")]
+    pub async fn edit_guild_incident_actions(
+        &self,
+        guild_id: GuildId,
+        map: &impl serde::Serialize,
+    ) -> Result<IncidentsData> {
+        self.fire(Request {
+            body: Some(to_vec(map)?),
+            multipart: None,
+            headers: None,
+            method: LightMethod::Put,
+            route: Route::GuildIncidentActions {
+                guild_id,
+            },
+            params: None,
+        })
+        .await
+    }
+
     /// Starts typing in the specified [`Channel`] for an indefinite period of time.
     ///
     /// Returns [`Typing`] that is used to trigger the typing. [`Typing::stop`] must be called on

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -354,6 +354,10 @@ routes! ('a, {
     api!("/guilds/{}/threads/active", guild_id),
     Some(RatelimitingKind::PathAndId(guild_id.into()));
 
+    GuildIncidentActions { guild_id: GuildId },
+    api!("/guilds/{}/incident-actions", guild_id),
+    Some(RatelimitingKind::PathAndId(guild_id.into()));
+
     Guilds,
     api!("/guilds"),
     Some(RatelimitingKind::Path);

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -3,6 +3,8 @@ use std::fmt;
 #[cfg(feature = "model")]
 use futures::stream::Stream;
 
+#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+use crate::builder::EditGuildIncidentActions;
 #[cfg(feature = "model")]
 use crate::builder::{
     AddMember,
@@ -1694,6 +1696,25 @@ impl GuildId {
     /// the request is not in the guild.
     pub async fn get_active_threads(self, http: impl AsRef<Http>) -> Result<ThreadsData> {
         http.as_ref().get_guild_active_threads(self).await
+    }
+
+    /// Edits the guild incident actions
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if invalid data is given. See [Discord's docs] for more details.
+    ///
+    /// May also return [`Error::Json`] if there is an error in deserializing the API response.
+    ///
+    /// [Discord's docs]: https://github.com/discord/discord-api-docs/pull/6396
+    #[cfg(feature = "unstable_discord_api")]
+    pub async fn edit_guild_incident_actions(
+        self,
+        http: &Http,
+        guild_id: GuildId,
+        builder: EditGuildIncidentActions,
+    ) -> Result<IncidentsData> {
+        builder.execute(http, guild_id).await
     }
 }
 

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+#[cfg(feature = "unstable_discord_api")]
+use super::IncidentsData;
 #[cfg(feature = "model")]
 use crate::builder::{
     CreateChannel,
@@ -174,6 +176,11 @@ pub struct PartialGuild {
     pub stickers: HashMap<StickerId, Sticker>,
     /// Whether the guild has the boost progress bar enabled
     pub premium_progress_bar_enabled: bool,
+    /// the id of the channel where this guild will recieve safety alerts.
+    pub safety_alerts_channel_id: Option<ChannelId>,
+    /// The incidents data for this guild, if any.
+    #[cfg(feature = "unstable_discord_api")]
+    pub incidents_data: Option<IncidentsData>,
 }
 
 #[cfg(feature = "model")]
@@ -1618,6 +1625,9 @@ impl From<Guild> for PartialGuild {
             preferred_locale: guild.preferred_locale,
             max_stage_video_channel_users: guild.max_stage_video_channel_users,
             premium_progress_bar_enabled: guild.premium_progress_bar_enabled,
+            safety_alerts_channel_id: guild.safety_alerts_channel_id,
+            #[cfg(feature = "unstable_discord_api")]
+            incidents_data: guild.incidents_data,
         }
     }
 }


### PR DESCRIPTION
marked under unstable because the docs are not merged.

I have not tested this in the slightest yet, will remain as a draft until I get around to doing that.

Permissions on the documentation is wrong (or user accounts don't have the same limits), so permissions are intentionally not mentioned on the docs i added for now.

Docs could do with some work too imo.