### PR TITLE
Replace `JsonMap` with `RawValue`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1833,13 +1833,11 @@ impl Http {
     pub async fn edit_member_me(
         &self,
         guild_id: GuildId,
-        map: &JsonMap,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Member> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Patch,

--- a/src/internal/prelude.rs
+++ b/src/internal/prelude.rs
@@ -14,5 +14,3 @@ pub use super::utils::join_to_string;
 pub use crate::error::Error;
 pub use crate::error::Result;
 pub use crate::secrets::{SecretString, Token};
-
-pub type JsonMap = serde_json::Map<String, Value>;

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -1,9 +1,9 @@
 use serde::de::Error as DeError;
 use serde::ser::{Serialize, Serializer};
-use serde_json::from_value;
+use serde_json::value::RawValue;
 
 use crate::model::prelude::*;
-use crate::model::utils::{default_true, deserialize_val};
+use crate::model::utils::default_true;
 
 enum_number! {
     /// The type of a component
@@ -52,19 +52,27 @@ pub enum ActionRowComponent {
 
 impl<'de> Deserialize<'de> for ActionRowComponent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        let map = JsonMap::deserialize(deserializer)?;
+        #[derive(Debug, Clone, Deserialize)]
+        struct ActionRowRaw {
+            #[serde(rename = "type")]
+            kind: ComponentType,
+        }
 
-        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
-        let value = Value::from(map);
+        let raw_data = <&RawValue>::deserialize(deserializer)?;
+        let raw = ActionRowRaw::deserialize(raw_data).map_err(DeError::custom)?;
 
-        match deserialize_val(raw_kind)? {
-            ComponentType::Button => from_value(value).map(ActionRowComponent::Button),
-            ComponentType::InputText => from_value(value).map(ActionRowComponent::InputText),
+        match raw.kind {
+            ComponentType::Button => Button::deserialize(raw_data).map(ActionRowComponent::Button),
+            ComponentType::InputText => {
+                InputText::deserialize(raw_data).map(ActionRowComponent::InputText)
+            },
             ComponentType::StringSelect
             | ComponentType::UserSelect
             | ComponentType::RoleSelect
             | ComponentType::MentionableSelect
-            | ComponentType::ChannelSelect => from_value(value).map(ActionRowComponent::SelectMenu),
+            | ComponentType::ChannelSelect => {
+                SelectMenu::deserialize(raw_data).map(ActionRowComponent::SelectMenu)
+            },
             ComponentType::ActionRow => {
                 return Err(DeError::custom("Invalid component type ActionRow"));
             },

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -52,7 +52,7 @@ pub enum ActionRowComponent {
 
 impl<'de> Deserialize<'de> for ActionRowComponent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        #[derive(Debug, Clone, Deserialize)]
+        #[derive(Deserialize)]
         struct ActionRowRaw {
             #[serde(rename = "type")]
             kind: ComponentType,

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -62,16 +62,18 @@ impl<'de> Deserialize<'de> for ActionRowComponent {
         let raw = ActionRowRaw::deserialize(raw_data).map_err(DeError::custom)?;
 
         match raw.kind {
-            ComponentType::Button => Button::deserialize(raw_data).map(ActionRowComponent::Button),
+            ComponentType::Button => {
+                Deserialize::deserialize(raw_data).map(ActionRowComponent::Button)
+            },
             ComponentType::InputText => {
-                InputText::deserialize(raw_data).map(ActionRowComponent::InputText)
+                Deserialize::deserialize(raw_data).map(ActionRowComponent::InputText)
             },
             ComponentType::StringSelect
             | ComponentType::UserSelect
             | ComponentType::RoleSelect
             | ComponentType::MentionableSelect
             | ComponentType::ChannelSelect => {
-                SelectMenu::deserialize(raw_data).map(ActionRowComponent::SelectMenu)
+                Deserialize::deserialize(raw_data).map(ActionRowComponent::SelectMenu)
             },
             ComponentType::ActionRow => {
                 return Err(DeError::custom("Invalid component type ActionRow"));

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -244,7 +244,7 @@ impl Interaction {
 // Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for Interaction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        #[derive(Debug, Clone, Deserialize)]
+        #[derive(Deserialize)]
         struct InteractionRaw {
             #[serde(rename = "type")]
             kind: InteractionType,
@@ -504,7 +504,7 @@ pub enum MessageInteractionMetadata {
 
 impl<'de> serde::Deserialize<'de> for MessageInteractionMetadata {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        #[derive(Debug, Clone, Deserialize)]
+        #[derive(Deserialize)]
         struct InteractionRaw {
             #[serde(rename = "type")]
             kind: InteractionType,

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -255,18 +255,16 @@ impl<'de> Deserialize<'de> for Interaction {
 
         match raw.kind {
             InteractionType::Command => {
-                CommandInteraction::deserialize(raw_data).map(Interaction::Command)
+                Deserialize::deserialize(raw_data).map(Interaction::Command)
             },
             InteractionType::Component => {
-                ComponentInteraction::deserialize(raw_data).map(Interaction::Component)
+                Deserialize::deserialize(raw_data).map(Interaction::Component)
             },
             InteractionType::Autocomplete => {
-                CommandInteraction::deserialize(raw_data).map(Interaction::Autocomplete)
+                Deserialize::deserialize(raw_data).map(Interaction::Autocomplete)
             },
-            InteractionType::Modal => {
-                ModalInteraction::deserialize(raw_data).map(Interaction::Modal)
-            },
-            InteractionType::Ping => PingInteraction::deserialize(raw_data).map(Interaction::Ping),
+            InteractionType::Modal => Deserialize::deserialize(raw_data).map(Interaction::Modal),
+            InteractionType::Ping => Deserialize::deserialize(raw_data).map(Interaction::Ping),
             InteractionType(_) => return Err(DeError::custom("Unknown interaction type")),
         }
         .map_err(DeError::custom)
@@ -516,15 +514,9 @@ impl<'de> serde::Deserialize<'de> for MessageInteractionMetadata {
         let raw = InteractionRaw::deserialize(raw_data).map_err(DeError::custom)?;
 
         match raw.kind {
-            InteractionType::Command => {
-                MessageCommandInteractionMetadata::deserialize(raw_data).map(Self::Command)
-            },
-            InteractionType::Component => {
-                MessageComponentInteractionMetadata::deserialize(raw_data).map(Self::Component)
-            },
-            InteractionType::Modal => {
-                MessageModalSubmitInteractionMetadata::deserialize(raw_data).map(Self::ModalSubmit)
-            },
+            InteractionType::Command => Deserialize::deserialize(raw_data).map(Self::Command),
+            InteractionType::Component => Deserialize::deserialize(raw_data).map(Self::Component),
+            InteractionType::Modal => Deserialize::deserialize(raw_data).map(Self::ModalSubmit),
 
             unknown => Ok(Self::Unknown(unknown)),
         }

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -1,6 +1,6 @@
 use serde::de::{Deserialize, Deserializer, Error as DeError};
 use serde::ser::{Serialize, Serializer};
-use serde_json::from_value;
+use serde_json::value::RawValue;
 
 use super::{
     CommandInteraction,
@@ -16,7 +16,7 @@ use crate::model::guild::PartialMember;
 use crate::model::id::{ApplicationId, GuildId, InteractionId, MessageId, UserId};
 use crate::model::monetization::Entitlement;
 use crate::model::user::User;
-use crate::model::utils::{StrOrInt, deserialize_val, remove_from_map};
+use crate::model::utils::StrOrInt;
 
 /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -244,17 +244,29 @@ impl Interaction {
 // Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for Interaction {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        let map = JsonMap::deserialize(deserializer)?;
+        #[derive(Debug, Clone, Deserialize)]
+        struct InteractionRaw {
+            #[serde(rename = "type")]
+            kind: InteractionType,
+        }
 
-        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
-        let value = Value::from(map);
+        let raw_data = <&RawValue>::deserialize(deserializer)?;
+        let raw = InteractionRaw::deserialize(raw_data).map_err(DeError::custom)?;
 
-        match deserialize_val(raw_kind)? {
-            InteractionType::Command => from_value(value).map(Interaction::Command),
-            InteractionType::Component => from_value(value).map(Interaction::Component),
-            InteractionType::Autocomplete => from_value(value).map(Interaction::Autocomplete),
-            InteractionType::Modal => from_value(value).map(Interaction::Modal),
-            InteractionType::Ping => from_value(value).map(Interaction::Ping),
+        match raw.kind {
+            InteractionType::Command => {
+                CommandInteraction::deserialize(raw_data).map(Interaction::Command)
+            },
+            InteractionType::Component => {
+                ComponentInteraction::deserialize(raw_data).map(Interaction::Component)
+            },
+            InteractionType::Autocomplete => {
+                CommandInteraction::deserialize(raw_data).map(Interaction::Autocomplete)
+            },
+            InteractionType::Modal => {
+                ModalInteraction::deserialize(raw_data).map(Interaction::Modal)
+            },
+            InteractionType::Ping => PingInteraction::deserialize(raw_data).map(Interaction::Ping),
             InteractionType(_) => return Err(DeError::custom("Unknown interaction type")),
         }
         .map_err(DeError::custom)
@@ -494,16 +506,29 @@ pub enum MessageInteractionMetadata {
 
 impl<'de> serde::Deserialize<'de> for MessageInteractionMetadata {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut data = JsonMap::deserialize(deserializer)?;
-        let kind: InteractionType = remove_from_map(&mut data, "type")?;
+        #[derive(Debug, Clone, Deserialize)]
+        struct InteractionRaw {
+            #[serde(rename = "type")]
+            kind: InteractionType,
+        }
 
-        match kind {
-            InteractionType::Command => deserialize_val(Value::from(data)).map(Self::Command),
-            InteractionType::Component => deserialize_val(Value::from(data)).map(Self::Component),
-            InteractionType::Modal => deserialize_val(Value::from(data)).map(Self::ModalSubmit),
+        let raw_data = <&RawValue>::deserialize(deserializer)?;
+        let raw = InteractionRaw::deserialize(raw_data).map_err(DeError::custom)?;
+
+        match raw.kind {
+            InteractionType::Command => {
+                MessageCommandInteractionMetadata::deserialize(raw_data).map(Self::Command)
+            },
+            InteractionType::Component => {
+                MessageComponentInteractionMetadata::deserialize(raw_data).map(Self::Component)
+            },
+            InteractionType::Modal => {
+                MessageModalSubmitInteractionMetadata::deserialize(raw_data).map(Self::ModalSubmit)
+            },
 
             unknown => Ok(Self::Unknown(unknown)),
         }
+        .map_err(DeError::custom)
     }
 }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -11,9 +11,9 @@ mod reaction;
 
 use std::fmt;
 
-use serde::de::{Error as DeError, Unexpected};
+use serde::de::Error as DeError;
 use serde::ser::SerializeMap as _;
-use serde_json::from_value;
+use serde_json::value::RawValue;
 
 pub use self::attachment::*;
 #[cfg(feature = "model")]
@@ -156,22 +156,20 @@ impl Channel {
 // Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for Channel {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let map = JsonMap::deserialize(deserializer)?;
+        #[derive(Debug, Clone, Deserialize)]
+        struct ChannelRaw {
+            #[serde(rename = "type")]
+            kind: u64,
+        }
 
-        let kind = {
-            let kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?;
-            kind.as_u64().ok_or_else(|| {
-                DeError::invalid_type(
-                    Unexpected::Other("non-positive integer"),
-                    &"a positive integer",
-                )
-            })?
-        };
+        let raw_data = <&RawValue>::deserialize(deserializer)?;
+        let raw = ChannelRaw::deserialize(raw_data).map_err(DeError::custom)?;
 
-        let value = Value::from(map);
-        match kind {
-            0 | 2 | 4 | 5 | 10 | 11 | 12 | 13 | 14 | 15 => from_value(value).map(Channel::Guild),
-            1 => from_value(value).map(Channel::Private),
+        match raw.kind {
+            0 | 2 | 4 | 5 | 10 | 11 | 12 | 13 | 14 | 15 => {
+                GuildChannel::deserialize(raw_data).map(Channel::Guild)
+            },
+            1 => PrivateChannel::deserialize(raw_data).map(Channel::Private),
             _ => return Err(DeError::custom("Unknown channel type")),
         }
         .map_err(DeError::custom)

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -156,7 +156,7 @@ impl Channel {
 // Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for Channel {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        #[derive(Debug, Clone, Deserialize)]
+        #[derive(Deserialize)]
         struct ChannelRaw {
             #[serde(rename = "type")]
             kind: u64,

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -167,9 +167,9 @@ impl<'de> Deserialize<'de> for Channel {
 
         match raw.kind {
             0 | 2 | 4 | 5 | 10 | 11 | 12 | 13 | 14 | 15 => {
-                GuildChannel::deserialize(raw_data).map(Channel::Guild)
+                Deserialize::deserialize(raw_data).map(Channel::Guild)
             },
-            1 => PrivateChannel::deserialize(raw_data).map(Channel::Private),
+            1 => Deserialize::deserialize(raw_data).map(Channel::Private),
             _ => return Err(DeError::custom("Unknown channel type")),
         }
         .map_err(DeError::custom)

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -468,9 +468,11 @@ pub struct MessageDeleteEvent {
 /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+// This ensures that `RawValue` is further supported in nested fields of `Message`.
+// Fields underneath #[serde(flatten)] cannot be deserialized as `RawValue`.
+#[serde(transparent)]
 #[non_exhaustive]
 pub struct MessageUpdateEvent {
-    #[serde(flatten)]
     pub message: Message,
 }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -973,7 +973,7 @@ fn raw_value_len(val: &RawValue) -> usize {
 // Manual impl needed to emulate integer enum tags
 impl<'de> Deserialize<'de> for GatewayEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        #[derive(Debug, Clone, Deserialize)]
+        #[derive(Deserialize)]
         struct GatewayEventRaw<'a> {
             op: Opcode,
             #[serde(rename = "s")]

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use arrayvec::ArrayVec;
 use serde::de::Error as DeError;
 use serde_cow::CowStr;
+use serde_json::value::RawValue;
 use small_fixed_array::FixedString;
 
 use super::prelude::*;
@@ -245,6 +246,12 @@ pub fn deserialize_components<'de, D>(deserializer: D) -> Result<FixedArray<Acti
 where
     D: Deserializer<'de>,
 {
+    #[derive(Deserialize)]
+    struct MinComponent {
+        #[serde(rename = "type")]
+        kind: u8,
+    }
+
     struct ComponentsVisitor;
 
     impl<'de> Visitor<'de> for ComponentsVisitor {
@@ -260,22 +267,23 @@ where
         {
             let mut components = Vec::with_capacity(seq.size_hint().unwrap_or_default());
 
-            while let Some(map) = seq.next_element::<JsonMap>()? {
+            while let Some(raw) = seq.next_element::<&RawValue>()? {
                 // We deserialize only the `kind` field to determine the component type.
                 // We later use this to check if its a supported component before deserializing the
                 // entire payload.
-                let raw_kind =
-                    map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
-                let kind: i64 = deserialize_val(raw_kind)?;
+                let min_component =
+                    MinComponent::deserialize(raw).map_err(serde::de::Error::custom)?;
 
                 // Action rows are the only top level component supported in serenity at this time.
-                if kind == 1 {
-                    let value = Value::from(map);
-                    components.push(ActionRow::deserialize(value).map_err(DeError::custom)?);
+                if min_component.kind == 1 {
+                    components.push(ActionRow::deserialize(raw).map_err(serde::de::Error::custom)?);
                 } else {
                     // Top level component is not an action row and cannot be supported on
                     // serenity@current without breaking changes, so we skip them.
-                    tracing::debug!("Skipping component with unsupported kind: {kind}");
+                    tracing::debug!(
+                        "Skipping component with unsupported kind: {}",
+                        min_component.kind
+                    );
                 }
             }
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -43,22 +43,6 @@ pub(super) fn icon_url(id: GuildId, icon: Option<&ImageHash>) -> Option<String> 
     })
 }
 
-pub fn deserialize_val<T, E>(val: Value) -> StdResult<T, E>
-where
-    T: serde::de::DeserializeOwned,
-    E: serde::de::Error,
-{
-    T::deserialize(val).map_err(serde::de::Error::custom)
-}
-
-pub fn remove_from_map<T, E>(map: &mut JsonMap, key: &'static str) -> StdResult<T, E>
-where
-    T: serde::de::DeserializeOwned,
-    E: serde::de::Error,
-{
-    map.remove(key).ok_or_else(|| serde::de::Error::missing_field(key)).and_then(deserialize_val)
-}
-
 pub(super) enum StrOrInt<'de> {
     String(String),
     Str(&'de str),


### PR DESCRIPTION
Entirely removes `JsonMap`, replacing all remaining uses with a combination of `RawValue` and helper structs for field access.