### PR TITLE
Handle query parameters for webhook requests

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4642,6 +4642,11 @@ impl Http {
         let url = Url::parse(url).map_err(HttpError::Url)?;
         let (webhook_id, token) =
             crate::utils::parse_webhook(&url).ok_or(HttpError::InvalidWebhook)?;
+        let mut params = url.query_pairs().collect::<Vec<(&str, String)>>();
+        let params = match params.len() {
+            0 => None,
+            _ => Some(params),
+        };
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4651,7 +4656,7 @@ impl Http {
                 webhook_id,
                 token,
             },
-            params: None,
+            params,
         })
         .await
     }


### PR DESCRIPTION
This pull request updates how query parameters are handled when sending webhook requests in the `Http` client. The main change is that query parameters from the URL are now parsed and passed along with the request, rather than always being set to `None`.

Improvements to webhook request handling:

* Query parameters from the URL are now parsed using `url.query_pairs()`, collected into a vector, and passed to the request if present, otherwise set to `None` (`src/http/client.rs`).
* The `params` field in the `Request` struct is now set to the parsed query parameters instead of always being `None` (`src/http/client.rs`).