### PR TITLE
Adjust SecretString docs to match implementation

### DIFF
--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -8,8 +8,8 @@ use aformat::{CapStr, aformat};
 
 /// A cheaply clonable, zeroed on drop, String.
 ///
-/// This is a simple newtype of `Arc<str>` that uses [`zeroize::Zeroize`] on last drop to avoid
-/// keeping it around in memory.
+/// This is a simple newtype of `Arc<str>` that does not reveal its
+/// content in its [`Debug`](std::fmt::Debug) output.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct SecretString(Arc<str>);
 


### PR DESCRIPTION
`SecretString` claims it zeroizes its content on last drop. This isn't currently the case and implementing that is around an `Arc<str>` is impractical -- requiring unsafe or further indirection -- and likely wouldn't be useful in reality.

This PR instead adjusts its documentation to simply state it does not reveal the content in its `Debug` output.