### PR TITLE
Gradient roles, guild tags, avatar decorations and nameplates

### DIFF
--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -54,6 +54,9 @@ pub struct EditRole<'a> {
     #[serde(rename = "color")]
     colour: Option<Colour>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "colors")]
+    colours: Option<CreateRoleColours>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     icon: Option<Option<String>>,
@@ -86,6 +89,7 @@ impl<'a> EditRole<'a> {
             colour: Some(role.colour),
             unicode_emoji: role.unicode_emoji.as_ref().map(|v| Some(v.clone())),
             audit_log_reason: None,
+            colours: Some(role.colours.into()),
             // TODO: Do we want to download role.icon?
             icon: None,
         }
@@ -147,6 +151,55 @@ impl<'a> EditRole<'a> {
     pub fn audit_log_reason(mut self, reason: &'a str) -> Self {
         self.audit_log_reason = Some(reason);
         self
+    }
+}
+
+/// The colours of a Discord role, secondary_colour and tertiary_colour may only be set if
+/// the [Guild] has the `ENHANCED_ROLE_COLORS` feature.
+///
+/// Note: 2024-07-05 - tertiary_colour is currently enforced to be set with a specific pair of
+/// primary and secondary colours, for current validation see
+/// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object-role-colors-object).
+#[derive(Clone, Debug, Default, Serialize)]
+#[must_use]
+#[expect(clippy::struct_field_names)]
+pub struct CreateRoleColours {
+    primary_color: Colour,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    secondary_color: Option<Colour>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tertiary_color: Option<Colour>,
+}
+
+impl CreateRoleColours {
+    pub fn new(primary_colour: Colour) -> Self {
+        Self {
+            primary_color: primary_colour,
+            secondary_color: None,
+            tertiary_color: None,
+        }
+    }
+
+    /// Sets the secondary colour for this role.
+    pub fn secondary_colour(mut self, secondary_colour: Colour) -> Self {
+        self.secondary_color = Some(secondary_colour);
+        self
+    }
+
+    /// Sets the tertiary colour for this role, see struct documentation for limitations.
+    pub fn tertiary_colour(mut self, tertiary_colour: Colour) -> Self {
+        self.tertiary_color = Some(tertiary_colour);
+        self
+    }
+}
+
+impl From<RoleColours> for CreateRoleColours {
+    fn from(c: RoleColours) -> CreateRoleColours {
+        CreateRoleColours {
+            primary_color: c.primary_colour,
+            secondary_color: c.secondary_colour,
+            tertiary_color: c.tertiary_colour,
+        }
     }
 }
 

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -162,7 +162,7 @@ impl<'a> EditRole<'a> {
 /// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object-role-colors-object).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
-#[expect(clippy::struct_field_names)]
+#[allow(clippy::struct_field_names)]
 pub struct CreateRoleColours {
     primary_color: Colour,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -227,8 +227,10 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     permissions: None,
                     avatar: self.avatar,
                     communication_disabled_until: self.communication_disabled_until,
-                    flags: GuildMemberFlags::default(),
+                    flags: self.flags.unwrap_or_default(),
                     unusual_dm_activity_until: self.unusual_dm_activity_until,
+                    avatar_decoration_data: self.avatar_decoration_data,
+                    banner: self.banner,
                 });
             }
 
