### PR TITLE
Add `flags` to `EditWebhookMessage` and `EditInteractionResponse`

### DIFF
--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -76,6 +76,11 @@ impl EditInteractionResponse {
     }
     super::button_and_select_menu_convenience_methods!(self.0.components);
 
+    /// Sets the flags for the message.
+    pub fn flags(self, flags: MessageFlags) -> Self {
+        Self(self.0.flags(flags))
+    }
+
     /// Sets attachments, see [`EditAttachments`] for more details.
     pub fn attachments(self, attachments: EditAttachments) -> Self {
         Self(self.0.attachments(attachments))

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -153,11 +153,10 @@ impl EditMessage {
     /// # Ok(()) }
     /// ```
     pub fn suppress_embeds(mut self, suppress: bool) -> Self {
-        // At time of writing, only `SUPPRESS_EMBEDS` can be set/unset when editing messages. See
-        // for details: https://discord.com/developers/docs/resources/channel#edit-message-jsonform-params
-        let flags = if suppress { MessageFlags::SUPPRESS_EMBEDS } else { MessageFlags::empty() };
-
-        self.flags = Some(flags);
+        // See for details: https://discord.com/developers/docs/resources/message#edit-message-jsonform-params
+        self.flags
+            .get_or_insert(MessageFlags::empty())
+            .set(MessageFlags::SUPPRESS_EMBEDS, suppress);
         self
     }
 

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -26,6 +26,8 @@ pub struct EditWebhookMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     embeds: Option<Vec<CreateEmbed>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<MessageFlags>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     allowed_mentions: Option<CreateAllowedMentions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) components: Option<Vec<CreateActionRow>>,
@@ -130,6 +132,12 @@ impl EditWebhookMessage {
         self
     }
     super::button_and_select_menu_convenience_methods!(self.components);
+
+    /// Sets the flags for the message.
+    pub fn flags(mut self, flags: MessageFlags) -> Self {
+        self.flags = Some(flags);
+        self
+    }
 
     /// Sets attachments, see [`EditAttachments`] for more details.
     pub fn attachments(mut self, attachments: EditAttachments) -> Self {


### PR DESCRIPTION
This PR adds the `flags` field/setter to `EditWebhookMessage` and `EditInteractionResponse`. It also modifies `EditMessage::suppress_embeds` because the `IS_COMPONENTS_V2` flag can also be set there now.

This allows upgrading webhook messages and interaction responses to components V2 in an edit (when merged into next also). This appears to be required when deferring interaction responses.