### PR TITLE
Switch `fxhash` dependency with `rustc-hash`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ secrecy = { version = "0.8.0", features = ["serde"] }
 arrayvec = { version = "0.7.4", features = ["serde"] }
 serde_cow = { version = "0.1.0" }
 # Optional dependencies
-fxhash = { version = "0.2.1", optional = true }
+rustc-hash = { version = "2.1.1", optional = true }
 simd-json = { version = "0.13.4", optional = true }
 uwl = { version = "0.6.0", optional = true }
 levenshtein = { version = "1.0.5", optional = true }
@@ -93,7 +93,7 @@ default_no_backend = [
 builder = []
 # Enables the cache, which stores the data received from Discord gateway to provide access to
 # complete guild data, channels, users and more without needing HTTP requests.
-cache = ["fxhash", "dashmap", "parking_lot"]
+cache = ["rustc-hash", "dashmap", "parking_lot"]
 # Enables collectors, a utility feature that lets you await interaction events in code with
 # zero setup, without needing to setup an InteractionCreate event listener.
 collector = ["gateway", "model"]

--- a/src/cache/wrappers.rs
+++ b/src/cache/wrappers.rs
@@ -81,7 +81,7 @@ impl<K: Eq + Hash, V> ReadOnlyMapRef<'_, K, V> {
         self.0.map_or(0, DashMap::len)
     }
 }
-pub struct Hasher(fxhash::FxHasher);
+pub struct Hasher(rustc_hash::FxHasher);
 impl std::hash::Hasher for Hasher {
     fn finish(&self) -> u64 {
         self.0.finish()
@@ -92,7 +92,7 @@ impl std::hash::Hasher for Hasher {
     }
 }
 #[derive(Clone, Default)]
-pub struct BuildHasher(fxhash::FxBuildHasher);
+pub struct BuildHasher(rustc_hash::FxBuildHasher);
 impl std::hash::BuildHasher for BuildHasher {
     type Hasher = Hasher;
 


### PR DESCRIPTION
`fxhash` has, for several years, been unmaintained. `rustc-hash` is an alternative offered by the Rust organisation. 

Fixes https://github.com/serenity-rs/serenity/issues/3420