### PR TITLE
Fix Heartbeat gateway event handling

### DIFF
--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -310,13 +310,6 @@ impl Shard {
     }
 
     #[instrument(skip(self))]
-    fn handle_heartbeat_event(&mut self) -> ShardAction {
-        info!("[{:?}] Received shard heartbeat", self.shard_info);
-
-        ShardAction::Heartbeat
-    }
-
-    #[instrument(skip(self))]
     fn handle_gateway_closed(
         &mut self,
         data: Option<&CloseFrame<'static>>,
@@ -425,7 +418,11 @@ impl Shard {
     pub fn handle_event(&mut self, event: &Result<GatewayEvent>) -> Result<Option<ShardAction>> {
         match event {
             Ok(GatewayEvent::Dispatch(seq, event)) => Ok(self.handle_gateway_dispatch(*seq, event)),
-            Ok(GatewayEvent::Heartbeat(..)) => Ok(Some(self.handle_heartbeat_event())),
+            Ok(GatewayEvent::Heartbeat(..)) => {
+                info!("[{:?}] Received shard heartbeat", self.shard_info);
+
+                Ok(Some(ShardAction::Heartbeat))
+            },
             Ok(GatewayEvent::HeartbeatAck) => {
                 self.last_heartbeat_ack = Some(Instant::now());
                 self.last_heartbeat_acknowledged = true;

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -310,25 +310,8 @@ impl Shard {
     }
 
     #[instrument(skip(self))]
-    fn handle_heartbeat_event(&mut self, s: u64) -> ShardAction {
+    fn handle_heartbeat_event(&mut self) -> ShardAction {
         info!("[{:?}] Received shard heartbeat", self.shard_info);
-
-        // Received seq is off -- attempt to resume.
-        if s > self.seq + 1 {
-            info!(
-                "[{:?}] Received off sequence (them: {}; us: {}); resuming",
-                self.shard_info, s, self.seq
-            );
-
-            if self.stage == ConnectionStage::Handshake {
-                self.stage = ConnectionStage::Identifying;
-
-                return ShardAction::Identify;
-            }
-            warn!("[{:?}] Heartbeat during non-Handshake; auto-reconnecting", self.shard_info);
-
-            return ShardAction::Reconnect(self.reconnection_type());
-        }
 
         ShardAction::Heartbeat
     }
@@ -442,7 +425,7 @@ impl Shard {
     pub fn handle_event(&mut self, event: &Result<GatewayEvent>) -> Result<Option<ShardAction>> {
         match event {
             Ok(GatewayEvent::Dispatch(seq, event)) => Ok(self.handle_gateway_dispatch(*seq, event)),
-            Ok(GatewayEvent::Heartbeat(s)) => Ok(Some(self.handle_heartbeat_event(*s))),
+            Ok(GatewayEvent::Heartbeat(..)) => Ok(Some(self.handle_heartbeat_event())),
             Ok(GatewayEvent::HeartbeatAck) => {
                 self.last_heartbeat_ack = Some(Instant::now());
                 self.last_heartbeat_acknowledged = true;

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1098,7 +1098,7 @@ pub struct MessagePollVoteRemoveEvent {
 #[serde(untagged)]
 pub enum GatewayEvent {
     Dispatch(u64, Event),
-    Heartbeat(#[deprecated = "never used"] u64),
+    Heartbeat(#[deprecated = "always 0 because it is never provided by the gateway"] u64),
     Reconnect,
     /// Whether the session can be resumed.
     InvalidateSession(bool),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1098,7 +1098,7 @@ pub struct MessagePollVoteRemoveEvent {
 #[serde(untagged)]
 pub enum GatewayEvent {
     Dispatch(u64, Event),
-    Heartbeat(u64),
+    Heartbeat(#[deprecated = "never used"] u64),
     Reconnect,
     /// Whether the session can be resumed.
     InvalidateSession(bool),
@@ -1118,7 +1118,9 @@ impl<'de> Deserialize<'de> for GatewayEvent {
                 deserialize_val(Value::from(map))?,
             ),
             Opcode::Heartbeat => {
-                GatewayEvent::Heartbeat(seq.ok_or_else(|| DeError::missing_field("s"))?)
+                // Placeholder value. Discord expects the last Dispatch
+                // sequence number and doesn't send it with the heartbeat.
+                GatewayEvent::Heartbeat(0)
             },
             Opcode::InvalidSession => {
                 GatewayEvent::InvalidateSession(remove_from_map(&mut map, "d")?)


### PR DESCRIPTION
Currently, serenity deserializes the Heartbeat gateway event (opcode 1) incorrectly (Discord->Bot heartbeats):

```
[WARN  serenity::gateway::ws] Err deserializing text: Json(Error("missing field `s`", line: 0, column: 0)); text: {"t":null,"s":null,"op":1,"d":null}
```

It attempts to deserialize a sequence number for it, however it is `null` in the payload and that matches Discord's documentation on gateway events: https://discord.com/developers/docs/events/gateway-events#payload-structure
(Heartbeat is not opcode 0, so `s` and `t` are `null`.)

What serenity intends to happen after is forcing a heartbeat immediately. This is correct according to the documentation: https://discord.com/developers/docs/events/gateway#sending-heartbeats
However, the deserialization error leads to this code being unreachable in practice.

This patch leaves the Heartbeat event's sequence field in, as it's technically part of the crate's public API, but sets it to 0 and ignores it during handling.

Some cursory testing indicates that this leads to the correct behavior:

```
[INFO  serenity::gateway::shard] handle_event; event=Ok(Heartbeat(0))
[INFO  serenity::gateway::shard] [ShardInfo { id: ShardId(0), total: 1 }] Received shard heartbeat
[INFO  serenity::gateway::ws] send_heartbeat; shard_info=ShardInfo { id: ShardId(0), total: 1 } seq=Some(4)
[TRACE serenity::gateway::ws] [ShardInfo { id: ShardId(0), total: 1 }] Sending heartbeat d: Some(4)
[TRACE serenity::gateway::bridge::shard_runner] [ShardRunner ShardInfo { id: ShardId(0), total: 1 }] loop iteration reached the end.
[TRACE serenity::gateway::bridge::shard_runner] [ShardRunner ShardInfo { id: ShardId(0), total: 1 }] loop iteration started.
[INFO  serenity::gateway::shard] handle_event; event=Ok(HeartbeatAck)
[TRACE serenity::gateway::shard] [ShardInfo { id: ShardId(0), total: 1 }] Received heartbeat ack
```

The current running theory is that this was never noticed because this gateway event _very_ rarely happens.
In my testing, Discord only sends this event when a heartbeat is overdue. So to test this, I disabled periodic heartbeats, except once after the Hello event.
