### PR TITLE
Update extract_map to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ bool_to_bitflags = { version = "0.1.2" }
 nonmax = { version = "0.5.5", features = ["serde"] }
 strum = { version = "0.26", features = ["derive"] }
 to-arraystring = "0.2.0"
-extract_map = { version = "0.2.0", features = ["serde", "iter_mut"] }
+extract_map = { version = "0.3.0", features = ["serde"] }
 aformat = "0.1.3"
 bytes = "1.5.0"
 ref-cast = "1.0.23"

--- a/src/internal/prelude.rs
+++ b/src/internal/prelude.rs
@@ -4,7 +4,7 @@
 
 pub use std::result::Result as StdResult;
 
-pub use extract_map::{ExtractKey, ExtractMap, LendingIterator};
+pub use extract_map::{ExtractKey, ExtractMap};
 pub use serde_json::Value;
 pub use small_fixed_array::{FixedArray, FixedString, TruncatingInto};
 pub use to_arraystring::ToArrayString;

--- a/src/internal/utils.rs
+++ b/src/internal/utils.rs
@@ -12,15 +12,3 @@ pub fn join_to_string(
     buf.truncate(buf.len() - 1);
     buf
 }
-
-// Required because of https://github.com/Crazytieguy/gat-lending-iterator/issues/31
-macro_rules! lending_for_each {
-    ($iter:expr, |$item:ident| $body:expr ) => {
-        let mut __iter = $iter;
-        while let Some(mut $item) = __iter.next() {
-            $body
-        }
-    };
-}
-
-pub(crate) use lending_for_each;

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -14,7 +14,6 @@ use crate::builder::{
 };
 #[cfg(feature = "model")]
 use crate::http::Http;
-use crate::internal::utils::lending_for_each;
 use crate::model::prelude::*;
 
 /// An interaction when a user invokes a slash command.
@@ -214,8 +213,7 @@ impl<'de> Deserialize<'de> for CommandInteraction {
                 interaction.user = member.user.clone();
             }
 
-            let iter = interaction.data.resolved.roles.iter_mut();
-            lending_for_each!(iter, |r| r.guild_id = guild_id);
+            interaction.data.resolved.roles.iter_mut().for_each(|r| r.guild_id = guild_id);
         }
         Ok(interaction)
     }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -9,7 +9,6 @@ use serde_json::value::RawValue;
 use strum::{EnumCount, IntoStaticStr, VariantNames};
 
 use crate::constants::Opcode;
-use crate::internal::utils::lending_for_each;
 use crate::model::prelude::*;
 
 /// Requires no gateway intents.
@@ -167,10 +166,10 @@ pub struct GuildCreateEvent {
 impl<'de> Deserialize<'de> for GuildCreateEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut guild: Guild = Guild::deserialize(deserializer)?;
-        lending_for_each!(guild.channels.iter_mut(), |x| x.base.guild_id = guild.id);
-        lending_for_each!(guild.threads.iter_mut(), |x| x.base.guild_id = guild.id);
-        lending_for_each!(guild.members.iter_mut(), |x| x.guild_id = guild.id);
-        lending_for_each!(guild.roles.iter_mut(), |x| x.guild_id = guild.id);
+        guild.channels.iter_mut().for_each(|x| x.base.guild_id = guild.id);
+        guild.threads.iter_mut().for_each(|x| x.base.guild_id = guild.id);
+        guild.members.iter_mut().for_each(|x| x.guild_id = guild.id);
+        guild.roles.iter_mut().for_each(|x| x.guild_id = guild.id);
         Ok(Self {
             guild,
         })
@@ -287,7 +286,7 @@ pub struct GuildMembersChunkEvent {
 impl<'de> Deserialize<'de> for GuildMembersChunkEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut event = Self::deserialize(deserializer)?; // calls #[serde(remote)]-generated inherent method
-        lending_for_each!(event.members.iter_mut(), |m| m.guild_id = event.guild_id);
+        event.members.iter_mut().for_each(|m| m.guild_id = event.guild_id);
         Ok(event)
     }
 }

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -5,7 +5,6 @@ use serde::Serialize;
 use crate::builder::EditGuild;
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
-use crate::internal::utils::lending_for_each;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::icon_url;
@@ -348,7 +347,7 @@ impl PartialGuild {
 impl<'de> Deserialize<'de> for PartialGuildGeneratedOriginal {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut guild = Self::deserialize(deserializer)?; // calls #[serde(remote)]-generated inherent method
-        lending_for_each!(guild.roles.iter_mut(), |r| r.guild_id = guild.id);
+        guild.roles.iter_mut().for_each(|r| r.guild_id = guild.id);
         Ok(guild)
     }
 }


### PR DESCRIPTION
This gets rid of the lending iterator stuff by using hashbrown::HashTable's iter_mut method.

As a side note, 0.2.2 also implements the Entry API.