### PR TITLE
Update documented guild limit for get_guilds

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4022,7 +4022,7 @@ impl Http {
 
     /// Gets a paginated list of the current user's guilds.
     ///
-    /// The `limit` has a maximum value of 100.
+    /// The `limit` has a maximum value of 200.
     ///
     /// [Discord's documentation][docs]
     ///


### PR DESCRIPTION
The limit is now 200, not 100, as per Discord's API docs which are linked in the edited doc comment.