### PR TITLE
Simplify struct names for editing attachments

### DIFF
--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -173,15 +173,10 @@ impl<'a> ImageData<'a> {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-struct ExistingAttachment {
-    id: AttachmentId,
-}
-
 #[derive(Clone, Debug)]
-enum NewOrExisting<'a> {
+enum EditAttachmentsInner<'a> {
     New(CreateAttachment<'a>),
-    Existing(ExistingAttachment),
+    Existing(AttachmentId),
 }
 
 /// You can add new attachments and edit existing ones using this builder.
@@ -242,7 +237,7 @@ enum NewOrExisting<'a> {
 #[derive(Default, Debug, Clone)]
 #[must_use]
 pub struct EditAttachments<'a> {
-    new_and_existing_attachments: Vec<NewOrExisting<'a>>,
+    inner: Vec<EditAttachmentsInner<'a>>,
 }
 
 impl<'a> EditAttachments<'a> {
@@ -266,15 +261,7 @@ impl<'a> EditAttachments<'a> {
     /// Discord will throw an error!**
     pub fn keep_all(msg: &Message) -> Self {
         Self {
-            new_and_existing_attachments: msg
-                .attachments
-                .iter()
-                .map(|a| {
-                    NewOrExisting::Existing(ExistingAttachment {
-                        id: a.id,
-                    })
-                })
-                .collect(),
+            inner: msg.attachments.iter().map(|a| EditAttachmentsInner::Existing(a.id)).collect(),
         }
     }
 
@@ -283,9 +270,7 @@ impl<'a> EditAttachments<'a> {
     ///
     /// Opposite of [`Self::remove`].
     pub fn keep(mut self, id: AttachmentId) -> Self {
-        self.new_and_existing_attachments.push(NewOrExisting::Existing(ExistingAttachment {
-            id,
-        }));
+        self.inner.push(EditAttachmentsInner::Existing(id));
         self
     }
 
@@ -294,9 +279,9 @@ impl<'a> EditAttachments<'a> {
     ///
     /// Opposite of [`Self::keep`].
     pub fn remove(mut self, id: AttachmentId) -> Self {
-        self.new_and_existing_attachments.retain(|a| match a {
-            NewOrExisting::Existing(a) => a.id != id,
-            NewOrExisting::New(_) => true,
+        self.inner.retain(|a| match a {
+            EditAttachmentsInner::Existing(existing_id) => *existing_id != id,
+            EditAttachmentsInner::New(_) => true,
         });
         self
     }
@@ -304,7 +289,7 @@ impl<'a> EditAttachments<'a> {
     /// Adds a new attachment to the attachment list.
     #[expect(clippy::should_implement_trait)] // Clippy thinks add == std::ops::Add::add
     pub fn add(mut self, attachment: CreateAttachment<'a>) -> Self {
-        self.new_and_existing_attachments.push(NewOrExisting::New(attachment));
+        self.inner.push(EditAttachmentsInner::New(attachment));
         self
     }
 
@@ -312,10 +297,10 @@ impl<'a> EditAttachments<'a> {
     /// are needed for the multipart form data.
     #[cfg(feature = "http")]
     pub(crate) fn new_attachments(&self) -> Vec<CreateAttachment<'a>> {
-        self.new_and_existing_attachments
+        self.inner
             .iter()
             .filter_map(|attachment| {
-                if let NewOrExisting::New(attachment) = &attachment {
+                if let EditAttachmentsInner::New(attachment) = &attachment {
                     Some(attachment.clone())
                 } else {
                     None
@@ -334,14 +319,19 @@ impl Serialize for EditAttachments<'_> {
             description: &'a Option<Cow<'a, str>>,
         }
 
+        #[derive(Serialize)]
+        struct ExistingAttachment {
+            id: AttachmentId,
+        }
+
         // Instead of an `AttachmentId`, the `id` field for new attachments corresponds to the
         // index of the new attachment in the multipart payload. The attachment data will be
         // labeled with `files[{id}]` in the multipart body. See `Multipart::build_form`.
         let mut id = 0;
-        let mut seq = serializer.serialize_seq(Some(self.new_and_existing_attachments.len()))?;
-        for attachment in &self.new_and_existing_attachments {
+        let mut seq = serializer.serialize_seq(Some(self.inner.len()))?;
+        for attachment in &self.inner {
             match attachment {
-                NewOrExisting::New(new_attachment) => {
+                EditAttachmentsInner::New(new_attachment) => {
                     let attachment = NewAttachment {
                         id,
                         filename: &new_attachment.filename,
@@ -350,8 +340,10 @@ impl Serialize for EditAttachments<'_> {
                     id += 1;
                     seq.serialize_element(&attachment)?;
                 },
-                NewOrExisting::Existing(existing_attachment) => {
-                    seq.serialize_element(existing_attachment)?;
+                EditAttachmentsInner::Existing(id) => {
+                    seq.serialize_element(&ExistingAttachment {
+                        id: *id,
+                    })?;
                 },
             }
         }


### PR DESCRIPTION
Makes things a bit more understandable, since the previous names were a bit confusing.