### PR TITLE
Add method for obtaining the guild id of a `Channel`

### DIFF
--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -189,6 +189,15 @@ impl Channel {
             Self::Private(ch) => ch.id.widen(),
         }
     }
+
+    /// If this is a guild channel or guild thread, returns the corresponding guild's Id.
+    pub fn guild_id(&self) -> Option<GuildId> {
+        match self {
+            Channel::GuildThread(thread) => Some(thread.base.guild_id),
+            Channel::Guild(channel) => Some(channel.base.guild_id),
+            Channel::Private(_) => None,
+        }
+    }
 }
 
 fn extract_type<'de, D>(deserializer: D) -> StdResult<(u64, &'de RawValue), D::Error>


### PR DESCRIPTION
Since `Channel` is non-exhaustive, then it's not easily possible for users to match against both the `Guild` and `GuildThread` variants to extract the id of the guild which contains said channel. This helper method allows this use-case.