### PR TITLE
Preserve full payload and deserialization error for unknown events

### DIFF
--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -57,7 +57,7 @@ pub use self::shard_runner::{ShardRunner, ShardRunnerMessage, ShardRunnerOptions
 use super::{ActivityData, ChunkGuildFilter, GatewayError, PresenceData, WsClient};
 use crate::constants::{self, CloseCode};
 use crate::internal::prelude::*;
-use crate::model::event::{DeserializedEvent, Event, GatewayEvent, UnknownEvent};
+use crate::model::event::{DeserializedEvent, Event, GatewayEvent};
 use crate::model::gateway::{GatewayIntents, ShardInfo};
 #[cfg(feature = "voice")]
 use crate::model::id::ChannelId;
@@ -318,12 +318,9 @@ impl Shard {
 
         let event = match event {
             DeserializedEvent::Success(event) => event,
-            DeserializedEvent::Unknown(UnknownEvent {
-                ty,
-                ref data,
-            }) => {
-                debug!("Unknown event: {ty}");
-                debug!("Failing event data: {data:?}");
+            DeserializedEvent::Unknown(event) => {
+                debug!("Failed to deserialize event data: {}", event.err);
+                debug!("Raw event data: {}", event.data);
                 return None;
             },
         };

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -958,14 +958,18 @@ pub enum DeserializedEvent {
 }
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct UnknownEvent {
-    #[serde(rename = "t")]
-    pub ty: String,
-    #[serde(rename = "d")]
     #[cfg_attr(feature = "typesize", typesize(with = raw_value_len))]
     pub data: Box<RawValue>,
+    pub err: String,
+}
+
+impl Serialize for UnknownEvent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
+        self.data.serialize(serializer)
+    }
 }
 
 #[cfg(feature = "typesize")]
@@ -999,11 +1003,12 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 
                 Self::Dispatch {
                     seq: raw.seq.ok_or_else(|| DeError::missing_field("s"))?,
-                    event: match Box::<Event>::deserialize(raw_data) {
+                    event: match Deserialize::deserialize(raw_data) {
                         Ok(event) => DeserializedEvent::Success(event),
-                        Err(_) => DeserializedEvent::Unknown(
-                            UnknownEvent::deserialize(raw_data).map_err(DeError::custom)?,
-                        ),
+                        Err(e) => DeserializedEvent::Unknown(UnknownEvent {
+                            data: Deserialize::deserialize(raw_data).map_err(DeError::custom)?,
+                            err: e.to_string(),
+                        }),
                     },
                 }
             },


### PR DESCRIPTION
Provide better information about exactly what went wrong with an unknown event. Sometimes it isn't actually a new event but rather an existing event that failed deserialization for some reason or another. Keeping the error message lets us log it for better debugability. Also, it makes sense to preserve the full original payload rather than parsing it only a little bit.