### PR TITLE
Don't delay starting first batch of shards

### DIFF
--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -143,23 +143,11 @@ impl ShardManager {
         self.initialize(shard_index, shard_init, shard_total);
         loop {
             let batch = self.queue.pop_batch();
-            let msg = if batch.is_empty() {
-                // This function is the only code that can add new shards
-                // to start to the queue directly (enforced by `&mut`), so
-                // if the batch is empty, it will always be empty until a
-                // `ShardManagerMessage::Boot` is received here.
-                self.manager_rx.next().await
-            } else {
-                self.checked_start(batch).await;
+            self.checked_start(batch).await;
 
-                // Include a timeout so we can start the next batch of
-                // shards even if no more messages are received.
-                timeout(self.wait_time_between_shard_start, self.manager_rx.next())
-                    .await
-                    .unwrap_or_default()
-            };
-
-            if let Some(msg) = msg {
+            if let Ok(Some(msg)) =
+                timeout(self.wait_time_between_shard_start, self.manager_rx.next()).await
+            {
                 match msg {
                     ShardManagerMessage::Boot(shard_id) => self.queue_for_start(shard_id),
                     ShardManagerMessage::Quit(res) => return res,

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -142,16 +142,29 @@ impl ShardManager {
     ) -> Result<(), GatewayError> {
         self.initialize(shard_index, shard_init, shard_total);
         loop {
-            if let Ok(Some(msg)) =
-                timeout(self.wait_time_between_shard_start, self.manager_rx.next()).await
-            {
+            let batch = self.queue.pop_batch();
+            let msg = if batch.is_empty() {
+                // This function is the only code that can add new shards
+                // to start to the queue directly (enforced by `&mut`), so
+                // if the batch is empty, it will always be empty until a
+                // `ShardManagerMessage::Boot` is received here.
+                self.manager_rx.next().await
+            } else {
+                self.checked_start(batch).await;
+
+                // Include a timeout so we can start the next batch of
+                // shards even if no more messages are received.
+                timeout(self.wait_time_between_shard_start, self.manager_rx.next())
+                    .await
+                    .unwrap_or_default()
+            };
+
+            if let Some(msg) = msg {
                 match msg {
                     ShardManagerMessage::Boot(shard_id) => self.queue_for_start(shard_id),
                     ShardManagerMessage::Quit(res) => return res,
                 }
             }
-            let batch = self.queue.pop_batch();
-            self.checked_start(batch).await;
         }
     }
 


### PR DESCRIPTION
Moves the check for `ShardManagerMessage` to the end of the `ShardManager::run` loop. This avoids unnecessarily waiting `wait_time_between_shard_start` once before ever starting shards.

~~Also no longer times out receiving `ShardManagerMessage` if no more shards need to be started currently. Since the run loop is the only place than can modify the queue, there is no chance of the queue changing while it is waiting for messages.~~