### PR TITLE
Add support for Label and File Upload components

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -523,6 +523,16 @@ impl<'a> CreateLabel<'a> {
         }
     }
 
+    /// Create a file upload with a specific label.
+    pub fn file_upload(label: impl Into<Cow<'a, str>>, file_upload: CreateFileUpload<'a>) -> Self {
+        Self {
+            kind: ComponentType::Label,
+            label: label.into(),
+            description: None,
+            component: CreateLabelComponent::FileUpload(file_upload),
+        }
+    }
+
     /// Sets the description of this component, which will display underneath the label text.
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
         self.description = Some(description.into());
@@ -537,6 +547,53 @@ impl<'a> CreateLabel<'a> {
 enum CreateLabelComponent<'a> {
     SelectMenu(CreateSelectMenu<'a>),
     InputText(CreateInputText<'a>),
+    FileUpload(CreateFileUpload<'a>),
+}
+
+/// A builder for creating a file upload in a modal.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#file-upload).
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
+pub struct CreateFileUpload<'a> {
+    #[serde(rename = "type")]
+    kind: ComponentType,
+    custom_id: Cow<'a, str>,
+    min_values: u8,
+    max_values: u8,
+    required: bool,
+}
+
+impl<'a> CreateFileUpload<'a> {
+    /// Creates a builder with the given custom id.
+    pub fn new(custom_id: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            kind: ComponentType::FileUpload,
+            custom_id: custom_id.into(),
+            min_values: 1,
+            max_values: 1,
+            required: true,
+        }
+    }
+
+    /// The minimum number of files that must be uploaded. Must be a number from 0 through 10, and
+    /// defaults to 1.
+    pub fn min_values(mut self, min_values: u8) -> Self {
+        self.min_values = min_values;
+        self
+    }
+
+    /// The maximum number of files that can be uploaded. Defaults to 1, but can be at most 10.
+    pub fn max_values(mut self, max_values: u8) -> Self {
+        self.max_values = max_values;
+        self
+    }
+
+    // Whether the file upload is required.
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
 }
 
 enum_number! {

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -4,18 +4,9 @@ use serde::Serialize;
 
 use crate::model::prelude::*;
 
-#[derive(Clone, Debug)]
-struct StaticU8<const VAL: u8>;
-
-impl<const VAL: u8> Serialize for StaticU8<VAL> {
-    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        ser.serialize_u8(VAL)
-    }
-}
-
 /// A builder for creating a components action row in a message.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#component-object).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#action-row).
 #[derive(Clone, Debug)]
 #[must_use]
 pub enum CreateActionRow<'a> {
@@ -110,7 +101,7 @@ pub enum CreateComponent<'a> {
 #[must_use]
 pub struct CreateSection<'a> {
     #[serde(rename = "type")]
-    kind: StaticU8<9>,
+    kind: ComponentType,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     components: Cow<'a, [CreateSectionComponent<'a>]>,
     accessory: CreateSectionAccessory<'a>,
@@ -125,7 +116,7 @@ impl<'a> CreateSection<'a> {
         accessory: CreateSectionAccessory<'a>,
     ) -> Self {
         CreateSection {
-            kind: StaticU8::<9>,
+            kind: ComponentType::Section,
             components: components.into(),
             accessory,
         }
@@ -170,7 +161,7 @@ pub enum CreateSectionComponent<'a> {
 #[derive(Clone, Debug, Serialize)]
 pub struct CreateTextDisplay<'a> {
     #[serde(rename = "type")]
-    kind: StaticU8<10>,
+    kind: ComponentType,
     content: Cow<'a, str>,
 }
 
