### PR TITLE
Limit top-level modal components in interaction data

### DIFF
--- a/src/collector/quick_modal.rs
+++ b/src/collector/quick_modal.rs
@@ -138,7 +138,7 @@ impl<'a> CreateQuickModal<'a> {
             .components
             .iter()
             .filter_map(|component| {
-                if let Component::Label(label) = component
+                if let ModalComponent::Label(label) = component
                     && let LabelComponent::InputText(text) = &label.component
                 {
                     if let Some(value) = &text.value {
@@ -148,7 +148,7 @@ impl<'a> CreateQuickModal<'a> {
                         None
                     }
                 } else {
-                    if !matches!(component, Component::TextDisplay(_)) {
+                    if !matches!(component, ModalComponent::TextDisplay(_)) {
                         tracing::warn!("expected input text in modal response, got {component:?}");
                     }
                     None

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -1,4 +1,6 @@
 use serde::Serialize;
+use serde::de::Error as DeError;
+use serde_json::value::RawValue;
 
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -215,7 +217,7 @@ pub struct ModalInteractionData {
     /// The custom id of the modal
     pub custom_id: FixedString,
     /// The components of the submitted modal interaction.
-    pub components: FixedArray<Component>,
+    pub components: FixedArray<ModalComponent>,
     /// The resolved entities from the selected options.
     #[serde(default)]
     pub resolved: CommandDataResolved,
@@ -227,7 +229,29 @@ pub struct ModalInteractionData {
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
-pub enum ModalInteractionComponent {
+pub enum ModalComponent {
     TextDisplay(TextDisplay),
     Label(Label),
+}
+
+impl<'de> Deserialize<'de> for ModalComponent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct ModalComponentRaw {
+            #[serde(rename = "type")]
+            kind: ComponentType,
+        }
+
+        let raw_data = <&RawValue>::deserialize(deserializer)?;
+        let raw = ModalComponentRaw::deserialize(raw_data).map_err(DeError::custom)?;
+
+        match raw.kind {
+            ComponentType::TextDisplay => Deserialize::deserialize(raw_data).map(Self::TextDisplay),
+            ComponentType::Label => Deserialize::deserialize(raw_data).map(Self::Label),
+            ComponentType(i) => {
+                return Err(DeError::custom(format_args!("Unknown modal component type {i}")));
+            },
+        }
+        .map_err(DeError::custom)
+    }
 }


### PR DESCRIPTION
Seems to have been missed in #3454.

The enum `ModalInteractionComponent`, representing the possible top-level components in a modal, was defined, but it wasn't used. This PR fixes that and adds deserialization logic.

Also renames it to `ModalComponent` to both match `CreateModalComponent` and the original PR description and reduce verbosity.