### PR TITLE
Add `content` to `TextDisplay`

### DIFF
--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -233,6 +233,7 @@ pub struct TextDisplay {
     /// Discord’s official documentation does not mention this field; however, it is currently
     /// returned by the API and represents meaningful data, so it is included here. This
     /// behavior is undocumented and may change or be removed by Discord at any time.
+    #[cfg(feature = "unstable_discord_api")]
     pub content: Option<String>,
 }
 

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -229,6 +229,11 @@ pub struct TextDisplay {
     /// Always [`ComponentType::TextDisplay`]
     #[serde(rename = "type")]
     pub kind: ComponentType,
+
+    /// Discord’s official documentation does not mention this field; however, it is currently
+    /// returned by the API and represents meaningful data, so it is included here. This
+    /// behavior is undocumented and may change or be removed by Discord at any time.
+    pub content: Option<String>,
 }
 
 /// A Media Gallery is a component that allows you to display media attachments in an organized


### PR DESCRIPTION
Fixes #3460

Payload from message component:
```rust
RawValue({
    "type":17,
    "spoiler":false,
    "id":1,
    "components":[
        {
            "type":10,
            "id":2,
            "content":"### Blackjack\nYour bet: 100 <:coin:1383692085529415680>\n\n**Your Hand**\n<:5:1383692755917733888> <:9:1383692701987246080> - 14\n\n**Dealer Hand**\n<:7:138369276838727
2704> <:blank:1390357737011155024> - 7"
        },
        {
            ...
        }
    ]
})
```