### PR TITLE
New minimal dependency for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ uwl = { version = "0.6.0", optional = true }
 levenshtein = { version = "1.0.5", optional = true }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.0.28", optional = true }
-reqwest = { version = "0.11.22", default-features = false, features = ["multipart", "stream"], optional = true }
+reqwest = { version = ">=0.11.22", default-features = false, features = ["multipart", "stream"], optional = true }
 static_assertions = { version = "1.1.0", optional = true }
 tokio-tungstenite = { version = "0.21.0", optional = true }
 typemap_rev = { version = "0.3.0", optional = true }


### PR DESCRIPTION
Reqwest has been released for a while and this crate seems to be fully compatible with both versions. In order to shrink our list of duplicate dependencies downstream I'm PRing this to keep folks from being able to use 0.11 but also jump on 0.12 if that fits their dependencies better.