### PR TITLE
Change from `doc_auto_cfg` to `doc_cfg` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! [examples]: https://github.com/serenity-rs/serenity/tree/current/examples
 //! [gateway docs]: crate::gateway
 #![doc(html_root_url = "https://docs.rs/serenity/*")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     unused,
     rust_2018_idioms,


### PR DESCRIPTION
Fixes docs publishing by switching to the new feature merged in https://github.com/rust-lang/rust/pull/138907