### PR TITLE
Fix channels that should be threads

### DIFF
--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -32,6 +32,35 @@ pub use self::thread::*;
 use crate::http::Http;
 use crate::model::prelude::*;
 
+impl From<ThreadId> for GenericChannelId {
+    fn from(val: ThreadId) -> Self {
+        Self::new(val.get())
+    }
+}
+
+impl From<ChannelId> for GenericChannelId {
+    fn from(val: ChannelId) -> Self {
+        Self::new(val.get())
+    }
+}
+
+impl GenericChannelId {
+    #[must_use]
+    pub fn split(self) -> (ChannelId, ThreadId) {
+        (self.expect_channel(), self.expect_thread())
+    }
+
+    #[must_use]
+    pub fn expect_channel(self) -> ChannelId {
+        ChannelId::new(self.get())
+    }
+
+    #[must_use]
+    pub fn expect_thread(self) -> ThreadId {
+        ThreadId::new(self.get())
+    }
+}
+
 /// A container for a reference to any Guild channel.
 #[derive(Clone, Copy, Debug)]
 // purposefully missing non-exhaustive, as discord considers new channel types like threads to be

--- a/src/model/channel/thread.rs
+++ b/src/model/channel/thread.rs
@@ -6,35 +6,6 @@ use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::utils::is_false;
 
-impl From<ThreadId> for GenericChannelId {
-    fn from(val: ThreadId) -> Self {
-        Self::new(val.get())
-    }
-}
-
-impl From<ChannelId> for GenericChannelId {
-    fn from(val: ChannelId) -> Self {
-        Self::new(val.get())
-    }
-}
-
-impl GenericChannelId {
-    #[must_use]
-    pub fn split(self) -> (ChannelId, ThreadId) {
-        (self.expect_channel(), self.expect_thread())
-    }
-
-    #[must_use]
-    pub fn expect_channel(self) -> ChannelId {
-        ChannelId::new(self.get())
-    }
-
-    #[must_use]
-    pub fn expect_thread(self) -> ThreadId {
-        ThreadId::new(self.get())
-    }
-}
-
 impl ThreadId {
     #[must_use]
     pub fn widen(self) -> GenericChannelId {
@@ -316,7 +287,7 @@ pub struct ThreadMember {
     #[serde(flatten)]
     pub inner: PartialThreadMember,
     /// The id of the thread.
-    pub id: ChannelId,
+    pub id: ThreadId,
     /// The id of the user.
     pub user_id: UserId,
     /// Additional information about the user.

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -765,7 +765,7 @@ pub struct ThreadListSyncEvent {
     /// well, so you know to clear that data.
     pub channel_ids: Option<Vec<ChannelId>>,
     /// All active threads in the given channels that the current user can access.
-    pub threads: FixedArray<GuildChannel>,
+    pub threads: FixedArray<GuildThread>,
     /// All thread member objects from the synced threads for the current user, indicating which
     /// threads the current user has been added to
     pub members: FixedArray<ThreadMember>,
@@ -791,7 +791,7 @@ pub struct ThreadMemberUpdateEvent {
 #[non_exhaustive]
 pub struct ThreadMembersUpdateEvent {
     /// The id of the thread.
-    pub id: ChannelId,
+    pub id: ThreadId,
     /// The id of the Guild.
     pub guild_id: GuildId,
     /// The approximate number of members in the thread, capped at 50.


### PR DESCRIPTION
Fixes the definitions of `ThreadListSyncEvent`, `ThreadMembersUpdateEvent`, and `ThreadMember` to refer to threads or thread ids. Also moves up the conversion functions for `GenericChannelId` from thread.rs into mod.rs.