### PR TITLE
Refactor FullEvent cache update function

### DIFF
--- a/src/cache/cache_update.rs
+++ b/src/cache/cache_update.rs
@@ -12,5 +12,5 @@ pub trait CacheUpdate {
     type Output;
 
     /// Updates the cache with the implementation.
-    fn update(&mut self, _: &Cache) -> Option<Self::Output>;
+    fn update(&self, _: &Cache) -> Option<Self::Output>;
 }

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -54,7 +54,7 @@ use crate::model::voice::VoiceState;
 impl CacheUpdate for ChannelCreateEvent {
     type Output = GuildChannel;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         cache
             .guilds
             .get_mut(&self.channel.base.guild_id)
@@ -65,7 +65,7 @@ impl CacheUpdate for ChannelCreateEvent {
 impl CacheUpdate for ChannelDeleteEvent {
     type Output = VecDeque<Message>;
 
-    fn update(&mut self, cache: &Cache) -> Option<VecDeque<Message>> {
+    fn update(&self, cache: &Cache) -> Option<VecDeque<Message>> {
         let (channel_id, guild_id) = (self.channel.id, self.channel.base.guild_id);
 
         cache.guilds.get_mut(&guild_id).map(|mut g| g.channels.remove(&channel_id));
@@ -78,7 +78,7 @@ impl CacheUpdate for ChannelDeleteEvent {
 impl CacheUpdate for ChannelUpdateEvent {
     type Output = GuildChannel;
 
-    fn update(&mut self, cache: &Cache) -> Option<GuildChannel> {
+    fn update(&self, cache: &Cache) -> Option<GuildChannel> {
         cache
             .guilds
             .get_mut(&self.channel.base.guild_id)
@@ -89,7 +89,7 @@ impl CacheUpdate for ChannelUpdateEvent {
 impl CacheUpdate for ChannelPinsUpdateEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(guild_id) = self.guild_id
             && let Some(mut guild) = cache.guilds.get_mut(&guild_id)
         {
@@ -111,7 +111,7 @@ impl CacheUpdate for ChannelPinsUpdateEvent {
 impl CacheUpdate for GuildCreateEvent {
     type Output = Vec<GuildId>;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         cache.unavailable_guilds.remove(&self.guild.id);
         let guild = self.guild.clone();
 
@@ -129,7 +129,7 @@ impl CacheUpdate for GuildCreateEvent {
 impl CacheUpdate for GuildDeleteEvent {
     type Output = Guild;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if self.guild.unavailable {
             cache.unavailable_guilds.insert(self.guild.id, ());
             cache.guilds.remove(&self.guild.id);
@@ -154,7 +154,7 @@ impl CacheUpdate for GuildDeleteEvent {
 impl CacheUpdate for GuildEmojisUpdateEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             guild.emojis.clone_from(&self.emojis);
         }
@@ -166,7 +166,7 @@ impl CacheUpdate for GuildEmojisUpdateEvent {
 impl CacheUpdate for GuildMemberAddEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(mut guild) = cache.guilds.get_mut(&self.member.guild_id) {
             guild.member_count += 1;
             guild.members.insert(self.member.clone());
@@ -179,7 +179,7 @@ impl CacheUpdate for GuildMemberAddEvent {
 impl CacheUpdate for GuildMemberRemoveEvent {
     type Output = Member;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             guild.member_count -= 1;
             return guild.members.remove(&self.user.id);
@@ -192,7 +192,7 @@ impl CacheUpdate for GuildMemberRemoveEvent {
 impl CacheUpdate for GuildMemberUpdateEvent {
     type Output = Member;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             let item = if let Some(mut member) = guild.members.get_mut(&self.user.id) {
                 let item = Some(member.clone());
@@ -250,7 +250,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
 impl CacheUpdate for GuildMembersChunkEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(mut g) = cache.guilds.get_mut(&self.guild_id) {
             g.members.extend(self.members.clone());
         }
@@ -262,7 +262,7 @@ impl CacheUpdate for GuildMembersChunkEvent {
 impl CacheUpdate for GuildRoleCreateEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         cache.guilds.get_mut(&self.role.guild_id).map(|mut g| g.roles.insert(self.role.clone()));
         None
     }
@@ -271,7 +271,7 @@ impl CacheUpdate for GuildRoleCreateEvent {
 impl CacheUpdate for GuildRoleDeleteEvent {
     type Output = Role;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         cache.guilds.get_mut(&self.guild_id).and_then(|mut g| g.roles.remove(&self.role_id))
     }
 }
@@ -279,7 +279,7 @@ impl CacheUpdate for GuildRoleDeleteEvent {
 impl CacheUpdate for GuildRoleUpdateEvent {
     type Output = Role;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(mut guild) = cache.guilds.get_mut(&self.role.guild_id)
             && let Some(mut role) = guild.roles.get_mut(&self.role.id)
         {
@@ -293,7 +293,7 @@ impl CacheUpdate for GuildRoleUpdateEvent {
 impl CacheUpdate for GuildStickersUpdateEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
             guild.stickers.clone_from(&self.stickers);
         }
@@ -305,7 +305,7 @@ impl CacheUpdate for GuildStickersUpdateEvent {
 impl CacheUpdate for GuildUpdateEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         if let Some(mut guild) = cache.guilds.get_mut(&self.guild.id) {
             guild.afk_metadata.clone_from(&self.guild.afk_metadata);
             guild.banner.clone_from(&self.guild.banner);
@@ -354,7 +354,7 @@ impl CacheUpdate for MessageCreateEvent {
     /// The oldest message, if the channel's message cache was already full.
     type Output = Message;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         // Update the relevant channel object with the new latest message if this message is newer
         let guild = self.message.guild_id.and_then(|g_id| cache.guilds.get_mut(&g_id));
 
@@ -415,7 +415,7 @@ fn update_channel_last_message_id(
 impl CacheUpdate for MessageUpdateEvent {
     type Output = Message;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         for message in cache.messages.get_mut(&self.message.channel_id)?.iter_mut() {
             if message.id == self.message.id {
                 let old_message = message.clone();
@@ -431,7 +431,7 @@ impl CacheUpdate for MessageUpdateEvent {
 impl CacheUpdate for PresenceUpdateEvent {
     type Output = Presence;
 
-    fn update(&mut self, cache: &Cache) -> Option<Presence> {
+    fn update(&self, cache: &Cache) -> Option<Presence> {
         if let Some(guild_id) = self.presence.guild_id
             && let Some(mut guild) = cache.guilds.get_mut(&guild_id)
         {
@@ -476,7 +476,7 @@ impl CacheUpdate for PresenceUpdateEvent {
 impl CacheUpdate for ReadyEvent {
     type Output = NonZeroU16;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         for unavailable in &self.ready.guilds {
             cache.guilds.remove(&unavailable.id);
             cache.unavailable_guilds.insert(unavailable.id, ());
@@ -502,7 +502,7 @@ impl CacheUpdate for ReadyEvent {
 impl CacheUpdate for ThreadCreateEvent {
     type Output = GuildThread;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         cache
             .guilds
             .get_mut(&self.thread.base.guild_id)
@@ -513,7 +513,7 @@ impl CacheUpdate for ThreadCreateEvent {
 impl CacheUpdate for ThreadUpdateEvent {
     type Output = GuildThread;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         cache
             .guilds
             .get_mut(&self.thread.base.guild_id)
@@ -524,7 +524,7 @@ impl CacheUpdate for ThreadUpdateEvent {
 impl CacheUpdate for ThreadDeleteEvent {
     type Output = GuildThread;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         cache
             .guilds
             .get_mut(&self.thread.guild_id)
@@ -535,7 +535,7 @@ impl CacheUpdate for ThreadDeleteEvent {
 impl CacheUpdate for ThreadListSyncEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         let mut guild = cache.guilds.get_mut(&self.guild_id)?;
         let Some(channel_ids) = &self.channel_ids else {
             // channel_ids is none, this is a full sync, easy path
@@ -580,7 +580,7 @@ impl CacheUpdate for ThreadListSyncEvent {
 impl CacheUpdate for UserUpdateEvent {
     type Output = CurrentUser;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         let mut user = cache.user.write();
         Some(std::mem::replace(&mut user, self.current_user.clone()))
     }
@@ -589,7 +589,7 @@ impl CacheUpdate for UserUpdateEvent {
 impl CacheUpdate for VoiceStateUpdateEvent {
     type Output = VoiceState;
 
-    fn update(&mut self, cache: &Cache) -> Option<VoiceState> {
+    fn update(&self, cache: &Cache) -> Option<VoiceState> {
         if let Some(guild_id) = self.voice_state.guild_id {
             if let Some(mut guild) = cache.guilds.get_mut(&guild_id) {
                 if let Some(member) = &self.voice_state.member {
@@ -617,7 +617,7 @@ impl CacheUpdate for VoiceStateUpdateEvent {
 impl CacheUpdate for VoiceChannelStatusUpdateEvent {
     type Output = FixedString<u16>;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         let mut guild = cache.guilds.get_mut(&self.guild_id)?;
         let mut channel = guild.channels.get_mut(&self.id)?;
 
@@ -635,7 +635,7 @@ fn update_guild_event(cache: &Cache, event: &ScheduledEvent) -> Option<Scheduled
 impl CacheUpdate for GuildScheduledEventCreateEvent {
     type Output = std::convert::Infallible;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         update_guild_event(cache, &self.event);
         None
     }
@@ -644,7 +644,7 @@ impl CacheUpdate for GuildScheduledEventCreateEvent {
 impl CacheUpdate for GuildScheduledEventUpdateEvent {
     type Output = ScheduledEvent;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         update_guild_event(cache, &self.event)
     }
 }
@@ -652,7 +652,7 @@ impl CacheUpdate for GuildScheduledEventUpdateEvent {
 impl CacheUpdate for GuildScheduledEventDeleteEvent {
     type Output = ScheduledEvent;
 
-    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
         let mut guild = cache.guilds.get_mut(&self.event.guild_id)?;
         guild.scheduled_events.remove(&self.event.id)
     }

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -3,13 +3,12 @@ use std::sync::Arc;
 use super::event_handler::{EventHandler, RawEventHandler};
 use super::{Context, FullEvent};
 #[cfg(feature = "cache")]
-use crate::cache::{Cache, CacheUpdate};
+use crate::cache::CacheUpdate;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
 use crate::internal::tokio::spawn_named;
 use crate::model::channel::ChannelType;
 use crate::model::event::Event;
-use crate::model::guild::Member;
 
 #[cfg(feature = "cache")]
 macro_rules! if_cache {
@@ -27,19 +26,19 @@ macro_rules! if_cache {
 
 #[cfg(feature = "cache")]
 macro_rules! update_cache {
-    ($cache:ident, $event:ident) => {
+    ($cache:expr, $event:ident) => {
         $event.update($cache)
     };
 }
 
 #[cfg(not(feature = "cache"))]
 macro_rules! update_cache {
-    ($cache:ident, $event:ident) => {};
+    ($cache:expr, $event:ident) => {};
 }
 
 /// Calls the user's event handlers and the framework handler.
 pub(crate) async fn dispatch_model(
-    event: Box<Event>,
+    event: Event,
     context: Context,
     #[cfg(feature = "framework")] framework: Option<Arc<dyn Framework>>,
     event_handler: Option<Arc<dyn EventHandler>>,
@@ -49,11 +48,8 @@ pub(crate) async fn dispatch_model(
         raw_handler.raw_event(context.clone(), &event).await;
     }
 
-    let (full_event, extra_event) = update_cache_with_event(
-        #[cfg(feature = "cache")]
-        &context.cache,
-        event,
-    );
+    let extra_event = get_virtual_event(&context, &event);
+    let full_event = update_cache_with_event(&context, event);
 
     spawn_named("dispatch::user", async move {
         #[cfg(feature = "framework")]
@@ -99,18 +95,8 @@ async fn dispatch_event_handler(
 }
 
 /// Updates the cache with the incoming event data and builds the full event data out of it.
-///
-/// Can return a secondary [`FullEvent`] for "virtual" events like [`FullEvent::CacheReady`] or
-/// [`FullEvent::ShardsReady`]. Secondary events are traditionally dispatched first.
-///
-/// Can return `None` if an event is unknown.
-#[cfg_attr(not(feature = "cache"), allow(unused_mut))]
-fn update_cache_with_event(
-    #[cfg(feature = "cache")] cache: &Cache,
-    event: Box<Event>,
-) -> (FullEvent, Option<FullEvent>) {
-    let mut extra_event = None;
-    let event = match *event {
+fn update_cache_with_event(ctx: &Context, event: Event) -> FullEvent {
+    match event {
         Event::CommandPermissionsUpdate(event) => FullEvent::CommandPermissionsUpdate {
             permission: event.permission,
         },
@@ -126,8 +112,8 @@ fn update_cache_with_event(
         Event::AutoModActionExecution(event) => FullEvent::AutoModActionExecution {
             execution: event.execution,
         },
-        Event::ChannelCreate(mut event) => {
-            update_cache!(cache, event);
+        Event::ChannelCreate(event) => {
+            update_cache!(&ctx.cache, event);
 
             let channel = event.channel;
             if channel.base.kind == ChannelType::Category {
@@ -140,8 +126,8 @@ fn update_cache_with_event(
                 }
             }
         },
-        Event::ChannelDelete(mut event) => {
-            let cached_messages = if_cache!(update_cache!(cache, event));
+        Event::ChannelDelete(event) => {
+            let cached_messages = if_cache!(update_cache!(&ctx.cache, event));
 
             let channel = event.channel;
             if channel.base.kind == ChannelType::Category {
@@ -158,8 +144,8 @@ fn update_cache_with_event(
         Event::ChannelPinsUpdate(event) => FullEvent::ChannelPinsUpdate {
             pin: event,
         },
-        Event::ChannelUpdate(mut event) => {
-            let old_channel = if_cache!(update_cache!(cache, event));
+        Event::ChannelUpdate(event) => {
+            let old_channel = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::ChannelUpdate {
                 old: old_channel,
@@ -178,31 +164,25 @@ fn update_cache_with_event(
             guild_id: event.guild_id,
             unbanned_user: event.user,
         },
-        Event::GuildCreate(mut event) => {
-            let is_new = if_cache!(Some(!cache.unavailable_guilds().contains(&event.guild.id)));
-
-            #[cfg(feature = "cache")]
-            if let Some(guilds) = update_cache!(cache, event) {
-                extra_event = Some(FullEvent::CacheReady {
-                    guilds,
-                });
-            }
+        Event::GuildCreate(event) => {
+            let is_new =
+                if_cache!(Some(!&ctx.cache.unavailable_guilds().contains(&event.guild.id)));
 
             FullEvent::GuildCreate {
                 guild: event.guild,
                 is_new,
             }
         },
-        Event::GuildDelete(mut event) => {
-            let full = if_cache!(update_cache!(cache, event));
+        Event::GuildDelete(event) => {
+            let full = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::GuildDelete {
                 incomplete: event.guild,
                 full,
             }
         },
-        Event::GuildEmojisUpdate(mut event) => {
-            update_cache!(cache, event);
+        Event::GuildEmojisUpdate(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::GuildEmojisUpdate {
                 guild_id: event.guild_id,
@@ -212,15 +192,15 @@ fn update_cache_with_event(
         Event::GuildIntegrationsUpdate(event) => FullEvent::GuildIntegrationsUpdate {
             guild_id: event.guild_id,
         },
-        Event::GuildMemberAdd(mut event) => {
-            update_cache!(cache, event);
+        Event::GuildMemberAdd(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::GuildMemberAddition {
                 new_member: event.member,
             }
         },
-        Event::GuildMemberRemove(mut event) => {
-            let member = if_cache!(update_cache!(cache, event));
+        Event::GuildMemberRemove(event) => {
+            let member = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::GuildMemberRemoval {
                 guild_id: event.guild_id,
@@ -228,12 +208,13 @@ fn update_cache_with_event(
                 member_data_if_available: member,
             }
         },
-        Event::GuildMemberUpdate(mut event) => {
-            let before = if_cache!(update_cache!(cache, event));
-            let after: Option<Member> = if_cache!({
-                let guild = cache.guild(event.guild_id);
-                guild.and_then(|g| g.members.get(&event.user.id).cloned())
-            });
+        Event::GuildMemberUpdate(event) => {
+            let before = if_cache!(update_cache!(&ctx.cache, event));
+            let after = if_cache!(
+                ctx.cache
+                    .guild(event.guild_id)
+                    .and_then(|g| g.members.get(&event.user.id).cloned())
+            );
 
             FullEvent::GuildMemberUpdate {
                 old_if_available: before,
@@ -241,22 +222,22 @@ fn update_cache_with_event(
                 event,
             }
         },
-        Event::GuildMembersChunk(mut event) => {
-            update_cache!(cache, event);
+        Event::GuildMembersChunk(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::GuildMembersChunk {
                 chunk: event,
             }
         },
-        Event::GuildRoleCreate(mut event) => {
-            update_cache!(cache, event);
+        Event::GuildRoleCreate(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::GuildRoleCreate {
                 new: event.role,
             }
         },
-        Event::GuildRoleDelete(mut event) => {
-            let role = if_cache!(update_cache!(cache, event));
+        Event::GuildRoleDelete(event) => {
+            let role = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::GuildRoleDelete {
                 guild_id: event.guild_id,
@@ -264,16 +245,16 @@ fn update_cache_with_event(
                 removed_role_data_if_available: role,
             }
         },
-        Event::GuildRoleUpdate(mut event) => {
-            let before = if_cache!(update_cache!(cache, event));
+        Event::GuildRoleUpdate(event) => {
+            let before = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::GuildRoleUpdate {
                 old_data_if_available: before,
                 new: event.role,
             }
         },
-        Event::GuildStickersUpdate(mut event) => {
-            update_cache!(cache, event);
+        Event::GuildStickersUpdate(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::GuildStickersUpdate {
                 guild_id: event.guild_id,
@@ -281,7 +262,7 @@ fn update_cache_with_event(
             }
         },
         Event::GuildUpdate(event) => {
-            let before = if_cache!(cache.guild(event.guild.id).map(|g| g.clone()));
+            let before = if_cache!(ctx.cache.guild(event.guild.id).map(|g| g.clone()));
 
             FullEvent::GuildUpdate {
                 old_data_if_available: before,
@@ -294,8 +275,8 @@ fn update_cache_with_event(
         Event::InviteDelete(event) => FullEvent::InviteDelete {
             data: event,
         },
-        Event::MessageCreate(mut event) => {
-            update_cache!(cache, event);
+        Event::MessageCreate(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::Message {
                 new_message: event.message,
@@ -311,16 +292,16 @@ fn update_cache_with_event(
             deleted_message_id: event.message_id,
             guild_id: event.guild_id,
         },
-        Event::MessageUpdate(mut event) => {
-            let before = if_cache!(update_cache!(cache, event));
+        Event::MessageUpdate(event) => {
+            let before = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::MessageUpdate {
                 old_if_available: before,
                 event,
             }
         },
-        Event::PresenceUpdate(mut event) => {
-            let old_data = if_cache!(update_cache!(cache, event));
+        Event::PresenceUpdate(event) => {
+            let old_data = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::PresenceUpdate {
                 old_data,
@@ -341,17 +322,8 @@ fn update_cache_with_event(
         Event::ReactionRemoveEmoji(event) => FullEvent::ReactionRemoveEmoji {
             removed_reactions: event.reaction,
         },
-        Event::Ready(mut event) => {
-            #[cfg(feature = "cache")]
-            if let Some(total_shards) = update_cache!(cache, event) {
-                extra_event = Some(FullEvent::ShardsReady {
-                    total_shards,
-                });
-            }
-
-            FullEvent::Ready {
-                data_about_bot: event.ready,
-            }
+        Event::Ready(event) => FullEvent::Ready {
+            data_about_bot: event.ready,
         },
         Event::Resumed(event) => FullEvent::Resume {
             event,
@@ -359,8 +331,8 @@ fn update_cache_with_event(
         Event::TypingStart(event) => FullEvent::TypingStart {
             event,
         },
-        Event::UserUpdate(mut event) => {
-            let before = if_cache!(update_cache!(cache, event));
+        Event::UserUpdate(event) => {
+            let before = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::UserUpdate {
                 old_data: before,
@@ -370,16 +342,16 @@ fn update_cache_with_event(
         Event::VoiceServerUpdate(event) => FullEvent::VoiceServerUpdate {
             event,
         },
-        Event::VoiceStateUpdate(mut event) => {
-            let before = if_cache!(update_cache!(cache, event));
+        Event::VoiceStateUpdate(event) => {
+            let before = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::VoiceStateUpdate {
                 old: before,
                 new: event.voice_state,
             }
         },
-        Event::VoiceChannelStatusUpdate(mut event) => {
-            let old = if_cache!(event.update(cache).map(Into::into));
+        Event::VoiceChannelStatusUpdate(event) => {
+            let old = if_cache!(event.update(&ctx.cache).map(Into::into));
 
             FullEvent::VoiceChannelStatusUpdate {
                 old,
@@ -416,32 +388,32 @@ fn update_cache_with_event(
         Event::StageInstanceDelete(event) => FullEvent::StageInstanceDelete {
             stage_instance: event.stage_instance,
         },
-        Event::ThreadCreate(mut event) => {
-            update_cache!(cache, event);
+        Event::ThreadCreate(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::ThreadCreate {
                 thread: event.thread,
                 newly_created: event.newly_created,
             }
         },
-        Event::ThreadUpdate(mut event) => {
-            let old = if_cache!(update_cache!(cache, event));
+        Event::ThreadUpdate(event) => {
+            let old = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::ThreadUpdate {
                 old,
                 new: event.thread,
             }
         },
-        Event::ThreadDelete(mut event) => {
-            let full_thread_data = if_cache!(update_cache!(cache, event));
+        Event::ThreadDelete(event) => {
+            let full_thread_data = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::ThreadDelete {
                 thread: event.thread,
                 full_thread_data,
             }
         },
-        Event::ThreadListSync(mut event) => {
-            update_cache!(cache, event);
+        Event::ThreadListSync(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::ThreadListSync {
                 thread_list_sync: event,
@@ -453,22 +425,22 @@ fn update_cache_with_event(
         Event::ThreadMembersUpdate(event) => FullEvent::ThreadMembersUpdate {
             thread_members_update: event,
         },
-        Event::GuildScheduledEventCreate(mut event) => {
-            update_cache!(cache, event);
+        Event::GuildScheduledEventCreate(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::GuildScheduledEventCreate {
                 event: event.event,
             }
         },
-        Event::GuildScheduledEventUpdate(mut event) => {
-            update_cache!(cache, event);
+        Event::GuildScheduledEventUpdate(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::GuildScheduledEventUpdate {
                 event: event.event,
             }
         },
-        Event::GuildScheduledEventDelete(mut event) => {
-            update_cache!(cache, event);
+        Event::GuildScheduledEventDelete(event) => {
+            update_cache!(&ctx.cache, event);
 
             FullEvent::GuildScheduledEventDelete {
                 event: event.event,
@@ -495,7 +467,30 @@ fn update_cache_with_event(
         Event::MessagePollVoteRemove(event) => FullEvent::MessagePollVoteRemove {
             event,
         },
-    };
+    }
+}
 
-    (event, extra_event)
+fn get_virtual_event(ctx: &Context, event: &Event) -> Option<FullEvent> {
+    match event {
+        Event::GuildCreate(event) =>
+        {
+            #[cfg(feature = "cache")]
+            if let Some(guilds) = update_cache!(&ctx.cache, event) {
+                return Some(FullEvent::CacheReady {
+                    guilds,
+                });
+            }
+        },
+        Event::Ready(event) =>
+        {
+            #[cfg(feature = "cache")]
+            if let Some(total_shards) = update_cache!(&ctx.cache, event) {
+                return Some(FullEvent::ShardsReady {
+                    total_shards,
+                });
+            }
+        },
+        _ => {},
+    }
+    None
 }

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -217,7 +217,7 @@ impl ShardRunner {
                             self.collectors.write().retain(|callback| (callback.0)(&event));
 
                             dispatch_model(
-                                event,
+                                *event,
                                 context,
                                 #[cfg(feature = "framework")]
                                 self.framework.clone(),


### PR DESCRIPTION
Separate out virtual events from the rest of the full event logic to make it clear which virtual events are possible and when. Also get rid of `&mut self` in CacheUpdate as raw events don't ever need to carry any mutable state.