### PR TITLE
rework event handling to allow framework to be dispatched concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Serenity supports bot login via the use of [`Client::builder`].
 You may also check your tokens prior to login via the use of
 [`validate_token`].
 
-Once logged in, you may add handlers to your client to dispatch [`Event`]s,
-by implementing the handlers in a trait, such as [`EventHandler::message`].
-This will cause your handler to be called when a [`Event::MessageCreate`] is
-received. Each handler is given a [`Context`], giving information about the
-event. See the [client's module-level documentation].
+Once logged in, you can add an event handler to your client to dispatch [`Event`]s.
+This will allow you to recieve and handle events as you see fit. For example, an
+[`Event::MessageCreate`] event will be dispatched to you when a message is sent.
+Every event will give you access to a [`Context`], giving information about the event.
+See the [client's module-level documentation].
+
 
 The [`Shard`] is transparently handled by the library, removing
 unnecessary complexity. Sharded connections are automatically handled for
@@ -215,7 +216,6 @@ a Rust-native cloud development platform that allows deploying Serenity bots for
 
 [`Cache`]: https://docs.rs/serenity/*/serenity/cache/struct.Cache.html
 [`Client::builder`]: https://docs.rs/serenity/*/serenity/client/struct.Client.html#method.builder
-[`EventHandler::message`]: https://docs.rs/serenity/*/serenity/client/trait.EventHandler.html#method.message
 [`Context`]: https://docs.rs/serenity/*/serenity/client/struct.Context.html
 [`Event`]: https://docs.rs/serenity/*/serenity/model/event/enum.Event.html
 [`Event::MessageCreate`]: https://docs.rs/serenity/*/serenity/model/event/enum.Event.html#variant.MessageCreate

--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -1,34 +1,44 @@
 use serenity::async_trait;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
+use serenity::gateway::client::FullEvent;
 use serenity::prelude::*;
 
 struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    // Set a handler for the `message` event. This is called whenever a new message is received.
-    //
-    // Event handlers are dispatched through a threadpool, and so multiple events can be dispatched
-    // simultaneously.
-    async fn message(&self, ctx: Context, msg: Message) {
-        if msg.content == "!ping" {
-            // Sending a message can fail, due to a network error, an authentication error, or lack
-            // of permissions to post in the channel, so log to stdout when some error happens,
-            // with a description of it.
-            if let Err(why) = msg.channel_id.say(&ctx.http, "Pong!").await {
-                println!("Error sending message: {why:?}");
-            }
-        }
-    }
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            // Set a handler for the `message` event. This is called whenever a new message is
+            // received.
+            //
+            // Event handlers are dispatched through a threadpool, and so multiple events can be
+            // dispatched simultaneously.
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                if new_message.content == "!ping" {
+                    // Sending a message can fail, due to a network error, an authentication error,
+                    // or lack of permissions to post in the channel, so log to
+                    // stdout when some error happens, with a description of it.
+                    if let Err(why) = new_message.channel_id.say(&ctx.http, "Pong!").await {
+                        println!("Error sending message: {why:?}");
+                    }
+                }
+            },
 
-    // Set a handler to be called on the `ready` event. This is called when a shard is booted, and
-    // a READY payload is sent by Discord. This payload contains data like the current user's guild
-    // Ids, current user data, private channels, and more.
-    //
-    // In this case, just print what the current user's username is.
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
+            // Set a handler to be called on the `ready` event. This is called when a shard is
+            // booted, and a READY payload is sent by Discord. This payload contains
+            // data like the current user's guild Ids, current user data, private
+            // channels, and more.
+            //
+            // In this case, just print what the current user's username is.
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
+        }
     }
 }
 

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -1,6 +1,5 @@
 use serenity::async_trait;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
+use serenity::gateway::client::FullEvent;
 use serenity::prelude::*;
 
 // Serenity implements transparent sharding in a way that you do not need to handle separate
@@ -22,18 +21,24 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
-        if msg.content == "!ping" {
-            println!("Shard {}", ctx.shard_id);
-
-            if let Err(why) = msg.channel_id.say(&ctx.http, "Pong!").await {
-                println!("Error sending message: {why:?}");
-            }
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                if new_message.content == "!ping" {
+                    if let Err(why) = new_message.channel_id.say(&ctx.http, "Pong!").await {
+                        println!("Error sending message: {why:?}");
+                    }
+                }
+            },
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
         }
-    }
-
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
     }
 }
 

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -1,32 +1,41 @@
 use serenity::async_trait;
 use serenity::builder::CreateMessage;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
+use serenity::gateway::client::FullEvent;
 use serenity::prelude::*;
 
 struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, context: Context, msg: Message) {
-        if msg.content == "!messageme" {
-            // If the `utils`-feature is enabled, then model structs will have a lot of useful
-            // methods implemented, to avoid using an often otherwise bulky Context, or even much
-            // lower-level `rest` method.
-            //
-            // In this case, you can direct message a User directly by simply calling a method on
-            // its instance, with the content of the message.
-            let builder = CreateMessage::new().content("Hello!");
-            let dm = msg.author.id.dm(&context.http, builder).await;
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                if new_message.content == "!messageme" {
+                    // If the `utils`-feature is enabled, then model structs will have a lot of
+                    // useful methods implemented, to avoid using an often
+                    // otherwise bulky Context, or even much lower-level `rest`
+                    // method.
+                    //
+                    // In this case, you can direct message a User directly by simply calling a
+                    // method on its instance, with the content of the message.
+                    let builder = CreateMessage::new().content("Hello!");
+                    let dm = new_message.author.id.dm(&ctx.http, builder).await;
 
-            if let Err(why) = dm {
-                println!("Error when direct messaging user: {why:?}");
-            }
+                    if let Err(why) = dm {
+                        println!("Error when direct messaging user: {why:?}");
+                    }
+                }
+            },
+
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
         }
-    }
-
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
     }
 }
 

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -1,6 +1,5 @@
 use serenity::async_trait;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
+use serenity::gateway::client::FullEvent;
 use serenity::prelude::*;
 use serenity::utils::MessageBuilder;
 
@@ -8,36 +7,44 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, context: Context, msg: Message) {
-        if msg.content == "!ping" {
-            let channel = match msg.channel(&context).await {
-                Ok(channel) => channel,
-                Err(why) => {
-                    println!("Error getting channel: {why:?}");
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                if new_message.content == "!ping" {
+                    let channel = match new_message.channel(ctx).await {
+                        Ok(channel) => channel,
+                        Err(why) => {
+                            println!("Error getting channel: {why:?}");
 
-                    return;
-                },
-            };
+                            return;
+                        },
+                    };
 
-            // The message builder allows for creating a message by mentioning users dynamically,
-            // pushing "safe" versions of content (such as bolding normalized content), displaying
-            // emojis, and more.
-            let response = MessageBuilder::new()
-                .push("User ")
-                .push_bold_safe(msg.author.name.as_str())
-                .push(" used the 'ping' command in the ")
-                .mention(&channel)
-                .push(" channel")
-                .build();
+                    // The message builder allows for creating a message by mentioning users
+                    // dynamically, pushing "safe" versions of content (such as
+                    // bolding normalized content), displaying emojis, and more.
+                    let response = MessageBuilder::new()
+                        .push("User ")
+                        .push_bold_safe(new_message.author.name.as_str())
+                        .push(" used the 'ping' command in the ")
+                        .mention(&channel)
+                        .push(" channel")
+                        .build();
 
-            if let Err(why) = msg.channel_id.say(&context.http, &response).await {
-                println!("Error sending message: {why:?}");
-            }
+                    if let Err(why) = new_message.channel_id.say(&ctx.http, &response).await {
+                        println!("Error sending message: {why:?}");
+                    }
+                }
+            },
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
         }
-    }
-
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
     }
 }
 

--- a/examples/e05_sample_bot_structure/src/main.rs
+++ b/examples/e05_sample_bot_structure/src/main.rs
@@ -4,8 +4,8 @@ use std::env;
 
 use serenity::async_trait;
 use serenity::builder::{CreateInteractionResponse, CreateInteractionResponseMessage};
+use serenity::gateway::client::FullEvent;
 use serenity::model::application::{Command, Interaction};
-use serenity::model::gateway::Ready;
 use serenity::model::id::GuildId;
 use serenity::prelude::*;
 
@@ -13,59 +13,76 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
-        if let Interaction::Command(command) = interaction {
-            println!("Received command interaction: {command:#?}");
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        // clippy can't decide between if it wants it collapsed, or if it wants you to use if let
+        // because its a single pattern.
+        #[expect(clippy::collapsible_match)]
+        match event {
+            FullEvent::InteractionCreate {
+                interaction, ..
+            } => {
+                if let Interaction::Command(command) = interaction {
+                    println!("Received command interaction: {command:#?}");
 
-            let content = match command.data.name.as_str() {
-                "ping" => Some(commands::ping::run(&command.data.options())),
-                "id" => Some(commands::id::run(&command.data.options())),
-                "attachmentinput" => Some(commands::attachmentinput::run(&command.data.options())),
-                "modal" => {
-                    commands::modal::run(&ctx, &command).await.unwrap();
-                    None
-                },
-                _ => Some("not implemented :(".to_string()),
-            };
+                    let content = match command.data.name.as_str() {
+                        "ping" => Some(commands::ping::run(&command.data.options())),
+                        "id" => Some(commands::id::run(&command.data.options())),
+                        "attachmentinput" => {
+                            Some(commands::attachmentinput::run(&command.data.options()))
+                        },
+                        "modal" => {
+                            commands::modal::run(ctx, command).await.unwrap();
+                            None
+                        },
+                        _ => Some("not implemented :(".to_string()),
+                    };
 
-            if let Some(content) = content {
-                let data = CreateInteractionResponseMessage::new().content(content);
-                let builder = CreateInteractionResponse::Message(data);
-                if let Err(why) = command.create_response(&ctx.http, builder).await {
-                    println!("Cannot respond to slash command: {why}");
+                    if let Some(content) = content {
+                        let data = CreateInteractionResponseMessage::new().content(content);
+                        let builder = CreateInteractionResponse::Message(data);
+                        if let Err(why) = command.create_response(&ctx.http, builder).await {
+                            println!("Cannot respond to slash command: {why}");
+                        }
+                    }
                 }
-            }
-        }
-    }
+            },
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
 
-    async fn ready(&self, ctx: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
+                let guild_id = GuildId::new(
+                    env::var("GUILD_ID")
+                        .expect("Expected GUILD_ID in environment")
+                        .parse()
+                        .expect("GUILD_ID must be an integer"),
+                );
 
-        let guild_id = GuildId::new(
-            env::var("GUILD_ID")
-                .expect("Expected GUILD_ID in environment")
-                .parse()
-                .expect("GUILD_ID must be an integer"),
-        );
+                let commands = guild_id
+                    .set_commands(&ctx.http, &[
+                        commands::ping::register(),
+                        commands::id::register(),
+                        commands::welcome::register(),
+                        commands::numberinput::register(),
+                        commands::attachmentinput::register(),
+                        commands::modal::register(),
+                    ])
+                    .await;
 
-        let commands = guild_id
-            .set_commands(&ctx.http, &[
-                commands::ping::register(),
-                commands::id::register(),
-                commands::welcome::register(),
-                commands::numberinput::register(),
-                commands::attachmentinput::register(),
-                commands::modal::register(),
-            ])
-            .await;
+                println!("I now have the following guild slash commands: {commands:#?}");
 
-        println!("I now have the following guild slash commands: {commands:#?}");
-
-        let guild_command =
-            Command::create_global_command(&ctx.http, commands::wonderful_command::register())
+                let guild_command = Command::create_global_command(
+                    &ctx.http,
+                    commands::wonderful_command::register(),
+                )
                 .await;
 
-        println!("I created the following global slash command: {guild_command:#?}");
+                println!("I created the following global slash command: {guild_command:#?}");
+
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
+        }
     }
 }
 

--- a/examples/e06_env_logging/src/main.rs
+++ b/examples/e06_env_logging/src/main.rs
@@ -1,29 +1,32 @@
 use serenity::async_trait;
-use serenity::model::event::ResumedEvent;
-use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 use tracing::{debug, error, info, instrument};
 
 struct Handler;
 
+use serenity::gateway::client::FullEvent;
+
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
-        // Log at the INFO level. This is a macro from the `tracing` crate.
-        info!("{} is connected!", ready.user.name);
-    }
-
-    // For instrument to work, all parameters must implement Debug.
-    //
-    // Handler doesn't implement Debug here, so we specify to skip that argument.
-    // Context doesn't implement Debug either, so it is also skipped.
-    #[instrument(skip(self, _ctx))]
-    async fn resume(&self, _ctx: Context, _resume: ResumedEvent) {
-        // Log at the DEBUG level.
-        //
-        // In this example, this will not show up in the logs because DEBUG is
-        // below INFO, which is the set debug level.
-        debug!("Resumed");
+    async fn dispatch(&self, _: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                // Log at the INFO level. This is a macro from the `tracing` crate.
+                info!("{} is connected!", data_about_bot.user.name);
+            },
+            FullEvent::Resume {
+                ..
+            } => {
+                // Log at the DEBUG level.
+                //
+                // In this example, this will not show up in the logs because DEBUG is
+                // below INFO, which is the set debug level.
+                debug!("Resumed");
+            },
+            _ => {},
+        }
     }
 }
 

