### PR TITLE
Remove implicit invite parsing in Invite::get

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3733,9 +3733,6 @@ impl Http {
         event_id: Option<ScheduledEventId>,
     ) -> Result<Invite> {
         let (member_counts_str, expiration_str, event_id_str);
-        #[cfg(feature = "utils")]
-        let code = crate::utils::parse_invite(code);
-
         let mut params = ArrayVec::<_, 3>::new();
 
         member_counts_str = member_counts.to_arraystring();

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -116,14 +116,7 @@ impl Invite {
         expiration: bool,
         event_id: Option<ScheduledEventId>,
     ) -> Result<Invite> {
-        let mut invite = code;
-
-        #[cfg(feature = "utils")]
-        {
-            invite = crate::utils::parse_invite(invite);
-        }
-
-        http.get_invite(invite, member_counts, expiration, event_id).await
+        http.get_invite(code, member_counts, expiration, event_id).await
     }
 
     /// Returns a URL to use for the invite.


### PR DESCRIPTION
This was undocumented and done twice, let's just get rid of it as users had to use the util if they were following the documentation anyway.