### PR TITLE
Remove deprecation warnings for guild specific premission checks

### DIFF
--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -428,6 +428,11 @@ impl Member {
     /// member.permissions(&cache).expect("permissions").bits());
     /// ```
     ///
+    /// # Note
+    ///
+    /// You likely want to use Guild::user_permissions_in instead as this function does not consider
+    /// permission overwrites.
+    ///
     /// # Errors
     ///
     /// Returns a [`ModelError::GuildNotFound`] if the guild the member's in could not be

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1912,9 +1912,11 @@ impl Guild {
     }
 
     /// Calculate a [`Member`]'s permissions in the guild.
+    ///
+    /// You likely want to use Guild::user_permissions_in instead as this function does not consider
+    /// permission overwrites.
     #[inline]
     #[must_use]
-    #[deprecated = "Use Guild::user_permissions_in, as this doesn't consider permission overwrites"]
     pub fn member_permissions(&self, member: &Member) -> Permissions {
         Self::user_permissions_in_(
             None,
@@ -1928,12 +1930,14 @@ impl Guild {
 
     /// Calculate a [`PartialMember`]'s permissions in the guild.
     ///
+    /// You likely want to use Guild::partial_member_permissions_in instead as this function does
+    /// not consider permission overwrites.
+    ///
     /// # Panics
     ///
     /// Panics if the passed [`UserId`] does not match the [`PartialMember`] id, if user is Some.
     #[inline]
     #[must_use]
-    #[deprecated = "Use Guild::partial_member_permissions_in, as this doesn't consider permission overwrites"]
     pub fn partial_member_permissions(
         &self,
         member_id: UserId,

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -1032,9 +1032,11 @@ impl PartialGuild {
     }
 
     /// Calculate a [`Member`]'s permissions in the guild.
+    ///
+    /// You likely want to use PartialGuild::user_permissions_in instead as this function does not
+    /// consider permission overwrites.
     #[inline]
     #[must_use]
-    #[deprecated = "Use PartialGuild::user_permissions_in, as this doesn't consider permission overwrites"]
     pub fn member_permissions(&self, member: &Member) -> Permissions {
         Guild::user_permissions_in_(
             None,
@@ -1048,12 +1050,14 @@ impl PartialGuild {
 
     /// Calculate a [`PartialMember`]'s permissions in the guild.
     ///
+    /// You likely want to use PartialGuild::partial_member_permissions_in instead as this function
+    /// does not consider permission overwrites.
+    ///
     /// # Panics
     ///
     /// Panics if the passed [`UserId`] does not match the [`PartialMember`] id, if user is Some.
     #[inline]
     #[must_use]
-    #[deprecated = "Use PartialGuild::partial_member_permissions_in, as this doesn't consider permission overwrites"]
     pub fn partial_member_permissions(
         &self,
         member_id: UserId,


### PR DESCRIPTION
Removes deprecation warnings now that #3116 is in and replaces them with comments.