### PR TITLE
Refactor CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
           - builder without model
           - unstable + typesize
           - unstable (no default features)
+          - temp cache
+          - temp cache + typesize
 
         include:
           - name: builder without model
@@ -96,6 +98,10 @@ jobs:
             features: default unstable typesize
           - name: unstable (no default features)
             features: unstable
+          - name: temp cache
+            features: default temp_cache
+          - name: temp cache + typesize
+            features: default temp_cache typesize
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,14 @@ jobs:
         name:
           - stable
           - beta
-          # The build matrix doesn't support the `env` variable in expressions
-          # see: jobs.nightly
-          # - nightly
+          - nightly
           - Windows
+          - macOS
           - native-tls
           - no default features
           - no cache
           - no gateway
-          - unstable Discord API features
+          - chrono
           - zlib compression
           - zstd compression
           - zlib and zstd compression
@@ -33,8 +32,12 @@ jobs:
         include:
           - name: beta
             toolchain: beta
+          - name: nightly
+            toolchain: nightly
           - name: Windows
             os: windows-latest
+          - name: macOS
+            os: macos-latest
           - name: native-tls
             features: default_native_tls
           - name: no default features
@@ -45,15 +48,6 @@ jobs:
             features: model rustls_backend
           - name: chrono
             features: chrono
-          - name: unstable API + typesize
-            features: default unstable typesize
-            dont-test: true
-          - name: builder without model
-            features: builder
-            dont-test: true
-          - name: unstable Discord API (no default features)
-            features: unstable
-            dont-test: true
           - name: zlib compression
             features: default transport_compression_zlib
           - name: zstd compression
@@ -68,60 +62,40 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.toolchain || 'stable' }}
+          toolchain: ${{
+              (matrix.toolchain == 'nightly' && env.rust_nightly)
+                || matrix.toolchain
+                || 'stable'
+            }}
 
       - name: Add problem matchers
-        shell: bash
         run: echo "::add-matcher::.github/matchers/rust.json"
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Build all features
-        if: matrix.features == ''
-        run: cargo build --features full
+      - name: Run tests
+        run: cargo test --no-default-features --features "${{ matrix.features || 'full' }}"
 
-      - name: Test all features
-        if: matrix.features == ''
-        run: cargo test --features full
-
-      - name: Build some features
-        if: matrix.features
-        run: cargo build --no-default-features --features "${{ matrix.features }}"
-
-      - name: Test some features
-        if: ${{ !matrix.dont-test && matrix.features }}
-        run: cargo test --no-default-features --features "${{ matrix.features }}"
-
-  nightly:
-    name: Test (nightly)
+  check:
+    name: Check
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+          - builder without model
+          - unstable + typesize
+          - unstable (no default features)
 
-      - name: Install toolchain (${{ env.rust_nightly }})
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.rust_nightly }}
-
-      - name: Add problem matchers
-        shell: bash
-        run: echo "::add-matcher::.github/matchers/rust.json"
-
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build all features
-        run: cargo build --features full
-
-      - name: Test all features
-        run: cargo test --features full
-
-  macOS:
-    name: Test (macOS)
-    runs-on: macos-latest
+        include:
+          - name: builder without model
+            features: builder
+          - name: unstable + typesize
+            features: default unstable typesize
+          - name: unstable (no default features)
+            features: unstable
 
     steps:
       - name: Checkout sources
@@ -131,24 +105,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Add problem matchers
-        shell: bash
         run: echo "::add-matcher::.github/matchers/rust.json"
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Build
-        run: cargo build
-
-      - name: Test
-        run: cargo test
+      - name: Run checks
+        run: cargo check --no-default-features --features "${{ matrix.features || 'full' }}"
 
   MSRV:
     runs-on: ubuntu-latest
 
     # We only run this job on the current branch as keeping MSRV the same is not important on next.
     if: (github.event_name == 'push' && github.ref_name == 'current') ||
-        (github.event_name == 'pull_request' && github.base_ref == 'current') 
+        (github.event_name == 'pull_request' && github.base_ref == 'current')
 
     steps:
       - name: Checkout sources
@@ -165,7 +135,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Check
+      - name: Run checks
         run: cargo check --features full
 
   min_versions:
@@ -200,10 +170,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install toolchain (${{ env.rust_nightly }})
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.rust_nightly }}
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Add problem matchers
         run: echo "::add-matcher::.github/matchers/rust.json"
@@ -214,8 +182,6 @@ jobs:
       - name: Build docs
         run: |
           cargo doc --no-deps --features full,unstable
-        env:
-          RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
 
   examples:
     name: Examples
@@ -266,3 +232,5 @@ jobs:
         run: cargo check -p e15_webhook
       - name: 'Check example 16'
         run: cargo check -p e16_interactions_endpoint
+      - name: 'Check testing example'
+        run: cargo check -p testing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ chrono = ["dep:chrono", "typesize?/chrono"]
 full = ["default", "collector", "voice", "voice_model", "interactions_endpoint"]
 
 # Enables temporary caching in functions that retrieve data via the HTTP API.
-temp_cache = ["cache", "mini-moka", "typesize?/mini_moka"]
+temp_cache = ["cache", "mini-moka", "typesize?/mini_moka", "typesize?/dashmap"]
 
 typesize = ["dep:typesize", "dashmap/typesize", "small-fixed-array/typesize", "bool_to_bitflags/typesize", "extract_map/typesize"]
 

--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -123,7 +123,7 @@ pub(crate) struct MaybeOwnedArc<T>(
 #[cfg(feature = "temp_cache")]
 impl<T> MaybeOwnedArc<T> {
     pub(crate) fn new(inner: T) -> Self {
-        Self(Arc::new(inner))
+        Self(Arc::new(inner).into())
     }
 
     pub(crate) fn get_inner(self) -> Arc<T> {
@@ -142,8 +142,10 @@ impl<T: typesize::TypeSize> typesize::TypeSize for MaybeOwnedArc<T> {
         self.0.extra_size()
     }
 
-    fn get_collection_item_count(&self) -> Option<usize> {
-        self.0.get_collection_item_count()
+    typesize::if_typesize_details! {
+        fn get_collection_item_count(&self) -> Option<usize> {
+            self.0.get_collection_item_count()
+        }
     }
 }
 
@@ -159,6 +161,6 @@ impl<T> std::ops::Deref for MaybeOwnedArc<T> {
 #[cfg(feature = "temp_cache")]
 impl<T> Clone for MaybeOwnedArc<T> {
     fn clone(&self) -> Self {
-        Self(Arc::clone(&self.0))
+        Self(self.0.clone().into())
     }
 }


### PR DESCRIPTION
This improves the ergonomics of the CI workflows and cuts down on CI runtime by adding a new `check` job for feature flags which only need to be tested using `cargo check` rather than `cargo test`. I removed the dedicated `nightly` job by including it in the `test` job.

Also added `temp_cache` to the list of features to check; for some reason it wasn't included in CI before.