### PR TITLE
Add support for guild tags, avatar decorations, and nameplates

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -229,8 +229,9 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     avatar: self.avatar,
                     banner: self.banner,
                     communication_disabled_until: self.communication_disabled_until,
-                    flags: GuildMemberFlags::default(),
+                    flags: self.flags.unwrap_or_default(),
                     unusual_dm_activity_until: self.unusual_dm_activity_until,
+                    avatar_decoration_data: self.avatar_decoration_data,
                 });
             }
 
@@ -466,6 +467,7 @@ impl CacheUpdate for PresenceUpdateEvent {
                         communication_disabled_until: None,
                         flags: GuildMemberFlags::default(),
                         unusual_dm_activity_until: None,
+                        avatar_decoration_data: None,
                     });
                 }
             }

--- a/src/gateway/bridge/shard_queuer.rs
+++ b/src/gateway/bridge/shard_queuer.rs
@@ -200,7 +200,7 @@ impl ShardQueuer {
         };
 
         spawn_named("shard_queuer::stop", async move {
-            drop(runner.run().await);
+            drop(Box::pin(runner.run()).await);
             debug!("[ShardRunner {:?}] Stopping", runner.shard.shard_info());
         });
 

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -481,6 +481,7 @@ pub struct MessageModalSubmitInteractionMetadata {
 
 /// Metadata about the interaction, including the source of the interaction relevant server and
 /// user IDs.
+#[allow(clippy::large_enum_variant)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -262,7 +262,10 @@ pub struct GuildMemberUpdateEvent {
     pub avatar: Option<ImageHash>,
     pub banner: Option<ImageHash>,
     pub communication_disabled_until: Option<Timestamp>,
+    // This is not documented but present on the event?
     pub unusual_dm_activity_until: Option<Timestamp>,
+    pub flags: Option<GuildMemberFlags>,
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
 }
 
 /// Requires no gateway intents.

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -282,6 +282,7 @@ impl PresenceUser {
             premium_type: PremiumType::None,
             primary_guild: None,
             avatar_decoration_data: None,
+            collectibles: None,
         })
     }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -280,6 +280,8 @@ impl PresenceUser {
             email: self.email,
             flags: self.public_flags.unwrap_or_default(),
             premium_type: PremiumType::None,
+            primary_guild: None,
+            avatar_decoration_data: None,
         })
     }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -244,16 +244,35 @@ pub struct ClientStatus {
 #[non_exhaustive]
 pub struct PresenceUser {
     pub id: UserId,
-    pub avatar: Option<ImageHash>,
-    pub bot: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator")]
-    pub discriminator: Option<NonZeroU16>,
-    pub email: Option<String>,
-    pub mfa_enabled: Option<bool>,
     #[serde(rename = "username")]
     pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator")]
+    pub discriminator: Option<NonZeroU16>,
+    pub global_name: Option<String>,
+    pub avatar: Option<ImageHash>,
+    #[serde(default)]
+    pub bot: Option<bool>,
+    #[serde(default)]
+    pub system: Option<bool>,
+    #[serde(default)]
+    pub mfa_enabled: Option<bool>,
+    pub banner: Option<ImageHash>,
+    #[serde(rename = "accent_color")]
+    pub accent_colour: Option<Colour>,
+    pub locale: Option<String>,
     pub verified: Option<bool>,
+    pub email: Option<String>,
+    #[serde(default)]
+    pub flags: Option<UserPublicFlags>,
+    #[serde(default)]
+    pub premium_type: Option<PremiumType>,
     pub public_flags: Option<UserPublicFlags>,
+    pub member: Option<Box<PartialMember>>,
+    pub primary_guild: Option<PrimaryGuild>,
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
+    pub collectibles: Option<Collectibles>,
+    // system is ommitted because it'll never be true
+    // TODO: should really go over these fields at some point and check them.
 }
 
 impl PresenceUser {
@@ -266,23 +285,23 @@ impl PresenceUser {
             avatar: self.avatar,
             bot: self.bot?,
             discriminator: self.discriminator,
-            global_name: None,
+            global_name: self.global_name,
             id: self.id,
             name: self.name?,
             public_flags: self.public_flags,
-            banner: None,
-            accent_colour: None,
-            member: None,
+            banner: self.banner,
+            accent_colour: self.accent_colour,
+            member: self.member,
             system: false,
             mfa_enabled: self.mfa_enabled.unwrap_or_default(),
-            locale: None,
+            locale: self.locale,
             verified: self.verified,
             email: self.email,
             flags: self.public_flags.unwrap_or_default(),
-            premium_type: PremiumType::None,
-            primary_guild: None,
-            avatar_decoration_data: None,
-            collectibles: None,
+            premium_type: self.premium_type.unwrap_or_default(),
+            primary_guild: self.primary_guild,
+            avatar_decoration_data: self.avatar_decoration_data,
+            collectibles: self.collectibles,
         })
     }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -271,7 +271,6 @@ pub struct PresenceUser {
     pub primary_guild: Option<PrimaryGuild>,
     pub avatar_decoration_data: Option<AvatarDecorationData>,
     pub collectibles: Option<Collectibles>,
-    // system is ommitted because it'll never be true
     // TODO: should really go over these fields at some point and check them.
 }
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -66,6 +66,8 @@ pub struct Member {
     ///
     /// Will be None or a time in the past if the user is not flagged.
     pub unusual_dm_activity_until: Option<Timestamp>,
+    /// Information about this member's guild specific avatar decoration.
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
 }
 
 bitflags! {
@@ -623,6 +625,8 @@ pub struct PartialMember {
     pub avatar: Option<ImageHash>,
     /// The member's guild banner hash
     pub banner: Option<ImageHash>,
+    /// Information about this member's avatar decoration.
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
 }
 
 impl From<PartialMember> for Member {
@@ -643,6 +647,7 @@ impl From<PartialMember> for Member {
             communication_disabled_until: None,
             guild_id: partial.guild_id.unwrap_or_default(),
             unusual_dm_activity_until: partial.unusual_dm_activity_until,
+            avatar_decoration_data: partial.avatar_decoration_data,
         }
     }
 }
