### PR TITLE
Add `attachment_size_limit` field

### DIFF
--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -88,6 +88,8 @@ pub struct CommandInteraction {
     pub authorizing_integration_owners: AuthorizingIntegrationOwners,
     /// The context where the interaction was triggered from.
     pub context: Option<InteractionContext>,
+    /// Attachment size limit in bytes
+    pub attachment_size_limit: u64,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -88,7 +88,7 @@ pub struct CommandInteraction {
     pub authorizing_integration_owners: AuthorizingIntegrationOwners,
     /// The context where the interaction was triggered from.
     pub context: Option<InteractionContext>,
-    /// Attachment size limit in bytes
+    /// Attachment size limit in bytes.
     pub attachment_size_limit: u32,
 }
 

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -89,7 +89,7 @@ pub struct CommandInteraction {
     /// The context where the interaction was triggered from.
     pub context: Option<InteractionContext>,
     /// Attachment size limit in bytes
-    pub attachment_size_limit: u64,
+    pub attachment_size_limit: u32,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -67,7 +67,7 @@ pub struct ComponentInteraction {
     pub authorizing_integration_owners: AuthorizingIntegrationOwners,
     /// The context where the interaction was triggered from.
     pub context: Option<InteractionContext>,
-    /// Attachment size limit in bytes
+    /// Attachment size limit in bytes.
     pub attachment_size_limit: u32,
 }
 

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -68,7 +68,7 @@ pub struct ComponentInteraction {
     /// The context where the interaction was triggered from.
     pub context: Option<InteractionContext>,
     /// Attachment size limit in bytes
-    pub attachment_size_limit: u64,
+    pub attachment_size_limit: u32,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -67,6 +67,8 @@ pub struct ComponentInteraction {
     pub authorizing_integration_owners: AuthorizingIntegrationOwners,
     /// The context where the interaction was triggered from.
     pub context: Option<InteractionContext>,
+    /// Attachment size limit in bytes
+    pub attachment_size_limit: u64,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -61,7 +61,7 @@ pub struct ModalInteraction {
     /// For monetized applications, any entitlements of the invoking user.
     pub entitlements: Vec<Entitlement>,
     /// Attachment size limit in bytes
-    pub attachment_size_limit: u64,
+    pub attachment_size_limit: u32,
 }
 
 #[cfg(feature = "model")]

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -60,7 +60,7 @@ pub struct ModalInteraction {
     pub guild_locale: Option<String>,
     /// For monetized applications, any entitlements of the invoking user.
     pub entitlements: Vec<Entitlement>,
-    /// Attachment size limit in bytes
+    /// Attachment size limit in bytes.
     pub attachment_size_limit: u32,
 }
 

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -60,6 +60,8 @@ pub struct ModalInteraction {
     pub guild_locale: Option<String>,
     /// For monetized applications, any entitlements of the invoking user.
     pub entitlements: Vec<Entitlement>,
+    /// Attachment size limit in bytes
+    pub attachment_size_limit: u64,
 }
 
 #[cfg(feature = "model")]


### PR DESCRIPTION
Implements [Per-Attachment File Upload Behavior for Apps](https://github.com/discord/discord-api-docs/pull/7451)

Fixes https://github.com/serenity-rs/serenity/issues/3455