### PR TITLE
Update cache for reaction events (next)

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -4,6 +4,14 @@ use std::num::NonZeroU16;
 use extract_map::entry::Entry;
 
 use super::{BaseGuildChannel, Cache, CacheUpdate, GenericChannelId, GuildThread};
+use crate::all::{
+    CountDetails,
+    MessageReaction,
+    ReactionAddEvent,
+    ReactionRemoveAllEvent,
+    ReactionRemoveEmojiEvent,
+    ReactionRemoveEvent,
+};
 use crate::internal::prelude::*;
 use crate::model::channel::{GuildChannel, Message};
 use crate::model::event::{
@@ -655,5 +663,136 @@ impl CacheUpdate for GuildScheduledEventDeleteEvent {
     fn update(&self, cache: &Cache) -> Option<Self::Output> {
         let mut guild = cache.guilds.get_mut(&self.event.guild_id)?;
         guild.scheduled_events.remove(&self.event.id)
+    }
+}
+
+impl CacheUpdate for ReactionAddEvent {
+    type Output = Message;
+
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
+        let reaction = &self.reaction;
+        let mut messages = cache.messages.get_mut(&reaction.channel_id)?;
+
+        for message in messages.iter_mut() {
+            if message.id != reaction.message_id {
+                continue;
+            }
+
+            let prev = message.clone();
+
+            match message.reactions.iter_mut().find(|r| r.reaction_type == reaction.emoji) {
+                Some(existing) => {
+                    existing.count += 1;
+                    if reaction.burst {
+                        existing.count_details.burst += 1;
+                    } else {
+                        existing.count_details.normal += 1;
+                    }
+                },
+                None => {
+                    let me = self.reaction.user_id == Some(cache.current_user().id);
+                    let new_reaction = MessageReaction {
+                        me,
+                        burst_colours: reaction.burst_colours.clone().unwrap_or_default(),
+                        count: 1,
+                        count_details: CountDetails {
+                            burst: if reaction.burst { 1 } else { 0 },
+                            normal: if reaction.burst { 0 } else { 1 },
+                        },
+                        me_burst: if me { reaction.burst } else { false },
+                        reaction_type: reaction.emoji.clone(),
+                    };
+
+                    message.reactions.push(new_reaction);
+                },
+            };
+
+            return Some(prev);
+        }
+
+        None
+    }
+}
+
+impl CacheUpdate for ReactionRemoveEvent {
+    type Output = Message;
+
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
+        let reaction = &self.reaction;
+        let mut messages = cache.messages.get_mut(&reaction.channel_id)?;
+
+        for message in messages.iter_mut() {
+            if message.id != reaction.message_id {
+                continue;
+            }
+
+            let old_message = message.clone();
+
+            let index = message.reactions.iter().position(|r| r.reaction_type == reaction.emoji)?;
+
+            let existing_reaction = &mut message.reactions[index];
+
+            existing_reaction.count -= 1;
+            if reaction.burst {
+                existing_reaction.count_details.burst -= 1;
+            } else {
+                existing_reaction.count_details.normal -= 1;
+            }
+
+            if existing_reaction.count == 0 {
+                message.reactions.remove(index);
+            }
+
+            return Some(old_message);
+        }
+
+        None
+    }
+}
+
+impl CacheUpdate for ReactionRemoveEmojiEvent {
+    type Output = Message;
+
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
+        let reaction = &self.reaction;
+        let mut messages = cache.messages.get_mut(&reaction.channel_id)?;
+
+        for message in messages.iter_mut() {
+            if message.id != reaction.message_id {
+                continue;
+            }
+
+            let old_message = message.clone();
+
+            let index = message.reactions.iter().position(|r| r.reaction_type == reaction.emoji)?;
+
+            message.reactions.remove(index);
+
+            return Some(old_message);
+        }
+
+        None
+    }
+}
+
+impl CacheUpdate for ReactionRemoveAllEvent {
+    type Output = Message;
+
+    fn update(&self, cache: &Cache) -> Option<Self::Output> {
+        let mut messages = cache.messages.get_mut(&self.channel_id)?;
+
+        for message in messages.iter_mut() {
+            if message.id != self.message_id {
+                continue;
+            }
+
+            let old_message = message.clone();
+
+            message.reactions.clear();
+
+            return Some(old_message);
+        }
+
+        None
     }
 }

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -680,32 +680,32 @@ impl CacheUpdate for ReactionAddEvent {
 
             let prev = message.clone();
 
-            match message.reactions.iter_mut().find(|r| r.reaction_type == reaction.emoji) {
-                Some(existing) => {
-                    existing.count += 1;
-                    if reaction.burst {
-                        existing.count_details.burst += 1;
-                    } else {
-                        existing.count_details.normal += 1;
-                    }
-                },
-                None => {
-                    let me = self.reaction.user_id == Some(cache.current_user().id);
-                    let new_reaction = MessageReaction {
-                        me,
-                        burst_colours: reaction.burst_colours.clone().unwrap_or_default(),
-                        count: 1,
-                        count_details: CountDetails {
-                            burst: if reaction.burst { 1 } else { 0 },
-                            normal: if reaction.burst { 0 } else { 1 },
-                        },
-                        me_burst: if me { reaction.burst } else { false },
-                        reaction_type: reaction.emoji.clone(),
-                    };
+            if let Some(existing) =
+                message.reactions.iter_mut().find(|r| r.reaction_type == reaction.emoji)
+            {
+                existing.count += 1;
+                if reaction.burst {
+                    existing.count_details.burst += 1;
+                } else {
+                    existing.count_details.normal += 1;
+                }
+                return Some(prev);
+            }
 
-                    message.reactions.push(new_reaction);
+            let me = self.reaction.user_id == Some(cache.current_user().id);
+            let new_reaction = MessageReaction {
+                me,
+                burst_colours: reaction.burst_colours.clone().unwrap_or_default(),
+                count: 1,
+                count_details: CountDetails {
+                    burst: u64::from(reaction.burst),
+                    normal: u64::from(!reaction.burst),
                 },
+                me_burst: if me { reaction.burst } else { false },
+                reaction_type: reaction.emoji.clone(),
             };
+
+            message.reactions.push(new_reaction);
 
             return Some(prev);
         }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -524,6 +524,8 @@ impl Default for Cache {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use crate::cache::{Cache, CacheUpdate, Settings};
     use crate::model::prelude::*;
 
@@ -561,6 +563,185 @@ mod test {
         // Add a third message, the first should now be removed.
         event.message.id = MessageId::new(5);
         assert!(event.update(&cache).is_some());
+
+        // Add a reaction for a channel
+        let message = &event.message;
+        let reaction_type = ReactionType::Unicode(FixedString::from_str("❓").unwrap());
+        let second_reaction_type = ReactionType::Unicode(FixedString::from_str("❗").unwrap());
+
+        let mut reaction_event = ReactionAddEvent {
+            reaction: Reaction {
+                user_id: Some(UserId::new(1)),
+                channel_id: message.channel_id,
+                message_id: message.id,
+                guild_id: message.guild_id,
+                member: None,
+                emoji: reaction_type.clone(),
+                message_author_id: Some(message.author.id),
+                burst: false,
+                burst_colours: None,
+                reaction_type: ReactionTypes::Normal,
+            },
+        };
+
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 1);
+        }
+
+        // Add second reaction
+        reaction_event.reaction.emoji = second_reaction_type;
+
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 2);
+        }
+
+        // Add a burst reaction
+        reaction_event.reaction.emoji = reaction_type.clone();
+        reaction_event.reaction.burst = true;
+        reaction_event.reaction.reaction_type = ReactionTypes::Burst;
+
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 2);
+            assert!(
+                message
+                    .reactions
+                    .iter()
+                    .find(|r| r.reaction_type == reaction_type
+                        && r.count == 2
+                        && r.count_details.burst == 1)
+                    .is_some()
+            );
+        }
+
+        // Remove a reaction
+        let mut reaction_remove_event = ReactionRemoveEvent {
+            reaction: reaction_event.reaction.clone(),
+        };
+
+        reaction_remove_event.reaction.emoji = reaction_type.clone();
+
+        assert!(cache.update(&mut reaction_remove_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 2);
+            assert!(
+                message
+                    .reactions
+                    .iter()
+                    .find(|r| r.reaction_type == reaction_type
+                        && r.count == 1
+                        && r.count_details.burst == 0)
+                    .is_some()
+            );
+        }
+
+        // Remove normal reaction, so the entire reaction should be removed
+        reaction_remove_event.reaction.burst = false;
+        reaction_remove_event.reaction.reaction_type = ReactionTypes::Normal;
+
+        assert!(cache.update(&mut reaction_remove_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 1);
+        }
+
+        // The instance should be removed when ReactionRemoveEmojiEvent is fired
+        let mut reaction_remove_event = ReactionRemoveEmojiEvent {
+            reaction: reaction_event.reaction.clone(),
+        };
+
+        // First prepare test data
+        reaction_event.reaction.emoji = reaction_type.clone();
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        reaction_event.reaction.burst = false;
+        reaction_event.reaction.reaction_type = ReactionTypes::Normal;
+
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        reaction_event.reaction.user_id = Some(UserId::new(2));
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 2);
+            assert!(
+                message
+                    .reactions
+                    .iter()
+                    .find(|r| r.reaction_type == reaction_type
+                        && r.count == 3
+                        && r.count_details.burst == 1
+                        && r.count_details.normal == 2)
+                    .is_some()
+            );
+        }
+
+        assert!(cache.update(&mut reaction_remove_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+            assert_eq!(message.reactions.len(), 1);
+        }
+
+        // All reactions should be removed when ReactionRemoveAllEvent is fired
+        let mut reaction_remove_event = ReactionRemoveAllEvent {
+            message_id: reaction_event.reaction.message_id,
+            channel_id: reaction_event.reaction.channel_id,
+            guild_id: reaction_event.reaction.guild_id,
+        };
+
+        // First add second reaction
+        assert!(cache.update(&mut reaction_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+            assert_eq!(message.reactions.len(), 2);
+        }
+
+        // Remove all reactions
+        assert!(cache.update(&mut reaction_remove_event).is_some());
+
+        {
+            let channel = cache.messages.get(&reaction_event.reaction.channel_id).unwrap();
+            let message =
+                channel.iter().find(|m| m.id == reaction_event.reaction.message_id).unwrap();
+
+            assert_eq!(message.reactions.len(), 0);
+        }
 
         {
             let channel = cache.messages.get(&event.message.channel_id).unwrap();

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -566,8 +566,9 @@ mod test {
 
         // Add a reaction for a channel
         let message = &event.message;
-        let reaction_type = ReactionType::Unicode(FixedString::from_str("❓").unwrap());
-        let second_reaction_type = ReactionType::Unicode(FixedString::from_str("❗").unwrap());
+        let reaction_type = ReactionType::Unicode(FixedString::from_str("\u{2753}").unwrap());
+        let second_reaction_type =
+            ReactionType::Unicode(FixedString::from_str("\u{2757}").unwrap());
 
         let mut reaction_event = ReactionAddEvent {
             reaction: Reaction {

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -308,19 +308,35 @@ fn update_cache_with_event(ctx: &Context, event: Event) -> FullEvent {
                 new_data: event.presence,
             }
         },
-        Event::ReactionAdd(event) => FullEvent::ReactionAdd {
-            add_reaction: event.reaction,
+        Event::ReactionAdd(event) => {
+            if_cache!(update_cache!(&ctx.cache, event));
+
+            FullEvent::ReactionAdd {
+                add_reaction: event.reaction,
+            }
         },
-        Event::ReactionRemove(event) => FullEvent::ReactionRemove {
-            removed_reaction: event.reaction,
+        Event::ReactionRemove(event) => {
+            if_cache!(update_cache!(&ctx.cache, event));
+
+            FullEvent::ReactionRemove {
+                removed_reaction: event.reaction,
+            }
         },
-        Event::ReactionRemoveAll(event) => FullEvent::ReactionRemoveAll {
-            guild_id: event.guild_id,
-            channel_id: event.channel_id,
-            removed_from_message_id: event.message_id,
+        Event::ReactionRemoveAll(event) => {
+            if_cache!(update_cache!(&ctx.cache, event));
+
+            FullEvent::ReactionRemoveAll {
+                guild_id: event.guild_id,
+                channel_id: event.channel_id,
+                removed_from_message_id: event.message_id,
+            }
         },
-        Event::ReactionRemoveEmoji(event) => FullEvent::ReactionRemoveEmoji {
-            removed_reactions: event.reaction,
+        Event::ReactionRemoveEmoji(event) => {
+            if_cache!(update_cache!(&ctx.cache, event));
+
+            FullEvent::ReactionRemoveEmoji {
+                removed_reactions: event.reaction,
+            }
         },
         Event::Ready(event) => FullEvent::Ready {
             data_about_bot: event.ready,

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -309,33 +309,37 @@ fn update_cache_with_event(ctx: &Context, event: Event) -> FullEvent {
             }
         },
         Event::ReactionAdd(event) => {
-            if_cache!(update_cache!(&ctx.cache, event));
+            let old_message_if_available = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::ReactionAdd {
                 add_reaction: event.reaction,
+                old_message_if_available,
             }
         },
         Event::ReactionRemove(event) => {
-            if_cache!(update_cache!(&ctx.cache, event));
+            let old_message_if_available = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::ReactionRemove {
                 removed_reaction: event.reaction,
+                old_message_if_available,
             }
         },
         Event::ReactionRemoveAll(event) => {
-            if_cache!(update_cache!(&ctx.cache, event));
+            let old_message_if_available = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::ReactionRemoveAll {
                 guild_id: event.guild_id,
                 channel_id: event.channel_id,
                 removed_from_message_id: event.message_id,
+                old_message_if_available,
             }
         },
         Event::ReactionRemoveEmoji(event) => {
-            if_cache!(update_cache!(&ctx.cache, event));
+            let old_message_if_available = if_cache!(update_cache!(&ctx.cache, event));
 
             FullEvent::ReactionRemoveEmoji {
                 removed_reactions: event.reaction,
+                old_message_if_available,
             }
         },
         Event::Ready(event) => FullEvent::Ready {

--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -241,22 +241,22 @@ full_event! {
     /// Dispatched when a new reaction is attached to a message.
     ///
     /// Provides the reaction's data.
-    ReactionAdd { add_reaction: Reaction };
+    ReactionAdd { old_message_if_available: Option<Message>, add_reaction: Reaction };
 
     /// Dispatched when a reaction is detached from a message.
     ///
     /// Provides the reaction's data.
-    ReactionRemove { removed_reaction: Reaction };
+    ReactionRemove { old_message_if_available: Option<Message>, removed_reaction: Reaction };
 
     /// Dispatched when all reactions of a message are detached from a message.
     ///
     /// Provides the channel's id, message's id, and guild's id if in a guild.
-    ReactionRemoveAll { guild_id: Option<GuildId>, channel_id: GenericChannelId, removed_from_message_id: MessageId };
+    ReactionRemoveAll { old_message_if_available: Option<Message>, guild_id: Option<GuildId>, channel_id: GenericChannelId, removed_from_message_id: MessageId };
 
     /// Dispatched when all reactions of a message for a given emoji are explicitly detached from a message.
     ///
     /// Provides the emoji's data, channel's id, message's id and guild's id if in a guild.
-    ReactionRemoveEmoji { removed_reactions: Reaction };
+    ReactionRemoveEmoji { old_message_if_available: Option<Message>, removed_reactions: Reaction };
 
     /// Dispatched when a user's presence is updated (e.g off -> on).
     ///

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -74,7 +74,7 @@ pub struct Message {
     pub embeds: FixedArray<Embed>,
     /// Array of reactions performed on the message.
     #[serde(default)]
-    pub reactions: FixedArray<MessageReaction>,
+    pub reactions: Vec<MessageReaction>,
     /// Non-repeating number used for ensuring message order.
     #[serde(default)]
     pub nonce: Option<Nonce>,

--- a/src/utils/custom_message.rs
+++ b/src/utils/custom_message.rs
@@ -152,7 +152,7 @@ impl CustomMessage {
     ///
     /// If not used, the default value is an empty vector (`Vec::default()`).
     pub fn reactions(&mut self, reactions: Vec<MessageReaction>) -> &mut Self {
-        self.msg.reactions = reactions.trunc_into();
+        self.msg.reactions = reactions;
 
         self
     }


### PR DESCRIPTION
next branch port of #3469

## Changes

Converted message reactions to Vec<MessageRection> to modify

Added `CacheUpdate` implementation for:
- `ReactionAddEvent`
- `ReactionRemoveEvent`
- `ReactionRemoveEmojiEvent`
- `ReactionRemoveAllEvent`

Fixes #3468