@@ -663,6 +668,7 @@ impl From<Member> for PartialMember {
             unusual_dm_activity_until: member.unusual_dm_activity_until,
             avatar: member.avatar,
             banner: member.banner,
+            avatar_decoration_data: member.avatar_decoration_data,
         }
     }
 }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -293,8 +293,11 @@ pub struct User {
     ///
     /// Note: just because this guild is populated does not mean the tag is visible.
     pub primary_guild: Option<PrimaryGuild>,
-    /// Data for this user's avatar decoration
+    /// Information about this user's avatar decoration.
     pub avatar_decoration_data: Option<AvatarDecorationData>,
+    /// The collectibles the user currently has active, excluding avatar decorations and profile
+    /// effects.
+    pub collectibles: Option<Collectibles>,
 }
 
 enum_number! {
@@ -407,6 +410,48 @@ impl AvatarDecorationData {
     /// Returns the formatted URL of the decoration.
     pub fn decoration_url(&self) -> String {
         avatar_decoration_url(&self.asset)
+    }
+}
+
+/// The collectibles the user has, excluding Avatar Decorations and Profile Effects.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#collectibles).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Collectibles {
+    /// The [`User`]'s nameplate, if they have one.
+    pub nameplate: Option<Nameplate>,
+}
+
+/// A nameplate, shown on the member list on official clients.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#nameplate-nameplate-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Nameplate {
+    /// Id of the nameplate SKU
+    pub sku_id: SkuId,
+    /// Path to the nameplate asset.
+    pub asset: String,
+    /// The label of this nameplate.
+    pub label: String,
+    /// background color of the nameplate, one of: `crimson`, `berry`, `sky`, `teal`, `forest`,
+    /// `bubble_gum`, `violet`, `cobalt`, `clover`, `lemon`, `white`
+    pub palette: String,
+}
+
+#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+impl Nameplate {
+    /// Gets the static version of the nameplate's url.
+    pub fn static_url(&self) -> String {
+        static_nameplate_url(&self.asset)
+    }
+
+    /// Gets the animated version of the nameplate's url.
+    pub fn url(&self) -> String {
+        nameplate_url(&self.asset)
     }
 }
 
@@ -891,6 +936,17 @@ fn primary_guild_badge_url(guild_id: Option<GuildId>, hash: Option<&ImageHash>) 
 #[cfg(feature = "model")]
 fn avatar_decoration_url(hash: &ImageHash) -> String {
     cdn!("/avatar-decoration-presets/{}.png?size=1024", hash)
+}
+
+#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+fn nameplate_url(path: &str) -> String {
+    cdn!("https://cdn.discordapp.com/assets/collectibles/{}/asset.webm", path)
+}
+
+#[cfg(all(feature = "unstable_discord_api", feature = "model"))]
+#[cfg(feature = "model")]
+fn static_nameplate_url(path: &str) -> String {
+    cdn!("https://cdn.discordapp.com/assets/collectibles/{}/static.png", path)
 }
 
 #[cfg(test)]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -289,6 +289,12 @@ pub struct User {
     /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields).
     // Box required to avoid infinitely recursive types
     pub member: Option<Box<PartialMember>>,
