### PR TITLE
Implement Pin Permission Split and Paginated Pin Endpoints

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3924,7 +3924,25 @@ impl Http {
     }
 
     /// Gets all pins of a channel.
-    pub async fn get_pins(&self, channel_id: GenericChannelId) -> Result<Vec<Message>> {
+    pub async fn get_pins(
+        &self,
+        channel_id: GenericChannelId,
+        before: Option<Timestamp>,
+        limit: Option<u8>,
+    ) -> Result<MessagePinsPage> {
+        let (before_str, limit_str);
+        let mut params = ArrayVec::<_, 2>::new();
+
+        if let Some(before) = before {
+            before_str = before.to_string();
+            params.push(("before", before_str.as_str()));
+        }
+
+        if let Some(limit) = limit {
+            limit_str = limit.to_arraystring();
+            params.push(("limit", limit_str.as_str()));
+        }
+
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3933,7 +3951,7 @@ impl Http {
             route: Route::ChannelPins {
                 channel_id,
             },
-            params: None,
+            params: Some(&params),
         })
         .await
     }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -138,11 +138,11 @@ routes! ('a, {
     Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelPin { channel_id: GenericChannelId, message_id: MessageId },
-    api!("/channels/{}/pins/{}", channel_id, message_id),
+    api!("/channels/{}/messages/pins/{}", channel_id, message_id),
     Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelPins { channel_id: GenericChannelId },
-    api!("/channels/{}/pins", channel_id),
+    api!("/channels/{}/messages/pins", channel_id),
     Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
 
     ChannelTyping { channel_id: GenericChannelId },

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -786,14 +786,14 @@ impl GenericChannelId {
 
     /// Pins a [`Message`] to the channel.
     ///
-    /// **Note**: Requires the [Manage Messages] permission.
+    /// **Note**: Requires the [Pin Messages] permission.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission, or if the channel has too
     /// many pinned messages.
     ///
-    /// [Manage Messages]: Permissions::MANAGE_MESSAGES
+    /// [Pin Messages]: Permissions::PIN_MESSAGES
     pub async fn pin(self, http: &Http, message_id: MessageId, reason: Option<&str>) -> Result<()> {
         http.pin_message(self, message_id, reason).await
     }
@@ -811,15 +811,20 @@ impl GenericChannelId {
     /// Returns [`Error::Http`] if the current user lacks permission to view the channel.
     ///
     /// [Read Message History]: Permissions::READ_MESSAGE_HISTORY
-    pub async fn pins(self, cache_http: impl CacheHttp) -> Result<Vec<Message>> {
-        let messages = cache_http.http().get_pins(self).await?;
+    pub async fn pins(
+        self,
+        cache_http: impl CacheHttp,
+        before: Option<Timestamp>,
+        limit: Option<u8>,
+    ) -> Result<MessagePinsPage> {
+        let page = cache_http.http().get_pins(self, before, limit).await?;
 
         #[cfg(feature = "cache")]
         if let Some(cache) = cache_http.cache() {
-            cache.fill_message_cache(self, messages.iter().cloned());
+            cache.fill_message_cache(self, page.items.iter().map(|m| m.message.clone()));
         }
 
-        Ok(messages)
+        Ok(page)
     }
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a certain [`Emoji`].
@@ -1001,13 +1006,13 @@ impl GenericChannelId {
 
     /// Unpins a [`Message`] in the channel given by its Id.
     ///
-    /// Requires the [Manage Messages] permission.
+    /// Requires the [Pin Messages] permission.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
-    /// [Manage Messages]: Permissions::MANAGE_MESSAGES
+    /// [Pin Messages]: Permissions::PIN_MESSAGES
     pub async fn unpin(
         self,
         http: &Http,

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -448,13 +448,13 @@ impl Message {
 
     /// Pins this message to its channel.
     ///
-    /// **Note**: Requires the [Manage Messages] permission.
+    /// **Note**: Requires the [Pin Messages] permission.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
-    /// [Manage Messages]: Permissions::MANAGE_MESSAGES
+    /// [Pin Messages]: Permissions::PIN_MESSAGES
     pub async fn pin(&self, http: &Http, reason: Option<&str>) -> Result<()> {
         self.channel_id.pin(http, self.id, reason).await
     }
@@ -546,13 +546,13 @@ impl Message {
 
     /// Unpins the message from its channel.
     ///
-    /// **Note**: Requires the [Manage Messages] permission.
+    /// **Note**: Requires the [Pin Messages] permission.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
-    /// [Manage Messages]: Permissions::MANAGE_MESSAGES
+    /// [Pin Messages]: Permissions::PIN_MESSAGES
     pub async fn unpin(&self, http: &Http, reason: Option<&str>) -> Result<()> {
         http.unpin_message(self.channel_id, self.id, reason).await
     }
@@ -1169,6 +1169,28 @@ pub struct PollAnswerCount {
     pub id: AnswerId,
     pub count: u64,
     pub me_voted: bool,
+}
+
+/// A pinned message returned as part of a paginated Get Channel Pins query.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/message#message-pin-object)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct MessagePin {
+    pub pinned_at: Timestamp,
+    pub message: Message,
+}
+
+/// The response data for a paginated Get Channel Pins query.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/message#get-channel-pins)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct MessagePinsPage {
+    pub items: Vec<MessagePin>,
+    pub has_more: bool,
 }
 
 // all tests here require cache, move if non-cache test is added

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -403,7 +403,9 @@ generate_permissions! {
     /// Allows attaching polls to message sends.
     SEND_POLLS, send_polls, "Send Polls" = 1 << 49;
     /// Allows user-installed apps to send public responses.
-    USE_EXTERNAL_APPS, use_external_apps, "Use External Apps" = 1 << 50
+    USE_EXTERNAL_APPS, use_external_apps, "Use External Apps" = 1 << 50;
+    /// Allows pinning and unpinning messages.
+    PIN_MESSAGES, pin_messages, "Pin Messages" = 1 << 51
 }
 
 #[cfg(feature = "model")]
@@ -428,6 +430,7 @@ impl Permissions {
             | Self::SEND_VOICE_MESSAGES
             | Self::SEND_POLLS
             | Self::USE_EXTERNAL_APPS
+            | Self::PIN_MESSAGES
     }
 }
 


### PR DESCRIPTION
Adds the Pin Messages permission, adjusts documentation regarding that.
Changes the client to use the new pin endpoints, including adjustments for paginated Get Channel Pins.

https://discord.com/developers/docs/change-log#pin-permission-split https://discord.com/developers/docs/change-log#paginated-pin-endpoints