### PR TITLE
Add `get_user_voice_state` endpoint

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4111,13 +4111,17 @@ impl Http {
         guild_id: GuildId,
         user_id: UserId,
     ) -> Result<VoiceState> {
-        self.fire::<VoiceState>(Request::new(
-            Route::GuildVoiceStates {
+        self.fire(Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Get,
+            route: Route::GuildVoiceStates {
                 guild_id,
                 user_id,
             },
-            LightMethod::Get,
-        ))
+            params: None
+        })
         .await
     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4104,6 +4104,23 @@ impl Http {
         .await
     }
 
+    /// Get User Voice State
+    /// Returns the specified user's voice state in the guild.
+    pub async fn get_user_voice_state(
+        &self,
+        guild_id: GuildId,
+        user_id: UserId,
+    ) -> Result<VoiceState> {
+        self.fire::<VoiceState>(Request::new(
+            Route::GuildVoiceStates {
+                guild_id,
+                user_id,
+            },
+            LightMethod::Get,
+        ))
+        .await
+    }
+
     /// Retrieves a webhook given its Id.
     ///
     /// This method requires authentication, whereas [`Http::get_webhook_with_token`] and

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1149,6 +1149,15 @@ impl GuildId {
         MembersIter::stream(http, self)
     }
 
+    /// Gets a user's voice state in this guild.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the user is not in a voice channel in this guild.
+    pub async fn get_user_voice_state(self, http: &Http, user_id: UserId) -> Result<VoiceState> {
+        http.get_user_voice_state(self, user_id).await
+    }
+
     /// Moves a member to a specific voice channel.
     ///
     /// **Note**: Requires the [Move Members] permission.


### PR DESCRIPTION
Noticed this endpoint was missing - https://discord.com/developers/docs/resources/voice#get-user-voice-state

I don't know if there is any standard on where methods are placed, so do let me know if you'd rather it be placed somewhere else.