+    /// The primary guild and tag the user has active.
+    ///
+    /// Note: just because this guild is populated does not mean the tag is visible.
+    pub primary_guild: Option<PrimaryGuild>,
+    /// Data for this user's avatar decoration
+    pub avatar_decoration_data: Option<AvatarDecorationData>,
 }
 
 enum_number! {
@@ -352,6 +358,55 @@ bitflags! {
         const SPAMMER = 1 << 20;
         /// User's flag as active developer
         const ACTIVE_DEVELOPER = 1 << 22;
+    }
+}
+
+/// User's Primary Guild object
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-user-primary-guild)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct PrimaryGuild {
+    /// the id of the user's primary guild.
+    pub identity_guild_id: Option<GuildId>,
+    // whether the user is displaying the primary guild's server tag. This can be null if the
+    // system clears the identity, e.g. because the server no longer supports tags.
+    pub identity_enabled: Option<bool>,
+    /// the text of the [`User`]'s server tag.
+    pub tag: Option<String>,
+    /// the hash of the server badge.
+    pub badge: Option<ImageHash>,
+}
+
+#[cfg(feature = "model")]
+impl PrimaryGuild {
+    #[must_use]
+    /// Returns the formatted URL of the badge's icon, if one exists.
+    pub fn badge_url(&self) -> Option<String> {
+        primary_guild_badge_url(self.identity_guild_id, self.badge.as_ref())
+    }
+}
+
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+/// The data for a [`User`]'s avatar decoration.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/user#avatar-decoration-data-object).
+pub struct AvatarDecorationData {
+    /// The avatar decoration hash
+    pub asset: ImageHash,
+    /// id of the avatar decoration's SKU
+    pub sku_id: SkuId,
+}
+
+#[cfg(feature = "model")]
+impl AvatarDecorationData {
+    #[must_use]
+    /// Returns the formatted URL of the decoration.
+    pub fn decoration_url(&self) -> String {
+        avatar_decoration_url(&self.asset)
     }
 }
 
@@ -822,6 +877,20 @@ fn tag(name: &str, discriminator: Option<NonZeroU16>) -> String {
         write!(tag, "{discriminator:04}").expect("writing to a string should never fail");
     }
     tag
+}
+
+#[cfg(feature = "model")]
+fn primary_guild_badge_url(guild_id: Option<GuildId>, hash: Option<&ImageHash>) -> Option<String> {
+    if let Some(guild_id) = guild_id {
+        return hash.map(|hash| cdn!("/guild-tag-badges/{}/{}.png?size=1024", guild_id, hash));
+    }
+
+    None
+}
+
+#[cfg(feature = "model")]
+fn avatar_decoration_url(hash: &ImageHash) -> String {
+    cdn!("/avatar-decoration-presets/{}.png?size=1024", hash)
 }
 
 #[cfg(test)]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -371,14 +371,14 @@ bitflags! {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct PrimaryGuild {
-    /// the id of the user's primary guild.
+    /// The id of the user's primary guild.
     pub identity_guild_id: Option<GuildId>,
-    // whether the user is displaying the primary guild's server tag. This can be null if the
-    // system clears the identity, e.g. because the server no longer supports tags.
+    /// Whether the user is displaying the primary guild's server tag. This can be null if the
+    /// system clears the identity, e.g. because the server no longer supports tags.
     pub identity_enabled: Option<bool>,
-    /// the text of the [`User`]'s server tag.
+    /// The text of the [`User`]'s server tag.
     pub tag: Option<String>,
-    /// the hash of the server badge.
+    /// The hash of the server badge.
     pub badge: Option<ImageHash>,
 }
 
@@ -437,7 +437,7 @@ pub struct Nameplate {
     pub asset: String,
     /// The label of this nameplate.
     pub label: String,
-    /// background color of the nameplate, one of: `crimson`, `berry`, `sky`, `teal`, `forest`,
+    /// Background color of the nameplate, one of: `crimson`, `berry`, `sky`, `teal`, `forest`,
     /// `bubble_gum`, `violet`, `cobalt`, `clover`, `lemon`, `white`
     pub palette: String,
 }
@@ -445,11 +445,13 @@ pub struct Nameplate {
 #[cfg(all(feature = "unstable_discord_api", feature = "model"))]
 impl Nameplate {
     /// Gets the static version of the nameplate's url.
+    #[must_use]
     pub fn static_url(&self) -> String {
         static_nameplate_url(&self.asset)
     }
 
     /// Gets the animated version of the nameplate's url.
+    #[must_use]
     pub fn url(&self) -> String {
         nameplate_url(&self.asset)
     }


### PR DESCRIPTION
The remainder of #3382, rebased and cleaned up. These features all have to do with user customization, so I think they can be PR'd together.