--- a/examples/e07_shard_manager/src/main.rs
+++ b/examples/e07_shard_manager/src/main.rs
@@ -22,7 +22,7 @@
 use std::time::Duration;
 
 use serenity::async_trait;
-use serenity::model::gateway::Ready;
+use serenity::gateway::client::FullEvent;
 use serenity::prelude::*;
 use tokio::time::sleep;
 
@@ -30,12 +30,20 @@ struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
-        if let Some(shard) = ready.shard {
-            // Note that array index 0 is 0-indexed, while index 1 is 1-indexed.
-            //
-            // This may seem unintuitive, but it models Discord's behaviour.
-            println!("{} is connected on shard {}/{}!", ready.user.name, shard.id, shard.total);
+    async fn dispatch(&self, _: &Context, event: &FullEvent) {
+        if let FullEvent::Ready {
+            data_about_bot, ..
+        } = event
+        {
+            if let Some(shard) = data_about_bot.shard {
+                // Note that array index 0 is 0-indexed, while index 1 is 1-indexed.
+                //
+                // This may seem unintuitive, but it models Discord's behaviour.
+                println!(
+                    "{} is connected on shard {}/{}!",
+                    data_about_bot.user.name, shard.id, shard.total
+                );
+            }
         }
     }
 }

--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -1,48 +1,56 @@
 use serenity::async_trait;
 use serenity::builder::{CreateAttachment, CreateEmbed, CreateEmbedFooter, CreateMessage};
+use serenity::gateway::client::FullEvent;
 use serenity::model::Timestamp;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 
 struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
-        if msg.content == "!hello" {
-            // The create message builder allows you to easily create embeds and messages using a
-            // builder syntax.
-            // This example will create a message that says "Hello, World!", with an embed that has
-            // a title, description, an image, three fields, and a footer.
-            let footer = CreateEmbedFooter::new("This is a footer");
-            let embed = CreateEmbed::new()
-                .title("This is a title")
-                .description("This is a description")
-                .image("attachment://ferris_eyes.png")
-                .fields([
-                    ("This is the first field", "This is a field body", true),
-                    ("This is the second field", "Both fields are inline", true),
-                ])
-                .field("This is the third field", "This is not an inline field", false)
-                .footer(footer)
-                // Add a timestamp for the current time
-                // This also accepts a rfc3339 Timestamp
-                .timestamp(Timestamp::now());
-            let builder = CreateMessage::new()
-                .content("Hello, World!")
-                .embed(embed)
-                .add_file(CreateAttachment::path("./ferris_eyes.png").await.unwrap());
-            let msg = msg.channel_id.send_message(&ctx.http, builder).await;
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                if new_message.content == "!hello" {
+                    // The create message builder allows you to easily create embeds and messages
+                    // using a builder syntax.
+                    // This example will create a message that says "Hello, World!", with an embed
+                    // that has a title, description, an image, three fields,
+                    // and a footer.
+                    let footer = CreateEmbedFooter::new("This is a footer");
+                    let embed = CreateEmbed::new()
+                        .title("This is a title")
+                        .description("This is a description")
+                        .image("attachment://ferris_eyes.png")
+                        .fields([
+                            ("This is the first field", "This is a field body", true),
+                            ("This is the second field", "Both fields are inline", true),
+                        ])
+                        .field("This is the third field", "This is not an inline field", false)
+                        .footer(footer)
+                        // Add a timestamp for the current time
+                        // This also accepts a rfc3339 Timestamp
+                        .timestamp(Timestamp::now());
+                    let builder = CreateMessage::new()
+                        .content("Hello, World!")
+                        .embed(embed)
+                        .add_file(CreateAttachment::path("./ferris_eyes.png").await.unwrap());
+                    let msg = new_message.channel_id.send_message(&ctx.http, builder).await;
 
-            if let Err(why) = msg {
-                println!("Error sending message: {why:?}");
-            }
+                    if let Err(why) = msg {
+                        println!("Error sending message: {why:?}");
+                    }
+                }
+            },
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
         }
-    }
-
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
     }
 }
 

--- a/examples/e09_collectors/src/main.rs
+++ b/examples/e09_collectors/src/main.rs
@@ -12,124 +12,143 @@ use serenity::prelude::*;
 
 struct Handler;
 
+use serenity::gateway::client::FullEvent;
+
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
-    }
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                let mut score = 0u32;
+                let _ = new_message
+                    .reply(&ctx.http, "How was that crusty crab called again? 10 seconds time!")
+                    .await;
 
-    async fn message(&self, ctx: Context, msg: Message) {
-        let mut score = 0u32;
-        let _ =
-            msg.reply(&ctx.http, "How was that crusty crab called again? 10 seconds time!").await;
+                // There is a method implemented for some models to conveniently collect replies.
+                // They return a builder that can be turned into a Stream, or here,
+                // where we can await a single reply
+                let collector =
+                    new_message.author.id.collect_messages(ctx).timeout(Duration::from_secs(10));
+                if let Some(answer) = collector.await {
+                    if answer.content.to_lowercase() == "ferris" {
+                        let _ = answer.reply(&ctx.http, "That's correct!").await;
+                        score += 1;
+                    } else {
+                        let _ = answer.reply(&ctx.http, "Wrong, it's Ferris!").await;
+                    }
+                } else {
+                    let _ = new_message.reply(&ctx.http, "No answer within 10 seconds.").await;
+                };
 
-        // There is a method implemented for some models to conveniently collect replies. They
-        // return a builder that can be turned into a Stream, or here, where we can await a
-        // single reply
-        let collector = msg.author.id.collect_messages(&ctx).timeout(Duration::from_secs(10));
-        if let Some(answer) = collector.await {
-            if answer.content.to_lowercase() == "ferris" {
-                let _ = answer.reply(&ctx.http, "That's correct!").await;
-                score += 1;
-            } else {
-                let _ = answer.reply(&ctx.http, "Wrong, it's Ferris!").await;
-            }
-        } else {
-            let _ = msg.reply(&ctx.http, "No answer within 10 seconds.").await;
-        };
+                let react_msg = new_message
+                    .reply(&ctx.http, "React with the reaction representing 1, you got 10 seconds!")
+                    .await
+                    .unwrap();
 
-        let react_msg = msg
-            .reply(&ctx.http, "React with the reaction representing 1, you got 10 seconds!")
-            .await
-            .unwrap();
+                // The message model can also be turned into a Collector to collect reactions on it.
+                let collector = react_msg
+                    .id
+                    .collect_reactions(ctx)
+                    .timeout(Duration::from_secs(10))
+                    .author_id(new_message.author.id);
 
-        // The message model can also be turned into a Collector to collect reactions on it.
-        let collector = react_msg
-            .id
-            .collect_reactions(&ctx)
-            .timeout(Duration::from_secs(10))
-            .author_id(msg.author.id);
+                if let Some(reaction) = collector.await {
+                    let _ = if reaction.emoji.as_data() == "1️⃣" {
+                        score += 1;
+                        new_message.reply(&ctx.http, "That's correct!").await
+                    } else {
+                        new_message.reply(&ctx.http, "Wrong!").await
+                    };
+                } else {
+                    let _ = new_message.reply(&ctx.http, "No reaction within 10 seconds.").await;
+                };
 
-        if let Some(reaction) = collector.await {
-            let _ = if reaction.emoji.as_data() == "1️⃣" {
-                score += 1;
-                msg.reply(&ctx.http, "That's correct!").await
-            } else {
-                msg.reply(&ctx.http, "Wrong!").await
-            };
-        } else {
-            let _ = msg.reply(&ctx.http, "No reaction within 10 seconds.").await;
-        };
+                let _ = new_message.reply(&ctx.http, "Write 5 messages in 10 seconds").await;
 
-        let _ = msg.reply(&ctx.http, "Write 5 messages in 10 seconds").await;
+                // We can create a collector from scratch too using this builder future.
+                let collector = MessageCollector::new(ctx)
+                // Only collect messages by this user.
+                    .author_id(new_message.author.id)
+                    .channel_id(new_message.channel_id)
+                    .timeout(Duration::from_secs(10))
+                    // Build the collector.
+                    .stream()
+                    .take(5);
 
-        // We can create a collector from scratch too using this builder future.
-        let collector = MessageCollector::new(&ctx)
-        // Only collect messages by this user.
-            .author_id(msg.author.id)
-            .channel_id(msg.channel_id)
-            .timeout(Duration::from_secs(10))
-            // Build the collector.
-            .stream()
-            .take(5);
+                // Let's acquire borrow HTTP to send a message inside the `async move`.
+                let http = &ctx.http;
 
-        // Let's acquire borrow HTTP to send a message inside the `async move`.
-        let http = &ctx.http;
+                // We want to process each message and get the length. There are a couple of ways to
+                // do this. Folding the stream with `fold` is one way.
+                //
+                // Using `then` to first reply and then create a new stream with all messages is
+                // another way to do it, which can be nice if you want to further
+                // process the messages.
+                //
+                // If you don't want to collect the stream, `for_each` may be sufficient.
+                let collected: Vec<_> = collector
+                    .then(|msg| async move {
+                        let _ = msg.reply(http, format!("I repeat: {}", msg.content)).await;
 
-        // We want to process each message and get the length. There are a couple of ways to do
-        // this. Folding the stream with `fold` is one way.
-        //
-        // Using `then` to first reply and then create a new stream with all messages is another way
-        // to do it, which can be nice if you want to further process the messages.
-        //
-        // If you don't want to collect the stream, `for_each` may be sufficient.
-        let collected: Vec<_> = collector
-            .then(|msg| async move {
-                let _ = msg.reply(http, format!("I repeat: {}", msg.content)).await;
+                        msg
+                    })
+                    .collect()
+                    .await;
 
-                msg
-            })
-            .collect()
-            .await;
+                if collected.len() >= 5 {
+                    score += 1;
+                }
 
-        if collected.len() >= 5 {
-            score += 1;
-        }
+                // We can also collect arbitrary events using the collect() function. For example,
+                // here we collect updates to the messages that the user sent above
+                // and check for them updating all 5 of them.
+                let mut collector = serenity::collector::collect(ctx, move |event| match event {
+                    // Only collect MessageUpdate events for the 5 MessageIds we're interested in.
+                    Event::MessageUpdate(event)
+                        if collected.iter().any(|msg| event.message.id == msg.id) =>
+                    {
+                        Some(event.message.id)
+                    },
+                    _ => None,
+                })
+                .take_until(Box::pin(tokio::time::sleep(Duration::from_secs(20))));
 
-        // We can also collect arbitrary events using the collect() function. For example, here we
-        // collect updates to the messages that the user sent above and check for them updating all
-        // 5 of them.
-        let mut collector = serenity::collector::collect(&ctx, move |event| match event {
-            // Only collect MessageUpdate events for the 5 MessageIds we're interested in.
-            Event::MessageUpdate(event)
-                if collected.iter().any(|msg| event.message.id == msg.id) =>
-            {
-                Some(event.message.id)
+                let _ = new_message
+                    .reply(&ctx.http, "Edit each of those 5 messages in 20 seconds")
+                    .await;
+                let mut edited = HashSet::new();
+                while let Some(edited_message_id) = collector.next().await {
+                    edited.insert(edited_message_id);
+                    if edited.len() >= 5 {
+                        break;
+                    }
+                }
+
+                if edited.len() >= 5 {
+                    score += 1;
+                    let _ = new_message.reply(&ctx.http, "Great! You edited 5 out of 5").await;
+                } else {
+                    let _ = new_message
+                        .reply(&ctx.http, format!("You only edited {} out of 5", edited.len()))
+                        .await;
+                }
+
+                let _ = new_message
+                    .reply(
+                        &ctx.http,
+                        format!("TIME'S UP! You completed {score} out of 4 tasks correctly!"),
+                    )
+                    .await;
             },
-            _ => None,
-        })
-        .take_until(Box::pin(tokio::time::sleep(Duration::from_secs(20))));
-
-        let _ = msg.reply(&ctx.http, "Edit each of those 5 messages in 20 seconds").await;
-        let mut edited = HashSet::new();
-        while let Some(edited_message_id) = collector.next().await {
-            edited.insert(edited_message_id);
-            if edited.len() >= 5 {
-                break;
-            }
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
         }
-
-        if edited.len() >= 5 {
-            score += 1;
-            let _ = msg.reply(&ctx.http, "Great! You edited 5 out of 5").await;
-        } else {
-            let _ =
-                msg.reply(&ctx.http, format!("You only edited {} out of 5", edited.len())).await;
-        }
-
-        let _ = msg
-            .reply(&ctx.http, format!("TIME'S UP! You completed {score} out of 4 tasks correctly!"))
-            .await;
     }
 }
 

--- a/examples/e10_gateway_intents/src/main.rs
+++ b/examples/e10_gateway_intents/src/main.rs
@@ -1,30 +1,32 @@
 use serenity::async_trait;
