### PR TITLE
Remove duplicate items from `Guild.features`' documentation

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -155,7 +155,7 @@ pub struct Guild {
     #[serde(with = "emojis")]
     pub emojis: HashMap<EmojiId, Emoji>,
     /// The guild features. These are user-invisible options which are used for Discord rollouts
-    /// and/or paid benefits. More information is available in [`discord's documentation`].
+    /// and/or paid benefits. More information is available at [`discord's documentation`].
     ///
     /// [`discord's documentation`]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
     pub features: Vec<String>,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -179,9 +179,6 @@ pub struct Guild {
     /// - `VERIFIED`
     /// - `VIP_REGIONS`
     /// - `WELCOME_SCREEN_ENABLED`
-    /// - `THREE_DAY_THREAD_ARCHIVE`
-    /// - `SEVEN_DAY_THREAD_ARCHIVE`
-    /// - `PRIVATE_THREADS`
     ///
     ///
     /// [`discord documentation`]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -154,34 +154,10 @@ pub struct Guild {
     /// All of the guild's custom emojis.
     #[serde(with = "emojis")]
     pub emojis: HashMap<EmojiId, Emoji>,
-    /// The guild features. More information available at [`discord documentation`].
+    /// The guild features. These are user-invisible options which are used for Discord rollouts
+    /// and/or paid benefits. More information is available in [`discord's documentation`].
     ///
-    /// The following is a list of known features:
-    /// - `ANIMATED_ICON`
-    /// - `BANNER`
-    /// - `COMMERCE`
-    /// - `COMMUNITY`
-    /// - `DISCOVERABLE`
-    /// - `FEATURABLE`
-    /// - `INVITE_SPLASH`
-    /// - `MEMBER_VERIFICATION_GATE_ENABLED`
-    /// - `MONETIZATION_ENABLED`
-    /// - `MORE_STICKERS`
-    /// - `NEWS`
-    /// - `PARTNERED`
-    /// - `PREVIEW_ENABLED`
-    /// - `PRIVATE_THREADS`
-    /// - `ROLE_ICONS`
-    /// - `SEVEN_DAY_THREAD_ARCHIVE`
-    /// - `THREE_DAY_THREAD_ARCHIVE`
-    /// - `TICKETED_EVENTS_ENABLED`
-    /// - `VANITY_URL`
-    /// - `VERIFIED`
-    /// - `VIP_REGIONS`
-    /// - `WELCOME_SCREEN_ENABLED`
-    ///
-    ///
-    /// [`discord documentation`]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
+    /// [`discord's documentation`]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
     pub features: Vec<String>,
     /// Indicator of whether the guild requires multi-factor authentication for [`Role`]s or
     /// [`User`]s with moderation permissions.


### PR DESCRIPTION
Hi! There really isn't much to this PR - it's just a documentation fix.

Specifically, in `serenity::model::guild::Guild`, the documentation for `Guild.features` featured a list of guild features - including three list items that were duplicates of previous items. This PR removes those three duplicates.