### PR TITLE
fix incorrect CommandPermissionType for `@everyone`.

### DIFF
--- a/src/builder/create_command_permission.rs
+++ b/src/builder/create_command_permission.rs
@@ -93,7 +93,7 @@ impl CreateCommandPermission {
     pub fn everyone(guild_id: GuildId, allow: bool) -> Self {
         Self(CommandPermission {
             id: guild_id.get().into(),
-            kind: CommandPermissionType::User,
+            kind: CommandPermissionType::Role,
             permission: allow,
         })
     }


### PR DESCRIPTION
`@everyone` is a role not a user, as such the current implementation doesn't work.