-use serenity::model::channel::Message;
-use serenity::model::gateway::{Presence, Ready};
 use serenity::prelude::*;
 
 struct Handler;
 
+use serenity::gateway::client::FullEvent;
+
 #[async_trait]
 impl EventHandler for Handler {
-    // This event will be dispatched for guilds, but not for direct messages.
-    async fn message(&self, _ctx: Context, msg: Message) {
-        println!("Received message: {}", msg.content);
-    }
-
-    // As the intents set in this example, this event shall never be dispatched.
-    // Try it by changing your status.
-    async fn presence_update(
-        &self,
-        _ctx: Context,
-        _old_data: Option<Presence>,
-        _new_data: Presence,
-    ) {
-        println!("Presence Update");
-    }
-
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
+    async fn dispatch(&self, _: &Context, event: &FullEvent) {
+        match event {
+            // This event will be dispatched for guilds, but not for direct messages.
+            FullEvent::Message {
+                new_message, ..
+            } => println!("Received message: {}", new_message.content),
+            // As the intents set in this example, this event shall never be dispatched.
+            // Try it by changing your status.
+            FullEvent::PresenceUpdate {
+                ..
+            } => {
+                println!("Presence Update")
+            },
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
+        }
     }
 }
 

--- a/examples/e11_global_data/src/main.rs
+++ b/examples/e11_global_data/src/main.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serenity::async_trait;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
 use serenity::prelude::*;
 
 // A container type is created for inserting into the Client's `data`, which allows for data to be
@@ -16,47 +14,58 @@ struct UserData {
     message_count: AtomicUsize,
 }
 
+use serenity::gateway::client::FullEvent;
 struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
-        // Since data is located in Context, this means you are able to use it within events!
-        let data = ctx.data::<UserData>();
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                // Since data is located in Context, this means you are able to use it within
+                // events!
+                let data = ctx.data::<UserData>();
 
-        // We are verifying if the bot id is the same as the message author id.
-        let owo_count = if msg.author.id != ctx.cache.current_user().id
-            && msg.content.to_lowercase().contains("owo")
-        {
-            // Here, we are checking how many "owo" there are in the message content.
-            let owo_in_msg = msg.content.to_ascii_lowercase().matches("owo").count();
+                // We are verifying if the bot id is the same as the message author id.
+                let owo_count = if new_message.author.id != ctx.cache.current_user().id
+                    && new_message.content.to_lowercase().contains("owo")
+                {
+                    // Here, we are checking how many "owo" there are in the message content.
+                    let owo_in_msg =
+                        new_message.content.to_ascii_lowercase().matches("owo").count();
 
-            // Atomic operations with ordering do not require mut to be modified.
-            // In this case, we want to increase the message count by 1.
-            // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
-            data.message_count.fetch_add(owo_in_msg, Ordering::SeqCst) + 1
-        } else {
-            // We don't need to check for "owo_count" if "owo" isn't in the message!
-            return;
-        };
+                    // Atomic operations with ordering do not require mut to be modified.
+                    // In this case, we want to increase the message count by 1.
+                    // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add
+                    data.message_count.fetch_add(owo_in_msg, Ordering::SeqCst) + 1
+                } else {
+                    // We don't need to check for "owo_count" if "owo" isn't in the message!
+                    return;
+                };
 
-        if msg.content.starts_with("~owo_count") {
-            let response = if owo_count == 1 {
-                Cow::Borrowed(
-                    "You are the first one to say owo this session! *because it's on the command name* :P",
-                )
-            } else {
-                Cow::Owned(format!("OWO Has been said {owo_count} times!"))
-            };
+                if new_message.content.starts_with("~owo_count") {
+                    let response = if owo_count == 1 {
+                        Cow::Borrowed(
+                            "You are the first one to say owo this session! *because it's on the command name* :P",
+                        )
+                    } else {
+                        Cow::Owned(format!("OWO Has been said {owo_count} times!"))
+                    };
 
-            if let Err(err) = msg.reply(&ctx.http, response).await {
-                eprintln!("Error sending response: {err:?}")
-            };
+                    if let Err(err) = new_message.reply(&ctx.http, response).await {
+                        eprintln!("Error sending response: {err:?}")
+                    };
+                }
+            },
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
         }
-    }
-
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
     }
 }
 

--- a/examples/e12_parallel_loops/src/main.rs
+++ b/examples/e12_parallel_loops/src/main.rs
@@ -5,62 +5,71 @@ use chrono::offset::Utc;
 use serenity::async_trait;
 use serenity::builder::{CreateEmbed, CreateMessage};
 use serenity::gateway::ActivityData;
-use serenity::model::channel::Message;
-use serenity::model::gateway::Ready;
-use serenity::model::id::{ChannelId, GuildId};
+use serenity::model::id::ChannelId;
 use serenity::prelude::*;
 
 struct Handler {
     is_loop_running: AtomicBool,
 }
 
+use serenity::gateway::client::FullEvent;
+
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
-        if msg.content.starts_with("!ping") {
-            if let Err(why) = msg.channel_id.say(&ctx.http, "Pong!").await {
-                eprintln!("Error sending message: {why:?}");
-            }
-        }
-    }
-
-    async fn ready(&self, _ctx: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
-    }
-
-    // We use the cache_ready event just in case some cache operation is required in whatever use
-    // case you have for this.
-    async fn cache_ready(&self, ctx: Context, _guilds: Vec<GuildId>) {
-        println!("Cache built successfully!");
-
-        // We need to check that the loop is not already running when this event triggers, as this
-        // event triggers every time the bot enters or leaves a guild, along every time the ready
-        // shard event triggers.
-        //
-        // An AtomicBool is used because it doesn't require a mutable reference to be changed, as
-        // we don't have one due to self being an immutable reference.
-        if !self.is_loop_running.load(Ordering::Relaxed) {
-            // We have to clone the ctx, as it gets moved into the new thread.
-            let ctx1 = ctx.clone();
-            // tokio::spawn creates a new green thread that can run in parallel with the rest of
-            // the application.
-            tokio::spawn(async move {
-                loop {
-                    log_system_load(&ctx1).await;
-                    tokio::time::sleep(Duration::from_secs(120)).await;
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                if new_message.content == "!ping" {
+                    if let Err(why) = new_message.channel_id.say(&ctx.http, "Pong!").await {
+                        println!("Error sending message: {why:?}");
+                    }
                 }
-            });
+            },
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            FullEvent::CacheReady {
+                ..
+            } => {
+                println!("Cache built successfully!");
 
-            // And of course, we can run more than one thread at different timings.
-            tokio::spawn(async move {
-                loop {
-                    set_activity_to_current_time(&ctx);
-                    tokio::time::sleep(Duration::from_secs(60)).await;
+                // We need to check that the loop is not already running when this event triggers,
+                // as this event triggers every time the bot enters or leaves a
+                // guild, along every time the ready shard event triggers.
+                //
+                // An AtomicBool is used because it doesn't require a mutable reference to be
+                // changed, as we don't have one due to self being an immutable
+                // reference.
+                if !self.is_loop_running.load(Ordering::Relaxed) {
+                    // We have to clone the ctx, as it gets moved into the new thread.
+                    let ctx1 = ctx.clone();
+                    // tokio::spawn creates a new green thread that can run in parallel with the
+                    // rest of the application.
+                    tokio::spawn(async move {
+                        loop {
+                            log_system_load(&ctx1).await;
+                            tokio::time::sleep(Duration::from_secs(120)).await;
+                        }
+                    });
+
+                    // And of course, we can run more than one thread at different timings.
+                    let ctx2 = ctx.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            set_activity_to_current_time(&ctx2);
+                            tokio::time::sleep(Duration::from_secs(60)).await;
+                        }
+                    });
+
+                    // Now that the loop is running, we set the bool to true
+                    self.is_loop_running.swap(true, Ordering::Relaxed);
                 }
-            });
-
-            // Now that the loop is running, we set the bool to true
-            self.is_loop_running.swap(true, Ordering::Relaxed);
+            },
+            _ => {},
         }
     }
 }

--- a/examples/e13_sqlite_database/src/main.rs
+++ b/examples/e13_sqlite_database/src/main.rs
@@ -10,61 +10,78 @@ struct Bot {
     database: sqlx::SqlitePool,
 }
 
+use serenity::gateway::client::FullEvent;
+
 #[async_trait]
 impl EventHandler for Bot {
-    async fn message(&self, ctx: Context, msg: Message) {
-        let user_id = msg.author.id.get() as i64;
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                let user_id = new_message.author.id.get() as i64;
 
-        if let Some(task_description) = msg.content.strip_prefix("~todo add") {
-            let task_description = task_description.trim();
-            // That's how we are going to use a sqlite command.
-            // We are inserting into the todo table, our task_description in task column and our
-            // user_id in user_Id column.
-            sqlx::query!(
-                "INSERT INTO todo (task, user_id) VALUES (?, ?)",
-                task_description,
-                user_id,
-            )
-            .execute(&self.database) // < Where the command will be executed
-            .await
-            .unwrap();
-
-            let response = format!("Successfully added `{task_description}` to your todo list");
-            msg.channel_id.say(&ctx.http, response).await.unwrap();
-        } else if let Some(task_index) = msg.content.strip_prefix("~todo remove") {
-            let task_index = task_index.trim().parse::<i64>().unwrap() - 1;
-
-            // "SELECT" will return the rowid of the todo rows where the user_Id column = user_id.
-            let entry = sqlx::query!(
-                "SELECT rowid, task FROM todo WHERE user_id = ? ORDER BY rowid LIMIT 1 OFFSET ?",
-                user_id,
-                task_index,
-            )
-            .fetch_one(&self.database) // < Just one data will be sent to entry
-            .await
-            .unwrap();
-
-            // Every todo row with rowid column = entry.rowid will be deleted.
-            sqlx::query!("DELETE FROM todo WHERE rowid = ?", entry.rowid)
-                .execute(&self.database)
-                .await
-                .unwrap();
-
-            let response = format!("Successfully completed `{}`!", entry.task);
-            msg.channel_id.say(&ctx.http, response).await.unwrap();
-        } else if msg.content.trim() == "~todo list" {
-            // "SELECT" will return the task of all rows where user_Id column = user_id in todo.
-            let todos = sqlx::query!("SELECT task FROM todo WHERE user_id = ? ORDER BY rowid", user_id)
-                    .fetch_all(&self.database) // < All matched data will be sent to todos
+                if let Some(task_description) = new_message.content.strip_prefix("~todo add") {
+                    let task_description = task_description.trim();
+                    // That's how we are going to use a sqlite command.
+                    // We are inserting into the todo table, our task_description in task column and
+                    // our user_id in user_Id column.
+                    sqlx::query!(
+                        "INSERT INTO todo (task, user_id) VALUES (?, ?)",
+                        task_description,
+                        user_id,
+                    )
+                    .execute(&self.database) // < Where the command will be executed
                     .await
                     .unwrap();
 
-            let mut response = format!("You have {} pending tasks:\n", todos.len());
-            for (i, todo) in todos.iter().enumerate() {
-                writeln!(response, "{}. {}", i + 1, todo.task).unwrap();
-            }
+                    let response =
+                        format!("Successfully added `{task_description}` to your todo list");
+                    new_message.channel_id.say(&ctx.http, response).await.unwrap();
+                } else if let Some(task_index) = new_message.content.strip_prefix("~todo remove") {
+                    let task_index = task_index.trim().parse::<i64>().unwrap() - 1;
 
-            msg.channel_id.say(&ctx.http, response).await.unwrap();
+                    // "SELECT" will return the rowid of the todo rows where the user_Id column =
+                    // user_id.
+                    let entry = sqlx::query!(
+                        "SELECT rowid, task FROM todo WHERE user_id = ? ORDER BY rowid LIMIT 1 OFFSET ?",
+                        user_id,
+                        task_index,
+                    )
+                    .fetch_one(&self.database) // < Just one data will be sent to entry
+                    .await
+                    .unwrap();
+
+                    // Every todo row with rowid column = entry.rowid will be deleted.
+                    sqlx::query!("DELETE FROM todo WHERE rowid = ?", entry.rowid)
+                        .execute(&self.database)
+                        .await
+                        .unwrap();
+
+                    let response = format!("Successfully completed `{}`!", entry.task);
+                    new_message.channel_id.say(&ctx.http, response).await.unwrap();
+                } else if new_message.content.trim() == "~todo list" {
+                    // "SELECT" will return the task of all rows where user_Id column = user_id in
+                    // todo.
+                    let todos = sqlx::query!("SELECT task FROM todo WHERE user_id = ? ORDER BY rowid", user_id)
+                            .fetch_all(&self.database) // < All matched data will be sent to todos
+                            .await
+                            .unwrap();
+
+                    let mut response = format!("You have {} pending tasks:\n", todos.len());
+                    for (i, todo) in todos.iter().enumerate() {
+                        writeln!(response, "{}. {}", i + 1, todo.task).unwrap();
+                    }
+
+                    new_message.channel_id.say(&ctx.http, response).await.unwrap();
+                }
+            },
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
         }
     }
 }

