### PR TITLE
Update cache for reaction events

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -1,4 +1,5 @@
 use super::{Cache, CacheUpdate};
+use crate::all::{CountDetails, MessageReaction};
 use crate::model::channel::{GuildChannel, Message};
 use crate::model::event::{
     ChannelCreateEvent,
@@ -20,6 +21,10 @@ use crate::model::event::{
     MessageCreateEvent,
     MessageUpdateEvent,
     PresenceUpdateEvent,
+    ReactionAddEvent,
+    ReactionRemoveAllEvent,
+    ReactionRemoveEmojiEvent,
+    ReactionRemoveEvent,
     ReadyEvent,
     ThreadCreateEvent,
     ThreadDeleteEvent,
@@ -592,5 +597,103 @@ impl CacheUpdate for VoiceChannelStatusUpdateEvent {
         let old = channel.status.clone();
         channel.status.clone_from(&self.status);
         old
+    }
+}
+
+impl CacheUpdate for ReactionAddEvent {
+    type Output = Message;
+
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        let reaction = &self.reaction;
+        let mut messages = cache.messages.get_mut(&reaction.channel_id)?;
+        let message = messages.get_mut(&reaction.message_id)?;
+        let old_message = message.clone();
+
+        match message.reactions.iter_mut().find(|r| r.reaction_type == reaction.emoji) {
+            Some(existing) => {
+                existing.count += 1;
+                if reaction.burst {
+                    existing.count_details.burst += 1;
+                } else {
+                    existing.count_details.normal += 1;
+                }
+            },
+            None => {
+                let me = self.reaction.user_id == Some(cache.current_user().id);
+                let new_reaction = MessageReaction {
+                    me,
+                    burst_colours: reaction.burst_colours.clone().unwrap_or_default(),
+                    count: 1,
+                    count_details: CountDetails {
+                        burst: if reaction.burst { 1 } else { 0 },
+                        normal: if reaction.burst { 0 } else { 1 },
+                    },
+                    me_burst: if me { reaction.burst } else { false },
+                    reaction_type: reaction.emoji.clone(),
+                };
+                message.reactions.push(new_reaction);
+            },
+        };
+
+        Some(old_message)
+    }
+}
+
+impl CacheUpdate for ReactionRemoveEvent {
+    type Output = Message;
+
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        let reaction = &self.reaction;
+        let mut messages = cache.messages.get_mut(&reaction.channel_id)?;
+        let message = messages.get_mut(&reaction.message_id)?;
+        let old_message = message.clone();
+
+        let index = message.reactions.iter().position(|r| r.reaction_type == reaction.emoji)?;
+
+        let existing_reaction = &mut message.reactions[index];
+
+        existing_reaction.count -= 1;
+        if reaction.burst {
+            existing_reaction.count_details.burst -= 1;
+        } else {
+            existing_reaction.count_details.normal -= 1;
+        }
+
+        if existing_reaction.count == 0 {
+            message.reactions.remove(index);
+        }
+
+        Some(old_message)
+    }
+}
+
+impl CacheUpdate for ReactionRemoveEmojiEvent {
+    type Output = Message;
+
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        let reaction = &self.reaction;
+        let mut messages = cache.messages.get_mut(&reaction.channel_id)?;
+        let message = messages.get_mut(&reaction.message_id)?;
+        let old_message = message.clone();
+
+        let index = message.reactions.iter().position(|r| r.reaction_type == reaction.emoji)?;
+
+        message.reactions.remove(index);
+
+        Some(old_message)
+    }
+}
+
+impl CacheUpdate for ReactionRemoveAllEvent {
+    type Output = Message;
+
+    fn update(&mut self, cache: &Cache) -> Option<Self::Output> {
+        let mut messages = cache.messages.get_mut(&self.channel_id)?;
+        let message = messages.get_mut(&self.message_id)?;
+        let old_message = message.clone();
+
+        message.reactions.clear();
+
+        Some(old_message)
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -819,6 +819,169 @@ mod test {
             assert!(!channel.contains_key(&MessageId::new(3)));
         }
 
+        // Add a reaction for a channel
+        let message = &event.message;
+        let reaction_type = ReactionType::Unicode("❓".into());
+        let second_reaction_type = ReactionType::Unicode("❗".into());
+
+        let mut reaction_event = ReactionAddEvent {
+            reaction: Reaction {
+                user_id: Some(UserId::new(1)),
+                channel_id: ChannelId::new(1),
+                message_id: message.id,
+                guild_id: message.guild_id,
+                member: None,
+                emoji: reaction_type.clone(),
+                message_author_id: Some(message.author.id),
+                burst: false,
+                burst_colours: None,
+                reaction_type: ReactionTypes::Normal,
+            },
+        };
+
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 1);
+        }
+
+        // Add second reaction
+        reaction_event.reaction.emoji = second_reaction_type;
+
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 2);
+        }
+
+        // Add a burst reaction
+        reaction_event.reaction.emoji = reaction_type.clone();
+        reaction_event.reaction.burst = true;
+        reaction_event.reaction.reaction_type = ReactionTypes::Burst;
+
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 2);
+            assert!(message
+                .reactions
+                .iter()
+                .find(|r| r.reaction_type == reaction_type
+                    && r.count == 2
+                    && r.count_details.burst == 1)
+                .is_some());
+        }
+
+        // Remove a reaction
+        let mut reaction_remove_event = ReactionRemoveEvent {
+            reaction: reaction_event.reaction.clone(),
+        };
+
+        reaction_remove_event.reaction.emoji = reaction_type.clone();
+
+        assert!(cache.update(&mut reaction_remove_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 2);
+            assert!(message
+                .reactions
+                .iter()
+                .find(|r| r.reaction_type == reaction_type
+                    && r.count == 1
+                    && r.count_details.burst == 0)
+                .is_some());
+        }
+
+        // Remove normal reaction, so the entire reaction should be removed
+        reaction_remove_event.reaction.burst = false;
+        reaction_remove_event.reaction.reaction_type = ReactionTypes::Normal;
+
+        assert!(cache.update(&mut reaction_remove_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 1);
+        }
+
+        // The instance should be removed when ReactionRemoveEmojiEvent is fired
+        let mut reaction_remove_event = ReactionRemoveEmojiEvent {
+            reaction: reaction_event.reaction.clone(),
+        };
+
+        // First prepare test data
+        reaction_event.reaction.emoji = reaction_type.clone();
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        reaction_event.reaction.burst = false;
+        reaction_event.reaction.reaction_type = ReactionTypes::Normal;
+
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        reaction_event.reaction.user_id = Some(UserId::new(2));
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 2);
+            assert!(message
+                .reactions
+                .iter()
+                .find(|r| r.reaction_type == reaction_type
+                    && r.count == 3
+                    && r.count_details.burst == 1
+                    && r.count_details.normal == 2)
+                .is_some());
+        }
+
+        assert!(cache.update(&mut reaction_remove_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+            assert_eq!(message.reactions.len(), 1);
+        }
+
+        // All reactions should be removed when ReactionRemoveAllEvent is fired
+        let mut reaction_remove_event = ReactionRemoveAllEvent {
+            message_id: reaction_event.reaction.message_id,
+            channel_id: reaction_event.reaction.channel_id,
+            guild_id: reaction_event.reaction.guild_id,
+        };
+
+        // First add second reaction
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+            assert_eq!(message.reactions.len(), 2);
+        }
+
+        // Remove all reactions
+        assert!(cache.update(&mut reaction_remove_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message = channel.get(&reaction_event.reaction.message_id).unwrap();
+            assert_eq!(message.reactions.len(), 0);
+        }
+
         let channel = GuildChannel {
             id: event.message.channel_id,
             guild_id: event.message.guild_id.unwrap(),

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -328,18 +328,33 @@ fn update_cache_with_event(
                 new_data: event.presence,
             }
         },
-        Event::ReactionAdd(event) => FullEvent::ReactionAdd {
-            add_reaction: event.reaction,
+        Event::ReactionAdd(mut event) => {
+            update_cache!(cache, event);
+            FullEvent::ReactionAdd {
+                add_reaction: event.reaction,
+            }
         },
-        Event::ReactionRemove(event) => FullEvent::ReactionRemove {
-            removed_reaction: event.reaction,
+        Event::ReactionRemove(mut event) => {
+            update_cache!(cache, event);
+
+            FullEvent::ReactionRemove {
+                removed_reaction: event.reaction,
+            }
         },
-        Event::ReactionRemoveAll(event) => FullEvent::ReactionRemoveAll {
-            channel_id: event.channel_id,
-            removed_from_message_id: event.message_id,
+        Event::ReactionRemoveAll(mut event) => {
+            update_cache!(cache, event);
+
+            FullEvent::ReactionRemoveAll {
+                channel_id: event.channel_id,
+                removed_from_message_id: event.message_id,
+            }
         },
-        Event::ReactionRemoveEmoji(event) => FullEvent::ReactionRemoveEmoji {
-            removed_reactions: event.reaction,
+        Event::ReactionRemoveEmoji(mut event) => {
+            update_cache!(cache, event);
+
+            FullEvent::ReactionRemoveEmoji {
+                removed_reactions: event.reaction,
+            }
         },
         Event::Ready(mut event) => {
             update_cache!(cache, event);


### PR DESCRIPTION
Added `CacheUpdate` implementation for:
- `ReactionAddEvent`
- `ReactionRemoveEvent`
- `ReactionRemoveEmojiEvent`
- `ReactionRemoveAllEvent`