### PR TITLE
filter component deserialization for messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rust-version = "1.74"
 [dependencies]
 # Required dependencies
 bitflags = "2.4.2"
-serde_json = "1.0.108"
+serde_json = { version = "1.0.108", features = ["raw_value"] }
 async-trait = "0.1.74"
 tracing = { version = "0.1.40", features = ["log"] }
 serde = { version = "1.0.192", features = ["derive"] }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -176,7 +176,7 @@ where
         where
             A: serde::de::SeqAccess<'de>,
         {
-            let mut components = Vec::new();
+            let mut components = Vec::with_capacity(seq.size_hint().unwrap_or_default());
 
             while let Some(raw) = seq.next_element::<&serde_json::value::RawValue>()? {
                 // We deserialize only the `kind` field to determine the component type.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -185,9 +185,7 @@ where
                 let min_component =
                     MinComponent::deserialize(raw).map_err(serde::de::Error::custom)?;
 
-                // This is an action row, the only top level supported component in serenity at this
-                // time, we only have deseliazed the kind until now to avoid parsing unsupported
-                // components.
+                // Action rows are the only top level component supported in serenity at this time.
                 if min_component.kind == 1 {
                     match ActionRow::deserialize(raw) {
                         Ok(valid_row) => components.push(valid_row),

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -179,11 +179,15 @@ where
             let mut components = Vec::new();
 
             while let Some(raw) = seq.next_element::<&serde_json::value::RawValue>()? {
+                // We deserialize only the `kind` field to determine the component type.
+                // We later use this to check if its a supported component before deserializing the
+                // entire payload.
                 let min_component =
                     MinComponent::deserialize(raw).map_err(serde::de::Error::custom)?;
 
                 // This is an action row, the only top level supported component in serenity at this
-                // time.
+                // time, we only have deseliazed the kind until now to avoid parsing unsupported
+                // components.
                 if min_component.kind == 1 {
                     match ActionRow::deserialize(raw) {
                         Ok(valid_row) => components.push(valid_row),

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -179,13 +179,13 @@ where
             let mut components = Vec::new();
 
             while let Some(raw) = seq.next_element::<&serde_json::value::RawValue>()? {
-                let min_component: MinComponent =
-                    serde_json::from_str(raw.get()).map_err(serde::de::Error::custom)?;
+                let min_component =
+                    MinComponent::deserialize(raw).map_err(serde::de::Error::custom)?;
 
                 // This is an action row, the only top level supported component in serenity at this
                 // time.
                 if min_component.kind == 1 {
-                    match serde_json::from_str::<ActionRow>(raw.get()) {
+                    match ActionRow::deserialize(raw) {
                         Ok(valid_row) => components.push(valid_row),
                         Err(_) => {
                             tracing::debug!("Failed to deserialize ActionRow, malformed data.");

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -157,6 +157,12 @@ fn deserialize_components<'de, D>(deserializer: D) -> Result<Vec<ActionRow>, D::
 where
     D: Deserializer<'de>,
 {
+    #[derive(Deserialize)]
+    struct MinComponent {
+        #[serde(rename = "type")]
+        kind: u8,
+    }
+
     struct ComponentsVisitor;
 
     impl<'de> Visitor<'de> for ComponentsVisitor {
@@ -171,14 +177,30 @@ where
             A: serde::de::SeqAccess<'de>,
         {
             let mut components = Vec::new();
-            while let Some(action_row) = seq.next_element::<serde_json::Value>()? {
-                match serde_json::from_value::<ActionRow>(action_row) {
-                    Ok(valid_row) => components.push(valid_row),
-                    Err(_) => {
-                        tracing::debug!("Could not deserialize interaction as ActionRow, likely new V2 component.");
-                    },
+
+            while let Some(raw) = seq.next_element::<&serde_json::value::RawValue>()? {
+                let min_component: MinComponent =
+                    serde_json::from_str(raw.get()).map_err(serde::de::Error::custom)?;
+
+                // This is an action row, the only top level supported component in serenity at this
+                // time.
+                if min_component.kind == 1 {
+                    match serde_json::from_str::<ActionRow>(raw.get()) {
+                        Ok(valid_row) => components.push(valid_row),
+                        Err(_) => {
+                            tracing::debug!("Failed to deserialize ActionRow, malformed data.");
+                        },
+                    }
+                } else {
+                    // Top level component is not an action row and cannot be supported on
+                    // serenity@current without breaking changes, so we skip them.
+                    tracing::debug!(
+                        "Skipping component with unsupported kind: {}",
+                        min_component.kind
+                    );
                 }
             }
+
             Ok(components)
         }
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -118,7 +118,7 @@ pub struct Message {
     /// The thread that was started from this message, includes thread member object.
     pub thread: Option<GuildChannel>,
     /// The components of this message
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_components")]
     pub components: Vec<ActionRow>,
     /// Array of message sticker item objects.
     #[serde(default)]
@@ -149,6 +149,41 @@ pub struct Message {
     ///
     /// Only present in [`MessageCreateEvent`].
     pub poll: Option<Box<Poll>>,
+}
+
+// Custom deserialize function to deserialize components safely without knocking the whole message
+// out when new components are found but not supported.
+fn deserialize_components<'de, D>(deserializer: D) -> Result<Vec<ActionRow>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ComponentsVisitor;
+
+    impl<'de> Visitor<'de> for ComponentsVisitor {
+        type Value = Vec<ActionRow>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a sequence of ActionRow elements")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut components = Vec::new();
+            while let Some(action_row) = seq.next_element::<serde_json::Value>()? {
+                match serde_json::from_value::<ActionRow>(action_row) {
+                    Ok(valid_row) => components.push(valid_row),
+                    Err(_) => {
+                        tracing::debug!("Could not deserialize interaction as ActionRow, likely new V2 component.");
+                    },
+                }
+            }
+            Ok(components)
+        }
+    }
+
+    deserializer.deserialize_seq(ComponentsVisitor)
 }
 
 #[cfg(feature = "model")]
@@ -1211,7 +1246,7 @@ pub struct MessageSnapshot {
     #[serde(rename = "type")]
     pub kind: MessageType,
     pub flags: Option<MessageFlags>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_components")]
     pub components: Vec<ActionRow>,
     #[serde(default)]
     pub sticker_items: Vec<StickerItem>,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -187,12 +187,7 @@ where
 
                 // Action rows are the only top level component supported in serenity at this time.
                 if min_component.kind == 1 {
-                    match ActionRow::deserialize(raw) {
-                        Ok(valid_row) => components.push(valid_row),
-                        Err(_) => {
-                            tracing::debug!("Failed to deserialize ActionRow, malformed data.");
-                        },
-                    }
+                    components.push(ActionRow::deserialize(raw).map_err(serde::de::Error::custom)?);
                 } else {
                     // Top level component is not an action row and cannot be supported on
                     // serenity@current without breaking changes, so we skip them.


### PR DESCRIPTION
Will prevent components v2 from causing messages to not deserialize, it is important that a new serenity release is released before the 2nd week of March as that is when these components will be enabled.

Not the most familiar with doing stuff like this so this may not be optimal, other implementations are welcome.