### PR TITLE
GuildMemberUpdateEvent.joined_at is nullable, to match API docs.

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -197,7 +197,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
             let item = if let Some(mut member) = guild.members.get_mut(&self.user.id) {
                 let item = Some(member.clone());
 
-                member.joined_at.clone_from(&Some(self.joined_at));
+                member.joined_at.clone_from(&self.joined_at);
                 member.nick.clone_from(&self.nick);
                 member.roles.clone_from(&self.roles);
                 member.user.clone_from(&self.user);
@@ -219,7 +219,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                 let mut new_member = Member {
                     __generated_flags: MemberGeneratedFlags::empty(),
                     guild_id: self.guild_id,
-                    joined_at: Some(self.joined_at),
+                    joined_at: self.joined_at,
                     nick: self.nick.clone(),
                     roles: self.roles.clone(),
                     user: self.user.clone(),

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -240,7 +240,7 @@ pub struct GuildMemberRemoveEvent {
 pub struct GuildMemberUpdateEvent {
     pub guild_id: GuildId,
     pub nick: Option<FixedString<u8>>,
-    pub joined_at: Timestamp,
+    pub joined_at: Option<Timestamp>,
     pub roles: FixedArray<RoleId>,
     pub user: User,
     pub premium_since: Option<Timestamp>,


### PR DESCRIPTION
According to https://github.com/discord/discord-api-docs/pull/2911, this can happen when "guest" members join stage channels.

Fixes #3422.