### PR TITLE
Accept `ImageData` when passing an image for an emoji in `GuildId::create_emoji`

### DIFF
--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -146,6 +146,12 @@ impl<'a> CreateAttachment<'a> {
 pub struct ImageData<'a>(Cow<'a, str>);
 
 impl<'a> ImageData<'a> {
+    /// Accesses the stored base64-encoded image data.
+    #[must_use]
+    pub fn as_base64(&self) -> &str {
+        &self.0
+    }
+
     /// Constructs image data from a base64-encoded blob of data. The string must be a valid data
     /// URI, for example:
     ///

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -22,6 +22,7 @@ use crate::builder::{
     EditRole,
     EditScheduledEvent,
     EditSticker,
+    ImageData,
 };
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, GuildRef};
@@ -360,14 +361,14 @@ impl GuildId {
         self,
         http: &Http,
         name: &str,
-        image: &str,
+        image: ImageData<'_>,
         roles: Option<Vec<RoleId>>,
         reason: Option<&str>,
     ) -> Result<Emoji> {
         #[derive(serde::Serialize)]
         struct CreateEmoji<'a> {
             name: &'a str,
-            image: &'a str,
+            image: ImageData<'a>,
             #[serde(skip_serializing_if = "Option::is_none")]
             roles: Option<Vec<RoleId>>,
         }


### PR DESCRIPTION
Previously, users were able to create the base64-encoded blob of data via `CreateAttachment::to_base64`, which returned a string. On `next`, this method had been replaced by `encode`, which returns an `ImageData` instead.

It is still the base64-encoded blob of data as before, but users were no longer able to access it directly. This wasn't too much of a problem, as many places that accepted a plain string switched to expecting `ImageData`. So for users, nothing practically has changed. _Except_ `GuildId::create_emoji`, which still wanted a string, yet users couldn't reuse any `ImageData` they might have already had.

This rectifies the issue by not only switching `image: &str` to `image: ImageData` in `GuildId::create_emoji`, but also adding an accessor method for the blob of data in `ImageData`.
