### PR TITLE
Bump MSRV to 1.85 and switch to the 2024 edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on: [push, pull_request]
 
 env:
-  rust_min: 1.82.0
-  rust_nightly: nightly-2024-11-01
+  rust_min: 1.85.0
+  rust_nightly: nightly-2025-02-19
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ homepage = "https://github.com/serenity-rs/serenity"
 repository = "https://github.com/serenity-rs/serenity.git"
 keywords = ["discord", "api"]
 license = "ISC"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 # Required dependencies

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
 
 ## MSRV Policy
 
-Serenity's minimum supported Rust version (MSRV) is Rust 1.82.
+Serenity's minimum supported Rust version (MSRV) is Rust 1.85.
 
 We opt to keep MSRV stable on the `current` branch. This means it will remain
 unchanged between minor releases. Occasionally, dependencies may violate SemVer
@@ -244,5 +244,5 @@ a Rust-native cloud development platform that allows deploying Serenity bots for
 [repo:andesite]: https://github.com/natanbc/andesite
 [repo:lavaplayer]: https://github.com/sedmelluq/lavaplayer
 [logo]: https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png
-[rust-version-badge]: https://img.shields.io/badge/rust-1.82.0+-93450a.svg?style=flat-square
-[rust-version-link]: https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html
+[rust-version-badge]: https://img.shields.io/badge/rust-1.85.0+-93450a.svg?style=flat-square
+[rust-version-link]: https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html

--- a/examples/e01_basic_ping_bot/Cargo.toml
+++ b/examples/e01_basic_ping_bot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e01_basic_ping_bot"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }

--- a/examples/e02_transparent_guild_sharding/Cargo.toml
+++ b/examples/e02_transparent_guild_sharding/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e02_transparent_guild_sharding"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }

--- a/examples/e03_struct_utilities/Cargo.toml
+++ b/examples/e03_struct_utilities/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e03_struct_utilities"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }

--- a/examples/e04_message_builder/Cargo.toml
+++ b/examples/e04_message_builder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e04_message_builder"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }

--- a/examples/e05_sample_bot_structure/Cargo.toml
+++ b/examples/e05_sample_bot_structure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e05_sample_bot_structure"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["collector", "rustls_backend"] }

--- a/examples/e06_env_logging/Cargo.toml
+++ b/examples/e06_env_logging/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e06_env_logging"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 tracing = "0.1.23"

--- a/examples/e07_shard_manager/Cargo.toml
+++ b/examples/e07_shard_manager/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e07_shard_manager"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/examples/e08_create_message_builder/Cargo.toml
+++ b/examples/e08_create_message_builder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e08_create_message_builder"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "chrono", "rustls_backend"] }

--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -1,8 +1,8 @@
 use serenity::async_trait;
 use serenity::builder::{CreateAttachment, CreateEmbed, CreateEmbedFooter, CreateMessage};
+use serenity::model::Timestamp;
 use serenity::model::channel::Message;
 use serenity::model::gateway::Ready;
-use serenity::model::Timestamp;
 use serenity::prelude::*;
 
 struct Handler;

--- a/examples/e09_collectors/Cargo.toml
+++ b/examples/e09_collectors/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e09_collectors"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies.serenity]
 features = ["collector", "framework", "rustls_backend"]

--- a/examples/e10_gateway_intents/Cargo.toml
+++ b/examples/e10_gateway_intents/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e10_gateway_intents"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }

--- a/examples/e11_global_data/Cargo.toml
+++ b/examples/e11_global_data/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e11_global_data"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../" }

--- a/examples/e11_global_data/src/main.rs
+++ b/examples/e11_global_data/src/main.rs
@@ -1,8 +1,8 @@
 //! In this example, you will be shown how to share data between events.
 
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serenity::async_trait;
 use serenity::model::channel::Message;
