### PR TITLE
Add required field to select menu components

### DIFF
--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -881,6 +881,8 @@ pub struct CreateSelectMenu<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     max_values: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    required: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
 
     #[serde(flatten)]
@@ -896,6 +898,7 @@ impl<'a> CreateSelectMenu<'a> {
             placeholder: None,
             min_values: None,
             max_values: None,
+            required: None,
             disabled: None,
             kind,
         }
@@ -926,7 +929,13 @@ impl<'a> CreateSelectMenu<'a> {
         self
     }
 
-    /// Sets the disabled state for the button.
+    /// Sets the required state for the select menu in modals. Ignored in messages.
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = Some(required);
+        self
+    }
+
+    /// Sets the disabled state for the select menu.
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = Some(disabled);
         self

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -650,6 +650,9 @@ pub struct SelectMenu {
     pub min_values: Option<u8>,
     /// The maximum number of selections allowed.
     pub max_values: Option<u8>,
+    /// Whether select menu is required to be filled in a modal. Default is true. Ignored in messages.
+    #[serde(default = "default_true")]
+    pub required: bool,
     /// Whether select menu is disabled.
     #[serde(default)]
     pub disabled: bool,

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -650,7 +650,8 @@ pub struct SelectMenu {
     pub min_values: Option<u8>,
     /// The maximum number of selections allowed.
     pub max_values: Option<u8>,
-    /// Whether select menu is required to be filled in a modal. Default is true. Ignored in messages.
+    /// Whether select menu is required to be filled in a modal. Default is true. Ignored in
+    /// messages.
     #[serde(default = "default_true")]
     pub required: bool,
     /// Whether select menu is disabled.


### PR DESCRIPTION
Currently, it is not possible to make select menu components optional in modals. The `disabled` field is only for message components. This adds the `required` field necessary for modals and updates the builder accordingly.

See select menu component footnotes in the [Discord API Component Reference](https://discord.com/developers/docs/components/reference#string-select).