### PR TITLE
Add guild role member counts endpoint

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -3896,6 +3897,27 @@ impl Http {
         if let Some(map) = value.as_object_mut() {
             map.insert("guild_id".to_string(), guild_id.get().into());
         }
+
+        from_value(value)
+    }
+
+    /// Retrieves a map of role IDs with total members each. Does not include `everyone` role.
+    pub async fn get_guild_role_member_counts(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<HashMap<RoleId, u32>> {
+        let value: Value = self
+            .fire(Request {
+                body: None,
+                multipart: None,
+                headers: None,
+                method: LightMethod::Get,
+                route: Route::GuildRoleMemberCounts {
+                    guild_id,
+                },
+                params: None,
+            })
+            .await?;
 
         from_value(value)
     }

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -310,6 +310,10 @@ routes! ('a, {
     api!("/guilds/{}/roles", guild_id),
     Some(RatelimitingKind::PathAndId(guild_id.into()));
 
+    GuildRoleMemberCounts { guild_id: GuildId },
+    api!("/guilds/{}/roles/member-counts", guild_id),
+    Some(RatelimitingKind::PathAndId(guild_id.into()));
+
     GuildScheduledEvent { guild_id: GuildId, event_id: ScheduledEventId },
     api!("/guilds/{}/scheduled-events/{}", guild_id, event_id),
     Some(RatelimitingKind::PathAndId(guild_id.into()));


### PR DESCRIPTION
Recently introduced and documented: https://github.com/discord/discord-api-docs/pull/8025

I did test the endpoint with an example bot. However, I'm not sure if `HashMap` is a good idea to use but I'm open to other options instead.