### PR TITLE
Clean up Result types for WsClient

### DIFF
--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -698,8 +698,7 @@ async fn connect(base_url: &str, compression: TransportCompression) -> Result<Ws
         Error::Gateway(GatewayError::BuildingUrl)
     })?;
 
-    let client = WsClient::connect(url, compression).await?;
-    Ok(client)
+    WsClient::connect(url, compression).await
 }
 
 struct ResumeMetadata {

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -8,8 +8,8 @@ use flate2::read::ZlibDecoder;
 use futures::{SinkExt, StreamExt};
 use tokio::net::TcpStream;
 use tokio::time::{Duration, timeout};
+use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
-use tokio_tungstenite::tungstenite::{Error as WsError, Message};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async_with_config};
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
@@ -20,7 +20,6 @@ use zstd_safe::{DStream as ZstdInflater, InBuffer, OutBuffer};
 
 use super::{ActivityData, ChunkGuildFilter, GatewayError, PresenceData, TransportCompression};
 use crate::constants::{self, Opcode};
-use crate::internal::prelude::*;
 use crate::model::event::GatewayEvent;
 use crate::model::gateway::{GatewayIntents, ShardInfo};
 #[cfg(feature = "voice")]
@@ -237,10 +236,7 @@ pub struct WsClient {
 const TIMEOUT: Duration = Duration::from_millis(500);
 
 impl WsClient {
-    pub(crate) async fn connect(
-        url: Url,
-        compression: TransportCompression,
-    ) -> StdResult<Self, WsError> {
+    pub(crate) async fn connect(url: Url, compression: TransportCompression) -> Result<Self> {
         let config = {
             let mut config = WebSocketConfig::default();
             config.max_message_size = None;
@@ -293,7 +289,7 @@ impl WsClient {
     }
 
     /// Delegate to `WebSocketStream::close`
-    pub(crate) async fn close(&mut self, msg: Option<CloseFrame>) -> StdResult<(), WsError> {
+    pub(crate) async fn close(&mut self, msg: Option<CloseFrame>) -> Result<()> {
         self.stream.close(msg).await?;
         Ok(())
     }


### PR DESCRIPTION
Follow-up to #3369 - using `StdResult` isn't necessary because we can already coerce `tungstenite::Error` into serenity's `Error`. Worth noting that this incurs a `Box` call for the error type, but this isn't a hot path by any means.