### PR TITLE
Add support for editing flags on Webhook/Interaction responses

### DIFF
--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -98,6 +98,12 @@ impl<'a> EditInteractionResponse<'a> {
         Self(self.0.clear_attachments())
     }
 
+    /// Sets the flags for this message.
+    pub fn flags(mut self, flags: MessageFlags) -> Self {
+        self.0.flags = Some(flags);
+        self
+    }
+
     /// Edits the initial interaction response. Does not work for ephemeral messages.
     ///
     /// The `application_id` used will usually be the bot's [`UserId`], except if the bot is very

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -29,6 +29,8 @@ pub struct EditWebhookMessage<'a> {
     pub(crate) components: Option<Cow<'a, [CreateComponent<'a>]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) attachments: Option<EditAttachments<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) flags: Option<MessageFlags>,
 
     #[serde(skip)]
     thread_id: Option<ThreadId>,
@@ -139,6 +141,12 @@ impl<'a> EditWebhookMessage<'a> {
     /// Shorthand for calling [`Self::attachments`] with [`EditAttachments::new`].
     pub fn clear_attachments(mut self) -> Self {
         self.attachments = Some(EditAttachments::new());
+        self
+    }
+
+    /// Sets the flags for this message.
+    pub fn flags(mut self, flags: MessageFlags) -> Self {
+        self.flags = Some(flags);
         self
     }
 


### PR DESCRIPTION
This is needed for the poise PR and in general is just missing when the Discord API supports it.

https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response