### PR TITLE
Fix documentation for Guild::preferred_locale

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -188,7 +188,7 @@ pub struct Guild {
     pub premium_tier: PremiumTier,
     /// The total number of users currently boosting this server.
     pub premium_subscription_count: Option<u64>,
-    /// The preferred locale of this guild only set if guild has the "DISCOVERABLE" feature,
+    /// The preferred locale of this guild only set if guild has the "COMMUNITY" feature,
     /// defaults to en-US.
     pub preferred_locale: String,
     /// The id of the channel where admins and moderators of Community guilds receive notices from

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -147,7 +147,7 @@ pub struct PartialGuild {
     pub premium_tier: PremiumTier,
     /// The total number of users currently boosting this server.
     pub premium_subscription_count: Option<u64>,
-    /// The preferred locale of this guild only set if guild has the "DISCOVERABLE" feature,
+    /// The preferred locale of this guild only set if guild has the "COMMUNITY" feature,
     /// defaults to en-US.
     pub preferred_locale: String,
     /// The id of the channel where admins and moderators of Community guilds receive notices from


### PR DESCRIPTION
## Summary
- Fixed incorrect documentation that stated `preferred_locale` is only available for guilds with the "DISCOVERABLE" feature
- Updated to correctly state it's available for guilds with the "COMMUNITY" feature

## Details
The `preferred_locale` field in both `Guild` and `PartialGuild` structs had incorrect documentation. According to Discord's documentation and user reports, this field is available for all guilds with the COMMUNITY feature enabled, not just DISCOVERABLE guilds.

Fixes #3363

## Test Plan
- [x] Documentation builds successfully
- [x] No functional changes, only documentation updates