### PR TITLE
Remove mentions of shuttle from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,6 @@ If you use the `native_tls_backend` and you are not developing on macOS or Windo
 
 - openssl
 
-# Hosting
-
-If you want a quick and easy way to host your bot, you can use [shuttle][project:shuttle],
-a Rust-native cloud development platform that allows deploying Serenity bots for free.
-
 # Projects extending Serenity
 
 - [lavalink-rs][project:lavalink-rs]: An interface to [Lavalink][repo:lavalink] and [Andesite][repo:andesite], an audio sending node based on [Lavaplayer][repo:lavaplayer]
@@ -240,7 +235,6 @@ a Rust-native cloud development platform that allows deploying Serenity bots for
 [project:lavalink-rs]: https://gitlab.com/vicky5124/lavalink-rs/
 [project:songbird]: https://github.com/serenity-rs/songbird
 [project:poise]: https://github.com/kangalioo/poise
-[project:shuttle]: https://github.com/shuttle-hq/shuttle
 [repo:lavalink]: https://github.com/freyacodes/Lavalink
 [repo:andesite]: https://github.com/natanbc/andesite
 [repo:lavaplayer]: https://github.com/sedmelluq/lavaplayer


### PR DESCRIPTION
Shuttle has shut down: https://docs.shuttle.dev/docs/shuttle-shutdown

The docs should be updated to reflect this.