### PR TITLE
Update two emoji functions with roles field

### DIFF
--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -318,10 +318,13 @@ impl GuildId {
         builder.execute(http, self).await
     }
 
-    /// Creates an emoji in the guild with a name and base64-encoded image.
+    /// Creates an emoji in the guild with a name and base64-encoded image and set of roles.
     ///
     /// The name of the emoji must be at least 2 characters long and can only contain alphanumeric
     /// characters and underscores.
+    ///
+    /// The emoji will only be visible by anyone that has the role(s) defined in the `roles`
+    /// parameter.
     ///
     /// Requires the [Create Guild Expressions] permission.
     ///
@@ -343,17 +346,21 @@ impl GuildId {
         http: &Http,
         name: &str,
         image: &str,
+        roles: Option<Vec<RoleId>>,
         reason: Option<&str>,
     ) -> Result<Emoji> {
         #[derive(serde::Serialize)]
         struct CreateEmoji<'a> {
             name: &'a str,
             image: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            roles: Option<Vec<RoleId>>,
         }
 
         let body = CreateEmoji {
             name,
             image,
+            roles,
         };
 
         http.create_emoji(self, &body, reason).await
@@ -565,11 +572,14 @@ impl GuildId {
         builder.execute(http, self).await
     }
 
-    /// Edits an [`Emoji`]'s name in the guild.
+    /// Edits an [`Emoji`]'s name and roles in the guild.
     ///
     /// **Note**: If the emoji was created by the current user, requires either the [Create Guild
     /// Expressions] or the [Manage Guild Expressions] permission. Otherwise, the [Manage Guild
     /// Expressions] permission is required.
+    ///
+    /// If an emoji was edited to be visible by the selected roles in the parameter, only those with
+    /// it can only see the emoji.
     ///
     /// # Errors
     ///
@@ -583,15 +593,19 @@ impl GuildId {
         http: &Http,
         emoji_id: EmojiId,
         name: &str,
+        roles: Option<Vec<RoleId>>,
         reason: Option<&str>,
     ) -> Result<Emoji> {
         #[derive(serde::Serialize)]
         struct EditEmoji<'a> {
             name: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            roles: Option<Vec<RoleId>>,
         }
 
         let map = EditEmoji {
             name,
+            roles,
         };
 
         http.edit_emoji(self, emoji_id, &map, reason).await


### PR DESCRIPTION
As was discussed/brought up [in Discord](https://discord.com/channels/381880193251409931/381912587505500160/1317791118813036564) a month ago for missing support for roles field in `create_emoji` and `edit_emoji`.

I feel like I am missing something prior to creating this PR but feel free to correct me on it though.

Yes, it is also tested on the bot before forking and creating the PR.