### PR TITLE
Change `CreateAttachment` to stream data from disk when possible

### DIFF
--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -36,7 +36,7 @@ impl EventHandler for Handler {
                     let builder = CreateMessage::new()
                         .content("Hello, World!")
                         .embed(embed)
-                        .add_file(CreateAttachment::path("./ferris_eyes.png").await.unwrap());
+                        .add_file(CreateAttachment::path("./ferris_eyes.png").unwrap());
                     let msg = new_message.channel_id.send_message(&ctx.http, builder).await;
 
                     if let Err(why) = msg {

--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -36,7 +36,7 @@ impl EventHandler for Handler {
                     let builder = CreateMessage::new()
                         .content("Hello, World!")
                         .embed(embed)
-                        .add_file(CreateAttachment::path("./ferris_eyes.png").unwrap());
+                        .add_file(CreateAttachment::path("./ferris_eyes.png".as_ref()).unwrap());
                     let msg = new_message.channel_id.send_message(&ctx.http, builder).await;
 
                     if let Err(why) = msg {

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -183,10 +183,15 @@ impl ImageData {
     }
 }
 
+#[derive(Clone, Debug, Serialize)]
+struct ExistingAttachment {
+    id: AttachmentId,
+}
+
 #[derive(Clone, Debug)]
-enum EditAttachmentsInner<'a> {
+enum NewOrExisting<'a> {
     New(CreateAttachment<'a>),
-    Existing(AttachmentId),
+    Existing(ExistingAttachment),
 }
 
 /// You can add new attachments and edit existing ones using this builder.
@@ -247,7 +252,7 @@ enum EditAttachmentsInner<'a> {
 #[derive(Default, Debug, Clone)]
 #[must_use]
 pub struct EditAttachments<'a> {
-    inner: Vec<EditAttachmentsInner<'a>>,
+    new_and_existing_attachments: Vec<NewOrExisting<'a>>,
 }
 
 impl<'a> EditAttachments<'a> {
@@ -271,7 +276,15 @@ impl<'a> EditAttachments<'a> {
     /// Discord will throw an error!**
     pub fn keep_all(msg: &Message) -> Self {
         Self {
-            inner: msg.attachments.iter().map(|a| EditAttachmentsInner::Existing(a.id)).collect(),
+            new_and_existing_attachments: msg
+                .attachments
+                .iter()
+                .map(|a| {
+                    NewOrExisting::Existing(ExistingAttachment {
+                        id: a.id,
+                    })
+                })
+                .collect(),
         }
     }
 
@@ -280,7 +293,9 @@ impl<'a> EditAttachments<'a> {
     ///
     /// Opposite of [`Self::remove`].
     pub fn keep(mut self, id: AttachmentId) -> Self {
-        self.inner.push(EditAttachmentsInner::Existing(id));
+        self.new_and_existing_attachments.push(NewOrExisting::Existing(ExistingAttachment {
+            id,
+        }));
         self
     }
 
@@ -289,9 +304,9 @@ impl<'a> EditAttachments<'a> {
     ///
     /// Opposite of [`Self::keep`].
     pub fn remove(mut self, id: AttachmentId) -> Self {
-        self.inner.retain(|a| match a {
-            EditAttachmentsInner::Existing(existing_id) => *existing_id != id,
-            EditAttachmentsInner::New(_) => true,
+        self.new_and_existing_attachments.retain(|a| match a {
+            NewOrExisting::Existing(a) => a.id != id,
+            NewOrExisting::New(_) => true,
         });
         self
     }
@@ -299,7 +314,7 @@ impl<'a> EditAttachments<'a> {
     /// Adds a new attachment to the attachment list.
     #[expect(clippy::should_implement_trait)] // Clippy thinks add == std::ops::Add::add
     pub fn add(mut self, attachment: CreateAttachment<'a>) -> Self {
-        self.inner.push(EditAttachmentsInner::New(attachment));
+        self.new_and_existing_attachments.push(NewOrExisting::New(attachment));
         self
     }
 
@@ -308,10 +323,10 @@ impl<'a> EditAttachments<'a> {
     /// this method can only be called once.
     #[cfg(feature = "http")]
     pub(crate) fn new_attachments(&mut self) -> Vec<CreateAttachment<'a>> {
-        self.inner
+        self.new_and_existing_attachments
             .iter()
             .filter_map(|attachment| {
-                if let EditAttachmentsInner::New(attachment) = &attachment {
+                if let NewOrExisting::New(attachment) = &attachment {
                     Some(attachment.clone())
                 } else {
                     None
@@ -330,19 +345,14 @@ impl Serialize for EditAttachments<'_> {
             description: &'a Option<Cow<'a, str>>,
         }
 
-        #[derive(Serialize)]
-        struct ExistingAttachment {
-            id: AttachmentId,
-        }
-
         // Instead of an `AttachmentId`, the `id` field for new attachments corresponds to the
         // index of the new attachment in the multipart payload. The attachment data will be
         // labeled with `files[{id}]` in the multipart body. See `Multipart::build_form`.
         let mut id = 0;
-        let mut seq = serializer.serialize_seq(Some(self.inner.len()))?;
-        for attachment in &self.inner {
+        let mut seq = serializer.serialize_seq(Some(self.new_and_existing_attachments.len()))?;
+        for attachment in &self.new_and_existing_attachments {
             match attachment {
-                EditAttachmentsInner::New(new_attachment) => {
+                NewOrExisting::New(new_attachment) => {
                     let attachment = NewAttachment {
                         id,
                         filename: &new_attachment.filename,
@@ -351,10 +361,8 @@ impl Serialize for EditAttachments<'_> {
                     id += 1;
                     seq.serialize_element(&attachment)?;
                 },
-                EditAttachmentsInner::Existing(id) => {
-                    seq.serialize_element(&ExistingAttachment {
-                        id: *id,
-                    })?;
+                NewOrExisting::Existing(existing_attachment) => {
+                    seq.serialize_element(existing_attachment)?;
                 },
             }
         }

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -7,9 +7,7 @@ use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use url::Url;
 
-#[cfg(doc)]
-use crate::error::Error;
-use crate::error::Result;
+use crate::error::{Error, Result, UrlError};
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::model::channel::Message;
@@ -122,7 +120,6 @@ impl<'a> CreateAttachment<'a> {
     /// # Errors
     ///
     /// See [`CreateAttachment::get_data`] for details.
-    #[must_use]
     pub async fn encode(&self) -> Result<ImageData> {
         use base64::engine::{Config, Engine};
 
@@ -152,8 +149,37 @@ impl<'a> CreateAttachment<'a> {
 pub struct ImageData(String);
 
 impl ImageData {
+    /// Constructs image data from a base64-encoded blob of data. The string must be a valid data
+    /// URI, and must be encoded with base64, for example:
+    ///
+    /// ```
+    /// use serenity::builder::ImageData;
+    ///
+    /// let s = "data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
+    /// assert!(ImageData::from_base64(s).is_ok());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Error::Url`] if the string is not a valid data URI. See the [Discord
+    /// docs](https://discord.com/developers/docs/reference#image-data).
     pub fn from_base64(s: &str) -> Result<Self> {
-        Ok(Self(Url::parse(s)?.into()))
+        let url = Url::parse(s).map_err(|_| UrlError::InvalidDataURI)?;
+
+        let err = Error::Url(UrlError::InvalidDataURI);
+        if url.scheme() != "data" {
+            return Err(err);
+        }
+
+        let Some((mimetype, encoding)) = url.path().split_once(';') else {
+            return Err(err);
+        };
+
+        if mimetype.split_once('/').is_some() && encoding.starts_with("base64,") {
+            Ok(Self(url.into()))
+        } else {
+            Err(err)
+        }
     }
 }
 

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -319,10 +319,9 @@ impl<'a> EditAttachments<'a> {
     }
 
     /// Clones all new attachments into a new Vec, keeping only data and filename, because those
-    /// are needed for the multipart form data. The data is taken out of `self` in the process, so
-    /// this method can only be called once.
+    /// are needed for the multipart form data.
     #[cfg(feature = "http")]
-    pub(crate) fn new_attachments(&mut self) -> Vec<CreateAttachment<'a>> {
+    pub(crate) fn new_attachments(&self) -> Vec<CreateAttachment<'a>> {
         self.new_and_existing_attachments
             .iter()
             .filter_map(|attachment| {

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -129,7 +129,7 @@ impl<'a> CreateAttachment<'a> {
         let mut encoded = String::with_capacity(encoded_size);
         encoded.push_str(PREFIX);
         engine.encode_string(&data, &mut encoded);
-        Ok(ImageData(encoded))
+        Ok(ImageData(encoded.into()))
     }
 
     /// Sets a description for the file (max 1024 characters).
@@ -143,9 +143,9 @@ impl<'a> CreateAttachment<'a> {
 /// payload directly as part of the JSON body, instead of as a multipart upload.
 #[derive(Clone, Debug, Serialize)]
 #[serde(transparent)]
-pub struct ImageData(String);
+pub struct ImageData<'a>(Cow<'a, str>);
 
-impl ImageData {
+impl<'a> ImageData<'a> {
     /// Constructs image data from a base64-encoded blob of data. The string must be a valid data
     /// URI, for example:
     ///
@@ -160,11 +160,12 @@ impl ImageData {
     ///
     /// Returns a [`Error::Url`] if the string is not a valid data URI. See the [Discord
     /// docs](https://discord.com/developers/docs/reference#image-data).
-    pub fn from_base64(s: &str) -> Result<Self> {
+    pub fn from_base64(s: impl Into<Cow<'a, str>>) -> Result<Self> {
+        let s = s.into();
         if let Some(("data", tail)) = s.split_once(':') {
             if let Some((mimetype, encoding)) = tail.split_once(';') {
                 if mimetype.split_once('/').is_some() && encoding.starts_with("base64,") {
-                    return Ok(Self(s.to_string()));
+                    return Ok(Self(s));
                 }
             }
         }

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -1,11 +1,10 @@
 use std::borrow::Cow;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use bytes::Bytes;
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
-use url::Url;
 
 use crate::error::{Error, Result, UrlError};
 #[cfg(feature = "http")]
@@ -17,7 +16,7 @@ use crate::model::id::AttachmentId;
 pub enum AttachmentData<'a> {
     Bytes(Bytes),
     File(&'a File),
-    Path(PathBuf),
+    Path(&'a Path),
 }
 
 /// A builder for creating a new attachment from a file path, file data, or URL.
@@ -47,8 +46,7 @@ impl<'a> CreateAttachment<'a> {
     /// # Errors
     ///
     /// Returns [`Error::Io`] if the path is not a valid file path.
-    pub fn path(path: impl AsRef<Path>) -> Result<Self> {
-        let path = path.as_ref().to_owned();
+    pub fn path(path: &'a Path) -> Result<Self> {
         let filename = path
             .file_name()
             .ok_or_else(|| std::io::Error::other("attachment path must not be a directory"))?
@@ -112,10 +110,7 @@ impl<'a> CreateAttachment<'a> {
         }
     }
 
-    /// Converts the stored data to a base64-encoded data URI.
-    ///
-    /// This is used in the library internally because Discord expects image data as base64 in many
-    /// places.
+    /// Converts the attachment data to a base64-encoded data URI.
     ///
     /// # Errors
     ///
@@ -144,13 +139,15 @@ impl<'a> CreateAttachment<'a> {
     }
 }
 
+/// A wrapper around some base64-encoded image data. Used when an endpoint expects the image
+/// payload directly as part of the JSON body, instead of as a multipart upload.
 #[derive(Clone, Debug, Serialize)]
 #[serde(transparent)]
 pub struct ImageData(String);
 
 impl ImageData {
     /// Constructs image data from a base64-encoded blob of data. The string must be a valid data
-    /// URI, and must be encoded with base64, for example:
+    /// URI, for example:
     ///
     /// ```
     /// use serenity::builder::ImageData;
@@ -164,22 +161,14 @@ impl ImageData {
     /// Returns a [`Error::Url`] if the string is not a valid data URI. See the [Discord
     /// docs](https://discord.com/developers/docs/reference#image-data).
     pub fn from_base64(s: &str) -> Result<Self> {
-        let url = Url::parse(s).map_err(|_| UrlError::InvalidDataURI)?;
-
-        let err = Error::Url(UrlError::InvalidDataURI);
-        if url.scheme() != "data" {
-            return Err(err);
+        if let Some(("data", tail)) = s.split_once(':') {
+            if let Some((mimetype, encoding)) = tail.split_once(';') {
+                if mimetype.split_once('/').is_some() && encoding.starts_with("base64,") {
+                    return Ok(Self(s.to_string()));
+                }
+            }
         }
-
-        let Some((mimetype, encoding)) = url.path().split_once(';') else {
-            return Err(err);
-        };
-
-        if mimetype.split_once('/').is_some() && encoding.starts_with("base64,") {
-            Ok(Self(url.into()))
-        } else {
-            Err(err)
-        }
+        Err(Error::Url(UrlError::InvalidDataURI))
     }
 }
 

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
-use reqwest::{IntoUrl, Url};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
+use url::Url;
 
 #[cfg(doc)]
 use crate::error::Error;
@@ -80,7 +80,7 @@ impl<'a> CreateAttachment<'a> {
     #[cfg(feature = "http")]
     pub async fn url(
         http: &Http,
-        url: impl IntoUrl,
+        url: impl reqwest::IntoUrl,
         filename: impl Into<Cow<'static, str>>,
     ) -> Result<Self> {
         let response = http.client.get(url).send().await?;

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
+use reqwest::{IntoUrl, Url};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
@@ -79,7 +80,7 @@ impl<'a> CreateAttachment<'a> {
     #[cfg(feature = "http")]
     pub async fn url(
         http: &Http,
-        url: impl reqwest::IntoUrl,
+        url: impl IntoUrl,
         filename: impl Into<Cow<'static, str>>,
     ) -> Result<Self> {
         let response = http.client.get(url).send().await?;
@@ -113,12 +114,16 @@ impl<'a> CreateAttachment<'a> {
         }
     }
 
-    /// Converts the stored data to the base64 representation.
+    /// Converts the stored data to a base64-encoded data URI.
     ///
     /// This is used in the library internally because Discord expects image data as base64 in many
     /// places.
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::get_data`] for details.
     #[must_use]
-    pub async fn to_base64(&self) -> Result<String> {
+    pub async fn encode(&self) -> Result<ImageData> {
         use base64::engine::{Config, Engine};
 
         const PREFIX: &str = "data:image/png;base64,";
@@ -132,13 +137,23 @@ impl<'a> CreateAttachment<'a> {
         let mut encoded = String::with_capacity(encoded_size);
         encoded.push_str(PREFIX);
         engine.encode_string(&data, &mut encoded);
-        Ok(encoded)
+        Ok(ImageData(encoded))
     }
 
     /// Sets a description for the file (max 1024 characters).
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
         self.description = Some(description.into());
         self
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub struct ImageData(String);
+
+impl ImageData {
+    pub fn from_base64(s: &str) -> Result<Self> {
+        Ok(Self(Url::parse(s)?.into()))
     }
 }
 

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 use serde::ser::{Serialize, SerializeSeq, Serializer};
@@ -14,6 +14,13 @@ use crate::http::Http;
 use crate::model::channel::Message;
 use crate::model::id::AttachmentId;
 
+#[derive(Clone, Debug)]
+pub enum AttachmentData<'a> {
+    Bytes(Bytes),
+    File(&'a File),
+    Path(PathBuf),
+}
+
 /// A builder for creating a new attachment from a file path, file data, or URL.
 ///
 /// [Discord docs](https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure).
@@ -23,16 +30,16 @@ use crate::model::id::AttachmentId;
 pub struct CreateAttachment<'a> {
     pub filename: Cow<'static, str>,
     pub description: Option<Cow<'a, str>>,
-    pub data: Bytes,
+    pub data: AttachmentData<'a>,
 }
 
 impl<'a> CreateAttachment<'a> {
     /// Builds an [`CreateAttachment`] from the raw attachment data.
     pub fn bytes(data: impl Into<Bytes>, filename: impl Into<Cow<'static, str>>) -> Self {
         CreateAttachment {
-            data: data.into(),
             filename: filename.into(),
             description: None,
+            data: AttachmentData::Bytes(data.into()),
         }
     }
 
@@ -40,33 +47,28 @@ impl<'a> CreateAttachment<'a> {
     ///
     /// # Errors
     ///
-    /// [`Error::Io`] if reading the file fails.
-    pub async fn path(path: impl AsRef<Path>) -> Result<Self> {
-        async fn inner(path: &Path) -> Result<CreateAttachment<'static>> {
-            let mut file = File::open(path).await?;
-            let mut data = Vec::new();
-            file.read_to_end(&mut data).await?;
-
-            let filename = path
-                .file_name()
-                .ok_or_else(|| std::io::Error::other("attachment path must not be a directory"))?;
-
-            Ok(CreateAttachment::bytes(data, filename.to_string_lossy().into_owned()))
-        }
-
-        inner(path.as_ref()).await
+    /// Returns [`Error::Io`] if the path is not a valid file path.
+    pub fn path(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref().to_owned();
+        let filename = path
+            .file_name()
+            .ok_or_else(|| std::io::Error::other("attachment path must not be a directory"))?
+            .to_string_lossy()
+            .into_owned();
+        Ok(CreateAttachment {
+            filename: filename.into(),
+            description: None,
+            data: AttachmentData::Path(path),
+        })
     }
 
     /// Builds an [`CreateAttachment`] by reading from a file handler.
-    ///
-    /// # Errors
-    ///
-    /// [`Error::Io`] error if reading the file fails.
-    pub async fn file(file: &File, filename: impl Into<Cow<'static, str>>) -> Result<Self> {
-        let mut data = Vec::new();
-        file.try_clone().await?.read_to_end(&mut data).await?;
-
-        Ok(CreateAttachment::bytes(data, filename))
+    pub fn file(file: &'a File, filename: impl Into<Cow<'static, str>>) -> Self {
+        CreateAttachment {
+            filename: filename.into(),
+            description: None,
+            data: AttachmentData::File(file),
+        }
     }
 
     /// Builds an [`CreateAttachment`] by downloading attachment data from a URL.
@@ -86,25 +88,51 @@ impl<'a> CreateAttachment<'a> {
         Ok(CreateAttachment::bytes(data, filename))
     }
 
+    /// Returns the underlying data for the attachment.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if fetching the data failed in some way. If the attachment is a
+    /// [`CreateAttachment::path`], then the file at the specified path was unable to be read. If
+    /// instead it's [`CreateAttachment::file`], then cloning the handle to the file failed, likely
+    /// due to hitting the system's limit on number of open file handles.
+    pub async fn get_data(&self) -> Result<Bytes> {
+        match &self.data {
+            AttachmentData::Bytes(bytes) => Ok(bytes.clone()),
+            AttachmentData::Path(path) => {
+                let mut file = File::open(path).await?;
+                let mut data = Vec::new();
+                file.read_to_end(&mut data).await?;
+                Ok(data.into())
+            },
+            AttachmentData::File(file) => {
+                let mut data = Vec::new();
+                file.try_clone().await?.read_to_end(&mut data).await?;
+                Ok(data.into())
+            },
+        }
+    }
+
     /// Converts the stored data to the base64 representation.
     ///
     /// This is used in the library internally because Discord expects image data as base64 in many
     /// places.
     #[must_use]
-    pub fn to_base64(&self) -> String {
+    pub async fn to_base64(&self) -> Result<String> {
         use base64::engine::{Config, Engine};
 
         const PREFIX: &str = "data:image/png;base64,";
+        let data = self.get_data().await?;
 
         let engine = base64::prelude::BASE64_STANDARD;
-        let encoded_size = base64::encoded_len(self.data.len(), engine.config().encode_padding())
+        let encoded_size = base64::encoded_len(data.len(), engine.config().encode_padding())
             .and_then(|len| len.checked_add(PREFIX.len()))
             .expect("buffer capacity overflow");
 
         let mut encoded = String::with_capacity(encoded_size);
         encoded.push_str(PREFIX);
-        engine.encode_string(&self.data, &mut encoded);
-        encoded
+        engine.encode_string(&data, &mut encoded);
+        Ok(encoded)
     }
 
     /// Sets a description for the file (max 1024 characters).
@@ -114,15 +142,10 @@ impl<'a> CreateAttachment<'a> {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-struct ExistingAttachment {
-    id: AttachmentId,
-}
-
 #[derive(Clone, Debug)]
-enum NewOrExisting<'a> {
+enum EditAttachmentsInner<'a> {
     New(CreateAttachment<'a>),
-    Existing(ExistingAttachment),
+    Existing(AttachmentId),
 }
 
 /// You can add new attachments and edit existing ones using this builder.
@@ -183,7 +206,7 @@ enum NewOrExisting<'a> {
 #[derive(Default, Debug, Clone)]
 #[must_use]
 pub struct EditAttachments<'a> {
-    new_and_existing_attachments: Vec<NewOrExisting<'a>>,
+    inner: Vec<EditAttachmentsInner<'a>>,
 }
 
 impl<'a> EditAttachments<'a> {
@@ -207,15 +230,7 @@ impl<'a> EditAttachments<'a> {
     /// Discord will throw an error!**
     pub fn keep_all(msg: &Message) -> Self {
         Self {
-            new_and_existing_attachments: msg
-                .attachments
-                .iter()
-                .map(|a| {
-                    NewOrExisting::Existing(ExistingAttachment {
-                        id: a.id,
-                    })
-                })
-                .collect(),
+            inner: msg.attachments.iter().map(|a| EditAttachmentsInner::Existing(a.id)).collect(),
         }
     }
 
@@ -224,9 +239,7 @@ impl<'a> EditAttachments<'a> {
     ///
     /// Opposite of [`Self::remove`].
     pub fn keep(mut self, id: AttachmentId) -> Self {
-        self.new_and_existing_attachments.push(NewOrExisting::Existing(ExistingAttachment {
-            id,
-        }));
+        self.inner.push(EditAttachmentsInner::Existing(id));
         self
     }
 
@@ -235,10 +248,9 @@ impl<'a> EditAttachments<'a> {
     ///
     /// Opposite of [`Self::keep`].
     pub fn remove(mut self, id: AttachmentId) -> Self {
-        #[expect(clippy::match_like_matches_macro)] // `matches!` is less clear here
-        self.new_and_existing_attachments.retain(|a| match a {
-            NewOrExisting::Existing(a) if a.id == id => false,
-            _ => true,
+        self.inner.retain(|a| match a {
+            EditAttachmentsInner::Existing(existing_id) => *existing_id != id,
+            EditAttachmentsInner::New(_) => true,
         });
         self
     }
@@ -246,7 +258,7 @@ impl<'a> EditAttachments<'a> {
     /// Adds a new attachment to the attachment list.
     #[expect(clippy::should_implement_trait)] // Clippy thinks add == std::ops::Add::add
     pub fn add(mut self, attachment: CreateAttachment<'a>) -> Self {
-        self.new_and_existing_attachments.push(NewOrExisting::New(attachment));
+        self.inner.push(EditAttachmentsInner::New(attachment));
         self
     }
 
@@ -254,19 +266,17 @@ impl<'a> EditAttachments<'a> {
     /// are needed for the multipart form data. The data is taken out of `self` in the process, so
     /// this method can only be called once.
     #[cfg(feature = "http")]
-    pub(crate) fn take_files(&mut self) -> Vec<CreateAttachment<'a>> {
-        let mut files = Vec::new();
-        for attachment in &mut self.new_and_existing_attachments {
-            if let NewOrExisting::New(attachment) = attachment {
-                let cloned_attachment = CreateAttachment::bytes(
-                    std::mem::take(&mut attachment.data),
-                    attachment.filename.clone(),
-                );
-
-                files.push(cloned_attachment);
-            }
-        }
-        files
+    pub(crate) fn new_attachments(&mut self) -> Vec<CreateAttachment<'a>> {
+        self.inner
+            .iter()
+            .filter_map(|attachment| {
+                if let EditAttachmentsInner::New(attachment) = &attachment {
+                    Some(attachment.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 }
 
@@ -279,14 +289,19 @@ impl Serialize for EditAttachments<'_> {
             description: &'a Option<Cow<'a, str>>,
         }
 
+        #[derive(Serialize)]
+        struct ExistingAttachment {
+            id: AttachmentId,
+        }
+
         // Instead of an `AttachmentId`, the `id` field for new attachments corresponds to the
         // index of the new attachment in the multipart payload. The attachment data will be
         // labeled with `files[{id}]` in the multipart body. See `Multipart::build_form`.
         let mut id = 0;
-        let mut seq = serializer.serialize_seq(Some(self.new_and_existing_attachments.len()))?;
-        for attachment in &self.new_and_existing_attachments {
+        let mut seq = serializer.serialize_seq(Some(self.inner.len()))?;
+        for attachment in &self.inner {
             match attachment {
-                NewOrExisting::New(new_attachment) => {
+                EditAttachmentsInner::New(new_attachment) => {
                     let attachment = NewAttachment {
                         id,
                         filename: &new_attachment.filename,
@@ -295,8 +310,10 @@ impl Serialize for EditAttachments<'_> {
                     id += 1;
                     seq.serialize_element(&attachment)?;
                 },
-                NewOrExisting::Existing(existing_attachment) => {
-                    seq.serialize_element(existing_attachment)?;
+                EditAttachmentsInner::Existing(id) => {
+                    seq.serialize_element(&ExistingAttachment {
+                        id: *id,
+                    })?;
                 },
             }
         }

--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -98,7 +98,7 @@ impl<'a> CreateForumPost<'a> {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     #[cfg(feature = "http")]
-    pub async fn execute(mut self, http: &Http, channel_id: ChannelId) -> Result<GuildChannel> {
+    pub async fn execute(self, http: &Http, channel_id: ChannelId) -> Result<GuildChannel> {
         let files = self.message.attachments.new_attachments();
         http.create_forum_post(channel_id, &self, files, self.audit_log_reason).await
     }

--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -99,7 +99,7 @@ impl<'a> CreateForumPost<'a> {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     #[cfg(feature = "http")]
     pub async fn execute(mut self, http: &Http, channel_id: ChannelId) -> Result<GuildChannel> {
-        let files = self.message.attachments.take_files();
+        let files = self.message.attachments.new_attachments();
         http.create_forum_post(channel_id, &self, files, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -131,7 +131,7 @@ impl CreateInteractionResponse<'_> {
         let files = match &mut self {
             CreateInteractionResponse::Message(msg)
             | CreateInteractionResponse::Defer(msg)
-            | CreateInteractionResponse::UpdateMessage(msg) => msg.attachments.take_files(),
+            | CreateInteractionResponse::UpdateMessage(msg) => msg.attachments.new_attachments(),
             _ => Vec::new(),
         };
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -179,7 +179,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.take_files();
+        let files = self.attachments.new_attachments();
 
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -295,7 +295,7 @@ impl<'a> CreateMessage<'a> {
     ) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.take_files();
+        let files = self.attachments.new_attachments();
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);
         }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -24,7 +24,7 @@ pub struct CreateScheduledEvent<'a> {
     description: Option<Cow<'a, str>>,
     entity_type: ScheduledEventType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    image: Option<ImageData>,
+    image: Option<ImageData<'a>>,
 
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,
@@ -110,7 +110,7 @@ impl<'a> CreateScheduledEvent<'a> {
     }
 
     /// Sets the cover image for the scheduled event.
-    pub fn image(mut self, image: ImageData) -> Self {
+    pub fn image(mut self, image: ImageData<'a>) -> Self {
         self.image = Some(image);
         self
     }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::CreateAttachment;
+use super::ImageData;
 #[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
@@ -24,7 +24,7 @@ pub struct CreateScheduledEvent<'a> {
     description: Option<Cow<'a, str>>,
     entity_type: ScheduledEventType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    image: Option<String>,
+    image: Option<ImageData>,
 
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,
@@ -110,13 +110,9 @@ impl<'a> CreateScheduledEvent<'a> {
     }
 
     /// Sets the cover image for the scheduled event.
-    ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    pub async fn image(mut self, image: &CreateAttachment<'_>) -> Result<Self> {
-        self.image = Some(image.to_base64().await?);
-        Ok(self)
+    pub fn image(mut self, image: ImageData) -> Self {
+        self.image = Some(image);
+        self
     }
 
     /// Sets the request's audit log reason.

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -110,9 +110,13 @@ impl<'a> CreateScheduledEvent<'a> {
     }
 
     /// Sets the cover image for the scheduled event.
-    pub fn image(mut self, image: &CreateAttachment<'_>) -> Self {
-        self.image = Some(image.to_base64());
-        self
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    pub async fn image(mut self, image: &CreateAttachment<'_>) -> Result<Self> {
+        self.image = Some(image.to_base64().await?);
+        Ok(self)
     }
 
     /// Sets the request's audit log reason.

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
-use super::CreateAttachment;
+use super::ImageData;
 #[cfg(feature = "http")]
 use crate::http::Http;
+#[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::prelude::*;
@@ -13,7 +14,7 @@ use crate::model::prelude::*;
 pub struct CreateWebhook<'a> {
     name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<String>,
+    avatar: Option<ImageData>,
 
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,
@@ -38,13 +39,9 @@ impl<'a> CreateWebhook<'a> {
     }
 
     /// Set the webhook's default avatar.
-    ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    pub async fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Result<Self> {
-        self.avatar = Some(avatar.to_base64().await?);
-        Ok(self)
+    pub fn avatar(mut self, avatar: ImageData) -> Self {
+        self.avatar = Some(avatar);
+        self
     }
 
     /// Sets the request's audit log reason.

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::prelude::*;
@@ -39,9 +38,13 @@ impl<'a> CreateWebhook<'a> {
     }
 
     /// Set the webhook's default avatar.
-    pub fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Self {
-        self.avatar = Some(avatar.to_base64());
-        self
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    pub async fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Result<Self> {
+        self.avatar = Some(avatar.to_base64().await?);
+        Ok(self)
     }
 
     /// Sets the request's audit log reason.

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -14,7 +14,7 @@ use crate::model::prelude::*;
 pub struct CreateWebhook<'a> {
     name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<ImageData>,
+    avatar: Option<ImageData<'a>>,
 
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,
@@ -39,7 +39,7 @@ impl<'a> CreateWebhook<'a> {
     }
 
     /// Set the webhook's default avatar.
-    pub fn avatar(mut self, avatar: ImageData) -> Self {
+    pub fn avatar(mut self, avatar: ImageData<'a>) -> Self {
         self.avatar = Some(avatar);
         self
     }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -91,7 +91,7 @@ impl<'a> EditGuild<'a> {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut guild = GuildId::new(1).to_partial_guild(&http).await?;
-    /// let icon = CreateAttachment::path("./guild_icon.png")?.encode().await?;
+    /// let icon = CreateAttachment::path("./guild_icon.png".as_ref())?.encode().await?;
     ///
     /// // assuming a `guild` has already been bound
     /// let builder = EditGuild::new().icon(Some(icon));

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -91,17 +91,24 @@ impl<'a> EditGuild<'a> {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut guild = GuildId::new(1).to_partial_guild(&http).await?;
-    /// let icon = CreateAttachment::path("./guild_icon.png").await?;
+    /// let icon = CreateAttachment::path("./guild_icon.png")?;
     ///
     /// // assuming a `guild` has already been bound
-    /// let builder = EditGuild::new().icon(Some(&icon));
+    /// let builder = EditGuild::new().icon(Some(&icon)).await?;
     /// guild.edit(&http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn icon(mut self, icon: Option<&CreateAttachment<'_>>) -> Self {
-        self.icon = Some(icon.map(CreateAttachment::to_base64));
-        self
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    pub async fn icon(mut self, icon: Option<&CreateAttachment<'_>>) -> Result<Self> {
+        self.icon = Some(match icon {
+            Some(attachment) => Some(attachment.to_base64().await?),
+            None => None,
+        });
+        Ok(self)
     }
 
     /// Clear the current guild icon, resetting it to the default logo.
@@ -181,10 +188,17 @@ impl<'a> EditGuild<'a> {
     /// Requires that the guild have the `BANNER` feature enabled. You can check this through a
     /// guild's [`features`] list.
     ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    ///
     /// [`features`]: Guild::features
-    pub fn banner(mut self, banner: Option<&CreateAttachment<'_>>) -> Self {
-        self.banner = Some(banner.map(CreateAttachment::to_base64).map(Cow::from));
-        self
+    pub async fn banner(mut self, banner: Option<&CreateAttachment<'_>>) -> Result<Self> {
+        self.banner = Some(match banner {
+            Some(attachment) => Some(attachment.to_base64().await?.into()),
+            None => None,
+        });
+        Ok(self)
     }
 
     /// Set the channel ID where welcome messages and boost events will be posted.

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -27,7 +27,7 @@ pub struct EditGuild<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_timeout: Option<AfkTimeout>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<Option<ImageData>>,
+    icon: Option<Option<ImageData<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<UserId>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -35,7 +35,7 @@ pub struct EditGuild<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     discovery_splash: Option<Option<Cow<'a, str>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    banner: Option<Option<ImageData>>,
+    banner: Option<Option<ImageData<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     system_channel_id: Option<Option<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -101,7 +101,7 @@ impl<'a> EditGuild<'a> {
     /// ```
     ///
     /// [`CreateAttachment`]: super::CreateAttachment
-    pub fn icon(mut self, icon: Option<ImageData>) -> Self {
+    pub fn icon(mut self, icon: Option<ImageData<'a>>) -> Self {
         self.icon = Some(icon);
         self
     }
@@ -184,7 +184,7 @@ impl<'a> EditGuild<'a> {
     /// guild's [`features`] list.
     ///
     /// [`features`]: Guild::features
-    pub fn banner(mut self, banner: Option<ImageData>) -> Self {
+    pub fn banner(mut self, banner: Option<ImageData<'a>>) -> Self {
         self.banner = Some(banner);
         self
     }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::CreateAttachment;
+use super::ImageData;
 #[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
@@ -27,7 +27,7 @@ pub struct EditGuild<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_timeout: Option<AfkTimeout>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<Option<String>>,
+    icon: Option<Option<ImageData>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<UserId>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -35,7 +35,7 @@ pub struct EditGuild<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     discovery_splash: Option<Option<Cow<'a, str>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    banner: Option<Option<Cow<'a, str>>>,
+    banner: Option<Option<ImageData>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     system_channel_id: Option<Option<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -91,24 +91,19 @@ impl<'a> EditGuild<'a> {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut guild = GuildId::new(1).to_partial_guild(&http).await?;
-    /// let icon = CreateAttachment::path("./guild_icon.png")?;
+    /// let icon = CreateAttachment::path("./guild_icon.png")?.encode().await?;
     ///
     /// // assuming a `guild` has already been bound
-    /// let builder = EditGuild::new().icon(Some(&icon)).await?;
+    /// let builder = EditGuild::new().icon(Some(icon));
     /// guild.edit(&http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
     ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    pub async fn icon(mut self, icon: Option<&CreateAttachment<'_>>) -> Result<Self> {
-        self.icon = Some(match icon {
-            Some(attachment) => Some(attachment.to_base64().await?),
-            None => None,
-        });
-        Ok(self)
+    /// [`CreateAttachment`]: super::CreateAttachment
+    pub fn icon(mut self, icon: Option<ImageData>) -> Self {
+        self.icon = Some(icon);
+        self
     }
 
     /// Clear the current guild icon, resetting it to the default logo.
@@ -188,17 +183,10 @@ impl<'a> EditGuild<'a> {
     /// Requires that the guild have the `BANNER` feature enabled. You can check this through a
     /// guild's [`features`] list.
     ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    ///
     /// [`features`]: Guild::features
-    pub async fn banner(mut self, banner: Option<&CreateAttachment<'_>>) -> Result<Self> {
-        self.banner = Some(match banner {
-            Some(attachment) => Some(attachment.to_base64().await?.into()),
-            None => None,
-        });
-        Ok(self)
+    pub fn banner(mut self, banner: Option<ImageData>) -> Self {
+        self.banner = Some(banner);
+        self
     }
 
     /// Set the channel ID where welcome messages and boost events will be posted.

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -114,7 +114,8 @@ impl<'a> EditInteractionResponse<'a> {
     pub async fn execute(mut self, http: &Http, interaction_token: &str) -> Result<Message> {
         self.0.check_length()?;
 
-        let files = self.0.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
+        let files =
+            self.0.attachments.as_mut().map_or(Vec::new(), EditAttachments::new_attachments);
 
         http.edit_original_interaction_response(interaction_token, &self, files).await
     }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -111,11 +111,11 @@ impl<'a> EditInteractionResponse<'a> {
     /// [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is an error in
     /// deserializing the API response.
     #[cfg(feature = "http")]
-    pub async fn execute(mut self, http: &Http, interaction_token: &str) -> Result<Message> {
+    pub async fn execute(self, http: &Http, interaction_token: &str) -> Result<Message> {
         self.0.check_length()?;
 
         let files =
-            self.0.attachments.as_mut().map_or(Vec::new(), EditAttachments::new_attachments);
+            self.0.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachments);
 
         http.edit_original_interaction_response(interaction_token, &self, files).await
     }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -237,7 +237,7 @@ impl<'a> EditMessage<'a> {
             }
         }
 
-        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
+        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::new_attachments);
 
         let http = cache_http.http();
         if self.allowed_mentions.is_none() {

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -237,7 +237,7 @@ impl<'a> EditMessage<'a> {
             }
         }
 
-        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::new_attachments);
+        let files = self.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachments);
 
         let http = cache_http.http();
         if self.allowed_mentions.is_none() {

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -18,9 +18,9 @@ pub struct EditProfile<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Option<ImageData>>,
+    avatar: Option<Option<ImageData<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    banner: Option<Option<ImageData>>,
+    banner: Option<Option<ImageData<'a>>>,
 }
 
 impl<'a> EditProfile<'a> {
@@ -40,14 +40,16 @@ impl<'a> EditProfile<'a> {
     /// # use serenity::http::Http;
     /// #
     /// # #[cfg(feature = "http")]
-    /// # async fn foo_(http: &Http, current_user: &mut CurrentUser) -> Result<(), SerenityError> {
+    /// # async fn run() -> Result<(), SerenityError> {
+    /// # let http: Http = unimplemented!();
+    /// # let mut user = CurrentUser::default();
     /// let avatar = CreateAttachment::path("./my_image.jpg".as_ref())?.encode().await?;
     /// let builder = EditProfile::new().avatar(avatar);
-    /// current_user.edit(http, builder).await?;
+    /// user.edit(&http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn avatar(mut self, avatar: ImageData) -> Self {
+    pub fn avatar(mut self, avatar: ImageData<'a>) -> Self {
         self.avatar = Some(Some(avatar));
         self
     }
@@ -69,7 +71,7 @@ impl<'a> EditProfile<'a> {
     }
 
     /// Sets the banner of the current user.
-    pub fn banner(mut self, banner: ImageData) -> Self {
+    pub fn banner(mut self, banner: ImageData<'a>) -> Self {
         self.banner = Some(Some(banner));
         self
     }

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
-use super::CreateAttachment;
+use super::ImageData;
 #[cfg(feature = "http")]
 use crate::http::Http;
+#[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::user::CurrentUser;
@@ -17,9 +18,9 @@ pub struct EditProfile<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Option<String>>,
+    avatar: Option<Option<ImageData>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    banner: Option<Option<String>>,
+    banner: Option<Option<ImageData>>,
 }
 
 impl<'a> EditProfile<'a> {
@@ -40,19 +41,15 @@ impl<'a> EditProfile<'a> {
     /// #
     /// # #[cfg(feature = "http")]
     /// # async fn foo_(http: &Http, current_user: &mut CurrentUser) -> Result<(), SerenityError> {
-    /// let avatar = CreateAttachment::path("./my_image.jpg").expect("Invalid filename.");
-    /// let builder = EditProfile::new().avatar(&avatar).await?;
+    /// let avatar = CreateAttachment::path("./my_image.jpg")?.encode().await?;
+    /// let builder = EditProfile::new().avatar(avatar);
     /// current_user.edit(http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    pub async fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Result<Self> {
-        self.avatar = Some(Some(avatar.to_base64().await?));
-        Ok(self)
+    pub fn avatar(mut self, avatar: ImageData) -> Self {
+        self.avatar = Some(Some(avatar));
+        self
     }
 
     /// Delete the current user's avatar, resetting it to the default logo.
@@ -72,13 +69,9 @@ impl<'a> EditProfile<'a> {
     }
 
     /// Sets the banner of the current user.
-    ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    pub async fn banner(mut self, banner: &CreateAttachment<'_>) -> Result<Self> {
-        self.banner = Some(Some(banner.to_base64().await?));
-        Ok(self)
+    pub fn banner(mut self, banner: ImageData) -> Self {
+        self.banner = Some(Some(banner));
+        self
     }
 
     /// Deletes the current user's banner, resetting it to the default.

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -41,7 +41,7 @@ impl<'a> EditProfile<'a> {
     /// #
     /// # #[cfg(feature = "http")]
     /// # async fn foo_(http: &Http, current_user: &mut CurrentUser) -> Result<(), SerenityError> {
-    /// let avatar = CreateAttachment::path("./my_image.jpg")?.encode().await?;
+    /// let avatar = CreateAttachment::path("./my_image.jpg".as_ref())?.encode().await?;
     /// let builder = EditProfile::new().avatar(avatar);
     /// current_user.edit(http, builder).await?;
     /// # Ok(())

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
 use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::user::CurrentUser;
@@ -41,14 +40,19 @@ impl<'a> EditProfile<'a> {
     /// #
     /// # #[cfg(feature = "http")]
     /// # async fn foo_(http: &Http, current_user: &mut CurrentUser) -> Result<(), SerenityError> {
-    /// let avatar = CreateAttachment::path("./my_image.jpg").await.expect("Failed to read image.");
-    /// current_user.edit(http, EditProfile::new().avatar(&avatar)).await?;
+    /// let avatar = CreateAttachment::path("./my_image.jpg").expect("Invalid filename.");
+    /// let builder = EditProfile::new().avatar(&avatar).await?;
+    /// current_user.edit(http, builder).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Self {
-        self.avatar = Some(Some(avatar.to_base64()));
-        self
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    pub async fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Result<Self> {
+        self.avatar = Some(Some(avatar.to_base64().await?));
+        Ok(self)
     }
 
     /// Delete the current user's avatar, resetting it to the default logo.
@@ -68,9 +72,13 @@ impl<'a> EditProfile<'a> {
     }
 
     /// Sets the banner of the current user.
-    pub fn banner(mut self, banner: &CreateAttachment<'_>) -> Self {
-        self.banner = Some(Some(banner.to_base64()));
-        self
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    pub async fn banner(mut self, banner: &CreateAttachment<'_>) -> Result<Self> {
+        self.banner = Some(Some(banner.to_base64().await?));
+        Ok(self)
     }
 
     /// Deletes the current user's banner, resetting it to the default.

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -50,7 +50,7 @@ pub struct EditRole<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<Option<ImageData>>,
+    icon: Option<Option<ImageData<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     unicode_emoji: Option<Option<Cow<'a, str>>>,
 
@@ -131,7 +131,7 @@ impl<'a> EditRole<'a> {
     }
 
     /// Set the role icon to a custom image.
-    pub fn icon(mut self, icon: Option<ImageData>) -> Self {
+    pub fn icon(mut self, icon: Option<ImageData<'a>>) -> Self {
         self.icon = Some(icon);
         self.unicode_emoji = Some(None);
         self

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::CreateAttachment;
+use super::ImageData;
 #[cfg(feature = "http")]
 use crate::http::Http;
 use crate::model::prelude::*;
@@ -50,7 +50,7 @@ pub struct EditRole<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<Option<Cow<'a, str>>>,
+    icon: Option<Option<ImageData>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     unicode_emoji: Option<Option<Cow<'a, str>>>,
 
@@ -131,17 +131,10 @@ impl<'a> EditRole<'a> {
     }
 
     /// Set the role icon to a custom image.
-    ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    pub async fn icon(mut self, icon: Option<&CreateAttachment<'_>>) -> Result<Self> {
-        self.icon = Some(match icon {
-            Some(attachment) => Some(attachment.to_base64().await?.into()),
-            None => None,
-        });
+    pub fn icon(mut self, icon: Option<ImageData>) -> Self {
+        self.icon = Some(icon);
         self.unicode_emoji = Some(None);
-        Ok(self)
+        self
     }
 
     /// Sets the request's audit log reason.

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -131,10 +131,17 @@ impl<'a> EditRole<'a> {
     }
 
     /// Set the role icon to a custom image.
-    pub fn icon(mut self, icon: Option<&CreateAttachment<'_>>) -> Self {
-        self.icon = Some(icon.map(CreateAttachment::to_base64).map(Into::into));
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    pub async fn icon(mut self, icon: Option<&CreateAttachment<'_>>) -> Result<Self> {
+        self.icon = Some(match icon {
+            Some(attachment) => Some(attachment.to_base64().await?.into()),
+            None => None,
+        });
         self.unicode_emoji = Some(None);
-        self
+        Ok(self)
     }
 
     /// Sets the request's audit log reason.

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::{CreateAttachment, CreateScheduledEventMetadata};
+use super::{CreateScheduledEventMetadata, ImageData};
 #[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
@@ -30,7 +30,7 @@ pub struct EditScheduledEvent<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<ScheduledEventStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    image: Option<String>,
+    image: Option<ImageData>,
 
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,
@@ -152,13 +152,9 @@ impl<'a> EditScheduledEvent<'a> {
     }
 
     /// Sets the cover image for the scheduled event.
-    ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    pub async fn image(mut self, image: &CreateAttachment<'_>) -> Result<Self> {
-        self.image = Some(image.to_base64().await?);
-        Ok(self)
+    pub fn image(mut self, image: ImageData) -> Self {
+        self.image = Some(image);
+        self
     }
 
     /// Sets the request's audit log reason.

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -30,7 +30,7 @@ pub struct EditScheduledEvent<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<ScheduledEventStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    image: Option<ImageData>,
+    image: Option<ImageData<'a>>,
 
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,
@@ -152,7 +152,7 @@ impl<'a> EditScheduledEvent<'a> {
     }
 
     /// Sets the cover image for the scheduled event.
-    pub fn image(mut self, image: ImageData) -> Self {
+    pub fn image(mut self, image: ImageData<'a>) -> Self {
         self.image = Some(image);
         self
     }

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -152,9 +152,13 @@ impl<'a> EditScheduledEvent<'a> {
     }
 
     /// Sets the cover image for the scheduled event.
-    pub fn image(mut self, image: &CreateAttachment<'_>) -> Self {
-        self.image = Some(image.to_base64());
-        self
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    pub async fn image(mut self, image: &CreateAttachment<'_>) -> Result<Self> {
+        self.image = Some(image.to_base64().await?);
+        Ok(self)
     }
 
     /// Sets the request's audit log reason.

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::CreateAttachment;
+use super::ImageData;
 #[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
@@ -14,7 +14,7 @@ pub struct EditWebhook<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Option<String>>,
+    avatar: Option<Option<ImageData>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<ChannelId>,
 
@@ -43,13 +43,9 @@ impl<'a> EditWebhook<'a> {
     }
 
     /// Set the webhook's default avatar.
-    ///
-    /// # Errors
-    ///
-    /// See [`CreateAttachment::to_base64`] for possible errors.
-    pub async fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Result<Self> {
-        self.avatar = Some(Some(avatar.to_base64().await?));
-        Ok(self)
+    pub fn avatar(mut self, avatar: ImageData) -> Self {
+        self.avatar = Some(Some(avatar));
+        self
     }
 
     /// Delete the webhook's avatar, resetting it to the default logo.

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -43,9 +43,13 @@ impl<'a> EditWebhook<'a> {
     }
 
     /// Set the webhook's default avatar.
-    pub fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Self {
-        self.avatar = Some(Some(avatar.to_base64()));
-        self
+    ///
+    /// # Errors
+    ///
+    /// See [`CreateAttachment::to_base64`] for possible errors.
+    pub async fn avatar(mut self, avatar: &CreateAttachment<'_>) -> Result<Self> {
+        self.avatar = Some(Some(avatar.to_base64().await?));
+        Ok(self)
     }
 
     /// Delete the webhook's avatar, resetting it to the default logo.

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -14,7 +14,7 @@ pub struct EditWebhook<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Option<ImageData>>,
+    avatar: Option<Option<ImageData<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<ChannelId>,
 
@@ -43,7 +43,7 @@ impl<'a> EditWebhook<'a> {
     }
 
     /// Set the webhook's default avatar.
-    pub fn avatar(mut self, avatar: ImageData) -> Self {
+    pub fn avatar(mut self, avatar: ImageData<'a>) -> Self {
         self.avatar = Some(Some(avatar));
         self
     }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -164,7 +164,7 @@ impl<'a> EditWebhookMessage<'a> {
     ) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::new_attachments);
+        let files = self.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachments);
 
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -164,7 +164,7 @@ impl<'a> EditWebhookMessage<'a> {
     ) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::take_files);
+        let files = self.attachments.as_mut().map_or(Vec::new(), EditAttachments::new_attachments);
 
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -354,7 +354,7 @@ impl<'a> ExecuteWebhook<'a> {
     ) -> Result<Option<Message>> {
         self.check_length()?;
 
-        let files = self.attachments.take_files();
+        let files = self.attachments.new_attachments();
 
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,6 @@ use reqwest::{Error as ReqwestError, header::InvalidHeaderValue};
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
-use url::ParseError as UrlError;
 
 #[cfg(feature = "gateway")]
 use crate::gateway::GatewayError;
@@ -54,8 +53,33 @@ pub enum Error {
     ///
     /// [`secrets`]: crate::secrets
     Token(TokenError),
-    /// When parsing an URL failed due to invalid input.
+    /// When parsing a URL failed due to invalid input.
     Url(UrlError),
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum UrlError {
+    Parsing(url::ParseError),
+    InvalidDataURI,
+}
+
+impl fmt::Display for UrlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parsing(inner) => fmt::Display::fmt(&inner, f),
+            Self::InvalidDataURI => f.write_str("Provided string is not a valid data URI"),
+        }
+    }
+}
+
+impl StdError for UrlError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Parsing(inner) => Some(inner),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(feature = "gateway")]
@@ -106,6 +130,12 @@ impl From<TokenError> for Error {
 impl From<UrlError> for Error {
     fn from(e: UrlError) -> Error {
         Error::Url(e)
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(e: url::ParseError) -> Error {
+        UrlError::Parsing(e).into()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use reqwest::{Error as ReqwestError, header::InvalidHeaderValue};
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
+use url::ParseError as UrlError;
 
 #[cfg(feature = "gateway")]
 use crate::gateway::GatewayError;
@@ -53,6 +54,8 @@ pub enum Error {
     ///
     /// [`secrets`]: crate::secrets
     Token(TokenError),
+    /// When parsing an URL failed due to invalid input.
+    Url(UrlError),
 }
 
 #[cfg(feature = "gateway")]
@@ -100,6 +103,12 @@ impl From<TokenError> for Error {
     }
 }
 
+impl From<UrlError> for Error {
+    fn from(e: UrlError) -> Error {
+        Error::Url(e)
+    }
+}
+
 #[cfg(feature = "http")]
 impl From<InvalidHeaderValue> for Error {
     fn from(e: InvalidHeaderValue) -> Error {
@@ -127,6 +136,7 @@ impl fmt::Display for Error {
             #[cfg(feature = "gateway")]
             Self::Tungstenite(inner) => fmt::Display::fmt(&inner, f),
             Self::Token(inner) => fmt::Display::fmt(&inner, f),
+            Self::Url(inner) => fmt::Display::fmt(&inner, f),
         }
     }
 }
@@ -145,6 +155,7 @@ impl StdError for Error {
             #[cfg(feature = "gateway")]
             Self::Tungstenite(inner) => Some(inner),
             Self::Token(inner) => Some(inner),
+            Self::Url(inner) => Some(inner),
         }
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4135,7 +4135,7 @@ impl Http {
     /// This method does _not_ require authentication
     #[cfg(feature = "utils")]
     pub async fn get_webhook_from_url(&self, url: &str) -> Result<Webhook> {
-        let url = Url::parse(url).map_err(HttpError::Url)?;
+        let url = Url::parse(url)?;
         let (webhook_id, token) =
             crate::utils::parse_webhook(&url).ok_or(HttpError::InvalidWebhook)?;
         self.fire(Request {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4408,7 +4408,8 @@ impl Http {
                     &self.client,
                     self.token.as_ref().map(Token::expose_secret),
                     self.proxy.as_deref(),
-                )?
+                )
+                .await?
                 .build()?;
             self.client.execute(request).await?
         };

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use reqwest::header::InvalidHeaderValue;
 use reqwest::{Error as ReqwestError, Method, Response, StatusCode};
 use serde::de::{Deserialize, Deserializer, Error as _};
-use url::ParseError as UrlError;
 
 use crate::internal::prelude::*;
 
@@ -309,8 +308,6 @@ pub enum HttpError {
     RateLimitI64F64,
     /// When the decoding of a ratelimit header could not be properly decoded from UTF-8.
     RateLimitUtf8,
-    /// When parsing an URL failed due to invalid input.
-    Url(UrlError),
     /// When parsing a Webhook fails due to invalid input.
     InvalidWebhook,
     /// Header value contains invalid input.
@@ -326,12 +323,6 @@ impl HttpError {
     #[must_use]
     pub fn is_unsuccessful_request(&self) -> bool {
         matches!(self, Self::UnsuccessfulRequest(_))
-    }
-
-    /// Returns true when the error is caused by the url containing invalid input
-    #[must_use]
-    pub fn is_url_error(&self) -> bool {
-        matches!(self, Self::Url(_))
     }
 
     /// Returns true when the error is caused by an invalid header
@@ -359,12 +350,6 @@ impl From<ErrorResponse> for HttpError {
 impl From<ReqwestError> for HttpError {
     fn from(error: ReqwestError) -> Self {
         Self::Request(error)
-    }
-}
-
-impl From<UrlError> for HttpError {
-    fn from(error: UrlError) -> Self {
-        Self::Url(error)
     }
 }
 
@@ -400,7 +385,6 @@ impl fmt::Display for HttpError {
             },
             Self::RateLimitI64F64 => f.write_str("Error decoding a header into an i64 or f64"),
             Self::RateLimitUtf8 => f.write_str("Error decoding a header from UTF-8"),
-            Self::Url(_) => f.write_str("Provided URL is incorrect."),
             Self::InvalidWebhook => f.write_str("Provided URL is not a valid webhook."),
             Self::InvalidHeader(_) => f.write_str("Provided value is an invalid header value."),
             Self::Request(_) => f.write_str("Error while sending HTTP request."),
@@ -412,7 +396,6 @@ impl fmt::Display for HttpError {
 impl StdError for HttpError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Self::Url(inner) => Some(inner),
             Self::Request(inner) => Some(inner),
             _ => None,
         }

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -1,13 +1,18 @@
 use std::borrow::Cow;
 
 use reqwest::multipart::{Form, Part};
+use tokio::fs::File;
 
-use crate::builder::CreateAttachment;
+use crate::builder::{AttachmentData, CreateAttachment};
 use crate::internal::prelude::*;
 
 impl CreateAttachment<'_> {
-    fn into_part(self) -> Result<Part> {
-        let mut part = Part::stream(self.data);
+    async fn into_part(self) -> Result<Part> {
+        let mut part = match self.data {
+            AttachmentData::Bytes(bytes) => Part::stream(bytes),
+            AttachmentData::File(file) => Part::stream(file.try_clone().await?),
+            AttachmentData::Path(path) => Part::stream(File::open(path).await?),
+        };
         part = guess_mime_str(part, &self.filename)?;
         part = part.file_name(self.filename);
         Ok(part)
@@ -35,16 +40,16 @@ pub struct Multipart<'a> {
 }
 
 impl Multipart<'_> {
-    pub(crate) fn build_form(self) -> Result<Form> {
+    pub(crate) async fn build_form(self) -> Result<Form> {
         let mut multipart = Form::new();
 
         match self.upload {
             MultipartUpload::File(upload_file) => {
-                multipart = multipart.part("file", upload_file.into_part()?);
+                multipart = multipart.part("file", upload_file.into_part().await?);
             },
             MultipartUpload::Attachments(attachment_files) => {
                 for (idx, file) in attachment_files.into_iter().enumerate() {
-                    multipart = multipart.part(format!("files[{idx}]"), file.into_part()?);
+                    multipart = multipart.part(format!("files[{idx}]"), file.into_part().await?);
                 }
             },
         }

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -192,11 +192,10 @@ impl Ratelimiter {
                 sleep(delay_time).await;
             }
 
-            let request = req.clone().build(
-                &self.client,
-                self.token.as_ref().map(Token::expose_secret),
-                None,
-            )?;
+            let request = req
+                .clone()
+                .build(&self.client, self.token.as_ref().map(Token::expose_secret), None)
+                .await?;
             let response = self.client.execute(request.build()?).await?;
 
             // Check if the request got ratelimited by checking for status 429, and if so, sleep

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -69,7 +69,7 @@ impl<'a> Request<'a> {
     ///
     /// Errors if the given proxy URL is invalid, or the token cannot be parsed into a HTTP header.
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(token)))]
-    pub fn build(
+    pub async fn build(
         self,
         client: &Client,
         token: Option<&str>,
@@ -102,7 +102,7 @@ impl<'a> Request<'a> {
 
         if let Some(multipart) = self.multipart {
             // Setting multipart adds the content-length header.
-            builder = builder.multipart(multipart.build_form()?);
+            builder = builder.multipart(multipart.build_form().await?);
         } else if let Some(bytes) = self.body {
             headers.insert(CONTENT_LENGTH, bytes.len().into());
             headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -651,8 +651,8 @@ impl ChannelId {
     /// let channel_id = ChannelId::new(7);
     ///
     /// let paths = [
-    ///     CreateAttachment::path("/path/to/file.jpg")?,
-    ///     CreateAttachment::path("/path/to/file2.jpg")?,
+    ///     CreateAttachment::path("/path/to/file.jpg".as_ref())?,
+    ///     CreateAttachment::path("/path/to/file2.jpg".as_ref())?,
     /// ];
     ///
     /// let builder = CreateMessage::new().content("some files");

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -651,8 +651,8 @@ impl ChannelId {
     /// let channel_id = ChannelId::new(7);
     ///
     /// let paths = [
-    ///     CreateAttachment::path("/path/to/file.jpg").await?,
-    ///     CreateAttachment::path("path/to/file2.jpg").await?,
+    ///     CreateAttachment::path("/path/to/file.jpg")?,
+    ///     CreateAttachment::path("/path/to/file2.jpg")?,
     /// ];
     ///
     /// let builder = CreateMessage::new().content("some files");
@@ -674,12 +674,12 @@ impl ChannelId {
     ///
     /// let channel_id = ChannelId::new(7);
     ///
-    /// let f1 = File::open("my_file.jpg").await?;
-    /// let f2 = File::open("my_file2.jpg").await?;
+    /// let f1 = File::open("/path/to/file.jpg").await?;
+    /// let f2 = File::open("/path/to/file2.jpg").await?;
     ///
     /// let files = [
-    ///     CreateAttachment::file(&f1, "my_file.jpg").await?,
-    ///     CreateAttachment::file(&f2, "my_file2.jpg").await?,
+    ///     CreateAttachment::file(&f1, "test_file1.jpg"),
+    ///     CreateAttachment::file(&f2, "test_file2.jpg"),
     /// ];
     ///
     /// let builder = CreateMessage::new().content("some files");

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -379,10 +379,10 @@ impl Guild {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut guild: Guild = unimplemented!();
-    /// let icon = CreateAttachment::path("./icon.png").await?;
+    /// let icon = CreateAttachment::path("./icon.png")?;
     ///
     /// // assuming a `guild` has already been bound
-    /// let builder = EditGuild::new().icon(Some(&icon));
+    /// let builder = EditGuild::new().icon(Some(&icon)).await?;
     /// guild.edit(&http, builder).await?;
     /// # Ok(())
     /// # }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -379,10 +379,10 @@ impl Guild {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut guild: Guild = unimplemented!();
-    /// let icon = CreateAttachment::path("./icon.png")?;
+    /// let icon = CreateAttachment::path("./icon.png")?.encode().await?;
     ///
     /// // assuming a `guild` has already been bound
-    /// let builder = EditGuild::new().icon(Some(&icon)).await?;
+    /// let builder = EditGuild::new().icon(Some(icon));
     /// guild.edit(&http, builder).await?;
     /// # Ok(())
     /// # }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -379,7 +379,7 @@ impl Guild {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut guild: Guild = unimplemented!();
-    /// let icon = CreateAttachment::path("./icon.png")?.encode().await?;
+    /// let icon = CreateAttachment::path("./icon.png".as_ref())?.encode().await?;
     ///
     /// // assuming a `guild` has already been bound
     /// let builder = EditGuild::new().icon(Some(icon));

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -161,8 +161,8 @@ impl CurrentUser {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut user = CurrentUser::default();
-    /// let avatar = CreateAttachment::path("./avatar.png")?;
-    /// let builder = EditProfile::new().avatar(&avatar).await?;
+    /// let avatar = CreateAttachment::path("./avatar.png")?.encode().await?;
+    /// let builder = EditProfile::new().avatar(avatar);
     /// user.edit(&http, builder).await;
     /// # Ok(())
     /// # }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -161,8 +161,9 @@ impl CurrentUser {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut user = CurrentUser::default();
-    /// let avatar = CreateAttachment::path("./avatar.png").await?;
-    /// user.edit(&http, EditProfile::new().avatar(&avatar)).await;
+    /// let avatar = CreateAttachment::path("./avatar.png")?;
+    /// let builder = EditProfile::new().avatar(&avatar).await?;
+    /// user.edit(&http, builder).await;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -161,7 +161,7 @@ impl CurrentUser {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let http: Http = unimplemented!();
     /// # let mut user = CurrentUser::default();
-    /// let avatar = CreateAttachment::path("./avatar.png")?.encode().await?;
+    /// let avatar = CreateAttachment::path("./avatar.png".as_ref())?.encode().await?;
     /// let builder = EditProfile::new().avatar(avatar);
     /// user.edit(&http, builder).await;
     /// # Ok(())


### PR DESCRIPTION
Implements #2690, as a second attempt at #2774. Defers reading from paths/files until the data is actually needed, which improves the performance of multipart file uploads by streaming directly from disk instead of copying into memory first. Cases where the file is included as a base64 string in the json payload are unaffected since the data needs to be encoded and written into the payload.