### PR TITLE
Add `QuickModal::field_with_description` method

### DIFF
--- a/src/collector/quick_modal.rs
+++ b/src/collector/quick_modal.rs
@@ -71,8 +71,19 @@ impl<'a> CreateQuickModal<'a> {
         label: impl Into<Cow<'a, str>>,
         input_text: CreateInputText<'a>,
     ) -> Self {
+        self.components.push(CreateComponent::Label(CreateLabel::input_text(label, input_text)));
+        self
+    }
+
+    /// Adds an input text field with a description.
+    pub fn field_with_description(
+        mut self,
+        label: impl Into<Cow<'a, str>>,
+        description: impl Into<Cow<'a, str>>,
+        input_text: CreateInputText<'a>,
+    ) -> Self {
         self.components.push(CreateComponent::Label(
-            CreateLabel::input_text(label, input_text).description("test"),
+            CreateLabel::input_text(label, input_text).description(description),
         ));
         self
     }


### PR DESCRIPTION
Follow-up to #3430. Adds an optional method to add a description to any input texts in quick modals. Changing the signature of `field` to take an `Option<impl Into<Cow<'a, str>>>` meant that passing `None` would require a turbofish, so adding a new method makes more sense. Also fixes extraneous testing code that got accidentally left in.