### PR TITLE
Implement `Eq` (and `PartialEq`) for `ActivityData`

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -70,7 +70,7 @@ pub struct PresenceData {
 }
 
 /// Activity data of the current user.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct ActivityData {
     /// The name of the activity
     pub name: String,


### PR DESCRIPTION
Allows two `ActivityData`s to be compared for equality. (For instance, my use case, checking if an `ActivityData` randomly selected from an array is equal to an `ActivityData` that was previously selected.)