### PR TITLE
Avoid boxed event reallocations

### DIFF
--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -44,7 +44,7 @@ macro_rules! update_cache {
 /// This MUST be called from a different task to the recv_event loop, to allow for
 /// intra-shard concurrency between the shard loop and event handler.
 pub(crate) async fn dispatch_model(
-    event: Event,
+    event: Box<Event>,
     context: Context,
     #[cfg(feature = "framework")] framework: Option<Arc<dyn Framework>>,
     event_handler: Option<Arc<dyn EventHandler>>,
@@ -110,10 +110,10 @@ async fn dispatch_event_handler(
 #[cfg_attr(not(feature = "cache"), allow(unused_mut))]
 fn update_cache_with_event(
     #[cfg(feature = "cache")] cache: &Cache,
-    event: Event,
+    event: Box<Event>,
 ) -> (FullEvent, Option<FullEvent>) {
     let mut extra_event = None;
-    let event = match event {
+    let event = match *event {
         Event::CommandPermissionsUpdate(event) => FullEvent::CommandPermissionsUpdate {
             permission: event.permission,
         },

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -306,7 +306,11 @@ impl Shard {
     }
 
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
-    fn handle_gateway_dispatch(&mut self, seq: u64, event: DeserializedEvent) -> Option<Event> {
+    fn handle_gateway_dispatch(
+        &mut self,
+        seq: u64,
+        event: DeserializedEvent,
+    ) -> Option<Box<Event>> {
         if seq > self.seq + 1 {
             warn!("[{:?}] Sequence off; them: {}, us: {}", self.shard_info, seq, self.seq);
         }
@@ -325,7 +329,7 @@ impl Shard {
             },
         };
 
-        match &event {
+        match &*event {
             Event::Ready(ready) => {
                 debug!("[{:?}] Received Ready", self.shard_info);
 
@@ -447,9 +451,7 @@ impl Shard {
             Ok(GatewayEvent::Dispatch {
                 seq,
                 event,
-            }) => Ok(self
-                .handle_gateway_dispatch(seq, *event)
-                .map(|e| ShardAction::Dispatch(Box::new(e)))),
+            }) => Ok(self.handle_gateway_dispatch(seq, event).map(ShardAction::Dispatch)),
             Ok(GatewayEvent::Heartbeat) => {
                 info!("[{:?}] Received shard heartbeat", self.shard_info);
 

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -217,7 +217,7 @@ impl ShardRunner {
                             spawn_named(
                                 "shard_runner::dispatch",
                                 dispatch_model(
-                                    *event,
+                                    event,
                                     context,
                                     #[cfg(feature = "framework")]
                                     self.framework.clone(),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -934,7 +934,7 @@ pub struct MessagePollVoteRemoveEvent {
 pub enum GatewayEvent {
     Dispatch {
         seq: u64,
-        event: Box<DeserializedEvent>,
+        event: DeserializedEvent,
     },
     Heartbeat,
     Reconnect,
@@ -944,13 +944,12 @@ pub enum GatewayEvent {
     HeartbeatAck,
 }
 
-#[expect(clippy::large_enum_variant)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
 #[serde(untagged)]
 pub enum DeserializedEvent {
-    Success(Event),
+    Success(Box<Event>),
     Unknown(UnknownEvent),
 }
 
@@ -996,13 +995,11 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 
                 Self::Dispatch {
                     seq: raw.seq.ok_or_else(|| DeError::missing_field("s"))?,
-                    event: {
-                        Box::new(match Event::deserialize(raw_data) {
-                            Ok(event) => DeserializedEvent::Success(event),
-                            Err(_) => DeserializedEvent::Unknown(
-                                UnknownEvent::deserialize(raw_data).map_err(DeError::custom)?,
-                            ),
-                        })
+                    event: match Box::<Event>::deserialize(raw_data) {
+                        Ok(event) => DeserializedEvent::Success(event),
+                        Err(_) => DeserializedEvent::Unknown(
+                            UnknownEvent::deserialize(raw_data).map_err(DeError::custom)?,
+                        ),
                     },
                 }
             },


### PR DESCRIPTION
Currently, Event is boxed during deserialisation only to be dereferenced in `Shard::handle_gateway_dispatch` and boxed again afterwards. This changes the box dance to dereference as late as possible, during cache updating, in hope that only fields matched on are memcopied.