### PR TITLE
Fix variable naming in `examples/e14_slash_commands` example

### DIFF
--- a/examples/e14_slash_commands/src/main.rs
+++ b/examples/e14_slash_commands/src/main.rs
@@ -61,11 +61,11 @@ impl EventHandler for Handler {
 
         println!("I now have the following guild slash commands: {commands:#?}");
 
-        let guild_command =
+        let global_command =
             Command::create_global_command(&ctx.http, commands::wonderful_command::register())
                 .await;
 
-        println!("I created the following global slash command: {guild_command:#?}");
+        println!("I created the following global slash command: {global_command:#?}");
     }
 }
 


### PR DESCRIPTION
Rename `guild_command` to `global_command` to match the global command creation call.