### PR TITLE
add `len` and `is_empty` methods to v2 components

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -134,6 +134,16 @@ impl<'a> CreateSection<'a> {
         }
     }
 
+    /// Returns the number of top level components in the section.
+    pub fn len(&self) -> usize {
+        self.components.len()
+    }
+
+    /// Returns `true` if the section contains no components.
+    pub fn is_empty(&self) -> bool {
+        self.components.is_empty()
+    }
+
     /// Sets the components for the section. Replaces the current value as set in [`Self::new`].
     ///
     /// **Note**: This will replace all existing components. Use [`Self::add_component()`] to add
@@ -482,6 +492,17 @@ impl<'a> CreateContainer<'a> {
         self.spoiler = Some(spoiler);
         self
     }
+
+    /// Returns the number of top level components in the container.
+    pub fn len(&self) -> usize {
+        self.components.len()
+    }
+
+    /// Returns `true` if the container contains no components.
+    pub fn is_empty(&self) -> bool {
+        self.components.is_empty()
+    }
+
 
     /// Sets the components of this container. Replaces the current value as set in [`Self::new`].
     ///


### PR DESCRIPTION
I'm working with a v2 component message that's built dynamically based on user inputs. It would be helpful to have a way to check the total number of components within a message to avoid hitting the 40-component limit.

I'm not sure what the standard approach is for this kind of access, so I'm open to feedback or alternative suggestions. Primarily looking for a lightweight way to introspect the current state of a component message.