### PR TITLE
Fix transport compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ ref-cast = "1.0.25"
 # Optional dependencies
 foldhash = { version = "0.2.0", optional = true }
 chrono = { version = "0.4.42", default-features = false, features = ["clock", "serde"], optional = true }
-flate2 = { version = "1.1.5", optional = true }
-zstd-safe = { version = "7.2.4", features = ["std"], optional = true }
+flate2 = { version = "1.1.9", features = ["zlib-rs"], optional = true }
+zstd = { version = "0.13", default-features = false, optional = true }
 reqwest = { version = ">=0.13", default-features = false, features = ["multipart", "stream", "json"], optional = true }
 tokio-tungstenite = { version = "0.28.0", features = ["url"], optional = true }
 percent-encoding = { version = "2.3.2", optional = true }
@@ -108,7 +108,7 @@ model = ["builder", "http", "utils"]
 # Enables zlib-stream transport compression of incoming gateway events.
 transport_compression_zlib = ["flate2", "gateway"]
 # Enables zstd-stream transport compression of incoming gateway events.
-transport_compression_zstd = ["zstd-safe", "gateway"]
+transport_compression_zstd = ["zstd", "gateway"]
 # Enables support for Discord API functionality that's not stable yet, as well as serenity APIs that
 # are allowed to change even in semver non-breaking updates.
 unstable = []

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -111,17 +111,15 @@ enum Compression {
 
 impl Compression {
     #[cfg(any(feature = "transport_compression_zlib", feature = "transport_compression_zstd"))]
-    const DECOMPRESSED_CAPACITY: usize = 256 * 1024;
+    const DECOMPRESSED_CAPACITY: usize = 174_504;
 
     fn inflate(&mut self, slice: &[u8]) -> Result<Option<&[u8]>> {
         match self {
             Compression::Payload {
                 decompressed,
             } => {
-                const DECOMPRESSION_MULTIPLIER: usize = 3;
-
                 decompressed.clear();
-                decompressed.reserve(slice.len() * DECOMPRESSION_MULTIPLIER);
+                decompressed.reserve(Self::DECOMPRESSED_CAPACITY);
 
                 ZlibDecoder::new(slice).read_to_end(decompressed).map_err(|why| {
                     warn!("Err decompressing bytes: {why:?}");

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -1,10 +1,10 @@
 use std::env::consts;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::time::{Duration, SystemTime};
 
-#[cfg(feature = "transport_compression_zlib")]
-use flate2::Decompress as ZlibInflater;
 use flate2::read::ZlibDecoder;
+#[cfg(feature = "transport_compression_zlib")]
+use flate2::write::ZlibDecoder as ZlibWriter;
 use futures::{SinkExt, StreamExt};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
@@ -16,7 +16,7 @@ use tracing::instrument;
 use tracing::{debug, trace, warn};
 use url::Url;
 #[cfg(feature = "transport_compression_zstd")]
-use zstd_safe::{DStream as ZstdInflater, InBuffer, OutBuffer};
+use zstd::stream::write::Decoder as ZstdWriter;
 
 use super::{ActivityData, ChunkGuildFilter, GatewayError, PresenceData, TransportCompression};
 use crate::constants::{self, Opcode};
@@ -99,22 +99,17 @@ enum Compression {
 
     #[cfg(feature = "transport_compression_zlib")]
     Zlib {
-        inflater: ZlibInflater,
+        decoder: ZlibWriter<Vec<u8>>,
         compressed: Vec<u8>,
-        decompressed: Box<[u8]>,
     },
 
     #[cfg(feature = "transport_compression_zstd")]
     Zstd {
-        inflater: ZstdInflater<'static>,
-        decompressed: Box<[u8]>,
+        decoder: ZstdWriter<'static, Vec<u8>>,
     },
 }
 
 impl Compression {
-    #[cfg(any(feature = "transport_compression_zlib", feature = "transport_compression_zstd"))]
-    const DECOMPRESSED_CAPACITY: usize = 64 * 1024;
-
     fn inflate(&mut self, slice: &[u8]) -> Result<Option<&[u8]>> {
         match self {
             Compression::Payload {
@@ -127,8 +122,6 @@ impl Compression {
 
                 ZlibDecoder::new(slice).read_to_end(decompressed).map_err(|why| {
                     warn!("Err decompressing bytes: {why:?}");
-                    debug!("Failing bytes: {slice:?}");
-
                     why
                 })?;
 
@@ -137,67 +130,42 @@ impl Compression {
 
             #[cfg(feature = "transport_compression_zlib")]
             Compression::Zlib {
-                inflater,
+                decoder,
                 compressed,
-                decompressed,
             } => {
                 const ZLIB_SUFFIX: [u8; 4] = [0x00, 0x00, 0xFF, 0xFF];
 
                 compressed.extend_from_slice(slice);
-                let length = compressed.len();
 
-                if length < 4 || compressed[length - 4..] != ZLIB_SUFFIX {
+                let len = compressed.len();
+
+                if len < 4 || compressed[len - 4..] != ZLIB_SUFFIX {
                     return Ok(None);
                 }
 
-                let pre_out = inflater.total_out();
-                inflater
-                    .decompress(compressed, decompressed, flate2::FlushDecompress::Sync)
-                    .map_err(GatewayError::DecompressZlib)?;
+                decoder.get_mut().clear();
+                decoder.write_all(compressed).map_err(|why| {
+                    warn!("Err decompressing bytes: {why:?}");
+                    why
+                })?;
+                decoder.flush()?;
                 compressed.clear();
-                let produced = (inflater.total_out() - pre_out) as usize;
 
-                Ok(Some(&decompressed[..produced]))
+                Ok(Some(decoder.get_ref().as_slice()))
             },
 
             #[cfg(feature = "transport_compression_zstd")]
             Compression::Zstd {
-                inflater,
-                decompressed,
+                decoder,
             } => {
-                let mut in_buffer = InBuffer::around(slice);
-                let mut out_buffer = OutBuffer::around(decompressed.as_mut());
+                decoder.get_mut().clear();
+                decoder.write_all(slice).map_err(|why| {
+                    warn!("Err decompressing bytes: {why:?}");
+                    why
+                })?;
+                decoder.flush()?;
 
-                let length = slice.len();
-                let mut processed = 0;
-
-                loop {
-                    match inflater.decompress_stream(&mut out_buffer, &mut in_buffer) {
-                        Ok(0) => break,
-                        Ok(_hint) => {},
-                        Err(code) => {
-                            return Err(Error::Gateway(GatewayError::DecompressZstd(code)));
-                        },
-                    }
-
-                    let in_pos = in_buffer.pos();
-
-                    let progressed = in_pos > processed;
-                    let read_all_input = in_pos == length;
-
-                    if !progressed {
-                        if read_all_input {
-                            break;
-                        }
-
-                        return Err(Error::Gateway(GatewayError::DecompressZstdCorrupted));
-                    }
-
-                    processed = in_pos;
-                }
-
-                let produced = out_buffer.pos();
-                Ok(Some(&decompressed[..produced]))
+                Ok(Some(decoder.get_ref().as_slice()))
             },
         }
     }
@@ -212,20 +180,13 @@ impl From<TransportCompression> for Compression {
 
             #[cfg(feature = "transport_compression_zlib")]
             TransportCompression::Zlib => Compression::Zlib {
-                inflater: ZlibInflater::new(true),
+                decoder: ZlibWriter::new(Vec::new()),
                 compressed: Vec::new(),
-                decompressed: vec![0; Self::DECOMPRESSED_CAPACITY].into_boxed_slice(),
             },
 
             #[cfg(feature = "transport_compression_zstd")]
-            TransportCompression::Zstd => {
-                let mut inflater = ZstdInflater::create();
-                inflater.init().expect("Failed to initialize Zstd decompressor");
-
-                Compression::Zstd {
-                    inflater,
-                    decompressed: vec![0; Self::DECOMPRESSED_CAPACITY].into_boxed_slice(),
-                }
+            TransportCompression::Zstd => Compression::Zstd {
+                decoder: ZstdWriter::new(Vec::new()).expect("Failed to initialize Zstd decoder"),
             },
         }
     }

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -110,7 +110,6 @@ enum Compression {
 }
 
 impl Compression {
-    #[cfg(any(feature = "transport_compression_zlib", feature = "transport_compression_zstd"))]
     const DECOMPRESSED_CAPACITY: usize = 174_504;
 
     fn inflate(&mut self, slice: &[u8]) -> Result<Option<&[u8]>> {

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -110,6 +110,9 @@ enum Compression {
 }
 
 impl Compression {
+    #[cfg(any(feature = "transport_compression_zlib", feature = "transport_compression_zstd"))]
+    const DECOMPRESSED_CAPACITY: usize = 256 * 1024;
+
     fn inflate(&mut self, slice: &[u8]) -> Result<Option<&[u8]>> {
         match self {
             Compression::Payload {
@@ -180,13 +183,14 @@ impl From<TransportCompression> for Compression {
 
             #[cfg(feature = "transport_compression_zlib")]
             TransportCompression::Zlib => Compression::Zlib {
-                decoder: ZlibWriter::new(Vec::new()),
+                decoder: ZlibWriter::new(Vec::with_capacity(Self::DECOMPRESSED_CAPACITY)),
                 compressed: Vec::new(),
             },
 
             #[cfg(feature = "transport_compression_zstd")]
             TransportCompression::Zstd => Compression::Zstd {
-                decoder: ZstdWriter::new(Vec::new()).expect("Failed to initialize Zstd decoder"),
+                decoder: ZstdWriter::new(Vec::with_capacity(Self::DECOMPRESSED_CAPACITY))
+                    .expect("Failed to initialize Zstd decoder"),
             },
         }
     }


### PR DESCRIPTION
I didn't run `cargo fmt --all` because it formatted tens of files, maybe that should be done in another PR.
From my own testing, both zlib and zstd work now.
I also enabled the `std` feature of the `zstd-safe` crate so that we don't have to manually manage the buffer, hope that's ok.

Before these changes the decompressed buffer had 64KB of fixed size, so larger messages would be truncated and that caused the parsing errors.
The code before for zlib also assumed decompression happened in one call, but `flate2::Decompress::decompress_vec` doesn't manage the vec so it only writes as much as it can currently fit in it.

