### PR TITLE
transition `Permissions` from `u64` to `SmolBitSet`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ extract_map = { version = "0.3.1", features = ["serde"] }
 aformat = "0.1.8"
 bytes = "1.11.0"
 ref-cast = "1.0.25"
+smolbitset = { version = "0.1.0", features = ["serde"] }
 # Optional dependencies
 foldhash = { version = "0.2.0", optional = true }
 chrono = { version = "0.4.42", default-features = false, features = ["clock", "serde"], optional = true }
@@ -131,7 +132,7 @@ full = ["default", "collector", "voice", "interactions_endpoint"]
 # Enables temporary caching in functions that retrieve data via the HTTP API.
 temp_cache = ["cache", "mini-moka", "typesize?/mini_moka", "typesize?/dashmap"]
 
-typesize = ["dep:typesize", "dashmap/typesize", "small-fixed-array/typesize", "bool_to_bitflags/typesize", "extract_map/typesize"]
+typesize = ["dep:typesize", "dashmap/typesize", "small-fixed-array/typesize", "bool_to_bitflags/typesize", "extract_map/typesize", "smolbitset/typesize"]
 
 # Enables compile-time heavy instrument macros from tracing
 tracing_instrument = ["tracing/attributes"]

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -30,10 +30,9 @@ impl<'a> CreateBotAuthParameters<'a> {
     #[must_use]
     pub fn build(self) -> String {
         // These bindings have to be defined before `valid_data`, due to Drop order.
-        let (client_id_str, guild_id_str, scope_str, bits_str);
+        let (client_id_str, guild_id_str, scope_str, perm_str);
 
         let mut valid_data = ArrayVec::<_, 5>::new();
-        let bits = self.permissions.bits();
 
         if let Some(client_id) = self.client_id {
             client_id_str = client_id.to_arraystring();
@@ -45,9 +44,9 @@ impl<'a> CreateBotAuthParameters<'a> {
             valid_data.push(("scope", &scope_str));
         }
 
-        if bits != 0 {
-            bits_str = bits.to_arraystring();
-            valid_data.push(("permissions", &bits_str));
+        perm_str = self.permissions.to_string();
+        if perm_str != "0" {
+            valid_data.push(("permissions", &perm_str));
         }
 
         if let Some(guild_id) = self.guild_id {

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -43,7 +43,7 @@ pub struct EditRole<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    permissions: Option<u64>,
+    permissions: Option<Permissions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "color")]
     colour: Option<Colour>,
@@ -78,7 +78,7 @@ impl<'a> EditRole<'a> {
             hoist: Some(role.hoist()),
             mentionable: Some(role.mentionable()),
             name: Some(Cow::Borrowed(&role.name)),
-            permissions: Some(role.permissions.bits()),
+            permissions: Some(role.permissions.clone()),
             position: Some(role.position),
             colour: Some(role.colour),
             unicode_emoji: role.unicode_emoji.as_ref().map(|v| Some(Cow::Borrowed(v.as_str()))),
@@ -122,7 +122,7 @@ impl<'a> EditRole<'a> {
 
     /// Set the role's permissions.
     pub fn permissions(mut self, permissions: Permissions) -> Self {
-        self.permissions = Some(permissions.bits());
+        self.permissions = Some(permissions);
         self
     }
 

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -58,10 +58,10 @@ impl Interaction {
     #[must_use]
     pub fn app_permissions(&self) -> Permissions {
         match self {
-            Self::Ping(i) => i.app_permissions,
-            Self::Command(i) | Self::Autocomplete(i) => i.app_permissions,
-            Self::Component(i) => i.app_permissions,
-            Self::Modal(i) => i.app_permissions,
+            Self::Ping(i) => i.app_permissions.clone(),
+            Self::Command(i) | Self::Autocomplete(i) => i.app_permissions.clone(),
+            Self::Component(i) => i.app_permissions.clone(),
+            Self::Modal(i) => i.app_permissions.clone(),
         }
     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -278,7 +278,7 @@ impl Guild {
                     .members
                     .iter()
                     .map(|member| self.user_permissions_in(channel, member))
-                    .all(Permissions::view_channel)
+                    .all(|perm| Permissions::view_channel(&perm))
         })
     }
 
@@ -894,17 +894,17 @@ impl Guild {
                 match overwrite.kind {
                     PermissionOverwriteType::Member(user_id) => {
                         if member_user_id == user_id {
-                            member_allow_overwrites = overwrite.allow;
-                            member_deny_overwrites = overwrite.deny;
+                            member_allow_overwrites = overwrite.allow.clone();
+                            member_deny_overwrites = overwrite.deny.clone();
                         }
                     },
                     PermissionOverwriteType::Role(role_id) => {
                         if role_id.get() == guild_id.get() {
-                            everyone_allow_overwrites = overwrite.allow;
-                            everyone_deny_overwrites = overwrite.deny;
+                            everyone_allow_overwrites = overwrite.allow.clone();
+                            everyone_deny_overwrites = overwrite.deny.clone();
                         } else if member_roles.contains(&role_id) {
-                            roles_allow_overwrites.push(overwrite.allow);
-                            roles_deny_overwrites.push(overwrite.deny);
+                            roles_allow_overwrites.push(overwrite.allow.clone());
+                            roles_deny_overwrites.push(overwrite.deny.clone());
                         }
                     },
                 }
@@ -915,7 +915,7 @@ impl Guild {
             is_guild_owner: member_user_id == guild_owner_id,
             everyone_permissions: if let Some(role) = guild_roles.get(&RoleId::new(guild_id.get()))
             {
-                role.permissions
+                role.permissions.clone()
             } else {
                 error!("@everyone role missing in {}", guild_id);
                 Permissions::empty()
@@ -924,7 +924,7 @@ impl Guild {
                 .iter()
                 .map(|role_id| {
                     if let Some(role) = guild_roles.get(role_id) {
-                        role.permissions
+                        role.permissions.clone()
                     } else {
                         warn!(
                             "{} on {} has non-existent role {:?}",
@@ -1043,7 +1043,7 @@ fn calculate_permissions(data: CalculatePermissions) -> Permissions {
     }
 
     // 3. Overwrites that deny permissions for @everyone are applied at a channel level
-    permissions &= !data.everyone_deny_overwrites;
+    permissions.and_not_assign(&data.everyone_deny_overwrites);
     // 4. Overwrites that allow permissions for @everyone are applied at a channel level
     permissions |= data.everyone_allow_overwrites;
 
@@ -1052,7 +1052,7 @@ fn calculate_permissions(data: CalculatePermissions) -> Permissions {
     for p in data.roles_deny_overwrites {
         role_deny_permissions |= p;
     }
-    permissions &= !role_deny_permissions;
+    permissions.and_not_assign(&role_deny_permissions);
 
     // 6. Overwrites that allow permissions for specific roles are applied at a channel level
     let mut role_allow_permissions = Permissions::empty();
@@ -1062,7 +1062,7 @@ fn calculate_permissions(data: CalculatePermissions) -> Permissions {
     permissions |= role_allow_permissions;
 
     // 7. Member-specific overwrites that deny permissions are applied at a channel level
-    permissions &= !data.member_deny_overwrites;
+    permissions.and_not_assign(&data.member_deny_overwrites);
     // 8. Member-specific overwrites that allow permissions are applied at a channel level
     permissions |= data.member_allow_overwrites;
 

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -38,10 +38,7 @@
 #[cfg(feature = "model")]
 use std::fmt;
 
-use serde::de::{Deserialize, Deserializer};
-use serde::ser::{Serialize, Serializer};
-
-use super::utils::StrOrInt;
+use serde::{Deserialize, Serialize};
 
 /// This macro generates the `Permissions` type and methods.
 ///
@@ -90,19 +87,26 @@ macro_rules! generate_permissions {
     {$ (
         $(#[doc = $doc:literal])*
         $(#[deprecated = $deprecated:literal])?
-        $perm_upper:ident, $perm_lower:ident, $name:literal = $value:expr
+        $perm_upper:ident, $perm_lower:ident, $name:literal = 1 << $value:expr
     );*} => {
-        bitflags::bitflags! {
-            impl Permissions: u64 {
-                $(
-                    $(#[doc = $doc])*
-                    $(#[deprecated = $deprecated])?
-                    const $perm_upper = $value;
-                )*
-            }
+        #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+        #[expect(non_camel_case_types, clippy::upper_case_acronyms)]
+        #[non_exhaustive]
+        pub enum PermissionFlag {
+            $(
+                $(#[doc = $doc])*
+                $(#[deprecated = $deprecated])?
+                $perm_upper = $value,
+            )*
         }
 
         impl Permissions {
+            $(
+                $(#[doc = $doc])*
+                $(#[deprecated = $deprecated])?
+                pub const $perm_upper: Self = Self(smolbitset::SmolBitSet::new_flag($value));
+            )*
+
             $(
                 #[doc = concat!("Shorthand for checking that the set of permissions contains the [", $name, "] permission.")]
                 #[doc = ""]
@@ -112,15 +116,23 @@ macro_rules! generate_permissions {
                     #[deprecated = $deprecated]
                     #[expect(deprecated)]
                 )?
-                pub fn $perm_lower(self) -> bool {
+                pub fn $perm_lower(&self) -> bool {
                     self.contains(Self::$perm_upper)
                 }
             )*
 
+            pub fn all() -> Self {
+                Self(smolbitset::SmolBitSet::from_bits(&[
+                    $(
+                        $value,
+                    )*
+                ]))
+            }
+
             /// Returns a list of names of all contained permissions.
             #[must_use]
             #[cfg(feature = "model")]
-            pub fn get_permission_names(self) -> Vec<&'static str> {
+            pub fn get_permission_names(&self) -> Vec<&'static str> {
                 let mut names = Vec::new();
 
                 $(
@@ -180,22 +192,22 @@ macro_rules! generate_permissions {
 /// [Speak]: Permissions::SPEAK
 /// [Use External Emojis]: Permissions::USE_EXTERNAL_EMOJIS
 /// [Use VAD]: Permissions::USE_VAD
-pub const PRESET_GENERAL: Permissions = Permissions::from_bits_truncate(
-    Permissions::ADD_REACTIONS.bits()
-        | Permissions::ATTACH_FILES.bits()
-        | Permissions::CHANGE_NICKNAME.bits()
-        | Permissions::CONNECT.bits()
-        | Permissions::CREATE_INSTANT_INVITE.bits()
-        | Permissions::EMBED_LINKS.bits()
-        | Permissions::MENTION_EVERYONE.bits()
-        | Permissions::READ_MESSAGE_HISTORY.bits()
-        | Permissions::VIEW_CHANNEL.bits()
-        | Permissions::SEND_MESSAGES.bits()
-        | Permissions::SEND_TTS_MESSAGES.bits()
-        | Permissions::SPEAK.bits()
-        | Permissions::USE_EXTERNAL_EMOJIS.bits()
-        | Permissions::USE_VAD.bits(),
-);
+pub const PRESET_GENERAL: Permissions = Permissions::from_individual_flags([
+    PermissionFlag::ADD_REACTIONS,
+    PermissionFlag::ATTACH_FILES,
+    PermissionFlag::CHANGE_NICKNAME,
+    PermissionFlag::CONNECT,
+    PermissionFlag::CREATE_INSTANT_INVITE,
+    PermissionFlag::EMBED_LINKS,
+    PermissionFlag::MENTION_EVERYONE,
+    PermissionFlag::READ_MESSAGE_HISTORY,
+    PermissionFlag::VIEW_CHANNEL,
+    PermissionFlag::SEND_MESSAGES,
+    PermissionFlag::SEND_TTS_MESSAGES,
+    PermissionFlag::SPEAK,
+    PermissionFlag::USE_EXTERNAL_EMOJIS,
+    PermissionFlag::USE_VAD,
+]);
 
 /// Returns a set of text-only permissions with the original `@everyone` permissions set to true.
 ///
@@ -223,19 +235,19 @@ pub const PRESET_GENERAL: Permissions = Permissions::from_bits_truncate(
 /// [Send Messages]: Permissions::SEND_MESSAGES
 /// [Send TTS Messages]: Permissions::SEND_TTS_MESSAGES
 /// [Use External Emojis]: Permissions::USE_EXTERNAL_EMOJIS
-pub const PRESET_TEXT: Permissions = Permissions::from_bits_truncate(
-    Permissions::ADD_REACTIONS.bits()
-        | Permissions::ATTACH_FILES.bits()
-        | Permissions::CHANGE_NICKNAME.bits()
-        | Permissions::CREATE_INSTANT_INVITE.bits()
-        | Permissions::EMBED_LINKS.bits()
-        | Permissions::MENTION_EVERYONE.bits()
-        | Permissions::READ_MESSAGE_HISTORY.bits()
-        | Permissions::VIEW_CHANNEL.bits()
-        | Permissions::SEND_MESSAGES.bits()
-        | Permissions::SEND_TTS_MESSAGES.bits()
-        | Permissions::USE_EXTERNAL_EMOJIS.bits(),
-);
+pub const PRESET_TEXT: Permissions = Permissions::from_individual_flags([
+    PermissionFlag::ADD_REACTIONS,
+    PermissionFlag::ATTACH_FILES,
+    PermissionFlag::CHANGE_NICKNAME,
+    PermissionFlag::CREATE_INSTANT_INVITE,
+    PermissionFlag::EMBED_LINKS,
+    PermissionFlag::MENTION_EVERYONE,
+    PermissionFlag::READ_MESSAGE_HISTORY,
+    PermissionFlag::VIEW_CHANNEL,
+    PermissionFlag::SEND_MESSAGES,
+    PermissionFlag::SEND_TTS_MESSAGES,
+    PermissionFlag::USE_EXTERNAL_EMOJIS,
+]);
 
 /// Returns a set of voice-only permissions with the original `@everyone` permissions set to true.
 ///
@@ -247,9 +259,11 @@ pub const PRESET_TEXT: Permissions = Permissions::from_bits_truncate(
 /// [Connect]: Permissions::CONNECT
 /// [Speak]: Permissions::SPEAK
 /// [Use VAD]: Permissions::USE_VAD
-pub const PRESET_VOICE: Permissions = Permissions::from_bits_truncate(
-    Permissions::CONNECT.bits() | Permissions::SPEAK.bits() | Permissions::USE_VAD.bits(),
-);
+pub const PRESET_VOICE: Permissions = Permissions::from_individual_flags([
+    PermissionFlag::CONNECT,
+    PermissionFlag::SPEAK,
+    PermissionFlag::USE_VAD,
+]);
 
 /// A set of permissions that can be assigned to [`User`]s and [`Role`]s via
 /// [`PermissionOverwrite`]s, roles globally in a [`Guild`], and to [`GuildChannel`]s.
@@ -262,9 +276,9 @@ pub const PRESET_VOICE: Permissions = Permissions::from_bits_truncate(
 /// [`Role`]: super::guild::Role
 /// [`User`]: super::user::User
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
-#[repr(Rust, packed)]
-pub struct Permissions(u64);
+#[derive(Clone, Default, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+//#[repr(Rust, packed)]
+pub struct Permissions(smolbitset::SmolBitSet);
 
 generate_permissions! {
     /// Allows for the creation of [`RichInvite`]s.
@@ -410,46 +424,79 @@ generate_permissions! {
     BYPASS_SLOWMODE, bypass_slowmode, "Bypass Slowmode" = 1 << 52
 }
 
+impl Permissions {
+    #[must_use]
+    pub fn empty() -> Self {
+        Self(smolbitset::SmolBitSet::new())
+    }
+
+    #[must_use]
+    const fn from_individual_flags<const N: usize>(perms: [PermissionFlag; N]) -> Self {
+        let mut bits_usize = [0; N];
+        let mut i = 0;
+
+        while i < N {
+            bits_usize[i] = perms[i] as usize;
+            i += 1;
+        }
+
+        Self(smolbitset::SmolBitSet::from_bits_small(bits_usize))
+    }
+
+    pub fn contains(&self, other: impl Into<Self>) -> bool {
+        let other = other.into().0;
+        let shared = self.0.clone() & &other;
+
+        shared == other
+    }
+
+    pub fn set(&mut self, permission: impl Into<Self>, value: bool) {
+        if value {
+            *self |= permission.into();
+        } else {
+            self.and_not_assign(&permission.into());
+        }
+    }
+
+    pub fn toggle(&mut self, permission: impl Into<Self>) {
+        *self ^= permission.into();
+    }
+
+    #[must_use]
+    pub fn and_not(&self, other: &Self) -> Self {
+        Self(self.0.clone().and_not(&other.0))
+    }
+
+    pub fn and_not_assign(&mut self, other: &Self) {
+        self.0.and_not_assign(&other.0);
+    }
+}
+
 #[cfg(feature = "model")]
 impl Permissions {
     #[must_use]
     pub fn dm_permissions() -> Self {
-        Self::ADD_REACTIONS
-            | Self::STREAM
-            | Self::VIEW_CHANNEL
-            | Self::SEND_MESSAGES
-            | Self::SEND_TTS_MESSAGES
-            | Self::EMBED_LINKS
-            | Self::ATTACH_FILES
-            | Self::READ_MESSAGE_HISTORY
-            | Self::MENTION_EVERYONE
-            | Self::USE_EXTERNAL_EMOJIS
-            | Self::CONNECT
-            | Self::SPEAK
-            | Self::USE_VAD
-            | Self::USE_APPLICATION_COMMANDS
-            | Self::USE_EXTERNAL_STICKERS
-            | Self::SEND_VOICE_MESSAGES
-            | Self::SEND_POLLS
-            | Self::USE_EXTERNAL_APPS
-            | Self::PIN_MESSAGES
-    }
-}
-
-// Manual impl needed because Permissions are usually sent as a stringified integer,
-// but audit log changes are sent as an int, which is probably a problem.
-impl<'de> Deserialize<'de> for Permissions {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let val = StrOrInt::deserialize(deserializer)?;
-        let val = val.parse().map_err(serde::de::Error::custom)?;
-
-        Ok(Permissions::from_bits_truncate(val))
-    }
-}
-
-impl Serialize for Permissions {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.collect_str(&self.bits())
+        Self::from_individual_flags([
+            PermissionFlag::ADD_REACTIONS,
+            PermissionFlag::STREAM,
+            PermissionFlag::VIEW_CHANNEL,
+            PermissionFlag::SEND_MESSAGES,
+            PermissionFlag::SEND_TTS_MESSAGES,
+            PermissionFlag::EMBED_LINKS,
+            PermissionFlag::ATTACH_FILES,
+            PermissionFlag::READ_MESSAGE_HISTORY,
+            PermissionFlag::MENTION_EVERYONE,
+            PermissionFlag::USE_EXTERNAL_EMOJIS,
+            PermissionFlag::CONNECT,
+            PermissionFlag::SPEAK,
+            PermissionFlag::USE_VAD,
+            PermissionFlag::USE_APPLICATION_COMMANDS,
+            PermissionFlag::USE_EXTERNAL_STICKERS,
+            PermissionFlag::SEND_VOICE_MESSAGES,
+            PermissionFlag::SEND_POLLS,
+            PermissionFlag::USE_EXTERNAL_APPS,
+            PermissionFlag::PIN_MESSAGES,
+        ])
     }
 }
 
@@ -472,6 +519,62 @@ impl fmt::Display for Permissions {
         }
 
         Ok(())
+    }
+}
+
+impl From<PermissionFlag> for Permissions {
+    fn from(value: PermissionFlag) -> Self {
+        Self(smolbitset::SmolBitSet::new_flag(value as u32))
+    }
+}
+
+impl std::ops::BitOr for Permissions {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for Permissions {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl std::ops::BitAnd for Permissions {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl std::ops::BitAndAssign for Permissions {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl std::ops::BitXor for Permissions {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Self(self.0 ^ rhs.0)
+    }
+}
+
+impl std::ops::BitXorAssign for Permissions {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        self.0 ^= rhs.0;
+    }
+}
+
+impl std::ops::Deref for Permissions {
+    type Target = smolbitset::SmolBitSet;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 


### PR DESCRIPTION
The overdue integration of [smolbitset](https://github.com/serenity-rs/smolbitset/) to prepare for the future breakage when discord goes past 64 permissions.

Things compile but I've not tested it yet.