@@ -42,7 +42,9 @@ impl EventHandler for Handler {
 
         if msg.content.starts_with("~owo_count") {
             let response = if owo_count == 1 {
-                Cow::Borrowed("You are the first one to say owo this session! *because it's on the command name* :P")
+                Cow::Borrowed(
+                    "You are the first one to say owo this session! *because it's on the command name* :P",
+                )
             } else {
                 Cow::Owned(format!("OWO Has been said {owo_count} times!"))
             };

--- a/examples/e12_parallel_loops/Cargo.toml
+++ b/examples/e12_parallel_loops/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e12_parallel_loops"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "cache", "rustls_backend"] }

--- a/examples/e13_sqlite_database/Cargo.toml
+++ b/examples/e13_sqlite_database/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e13_sqlite_database"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }

--- a/examples/e14_message_components/Cargo.toml
+++ b/examples/e14_message_components/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e14_message_components"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "collector", "rustls_backend"] }

--- a/examples/e15_webhook/Cargo.toml
+++ b/examples/e15_webhook/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e15_webhook"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["model", "rustls_backend"] }

--- a/examples/e16_interactions_endpoint/Cargo.toml
+++ b/examples/e16_interactions_endpoint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e16_interactions_endpoint"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
-edition = "2018"
+edition.workspace = true
 
 [dependencies]
 serenity = { path = "../../", default-features = false, features = ["builder", "interactions_endpoint"] }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,3 @@
-edition = "2021"
 match_block_trailing_comma = true
 newline_style = "Unix"
 use_field_init_shorthand = true

--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -20,11 +20,7 @@ enum ParseAction {
 
 impl ParseAction {
     fn from_allow(allow: bool) -> Self {
-        if allow {
-            Self::Insert
-        } else {
-            Self::Remove
-        }
+        if allow { Self::Insert } else { Self::Remove }
     }
 }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -32,8 +32,8 @@ use std::sync::Arc;
 #[cfg(feature = "temp_cache")]
 use std::time::Duration;
 
-use dashmap::mapref::one::{MappedRef, Ref};
 use dashmap::DashMap;
+use dashmap::mapref::one::{MappedRef, Ref};
 #[cfg(feature = "temp_cache")]
 use mini_moka::sync::Cache as MokaCache;
 use parking_lot::RwLock;

--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -4,9 +4,9 @@ use std::hash::Hash;
 #[cfg(feature = "temp_cache")]
 use std::sync::Arc;
 
+use dashmap::DashMap;
 use dashmap::mapref::multiple::RefMulti;
 use dashmap::mapref::one::{Ref, RefMut};
-use dashmap::DashMap;
 #[cfg(feature = "typesize")]
 use typesize::TypeSize;
 
@@ -128,7 +128,7 @@ impl<T> MaybeOwnedArc<T> {
 
     pub(crate) fn get_inner(self) -> Arc<T> {
         #[cfg(feature = "typesize")]
-        let inner = self.0 .0;
+        let inner = self.0.0;
         #[cfg(not(feature = "typesize"))]
         let inner = self.0;
 

--- a/src/collector/quick_modal.rs
+++ b/src/collector/quick_modal.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::future::Future;
 
 use crate::builder::{CreateActionRow, CreateInputText, CreateInteractionResponse, CreateModal};
 use crate::collector::ModalInteractionCollector;

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::io::Error as IoError;
 
 #[cfg(feature = "http")]
-use reqwest::{header::InvalidHeaderValue, Error as ReqwestError};
+use reqwest::{Error as ReqwestError, header::InvalidHeaderValue};
 #[cfg(feature = "gateway")]
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 #[cfg(feature = "tracing_instrument")]

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -27,7 +27,6 @@ mod context;
 pub(crate) mod dispatch;
 mod event_handler;
 
-use std::future::IntoFuture;
 use std::num::NonZeroU16;
 use std::ops::Range;
 use std::sync::Arc;

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -45,11 +45,11 @@ pub use self::event_handler::{EventHandler, FullEvent, RawEventHandler};
 use super::VoiceGatewayManager;
 use super::{
     ActivityData,
+    DEFAULT_WAIT_BETWEEN_SHARD_START,
     PresenceData,
     ShardManager,
     ShardManagerOptions,
     TransportCompression,
-    DEFAULT_WAIT_BETWEEN_SHARD_START,
 };
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
@@ -394,9 +394,9 @@ impl IntoFuture for ClientBuilder {
 /// "ping-pong" bot is simple:
 ///
 /// ```no_run
+/// use serenity::Client;
 /// use serenity::model::prelude::*;
 /// use serenity::prelude::*;
-/// use serenity::Client;
 ///
 /// struct Handler;
 ///
@@ -741,11 +741,7 @@ impl Client {
             #[cfg(feature = "cache")]
             let cache_user_id = {
                 let cache_user = self.cache.current_user();
-                if cache_user.id == UserId::default() {
-                    None
-                } else {
-                    Some(cache_user.id)
-                }
+                if cache_user.id == UserId::default() { None } else { Some(cache_user.id) }
             };
 
             #[cfg(not(feature = "cache"))]

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -39,7 +39,7 @@ use std::time::{Duration as StdDuration, Instant};
 
 #[cfg(any(feature = "transport_compression_zlib", feature = "transport_compression_zstd"))]
 use aformat::aformat_into;
-use aformat::{aformat, ArrayString, CapStr};
+use aformat::{ArrayString, CapStr, aformat};
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 #[cfg(feature = "tracing_instrument")]
@@ -48,10 +48,10 @@ use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
 pub use self::shard_manager::{
+    DEFAULT_WAIT_BETWEEN_SHARD_START,
     ShardManager,
     ShardManagerMessage,
     ShardManagerOptions,
-    DEFAULT_WAIT_BETWEEN_SHARD_START,
 };
 pub use self::shard_messenger::ShardMessenger;
 pub use self::shard_queue::ShardQueue;

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -5,8 +5,8 @@ use std::sync::OnceLock;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use futures::StreamExt;
+use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use tokio::time::{sleep, timeout};
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
@@ -27,9 +27,9 @@ use super::{
 use crate::cache::Cache;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
-use crate::gateway::client::{EventHandler, RawEventHandler};
 #[cfg(feature = "voice")]
 use crate::gateway::VoiceGatewayManager;
+use crate::gateway::client::{EventHandler, RawEventHandler};
 use crate::gateway::{ConnectionStage, GatewayError, PresenceData, TransportCompression};
 use crate::http::Http;
 use crate::internal::prelude::*;

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -2,9 +2,9 @@ use std::sync::{Arc, Mutex};
 
 use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
 use tokio_tungstenite::tungstenite;
+use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
-use tokio_tungstenite::tungstenite::Message;
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
 use tracing::{debug, error, trace, warn};
@@ -23,10 +23,10 @@ use super::{
 use crate::cache::Cache;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
-use crate::gateway::client::dispatch::dispatch_model;
-use crate::gateway::client::{Context, EventHandler, RawEventHandler};
 #[cfg(feature = "voice")]
 use crate::gateway::VoiceGatewayManager;
+use crate::gateway::client::dispatch::dispatch_model;
+use crate::gateway::client::{Context, EventHandler, RawEventHandler};
 use crate::gateway::{ActivityData, ChunkGuildFilter, GatewayError};
 use crate::http::Http;
 use crate::internal::prelude::*;
@@ -158,10 +158,10 @@ impl ShardRunner {
                     ShardAction::Heartbeat => {
                         if let Err(e) = self.shard.heartbeat().await {
                             debug!(
-                            "[ShardRunner {:?}] Reconnecting due to error while heartbeating: {:?}",
-                            self.shard.shard_info(),
-                            e
-                        );
+                                "[ShardRunner {:?}] Reconnecting due to error while heartbeating: {:?}",
+                                self.shard.shard_info(),
+                                e
+                            );
                             if !self.reconnect().await {
                                 return Ok(());
                             }
@@ -170,10 +170,10 @@ impl ShardRunner {
                     ShardAction::Identify => {
                         if let Err(e) = self.shard.identify().await {
                             debug!(
-                            "[ShardRunner {:?}] Reconnecting due to error while identifying: {:?}",
-                            self.shard.shard_info(),
-                            e
-                        );
+                                "[ShardRunner {:?}] Reconnecting due to error while identifying: {:?}",
+                                self.shard.shard_info(),
+                                e
+                            );
                             if !self.reconnect().await {
                                 return Ok(());
                             }

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -2,15 +2,15 @@ use std::env::consts;
 use std::io::Read;
 use std::time::SystemTime;
 
-use flate2::read::ZlibDecoder;
 #[cfg(feature = "transport_compression_zlib")]
 use flate2::Decompress as ZlibInflater;
+use flate2::read::ZlibDecoder;
 use futures::{SinkExt, StreamExt};
 use tokio::net::TcpStream;
-use tokio::time::{timeout, Duration};
+use tokio::time::{Duration, timeout};
 use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
 use tokio_tungstenite::tungstenite::{Error as WsError, Message};
-use tokio_tungstenite::{connect_async_with_config, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async_with_config};
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
 use tracing::{debug, trace, warn};
@@ -164,7 +164,7 @@ impl Compression {
                         Ok(0) => break,
                         Ok(_hint) => {},
                         Err(code) => {
-                            return Err(Error::Gateway(GatewayError::DecompressZstd(code)))
+                            return Err(Error::Gateway(GatewayError::DecompressZstd(code)));
                         },
                     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -5,11 +5,11 @@ use std::cell::Cell;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use arrayvec::ArrayVec;
-use nonmax::{NonMaxU16, NonMaxU8};
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use reqwest::header::{HeaderMap as Headers, HeaderValue};
+use nonmax::{NonMaxU8, NonMaxU16};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 #[cfg(feature = "utils")]
 use reqwest::Url;
+use reqwest::header::{HeaderMap as Headers, HeaderValue};
 use reqwest::{Client, ClientBuilder, Response as ReqwestResponse, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::ser::SerializeSeq as _;
@@ -263,11 +263,7 @@ impl Http {
 
     pub fn application_id(&self) -> Option<ApplicationId> {
         let application_id = self.application_id.load(Ordering::Relaxed);
-        if application_id == u64::MAX {
-            None
-        } else {
-            Some(ApplicationId::new(application_id))
-        }
+        if application_id == u64::MAX { None } else { Some(ApplicationId::new(application_id)) }
     }
 
     fn try_application_id(&self) -> Result<ApplicationId> {
@@ -303,11 +299,7 @@ impl Http {
             })
             .await?;
 
-        if response.status() == 204 {
-            Ok(None)
-        } else {
-            Ok(Some(response.json().await?))
-        }
+        if response.status() == 204 { Ok(None) } else { Ok(Some(response.json().await?)) }
     }
 
     /// Adds a single [`Role`] to a [`Member`] in a [`Guild`].
@@ -4409,7 +4401,9 @@ impl Http {
         if status.is_success() {
             if status != StatusCode::NO_CONTENT {
                 let route = route.path();
-                warn!("Mismatched successful response status from {route}! Expected 'No Content' but got {status}");
+                warn!(
+                    "Mismatched successful response status from {route}! Expected 'No Content' but got {status}"
+                );
             }
 
             return Ok(());

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -44,7 +44,7 @@ use dashmap::DashMap;
 use reqwest::header::HeaderMap;
 use reqwest::{Client, Response, StatusCode};
 use tokio::sync::Mutex;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tracing::debug;
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,11 +1,11 @@
 use std::fmt::Write;
 
 use reqwest::header::{
-    HeaderMap as Headers,
-    HeaderValue,
     AUTHORIZATION,
     CONTENT_LENGTH,
     CONTENT_TYPE,
+    HeaderMap as Headers,
+    HeaderValue,
     USER_AGENT,
 };
 use reqwest::{Client, RequestBuilder as ReqwestRequestBuilder};

--- a/src/http/typing.rs
+++ b/src/http/typing.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tokio::sync::oneshot::error::TryRecvError;
 use tokio::sync::oneshot::{self, Sender};
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 use crate::http::Http;
 use crate::internal::prelude::*;

--- a/src/internal/tokio.rs
+++ b/src/internal/tokio.rs
@@ -1,7 +1,4 @@
 #[cfg(feature = "http")]
-use std::future::Future;
-
-#[cfg(feature = "http")]
 pub fn spawn_named<F, T>(_name: &str, future: F) -> tokio::task::JoinHandle<T>
 where
     F: Future<Output = T> + Send + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@
 #![forbid(unsafe_code)]
 #![warn(
     unused,
-    rust_2018_idioms,
     clippy::unwrap_used,
     clippy::clone_on_ref_ptr,
     clippy::non_ascii_literal,

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -66,10 +66,10 @@ impl<'de> Deserialize<'de> for ActionRowComponent {
             | ComponentType::MentionableSelect
             | ComponentType::ChannelSelect => from_value(value).map(ActionRowComponent::SelectMenu),
             ComponentType::ActionRow => {
-                return Err(DeError::custom("Invalid component type ActionRow"))
+                return Err(DeError::custom("Invalid component type ActionRow"));
             },
             ComponentType(i) => {
-                return Err(DeError::custom(format_args!("Unknown component type {i}")))
+                return Err(DeError::custom(format_args!("Unknown component type {i}")));
             },
         }
         .map_err(DeError::custom)

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -10,13 +10,13 @@ use super::{
     PingInteraction,
 };
 use crate::internal::prelude::*;
+use crate::model::Permissions;
 #[cfg(not(feature = "unstable"))]
 use crate::model::guild::PartialMember;
 use crate::model::id::{ApplicationId, GuildId, InteractionId, MessageId, UserId};
 use crate::model::monetization::Entitlement;
 use crate::model::user::User;
-use crate::model::utils::{deserialize_val, remove_from_map, StrOrInt};
-use crate::model::Permissions;
+use crate::model::utils::{StrOrInt, deserialize_val, remove_from_map};
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -541,7 +541,9 @@ impl serde::Serialize for MessageInteractionMetadata {
                 serialize_with_type(serializer, val, InteractionType::Modal)
             },
             &MessageInteractionMetadata::Unknown(InteractionType(kind)) => {
-                tracing::warn!("Tried to serialize MessageInteractionMetadata::Unknown({kind}), serialising null instead");
+                tracing::warn!(
+                    "Tried to serialize MessageInteractionMetadata::Unknown({kind}), serialising null instead"
+                );
                 serializer.serialize_none()
             },
         }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use nonmax::{NonMaxU16, NonMaxU32, NonMaxU8};
+use nonmax::{NonMaxU8, NonMaxU16, NonMaxU32};
 
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -398,11 +398,7 @@ impl GuildChannel {
                 .iter()
                 .filter_map(|v| {
                     v.channel_id.and_then(|c| {
-                        if c == self.id {
-                            guild.members.get(&v.user_id).cloned()
-                        } else {
-                            None
-                        }
+                        if c == self.id { guild.members.get(&v.user_id).cloned() } else { None }
                     })
                 })
                 .collect()),

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -14,7 +14,7 @@ use crate::constants;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
 use crate::model::prelude::*;
-use crate::model::utils::{discord_colours, StrOrInt};
+use crate::model::utils::{StrOrInt, discord_colours};
 
 /// A representation of a message over a guild's text channel, a group, or a private channel.
 ///
@@ -1133,8 +1133,8 @@ mod tests {
         User,
         UserId,
     };
-    use crate::cache::wrappers::MaybeMap;
     use crate::cache::Cache;
+    use crate::cache::wrappers::MaybeMap;
 
     fn new_extract_map<K, T>(val: T) -> ExtractMap<K, T>
     where

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 #[cfg(feature = "model")]
 use nonmax::NonMaxU8;
 #[cfg(feature = "http")]
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeMap, Serializer};
 #[cfg(feature = "model")]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -3,8 +3,8 @@
 //! Every event includes the gateway intent required to receive it, as well as a link to the
 //! Discord documentation for the event.
 
-use serde::de::Error as DeError;
 use serde::Serialize;
+use serde::de::Error as DeError;
 use serde_json::value::RawValue;
 use strum::{EnumCount, IntoStaticStr, VariantNames};
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -3,7 +3,7 @@ use std::fmt;
 #[cfg(feature = "model")]
 use futures::stream::Stream;
 #[cfg(feature = "model")]
-use nonmax::{NonMaxU16, NonMaxU8};
+use nonmax::{NonMaxU8, NonMaxU16};
 
 #[cfg(feature = "model")]
 use crate::builder::{

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1265,7 +1265,7 @@ mod test {
 
         use crate::model::prelude::*;
 
-        fn gen_member() -> Member {
+        fn get_member() -> Member {
             Member {
                 nick: Some(FixedString::from_static_trunc("aaaa")),
                 user: User {
@@ -1277,8 +1277,8 @@ mod test {
             }
         }
 
-        fn gen() -> Guild {
-            let m = gen_member();
+        fn get_guild() -> Guild {
+            let m = get_member();
 
             Guild {
                 members: ExtractMap::from_iter([m]),
@@ -1288,18 +1288,18 @@ mod test {
 
         #[test]
         fn member_named_username() {
-            let guild = gen();
+            let guild = get_guild();
             let lhs = guild.member_named("test#1432").unwrap().display_name();
 
-            assert_eq!(lhs, gen_member().display_name());
+            assert_eq!(lhs, get_member().display_name());
         }
 
         #[test]
         fn member_named_nickname() {
-            let guild = gen();
+            let guild = get_guild();
             let lhs = guild.member_named("aaaa").unwrap().display_name();
 
-            assert_eq!(lhs, gen_member().display_name());
+            assert_eq!(lhs, get_member().display_name());
         }
     }
 }

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -4,7 +4,7 @@ use std::fmt;
 #[cfg(all(feature = "model", feature = "utils"))]
 use std::str::FromStr;
 
-use aformat::{aformat_into, ArrayString, ToArrayString};
+use aformat::{ArrayString, ToArrayString, aformat_into};
 
 use super::prelude::*;
 #[cfg(all(feature = "model", feature = "utils"))]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -78,6 +78,8 @@ pub mod prelude {
     };
     #[doc(hidden)]
     pub use super::{
+        ModelError,
+        Timestamp,
         application::*,
         channel::*,
         colour::*,
@@ -96,8 +98,6 @@ pub mod prelude {
         user::*,
         voice::*,
         webhook::*,
-        ModelError,
-        Timestamp,
     };
     pub(crate) use crate::internal::prelude::*;
 }

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(not(feature = "chrono"))]
 pub use time::error::Parse as InnerError;
 #[cfg(not(feature = "chrono"))]
-use time::{format_description::well_known::Rfc3339, serde::rfc3339, Duration, OffsetDateTime};
+use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339, serde::rfc3339};
 
 /// Discord's epoch starts at "2015-01-01T00:00:00+00:00"
 const DISCORD_EPOCH: u64 = 1_420_070_400_000;

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -1,7 +1,7 @@
 //! Representations of voice information.
 
-use serde::de::{Deserialize, Deserializer};
 use serde::Serialize;
+use serde::de::{Deserialize, Deserializer};
 
 use crate::model::prelude::*;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,14 +17,14 @@ pub use tokio::sync::{Mutex, RwLock};
 
 pub use crate::error::Error as SerenityError;
 #[cfg(feature = "gateway")]
-pub use crate::gateway::client::{Client, Context, EventHandler, RawEventHandler};
-#[cfg(feature = "gateway")]
 pub use crate::gateway::GatewayError;
+#[cfg(feature = "gateway")]
+pub use crate::gateway::client::{Client, Context, EventHandler, RawEventHandler};
 #[cfg(feature = "http")]
 pub use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 pub use crate::http::HttpError;
 pub use crate::model::mention::Mentionable;
 #[cfg(feature = "model")]
-pub use crate::model::{gateway::GatewayIntents, ModelError};
+pub use crate::model::{ModelError, gateway::GatewayIntents};
 pub use crate::secrets::Token;

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use aformat::{aformat, CapStr};
+use aformat::{CapStr, aformat};
 
 /// A cheaply clonable, zeroed on drop, String.
 ///

--- a/src/utils/argument_convert/mod.rs
+++ b/src/utils/argument_convert/mod.rs
@@ -124,7 +124,7 @@ pub fn parse_message_id_pair(s: &str) -> Option<(ChannelId, MessageId)> {
 /// ```
 #[must_use]
 pub fn parse_message_url(s: &str) -> Option<(GuildId, ChannelId, MessageId)> {
-    use aformat::{aformat, CapStr};
+    use aformat::{CapStr, aformat};
 
     for domain in DOMAINS {
         let prefix = aformat!("https://{}/channels/", CapStr::<MAX_DOMAIN_LEN>(domain));
@@ -163,7 +163,7 @@ pub fn parse_message_url(s: &str) -> Option<(GuildId, ChannelId, MessageId)> {
 /// ```
 #[must_use]
 pub fn parse_channel_url(s: &str) -> Option<(GuildId, ChannelId)> {
-    use aformat::{aformat, CapStr};
+    use aformat::{CapStr, aformat};
 
     for domain in DOMAINS {
         let prefix = aformat!("https://{}/channels/", CapStr::<MAX_DOMAIN_LEN>(domain));

--- a/src/utils/content_safe.rs
+++ b/src/utils/content_safe.rs
@@ -60,7 +60,7 @@ impl Default for ContentSafeOptions {
 /// ```rust
 /// # let cache = serenity::cache::Cache::default();
 /// # let guild = serenity::model::guild::Guild::default();
-/// use serenity::utils::{content_safe, ContentSafeOptions};
+/// use serenity::utils::{ContentSafeOptions, content_safe};
 ///
 /// let with_mention = "@everyone";
 /// let without_mention = content_safe(&guild, &with_mention, ContentSafeOptions::default(), &[]);
@@ -73,7 +73,7 @@ impl Default for ContentSafeOptions {
 /// ```rust
 /// use serenity::cache::Cache;
 /// use serenity::model::channel::Message;
-/// use serenity::utils::{content_safe, ContentSafeOptions};
+/// use serenity::utils::{ContentSafeOptions, content_safe};
 ///
 /// fn filter_message(cache: &Cache, message: &Message) -> String {
 ///     if let Some(guild) = message.guild(cache) {

--- a/src/utils/formatted_timestamp.rs
+++ b/src/utils/formatted_timestamp.rs
@@ -2,7 +2,7 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::str::FromStr;
 
-use aformat::{aformat_into, ArrayString, ToArrayString};
+use aformat::{ArrayString, ToArrayString, aformat_into};
 
 use crate::model::Timestamp;
 

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -858,7 +858,7 @@ pub trait EmbedMessageBuilding {
     /// ```
     #[must_use]
     fn push_named_link<'a>(self, name: impl Into<Content<'a>>, url: impl Into<Content<'a>>)
-        -> Self;
+    -> Self;
 
     /// Pushes a named link intended for use in an embed, but with a normalized name to avoid
     /// escaping issues.

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1102,7 +1102,7 @@ mod test {
     use super::MessageBuilder;
     use crate::model::prelude::*;
 
-    macro_rules! gen {
+    macro_rules! generate {
         ($($fn:ident => [$($text:expr => $expected:expr),+]),+) => ({
             $(
                 $(
@@ -1217,7 +1217,7 @@ mod test {
 
     #[test]
     fn push_safe() {
-        gen! {
+        generate! {
             push_safe => [
                 "" => "",
                 "foo" => "foo",
@@ -1293,7 +1293,7 @@ mod test {
 
     #[test]
     fn push_unsafe() {
-        gen! {
+        generate! {
             push_bold => [
                 "a" => "**a**",
                 "" => "****",

--- a/voice-model/benches/de.rs
+++ b/voice-model/benches/de.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use serenity_voice_model::Event;
 
 pub fn json_deser(c: &mut Criterion) {


### PR DESCRIPTION
Running `cargo fix --edition` produces a lot of noise, and the relative drop order change shouldn't affect us because we don't use any unsafe code. What I did was manually change the edition and then just fix the compiler errors.