--- a/examples/e14_message_components/src/main.rs
+++ b/examples/e14_message_components/src/main.rs
@@ -26,111 +26,135 @@ fn sound_button(name: &str, emoji: ReactionType) -> CreateButton {
 
 struct Handler;
 
+use serenity::gateway::client::FullEvent;
+
 #[async_trait]
 impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
-        if msg.content != "animal" {
-            return;
-        }
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                if new_message.content != "animal" {
+                    return;
+                }
 
-        // Ask the user for its favorite animal
-        let m = msg
-            .channel_id
-            .send_message(
-                &ctx.http,
-                CreateMessage::new().content("Please select your favorite animal").select_menu(
-                    CreateSelectMenu::new("animal_select", CreateSelectMenuKind::String {
-                        options: Cow::Borrowed(&[
-                            CreateSelectMenuOption::new("🐈 meow", "Cat"),
-                            CreateSelectMenuOption::new("🐕 woof", "Dog"),
-                            CreateSelectMenuOption::new("🐎 neigh", "Horse"),
-                            CreateSelectMenuOption::new("🦙 hoooooooonk", "Alpaca"),
-                            CreateSelectMenuOption::new("🦀 crab rave", "Ferris"),
-                        ]),
-                    })
-                    .custom_id("animal_select")
-                    .placeholder("No animal selected"),
-                ),
-            )
-            .await
-            .unwrap();
+                // Ask the user for its favorite animal
+                let m = new_message
+                    .channel_id
+                    .send_message(
+                        &ctx.http,
+                        CreateMessage::new()
+                            .content("Please select your favorite animal")
+                            .select_menu(
+                                CreateSelectMenu::new(
+                                    "animal_select",
+                                    CreateSelectMenuKind::String {
+                                        options: Cow::Borrowed(&[
+                                            CreateSelectMenuOption::new("🐈 meow", "Cat"),
+                                            CreateSelectMenuOption::new("🐕 woof", "Dog"),
+                                            CreateSelectMenuOption::new("🐎 neigh", "Horse"),
+                                            CreateSelectMenuOption::new("🦙 hoooooooonk", "Alpaca"),
+                                            CreateSelectMenuOption::new("🦀 crab rave", "Ferris"),
+                                        ]),
+                                    },
+                                )
+                                .custom_id("animal_select")
+                                .placeholder("No animal selected"),
+                            ),
+                    )
+                    .await
+                    .unwrap();
 
-        // Wait for the user to make a selection
-        // This uses a collector to wait for an incoming event without needing to listen for it
-        // manually in the EventHandler.
-        let interaction = match m
-            .id
-            .collect_component_interactions(&ctx)
-            .timeout(Duration::from_secs(60 * 3))
-            .await
-        {
-            Some(x) => x,
-            None => {
-                m.reply(&ctx.http, "Timed out").await.unwrap();
-                return;
+                // Wait for the user to make a selection
+                // This uses a collector to wait for an incoming event without needing to listen for
+                // it manually in the EventHandler.
+                let interaction = match m
+                    .id
+                    .collect_component_interactions(ctx)
+                    .timeout(Duration::from_secs(60 * 3))
+                    .await
+                {
+                    Some(x) => x,
+                    None => {
+                        m.reply(&ctx.http, "Timed out").await.unwrap();
+                        return;
+                    },
+                };
+
+                // data.values contains the selected value from each select menus. We only have one
+                // menu, so we retrieve the first
+                let animal = match &interaction.data.kind {
+                    ComponentInteractionDataKind::StringSelect {
+                        values,
+                    } => &values[0],
+                    _ => panic!("unexpected interaction data kind"),
+                };
+
+                // Acknowledge the interaction and edit the message
+                interaction
+                    .create_response(
+                        &ctx.http,
+                        CreateInteractionResponse::UpdateMessage(
+                            CreateInteractionResponseMessage::default()
+                                .content(format!("You chose: **{animal}**\nNow choose a sound!"))
+                                .button(sound_button("meow", "🐈".parse().unwrap()))
+                                .button(sound_button("woof", "🐕".parse().unwrap()))
+                                .button(sound_button("neigh", "🐎".parse().unwrap()))
+                                .button(sound_button("hoooooooonk", "🦙".parse().unwrap()))
+                                .button(sound_button(
+                                    "crab rave",
+                                    // Custom emojis in Discord are represented with
+                                    // `<:EMOJI_NAME:EMOJI_ID>`. You can see this by posting an
+                                    // emoji in your server and
+                                    // putting a backslash before the emoji.
+                                    //
+                                    // Because ReactionType implements FromStr, we can use .parse()
+                                    // to convert the textual
+                                    // emoji representation to ReactionType
+                                    "<:ferris:381919740114763787>".parse().unwrap(),
+                                )),
+                        ),
+                    )
+                    .await
+                    .unwrap();
+
+                // Wait for multiple interactions
+                let mut interaction_stream =
+                    m.id.collect_component_interactions(ctx)
+                        .timeout(Duration::from_secs(60 * 3))
+                        .stream();
+
+                while let Some(interaction) = interaction_stream.next().await {
+                    let sound = &interaction.data.custom_id;
+                    // Acknowledge the interaction and send a reply
+                    interaction
+                        .create_response(
+                            &ctx.http,
+                            // This time we dont edit the message but reply to it
+                            CreateInteractionResponse::Message(
+                                CreateInteractionResponseMessage::default()
+                                    // Make the message hidden for other users by setting `ephemeral(true)`.
+                                    .ephemeral(true)
+                                    .content(format!("The **{animal}** says __{sound}__")),
+                            ),
+                        )
+                        .await
+                        .unwrap();
+                }
+
+                // Delete the orig message or there will be dangling components (components that
+                // still exist, but no collector is running so any user who presses
+                // them sees an error)
+                m.delete(&ctx.http, None).await.unwrap()
             },
-        };
-
-        // data.values contains the selected value from each select menus. We only have one menu,
-        // so we retrieve the first
-        let animal = match &interaction.data.kind {
-            ComponentInteractionDataKind::StringSelect {
-                values,
-            } => &values[0],
-            _ => panic!("unexpected interaction data kind"),
-        };
-
-        // Acknowledge the interaction and edit the message
-        interaction
-            .create_response(
-                &ctx.http,
-                CreateInteractionResponse::UpdateMessage(
-                    CreateInteractionResponseMessage::default()
-                        .content(format!("You chose: **{animal}**\nNow choose a sound!"))
-                        .button(sound_button("meow", "🐈".parse().unwrap()))
-                        .button(sound_button("woof", "🐕".parse().unwrap()))
-                        .button(sound_button("neigh", "🐎".parse().unwrap()))
-                        .button(sound_button("hoooooooonk", "🦙".parse().unwrap()))
-                        .button(sound_button(
-                            "crab rave",
-                            // Custom emojis in Discord are represented with
-                            // `<:EMOJI_NAME:EMOJI_ID>`. You can see this by posting an emoji in
-                            // your server and putting a backslash before the emoji.
-                            //
-                            // Because ReactionType implements FromStr, we can use .parse() to
-                            // convert the textual emoji representation to ReactionType
-                            "<:ferris:381919740114763787>".parse().unwrap(),
-                        )),
-                ),
-            )
-            .await
-            .unwrap();
-
-        // Wait for multiple interactions
-        let mut interaction_stream =
-            m.id.collect_component_interactions(&ctx).timeout(Duration::from_secs(60 * 3)).stream();
-
-        while let Some(interaction) = interaction_stream.next().await {
-            let sound = &interaction.data.custom_id;
-            // Acknowledge the interaction and send a reply
-            interaction
-                .create_response(
-                    &ctx.http,
-                    // This time we dont edit the message but reply to it
-                    CreateInteractionResponse::Message(
-                        CreateInteractionResponseMessage::default()
-                            // Make the message hidden for other users by setting `ephemeral(true)`.
-                            .ephemeral(true)
-                            .content(format!("The **{animal}** says __{sound}__")),
-                    ),
-                )
-                .await
-                .unwrap();
+            FullEvent::Ready {
+                data_about_bot, ..
+            } => {
+                println!("{} is connected!", data_about_bot.user.name);
+            },
+            _ => {},
         }
-
-        // Delete the orig message or there will be dangling components (components that still
-        // exist, but no collector is running so any user who presses them sees an error)
-        m.delete(&ctx.http, None).await.unwrap()
     }
 }
 

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use serenity::async_trait;
 use serenity::builder::*;
 use serenity::collector::CollectComponentInteractions;
 use serenity::model::prelude::*;
@@ -10,7 +11,7 @@ mod model_type_sizes;
 const IMAGE_URL: &str = "https://raw.githubusercontent.com/serenity-rs/serenity/current/logo.png";
 const IMAGE_URL_2: &str = "https://rustacean.net/assets/rustlogo.png";
 
