### PR TITLE
deprecate Member::distinct

### DIFF
--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -240,6 +240,7 @@ impl Member {
     /// Returns the DiscordTag of a Member, taking possible nickname into account.
     #[inline]
     #[must_use]
+    #[deprecated = "Use User::tag to get the correct Discord username format or Self::display_name for the name that users will see."]
     pub fn distinct(&self) -> String {
         if let Some(discriminator) = self.user.discriminator {
             format!("{}#{:04}", self.display_name(), discriminator.get())

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -239,7 +239,9 @@ fn clean_mention(
                 if let Some(guild) = cache.guild(guild_id) {
                     if let Some(member) = guild.members.get(&id) {
                         return if options.show_discriminator {
-                            format!("@{}", member.distinct())
+                            #[allow(deprecated)]
+                            let name = member.distinct();
+                            format!("@{name}")
                         } else {
                             format!("@{}", member.display_name())
                         }


### PR DESCRIPTION
This method is just wrong, only the username is accompanied by the discriminator, not the global name or nickname, so this method only adds confusion.