### PR TITLE
Rename `dep_time` dependency to `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.192", features = ["derive"] }
 url = { version = "2.4.1", features = ["serde"] }
 tokio = { version = "1.34.0", features = ["fs", "macros", "rt", "sync", "time", "io-util"] }
 futures = { version = "0.3.29", default-features = false, features = ["std"] }
-dep_time = { version = "0.3.36", package = "time", features = ["formatting", "parsing", "serde-well-known"] }
+time = { version = "0.3.36", features = ["formatting", "parsing", "serde-well-known"] }
 base64 = { version = "0.22.0" }
 secrecy = { version = "0.8.0", features = ["serde"] }
 arrayvec = { version = "0.7.4", features = ["serde"] }

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -36,11 +36,11 @@ use std::str::FromStr;
 pub use chrono::ParseError as InnerError;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
-#[cfg(not(feature = "chrono"))]
-pub use dep_time::error::Parse as InnerError;
-#[cfg(not(feature = "chrono"))]
-use dep_time::{format_description::well_known::Rfc3339, serde::rfc3339, Duration, OffsetDateTime};
 use serde::{Deserialize, Serialize};
+#[cfg(not(feature = "chrono"))]
+pub use time::error::Parse as InnerError;
+#[cfg(not(feature = "chrono"))]
+use time::{format_description::well_known::Rfc3339, serde::rfc3339, Duration, OffsetDateTime};
 
 /// Discord's epoch starts at "2015-01-01T00:00:00+00:00"
 const DISCORD_EPOCH: u64 = 1_420_070_400_000;


### PR DESCRIPTION
We no longer have a crate feature named `time`, so renaming the dependency isn't needed anymore.