### PR TITLE
Fix clippy warnings from clippy::unwrap_used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   rust_min: 1.74.0
-  rust_nightly: nightly-2024-03-09
+  rust_nightly: nightly-2025-05-18
 
 jobs:
   test:
@@ -161,6 +161,11 @@ jobs:
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
+
+      - name: Pin problematic dependencies to working versions
+        run: |
+          cargo update idna_adapter --precise 1.1.0
+          cargo update triomphe --precise 0.1.11
 
       - name: Check
         run: cargo check --features full

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,6 @@ edition = "2021"
 rust-version = "1.74"
 
 [dependencies]
-#!! Downgrade to versions still supporting v1.74.0
-#!! Make sure to remove on `next`
-litemap = "=0.7.4"
-zerofrom = "=0.1.5"
-
 # Required dependencies
 bitflags = "2.4.2"
 serde_json = "1.0.108"

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -959,7 +959,8 @@ fn flatten_group_to_plain_string(
     let repeated_indent_str = help_options.indention_prefix.repeat(nest_level);
 
     if nest_level > 0 {
-        write!(group_text, "\n{repeated_indent_str}**{}**", group.name).unwrap();
+        write!(group_text, "\n{repeated_indent_str}**{}**", group.name)
+            .expect("writing to a string should never fail");
     }
 
     if group.prefixes.is_empty() {
@@ -970,7 +971,7 @@ fn flatten_group_to_plain_string(
             " ({}: `{}`): ",
             help_options.group_prefix,
             group.prefixes.join("`, `"),
-        ).unwrap();
+        ).expect("writing to a string should never fail");
     }
 
     let joined_commands = group.command_names.join(", ");
@@ -1232,7 +1233,7 @@ fn grouped_commands_to_plain_string(
     result.push('\n');
 
     for group in groups {
-        write!(result, "\n**{}**", &group.name).unwrap();
+        write!(result, "\n**{}**", &group.name).expect("writing to a string should never fail");
 
         flatten_group_to_plain_string(&mut result, group, 0, help_options);
     }
@@ -1245,15 +1246,16 @@ fn grouped_commands_to_plain_string(
 fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<'_>) -> String {
     let mut result = String::new();
 
-    writeln!(result, "__**{}**__", command.name).unwrap();
+    writeln!(result, "__**{}**__", command.name).expect("writing to a string should never fail");
 
     if !command.aliases.is_empty() {
         write!(result, "**{}**: `{}`", help_options.aliases_label, command.aliases.join("`, `"))
-            .unwrap();
+            .expect("writing to a string should never fail");
     }
 
     if let Some(description) = command.description {
-        writeln!(result, "**{}**: {description}", help_options.description_label).unwrap();
+        writeln!(result, "**{}**: {description}", help_options.description_label)
+            .expect("writing to a string should never fail");
     }
 
     if let Some(usage) = command.usage {
@@ -1263,10 +1265,10 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
                 "**{}**: `{first_prefix} {} {usage}`",
                 help_options.usage_label, command.name
             )
-            .unwrap();
+            .expect("writing to a string should never fail");
         } else {
             writeln!(result, "**{}**: `{} {usage}`", help_options.usage_label, command.name)
-                .unwrap();
+                .expect("writing to a string should never fail");
         }
     }
 
@@ -1278,7 +1280,7 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
                     "**{}**: `{first_prefix} {} {example}`",
                     help_options.usage_sample_label, command.name
                 )
-                .unwrap();
+                .expect("writing to a string should never fail");
             };
             command.usage_sample.iter().for_each(format_example);
         } else {
@@ -1288,16 +1290,18 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
                     "**{}**: `{} {example}`",
                     help_options.usage_sample_label, command.name
                 )
-                .unwrap();
+                .expect("writing to a string should never fail");
             };
             command.usage_sample.iter().for_each(format_example);
         }
     }
 
-    writeln!(result, "**{}**: {}", help_options.grouped_label, command.group_name).unwrap();
+    writeln!(result, "**{}**: {}", help_options.grouped_label, command.group_name)
+        .expect("writing to a string should never fail");
 
     if !help_options.available_text.is_empty() && !command.availability.is_empty() {
-        writeln!(result, "**{}**: {}", help_options.available_text, command.availability).unwrap();
+        writeln!(result, "**{}**: {}", help_options.available_text, command.availability)
+            .expect("writing to a string should never fail");
     }
 
     if !command.sub_commands.is_empty() {
@@ -1307,7 +1311,7 @@ fn single_command_to_plain_string(help_options: &HelpOptions, command: &Command<
             help_options.sub_commands_label,
             command.sub_commands.join("`, `"),
         )
-        .unwrap();
+        .expect("writing to a string should never fail");
     }
 
     result
@@ -1385,8 +1389,7 @@ pub async fn plain(
     msg.channel_id.say(&ctx, result).await
 }
 
-#[cfg(test)]
-#[cfg(all(feature = "cache", feature = "http"))]
+#[cfg(all(test, feature = "cache", feature = "http"))]
 mod tests {
     use super::{SuggestedCommandName, Suggestions};
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -80,7 +80,7 @@ impl<'a> Request<'a> {
         if let Some(params) = self.params {
             path += "?";
             for (param, value) in params {
-                write!(path, "&{param}={value}").unwrap();
+                write!(path, "&{param}={value}").expect("writing to a string should never fail");
             }
         }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -420,7 +420,8 @@ impl Message {
             at_distinct.push_str(&u.name);
             if let Some(discriminator) = u.discriminator {
                 at_distinct.push('#');
-                write!(at_distinct, "{:04}", discriminator.get()).unwrap();
+                write!(at_distinct, "{:04}", discriminator.get())
+                    .expect("writing to a string should never fail");
             }
 
             let mut m = u.mention().to_string();

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -830,7 +830,7 @@ fn tag(name: &str, discriminator: Option<NonZeroU16>) -> String {
     tag.push_str(name);
     if let Some(discriminator) = discriminator {
         tag.push('#');
-        write!(tag, "{discriminator:04}").unwrap();
+        write!(tag, "{discriminator:04}").expect("writing to a string should never fail");
     }
     tag
 }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -187,7 +187,7 @@ impl MessageBuilder {
 
     #[inline]
     fn push_<C: std::fmt::Display + ?Sized>(&mut self, content: &C) -> &mut Self {
-        write!(self.0, "{content}").unwrap();
+        write!(self.0, "{content}").expect("writing to a string should never fail");
 
         self
     }
@@ -931,7 +931,8 @@ pub trait EmbedMessageBuilding {
 
 impl EmbedMessageBuilding for MessageBuilder {
     fn push_named_link(&mut self, name: impl Into<Content>, url: impl Into<Content>) -> &mut Self {
-        write!(self.0, "[{}]({})", name.into(), url.into()).unwrap();
+        write!(self.0, "[{}]({})", name.into(), url.into())
+            .expect("writing to a string should never fail");
 
         self
     }


### PR DESCRIPTION
1.87 fixed this lint failing to trigger when a macro returned Result, causing all this.