### PR TITLE
Restrict top-level components in messages and modals

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -370,18 +370,18 @@ pub struct CreateFile<'a> {
 impl<'a> CreateFile<'a> {
     /// Create a new builder for the file component. Refer to this builders documentation for
     /// limits.
-    pub fn new(file: impl Into<CreateUnfurledMediaItem<'a>>) -> Self {
+    pub fn new(file: CreateUnfurledMediaItem<'a>) -> Self {
         CreateFile {
             kind: ComponentType::File,
-            file: file.into(),
+            file,
             spoiler: None,
         }
     }
 
     // Only supports `attachment://filename.extension` format, refer to this builders documentation
     // for more details. Replaces the current value as set in [`Self::new`].
-    pub fn file(mut self, file: impl Into<CreateUnfurledMediaItem<'a>>) -> Self {
-        self.file = file.into();
+    pub fn file(mut self, file: CreateUnfurledMediaItem<'a>) -> Self {
+        self.file = file;
         self
     }
 
@@ -437,13 +437,12 @@ pub struct CreateContainer<'a> {
     accent_color: Option<Colour>,
     #[serde(skip_serializing_if = "Option::is_none")]
     spoiler: Option<bool>,
-    components: Cow<'a, [CreateComponent<'a>]>,
+    components: Cow<'a, [CreateContainerComponent<'a>]>,
 }
 
 impl<'a> CreateContainer<'a> {
-    /// Create a new container, with an array of components inside. This component may contain any
-    /// other component except another container!
-    pub fn new(components: impl Into<Cow<'a, [CreateComponent<'a>]>>) -> Self {
+    /// Create a new container, with an array of components inside.
+    pub fn new(components: impl Into<Cow<'a, [CreateContainerComponent<'a>]>>) -> Self {
         CreateContainer {
             kind: ComponentType::Container,
             accent_color: None,
@@ -475,7 +474,10 @@ impl<'a> CreateContainer<'a> {
     ///
     /// **Note**: This will replace all existing components. Use [`Self::add_component()`] to add
     /// additional components.
-    pub fn components(mut self, components: impl Into<Cow<'a, [CreateComponent<'a>]>>) -> Self {
+    pub fn components(
+        mut self,
+        components: impl Into<Cow<'a, [CreateContainerComponent<'a>]>>,
+    ) -> Self {
         self.components = components.into();
         self
     }
@@ -483,10 +485,23 @@ impl<'a> CreateContainer<'a> {
     /// Adds an additional component to this container.
     ///
     /// **Note**: This will add additional components. Use [`Self::components()`] to replace them.
-    pub fn add_component(mut self, component: CreateComponent<'a>) -> Self {
+    pub fn add_component(mut self, component: CreateContainerComponent<'a>) -> Self {
         self.components.to_mut().push(component);
         self
     }
+}
+
+/// An enum of all valid container components.
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
+#[serde(untagged)]
+pub enum CreateContainerComponent<'a> {
+    ActionRow(CreateActionRow<'a>),
+    Section(CreateSection<'a>),
+    TextDisplay(CreateTextDisplay<'a>),
+    MediaGallery(CreateMediaGallery<'a>),
+    File(CreateFile<'a>),
+    Separator(CreateSeparator),
 }
 
 /// A builder for creating a label that can hold an [`InputText`] or [`SelectMenu`].

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -7,7 +7,9 @@ use super::{
     CreateAttachment,
     CreateComponent,
     CreateEmbed,
+    CreateLabel,
     CreatePoll,
+    CreateTextDisplay,
     EditAttachments,
 };
 #[cfg(feature = "http")]
@@ -423,7 +425,7 @@ impl<'a> CreateAutocompleteResponse<'a> {
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateModal<'a> {
-    components: Cow<'a, [CreateComponent<'a>]>,
+    components: Cow<'a, [CreateModalComponent<'a>]>,
     custom_id: Cow<'a, str>,
     title: Cow<'a, str>,
 }
@@ -441,8 +443,19 @@ impl<'a> CreateModal<'a> {
     /// Sets the components of this message.
     ///
     /// Overwrites existing components.
-    pub fn components(mut self, components: impl Into<Cow<'a, [CreateComponent<'a>]>>) -> Self {
+    pub fn components(
+        mut self,
+        components: impl Into<Cow<'a, [CreateModalComponent<'a>]>>,
+    ) -> Self {
         self.components = components.into();
         self
     }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
+#[serde(untagged)]
+pub enum CreateModalComponent<'a> {
+    TextDisplay(CreateTextDisplay<'a>),
+    Label(CreateLabel<'a>),
 }

--- a/src/collector/quick_modal.rs
+++ b/src/collector/quick_modal.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 
 use crate::builder::{
-    CreateComponent,
     CreateInputText,
     CreateInteractionResponse,
     CreateLabel,
     CreateModal,
+    CreateModalComponent,
     CreateTextDisplay,
 };
 use crate::collector::ModalInteractionCollector;
@@ -38,7 +38,7 @@ pub struct QuickModalResponse {
 pub struct CreateQuickModal<'a> {
     title: Cow<'a, str>,
     timeout: Option<std::time::Duration>,
-    components: Vec<CreateComponent<'a>>,
+    components: Vec<CreateModalComponent<'a>>,
 }
 
 impl<'a> CreateQuickModal<'a> {
@@ -61,7 +61,7 @@ impl<'a> CreateQuickModal<'a> {
 
     /// Adds a text display field.
     pub fn text(mut self, content: impl Into<Cow<'a, str>>) -> Self {
-        self.components.push(CreateComponent::TextDisplay(CreateTextDisplay::new(content)));
+        self.components.push(CreateModalComponent::TextDisplay(CreateTextDisplay::new(content)));
         self
     }
 
@@ -71,7 +71,8 @@ impl<'a> CreateQuickModal<'a> {
         label: impl Into<Cow<'a, str>>,
         input_text: CreateInputText<'a>,
     ) -> Self {
-        self.components.push(CreateComponent::Label(CreateLabel::input_text(label, input_text)));
+        self.components
+            .push(CreateModalComponent::Label(CreateLabel::input_text(label, input_text)));
         self
     }
 
@@ -82,7 +83,7 @@ impl<'a> CreateQuickModal<'a> {
         description: impl Into<Cow<'a, str>>,
         input_text: CreateInputText<'a>,
     ) -> Self {
-        self.components.push(CreateComponent::Label(
+        self.components.push(CreateModalComponent::Label(
             CreateLabel::input_text(label, input_text).description(description),
         ));
         self

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -33,7 +33,7 @@ enum_number! {
     }
 }
 
-/// Represents Discord components, a part of messages that are usually interactable.
+/// Represents top-level Discord components, a part of messages that are usually interactable.
 ///
 /// # Component Versioning
 ///
@@ -46,14 +46,11 @@ enum_number! {
 #[non_exhaustive]
 pub enum Component {
     ActionRow(ActionRow),
-    Button(Button),
-    SelectMenu(SelectMenu),
     Section(Section),
     TextDisplay(TextDisplay),
-    Thumbnail(Thumbnail),
     MediaGallery(MediaGallery),
-    Separator(Separator),
     File(FileComponent),
+    Separator(Separator),
     Container(Container),
     Label(Label),
     Unknown(u8),
@@ -77,14 +74,6 @@ impl<'de> Deserialize<'de> for Component {
 
         match raw.kind {
             ComponentType::ActionRow => Deserialize::deserialize(value).map(Component::ActionRow),
-            ComponentType::Button => Deserialize::deserialize(value).map(Component::Button),
-            ComponentType::StringSelect
-            | ComponentType::UserSelect
-            | ComponentType::RoleSelect
-            | ComponentType::MentionableSelect
-            | ComponentType::ChannelSelect => {
-                Deserialize::deserialize(value).map(Component::SelectMenu)
-            },
             ComponentType::Section => Deserialize::deserialize(value).map(Component::Section),
             ComponentType::TextDisplay => {
                 Deserialize::deserialize(value).map(Component::TextDisplay)
@@ -95,7 +84,6 @@ impl<'de> Deserialize<'de> for Component {
             ComponentType::Separator => Deserialize::deserialize(value).map(Component::Separator),
             ComponentType::File => Deserialize::deserialize(value).map(Component::File),
             ComponentType::Container => Deserialize::deserialize(value).map(Component::Container),
-            ComponentType::Thumbnail => Deserialize::deserialize(value).map(Component::Thumbnail),
             ComponentType::Label => Deserialize::deserialize(value).map(Component::Label),
             ComponentType(i) => Ok(Component::Unknown(i)),
         }
@@ -113,15 +101,82 @@ pub struct Section {
     /// Always [`ComponentType::Section`]
     #[serde(rename = "type")]
     pub kind: ComponentType,
-    /// The components inside of the section.
-    ///
-    /// As of 2025-02-28, this is limited to just [`ComponentType::TextDisplay`] with up to 3 max.
-    pub components: FixedArray<Component>,
+    /// The components inside of the section. At least one is required, with a maximum limit of 3.
+    pub components: FixedArray<SectionComponent>,
     /// The accessory to the side of the section.
-    ///
-    /// As of 2025-02-28, this is limited to [`ComponentType::Button`] or
-    /// [`ComponentType::Thumbnail`]
-    pub accessory: Box<Component>,
+    pub accessory: Box<SectionAccessory>,
+}
+
+/// A child component representing the content of a section.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#section-section-child-components)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
+pub enum SectionComponent {
+    TextDisplay(TextDisplay),
+}
+
+impl<'de> Deserialize<'de> for SectionComponent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct SectionComponentRaw {
+            #[serde(rename = "type")]
+            kind: ComponentType,
+        }
+
+        let raw_data = <&RawValue>::deserialize(deserializer)?;
+        let raw = SectionComponentRaw::deserialize(raw_data).map_err(DeError::custom)?;
+
+        match raw.kind {
+            ComponentType::TextDisplay => {
+                Deserialize::deserialize(raw_data).map(SectionComponent::TextDisplay)
+            },
+            ComponentType(i) => {
+                return Err(DeError::custom(format_args!("Unknown section component type {i}")));
+            },
+        }
+        .map_err(DeError::custom)
+    }
+}
+
+/// A component that is contextually associated to the content of a section.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#section-section-accessory-components)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
+pub enum SectionAccessory {
+    Button(Button),
+    Thumbnail(Thumbnail),
+}
+
+impl<'de> Deserialize<'de> for SectionAccessory {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct SectionAccessoryRaw {
+            #[serde(rename = "type")]
+            kind: ComponentType,
+        }
+
+        let raw_data = <&RawValue>::deserialize(deserializer)?;
+        let raw = SectionAccessoryRaw::deserialize(raw_data).map_err(DeError::custom)?;
+
+        match raw.kind {
+            ComponentType::Button => {
+                Deserialize::deserialize(raw_data).map(SectionAccessory::Button)
+            },
+            ComponentType::Thumbnail => {
+                Deserialize::deserialize(raw_data).map(SectionAccessory::Thumbnail)
+            },
+            ComponentType(i) => {
+                return Err(DeError::custom(format_args!(
+                    "Unknown section accessory component type {i}"
+                )));
+            },
+        }
+        .map_err(DeError::custom)
+    }
 }
 
 /// A section component's thumbnail.
@@ -269,11 +324,63 @@ pub struct Container {
     /// Whether or not this component is spoilered.
     pub spoiler: Option<bool>,
     /// The components within this container.
-    ///
-    /// As of 2025-02-28, this can be [`ComponentType::ActionRow`], [`ComponentType::Section`],
-    /// [`ComponentType::TextDisplay`], [`ComponentType::MediaGallery`], [`ComponentType::File`] or
-    /// [`ComponentType::Separator`]
-    pub components: FixedArray<Component>,
+    pub components: FixedArray<ContainerComponent>,
+}
+
+/// A child component encapsulated within a container.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#container-container-child-components)
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[non_exhaustive]
+pub enum ContainerComponent {
+    ActionRow(ActionRow),
+    Section(Section),
+    TextDisplay(TextDisplay),
+    MediaGallery(MediaGallery),
+    File(FileComponent),
+    Separator(Separator),
+}
+
+impl<'de> Deserialize<'de> for ContainerComponent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde_json::value::RawValue;
+
+        #[derive(Deserialize)]
+        struct ContainerComponentRaw {
+            #[serde(rename = "type")]
+            kind: ComponentType,
+        }
+
+        let value = <&RawValue>::deserialize(deserializer)?;
+        let raw = ContainerComponentRaw::deserialize(value).map_err(DeError::custom)?;
+
+        match raw.kind {
+            ComponentType::ActionRow => {
+                Deserialize::deserialize(value).map(ContainerComponent::ActionRow)
+            },
+            ComponentType::Section => {
+                Deserialize::deserialize(value).map(ContainerComponent::Section)
+            },
+            ComponentType::TextDisplay => {
+                Deserialize::deserialize(value).map(ContainerComponent::TextDisplay)
+            },
+            ComponentType::MediaGallery => {
+                Deserialize::deserialize(value).map(ContainerComponent::MediaGallery)
+            },
+            ComponentType::Separator => {
+                Deserialize::deserialize(value).map(ContainerComponent::Separator)
+            },
+            ComponentType::File => Deserialize::deserialize(value).map(ContainerComponent::File),
+            ComponentType(i) => {
+                return Err(DeError::custom(format_args!("Unknown container component type {i}")));
+            },
+        }
+        .map_err(DeError::custom)
+    }
 }
 
 /// A layout component that wraps modal components with a label and optional description.
@@ -329,7 +436,7 @@ impl<'de> Deserialize<'de> for LabelComponent {
                 Deserialize::deserialize(raw_data).map(LabelComponent::FileUpload)
             },
             ComponentType(i) => {
-                return Err(DeError::custom(format_args!("Unknown component type {i}")));
+                return Err(DeError::custom(format_args!("Unknown label component type {i}")));
             },
         }
         .map_err(DeError::custom)
@@ -403,7 +510,7 @@ impl<'de> Deserialize<'de> for ActionRowComponent {
                 return Err(DeError::custom("Invalid component type ActionRow"));
             },
             ComponentType(i) => {
-                return Err(DeError::custom(format_args!("Unknown component type {i}")));
+                return Err(DeError::custom(format_args!("Unknown action row component type {i}")));
             },
         }
         .map_err(DeError::custom)

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -229,8 +229,6 @@ pub struct TextDisplay {
     /// Always [`ComponentType::TextDisplay`]
     #[serde(rename = "type")]
     pub kind: ComponentType,
-    /// The content of this text display component.
-    pub content: FixedString<u16>,
 }
 
 /// A Media Gallery is a component that allows you to display media attachments in an organized

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -214,9 +214,20 @@ impl Serialize for ModalInteraction {
 pub struct ModalInteractionData {
     /// The custom id of the modal
     pub custom_id: FixedString,
-    /// The components.
+    /// The components of the submitted modal interaction.
     pub components: FixedArray<Component>,
     /// The resolved entities from the selected options.
     #[serde(default)]
     pub resolved: CommandDataResolved,
+}
+
+/// A component which can appear inside a modal form submission.
+///
+/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-component-interaction-response-structures)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
+pub enum ModalInteractionComponent {
+    TextDisplay(TextDisplay),
+    Label(Label),
 }


### PR DESCRIPTION
Only certain components can appear at the top level in messages. This changes the definition of `Component` to reflect that by removing variants which cannot appear at the top level and must be included inside another component. This aligns the `Component` type with the `CreateComponent` builder. Also, Sections and Containers can only contain a subset of component types, so added a dedicated enum for those. The corresponding builders already exist.

Similarly for modal forms, only Labels and Text Displays can appear at the top level (Action Rows are deprecated). So I added a `ModalComponent` enum which reflects that, and also a `CreateModalComponent` builder.