@@ -180,7 +171,7 @@ impl<'a> CreateTextDisplay<'a> {
     /// Note: All components on a message shares the same **4000** character limit.
     pub fn new(content: impl Into<Cow<'a, str>>) -> Self {
         CreateTextDisplay {
-            kind: StaticU8::<10>,
+            kind: ComponentType::TextDisplay,
             content: content.into(),
         }
     }
@@ -210,7 +201,7 @@ pub enum CreateSectionAccessory<'a> {
 #[must_use]
 pub struct CreateThumbnail<'a> {
     #[serde(rename = "type")]
-    kind: StaticU8<11>,
+    kind: ComponentType,
     media: CreateUnfurledMediaItem<'a>,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<Cow<'a, str>>,
@@ -222,7 +213,7 @@ impl<'a> CreateThumbnail<'a> {
     /// Creates a new thumbnail with a media item.
     pub fn new(media: CreateUnfurledMediaItem<'a>) -> Self {
         CreateThumbnail {
-            kind: StaticU8::<11>,
+            kind: ComponentType::Thumbnail,
             media,
             description: None,
             spoiler: None,
@@ -277,7 +268,7 @@ impl<'a> CreateUnfurledMediaItem<'a> {
 #[must_use]
 pub struct CreateMediaGallery<'a> {
     #[serde(rename = "type")]
-    kind: StaticU8<12>,
+    kind: ComponentType,
     items: Cow<'a, [CreateMediaGalleryItem<'a>]>,
 }
 
@@ -285,7 +276,7 @@ impl<'a> CreateMediaGallery<'a> {
     /// Creates a new media gallery with up to **10** items.
     pub fn new(items: impl Into<Cow<'a, [CreateMediaGalleryItem<'a>]>>) -> Self {
         CreateMediaGallery {
-            kind: StaticU8::<12>,
+            kind: ComponentType::MediaGallery,
             items: items.into(),
         }
     }
@@ -370,7 +361,7 @@ impl<'a> CreateMediaGalleryItem<'a> {
 #[must_use]
 pub struct CreateFile<'a> {
     #[serde(rename = "type")]
-    kind: StaticU8<13>,
+    kind: ComponentType,
     file: CreateUnfurledMediaItem<'a>,
     #[serde(skip_serializing_if = "Option::is_none")]
     spoiler: Option<bool>,
@@ -381,7 +372,7 @@ impl<'a> CreateFile<'a> {
     /// limits.
     pub fn new(file: impl Into<CreateUnfurledMediaItem<'a>>) -> Self {
         CreateFile {
-            kind: StaticU8::<13>,
+            kind: ComponentType::File,
             file: file.into(),
             spoiler: None,
         }
@@ -406,7 +397,7 @@ impl<'a> CreateFile<'a> {
 #[must_use]
 pub struct CreateSeparator {
     #[serde(rename = "type")]
-    kind: StaticU8<14>,
+    kind: ComponentType,
     divider: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     spacing: Option<Spacing>,
@@ -416,7 +407,7 @@ impl CreateSeparator {
     /// Creates a new separator, with or without a divider.
     pub fn new(divider: bool) -> Self {
         CreateSeparator {
-            kind: StaticU8::<14>,
+            kind: ComponentType::Separator,
             divider,
             spacing: None,
         }
@@ -441,7 +432,7 @@ impl CreateSeparator {
 #[must_use]
 pub struct CreateContainer<'a> {
     #[serde(rename = "type")]
-    kind: StaticU8<17>,
+    kind: ComponentType,
     #[serde(skip_serializing_if = "Option::is_none")]
     accent_color: Option<Colour>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -454,7 +445,7 @@ impl<'a> CreateContainer<'a> {
     /// other component except another container!
     pub fn new(components: impl Into<Cow<'a, [CreateComponent<'a>]>>) -> Self {
         CreateContainer {
-            kind: StaticU8::<17>,
+            kind: ComponentType::Container,
             accent_color: None,
             spoiler: None,
             components: components.into(),
@@ -499,11 +490,13 @@ impl<'a> CreateContainer<'a> {
 }
 
 /// A builder for creating a label that can hold an [`InputText`] or [`SelectMenu`].
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#label).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateLabel<'a> {
     #[serde(rename = "type")]
-    kind: StaticU8<18>,
+    kind: ComponentType,
     label: Cow<'a, str>,
     description: Option<Cow<'a, str>>,
     component: CreateLabelComponent<'a>,
@@ -513,7 +506,7 @@ impl<'a> CreateLabel<'a> {
     /// Create a select menu with a specific label.
     pub fn select_menu(label: impl Into<Cow<'a, str>>, select_menu: CreateSelectMenu<'a>) -> Self {
         Self {
-            kind: StaticU8::<18>,
+            kind: ComponentType::Label,
             label: label.into(),
             description: None,
             component: CreateLabelComponent::SelectMenu(select_menu),
@@ -523,7 +516,7 @@ impl<'a> CreateLabel<'a> {
     /// Create a text input with a specific label.
     pub fn input_text(label: impl Into<Cow<'a, str>>, input_text: CreateInputText<'a>) -> Self {
         Self {
-            kind: StaticU8::<18>,
+            kind: ComponentType::Label,
             label: label.into(),
             description: None,
             component: CreateLabelComponent::InputText(input_text),
@@ -716,7 +709,7 @@ impl Serialize for CreateSelectMenuDefault {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#component-object-component-types).
 #[derive(Clone, Debug)]
 pub enum CreateSelectMenuKind<'a> {
     String {
@@ -804,7 +797,7 @@ impl Serialize for CreateSelectMenuKind<'_> {
 
 /// A builder for creating a select menu component in a message
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#component-object-component-types).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateSelectMenu<'a> {
@@ -870,7 +863,7 @@ impl<'a> CreateSelectMenu<'a> {
 
 /// A builder for creating an option of a select menu component in a message
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure)
+/// [Discord docs](https://discord.com/developers/docs/components/reference#string-select-select-option-structure)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateSelectMenuOption<'a> {
@@ -930,7 +923,7 @@ impl<'a> CreateSelectMenuOption<'a> {
 
 /// A builder for creating an input text component in a modal
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#text-input).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateInputText<'a> {

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -21,8 +21,6 @@ impl<const VAL: u8> Serialize for StaticU8<VAL> {
 pub enum CreateActionRow<'a> {
     Buttons(Cow<'a, [CreateButton<'a>]>),
     SelectMenu(CreateSelectMenu<'a>),
-    /// Only valid in modals!
-    InputText(CreateInputText<'a>),
 }
 
 impl<'a> CreateActionRow<'a> {
@@ -32,10 +30,6 @@ impl<'a> CreateActionRow<'a> {
 
     pub fn select_menu(select_menu: impl Into<CreateSelectMenu<'a>>) -> Self {
         Self::SelectMenu(select_menu.into())
-    }
-
-    pub fn input_text(input_text: impl Into<CreateInputText<'a>>) -> Self {
-        Self::InputText(input_text.into())
     }
 }
 
@@ -49,7 +43,6 @@ impl serde::Serialize for CreateActionRow<'_> {
         match self {
             CreateActionRow::Buttons(buttons) => map.serialize_entry("components", &buttons)?,
             CreateActionRow::SelectMenu(select) => map.serialize_entry("components", &[select])?,
-            CreateActionRow::InputText(input) => map.serialize_entry("components", &[input])?,
         }
 
         map.end()
@@ -105,6 +98,10 @@ pub enum CreateComponent<'a> {
     ///
     /// A container is a flexible component that can hold multiple nested components.
     Container(CreateContainer<'a>),
+    /// Represents a label component (V2).
+    ///
+    /// A label is used to hold other components in a modal.
+    Label(CreateLabel<'a>),
 }
 
 /// A builder to create a section component, supports up to a max of **3** components with an
@@ -501,6 +498,54 @@ impl<'a> CreateContainer<'a> {
     }
 }
 
+/// A builder for creating a label that can hold an [`InputText`] or [`SelectMenu`].
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
+pub struct CreateLabel<'a> {
+    #[serde(rename = "type")]
+    kind: StaticU8<18>,
+    label: Cow<'a, str>,
+    description: Option<Cow<'a, str>>,
+    component: CreateLabelComponent<'a>,
+}
+
+impl<'a> CreateLabel<'a> {
+    /// Create a select menu with a specific label.
+    pub fn select_menu(label: impl Into<Cow<'a, str>>, select_menu: CreateSelectMenu<'a>) -> Self {
+        Self {
+            kind: StaticU8::<18>,
+            label: label.into(),
+            description: None,
+            component: CreateLabelComponent::SelectMenu(select_menu),
+        }
+    }
+
+    /// Create a text input with a specific label.
+    pub fn input_text(label: impl Into<Cow<'a, str>>, input_text: CreateInputText<'a>) -> Self {
+        Self {
+            kind: StaticU8::<18>,
+            label: label.into(),
+            description: None,
+            component: CreateLabelComponent::InputText(input_text),
+        }
+    }
+
+    /// Sets the description of this component, which will display underneath the label text.
+    pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+}
+
+/// An enum of all valid label components.
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
+#[serde(untagged)]
+enum CreateLabelComponent<'a> {
+    SelectMenu(CreateSelectMenu<'a>),
+    InputText(CreateInputText<'a>),
+}
+
 enum_number! {
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -893,7 +938,6 @@ pub struct CreateInputText<'a> {
     kind: ComponentType,
     custom_id: Cow<'a, str>,
     style: InputTextStyle,
-    label: Option<Cow<'a, str>>,
     min_length: Option<u16>,
     max_length: Option<u16>,
     required: bool,
@@ -906,14 +950,9 @@ pub struct CreateInputText<'a> {
 impl<'a> CreateInputText<'a> {
     /// Creates a text input with the given style, label, and custom id (a developer-defined
     /// identifier), leaving all other fields empty.
-    pub fn new(
-        style: InputTextStyle,
-        label: impl Into<Cow<'a, str>>,
-        custom_id: impl Into<Cow<'a, str>>,
-    ) -> Self {
+    pub fn new(style: InputTextStyle, custom_id: impl Into<Cow<'a, str>>) -> Self {
         Self {
             style,
-            label: Some(label.into()),
             custom_id: custom_id.into(),
 
             placeholder: None,
@@ -929,12 +968,6 @@ impl<'a> CreateInputText<'a> {
     /// Sets the style of this input text. Replaces the current value as set in [`Self::new`].
     pub fn style(mut self, kind: InputTextStyle) -> Self {
         self.style = kind;
-        self
-    }
-
-    /// Sets the label of this input text. Replaces the current value as set in [`Self::new`].
-    pub fn label(mut self, label: impl Into<Cow<'a, str>>) -> Self {
-        self.label = Some(label.into());
         self
     }
 

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 
 use super::create_poll::Ready;
 use super::{
-    CreateActionRow,
     CreateAllowedMentions,
     CreateAttachment,
     CreateComponent,
@@ -424,7 +423,7 @@ impl<'a> CreateAutocompleteResponse<'a> {
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateModal<'a> {
-    components: Cow<'a, [CreateActionRow<'a>]>,
+    components: Cow<'a, [CreateComponent<'a>]>,
     custom_id: Cow<'a, str>,
     title: Cow<'a, str>,
 }
@@ -442,7 +441,7 @@ impl<'a> CreateModal<'a> {
     /// Sets the components of this message.
     ///
     /// Overwrites existing components.
-    pub fn components(mut self, components: impl Into<Cow<'a, [CreateActionRow<'a>]>>) -> Self {
+    pub fn components(mut self, components: impl Into<Cow<'a, [CreateComponent<'a>]>>) -> Self {
         self.components = components.into();
         self
     }

--- a/src/collector/quick_modal.rs
+++ b/src/collector/quick_modal.rs
@@ -1,6 +1,13 @@
 use std::borrow::Cow;
 
-use crate::builder::{CreateActionRow, CreateInputText, CreateInteractionResponse, CreateModal};
+use crate::builder::{
+    CreateComponent,
+    CreateInputText,
+    CreateInteractionResponse,
+    CreateLabel,
+    CreateModal,
+    CreateTextDisplay,
+};
 use crate::collector::ModalInteractionCollector;
 use crate::gateway::client::Context;
 use crate::internal::prelude::*;
@@ -31,7 +38,7 @@ pub struct QuickModalResponse {
 pub struct CreateQuickModal<'a> {
     title: Cow<'a, str>,
     timeout: Option<std::time::Duration>,
-    input_texts: Vec<CreateInputText<'a>>,
+    components: Vec<CreateComponent<'a>>,
 }
 
 impl<'a> CreateQuickModal<'a> {
@@ -39,7 +46,7 @@ impl<'a> CreateQuickModal<'a> {
         Self {
             title: title.into(),
             timeout: None,
-            input_texts: Vec::new(),
+            components: Vec::new(),
         }
     }
 
@@ -52,12 +59,21 @@ impl<'a> CreateQuickModal<'a> {
         self
     }
 
+    /// Adds a text display field.
+    pub fn text(mut self, content: impl Into<Cow<'a, str>>) -> Self {
+        self.components.push(CreateComponent::TextDisplay(CreateTextDisplay::new(content)));
+        self
+    }
+
     /// Adds an input text field.
-    ///
-    /// As the `custom_id` field of [`CreateInputText`], just supply an empty string. All custom
-    /// IDs are overwritten by [`CreateQuickModal`] when sending the modal.
-    pub fn field(mut self, input_text: CreateInputText<'a>) -> Self {
-        self.input_texts.push(input_text);
+    pub fn field(
+        mut self,
+        label: impl Into<Cow<'a, str>>,
+        input_text: CreateInputText<'a>,
+    ) -> Self {
+        self.components.push(CreateComponent::Label(
+            CreateLabel::input_text(label, input_text).description("test"),
+        ));
         self
     }
 
@@ -65,14 +81,18 @@ impl<'a> CreateQuickModal<'a> {
     ///
     /// Wraps [`Self::field`].
     pub fn short_field(self, label: impl Into<Cow<'a, str>>) -> Self {
-        self.field(CreateInputText::new(InputTextStyle::Short, label, ""))
+        let input_text =
+            CreateInputText::new(InputTextStyle::Short, self.components.len().to_string());
+        self.field(label, input_text)
     }
 
     /// Convenience method to add a multi-line input text field.
     ///
     /// Wraps [`Self::field`].
     pub fn paragraph_field(self, label: impl Into<Cow<'a, str>>) -> Self {
-        self.field(CreateInputText::new(InputTextStyle::Paragraph, label, ""))
+        let input_text =
+            CreateInputText::new(InputTextStyle::Paragraph, self.components.len().to_string());
+        self.field(label, input_text)
     }
 
     /// # Errors
@@ -84,22 +104,13 @@ impl<'a> CreateQuickModal<'a> {
         interaction_id: InteractionId,
         token: &str,
     ) -> Result<Option<QuickModalResponse>, crate::Error> {
-        let modal_custom_id = interaction_id.to_arraystring();
         let builder = CreateInteractionResponse::Modal(
-            CreateModal::new(modal_custom_id.as_str(), self.title).components(
-                self.input_texts
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, input_text)| {
-                        CreateActionRow::InputText(input_text.custom_id(i.to_string()))
-                    })
-                    .collect::<Vec<_>>(),
-            ),
+            CreateModal::new(interaction_id.to_string(), self.title).components(self.components),
         );
         builder.execute(&ctx.http, interaction_id, token).await?;
 
         let collector = ModalInteractionCollector::new(ctx)
-            .custom_ids(vec![FixedString::from_str_trunc(&modal_custom_id)]);
+            .custom_ids(vec![FixedString::from_str_trunc(&interaction_id.to_string())]);
 
         let collector = match self.timeout {
             Some(timeout) => collector.timeout(timeout),
@@ -114,23 +125,22 @@ impl<'a> CreateQuickModal<'a> {
             .data
             .components
             .iter()
-            .filter_map(|row| match row.components.first() {
-                Some(ActionRowComponent::InputText(text)) => {
+            .filter_map(|component| {
+                if let Component::Label(label) = component
+                    && let LabelComponent::InputText(text) = &label.component
+                {
                     if let Some(value) = &text.value {
                         Some(value.clone())
                     } else {
                         tracing::warn!("input text value was empty in modal response");
                         None
                     }
-                },
-                Some(other) => {
-                    tracing::warn!("expected input text in modal response, got {:?}", other);
+                } else {
+                    if !matches!(component, Component::TextDisplay(_)) {
+                        tracing::warn!("expected input text in modal response, got {component:?}");
+                    }
                     None
-                },
-                None => {
-                    tracing::warn!("empty action row");
-                    None
-                },
+                }
             })
             .collect();
 

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -228,7 +228,7 @@ impl Serialize for CommandInteraction {
 
 /// The command data payload.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -240,9 +240,10 @@ pub struct CommandData {
     /// The application command type of the triggered application command.
     #[serde(rename = "type")]
     pub kind: CommandType,
-    /// The parameters and the given values. The converted objects from the given options.
+    /// The converted objects from the given options.
     #[serde(default)]
     pub resolved: CommandDataResolved,
+    /// The parameters and the given values.
     #[serde(default)]
     pub options: FixedArray<CommandDataOption>,
     /// The Id of the guild the command is registered to.

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -28,6 +28,7 @@ enum_number! {
         Separator = 14,
         Container = 17,
         Label = 18,
+        FileUpload = 19,
         _ => Unknown(u8),
     }
 }
@@ -299,6 +300,7 @@ pub struct Label {
 pub enum LabelComponent {
     SelectMenu(SelectMenu),
     InputText(InputText),
+    FileUpload(FileUpload),
 }
 
 impl<'de> Deserialize<'de> for LabelComponent {
@@ -323,12 +325,29 @@ impl<'de> Deserialize<'de> for LabelComponent {
             ComponentType::InputText => {
                 Deserialize::deserialize(raw_data).map(LabelComponent::InputText)
             },
+            ComponentType::FileUpload => {
+                Deserialize::deserialize(raw_data).map(LabelComponent::FileUpload)
+            },
             ComponentType(i) => {
                 return Err(DeError::custom(format_args!("Unknown component type {i}")));
             },
         }
         .map_err(DeError::custom)
     }
+}
+
+/// An interactive component that allows users to upload files in modals.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[non_exhaustive]
+pub struct FileUpload {
+    /// Always [`ComponentType::FileUpload`]
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Developer-defined identifier for the file upload; max 100 characters
+    pub custom_id: FixedString,
+    /// IDs of the uploaded files found in [`ModalInteractionData::resolved`].
+    pub values: FixedArray<AttachmentId>,
 }
 
 /// An action row.

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -27,6 +27,7 @@ enum_number! {
         File = 13,
         Separator = 14,
         Container = 17,
+        Label = 18,
         _ => Unknown(u8),
     }
 }
@@ -53,11 +54,12 @@ pub enum Component {
     Separator(Separator),
     File(FileComponent),
     Container(Container),
+    Label(Label),
     Unknown(u8),
 }
 
 impl<'de> Deserialize<'de> for Component {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -93,6 +95,7 @@ impl<'de> Deserialize<'de> for Component {
             ComponentType::File => Deserialize::deserialize(value).map(Component::File),
             ComponentType::Container => Deserialize::deserialize(value).map(Component::Container),
             ComponentType::Thumbnail => Deserialize::deserialize(value).map(Component::Thumbnail),
+            ComponentType::Label => Deserialize::deserialize(value).map(Component::Label),
             ComponentType(i) => Ok(Component::Unknown(i)),
         }
         .map_err(DeError::custom)
@@ -272,6 +275,62 @@ pub struct Container {
     pub components: FixedArray<Component>,
 }
 
+/// A layout component that wraps modal components with a label and optional description.
+///
+/// **Note**: Labels can only appear within modals, and will not include the `label` or
+/// `description` field when part of a modal response.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#label-label-interaction-response-structure)
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[non_exhaustive]
+pub struct Label {
+    /// Always [`ComponentType::Label`]
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// The component within the label.
+    pub component: LabelComponent,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum LabelComponent {
+    SelectMenu(SelectMenu),
+    InputText(InputText),
+}
+
+impl<'de> Deserialize<'de> for LabelComponent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct LabelComponentRaw {
+            #[serde(rename = "type")]
+            kind: ComponentType,
+        }
+
+        let raw_data = <&RawValue>::deserialize(deserializer)?;
+        let raw = LabelComponentRaw::deserialize(raw_data).map_err(DeError::custom)?;
+
+        match raw.kind {
+            ComponentType::StringSelect
+            | ComponentType::UserSelect
+            | ComponentType::RoleSelect
+            | ComponentType::MentionableSelect
+            | ComponentType::ChannelSelect => {
+                Deserialize::deserialize(raw_data).map(LabelComponent::SelectMenu)
+            },
+            ComponentType::InputText => {
+                Deserialize::deserialize(raw_data).map(LabelComponent::InputText)
+            },
+            ComponentType(i) => {
+                return Err(DeError::custom(format_args!("Unknown component type {i}")));
+            },
+        }
+        .map_err(DeError::custom)
+    }
+}
+
 /// An action row.
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#action-rows).
@@ -291,16 +350,16 @@ pub struct ActionRow {
 ///
 /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#component-object-component-types).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
 #[non_exhaustive]
 pub enum ActionRowComponent {
     Button(Button),
     SelectMenu(SelectMenu),
-    InputText(InputText),
 }
 
 impl<'de> Deserialize<'de> for ActionRowComponent {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
         struct ActionRowRaw {
             #[serde(rename = "type")]
@@ -313,9 +372,6 @@ impl<'de> Deserialize<'de> for ActionRowComponent {
         match raw.kind {
             ComponentType::Button => {
                 Deserialize::deserialize(raw_data).map(ActionRowComponent::Button)
-            },
-            ComponentType::InputText => {
-                Deserialize::deserialize(raw_data).map(ActionRowComponent::InputText)
             },
             ComponentType::StringSelect
             | ComponentType::UserSelect
@@ -332,16 +388,6 @@ impl<'de> Deserialize<'de> for ActionRowComponent {
             },
         }
         .map_err(DeError::custom)
-    }
-}
-
-impl Serialize for ActionRowComponent {
-    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
-        match self {
-            Self::Button(c) => c.serialize(serializer),
-            Self::InputText(c) => c.serialize(serializer),
-            Self::SelectMenu(c) => c.serialize(serializer),
-        }
     }
 }
 
@@ -465,7 +511,7 @@ pub struct SelectMenu {
     #[serde(rename = "type")]
     pub kind: ComponentType,
     /// An identifier defined by the developer for the select menu.
-    pub custom_id: Option<FixedString>,
+    pub custom_id: FixedString,
     /// The options of this select menu.
     ///
     /// Required for [`ComponentType::StringSelect`] and unavailable for all others.
@@ -516,19 +562,13 @@ pub struct InputText {
     #[serde(rename = "type")]
     pub kind: ComponentType,
     /// Developer-defined identifier for the input; max 100 characters
-    pub custom_id: FixedString<u16>,
+    pub custom_id: FixedString,
     /// The [`InputTextStyle`]. Required when sending modal data.
     ///
     /// Discord docs are wrong here; it says the field is always sent in modal submit interactions
     /// but it's not. It's only required when _sending_ modal data to Discord.
     /// <https://github.com/discord/discord-api-docs/issues/6141>
     pub style: Option<InputTextStyle>,
-    /// Label for this component; max 45 characters. Required when sending modal data.
-    ///
-    /// Discord docs are wrong here; it says the field is always sent in modal submit interactions
-    /// but it's not. It's only required when _sending_ modal data to Discord.
-    /// <https://github.com/discord/discord-api-docs/issues/6141>
-    pub label: Option<FixedString<u8>>,
     /// Minimum input length for a text input; min 0, max 4000
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_length: Option<u16>,

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -145,7 +145,7 @@ pub struct Thumbnail {
 
 /// A url or attachment.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#unfurled-media-item-structure)
+/// [Discord docs](https://discord.com/developers/docs/components/reference#unfurled-media-item)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -333,7 +333,7 @@ impl<'de> Deserialize<'de> for LabelComponent {
 
 /// An action row.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#action-rows).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#action-row).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -348,7 +348,7 @@ pub struct ActionRow {
 
 /// A component which can be inside of an [`ActionRow`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#component-object-component-types).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#action-row-action-row-child-components).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
@@ -461,7 +461,7 @@ impl Serialize for ButtonKind {
 
 /// A button component.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#button).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[non_exhaustive]
@@ -500,7 +500,7 @@ enum_number! {
 
 /// A select menu component.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#component-object-component-types).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -533,7 +533,7 @@ pub struct SelectMenu {
 
 /// A select menu component options.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#string-select-select-option-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -553,7 +553,7 @@ pub struct SelectMenuOption {
 
 /// An input text component for modal interactions
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure).
+/// [Discord docs](https://discord.com/developers/docs/components/reference#text-input).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -591,7 +591,7 @@ pub struct InputText {
 enum_number! {
     /// The style of the input text
     ///
-    /// [Discord docs](https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-styles).
+    /// [Discord docs](https://discord.com/developers/docs/components/reference#text-input-text-input-styles).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -315,7 +315,7 @@ pub struct ComponentInteractionData {
     /// Type and type-specific data of this component interaction.
     #[serde(flatten)]
     pub kind: ComponentInteractionDataKind,
-    /// The parameters and the given values. The converted objects from the given options.
+    /// The resolved entities from the selected options.
     #[serde(default)]
     pub resolved: CommandDataResolved,
 }

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -22,8 +22,6 @@ use crate::model::utils::StrOrInt;
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-// breaking to change this on current, not sure if worth on next
-#[expect(clippy::large_enum_variant)]
 pub enum Interaction {
     Ping(PingInteraction),
     Command(CommandInteraction),

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -207,7 +207,7 @@ impl Serialize for ModalInteraction {
 
 /// A modal submit interaction data, provided by [`ModalInteraction::data`]
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure).
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -216,4 +216,7 @@ pub struct ModalInteractionData {
     pub custom_id: FixedString,
     /// The components.
     pub components: FixedArray<Component>,
+    /// The resolved entities from the selected options.
+    #[serde(default)]
+    pub resolved: CommandDataResolved,
 }

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -215,5 +215,5 @@ pub struct ModalInteractionData {
     /// The custom id of the modal
     pub custom_id: FixedString,
     /// The components.
-    pub components: FixedArray<ActionRow>,
+    pub components: FixedArray<Component>,
 }


### PR DESCRIPTION
Labels are a new top-level component only supported in modals that can hold a Text Input, Select Menu, or File Upload (another new component) inside it. Oddly enough, the label and description are removed from the label payload when sent back as part of a modal response. See the [docs](https://discord.com/developers/docs/components/reference#label).

Text Inputs inside Action Rows are deprecated, therefore I removed the `InputText` variant for `ActionRowComponent`. Also, at the moment modals can include Action Rows, Text Displays, and Labels as top-level components, so I changed modal responses to store `Component` instead of `ActionRow` and added a `text` method to quick modals. I thought about adding select menu support to quick modals but the methods felt a little too verbose.