@@ -463,6 +465,8 @@ impl CacheUpdate for PresenceUpdateEvent {
                         communication_disabled_until: None,
                         flags: GuildMemberFlags::default(),
                         unusual_dm_activity_until: None,
+                        banner: None,
+                        avatar_decoration_data: None,
                     });
                 }
             }

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -200,6 +200,9 @@ impl ShardQueuer {
         };
 
         spawn_named("shard_queuer::stop", async move {
+            // just over the large futures threshold but refactoring this is not worth the time for
+            // something so low impact
+            #[allow(clippy::large_futures)]
             drop(runner.run().await);
             debug!("[ShardRunner {:?}] Stopping", runner.shard.shard_info());
         });

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -482,6 +482,8 @@ pub struct MessageModalSubmitInteractionMetadata {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
+// cannot box on current due to breaking changes
+#[allow(clippy::large_enum_variant)]
 pub enum MessageInteractionMetadata {
     Command(MessageCommandInteractionMetadata),
     Component(MessageComponentInteractionMetadata),

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -24,7 +24,7 @@
 /// # fn main() {
 /// # let role = from_value::<Role>(json!({
 /// #     "color": Colour::BLURPLE,
-///       "colors": RoleColours::default(),
+/// #     "colors": RoleColours::default(),
 /// #     "hoist": false,
 /// #     "id": RoleId::new(1),
 /// #     "guild_id": GuildId::new(2),

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -19,6 +19,7 @@
 /// # use serenity::model::id::RoleId;
 /// # use serenity::model::id::GuildId;
 /// # use serenity::model::permissions;
+/// # use serenity::model::guild::RoleColours;
 /// #
 /// # fn main() {
 /// # let role = from_value::<Role>(json!({

--- a/src/model/colour.rs
+++ b/src/model/colour.rs
@@ -23,6 +23,7 @@
 /// # fn main() {
 /// # let role = from_value::<Role>(json!({
 /// #     "color": Colour::BLURPLE,
+///       "colors": RoleColours::default(),
 /// #     "hoist": false,
 /// #     "id": RoleId::new(1),
 /// #     "guild_id": GuildId::new(2),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -261,7 +261,11 @@ pub struct GuildMemberUpdateEvent {
     pub mute: bool,
     pub avatar: Option<ImageHash>,
     pub communication_disabled_until: Option<Timestamp>,
+    // This is not documented but present on the event?
     pub unusual_dm_activity_until: Option<Timestamp>,
+    pub banner: Option<ImageHash>,
+    pub flags: Option<GuildMemberFlags>,
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
 }
 
 /// Requires no gateway intents.

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -282,6 +282,7 @@ impl PresenceUser {
             premium_type: PremiumType::None,
             primary_guild: None,
             avatar_decoration_data: None,
+            collectibles: None,
         })
     }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -280,6 +280,8 @@ impl PresenceUser {
             email: self.email,
             flags: self.public_flags.unwrap_or_default(),
             premium_type: PremiumType::None,
+            primary_guild: None,
+            avatar_decoration_data: None,
         })
     }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -244,16 +244,35 @@ pub struct ClientStatus {
 #[non_exhaustive]
 pub struct PresenceUser {
     pub id: UserId,
-    pub avatar: Option<ImageHash>,
-    pub bot: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator")]
-    pub discriminator: Option<NonZeroU16>,
-    pub email: Option<String>,
-    pub mfa_enabled: Option<bool>,
     #[serde(rename = "username")]
     pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator")]
+    pub discriminator: Option<NonZeroU16>,
+    pub global_name: Option<String>,
+    pub avatar: Option<ImageHash>,
+    #[serde(default)]
+    pub bot: Option<bool>,
+    #[serde(default)]
+    pub system: Option<bool>,
+    #[serde(default)]
+    pub mfa_enabled: Option<bool>,
+    pub banner: Option<ImageHash>,
+    #[serde(rename = "accent_color")]
+    pub accent_colour: Option<Colour>,
+    pub locale: Option<String>,
     pub verified: Option<bool>,
+    pub email: Option<String>,
+    #[serde(default)]
+    pub flags: Option<UserPublicFlags>,
+    #[serde(default)]
+    pub premium_type: Option<PremiumType>,
     pub public_flags: Option<UserPublicFlags>,
+    pub member: Option<Box<PartialMember>>,
+    pub primary_guild: Option<PrimaryGuild>,
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
+    pub collectibles: Option<Collectibles>,
+    // system is ommitted because it'll never be true
+    // TODO: should really go over these fields at some point and check them.
 }
 
 impl PresenceUser {
@@ -266,23 +285,23 @@ impl PresenceUser {
             avatar: self.avatar,
             bot: self.bot?,
             discriminator: self.discriminator,
-            global_name: None,
+            global_name: self.global_name,
             id: self.id,
             name: self.name?,
             public_flags: self.public_flags,
-            banner: None,
-            accent_colour: None,
-            member: None,
+            banner: self.banner,
+            accent_colour: self.accent_colour,
+            member: self.member,
             system: false,
             mfa_enabled: self.mfa_enabled.unwrap_or_default(),
-            locale: None,
+            locale: self.locale,
             verified: self.verified,
             email: self.email,
             flags: self.public_flags.unwrap_or_default(),
-            premium_type: PremiumType::None,
-            primary_guild: None,
-            avatar_decoration_data: None,
-            collectibles: None,
+            premium_type: self.premium_type.unwrap_or_default(),
+            primary_guild: self.primary_guild,
+            avatar_decoration_data: self.avatar_decoration_data,
+            collectibles: self.collectibles,
         })
     }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -30,6 +30,8 @@ pub struct Member {
     pub nick: Option<String>,
     /// The guild avatar hash
     pub avatar: Option<ImageHash>,
+    /// The member's guild specific banner.
+    pub banner: Option<ImageHash>,
     /// Vector of Ids of [`Role`]s given to the member.
     pub roles: Vec<RoleId>,
     /// Timestamp representing the date when the member joined.
@@ -64,6 +66,8 @@ pub struct Member {
     ///
     /// Will be None or a time in the past if the user is not flagged.
     pub unusual_dm_activity_until: Option<Timestamp>,
+    /// Information about this member's guild specific avatar decoration.
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
 }
 
 bitflags! {
@@ -538,6 +542,17 @@ impl Member {
     pub fn face(&self) -> String {
         self.avatar_url().unwrap_or_else(|| self.user.face())
     }
+
+    /// Returns the formatted URL of the user's banner, if one exists.
+    ///
+    /// This will produce a WEBP image URL, or GIF if the user has a GIF banner.
+    ///
+    /// **Note**: This will only be present if the user is fetched via Rest API.
+    #[inline]
+    #[must_use]
+    pub fn banner_url(&self) -> Option<String> {
+        banner_url(Some(self.guild_id), self.user.id, self.banner.as_ref())
+    }
 }
 
 impl fmt::Display for Member {
@@ -609,6 +624,10 @@ pub struct PartialMember {
     pub unusual_dm_activity_until: Option<Timestamp>,
     /// The guild avatar hash
     pub avatar: Option<ImageHash>,
+    /// The guild banner hash
+    pub banner: Option<ImageHash>,
+    /// Information about this member's avatar decoration.
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
 }
 
 impl From<PartialMember> for Member {
@@ -628,6 +647,8 @@ impl From<PartialMember> for Member {
             communication_disabled_until: None,
             guild_id: partial.guild_id.unwrap_or_default(),
             unusual_dm_activity_until: partial.unusual_dm_activity_until,
+            banner: partial.banner,
+            avatar_decoration_data: partial.avatar_decoration_data,
         }
     }
 }
@@ -647,6 +668,8 @@ impl From<Member> for PartialMember {
             permissions: member.permissions,
             unusual_dm_activity_until: member.unusual_dm_activity_until,
             avatar: member.avatar,
+            banner: member.banner,
+            avatar_decoration_data: member.avatar_decoration_data,
         }
     }
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -155,32 +155,37 @@ pub struct Guild {
     /// The guild features. More information available at [`discord documentation`].
     ///
     /// The following is a list of known features:
+    /// - `ANIMATED_BANNER`
     /// - `ANIMATED_ICON`
+    /// - `APPLICATION_COMMAND_PERMISSIONS_V2`
+    /// - `AUTO_MODERATION`
     /// - `BANNER`
-    /// - `COMMERCE`
     /// - `COMMUNITY`
+    /// - `CREATOR_MONETIZABLE_PROVISIONAL`
+    /// - `CREATOR_STORE_PAGE`
+    /// - `DEVELOPER_SUPPORT_SERVER`
     /// - `DISCOVERABLE`
     /// - `FEATURABLE`
+    /// - `INVITES_DISABLED`
     /// - `INVITE_SPLASH`
     /// - `MEMBER_VERIFICATION_GATE_ENABLED`
-    /// - `MONETIZATION_ENABLED`
+    /// - `MORE_SOUNDBOARD`
     /// - `MORE_STICKERS`
     /// - `NEWS`
     /// - `PARTNERED`
     /// - `PREVIEW_ENABLED`
-    /// - `PRIVATE_THREADS`
+    /// - `RAID_ALERTS_DISABLED`
     /// - `ROLE_ICONS`
-    /// - `SEVEN_DAY_THREAD_ARCHIVE`
-    /// - `THREE_DAY_THREAD_ARCHIVE`
+    /// - `ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE`
+    /// - `ROLE_SUBSCRIPTIONS_ENABLED`
+    /// - `SOUNDBOARD`
     /// - `TICKETED_EVENTS_ENABLED`
     /// - `VANITY_URL`
     /// - `VERIFIED`
     /// - `VIP_REGIONS`
     /// - `WELCOME_SCREEN_ENABLED`
-    /// - `THREE_DAY_THREAD_ARCHIVE`
-    /// - `SEVEN_DAY_THREAD_ARCHIVE`
-    /// - `PRIVATE_THREADS`
-    ///
+    /// - `GUESTS_ENABLED`
+    /// - `ENHANCED_ROLE_COLORS`
     ///
     /// [`discord documentation`]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
     pub features: Vec<String>,

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -36,6 +36,8 @@ pub struct Role {
     /// The colour of the role.
     #[serde(rename = "color")]
     pub colour: Colour,
+    #[serde(rename = "colors")]
+    pub colours: RoleColours,
     /// Indicator of whether the role is pinned above lesser roles.
     ///
     /// In the client, this causes [`Member`]s in the role to be seen above those in roles with a
@@ -74,6 +76,24 @@ pub struct Role {
     pub icon: Option<ImageHash>,
     /// Role unicoded image.
     pub unicode_emoji: Option<String>,
+}
+
+/// The colours of a Discord role, secondary_colour and tertiary_colour may only be set if
+/// the [Guild] has the `ENHANCED_ROLE_COLORS` feature.
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct RoleColours {
+    /// the primary color for the role
+    #[serde(rename = "primary_color")]
+    pub primary_colour: Colour,
+    /// the secondary color for the role, this will make the role a gradient between the other
+    /// provided colors
+    #[serde(rename = "secondary_color")]
+    pub secondary_colour: Option<Colour>,
+    /// the tertiary color for the role, this will turn the gradient into a holographic style
+    #[serde(rename = "tertiary_color")]
+    pub tertiary_colour: Option<Colour>,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -293,8 +293,11 @@ pub struct User {
     ///
     /// Note: just because this guild is populated does not mean the tag is visible.
     pub primary_guild: Option<PrimaryGuild>,
-    /// Data for this user's avatar decoration
+    /// Information about this user's avatar decoration.
     pub avatar_decoration_data: Option<AvatarDecorationData>,
+    /// The collectibles the user currently has active, excluding avatar decorations and profile
+    /// effects.
+    pub collectibles: Option<Collectibles>,
 }
 
 enum_number! {
@@ -407,6 +410,48 @@ impl AvatarDecorationData {
     /// Returns the formatted URL of the decoration.
     pub fn decoration_url(&self) -> String {
         avatar_decoration_url(&self.asset)
+    }
+}
+
+/// The collectibles the user has, excluding Avatar Decorations and Profile Effects.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#collectibles).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Collectibles {
+    /// The [`User`]'s nameplate, if they have one.
+    pub nameplate: Option<Nameplate>,
+}
+
+/// A nameplate, shown on the member list on official clients.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#nameplate-nameplate-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Nameplate {
+    /// Id of the nameplate SKU
+    pub sku_id: SkuId,
+    /// Path to the nameplate asset.
+    pub asset: String,
+    /// The label of this nameplate.
+    pub label: String,
+    /// background color of the nameplate, one of: `crimson`, `berry`, `sky`, `teal`, `forest`,
+    /// `bubble_gum`, `violet`, `cobalt`, `clover`, `lemon`, `white`
+    pub palette: String,
+}
+
+#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+impl Nameplate {
+    /// Gets the static version of the nameplate's url.
+    pub fn static_url(&self) -> String {
+        static_nameplate_url(&self.asset)
+    }
+
+    /// Gets the animated version of the nameplate's url.
+    pub fn url(&self) -> String {
+        nameplate_url(&self.asset)
     }
 }
 
@@ -902,6 +947,17 @@ fn primary_guild_badge_url(guild_id: Option<GuildId>, hash: Option<&ImageHash>) 
 #[cfg(feature = "model")]
 fn avatar_decoration_url(hash: &ImageHash) -> String {
     cdn!("/avatar-decoration-presets/{}.png?size=1024", hash)
+}
+
+#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+fn nameplate_url(path: &str) -> String {
+    cdn!("https://cdn.discordapp.com/assets/collectibles/{}/asset.webm", path)
+}
+
+#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "model")]
+fn static_nameplate_url(path: &str) -> String {
+    cdn!("https://cdn.discordapp.com/assets/collectibles/{}/static.png", path)
 }
 
 #[cfg(test)]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -373,8 +373,8 @@ bitflags! {
 pub struct PrimaryGuild {
     /// the id of the user's primary guild.
     pub identity_guild_id: Option<GuildId>,
-    // whether the user is displaying the primary guild's server tag. This can be null if the
-    // system clears the identity, e.g. because the server no longer supports tags.
+    /// whether the user is displaying the primary guild's server tag. This can be null if the
+    /// system clears the identity, e.g. because the server no longer supports tags.
     pub identity_enabled: Option<bool>,
     /// the text of the [`User`]'s server tag.
     pub tag: Option<String>,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -491,7 +491,7 @@ impl User {
     #[inline]
     #[must_use]
     pub fn banner_url(&self) -> Option<String> {
-        banner_url(self.id, self.banner.as_ref())
+        banner_url(None, self.id, self.banner.as_ref())
     }
 
     /// Creates a direct message channel between the [current user] and the user. This can also
@@ -914,10 +914,18 @@ fn static_avatar_url(user_id: UserId, hash: Option<&ImageHash>) -> Option<String
 }
 
 #[cfg(feature = "model")]
-fn banner_url(user_id: UserId, hash: Option<&ImageHash>) -> Option<String> {
+pub(super) fn banner_url(
+    guild_id: Option<GuildId>,
+    user_id: UserId,
+    hash: Option<&ImageHash>,
+) -> Option<String> {
     hash.map(|hash| {
         let ext = if hash.is_animated() { "gif" } else { "webp" };
-        cdn!("/banners/{}/{}.{}?size=1024", user_id, hash, ext)
+        if let Some(guild_id) = guild_id {
+            cdn!("/guilds/{}/users/{}/banners/{}.{}?size=1024", guild_id, user_id, hash, ext)
+        } else {
+            cdn!("/banners/{}/{}.{}?size=1024", user_id, hash, ext)
+        }
     })
 }
 

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -289,6 +289,12 @@ pub struct User {
     /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields).
     // Box required to avoid infinitely recursive types
     pub member: Option<Box<PartialMember>>,
+    /// The primary guild and tag the user has active.
+    ///
+    /// Note: just because this guild is populated does not mean the tag is visible.
+    pub primary_guild: Option<PrimaryGuild>,
+    /// Data for this user's avatar decoration
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
 }
 
 enum_number! {
@@ -352,6 +358,55 @@ bitflags! {
         const SPAMMER = 1 << 20;
         /// User's flag as active developer
         const ACTIVE_DEVELOPER = 1 << 22;
+    }
+}
+
+/// User's Primary Guild object
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-user-primary-guild)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct PrimaryGuild {
+    /// the id of the user's primary guild.
+    pub identity_guild_id: Option<GuildId>,
+    // whether the user is displaying the primary guild's server tag. This can be null if the
+    // system clears the identity, e.g. because the server no longer supports tags.
+    pub identity_enabled: Option<bool>,
+    /// the text of the [`User`]'s server tag.
+    pub tag: Option<String>,
+    /// the hash of the server badge.
+    pub badge: Option<ImageHash>,
+}
+
+#[cfg(feature = "model")]
+impl PrimaryGuild {
+    #[must_use]
+    /// Returns the formatted URL of the badge's icon, if one exists.
+    pub fn badge_url(&self) -> Option<String> {
+        primary_guild_badge_url(self.identity_guild_id, self.badge.as_ref())
+    }
+}
+
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+/// The data for a [`User`]'s avatar decoration.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#avatar-decoration-data-object).
+pub struct AvatarDecorationData {
+    /// The avatar decoration hash
+    pub asset: ImageHash,
+    /// id of the avatar decoration's SKU
+    pub sku_id: SkuId,
+}
+
+#[cfg(feature = "model")]
+impl AvatarDecorationData {
+    #[must_use]
+    /// Returns the formatted URL of the decoration.
+    pub fn decoration_url(&self) -> String {
+        avatar_decoration_url(&self.asset)
     }
 }
 
@@ -833,6 +888,20 @@ fn tag(name: &str, discriminator: Option<NonZeroU16>) -> String {
         write!(tag, "{discriminator:04}").expect("writing to a string should never fail");
     }
     tag
+}
+
+#[cfg(feature = "model")]
+fn primary_guild_badge_url(guild_id: Option<GuildId>, hash: Option<&ImageHash>) -> Option<String> {
+    if let Some(guild_id) = guild_id {
+        return hash.map(|hash| cdn!("/guild-tag-badges/{}/{}.png?size=1024", guild_id, hash));
+    }
+
+    None
+}
+
+#[cfg(feature = "model")]
+fn avatar_decoration_url(hash: &ImageHash) -> String {
+    cdn!("/avatar-decoration-presets/{}.png?size=1024", hash)
 }
 
 #[cfg(test)]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -445,11 +445,13 @@ pub struct Nameplate {
 #[cfg(all(feature = "unstable_discord_api", feature = "model"))]
 impl Nameplate {
     /// Gets the static version of the nameplate's url.
+    #[must_use]
     pub fn static_url(&self) -> String {
         static_nameplate_url(&self.asset)
     }
 
     /// Gets the animated version of the nameplate's url.
+    #[must_use]
     pub fn url(&self) -> String {
         nameplate_url(&self.asset)
     }


### PR DESCRIPTION
Fixes #3375.

Adds support for the mentioned discord features, 

Copied the guild features from the discord docs, its unclear what other ones exist (i could go digging for them, but its pretty useless because it'll never be non exhaustive and even their list isn't complete)

Derived `Copy` on RoleColours which is fine and it works on avatar decorations too but if discord adds a field its probably best to not have it copy? Let me know what you think and if i should remove this derive.

For some reason Discord didn't add nameplate image formats to the docs for whatever reason, but links said docs, so I peeked at devtools to see what the discord client is doing and found the links. I've left this under unstable though as i don't know if discord will be changing anything later. But given its just links we could probably just remove the feature flag?

Heres a peak at the object:
```json
    "collectibles": {
        "nameplate": {
            "asset": "nameplates/nameplates/cherry_blossoms/",
            "skuId": "1349849614102036581",
            "expiresAt": null,
            "label": "COLLECTIBLES_NAMEPLATES_CHERRY_BLOSSOMS_A11Y",
            "palette": "berry"
        }
    }
```

And the links for example
https://cdn.discordapp.com/assets/collectibles/nameplates/nameplates/cherry_blossoms/asset.webm
https://cdn.discordapp.com/assets/collectibles/nameplates/nameplates/cherry_blossoms/static.png

The test fix I have NO idea what to do, why are we parsing a role from json here?