-async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
+async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
     let channel_id = msg.channel_id;
     let guild_id = msg.guild_id.unwrap();
     if let Some(_args) = msg.content.strip_prefix("testmessage ") {
@@ -236,9 +237,9 @@ async fn message(ctx: &Context, msg: Message) -> Result<(), serenity::Error> {
     Ok(())
 }
 
-async fn interaction(
+async fn command_interaction(
     ctx: &Context,
-    interaction: CommandInteraction,
+    interaction: &CommandInteraction,
 ) -> Result<(), serenity::Error> {
     if interaction.data.name == "editattachments" {
         // Respond with an image
@@ -377,32 +378,40 @@ async fn interaction(
 }
 
 struct Handler;
-#[serenity::async_trait]
-impl EventHandler for Handler {
-    async fn message(&self, ctx: Context, msg: Message) {
-        message(&ctx, msg).await.unwrap();
-    }
 
-    async fn interaction_create(&self, ctx: Context, i: Interaction) {
-        match i {
-            Interaction::Command(i) => interaction(&ctx, i).await.unwrap(),
-            Interaction::Component(i) => println!("{:#?}", i.data),
-            Interaction::Autocomplete(i) => {
-                i.create_response(
-                    &ctx.http,
-                    CreateInteractionResponse::Autocomplete(
-                        CreateAutocompleteResponse::new().add_choice("suggestion"),
-                    ),
-                )
-                .await
-                .unwrap();
+use serenity::gateway::client::FullEvent;
+
+#[async_trait]
+impl EventHandler for Handler {
+    async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+        match event {
+            FullEvent::Message {
+                new_message, ..
+            } => {
+                message(ctx, new_message).await.unwrap();
             },
+            FullEvent::InteractionCreate {
+                interaction, ..
+            } => match interaction {
+                Interaction::Command(i) => command_interaction(ctx, i).await.unwrap(),
+                Interaction::Component(i) => println!("{:#?}", i.data),
+                Interaction::Autocomplete(i) => {
+                    i.create_response(
+                        &ctx.http,
+                        CreateInteractionResponse::Autocomplete(
+                            CreateAutocompleteResponse::new().add_choice("suggestion"),
+                        ),
+                    )
+                    .await
+                    .unwrap();
+                },
+                _ => {},
+            },
+            FullEvent::ReactionRemoveEmoji {
+                removed_reactions, ..
+            } => println!("Got ReactionRemoveEmoji event: {removed_reactions:?}"),
             _ => {},
         }
-    }
-
-    async fn reaction_remove_emoji(&self, _ctx: Context, removed_reactions: Reaction) {
-        println!("Got ReactionRemoveEmoji event: {removed_reactions:?}");
     }
 }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -264,19 +264,6 @@ impl Cache {
     /// This can be used in combination with [`Shard::chunk_guild`], and can be used to determine
     /// how many members have not yet been received.
     ///
-    /// ```rust,no_run
-    /// # use serenity::model::prelude::*;
-    /// # use serenity::prelude::*;
-    /// struct Handler;
-    ///
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn cache_ready(&self, ctx: Context, _: Vec<GuildId>) {
-    ///         println!("{} unknown members", ctx.cache.unknown_members());
-    ///     }
-    /// }
-    /// ```
-    ///
     /// [`Shard::chunk_guild`]: crate::gateway::Shard::chunk_guild
     pub fn unknown_members(&self) -> u64 {
         let mut total = 0;
@@ -305,17 +292,23 @@ impl Cache {
     /// Print all of the Ids of guilds in the Cache:
     ///
     /// ```rust,no_run
-    /// # use serenity::model::prelude::*;
+    /// # use serenity::gateway::client::FullEvent;
     /// # use serenity::prelude::*;
-    /// #
+    ///
     /// struct Handler;
     ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, context: Context, _: Ready) {
-    ///         let guilds = context.cache.guilds().len();
-    ///
-    ///         println!("Guilds in the Cache: {}", guilds);
+    ///     async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+    ///         match event {
+    ///             FullEvent::Ready {
+    ///                 data_about_bot, ..
+    ///             } => {
+    ///                 let guilds = ctx.cache.guilds().len();
+    ///                 println!("Guilds in the Cache: {guilds}");
+    ///             },
+    ///             _ => {},
+    ///         }
     ///     }
     /// }
     /// ```
@@ -391,7 +384,7 @@ impl Cache {
     ///
     /// # Examples
     ///
-    /// Retrieving the message object from a channel, in a [`EventHandler::message`] context:
+    /// Retrieving the message object from a channel.
     ///
     /// ```rust,no_run
     /// # use serenity::cache::Cache;
@@ -405,8 +398,6 @@ impl Cache {
     /// };
     /// # }
     /// ```
-    ///
-    /// [`EventHandler::message`]: crate::gateway::client::EventHandler::message
     pub fn message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<MessageRef<'_>> {
         #[cfg(feature = "temp_cache")]
         if let Some(message) = self.temp_messages.get(&message_id) {

--- a/src/gateway/client/context.rs
+++ b/src/gateway/client/context.rs
@@ -94,52 +94,12 @@ impl Context {
 
     /// Sets the current user as being [`Online`]. This maintains the current activity.
     ///
-    /// # Examples
-    ///
-    /// Set the current user to being online on the shard:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::channel::Message;
-    /// #
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
-    ///         if msg.content == "!online" {
-    ///             ctx.online();
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    ///
     /// [`Online`]: OnlineStatus::Online
     pub fn online(&self) {
         self.set_status(OnlineStatus::Online);
     }
 
     /// Sets the current user as being [`Idle`]. This maintains the current activity.
-    ///
-    /// # Examples
-    ///
-    /// Set the current user to being idle on the shard:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::channel::Message;
-    /// #
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
-    ///         if msg.content == "!idle" {
-    ///             ctx.idle();
-    ///         }
-    ///     }
-    /// }
-    /// ```
     ///
     /// [`Idle`]: OnlineStatus::Idle
     pub fn idle(&self) {
@@ -148,25 +108,6 @@ impl Context {
 
     /// Sets the current user as being [`DoNotDisturb`]. This maintains the current activity.
     ///
-    /// # Examples
-    ///
-    /// Set the current user to being Do Not Disturb on the shard:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::channel::Message;
-    /// #
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
-    ///         if msg.content == "!dnd" {
-    ///             ctx.dnd();
-    ///         }
-    ///     }
-    /// }
-    /// ```
     ///
     /// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb
     pub fn dnd(&self) {
@@ -174,26 +115,6 @@ impl Context {
     }
 
     /// Sets the current user as being [`Invisible`]. This maintains the current activity.
-    ///
-    /// # Examples
-    ///
-    /// Set the current user to being invisible on the shard:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::channel::Message;
-    /// #
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
-    ///         if msg.content == "!invisible" {
-    ///             ctx.invisible();
-    ///         }
-    ///     }
-    /// }
-    /// ```
     ///
     /// [`Invisible`]: OnlineStatus::Invisible
     pub fn invisible(&self) {
@@ -205,28 +126,6 @@ impl Context {
     /// Note that [`Offline`] is not a valid online status, so it is automatically converted to
     /// [`Invisible`].
     ///
-    /// Other presence settings are maintained.
-    ///
-    /// # Examples
-    ///
-    /// Setting the current online status to [`DoNotDisturb`]:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::gateway::Ready;
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn ready(&self, ctx: Context, _: Ready) {
-    ///         use serenity::model::user::OnlineStatus;
-    ///
-    ///         ctx.set_status(OnlineStatus::DoNotDisturb);
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb
     /// [`Invisible`]: OnlineStatus::Invisible
     /// [`Offline`]: OnlineStatus::Offline
     pub fn set_status(&self, mut online_status: OnlineStatus) {
@@ -245,56 +144,12 @@ impl Context {
     ///
     /// Use [`Self::set_presence`] for fine-grained control over individual details.
     ///
-    /// # Examples
-    ///
-    /// Reset the current user's presence on the shard:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::channel::Message;
-    /// #
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
-    ///         if msg.content == "!reset_presence" {
-    ///             ctx.reset_presence();
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// [`Event::Resumed`]: crate::model::event::Event::Resumed
     /// [`Online`]: OnlineStatus::Online
     pub fn reset_presence(&self) {
         self.set_presence(None, OnlineStatus::Online);
     }
 
     /// Sets the current activity.
-    ///
-    /// # Examples
-    ///
-    /// Create a command named `~setgame` that accepts a name of a game to be playing:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::channel::Message;
-    /// # struct Handler;
-    /// #
-    /// use serenity::gateway::ActivityData;
-    ///
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn message(&self, ctx: Context, msg: Message) {
-    ///         let mut args = msg.content.splitn(2, ' ');
-    ///
-    ///         if let (Some("~setgame"), Some(game)) = (args.next(), args.next()) {
-    ///             ctx.set_activity(Some(ActivityData::playing(game)));
-    ///         }
-    ///     }
-    /// }
-    /// ```
     pub fn set_activity(&self, activity: Option<ActivityData>) {
         self.send_to_shard(ShardRunnerMessage::SetPresence {
             activity: Some(activity),
@@ -303,49 +158,6 @@ impl Context {
     }
 
     /// Sets the current user's presence, providing all fields to be passed.
-    ///
-    /// # Examples
-    ///
-    /// Setting the current user as having no activity and being [`Idle`]:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::gateway::Ready;
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn ready(&self, ctx: Context, _: Ready) {
-    ///         use serenity::model::user::OnlineStatus;
-    ///
-    ///         ctx.set_presence(None, OnlineStatus::Idle);
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// Setting the current user as playing `"Heroes of the Storm"`, while being [`DoNotDisturb`]:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::gateway::Ready;
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn ready(&self, context: Context, _: Ready) {
-    ///         use serenity::gateway::ActivityData;
-    ///         use serenity::model::user::OnlineStatus;
-    ///
-    ///         let activity = ActivityData::playing("Heroes of the Storm");
-    ///         let status = OnlineStatus::DoNotDisturb;
-    ///
-    ///         context.set_presence(Some(activity), status);
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// [`DoNotDisturb`]: OnlineStatus::DoNotDisturb
-    /// [`Idle`]: OnlineStatus::Idle
     pub fn set_presence(&self, activity: Option<ActivityData>, mut status: OnlineStatus) {
         if status == OnlineStatus::Offline {
             status = OnlineStatus::Invisible;
@@ -374,22 +186,31 @@ impl Context {
     ///
     /// ```rust,no_run
     /// # use serenity::prelude::*;
-    /// # use serenity::gateway::ChunkGuildFilter;
     /// # use serenity::model::gateway::Ready;
+    /// # use serenity::gateway::client::FullEvent;
+    /// # use serenity::gateway::{ChunkGuildFilter, Shard};
+    /// # use serenity::all::GuildId;
+    ///
     /// # struct Handler;
     /// #
+    ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, context: Context, _: Ready) {
-    ///         use serenity::model::id::GuildId;
-    ///
-    ///         context.chunk_guild(
-    ///             GuildId::new(81384788765712384),
-    ///             Some(2000),
-    ///             false,
-    ///             ChunkGuildFilter::None,
-    ///             None,
-    ///         );
+    ///     async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+    ///         match event {
+    ///             FullEvent::Ready {
+    ///                 ..
+    ///             } => {
+    ///                 ctx.chunk_guild(
+    ///                     GuildId::new(81384788765712384),
+    ///                     Some(2000),
+    ///                     false,
+    ///                     ChunkGuildFilter::None,
+    ///                     None,
+    ///                 );
+    ///             },
+    ///             _ => {},
+    ///         }
     ///     }
     /// }
     /// ```
@@ -400,21 +221,30 @@ impl Context {
     /// ```rust,no_run
     /// # use serenity::prelude::*;
     /// # use serenity::model::gateway::Ready;
+    /// # use serenity::gateway::client::FullEvent;
     /// # use serenity::gateway::{ChunkGuildFilter, Shard};
+    /// # use serenity::all::GuildId;
+    ///
     /// # struct Handler;
     /// #
+    ///
     /// #[serenity::async_trait]
     /// impl EventHandler for Handler {
-    ///     async fn ready(&self, context: Context, _: Ready) {
-    ///         use serenity::model::id::GuildId;
-    ///
-    ///         context.chunk_guild(
-    ///             GuildId::new(81384788765712384),
-    ///             Some(20),
-    ///             false,
-    ///             ChunkGuildFilter::Query("do".to_owned()),
-    ///             Some("request".to_string()),
-    ///         );
+    ///     async fn dispatch(&self, ctx: &Context, event: &FullEvent) {
+    ///         match event {
+    ///             FullEvent::Ready {
+    ///                 ..
+    ///             } => {
+    ///                 ctx.chunk_guild(
+    ///                     GuildId::new(81384788765712384),
+    ///                     Some(20),
+    ///                     false,
+    ///                     ChunkGuildFilter::Query("do".to_owned()),
+    ///                     Some("request".to_string()),
+    ///                 );
+    ///             },
+    ///             _ => {},
+    ///         }
     ///     }
     /// }
     /// ```
@@ -437,30 +267,6 @@ impl Context {
 
     /// Indicates to the gateway that the client wants to join, move, or disconnect from a voice
     /// channel.
-    ///
-    /// # Examples
-    ///
-    /// Join a voice channel, while staying muted:
-    ///
-    /// ```rust,no_run
-    /// # use serenity::prelude::*;
-    /// # use serenity::model::gateway::Ready;
-    /// # struct Handler;
-    /// #
-    /// #[serenity::async_trait]
-    /// impl EventHandler for Handler {
-    ///     async fn ready(&self, context: Context, _: Ready) {
-    ///         use serenity::model::id::{ChannelId, GuildId};
-    ///
-    ///         context.update_voice_state(
-    ///             GuildId::new(81384788765712384),
-    ///             Some(ChannelId::new(111880193700067777)),
-    ///             true,
-    ///             false,
-    ///         )
-    ///     }
-    /// }
-    /// ```
     #[cfg(feature = "voice")]
     pub fn update_voice_state(
         &self,

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -61,20 +61,43 @@ pub(crate) async fn dispatch_model(
     );
 
     #[cfg(feature = "framework")]
+    tokio::join!(
+        dispatch_framework(&context, framework, &full_event, extra_event.as_ref()),
+        dispatch_event_handler(&context, event_handler, &full_event, extra_event.as_ref())
+    );
+
+    #[cfg(not(feature = "framework"))]
+    dispatch_event_handler(&context, event_handler, &full_event, extra_event.as_ref()).await;
+}
+
+#[cfg(feature = "framework")]
+async fn dispatch_framework(
+    context: &Context,
+    framework: Option<Arc<dyn Framework>>,
+    full_event: &FullEvent,
+    extra_event: Option<&FullEvent>,
+) {
     if let Some(framework) = framework {
-        if let Some(extra_event) = &extra_event {
-            framework.dispatch(&context, extra_event).await;
+        if let Some(extra_event) = extra_event {
+            framework.dispatch(context, extra_event).await;
         }
 
-        framework.dispatch(&context, &full_event).await;
+        framework.dispatch(context, full_event).await;
     }
+}
 
+async fn dispatch_event_handler(
+    context: &Context,
+    event_handler: Option<Arc<dyn EventHandler>>,
+    full_event: &FullEvent,
+    extra_event: Option<&FullEvent>,
+) {
     if let Some(handler) = event_handler {
         if let Some(extra_event) = extra_event {
-            extra_event.dispatch(context.clone(), &*handler).await;
+            handler.dispatch(context, extra_event).await;
         }
 
-        full_event.dispatch(context, &*handler).await;
+        handler.dispatch(context, full_event).await;
     }
 }
 

--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -10,44 +10,40 @@ use crate::gateway::ShardStageUpdateEvent;
 use crate::http::RatelimitInfo;
 use crate::model::prelude::*;
 
-macro_rules! event_handler {
+#[async_trait]
+pub trait EventHandler: Send + Sync {
+    /// Checks if the `event` should be dispatched or ignored. Returns `true` by default.
+    ///
+    /// Returning `false` will drop an event and prevent it being dispatched by any
+    /// frameworks and will exclude it from any collectors.
+    ///
+    /// ## Warning
+    ///
+    /// This will run synchronously on every event in the dispatch loop
+    /// of the shard that is receiving the event. If your filter code
+    /// takes too long, it may delay other events from being dispatched
+    /// in a timely manner. It is recommended to keep the runtime
+    /// complexity of the filter code low to avoid unnecessarily blocking
+    /// your bot.
+    fn filter_event(&self, _context: &Context, _event: &Event) -> bool {
+        true
+    }
+
+    /// Dispatches an event through this handler, allowing for event matching and handling
+    /// based on individual event variants.
+    async fn dispatch(&self, _context: &Context, _event: &FullEvent) {}
+
+    /// Dispatched when an HTTP rate limit is hit.
+    async fn ratelimit(&self, _data: RatelimitInfo) {}
+}
+
+macro_rules! full_event {
     ( $(
         $( #[doc = $doc:literal] )*
         $( #[deprecated = $deprecated:literal] )?
         $( #[cfg(feature = $feature:literal)] )?
-        $variant_name:ident { $( $arg_name:ident: $arg_type:ty ),* } => async fn $method_name:ident(&self $(, $context:ident: Context)?);
+        $variant_name:ident { $( $arg_name:ident: $arg_type:ty ),* };
     )* ) => {
-        /// The core trait for handling events by serenity.
-        #[async_trait]
-        pub trait EventHandler: Send + Sync {
-            $(
-                $( #[doc = $doc] )*
-                $( #[cfg(feature = $feature)] )?
-                $( #[deprecated = $deprecated] )?
-                async fn $method_name(&self, $($context: Context,)? $( $arg_name: $arg_type ),*) {
-                    // Suppress unused argument warnings
-                    drop(( $($context,)? $($arg_name),* ))
-                }
-            )*
-
-            /// Checks if the `event` should be dispatched or ignored. Returns `true` by default.
-            ///
-            /// Returning `false` will drop an event and prevent it being dispatched by any
-            /// frameworks and will exclude it from any collectors.
-            ///
-            /// ## Warning
-            ///
-            /// This will run synchronously on every event in the dispatch loop
-            /// of the shard that is receiving the event. If your filter code
-            /// takes too long, it may delay other events from being dispatched
-            /// in a timely manner. It is recommended to keep the runtime
-            /// complexity of the filter code low to avoid unnecessarily blocking
-            /// your bot.
-            fn filter_event(&self, _context: &Context, _event: &Event) -> bool {
-                true
-            }
-        }
-
         /// This enum stores every possible event that an [`EventHandler`] can receive.
         #[cfg_attr(not(feature = "unstable"), non_exhaustive)]
         #[derive(Clone, Debug, VariantNames, IntoStaticStr, EnumCount, Serialize)]
@@ -55,77 +51,38 @@ macro_rules! event_handler {
         pub enum FullEvent {
             $(
                 $( #[doc = $doc] )*
-                $( #[cfg(feature = $feature)] )?
                 $( #[deprecated = $deprecated] )?
+                $( #[cfg(feature = $feature)] )?
+                #[cfg_attr(not(feature = "unstable"), non_exhaustive)]
                 $variant_name {
                     $( $arg_name: $arg_type ),*
                 },
             )*
         }
-
-        impl FullEvent {
-            /// Returns the name of this event as a snake case string
-            ///
-            /// ```rust,no_run
-            /// # use serenity::gateway::client::{Context, FullEvent};
-            /// # fn foo_(ctx: Context, event: FullEvent) {
-            /// if let FullEvent::Message { .. } = &event {
-            ///     assert_eq!(event.snake_case_name(), "message");
-            /// }
-            /// # }
-            /// ```
-            #[must_use]
-            pub fn snake_case_name(&self) -> &'static str {
-                match self {
-                    $(
-                        $( #[cfg(feature = $feature)] )?
-                        Self::$variant_name { .. } => stringify!($method_name),
-                    )*
-                }
-            }
-
-            /// Runs the given [`EventHandler`]'s code for this event.
-            pub async fn dispatch(self, ctx: Context, handler: &dyn EventHandler) {
-                match self {
-                    $(
-                        $( #[cfg(feature = $feature)] )?
-                        Self::$variant_name { $( $arg_name ),* } => {
-                            $( let $context = ctx; )?
-                            handler.$method_name( $($context,)? $( $arg_name ),* ).await;
-                        }
-                    )*
-                }
-            }
-        }
-    };
+    }
 }
 
-event_handler! {
+full_event! {
     /// Dispatched when the permissions of an application command was updated.
     ///
     /// Provides said permission's data.
-    CommandPermissionsUpdate { permission: CommandPermissions } => async fn command_permissions_update(&self, ctx: Context);
-
+    CommandPermissionsUpdate { permission: CommandPermissions };
     /// Dispatched when an auto moderation rule was created.
     ///
     /// Provides said rule's data.
-    AutoModRuleCreate { rule: AutoModRule } => async fn auto_moderation_rule_create(&self, ctx: Context);
-
+    AutoModRuleCreate { rule: AutoModRule };
     /// Dispatched when an auto moderation rule was updated.
     ///
     /// Provides said rule's data.
-    AutoModRuleUpdate { rule: AutoModRule } => async fn auto_moderation_rule_update(&self, ctx: Context);
-
+    AutoModRuleUpdate { rule: AutoModRule };
     /// Dispatched when an auto moderation rule was deleted.
     ///
     /// Provides said rule's data.
-    AutoModRuleDelete { rule: AutoModRule } => async fn auto_moderation_rule_delete(&self, ctx: Context);
-
+    AutoModRuleDelete { rule: AutoModRule };
     /// Dispatched when an auto moderation rule was triggered and an action was executed.
     ///
     /// Provides said action execution's data.
-    AutoModActionExecution { execution: ActionExecution } => async fn auto_moderation_action_execution(&self, ctx: Context);
-
+    AutoModActionExecution { execution: ActionExecution };
     /// Dispatched when the cache has received and inserted all data from guilds.
     ///
     /// This process happens upon starting your bot and should be fairly quick. However, cache
@@ -133,62 +90,50 @@ event_handler! {
     ///
     /// Provides the cached guilds' ids.
     #[cfg(feature = "cache")]
-    CacheReady { guilds: Vec<GuildId> } => async fn cache_ready(&self, ctx: Context);
-
+    CacheReady { guilds: Vec<GuildId> };
     /// Dispatched when every shard has received a Ready event
     #[cfg(feature = "cache")]
-    ShardsReady { total_shards: NonZeroU16 } => async fn shards_ready(&self, ctx: Context);
-
+    ShardsReady { total_shards: NonZeroU16 };
     /// Dispatched when a channel is created.
     ///
     /// Provides said channel's data.
-    ChannelCreate { channel: GuildChannel } => async fn channel_create(&self, ctx: Context);
-
+    ChannelCreate { channel: GuildChannel };
     /// Dispatched when a category is created.
     ///
     /// Provides said category's data.
-    CategoryCreate { category: GuildChannel } => async fn category_create(&self, ctx: Context);
-
+    CategoryCreate { category: GuildChannel };
     /// Dispatched when a category is deleted.
     ///
     /// Provides said category's data.
-    CategoryDelete { category: GuildChannel } => async fn category_delete(&self, ctx: Context);
-
+    CategoryDelete { category: GuildChannel };
     /// Dispatched when a channel is deleted.
     ///
     /// Provides said channel's data.
-    ChannelDelete { channel: GuildChannel, messages: Option<VecDeque<Message>> } => async fn channel_delete(&self, ctx: Context);
-
+    ChannelDelete { channel: GuildChannel, messages: Option<VecDeque<Message>> };
     /// Dispatched when a pin is added, deleted.
     ///
     /// Provides said pin's data.
-    ChannelPinsUpdate { pin: ChannelPinsUpdateEvent } => async fn channel_pins_update(&self, ctx: Context);
-
+    ChannelPinsUpdate { pin: ChannelPinsUpdateEvent };
     /// Dispatched when a channel is updated.
     ///
     /// The old channel data is only provided when the cache feature is enabled.
-    ChannelUpdate { old: Option<GuildChannel>, new: GuildChannel } => async fn channel_update(&self, ctx: Context);
-
+    ChannelUpdate { old: Option<GuildChannel>, new: GuildChannel };
     /// Dispatched when a new audit log entry is created.
     ///
     /// Provides said entry's data and the id of the guild where it was created.
-    GuildAuditLogEntryCreate { entry: AuditLogEntry, guild_id: GuildId } => async fn guild_audit_log_entry_create(&self, ctx: Context);
-
+    GuildAuditLogEntryCreate { entry: AuditLogEntry, guild_id: GuildId };
     /// Dispatched when a user is banned from a guild.
     ///
     /// Provides the guild's id and the banned user's data.
-    GuildBanAddition { guild_id: GuildId, banned_user: User } => async fn guild_ban_addition(&self, ctx: Context);
-
+    GuildBanAddition { guild_id: GuildId, banned_user: User };
     /// Dispatched when a user's ban is lifted from a guild.
     ///
     /// Provides the guild's id and the lifted user's data.
-    GuildBanRemoval { guild_id: GuildId, unbanned_user: User } => async fn guild_ban_removal(&self, ctx: Context);
-
+    GuildBanRemoval { guild_id: GuildId, unbanned_user: User };
     /// Dispatched when a guild is created; or an existing guild's data is sent to us.
     ///
     /// Provides the guild's data and whether the guild is new (only when cache feature is enabled).
-    GuildCreate { guild: Guild, is_new: Option<bool> } => async fn guild_create(&self, ctx: Context);
-
+    GuildCreate { guild: Guild, is_new: Option<bool> };
     /// Dispatched when a guild is deleted.
     ///
     /// Provides the partial data of the guild sent by discord, and the full data from the cache,
@@ -199,28 +144,23 @@ event_handler! {
     /// flag is true, the guild went offline.
     ///
     /// [`unavailable`]: UnavailableGuild::unavailable
-    GuildDelete { incomplete: UnavailableGuild, full: Option<Guild> } => async fn guild_delete(&self, ctx: Context);
-
+    GuildDelete { incomplete: UnavailableGuild, full: Option<Guild> };
     // the emojis were updated.
-
     /// Dispatched when the emojis are updated.
     ///
     /// Provides the guild's id and the new state of the emojis in the guild.
-    GuildEmojisUpdate { guild_id: GuildId, current_state: ExtractMap<EmojiId, Emoji> } => async fn guild_emojis_update(&self, ctx: Context);
-
+    GuildEmojisUpdate { guild_id: GuildId, current_state: ExtractMap<EmojiId, Emoji> };
     /// Dispatched when a guild's integration is added, updated or removed.
     ///
     /// Provides the guild's id.
-    GuildIntegrationsUpdate { guild_id: GuildId } => async fn guild_integrations_update(&self, ctx: Context);
-
+    GuildIntegrationsUpdate { guild_id: GuildId };
     /// Dispatched when a user joins a guild.
     ///
     /// Provides the guild's id and the user's member data.
     ///
     /// Note: This event will not trigger unless the "guild members" privileged intent is enabled
     /// on the bot application page.
-    GuildMemberAddition { new_member: Member } => async fn guild_member_addition(&self, ctx: Context);
-
+    GuildMemberAddition { new_member: Member };
     /// Dispatched when a user's membership ends by leaving, getting kicked, or being banned.
     ///
     /// Provides the guild's id, the user's data, and the user's member data if cache feature is
@@ -228,8 +168,7 @@ event_handler! {
     ///
     /// Note: This event will not trigger unless the "guild members" privileged intent is enabled
     /// on the bot application page.
-    GuildMemberRemoval { guild_id: GuildId, user: User, member_data_if_available: Option<Member> } => async fn guild_member_removal(&self, ctx: Context);
-
+    GuildMemberRemoval { guild_id: GuildId, user: User, member_data_if_available: Option<Member> };
     /// Dispatched when a member is updated (e.g their nickname is updated).
     ///
     /// Provides the member's old and new data (if cache feature is enabled and data is available)
@@ -237,90 +176,89 @@ event_handler! {
     ///
     /// Note: This event will not trigger unless the "guild members" privileged intent is enabled
     /// on the bot application page.
-    GuildMemberUpdate { old_if_available: Option<Member>, new: Option<Member>, event: GuildMemberUpdateEvent } => async fn guild_member_update(&self, ctx: Context);
-
+    GuildMemberUpdate { old_if_available: Option<Member>, new: Option<Member>, event: GuildMemberUpdateEvent };
     /// Dispatched when the data for offline members was requested.
     ///
     /// Provides the guild's id and the data.
-    GuildMembersChunk { chunk: GuildMembersChunkEvent } => async fn guild_members_chunk(&self, ctx: Context);
+    GuildMembersChunk { chunk: GuildMembersChunkEvent };
 
     /// Dispatched when a role is created.
     ///
     /// Provides the guild's id and the new role's data.
-    GuildRoleCreate { new: Role } => async fn guild_role_create(&self, ctx: Context);
+    GuildRoleCreate { new: Role };
 
     /// Dispatched when a role is deleted.
     ///
     /// Provides the guild's id, the role's id and its data (if cache feature is enabled and the
     /// data is available).
-    GuildRoleDelete { guild_id: GuildId, removed_role_id: RoleId, removed_role_data_if_available: Option<Role> } => async fn guild_role_delete(&self, ctx: Context);
+    GuildRoleDelete { guild_id: GuildId, removed_role_id: RoleId, removed_role_data_if_available: Option<Role> };
 
     /// Dispatched when a role is updated.
     ///
     /// Provides the guild's id, the role's old (if cache feature is enabled and the data is
     /// available) and new data.
-    GuildRoleUpdate { old_data_if_available: Option<Role>, new: Role } => async fn guild_role_update(&self, ctx: Context);
+    GuildRoleUpdate { old_data_if_available: Option<Role>, new: Role };
 
     /// Dispatched when the stickers are updated.
     ///
     /// Provides the guild's id and the new state of the stickers in the guild.
-    GuildStickersUpdate { guild_id: GuildId, current_state: ExtractMap<StickerId, Sticker> } => async fn guild_stickers_update(&self, ctx: Context);
+    GuildStickersUpdate { guild_id: GuildId, current_state: ExtractMap<StickerId, Sticker> };
 
     /// Dispatched when the guild is updated.
     ///
     /// Provides the guild's old data (if cache feature is enabled and the data is available)
     /// and the new data.
-    GuildUpdate { old_data_if_available: Option<Guild>, new_data: PartialGuild } => async fn guild_update(&self, ctx: Context);
+    GuildUpdate { old_data_if_available: Option<Guild>, new_data: PartialGuild };
 
     /// Dispatched when a invite is created.
     ///
     /// Provides data about the invite.
-    InviteCreate { data: InviteCreateEvent } => async fn invite_create(&self, ctx: Context);
+    InviteCreate { data: InviteCreateEvent };
 
     /// Dispatched when a invite is deleted.
     ///
     /// Provides data about the invite.
-    InviteDelete { data: InviteDeleteEvent } => async fn invite_delete(&self, ctx: Context);
+    InviteDelete { data: InviteDeleteEvent };
 
     /// Dispatched when a message is created.
     ///
     /// Provides the message's data.
-    Message { new_message: Message } => async fn message(&self, ctx: Context);
+    Message { new_message: Message };
 
     /// Dispatched when a message is deleted.
     ///
     /// Provides the guild's id, the channel's id and the message's id.
-    MessageDelete { channel_id: ChannelId, deleted_message_id: MessageId, guild_id: Option<GuildId> } => async fn message_delete(&self, ctx: Context);
-
+    MessageDelete { channel_id: ChannelId, deleted_message_id: MessageId, guild_id: Option<GuildId> };
     /// Dispatched when multiple messages were deleted at once.
     ///
     /// Provides the guild's id, channel's id and the deleted messages' ids.
-    MessageDeleteBulk { channel_id: ChannelId, multiple_deleted_messages_ids: Vec<MessageId>, guild_id: Option<GuildId> } => async fn message_delete_bulk(&self, ctx: Context);
+    MessageDeleteBulk { channel_id: ChannelId, multiple_deleted_messages_ids: Vec<MessageId>, guild_id: Option<GuildId> };
 
     /// Dispatched when a message is updated.
     ///
-    /// Provides the message update data, as well as the old message if cache feature is enabled and the data is available.
-    MessageUpdate { old_if_available: Option<Message>, event: MessageUpdateEvent } => async fn message_update(&self, ctx: Context);
+    /// Provides the message update data, as well as the old message if cache feature is enabled and
+    /// the data is available.
+    MessageUpdate { old_if_available: Option<Message>, event: MessageUpdateEvent };
 
     /// Dispatched when a new reaction is attached to a message.
     ///
     /// Provides the reaction's data.
-    ReactionAdd { add_reaction: Reaction } => async fn reaction_add(&self, ctx: Context);
+    ReactionAdd { add_reaction: Reaction };
 
     /// Dispatched when a reaction is detached from a message.
     ///
     /// Provides the reaction's data.
-    ReactionRemove { removed_reaction: Reaction } => async fn reaction_remove(&self, ctx: Context);
+    ReactionRemove { removed_reaction: Reaction };
 
     /// Dispatched when all reactions of a message are detached from a message.
     ///
     /// Provides the channel's id, message's id, and guild's id if in a guild.
-    ReactionRemoveAll { guild_id: Option<GuildId>, channel_id: ChannelId, removed_from_message_id: MessageId } => async fn reaction_remove_all(&self, ctx: Context);
+    ReactionRemoveAll { guild_id: Option<GuildId>, channel_id: ChannelId, removed_from_message_id: MessageId };
 
     /// Dispatched when all reactions of a message are detached from a message.
     ///
     /// Provides the channel's id and the message's id.
-    ReactionRemoveEmoji { removed_reactions: Reaction } => async fn reaction_remove_emoji(&self, ctx: Context);
+    ReactionRemoveEmoji { removed_reactions: Reaction };
 
     /// Dispatched when a user's presence is updated (e.g off -> on).
     ///
@@ -329,112 +267,100 @@ event_handler! {
     ///
     /// Note: This event will not trigger unless the "guild presences" privileged intent is enabled
     /// on the bot application page.
-    PresenceUpdate { old_data: Option<Presence>, new_data: Presence } => async fn presence_update(&self, ctx: Context);
+    PresenceUpdate { old_data: Option<Presence>, new_data: Presence };
 
     /// Dispatched upon startup.
     ///
     /// Provides data about the bot and the guilds it's in.
-    Ready { data_about_bot: Ready } => async fn ready(&self, ctx: Context);
-
+    Ready { data_about_bot: Ready };
     /// Dispatched upon reconnection.
-    Resume { event: ResumedEvent } => async fn resume(&self, ctx: Context);
+    Resume { event: ResumedEvent };
 
     /// Dispatched when a shard's connection stage is updated
     ///
     /// Provides the context of the shard and the event information about the update.
-    ShardStageUpdate { event: ShardStageUpdateEvent } => async fn shard_stage_update(&self, ctx: Context);
+    ShardStageUpdate { event: ShardStageUpdateEvent };
 
     /// Dispatched when a user starts typing.
-    TypingStart { event: TypingStartEvent } => async fn typing_start(&self, ctx: Context);
+    TypingStart { event: TypingStartEvent };
 
     /// Dispatched when the bot's data is updated.
     ///
     /// Provides the old (if cache feature is enabled and the data is available) and new data.
-    UserUpdate { old_data: Option<CurrentUser>, new: CurrentUser } => async fn user_update(&self, ctx: Context);
+    UserUpdate { old_data: Option<CurrentUser>, new: CurrentUser };
 
     /// Dispatched when a guild's voice server was updated (or changed to another one).
     ///
     /// Provides the voice server's data.
-    VoiceServerUpdate { event: VoiceServerUpdateEvent } => async fn voice_server_update(&self, ctx: Context);
+    VoiceServerUpdate { event: VoiceServerUpdateEvent };
 
     /// Dispatched when a user joins, leaves or moves to a voice channel.
     ///
     /// Provides the guild's id (if available) and the old state (if cache feature is enabled and
     /// [`GatewayIntents::GUILDS`] is enabled) and the new state of the guild's voice channels.
-    VoiceStateUpdate { old: Option<VoiceState>, new: VoiceState } => async fn voice_state_update(&self, ctx: Context);
+    VoiceStateUpdate { old: Option<VoiceState>, new: VoiceState };
 
     /// Dispatched when a voice channel's status is updated.
     ///
     /// Provides the status, channel's id and the guild's id.
-    VoiceChannelStatusUpdate { old: Option<String>, status: Option<String>, id: ChannelId, guild_id: GuildId } => async fn voice_channel_status_update(&self, ctx: Context);
-
+    VoiceChannelStatusUpdate { old: Option<String>, status: Option<String>, id: ChannelId,  guild_id: GuildId };
     /// Dispatched when a guild's webhook is updated.
     ///
     /// Provides the guild's id and the channel's id the webhook belongs in.
-    WebhookUpdate { guild_id: GuildId, belongs_to_channel_id: ChannelId } => async fn webhook_update(&self, ctx: Context);
-
-    /// Dispatched when an interaction is created (e.g a slash command was used or a button was clicked).
+    WebhookUpdate { guild_id: GuildId, belongs_to_channel_id: ChannelId };
+    /// Dispatched when an interaction is created (e.g a slash command was used or a button was
+    /// clicked).
     ///
     /// Provides the created interaction.
-    InteractionCreate { interaction: Interaction } => async fn interaction_create(&self, ctx: Context);
-
+    InteractionCreate { interaction: Interaction };
     /// Dispatched when a guild integration is created.
     ///
     /// Provides the created integration.
-    IntegrationCreate { integration: Integration } => async fn integration_create(&self, ctx: Context);
-
+    IntegrationCreate { integration: Integration };
     /// Dispatched when a guild integration is updated.
     ///
     /// Provides the updated integration.
-    IntegrationUpdate { integration: Integration } => async fn integration_update(&self, ctx: Context);
-
+    IntegrationUpdate { integration: Integration };
     /// Dispatched when a guild integration is deleted.
     ///
-    /// Provides the integration's id, the id of the guild it belongs to, and its associated application id
-    IntegrationDelete { integration_id: IntegrationId, guild_id: GuildId, application_id: Option<ApplicationId> } => async fn integration_delete(&self, ctx: Context);
-
+    /// Provides the integration's id, the id of the guild it belongs to, and its associated
+    /// application id
+    IntegrationDelete { integration_id: IntegrationId, guild_id: GuildId, application_id: Option<ApplicationId> };
     /// Dispatched when a stage instance is created.
     ///
     /// Provides the created stage instance.
-    StageInstanceCreate { stage_instance: StageInstance } => async fn stage_instance_create(&self, ctx: Context);
-
+    StageInstanceCreate { stage_instance: StageInstance };
     /// Dispatched when a stage instance is updated.
     ///
     /// Provides the updated stage instance.
-    StageInstanceUpdate { stage_instance: StageInstance } => async fn stage_instance_update(&self, ctx: Context);
-
+    StageInstanceUpdate { stage_instance: StageInstance };
     /// Dispatched when a stage instance is deleted.
     ///
     /// Provides the deleted stage instance.
-    StageInstanceDelete { stage_instance: StageInstance } => async fn stage_instance_delete(&self, ctx: Context);
-
+    StageInstanceDelete { stage_instance: StageInstance };
     /// Dispatched when a thread is created or the current user is added to a private thread.
     ///
     /// Provides the thread and if the thread was newly created.
-    ThreadCreate { thread: GuildChannel, newly_created: Option<bool> } => async fn thread_create(&self, ctx: Context);
-
+    ThreadCreate { thread: GuildChannel, newly_created: Option<bool> };
     /// Dispatched when a thread is updated.
     ///
-    /// Provides the updated thread and the old thread data, provided the thread was cached prior to dispatch.
-    ThreadUpdate { old: Option<GuildChannel>, new: GuildChannel } => async fn thread_update(&self, ctx: Context);
-
+    /// Provides the updated thread and the old thread data, provided the thread was cached prior to
+    /// dispatch.
+    ThreadUpdate { old: Option<GuildChannel>, new: GuildChannel };
     /// Dispatched when a thread is deleted.
     ///
     /// Provides the partial data about the deleted thread and, if it was present in the cache
     /// before its deletion, its full data.
-    ThreadDelete { thread: PartialGuildChannel, full_thread_data: Option<GuildChannel> } => async fn thread_delete(&self, ctx: Context);
-
+    ThreadDelete { thread: PartialGuildChannel, full_thread_data: Option<GuildChannel> };
     /// Dispatched when the current user gains access to a channel.
     ///
     /// Provides the threads the current user can access, the thread members, the guild Id, and the
     /// channel Ids of the parent channels being synced.
-    ThreadListSync { thread_list_sync: ThreadListSyncEvent } => async fn thread_list_sync(&self, ctx: Context);
-
+    ThreadListSync { thread_list_sync: ThreadListSyncEvent };
     /// Dispatched when the [`ThreadMember`] for the current user is updated.
     ///
     /// Provides the updated thread member.
-    ThreadMemberUpdate { thread_member: ThreadMember } => async fn thread_member_update(&self, ctx: Context);
-
+    ThreadMemberUpdate { thread_member: ThreadMember };
     /// Dispatched when anyone is added to or removed from a thread. If the current user does not
     /// have the [`GatewayIntents::GUILDS`], then this event will only be sent if the current user
     /// was added to or removed from the thread.
@@ -443,63 +369,50 @@ event_handler! {
     /// the thread Id and its guild Id.
     ///
     /// [`GatewayIntents::GUILDS`]: crate::model::gateway::GatewayIntents::GUILDS
-    ThreadMembersUpdate { thread_members_update: ThreadMembersUpdateEvent } => async fn thread_members_update(&self, ctx: Context);
-
+    ThreadMembersUpdate { thread_members_update: ThreadMembersUpdateEvent };
     /// Dispatched when a scheduled event is created.
     ///
     /// Provides data about the scheduled event.
-    GuildScheduledEventCreate { event: ScheduledEvent } => async fn guild_scheduled_event_create(&self, ctx: Context);
-
+    GuildScheduledEventCreate { event: ScheduledEvent };
     /// Dispatched when a scheduled event is updated.
     ///
     /// Provides data about the scheduled event.
-    GuildScheduledEventUpdate { event: ScheduledEvent } => async fn guild_scheduled_event_update(&self, ctx: Context);
-
+    GuildScheduledEventUpdate { event: ScheduledEvent };
     /// Dispatched when a scheduled event is deleted.
     ///
     /// Provides data about the scheduled event.
-    GuildScheduledEventDelete { event: ScheduledEvent } => async fn guild_scheduled_event_delete(&self, ctx: Context);
-
+    GuildScheduledEventDelete { event: ScheduledEvent };
     /// Dispatched when a guild member has subscribed to a scheduled event.
     ///
     /// Provides data about the subscription.
-    GuildScheduledEventUserAdd { subscribed: GuildScheduledEventUserAddEvent } => async fn guild_scheduled_event_user_add(&self, ctx: Context);
-
+    GuildScheduledEventUserAdd { subscribed: GuildScheduledEventUserAddEvent };
     /// Dispatched when a guild member has unsubscribed from a scheduled event.
     ///
     /// Provides data about the cancelled subscription.
-    GuildScheduledEventUserRemove { unsubscribed: GuildScheduledEventUserRemoveEvent } => async fn guild_scheduled_event_user_remove(&self, ctx: Context);
-
+    GuildScheduledEventUserRemove { unsubscribed: GuildScheduledEventUserRemoveEvent };
     /// Dispatched when a user subscribes to a SKU.
     ///
     /// Provides data about the subscription.
-    EntitlementCreate { entitlement: Entitlement } => async fn entitlement_create(&self, ctx: Context);
-
+    EntitlementCreate { entitlement: Entitlement };
     /// Dispatched when a user's entitlement has been updated, such as when a subscription is
     /// renewed for the next billing period.
     ///
     /// Provides data abut the updated subscription. If the entitlement is renewed, the
     /// [`Entitlement::ends_at`] field will have changed.
-    EntitlementUpdate { entitlement: Entitlement } => async fn entitlement_update(&self, ctx: Context);
-
+    EntitlementUpdate { entitlement: Entitlement };
     /// Dispatched when a user's entitlement has been deleted. This happens rarely, but can occur
     /// if a subscription is refunded or otherwise deleted by Discord. Entitlements are not deleted
     /// when they expire.
     ///
     /// Provides data about the subscription. Specifically, the [`Entitlement::deleted`] field will
     /// be set.
-    EntitlementDelete { entitlement: Entitlement } => async fn entitlement_delete(&self, ctx: Context);
-
+    EntitlementDelete { entitlement: Entitlement };
     /// Dispatched when a user votes on a message poll.
     ///
     /// This will be dispatched multiple times if multiple answers are selected.
-    MessagePollVoteAdd { event: MessagePollVoteAddEvent } => async fn poll_vote_add(&self, ctx: Context);
-
+    MessagePollVoteAdd { event: MessagePollVoteAddEvent };
     /// Dispatched when a user removes a previous vote on a poll.
-    MessagePollVoteRemove { event: MessagePollVoteRemoveEvent } => async fn poll_vote_remove(&self, ctx: Context);
-
-    /// Dispatched when an HTTP rate limit is hit
-    Ratelimit { data: RatelimitInfo } => async fn ratelimit(&self);
+    MessagePollVoteRemove { event: MessagePollVoteRemoveEvent };
 }
 
 /// This core trait for handling raw events

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -382,42 +382,11 @@ impl IntoFuture for ClientBuilder {
 ///
 /// # Event Handlers
 ///
-/// Event handlers can be configured. For example, the event handler [`EventHandler::message`] will
-/// be dispatched to whenever a [`Event::MessageCreate`] is received over the connection.
+/// Event handlers can be configured. For example, the event handler will be dispatched to
+/// whenever a [`Event::MessageCreate`] is received over the connection.
 ///
 /// Note that you do not need to manually handle events, as they are handled internally and then
-/// dispatched to your event handlers.
-///
-/// # Examples
-///
-/// Creating a Client instance and adding a handler on every message receive, acting as a
-/// "ping-pong" bot is simple:
-///
-/// ```no_run
-/// use serenity::Client;
-/// use serenity::model::prelude::*;
-/// use serenity::prelude::*;
-///
-/// struct Handler;
-///
-/// #[serenity::async_trait]
-/// impl EventHandler for Handler {
-///     async fn message(&self, context: Context, msg: Message) {
-///         if msg.content == "!ping" {
-///             let _ = msg.channel_id.say(&context.http, "Pong!");
-///         }
-///     }
-/// }
-///
-/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// let token = Token::from_env("DISCORD_TOKEN")?;
-/// let mut client =
-///     Client::builder(token, GatewayIntents::default()).event_handler(Handler).await?;
-///
-/// client.start().await?;
-/// # Ok(())
-/// # }
-/// ```
+/// dispatched to your event handler.
 ///
 /// [`Shard`]: crate::gateway::Shard
 /// [`Event::MessageCreate`]: crate::model::event::Event::MessageCreate

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -152,7 +152,14 @@ impl ShardRunner {
                     };
 
                     spawn_named("dispatch::event_handler::shard_stage_update", async move {
-                        event_handler.shard_stage_update(context, event).await;
+                        event_handler
+                            .dispatch(
+                                &context,
+                                &crate::gateway::client::FullEvent::ShardStageUpdate {
+                                    event,
+                                },
+                            )
+                            .await;
                     });
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,11 @@
 //!
 //! Serenity supports bot user authentication via the use of [`Client::builder`].
 //!
-//! Once logged in, you may add handlers to your client to dispatch [`Event`]s, such as
-//! [`EventHandler::message`]. This will cause your handler to be called when a
-//! [`Event::MessageCreate`] is received. Each handler is given a [`Context`], giving information
-//! about the event. See the [client's module-level documentation].
+//! Once logged in, you can add an event handler to your client to dispatch [`Event`]s.
+//! This will allow you to recieve and handle events as you see fit. For example, an
+//! [`Event::MessageCreate`] event will be dispatched to you when a message is sent.
+//! Every event will give you access to a [`Context`], giving information about the event.
+//! See the [client's module-level documentation].
 //!
 //! The [`Shard`] is transparently handled by the library, removing unnecessary complexity. Sharded
 //! connections are automatically handled for you. See the [gateway's documentation][gateway docs]
@@ -38,7 +39,6 @@
 //!
 //! [`Cache`]: crate::cache::Cache
 //! [`Context`]: crate::gateway::client::Context
-//! [`EventHandler::message`]: crate::gateway::client::EventHandler::message
 //! [`Event`]: crate::model::event::Event
 //! [`Event::MessageCreate`]: crate::model::event::Event::MessageCreate
 //! [`Shard`]: crate::gateway::Shard

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -143,7 +143,7 @@ impl Command {
     ///
     /// See [`CreateCommand::execute`] for a list of possible errors.
     ///
-    /// [`InteractionCreate`]: crate::gateway::client::EventHandler::interaction_create
+    /// [`InteractionCreate`]: crate::gateway::client::FullEvent::InteractionCreate
     pub async fn create_global_command(http: &Http, builder: CreateCommand<'_>) -> Result<Command> {
         builder.execute(http, None).await
     }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1036,68 +1036,27 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 #[non_exhaustive]
 pub enum Event {
     /// The permissions of an [`Command`] was changed.
-    ///
-    /// Fires the [`EventHandler::command_permissions_update`] event.
-    ///
-    /// [`Command`]: crate::model::application::Command
-    /// [`EventHandler::command_permissions_update`]: crate::gateway::client::EventHandler::command_permissions_update
     #[serde(rename = "APPLICATION_COMMAND_PERMISSIONS_UPDATE")]
     CommandPermissionsUpdate(CommandPermissionsUpdateEvent),
     /// A [`AutoModRule`] was created.
-    ///
-    /// Fires the [`EventHandler::auto_moderation_rule_create`] event.
-    ///
-    /// [`EventHandler::auto_moderation_rule_create`]:
-    /// crate::gateway::client::EventHandler::auto_moderation_rule_create
     #[serde(rename = "AUTO_MODERATION_RULE_CREATE")]
     AutoModRuleCreate(AutoModRuleCreateEvent),
     /// A [`AutoModRule`] has been updated.
-    ///
-    /// Fires the [`EventHandler::auto_moderation_rule_update`] event.
-    ///
-    /// [`EventHandler::auto_moderation_rule_update`]:
-    /// crate::gateway::client::EventHandler::auto_moderation_rule_update
     #[serde(rename = "AUTO_MODERATION_RULE_UPDATE")]
     AutoModRuleUpdate(AutoModRuleUpdateEvent),
     /// A [`AutoModRule`] was deleted.
-    ///
-    /// Fires the [`EventHandler::auto_moderation_rule_delete`] event.
-    ///
-    /// [`EventHandler::auto_moderation_rule_delete`]:
-    /// crate::gateway::client::EventHandler::auto_moderation_rule_delete
     #[serde(rename = "AUTO_MODERATION_RULE_DELETE")]
     AutoModRuleDelete(AutoModRuleDeleteEvent),
     /// A [`AutoModRule`] was triggered and an action was executed.
-    ///
-    /// Fires the [`EventHandler::auto_moderation_action_execution`] event.
-    ///
-    /// [`EventHandler::auto_moderation_action_execution`]:
-    /// crate::gateway::client::EventHandler::auto_moderation_action_execution
     #[serde(rename = "AUTO_MODERATION_ACTION_EXECUTION")]
     AutoModActionExecution(AutoModActionExecutionEvent),
     /// A [`Channel`] was created.
-    ///
-    /// Fires the [`EventHandler::channel_create`] event.
-    ///
-    /// [`EventHandler::channel_create`]: crate::gateway::client::EventHandler::channel_create
     ChannelCreate(ChannelCreateEvent),
     /// A [`Channel`] has been deleted.
-    ///
-    /// Fires the [`EventHandler::channel_delete`] event.
-    ///
-    /// [`EventHandler::channel_delete`]: crate::gateway::client::EventHandler::channel_delete
     ChannelDelete(ChannelDeleteEvent),
     /// The pins for a [`Channel`] have been updated.
-    ///
-    /// Fires the [`EventHandler::channel_pins_update`] event.
-    ///
-    /// [`EventHandler::channel_pins_update`]: crate::gateway::client::EventHandler::channel_pins_update
     ChannelPinsUpdate(ChannelPinsUpdateEvent),
     /// A [`Channel`] has been updated.
-    ///
-    /// Fires the [`EventHandler::channel_update`] event.
-    ///
-    /// [`EventHandler::channel_update`]: crate::gateway::client::EventHandler::channel_update
     ChannelUpdate(ChannelUpdateEvent),
     GuildAuditLogEntryCreate(GuildAuditLogEntryCreateEvent),
     GuildBanAdd(GuildBanAddEvent),
@@ -1118,16 +1077,8 @@ pub enum Event {
     GuildStickersUpdate(GuildStickersUpdateEvent),
     GuildUpdate(GuildUpdateEvent),
     /// An [`Invite`] was created.
-    ///
-    /// Fires the [`EventHandler::invite_create`] event handler.
-    ///
-    /// [`EventHandler::invite_create`]: crate::gateway::client::EventHandler::invite_create
     InviteCreate(InviteCreateEvent),
     /// An [`Invite`] was deleted.
-    ///
-    /// Fires the [`EventHandler::invite_delete`] event handler.
-    ///
-    /// [`EventHandler::invite_delete`]: crate::gateway::client::EventHandler::invite_delete
     InviteDelete(InviteDeleteEvent),
     MessageCreate(MessageCreateEvent),
     MessageDelete(MessageDeleteEvent),
@@ -1137,31 +1088,15 @@ pub enum Event {
     /// A member's presence state (or username or avatar) has changed
     PresenceUpdate(PresenceUpdateEvent),
     /// A reaction was added to a message.
-    ///
-    /// Fires the [`EventHandler::reaction_add`] event handler.
-    ///
-    /// [`EventHandler::reaction_add`]: crate::gateway::client::EventHandler::reaction_add
     #[serde(rename = "MESSAGE_REACTION_ADD")]
     ReactionAdd(ReactionAddEvent),
     /// A reaction was removed to a message.
-    ///
-    /// Fires the [`EventHandler::reaction_remove`] event handler.
-    ///
-    /// [`EventHandler::reaction_remove`]: crate::gateway::client::EventHandler::reaction_remove
     #[serde(rename = "MESSAGE_REACTION_REMOVE")]
     ReactionRemove(ReactionRemoveEvent),
     /// A request was issued to remove all [`Reaction`]s from a [`Message`].
-    ///
-    /// Fires the [`EventHandler::reaction_remove_all`] event handler.
-    ///
-    /// [`EventHandler::reaction_remove_all`]: crate::gateway::client::EventHandler::reaction_remove_all
     #[serde(rename = "MESSAGE_REACTION_REMOVE_ALL")]
     ReactionRemoveAll(ReactionRemoveAllEvent),
     /// Sent when a bot removes all instances of a given emoji from the reactions of a message.
-    ///
-    /// Fires the [`EventHandler::reaction_remove_emoji`] event handler.
-    ///
-    /// [`EventHandler::reaction_remove_emoji`]: crate::gateway::client::EventHandler::reaction_remove_emoji
     #[serde(rename = "MESSAGE_REACTION_REMOVE_EMOJI")]
     ReactionRemoveEmoji(ReactionRemoveEmojiEvent),
     /// The first event in a connection, containing the initial ready cache.


### PR DESCRIPTION
I specifically decided to completely rework the way that users will handle events for a couple reasons:
1. It was easier for me to do this then spam references on all of the stuff within FullEvent, then provide lifetimes for it
2. This *finally* would allow us to add fields to events without having to do a breaking version bump

The main reason for this PR to begin with was that the current pattern would allow commands in poise (which are done in the framework event handler) to block the execution of the regular event handler for an extended period of time (say, you were for example using a paginator, it would block for the entire duration of the command which would take a very long time with a paginator).

This PR *should* fix that by swapping the event handler to use references and then using `tokio::join!`.

Also the ratelimit one can't be handled the new way because Context isn't available and making it Option<Context> for a single event is wrong imo