### PR TITLE
Update discord docs links (next)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ If you use the `native_tls_backend` and you are not developing on macOS or Windo
 [`validate_token`]: https://docs.rs/serenity/*/serenity/utils/fn.validate_token.html
 [cache docs]: https://docs.rs/serenity/*/serenity/cache/index.html
 [client's module-level documentation]: https://docs.rs/serenity/*/serenity/client/index.html
-[discord docs]: https://discord.com/developers/docs/intro
+[discord docs]: https://docs.discord.com/developers/intro
 [examples]: https://github.com/serenity-rs/serenity/tree/current/examples
 [gateway docs]: https://docs.rs/serenity/*/serenity/gateway/index.html
 [project:lavalink-rs]: https://gitlab.com/vicky5124/lavalink-rs/

--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 
 /// A builder to add parameters when using [`GuildId::add_member`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#add-guild-member).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#add-guild-member).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct AddMember<'a> {

--- a/src/builder/create_allowed_mentions.rs
+++ b/src/builder/create_allowed_mentions.rs
@@ -70,7 +70,7 @@ impl ParseAction {
 /// # }
 /// ```
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#allowed-mentions-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#allowed-mentions-object).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateAllowedMentions<'a> {

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -21,7 +21,7 @@ pub enum AttachmentData<'a> {
 
 /// A builder for creating a new attachment from a file path, file data, or URL.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#attachment-object-attachment-structure).
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 #[must_use]
@@ -165,7 +165,7 @@ impl<'a> DataUri<'a> {
     /// # Errors
     ///
     /// Returns a [`Error::Url`] if the string is not a valid data URI. See the [Discord
-    /// docs](https://discord.com/developers/docs/reference#image-data).
+    /// docs](https://docs.discord.com/developers/reference#image-data).
     pub fn from_base64(s: impl Into<Cow<'a, str>>) -> Result<Self> {
         let s = s.into();
         if let Some(("data", tail)) = s.split_once(':')

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -12,7 +12,7 @@ use crate::model::prelude::*;
 ///
 /// Except [`Self::name`], all fields are optional.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#create-guild-channel).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#create-guild-channel).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateChannel<'a> {

--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -12,7 +12,7 @@ use crate::model::prelude::*;
 ///
 /// [`CommandOption`]: crate::model::application::CommandOption
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateCommandOption<'a> {
@@ -323,8 +323,8 @@ impl<'a> CreateCommandOption<'a> {
 /// [`Command`]: crate::model::application::Command
 ///
 /// Discord docs:
-/// - [global command](https://discord.com/developers/docs/interactions/application-commands#create-global-application-command)
-/// - [guild command](https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command)
+/// - [global command](https://docs.discord.com/developers/interactions/application-commands#create-global-application-command)
+/// - [guild command](https://docs.discord.com/developers/interactions/application-commands#create-guild-application-command)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateCommand<'a> {
@@ -487,7 +487,7 @@ impl<'a> CreateCommand<'a> {
     ///
     /// May also return [`Error::Json`] if there is an error in deserializing the API response.
     ///
-    /// [Discord's docs]: https://discord.com/developers/docs/interactions/slash-commands
+    /// [Discord's docs]: https://docs.discord.com/developers/interactions/application-commands#slash-commands
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: Option<GuildId>) -> Result<Command> {
         match guild_id {

--- a/src/builder/create_command_permission.rs
+++ b/src/builder/create_command_permission.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 
 /// A builder for creating several [`CommandPermission`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#edit-application-command-permissions).
 // Cannot be replaced by a simple Vec<CreateCommandPermission> because we need the schema with
 // the `permissions` field, and also to be forward compatible if a new field beyond just
 // `permissions` is added to the HTTP endpoint
@@ -36,7 +36,7 @@ impl<'a> EditCommandPermissions<'a> {
     ///
     /// May also return [`Error::Json`] if there is an error in deserializing the API response.
     ///
-    /// [Discord's docs]: https://discord.com/developers/docs/interactions/slash-commands
+    /// [Discord's docs]: https://docs.discord.com/developers/interactions/application-commands#slash-commands
     #[cfg(feature = "http")]
     pub async fn execute(
         self,
@@ -50,7 +50,7 @@ impl<'a> EditCommandPermissions<'a> {
 
 /// A builder for creating an [`CommandPermission`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateCommandPermission(CommandPermission);

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -6,7 +6,7 @@ use crate::model::prelude::*;
 
 /// A builder for creating a components action row in a message.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#action-row).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#action-row).
 #[derive(Clone, Debug)]
 #[must_use]
 pub enum CreateActionRow<'a> {
@@ -356,7 +356,7 @@ impl<'a> CreateMediaGalleryItem<'a> {
 /// item to "attachment://example.txt".
 ///
 /// For more details on naming and rules for attachments,
-/// refer to the [Discord Documentation](https://discord.com/developers/docs/reference#uploading-files).
+/// refer to the [Discord Documentation](https://docs.discord.com/developers/reference#uploading-files).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateFile<'a> {
@@ -506,7 +506,7 @@ pub enum CreateContainerComponent<'a> {
 
 /// A builder for creating a label that can hold an [`InputText`] or [`SelectMenu`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#label).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#label).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateLabel<'a> {
@@ -603,7 +603,7 @@ enum CreateLabelComponent<'a> {
 
 /// A builder for creating a file upload in a modal.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#file-upload).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#file-upload).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateFileUpload<'a> {
@@ -1057,7 +1057,7 @@ impl Serialize for CreateSelectMenuDefault {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/components/reference#component-object-component-types).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#component-object-component-types).
 #[derive(Clone, Debug)]
 pub enum CreateSelectMenuKind<'a> {
     String {
@@ -1145,7 +1145,7 @@ impl Serialize for CreateSelectMenuKind<'_> {
 
 /// A builder for creating a select menu component in a message
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#component-object-component-types).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#component-object-component-types).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateSelectMenu<'a> {
@@ -1220,7 +1220,7 @@ impl<'a> CreateSelectMenu<'a> {
 
 /// A builder for creating an option of a select menu component in a message.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#string-select-select-option-structure)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#string-select-select-option-structure)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateSelectMenuOption<'a> {
@@ -1280,7 +1280,7 @@ impl<'a> CreateSelectMenuOption<'a> {
 
 /// A builder for creating an input text component in a modal
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#text-input).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#text-input).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateInputText<'a> {

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -12,7 +12,7 @@
 //!
 //! [`ChannelId::send_message`]: crate::model::id::ChannelId::send_message
 //! [`ExecuteWebhook::embeds`]: crate::builder::ExecuteWebhook::embeds
-//! [here]: https://discord.com/developers/docs/resources/channel#embed-object
+//! [here]: https://docs.discord.com/developers/resources/message#embed-object
 
 use std::borrow::Cow;
 
@@ -20,7 +20,7 @@ use crate::model::prelude::*;
 
 /// A builder to create an embed in a message
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object)
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateEmbed<'a> {
@@ -133,7 +133,7 @@ impl<'a> CreateEmbed<'a> {
 
     /// Set the image associated with the embed.
     ///
-    /// Refer [Discord Documentation](https://discord.com/developers/docs/reference#uploading-files)
+    /// Refer [Discord Documentation](https://docs.discord.com/developers/reference#uploading-files)
     /// for rules on naming local attachments.
     pub fn image(mut self, url: impl Into<Cow<'a, str>>) -> Self {
         self.image = Some(CreateEmbedImage {

--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -9,7 +9,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#start-thread-in-forum-channel).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#start-thread-in-forum-or-media-channel).
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateForumPost<'a> {

--- a/src/builder/create_forum_tag.rs
+++ b/src/builder/create_forum_tag.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#forum-tag-object-forum-tag-structure)
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#forum-tag-object-forum-tag-structure)
 ///
 /// Contrary to the [`ForumTag`] struct, only the name field is required.
 #[must_use]

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -17,7 +17,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object).
 #[derive(Clone, Debug)]
 pub enum CreateInteractionResponse<'a> {
     /// Acknowledges a Ping (only required when your bot uses an HTTP endpoint URL).
@@ -147,7 +147,7 @@ impl CreateInteractionResponse<'_> {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-messages).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-messages).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateInteractionResponseMessage<'a> {
@@ -332,7 +332,7 @@ impl From<f64> for AutocompleteValue<'static> {
 }
 
 // Same as CommandOptionChoice according to Discord, see
-// [Autocomplete docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete).
+// [Autocomplete docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-autocomplete).
 #[must_use]
 #[derive(Clone, Debug, Serialize)]
 pub struct AutocompleteChoice<'a> {
@@ -371,7 +371,7 @@ impl<'a, S: Into<Cow<'a, str>>> From<S> for AutocompleteChoice<'a> {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-autocomplete)
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-autocomplete)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateAutocompleteResponse<'a> {
@@ -388,7 +388,7 @@ impl<'a> CreateAutocompleteResponse<'a> {
     ///
     /// See the official docs on [`Application Command Option Choices`] for more information.
     ///
-    /// [`Application Command Option Choices`]: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-choice-structure
+    /// [`Application Command Option Choices`]: https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-choice-structure
     pub fn set_choices(mut self, choices: impl Into<Cow<'a, [AutocompleteChoice<'a>]>>) -> Self {
         self.choices = choices.into();
         self
@@ -421,7 +421,7 @@ impl<'a> CreateAutocompleteResponse<'a> {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-modal).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-modal).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateModal<'a> {

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -15,7 +15,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#create-followup-message)
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#create-followup-message)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateInteractionResponseFollowup<'a> {

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -23,7 +23,7 @@ use crate::model::prelude::*;
 /// # }
 /// ```
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#create-channel-invite)
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#create-channel-invite)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateInvite<'a> {

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -48,7 +48,7 @@ use crate::model::prelude::*;
 /// # }
 /// ```
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#create-message)
+/// [Discord docs](https://docs.discord.com/developers/resources/message#create-message)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateMessage<'a> {

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -7,7 +7,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#create-guild-scheduled-event)
+/// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#create-guild-scheduled-event)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateScheduledEvent<'a> {

--- a/src/builder/create_soundboard.rs
+++ b/src/builder/create_soundboard.rs
@@ -7,7 +7,7 @@ use crate::model::prelude::*;
 
 /// A builder to create a soundboard sound.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/soundboard#soundboard-resource)
+/// [Discord docs](https://docs.discord.com/developers/resources/soundboard#create-guild-soundboard-sound)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateSoundboard<'a> {

--- a/src/builder/create_stage_instance.rs
+++ b/src/builder/create_stage_instance.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 
 /// Builder for creating a stage instance
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#create-stage-instance)
+/// [Discord docs](https://docs.discord.com/developers/resources/stage-instance#create-stage-instance)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateStageInstance<'a> {

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -10,7 +10,7 @@ use crate::model::prelude::*;
 
 /// A builder to create a guild sticker
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/sticker#create-guild-sticker)
+/// [Discord docs](https://docs.discord.com/developers/resources/sticker#create-guild-sticker)
 #[derive(Clone, Debug)]
 #[must_use]
 pub struct CreateSticker<'a> {

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -9,8 +9,8 @@ use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Discord docs:
-/// - [starting thread from message](https://discord.com/developers/docs/resources/channel#start-thread-from-message)
-/// - [starting thread without message](https://discord.com/developers/docs/resources/channel#start-thread-without-message)
+/// - [starting thread from message](https://docs.discord.com/developers/resources/channel#start-thread-from-message)
+/// - [starting thread without message](https://docs.discord.com/developers/resources/channel#start-thread-without-message)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateThread<'a> {

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -8,7 +8,7 @@ use crate::internal::prelude::*;
 #[cfg(feature = "http")]
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/resources/webhook#create-webhook)
+/// [Discord docs](https://docs.discord.com/developers/resources/webhook#create-webhook)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateWebhook<'a> {

--- a/src/builder/edit_automod_rule.rs
+++ b/src/builder/edit_automod_rule.rs
@@ -13,7 +13,7 @@ use crate::model::prelude::*;
 ///
 /// See [`GuildId::create_automod_rule`] for details.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#modify-auto-moderation-rule)
+/// [Discord docs](https://docs.discord.com/developers/resources/auto-moderation#modify-auto-moderation-rule)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct EditAutoModRule<'a> {

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -11,7 +11,7 @@ use crate::model::prelude::*;
 
 /// A builder to edit a [`GuildChannel`] for use via [`GuildChannel::edit`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#modify-channel-json-params-guild-channel).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#modify-channel-json-params-guild-channel).
 ///
 /// # Examples
 ///

--- a/src/builder/edit_command.rs
+++ b/src/builder/edit_command.rs
@@ -11,8 +11,8 @@ use crate::model::prelude::*;
 /// [`Command`]: crate::model::application::Command
 ///
 /// Discord docs:
-/// - [global command](https://discord.com/developers/docs/interactions/application-commands#edit-global-application-command)
-/// - [guild command](https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command)
+/// - [global command](https://docs.discord.com/developers/interactions/application-commands#edit-global-application-command)
+/// - [guild command](https://docs.discord.com/developers/interactions/application-commands#edit-guild-application-command)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditCommand<'a> {
@@ -163,7 +163,7 @@ impl<'a> EditCommand<'a> {
     ///
     /// May also return [`Error::Json`] if there is an error in deserializing the API response.
     ///
-    /// [Discord's docs]: https://discord.com/developers/docs/interactions/slash-commands
+    /// [Discord's docs]: https://docs.discord.com/developers/interactions/application-commands#slash-commands
     #[cfg(feature = "http")]
     pub async fn execute(
         self,

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -9,7 +9,7 @@ use crate::model::prelude::*;
 
 /// A builder to optionally edit certain fields of a guild
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#modify-guild).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#modify-guild).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditGuild<'a> {

--- a/src/builder/edit_guild_incident_actions.rs
+++ b/src/builder/edit_guild_incident_actions.rs
@@ -6,7 +6,7 @@ use crate::model::prelude::*;
 
 /// A builder for editing guild incident actions.
 ///
-/// [Discord's docs]: https://discord.com/developers/docs/resources/guild#modify-guild-incident-actions
+/// [Discord's docs]: https://docs.discord.com/developers/resources/guild#modify-guild-incident-actions
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditGuildIncidentActions {

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 
 /// A builder to edit the welcome screen of a guild
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen)
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#modify-guild-welcome-screen)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditGuildWelcomeScreen<'a> {
@@ -78,7 +78,7 @@ impl<'a> EditGuildWelcomeScreen<'a> {
 
 /// A builder for creating a [`GuildWelcomeChannel`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure)
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateGuildWelcomeChannel<'a> {

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -6,7 +6,7 @@ use crate::model::prelude::*;
 
 /// A builder to specify the fields to edit in a [`GuildWidget`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#modify-guild-widget)
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#modify-guild-widget)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditGuildWidget<'a> {

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -14,7 +14,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response)
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#edit-original-interaction-response)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditInteractionResponse<'a>(EditWebhookMessage<'a>);

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -9,7 +9,7 @@ use crate::model::prelude::*;
 /// A builder which edits the properties of a [`Member`], to be used in conjunction with
 /// [`Member::edit`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#modify-guild-member)
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#modify-guild-member)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditMember<'a> {

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -32,7 +32,7 @@ use crate::model::prelude::*;
 /// # }
 /// ```
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#edit-message)
+/// [Discord docs](https://docs.discord.com/developers/resources/message#edit-message)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditMessage<'a> {
@@ -121,7 +121,7 @@ impl<'a> EditMessage<'a> {
     ///
     /// [`CreateMessage::flags`]: super::CreateMessage::flags
     pub fn suppress_embeds(mut self, suppress: bool) -> Self {
-        // See for details: https://discord.com/developers/docs/resources/message#edit-message-jsonform-params
+        // See for details: https://docs.discord.com/developers/resources/message#edit-message-json/form-params
         self.flags
             .get_or_insert(MessageFlags::empty())
             .set(MessageFlags::SUPPRESS_EMBEDS, suppress);

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -11,7 +11,7 @@ use crate::model::user::CurrentUser;
 /// A builder to edit the current user's settings, to be used in conjunction with
 /// [`CurrentUser::edit`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#modify-current-user)
+/// [Discord docs](https://docs.discord.com/developers/resources/user#modify-current-user)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditProfile<'a> {

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -36,7 +36,7 @@ use crate::model::prelude::*;
 /// # }
 /// ```
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#modify-guild-role)
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#modify-guild-role)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditRole<'a> {
@@ -190,7 +190,7 @@ impl<'a> EditRole<'a> {
 ///
 /// Note: 2024-07-05 - tertiary_colour is currently enforced to be set with a specific pair of
 /// primary and secondary colours, for current validation see
-/// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object-role-colors-object).
+/// [Discord docs](https://docs.discord.com/developers/topics/permissions#role-object-role-colors-object).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 #[expect(clippy::struct_field_names)]

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -7,7 +7,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#modify-guild-scheduled-event)
+/// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#modify-guild-scheduled-event)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditScheduledEvent<'a> {
@@ -103,7 +103,7 @@ impl<'a> EditScheduledEvent<'a> {
     /// [`StageInstance`]: ScheduledEventType::StageInstance
     /// [`Voice`]: ScheduledEventType::Voice
     /// [`External`]: ScheduledEventType::External
-    /// [Discord docs]: https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-field-requirements-by-entity-type
+    /// [Discord docs]: https://docs.discord.com/developers/resources/guild-scheduled-event#guild-scheduled-event-object-field-requirements-by-entity-type
     pub fn kind(mut self, kind: ScheduledEventType) -> Self {
         if let ScheduledEventType::External = kind {
             self.channel_id = Some(None);

--- a/src/builder/edit_soundboard.rs
+++ b/src/builder/edit_soundboard.rs
@@ -6,7 +6,7 @@ use crate::model::prelude::*;
 
 /// A builder to create or edit a [`Soundboard`] for use with [`GuildId::edit_soundboard`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/soundboard#soundboard-resource)
+/// [Discord docs](https://docs.discord.com/developers/resources/soundboard#modify-guild-soundboard-sound)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditSoundboard<'a> {

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -8,7 +8,7 @@ use crate::model::prelude::*;
 
 /// Edits a [`StageInstance`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#modify-stage-instance)
+/// [Discord docs](https://docs.discord.com/developers/resources/stage-instance#modify-stage-instance)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditStageInstance<'a> {

--- a/src/builder/edit_sticker.rs
+++ b/src/builder/edit_sticker.rs
@@ -14,7 +14,7 @@ use crate::model::prelude::*;
 /// - [`GuildId::edit_sticker`]
 /// - [`Sticker::edit`]
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/sticker#modify-guild-sticker)
+/// [Discord docs](https://docs.discord.com/developers/resources/sticker#modify-guild-sticker)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditSticker<'a> {

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -8,7 +8,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#modify-channel-json-params-thread).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#modify-channel-json-params-thread).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditThread<'a> {

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -8,8 +8,8 @@ use crate::model::prelude::*;
 /// [`GuildChannel::edit_voice_state`].
 ///
 /// Discord docs:
-/// - [current user](https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state)
-/// - [other users](https://discord.com/developers/docs/resources/guild#modify-user-voice-state)
+/// - [current user](https://docs.discord.com/developers/resources/voice#modify-current-user-voice-state)
+/// - [other users](https://docs.discord.com/developers/resources/voice#modify-user-voice-state)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditVoiceState {

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -7,7 +7,7 @@ use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://discord.com/developers/docs/resources/webhook#modify-webhook)
+/// [Discord docs](https://docs.discord.com/developers/resources/webhook#modify-webhook)
 #[derive(Debug, Default, Clone, Serialize)]
 #[must_use]
 pub struct EditWebhook<'a> {

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -15,7 +15,7 @@ use crate::model::prelude::*;
 
 /// A builder to specify the fields to edit in an existing [`Webhook`]'s message.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/webhook#edit-webhook-message)
+/// [Discord docs](https://docs.discord.com/developers/resources/webhook#edit-webhook-message)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditWebhookMessage<'a> {

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -53,7 +53,7 @@ use crate::model::prelude::*;
 /// # }
 /// ```
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/webhook#execute-webhook)
+/// [Discord docs](https://docs.discord.com/developers/resources/webhook#execute-webhook)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct ExecuteWebhook<'a> {

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -45,7 +45,7 @@ use crate::model::prelude::*;
 /// # }
 /// ```
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#get-channel-messages)
+/// [Discord docs](https://docs.discord.com/developers/resources/message#get-channel-messages)
 #[derive(Clone, Copy, Debug, Default)]
 #[must_use]
 pub struct GetMessages {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -38,7 +38,7 @@ pub const USER_AGENT: &str = concat!(
 enum_number! {
     /// An enum representing the gateway opcodes.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes).
+    /// [Discord docs](https://docs.discord.com/developers/topics/opcodes-and-status-codes#gateway-gateway-opcodes).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[non_exhaustive]
     pub enum Opcode {
@@ -75,7 +75,7 @@ enum_number! {
 enum_number! {
     /// An enum representing the gateway close codes.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes)
+    /// [Discord docs](https://docs.discord.com/developers/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes)
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[non_exhaustive]
     pub enum CloseCode {

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -216,9 +216,9 @@ impl ClientBuilder {
     /// enabled in the *developer portal*. Once the bot is in 100 guilds or more, [the bot must be
     /// verified] in order to use privileged intents.
     ///
-    /// [gateway intent]: https://discord.com/developers/docs/topics/gateway#privileged-intents
-    /// [Privileged intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
-    /// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
+    /// [gateway intent]: https://docs.discord.com/developers/events/gateway#gateway-intents
+    /// [Privileged intents]: https://docs.discord.com/developers/events/gateway#privileged-intents
+    /// [the bot must be verified]: https://support.discord.com/hc/en-us/community/posts/360050817314-Discord-Bots-Info
     pub fn intents(mut self, intents: GatewayIntents) -> Self {
         self.intents = intents;
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -140,7 +140,7 @@ impl From<Activity> for ActivityData {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#request-guild-members).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#request-guild-members).
 #[derive(Clone, Debug)]
 pub enum ChunkGuildFilter {
     /// Returns all members of the guilds specified. Requires GUILD_MEMBERS intent.

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -189,7 +189,7 @@ impl ShardManager {
     // This function assumes that each of the shard ids are bucketed separately according to
     // `max_concurrency`. If this assumption is violated, you will likely get ratelimited.
     //
-    // See: https://discord.com/developers/docs/events/gateway#sharding-max-concurrency
+    // See: https://docs.discord.com/developers/events/gateway#sharding-max-concurrency
     async fn checked_start(&mut self, shard_ids: Vec<ShardId>) {
         if shard_ids.is_empty() {
             return;

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -502,7 +502,7 @@ pub enum ShardRunnerMessage {
     ///
     /// See the [Discord docs].
     ///
-    /// [Discord docs]: https://discord.com/developers/docs/events/gateway#initiating-a-disconnect
+    /// [Discord docs]: https://docs.discord.com/developers/events/gateway#initiating-a-disconnect
     Shutdown(u16),
     /// Indicates that the client is to send a member chunk message.
     ChunkGuild {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -221,7 +221,7 @@ fn reason_into_header(reason: &str) -> Headers {
     let mut headers = Headers::new();
 
     // "The X-Audit-Log-Reason header supports 1-512 URL-encoded UTF-8 characters."
-    // https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object
+    // https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object
     let header_value = match Cow::from(utf8_percent_encode(reason, NON_ALPHANUMERIC)) {
         Cow::Borrowed(value) => HeaderValue::from_str(value),
         Cow::Owned(value) => HeaderValue::try_from(value),
@@ -354,7 +354,7 @@ impl Http {
 
     /// Bans multiple users from a [`Guild`], optionally removing their messages.
     ///
-    /// See the [Discord docs](https://discord.com/developers/docs/resources/guild#bulk-guild-ban)
+    /// See the [Discord docs](https://docs.discord.com/developers/resources/guild#bulk-guild-ban)
     /// for more information.
     pub async fn bulk_ban_users(
         &self,
@@ -632,7 +632,7 @@ impl Http {
     /// over a [`Shard`], if at least one is running.
     ///
     /// [`Shard`]: crate::gateway::Shard
-    #[deprecated = "This endpoint has been deprecated by Discord and will stop functioning after July 15, 2025. For more information, see: https://discord.com/developers/docs/change-log#deprecating-guild-creation-by-apps"]
+    #[deprecated = "This endpoint has been deprecated by Discord and will stop functioning after July 15, 2025. For more information, see: https://docs.discord.com/developers/change-log#deprecating-guild-creation-by-apps"]
     pub async fn create_guild(&self, map: &impl serde::Serialize) -> Result<PartialGuild> {
         self.fire(Request {
             body: Some(to_vec(map)?),
@@ -2201,7 +2201,7 @@ impl Http {
     ///
     /// Refer to the [Discord docs] for more information on how this works.
     ///
-    /// [Discord docs]: https://discord.com/developers/docs/resources/webhook#execute-webhook-query-string-params
+    /// [Discord docs]: https://docs.discord.com/developers/resources/webhook#execute-webhook-query-string-params
     pub async fn execute_webhook_with_components(
         &self,
         webhook_id: WebhookId,

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -33,7 +33,7 @@
 //! associated u64 as data. This is the Id of the parameter, differentiating between different
 //! ratelimits.
 //!
-//! [Taken from]: https://discord.com/developers/docs/topics/rate-limits#rate-limits
+//! [Taken from]: https://docs.discord.com/developers/topics/rate-limits#rate-limits
 
 use std::borrow::Cow;
 use std::fmt;
@@ -274,7 +274,7 @@ impl Ratelimiter {
 /// **Note**: You should _not_ mutate any of the fields, as this can help cause 429s.
 ///
 /// [`Http`]: super::Http
-/// [Discord docs]: https://discord.com/developers/docs/topics/rate-limits
+/// [Discord docs]: https://docs.discord.com/developers/topics/rate-limits
 #[derive(Debug)]
 pub struct Ratelimit {
     /// The total number of requests that can be made in a period of time.

--- a/src/interactions_endpoint.rs
+++ b/src/interactions_endpoint.rs
@@ -3,7 +3,7 @@
 //! "You can optionally configure an interactions endpoint to receive interactions via HTTP POSTs
 //! rather than over Gateway with a bot user."
 //!
-//! <https://discord.com/developers/docs/tutorials/upgrading-to-application-commands#adding-an-interactions-endpoint-url>
+//! <https://docs.discord.com/developers/tutorials/upgrading-to-application-commands#adding-an-interactions-endpoint-url>
 //!
 //! See [`Verifier`] for example usage.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //! [`examples`]: https://github.com/serenity-rs/serenity/blob/current/examples
 //! [cache docs]: crate::cache
 //! [client's module-level documentation]: crate::gateway::client
-//! [docs]: https://discord.com/developers/docs/intro
+//! [docs]: https://docs.discord.com/developers/intro
 //! [examples]: https://github.com/serenity-rs/serenity/tree/current/examples
 //! [gateway docs]: crate::gateway
 #![doc(html_root_url = "https://docs.rs/serenity/*")]

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -11,7 +11,7 @@ use crate::model::prelude::*;
 
 /// The base command model that belongs to an application.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-structure).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -34,13 +34,13 @@ pub struct Command {
     ///
     /// If the name is localized, either this field or [`Self::name_localizations`] is set,
     /// depending on which endpoint this data was retrieved from
-    /// ([source](https://discord.com/developers/docs/interactions/application-commands#retrieving-localized-commands)).
+    /// ([source](https://docs.discord.com/developers/interactions/application-commands#retrieving-localized-commands)).
     pub name_localized: Option<FixedString<u8>>,
     /// All localized command names.
     ///
     /// If the name is localized, either this field or [`Self::name_localized`] is set, depending
     /// on which endpoint this data was retrieved from
-    /// ([source](https://discord.com/developers/docs/interactions/application-commands#retrieving-localized-commands)).
+    /// ([source](https://docs.discord.com/developers/interactions/application-commands#retrieving-localized-commands)).
     pub name_localizations: Option<HashMap<String, String>>,
     /// The command description.
     pub description: FixedString<u16>,
@@ -48,13 +48,13 @@ pub struct Command {
     ///
     /// If the description is localized, either this field or [`Self::description_localizations`]
     /// is set, depending on which endpoint this data was retrieved from
-    /// ([source](https://discord.com/developers/docs/interactions/application-commands#retrieving-localized-commands)).
+    /// ([source](https://docs.discord.com/developers/interactions/application-commands#retrieving-localized-commands)).
     pub description_localized: Option<FixedString<u16>>,
     /// All localized command descriptions.
     ///
     /// If the description is localized, either this field or [`Self::description_localized`] is
     /// set, depending on which endpoint this data was retrieved from
-    /// ([source](https://discord.com/developers/docs/interactions/application-commands#retrieving-localized-commands)).
+    /// ([source](https://docs.discord.com/developers/interactions/application-commands#retrieving-localized-commands)).
     pub description_localizations: Option<HashMap<String, String>>,
     /// The parameters for the command.
     #[serde(default)]
@@ -66,7 +66,7 @@ pub struct Command {
     #[serde(default)]
     #[cfg(not(feature = "unstable"))]
     pub dm_permission: Option<bool>,
-    /// Indicates whether the command is [age-restricted](https://discord.com/developers/docs/interactions/application-commands#agerestricted-commands),
+    /// Indicates whether the command is [age-restricted](https://docs.discord.com/developers/interactions/application-commands#age-restricted-commands),
     /// defaults to false.
     #[serde(default)]
     pub nsfw: bool,
@@ -213,7 +213,7 @@ impl Command {
 enum_number! {
     /// The type of an application command.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types).
+    /// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -230,7 +230,7 @@ enum_number! {
     /// Signifies how the invocation of a command of type [`PrimaryEntryPoint`] should be handled.
     ///
     /// [`PrimaryEntryPoint`]: CommandType::PrimaryEntryPoint
-    /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-entry-point-command-handler-types)
+    /// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-object-entry-point-command-handler-types)
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -243,7 +243,7 @@ enum_number! {
 
 /// The parameters for an [`Command`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
@@ -304,7 +304,7 @@ pub struct CommandOption {
 enum_number! {
     /// The type of an [`CommandOption`].
     ///
-    /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
+    /// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -326,7 +326,7 @@ enum_number! {
 
 /// The only valid values a user can pick in an [`CommandOption`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-choice-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-choice-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -342,7 +342,7 @@ pub struct CommandOptionChoice {
 
 /// An [`Command`] permission.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -359,7 +359,7 @@ pub struct CommandPermissions {
 
 /// The [`CommandPermission`] data.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -376,7 +376,7 @@ pub struct CommandPermission {
 enum_number! {
     /// The type of a [`CommandPermission`].
     ///
-    /// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
+    /// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-permissions-object-application-command-permission-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -18,7 +18,7 @@ use crate::model::prelude::*;
 
 /// An interaction when a user invokes a slash command.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
@@ -230,7 +230,7 @@ impl Serialize for CommandInteraction {
 
 /// The command data payload.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-data-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-application-command-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -443,7 +443,7 @@ pub enum ResolvedTarget<'a> {
 /// The resolved data of a command data interaction payload. It contains the objects of
 /// [`CommandDataOption`]s.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -497,7 +497,7 @@ pub struct CommandDataResolved {
 ///
 /// Their resolved objects can be found on [`CommandData::resolved`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-interaction-data-option-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-application-command-interaction-data-option-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
@@ -620,7 +620,7 @@ impl Serialize for CommandDataOption {
 
 /// The value of an [`CommandDataOption`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).
+/// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-object-application-command-option-type).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -486,7 +486,7 @@ pub struct RadioGroup {
     pub kind: ComponentType,
     /// Developer-defined identifier for the radio group; max 100 characters
     pub custom_id: FixedString,
-    /// Value of the selected [`CreateRadioGroupOption`].
+    /// Value of the selected [`CreateRadioGroupOption`][crate::builder::CreateRadioGroupOption].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<FixedString>,
 }
@@ -501,7 +501,7 @@ pub struct CheckboxGroup {
     pub kind: ComponentType,
     /// Developer-defined identifier for the checkbox group; max 100 characters
     pub custom_id: FixedString,
-    /// Values of the selected [`CreateCheckboxGroupOption`].
+    /// Values of the selected [`CreateCheckboxGroupOption`][crate::builder::CreateCheckboxGroupOption].
     pub values: FixedArray<String>,
 }
 

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -96,7 +96,7 @@ impl<'de> Deserialize<'de> for Component {
 
 /// A component that is a container for up to 3 text display components and an accessory.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#section)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#section)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -112,7 +112,7 @@ pub struct Section {
 
 /// A child component representing the content of a section.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#section-section-child-components)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#section-section-child-components)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
@@ -145,7 +145,7 @@ impl<'de> Deserialize<'de> for SectionComponent {
 
 /// A component that is contextually associated to the content of a section.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#section-section-accessory-components)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#section-section-accessory-components)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
@@ -186,7 +186,7 @@ impl<'de> Deserialize<'de> for SectionAccessory {
 ///
 /// See [`Section`] for how this fits within a section.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#thumbnail)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#thumbnail)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -204,7 +204,7 @@ pub struct Thumbnail {
 
 /// A url or attachment.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#unfurled-media-item)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#unfurled-media-item)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -224,7 +224,7 @@ pub struct UnfurledMediaItem {
 /// A component that allows you to add text to your message, similiar to the `content` field of a
 /// message.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#text-display)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#text-display)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -243,7 +243,7 @@ pub struct TextDisplay {
 /// A Media Gallery is a component that allows you to display media attachments in an organized
 /// gallery format.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#media-gallery)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#media-gallery)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -259,7 +259,7 @@ pub struct MediaGallery {
 ///
 /// Belongs to [`MediaGallery`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#media-gallery-media-gallery-item-structure)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#media-gallery-media-gallery-item-structure)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -274,7 +274,7 @@ pub struct MediaGalleryItem {
 
 /// A component that adds vertical padding and visual division between other components.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#separator)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#separator)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -302,7 +302,7 @@ enum_number! {
 
 /// A file component, will not render a text preview to the user.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#file)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#file)
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[non_exhaustive]
@@ -318,7 +318,7 @@ pub struct FileComponent {
 
 /// A container component, similar to an embed but without all the functionality.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#container)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#container)
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[non_exhaustive]
@@ -336,7 +336,7 @@ pub struct Container {
 
 /// A child component encapsulated within a container.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#container-container-child-components)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#container-container-child-components)
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[non_exhaustive]
@@ -395,7 +395,7 @@ impl<'de> Deserialize<'de> for ContainerComponent {
 /// **Note**: Labels can only appear within modals, and will not include the `label` or
 /// `description` field when part of a modal response.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#label-label-interaction-response-structure)
+/// [Discord docs](https://docs.discord.com/developers/components/reference#label-label-interaction-response-structure)
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[non_exhaustive]
@@ -521,7 +521,7 @@ pub struct Checkbox {
 
 /// An action row.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#action-row).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#action-row).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -536,7 +536,7 @@ pub struct ActionRow {
 
 /// A component which can be inside of an [`ActionRow`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#action-row-action-row-child-components).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#action-row-action-row-child-components).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
@@ -649,7 +649,7 @@ impl Serialize for ButtonKind {
 
 /// A button component.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#button).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#button).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[non_exhaustive]
@@ -688,7 +688,7 @@ enum_number! {
 
 /// A select menu component.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#component-object-component-types).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#component-object-component-types).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -727,7 +727,7 @@ pub struct SelectMenu {
 
 /// A select menu component options.
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#string-select-select-option-structure).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#string-select-select-option-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -747,7 +747,7 @@ pub struct SelectMenuOption {
 
 /// An input text component for modal interactions
 ///
-/// [Discord docs](https://discord.com/developers/docs/components/reference#text-input).
+/// [Discord docs](https://docs.discord.com/developers/components/reference#text-input).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -785,7 +785,7 @@ pub struct InputText {
 enum_number! {
     /// The style of the input text
     ///
-    /// [Discord docs](https://discord.com/developers/docs/components/reference#text-input-text-input-styles).
+    /// [Discord docs](https://docs.discord.com/developers/components/reference#text-input-text-input-styles).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -501,7 +501,8 @@ pub struct CheckboxGroup {
     pub kind: ComponentType,
     /// Developer-defined identifier for the checkbox group; max 100 characters
     pub custom_id: FixedString,
-    /// Values of the selected [`CreateCheckboxGroupOption`][crate::builder::CreateCheckboxGroupOption].
+    /// Values of the selected
+    /// [`CreateCheckboxGroupOption`][crate::builder::CreateCheckboxGroupOption].
     pub values: FixedArray<String>,
 }
 

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -15,7 +15,7 @@ use crate::model::prelude::*;
 
 /// An interaction triggered by a message component.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
@@ -307,7 +307,7 @@ impl Serialize for ComponentInteractionDataKind {
 
 /// A message component interaction data, provided by [`ComponentInteraction::data`]
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-message-component-data-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-message-component-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -18,7 +18,7 @@ use crate::model::monetization::Entitlement;
 use crate::model::user::User;
 use crate::model::utils::StrOrInt;
 
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object)
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -285,7 +285,7 @@ impl Serialize for Interaction {
 enum_number! {
     /// The type of an Interaction.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type).
+    /// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -301,7 +301,7 @@ enum_number! {
 
 /// A cleaned up enum for determining the authorizing owner for an [`Interaction`].
 ///
-/// [Discord Docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-authorizing-integration-owners-object)
+/// [Discord Docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-authorizing-integration-owners-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -400,7 +400,7 @@ impl serde::Serialize for AuthorizingIntegrationOwners {
 ///
 /// [`Message`]: crate::model::channel::Message
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#message-interaction-object).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#message-interaction-object).
 #[cfg(not(feature = "unstable"))]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -23,7 +23,7 @@ use super::prelude::*;
 
 /// Partial information about the given application.
 ///
-/// Discord docs: [application field of Ready](https://discord.com/developers/docs/topics/gateway-events#ready-ready-event-fields)
+/// Discord docs: [application field of Ready](https://docs.discord.com/developers/events/gateway-events#ready-ready-event-fields)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -36,7 +36,7 @@ pub struct PartialCurrentApplicationInfo {
 
 /// Information about the current application and its owner.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/application#application-object-application-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/application#application-object-application-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CurrentApplicationInfo {
@@ -89,7 +89,7 @@ impl ApplicationId {
     ///
     /// If included in a message, will render as a rich embed. See the [Discord docs] for details.
     ///
-    /// [Discord docs]: https://discord.com/developers/docs/monetization/managing-your-store#linking-to-your-store
+    /// [Discord docs]: https://docs.discord.com/developers/monetization/managing-skus#linking-to-your-store
     #[must_use]
     pub fn store_url(self) -> String {
         format!("https://discord.com/application-directory/{self}/store")
@@ -99,7 +99,7 @@ impl ApplicationId {
 enum_number! {
     /// An enum representing the [installation contexts].
     ///
-    /// [interaction contexts](https://discord.com/developers/docs/resources/application#application-object-application-integration-types).
+    /// [interaction contexts](https://docs.discord.com/developers/resources/application#application-object-application-integration-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -113,7 +113,7 @@ enum_number! {
 enum_number! {
     /// An enum representing the different [interaction contexts].
     ///
-    /// [interaction contexts](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types).
+    /// [interaction contexts](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-context-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -130,7 +130,7 @@ enum_number! {
 
 /// Information about how the [`CurrentApplicationInfo`] is installed.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/application#application-object-application-integration-types).
+/// [Discord docs](https://docs.discord.com/developers/resources/application#application-object-application-integration-types).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InstallationContextConfig {
     pub oauth2_install_params: Option<InstallParams>,
@@ -138,7 +138,7 @@ pub struct InstallationContextConfig {
 
 /// Information about the Team group of the application.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-team-object).
+/// [Discord docs](https://docs.discord.com/developers/topics/teams#data-models-team-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Team {
@@ -156,7 +156,7 @@ pub struct Team {
 
 /// Information about a Member on a Team.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-team-member-object).
+/// [Discord docs](https://docs.discord.com/developers/topics/teams#data-models-team-member-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct TeamMember {
@@ -171,7 +171,7 @@ pub struct TeamMember {
 }
 
 enum_number! {
-    /// [Discord docs](https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum).
+    /// [Discord docs](https://docs.discord.com/developers/topics/teams#data-models-membership-state-enum).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[non_exhaustive]
     pub enum MembershipState {
@@ -226,7 +226,7 @@ impl Ord for TeamMemberRole {
 bitflags! {
     /// The flags of the application.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/application#application-object-application-flags).
+    /// [Discord docs](https://docs.discord.com/developers/resources/application#application-object-application-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ApplicationFlags: u64 {
@@ -238,11 +238,11 @@ bitflags! {
         /// on the Bot page in your app's settings
         const GATEWAY_PRESENCE_LIMITED = 1 << 13;
         /// Intent required for bots in 100 or more servers to receive member-related events like
-        /// guild_member_add. See the list of member-related events under [GUILD_MEMBERS](https://discord.com/developers/docs/topics/gateway#list-of-intents)
+        /// guild_member_add. See the list of member-related events under [GUILD_MEMBERS](https://docs.discord.com/developers/events/gateway#list-of-intents)
         const GATEWAY_GUILD_MEMBERS = 1 << 14;
         /// Intent required for bots in under 100 servers to receive member-related events like
         /// guild_member_add, found on the Bot page in your app's settings. See the list of
-        /// member-related events under [GUILD_MEMBERS](https://discord.com/developers/docs/topics/gateway#list-of-intents)
+        /// member-related events under [GUILD_MEMBERS](https://docs.discord.com/developers/events/gateway#list-of-intents)
         const GATEWAY_GUILD_MEMBERS_LIMITED = 1 << 15;
         /// Indicates unusual growth of an app that prevents verification
         const VERIFICATION_PENDING_GUILD_LIMIT = 1 << 16;
@@ -261,7 +261,7 @@ bitflags! {
 
 /// Settings for the application's default in-app authorization link
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/application#install-params-object-install-params-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/application#install-params-object-install-params-structure).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct InstallParams {

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -15,7 +15,7 @@ use crate::model::prelude::*;
 
 /// An interaction triggered by a modal submit.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
@@ -211,7 +211,7 @@ impl Serialize for ModalInteraction {
 
 /// A modal submit interaction data, provided by [`ModalInteraction::data`]
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -227,7 +227,7 @@ pub struct ModalInteractionData {
 
 /// A component which can appear inside a modal form submission.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-component-interaction-response-structures)
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-component-interaction-response-structures)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]

--- a/src/model/application/oauth.rs
+++ b/src/model/application/oauth.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// The available OAuth2 Scopes.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).
+/// [Discord docs](https://docs.discord.com/developers/topics/oauth2#shared-resources-oauth2-scopes).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[non_exhaustive]

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -4,7 +4,7 @@ use crate::model::prelude::*;
 
 /// A ping interaction, which can only be received through an endpoint url.
 ///
-/// [Discord docs](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure).
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -25,7 +25,7 @@ where
 
 /// A file uploaded with a message. Not to be confused with [`Embed`]s.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#attachment-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#attachment-object).
 ///
 /// [`Embed`]: super::Embed
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -10,7 +10,7 @@ use crate::model::prelude::*;
 /// **Note**: Maximum amount of characters you can put is 256 in a field name,
 /// 1024 in a field value, and 4096 in a description.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object).
 ///
 /// [slack's attachments]: https://api.slack.com/docs/message-attachments
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -73,7 +73,7 @@ pub struct Embed {
 
 /// An author object in an embed.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-author-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -95,7 +95,7 @@ pub struct EmbedAuthor {
 
 /// A field object in an embed.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-field-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -141,7 +141,7 @@ impl EmbedField {
 
 /// Footer information for an embed.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-footer-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -160,7 +160,7 @@ pub struct EmbedFooter {
 
 /// An image object in an embed.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-image-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-image-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -179,7 +179,7 @@ pub struct EmbedImage {
 
 /// The provider of an embed.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-provider-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -192,7 +192,7 @@ pub struct EmbedProvider {
 
 /// The dimensions and URL of an embed thumbnail.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-thumbnail-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -211,7 +211,7 @@ pub struct EmbedThumbnail {
 
 /// Video information for an embed.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-video-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/followed_channel.rs
+++ b/src/model/channel/followed_channel.rs
@@ -2,7 +2,7 @@ use super::{ChannelId, WebhookId};
 
 /// A container for the IDs returned by following a news channel.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#followed-channel-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#followed-channel-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct FollowedChannel {

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -19,7 +19,7 @@ use crate::model::prelude::*;
 
 /// Represents the shared fields between [`GuildChannel`] and [`GuildThread`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/threads#thread-fields)
+/// [Discord docs](https://docs.discord.com/developers/topics/threads#thread-fields)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -55,7 +55,7 @@ impl BaseGuildChannel {
 
 /// Represents a channel in a [`Guild`], excluding thread information.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -145,7 +145,7 @@ pub struct GuildChannel {
 enum_number! {
     /// See [`GuildChannel::default_forum_layout`].
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-forum-layout-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-forum-layout-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]

--- a/src/model/channel/interaction_channel.rs
+++ b/src/model/channel/interaction_channel.rs
@@ -16,8 +16,8 @@ pub struct BaseInteractionChannel {
 
 /// Represents a partial channel from an interaction.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object),
-/// [subset specification](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object),
+/// [subset specification](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -31,8 +31,8 @@ pub struct InteractionChannel {
 
 /// Represents a partial thread from an interaction.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object),
-/// [subset specification](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object),
+/// [subset specification](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -20,8 +20,8 @@ use crate::model::utils::{StrOrInt, discord_colours};
 
 /// A representation of a message over a guild's text channel, a group, or a private channel.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object) with some
-/// [extra fields](https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#message-object) with some
+/// [extra fields](https://docs.discord.com/developers/events/gateway-events#message-create-message-create-extra-fields).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
@@ -65,7 +65,7 @@ pub struct Message {
     ///
     /// [Refer to Discord's documentation for more information][discord-docs].
     ///
-    /// [discord-docs]: https://discord.com/developers/docs/resources/channel#message-object
+    /// [discord-docs]: https://docs.discord.com/developers/resources/message#message-object
     #[serde(default)]
     pub mention_channels: FixedArray<ChannelMention>,
     /// An vector of the files attached to a message.
@@ -619,7 +619,7 @@ impl From<&Message> for MessageId {
 /// Multiple of the same [reaction type] are sent into one [`MessageReaction`], with an associated
 /// [`Self::count`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#reaction-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#reaction-object).
 ///
 /// [reaction type]: ReactionType
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -645,7 +645,7 @@ pub struct MessageReaction {
 
 /// A representation of reaction count details.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#reaction-count-details-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#reaction-count-details-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -657,7 +657,7 @@ pub struct CountDetails {
 enum_number! {
     /// Differentiates between regular and different types of system messages.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/message#message-object-message-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -727,7 +727,7 @@ enum_number! {
 }
 
 enum_number! {
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-activity-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/message#message-object-message-activity-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -742,8 +742,8 @@ enum_number! {
 
 /// Rich Presence application information.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/application#application-object),
-/// [subset undocumented](https://discord.com/developers/docs/resources/channel#message-object-message-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/application#application-object),
+/// [subset undocumented](https://docs.discord.com/developers/resources/message#message-object-message-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -762,7 +762,7 @@ pub struct MessageApplication {
 
 /// Rich Presence activity information.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-activity-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#message-object-message-activity-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -777,7 +777,7 @@ pub struct MessageActivity {
 enum_number! {
     /// Message Reference Type information
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/message#message-reference-types)
+    /// [Discord docs](https://docs.discord.com/developers/resources/message#message-reference-types)
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -791,7 +791,7 @@ enum_number! {
 
 /// Reference data sent with crossposted messages.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#message-reference-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -853,7 +853,7 @@ impl From<&Message> for MessageReference {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-mention-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/message#channel-mention-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -869,7 +869,7 @@ pub struct ChannelMention {
     pub name: FixedString,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/message#message-snapshot-structure)
+/// [Discord docs](https://docs.discord.com/developers/resources/message#message-snapshot-structure)
 ///
 /// For field documentation, see [`Message`].
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -913,7 +913,7 @@ where
 bitflags! {
     /// Describes extra features of the message.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#message-object-message-flags).
+    /// [Discord docs](https://docs.discord.com/developers/resources/message#message-object-message-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct MessageFlags: u64 {
@@ -962,7 +962,7 @@ bitflags! {
         /// - Files will not have a simple text preview.
         /// - URLs will not generate embeds.
         ///
-        /// For more details, refer to the Discord documentation: [https://discord.com/developers/docs/components/reference#component-reference]
+        /// For more details, refer to the Discord documentation: [https://docs.discord.com/developers/components/reference#component-reference]
         const IS_COMPONENTS_V2 = 1 << 15;
 
     }
@@ -1031,7 +1031,7 @@ impl<'de> serde::Deserialize<'de> for Nonce {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#role-subscription-data-object)
+/// [Discord docs](https://docs.discord.com/developers/resources/message#role-subscription-data-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RoleSubscriptionData {
@@ -1047,7 +1047,7 @@ pub struct RoleSubscriptionData {
 
 /// A poll that has been attached to a [`Message`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-object)
+/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1068,7 +1068,7 @@ pub struct Poll {
 ///
 /// Currently holds text and an optional emoji, but this is expected to change in future
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-media-object)
+/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-media-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1079,7 +1079,7 @@ pub struct PollMedia {
 
 /// The "Partial Emoji" attached to a [`PollMedia`] model.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-media-object)
+/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-media-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -1121,7 +1121,7 @@ impl From<EmojiId> for PollMediaEmoji {
 
 /// A possible answer for a [`Poll`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-answer-object)
+/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-answer-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1135,7 +1135,7 @@ enum_number! {
     ///
     /// Currently, there is only the one option.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/poll#layout-type)
+    /// [Discord docs](https://docs.discord.com/developers/resources/poll#layout-type)
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -1150,7 +1150,7 @@ enum_number! {
 ///
 /// If `is_finalized` is `false`, `answer_counts` will be inaccurate due to Discord's scale.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-results-object-poll-results-object-structure)
+/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-results-object-poll-results-object-structure)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1161,7 +1161,8 @@ pub struct PollResults {
 
 /// The count of a single [`PollAnswer`]'s results.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/poll#poll-results-object-poll-answer-count-object-structure)
+/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-results-object-poll-results-object-structure)
+// TODO: https://docs.discord.com/developers/resources/poll#poll-results-object-poll-answer-count-object-structure
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1173,7 +1174,7 @@ pub struct PollAnswerCount {
 
 /// A pinned message returned as part of a paginated Get Channel Pins query.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/message#message-pin-object)
+/// [Discord docs](https://docs.discord.com/developers/resources/message#message-pin-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1184,7 +1185,7 @@ pub struct MessagePin {
 
 /// The response data for a paginated Get Channel Pins query.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/message#get-channel-pins)
+/// [Discord docs](https://docs.discord.com/developers/resources/message#get-channel-pins)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -251,7 +251,7 @@ impl fmt::Display for Channel {
 enum_number! {
     /// A representation of a type of channel.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-channel-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -309,7 +309,7 @@ impl ChannelType {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#overwrite-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct PermissionOverwriteData {
     allow: Permissions,
@@ -363,7 +363,7 @@ impl From<PermissionOverwrite> for PermissionOverwriteData {
 
 /// A channel-specific permission overwrite for a member or role.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#overwrite-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(try_from = "PermissionOverwriteData", into = "PermissionOverwriteData")]
@@ -380,7 +380,7 @@ pub struct PermissionOverwrite {
 /// If you would like to modify the default permissions of a channel, you can get its [`RoleId`]
 /// from [`GuildId::everyone_role`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#overwrite-object-overwrite-structure) (field `type`).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#overwrite-object-overwrite-structure) (field `type`).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
@@ -394,7 +394,7 @@ pub enum PermissionOverwriteType {
 enum_number! {
     /// The video quality mode for a voice channel.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-video-quality-modes).
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-video-quality-modes).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -411,7 +411,7 @@ enum_number! {
 enum_number! {
     /// See [`StageInstance::privacy_level`].
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level).
+    /// [Discord docs](https://docs.discord.com/developers/resources/stage-instance#stage-instance-object-privacy-level).
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -428,7 +428,7 @@ enum_number! {
 enum_number! {
     /// See [`ThreadMetadata::auto_archive_duration`].
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object)
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#thread-metadata-object)
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -442,7 +442,7 @@ enum_number! {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/stage-instance#stage-instance-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -465,11 +465,11 @@ pub struct StageInstance {
 
 /// A response to getting several threads channels.
 ///
-/// Discord docs: defined [multiple times](https://discord.com/developers/docs/topics/threads#enumerating-threads):
-/// [1](https://discord.com/developers/docs/resources/guild#list-active-guild-threads-response-body),
-/// [2](https://discord.com/developers/docs/resources/channel#list-private-archived-threads-response-body),
-/// [3](https://discord.com/developers/docs/resources/channel#list-public-archived-threads-response-body),
-/// [4](https://discord.com/developers/docs/resources/channel#list-private-archived-threads-response-body)
+/// Discord docs: defined [multiple times](https://docs.discord.com/developers/topics/threads#enumerating-threads):
+/// [1](https://docs.discord.com/developers/resources/guild#list-active-guild-threads-response-body),
+/// [2](https://docs.discord.com/developers/resources/channel#list-private-archived-threads-response-body),
+/// [3](https://docs.discord.com/developers/resources/channel#list-public-archived-threads-response-body),
+/// [4](https://docs.discord.com/developers/resources/channel#list-joined-private-archived-threads-response-body)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -485,7 +485,7 @@ pub struct ThreadsData {
 
 /// An object that specifies the emoji to use for Forum related emoji parameters.
 ///
-/// See [Discord](https://discord.com/developers/docs/resources/channel#default-reaction-object)
+/// See [Discord](https://docs.discord.com/developers/resources/channel#default-reaction-object)
 /// [docs]()
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone)]
@@ -539,7 +539,7 @@ impl<'de> serde::Deserialize<'de> for ForumEmoji {
 
 /// An object that represents a tag able to be applied to a thread in a `GUILD_FORUM` channel.
 ///
-/// See [Discord docs](https://discord.com/developers/docs/resources/channel#forum-tag-object)
+/// See [Discord docs](https://docs.discord.com/developers/resources/channel#forum-tag-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -559,7 +559,7 @@ pub struct ForumTag {
 enum_number! {
     /// The sort order for threads in a forum.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-sort-order-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-sort-order-types).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[non_exhaustive]
@@ -575,7 +575,7 @@ enum_number! {
 bitflags! {
     /// Describes extra features of the channel.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object-channel-flags).
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-channel-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ChannelFlags: u64 {

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -7,7 +7,7 @@ use crate::model::utils::single_recipient;
 
 /// A Direct Message text channel with another user.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -20,7 +20,7 @@ use crate::model::utils::discord_colours_opt;
 
 /// An emoji reaction to a message.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#message-reaction-add-message-reaction-add-event-fields).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-reaction-add-message-reaction-add-event-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]

--- a/src/model/channel/thread.rs
+++ b/src/model/channel/thread.rs
@@ -224,7 +224,7 @@ impl ExtractKey<ThreadId> for GuildThread {
 
 /// A thread data.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#thread-metadata-object).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Default, serde::Deserialize, serde::Serialize)]
@@ -253,8 +253,8 @@ pub struct ThreadMetadata {
 
 /// A partial guild thread.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/channel#channel-object),
-/// [subset description](https://discord.com/developers/docs/topics/gateway#thread-delete)
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object),
+/// [subset description](https://docs.discord.com/developers/events/gateway-events#thread-delete)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -284,8 +284,8 @@ pub struct PartialThreadMember {
 ///
 /// [Discord docs], [extra fields].
 ///
-/// [Discord docs]: https://discord.com/developers/docs/resources/channel#thread-member-object,
-/// [extra fields]: https://discord.com/developers/docs/topics/gateway-events#thread-member-update-thread-member-update-event-extra-fields
+/// [Discord docs]: https://docs.discord.com/developers/resources/channel#thread-member-object,
+/// [extra fields]: https://docs.discord.com/developers/events/gateway-events#thread-member-update-thread-member-update-event-extra-fields
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -305,17 +305,17 @@ pub struct ThreadMember {
     ///
     /// Always present in [`ThreadMemberUpdateEvent`], otherwise `None`.
     pub guild_id: Option<GuildId>,
-    // According to https://discord.com/developers/docs/topics/gateway-events#thread-members-update,
+    // According to https://docs.discord.com/developers/events/gateway-events#thread-members-update,
     // > the thread member objects will also include the guild member and nullable presence objects
     // > for each added thread member
-    // Which implies that ThreadMember has a presence field. But https://discord.com/developers/docs/resources/channel#thread-member-object
+    // Which implies that ThreadMember has a presence field. But https://docs.discord.com/developers/resources/channel#thread-member-object
     // says that's not true. I'm not adding the presence field here for now
 }
 
 bitflags! {
     /// Describes extra features of the message.
     ///
-    /// Discord docs: flags field on [Thread Member](https://discord.com/developers/docs/resources/channel#thread-member-object).
+    /// Discord docs: flags field on [Thread Member](https://docs.discord.com/developers/resources/channel#thread-member-object).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ThreadMemberFlags: u64 {

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 
 /// Information about a connection between the current user and a third party service.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-connection-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/user#connection-object-connection-structure).
 #[bool_to_bitflags::bool_to_bitflags]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
@@ -15,7 +15,7 @@ pub struct Connection {
     pub name: FixedString,
     /// The service that this connection represents (e.g. twitch, youtube)
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-services).
+    /// [Discord docs](https://docs.discord.com/developers/resources/user#connection-object-services).
     #[serde(rename = "type")]
     pub kind: FixedString,
     /// Whether this connection has been revoked and is no longer valid.
@@ -39,7 +39,7 @@ pub struct Connection {
 enum_number! {
     /// The visibility of a user connection on a user's profile.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/user#connection-object-visibility-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/user#connection-object-visibility-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[non_exhaustive]
     pub enum ConnectionVisibility {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -13,7 +13,7 @@ use crate::model::prelude::*;
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#application-command-permissions-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#application-command-permissions-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -24,7 +24,7 @@ pub struct CommandPermissionsUpdateEvent {
 
 /// Requires [`GatewayIntents::AUTO_MODERATION_CONFIGURATION`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#auto-moderation-rule-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -35,7 +35,7 @@ pub struct AutoModRuleCreateEvent {
 
 /// Requires [`GatewayIntents::AUTO_MODERATION_CONFIGURATION`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#auto-moderation-rule-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -46,7 +46,7 @@ pub struct AutoModRuleUpdateEvent {
 
 /// Requires [`GatewayIntents::AUTO_MODERATION_CONFIGURATION`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#auto-moderation-rule-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -57,7 +57,7 @@ pub struct AutoModRuleDeleteEvent {
 
 /// Requires [`GatewayIntents::AUTO_MODERATION_EXECUTION`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#auto-moderation-action-execution).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -73,7 +73,7 @@ pub struct AutoModActionExecutionEvent {
 ///
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#channel-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -85,7 +85,7 @@ pub struct ChannelCreateEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#channel-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -96,7 +96,7 @@ pub struct ChannelDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILDS`] or [`GatewayIntents::DIRECT_MESSAGES`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-pins-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#channel-pins-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -108,7 +108,7 @@ pub struct ChannelPinsUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#channel-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#channel-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -119,7 +119,7 @@ pub struct ChannelUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_MODERATION`] and [`Permissions::VIEW_AUDIT_LOG`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-audit-log-entry-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -131,7 +131,7 @@ pub struct GuildAuditLogEntryCreateEvent {
 
 /// Requires [`GatewayIntents::GUILD_MODERATION`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-ban-add).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-ban-add).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -142,7 +142,7 @@ pub struct GuildBanAddEvent {
 
 /// Requires [`GatewayIntents::GUILD_MODERATION`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-ban-remove).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -153,7 +153,7 @@ pub struct GuildBanRemoveEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(transparent)]
@@ -178,7 +178,7 @@ impl<'de> Deserialize<'de> for GuildCreateEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -189,7 +189,7 @@ pub struct GuildDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILD_EMOJIS_AND_STICKERS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-emojis-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -200,7 +200,7 @@ pub struct GuildEmojisUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_INTEGRATIONS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-integrations-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -210,7 +210,7 @@ pub struct GuildIntegrationsUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-add).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-member-add).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -221,7 +221,7 @@ pub struct GuildMemberAddEvent {
 
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-remove).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-member-remove).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -232,7 +232,7 @@ pub struct GuildMemberRemoveEvent {
 
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-member-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-member-update).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -261,7 +261,7 @@ pub struct GuildMemberUpdateEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-members-chunk).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]
@@ -303,7 +303,7 @@ impl Serialize for GuildMembersChunkEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/events/gateway-events#soundboard-sounds).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#soundboard-sounds).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -316,7 +316,7 @@ pub struct SoundboardSoundsEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/events/gateway-events#guild-soundboard-sound-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-soundboard-sound-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -327,7 +327,7 @@ pub struct SoundboardSoundCreateEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/events/gateway-events#guild-soundboard-sound-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-soundboard-sound-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -338,7 +338,7 @@ pub struct SoundboardSoundUpdateEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/events/gateway-events#guild-soundboard-sounds-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-soundboard-sounds-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -349,7 +349,7 @@ pub struct SoundboardSoundsUpdateEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/events/gateway-events#guild-soundboard-sound-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-soundboard-sound-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -368,7 +368,7 @@ struct RoleEventHelper {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-role-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
@@ -389,7 +389,7 @@ impl<'de> Deserialize<'de> for GuildRoleCreateEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-role-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -400,7 +400,7 @@ pub struct GuildRoleDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-role-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-role-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
@@ -421,7 +421,7 @@ impl<'de> Deserialize<'de> for GuildRoleUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_EMOJIS_AND_STICKERS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-stickers-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -432,7 +432,7 @@ pub struct GuildStickersUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_INVITES`] and [`Permissions::MANAGE_CHANNELS`] permission.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#invite-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#invite-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -466,7 +466,7 @@ pub struct InviteCreateEvent {
 
 /// Requires [`GatewayIntents::GUILD_INVITES`] and [`Permissions::MANAGE_CHANNELS`] permission.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#invite-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#invite-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -478,7 +478,7 @@ pub struct InviteDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -490,7 +490,7 @@ pub struct GuildUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_MESSAGES`] or [`GatewayIntents::DIRECT_MESSAGES`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -501,7 +501,7 @@ pub struct MessageCreateEvent {
 
 /// Requires [`GatewayIntents::GUILD_MESSAGES`] or [`GatewayIntents::DIRECT_MESSAGES`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-delete-bulk).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-delete-bulk).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -513,7 +513,7 @@ pub struct MessageDeleteBulkEvent {
 
 /// Requires [`GatewayIntents::GUILD_MESSAGES`] or [`GatewayIntents::DIRECT_MESSAGES`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -526,7 +526,7 @@ pub struct MessageDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILD_MESSAGES`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 // This ensures that `RawValue` is further supported in nested fields of `Message`.
@@ -539,7 +539,7 @@ pub struct MessageUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_PRESENCES`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#presence-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#presence-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -551,7 +551,7 @@ pub struct PresenceUpdateEvent {
 /// Requires [`GatewayIntents::GUILD_MESSAGE_REACTIONS`] or
 /// [`GatewayIntents::DIRECT_MESSAGE_REACTIONS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-add).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-reaction-add).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -563,7 +563,7 @@ pub struct ReactionAddEvent {
 /// Requires [`GatewayIntents::GUILD_MESSAGE_REACTIONS`] or
 /// [`GatewayIntents::DIRECT_MESSAGE_REACTIONS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-reaction-remove).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -578,7 +578,7 @@ pub struct ReactionRemoveEvent {
 /// Requires [`GatewayIntents::GUILD_MESSAGE_REACTIONS`] or
 /// [`GatewayIntents::DIRECT_MESSAGE_REACTIONS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-all).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-reaction-remove-all).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -591,7 +591,7 @@ pub struct ReactionRemoveAllEvent {
 /// Requires [`GatewayIntents::GUILD_MESSAGE_REACTIONS`] or
 /// [`GatewayIntents::DIRECT_MESSAGE_REACTIONS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-emoji-message-reaction-remove-emoji-event-fields).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-reaction-remove-emoji-message-reaction-remove-emoji-event-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -604,7 +604,7 @@ pub struct ReactionRemoveEmojiEvent {
 ///
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#ready).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#ready).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -615,7 +615,7 @@ pub struct ReadyEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#resumed).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#resumed).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -623,7 +623,7 @@ pub struct ResumedEvent {}
 
 /// Requires [`GatewayIntents::GUILD_MESSAGE_TYPING`] or [`GatewayIntents::DIRECT_MESSAGE_TYPING`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#typing-start).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#typing-start).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -644,7 +644,7 @@ pub struct TypingStartEvent {
 ///
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#user-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#user-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -655,7 +655,7 @@ pub struct UserUpdateEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#voice-server-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#voice-server-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -667,7 +667,7 @@ pub struct VoiceServerUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_VOICE_STATES`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#voice-state-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#voice-state-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -690,7 +690,7 @@ pub struct VoiceChannelStatusUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_WEBHOOKS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#webhooks-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#webhooks-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -701,7 +701,7 @@ pub struct WebhookUpdateEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#interaction-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#interaction-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -712,7 +712,7 @@ pub struct InteractionCreateEvent {
 
 /// Requires [`GatewayIntents::GUILD_INTEGRATIONS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#integration-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#integration-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -723,7 +723,7 @@ pub struct IntegrationCreateEvent {
 
 /// Requires [`GatewayIntents::GUILD_INTEGRATIONS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#integration-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#integration-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -734,7 +734,7 @@ pub struct IntegrationUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_INTEGRATIONS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#integration-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#integration-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -746,7 +746,7 @@ pub struct IntegrationDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#stage-instance-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#stage-instance-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -757,7 +757,7 @@ pub struct StageInstanceCreateEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#stage-instance-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#stage-instance-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -768,7 +768,7 @@ pub struct StageInstanceUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#stage-instance-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#stage-instance-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -779,7 +779,7 @@ pub struct StageInstanceDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#thread-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -791,7 +791,7 @@ pub struct ThreadCreateEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#thread-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -802,7 +802,7 @@ pub struct ThreadUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#thread-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -813,7 +813,7 @@ pub struct ThreadDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILDS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-list-sync).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#thread-list-sync).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -834,7 +834,7 @@ pub struct ThreadListSyncEvent {
 /// Requires [`GatewayIntents::GUILDS`], and, to receive this event for other users,
 /// [`GatewayIntents::GUILD_MEMBERS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-member-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#thread-member-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -845,7 +845,7 @@ pub struct ThreadMemberUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_MEMBERS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#thread-members-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#thread-members-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -869,7 +869,7 @@ pub struct ThreadMembersUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-create).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-scheduled-event-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -880,7 +880,7 @@ pub struct GuildScheduledEventCreateEvent {
 
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-update).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-scheduled-event-update).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -891,7 +891,7 @@ pub struct GuildScheduledEventUpdateEvent {
 
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-delete).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-scheduled-event-delete).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -902,7 +902,7 @@ pub struct GuildScheduledEventDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-scheduled-event-user-add).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -915,7 +915,7 @@ pub struct GuildScheduledEventUserAddEvent {
 
 /// Requires [`GatewayIntents::GUILD_SCHEDULED_EVENTS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-scheduled-event-user-remove).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -928,7 +928,7 @@ pub struct GuildScheduledEventUserRemoveEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#entitlement-create)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -939,7 +939,7 @@ pub struct EntitlementCreateEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#entitlement-update)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -950,7 +950,7 @@ pub struct EntitlementUpdateEvent {
 
 /// Requires no gateway intents.
 ///
-/// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#new-entitlement)
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#entitlement-delete)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -961,7 +961,7 @@ pub struct EntitlementDeleteEvent {
 
 /// Requires [`GatewayIntents::GUILD_MESSAGE_POLLS`] or [`GatewayIntents::DIRECT_MESSAGE_POLLS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-poll-vote-add)
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-poll-vote-add)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -975,7 +975,7 @@ pub struct MessagePollVoteAddEvent {
 
 /// Requires [`GatewayIntents::GUILD_MESSAGE_POLLS`] or [`GatewayIntents::DIRECT_MESSAGE_POLLS`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-poll-vote-remove)
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-poll-vote-remove)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -987,7 +987,7 @@ pub struct MessagePollVoteRemoveEvent {
     pub answer_id: AnswerId,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#payload-structure).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#payload-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
@@ -1092,7 +1092,7 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 
 /// Event received over a websocket connection
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#receive-events).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#receive-events).
 #[expect(clippy::large_enum_variant)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, EnumCount, VariantNames, IntoStaticStr)]

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -15,7 +15,7 @@ use super::utils::*;
 ///
 /// This is only applicable to bot users.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#get-gateway-bot-json-response).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway#get-gateway-bot-json-response).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct BotGateway {
@@ -30,7 +30,7 @@ pub struct BotGateway {
 
 /// Representation of an activity that a [`User`] is performing.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-structure).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -80,7 +80,7 @@ pub struct Activity {
     pub created_at: u64,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-buttons).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-buttons).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -96,7 +96,7 @@ pub struct ActivityButton {
 
 /// The assets for an activity.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-assets).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-assets).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -114,7 +114,7 @@ pub struct ActivityAssets {
 bitflags! {
     /// A set of flags defining what is in an activity's payload.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-flags).
+    /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ActivityFlags: u64 {
@@ -141,7 +141,7 @@ bitflags! {
 
 /// Information about an activity's party.
 ///
-/// [Discord docs](https://discord.com/developers/docs/game-sdk/activities#data-models-activityparty-struct).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-party).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -154,7 +154,7 @@ pub struct ActivityParty {
 
 /// Secrets for an activity.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-secrets).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-secrets).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -170,7 +170,7 @@ pub struct ActivitySecrets {
 
 /// Representation of an emoji used in a custom status
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-emoji).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-emoji).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -184,7 +184,7 @@ pub struct ActivityEmoji {
 }
 
 enum_number! {
-    /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-types).
+    /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -209,7 +209,7 @@ enum_number! {
 ///
 /// For the bot-specific gateway, refer to [`BotGateway`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#get-gateway-example-response).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway#get-gateway-example-response).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Gateway {
@@ -219,7 +219,7 @@ pub struct Gateway {
 
 /// Information detailing the current active status of a [`User`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#client-status-object).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#client-status-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -234,8 +234,8 @@ pub struct ClientStatus {
 /// Fields should be identical to those of [`User`], except that every field but `id` is
 /// optional. This is currently not implemented fully.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#user-object),
-/// [modification description](https://discord.com/developers/docs/topics/gateway-events#presence-update).
+/// [Discord docs](https://docs.discord.com/developers/resources/user#user-object),
+/// [modification description](https://docs.discord.com/developers/events/gateway-events#presence-update).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
@@ -321,7 +321,7 @@ impl PresenceUser {
 
 /// Information detailing the current online status of a [`User`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#presence-update-presence-update-event-fields).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#presence-update-presence-update-event-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -347,7 +347,7 @@ impl ExtractKey<UserId> for Presence {
 
 /// An initial set of information given after IDENTIFYing to the gateway.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#ready-ready-event-fields).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#ready-ready-event-fields).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -371,7 +371,7 @@ pub struct Ready {
 
 /// Information describing how many gateway sessions you can initiate within a ratelimit period.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#session-start-limit-object-session-start-limit-structure).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway#session-start-limit-object-session-start-limit-structure).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct SessionStartLimit {
@@ -424,7 +424,7 @@ impl serde::Serialize for ShardInfo {
 
 /// Timestamps of when a user started and/or is ending their activity.
 ///
-/// [Discord docs](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytimestamps-struct).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-timestamps).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -453,11 +453,11 @@ bitflags! {
     /// **Note**: Once the bot is in 100 guilds or more, [the bot must be verified] in order to use
     /// privileged intents.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/topics/gateway#list-of-intents).
+    /// [Discord docs](https://docs.discord.com/developers/events/gateway#list-of-intents).
     ///
-    /// [Gateway Intents]: https://discord.com/developers/docs/topics/gateway#gateway-intents
-    /// [Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
-    /// [the bot must be verified]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
+    /// [Gateway Intents]: https://docs.discord.com/developers/events/gateway#gateway-intents
+    /// [Privileged Intents]: https://docs.discord.com/developers/events/gateway#privileged-intents
+    /// [the bot must be verified]: https://support.discord.com/hc/en-us/community/posts/360050817314-Discord-Bots-Info
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
     pub struct GatewayIntents: u64 {
@@ -483,7 +483,7 @@ bitflags! {
         ///  - STAGE_INSTANCE_DELETE
         ///
         /// **Info:** The THREAD_MEMBERS_UPDATE event contains different data depending on which
-        /// intents are used. See [Discord's Docs](https://discord.com/developers/docs/topics/gateway-events#thread-members-update)
+        /// intents are used. See [Discord's Docs](https://docs.discord.com/developers/events/gateway-events#thread-members-update)
         /// for more information.
         const GUILDS = 1;
         /// Enables the following gateway events:
@@ -497,7 +497,7 @@ bitflags! {
         /// well as enabling it in your code.
         ///
         /// **Info:** The THREAD_MEMBERS_UPDATE event contains different data depending on which
-        /// intents are used. See [Discord's Docs](https://discord.com/developers/docs/topics/gateway-events#thread-members-update)
+        /// intents are used. See [Discord's Docs](https://docs.discord.com/developers/events/gateway-events#thread-members-update)
         /// for more information.
         const GUILD_MEMBERS = 1 << 1;
 
@@ -570,7 +570,7 @@ bitflags! {
 
         /// Enables receiving message content in gateway events
         ///
-        /// See [Discord's Docs](https://discord.com/developers/docs/topics/gateway#message-content-intent) for more information
+        /// See [Discord's Docs](https://docs.discord.com/developers/events/gateway#message-content-intent) for more information
         ///
         /// **Info**: This intent is *privileged*. In order to use it, you must head to your
         /// application in the Developer Portal and enable the toggle for *Privileged Intents*,

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -13,7 +13,7 @@ use crate::model::prelude::*;
 
 /// Determines the action that was done on a target.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -143,7 +143,7 @@ impl Serialize for Action {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -153,7 +153,7 @@ pub enum ChannelAction {
     Delete = 12,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -163,7 +163,7 @@ pub enum ChannelOverwriteAction {
     Delete = 15,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -179,7 +179,7 @@ pub enum MemberAction {
     BotAdd = 28,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -189,7 +189,7 @@ pub enum RoleAction {
     Delete = 32,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -199,7 +199,7 @@ pub enum InviteAction {
     Delete = 42,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -209,7 +209,7 @@ pub enum WebhookAction {
     Delete = 52,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -219,7 +219,7 @@ pub enum EmojiAction {
     Delete = 62,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -230,7 +230,7 @@ pub enum MessageAction {
     Unpin = 75,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -240,7 +240,7 @@ pub enum IntegrationAction {
     Delete = 82,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -250,7 +250,7 @@ pub enum StageInstanceAction {
     Delete = 85,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -260,7 +260,7 @@ pub enum StickerAction {
     Delete = 92,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -270,7 +270,7 @@ pub enum ScheduledEventAction {
     Delete = 102,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -280,7 +280,7 @@ pub enum ThreadAction {
     Delete = 112,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
@@ -294,7 +294,7 @@ pub enum AutoModAction {
     QuarantineUser = 146,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
@@ -312,7 +312,7 @@ pub enum VoiceChannelStatusAction {
     StatusDelete = 193,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -341,7 +341,7 @@ pub struct AuditLogs {
 
 /// Partial version of [`Integration`], used in [`AuditLogs::integrations`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-object-example-partial-integration-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-object-example-partial-integration-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -354,7 +354,7 @@ pub struct PartialIntegration {
     pub application: Option<IntegrationApplication>,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[non_exhaustive]
@@ -377,7 +377,7 @@ pub struct AuditLogEntry {
     pub options: Option<AuditLogEntryOptions>,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info).
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-optional-audit-entry-info).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[non_exhaustive]

--- a/src/model/guild/automod.rs
+++ b/src/model/guild/automod.rs
@@ -1,6 +1,6 @@
 //! Auto moderation types
 //!
-//! [Discord docs](https://discord.com/developers/docs/resources/auto-moderation)
+//! [Discord docs](https://docs.discord.com/developers/resources/auto-moderation)
 
 use std::time::Duration;
 
@@ -12,7 +12,7 @@ use crate::model::prelude::*;
 
 /// Configured auto moderation rule.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -46,7 +46,7 @@ pub struct AutoModRule {
 
 /// Indicates in what event context a rule should be checked.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types).
+/// [Discord docs](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object-event-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
@@ -77,8 +77,8 @@ impl From<EventType> for u8 {
 /// Characterizes the type of content which can trigger the rule.
 ///
 /// Discord docs:
-/// [type](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types),
-/// [metadata](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata)
+/// [type](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object-trigger-types),
+/// [metadata](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -87,7 +87,7 @@ pub enum Trigger {
         /// Substrings which will be searched for in content (Maximum of 1000)
         ///
         /// A keyword can be a phrase which contains multiple words.
-        /// [Wildcard symbols](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
+        /// [Wildcard symbols](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies)
         /// can be used to customize how each keyword will be matched. Each keyword must be 60
         /// characters or less.
         strings: Vec<String>,
@@ -217,7 +217,7 @@ impl Trigger {
 
 /// Type of [`Trigger`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types).
+/// [Discord docs](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object-trigger-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
@@ -261,7 +261,7 @@ impl From<TriggerType> for u8 {
 ///
 /// [`Change::TriggerMetadata`]: crate::model::guild::audit_log::Change::TriggerMetadata
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata).
+/// [Discord docs](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -280,7 +280,7 @@ pub struct TriggerMetadata {
 
 /// Internally pre-defined wordsets which will be searched for in content.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types).
+/// [Discord docs](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[serde(from = "u8", into = "u8")]
@@ -319,7 +319,7 @@ impl From<KeywordPresetType> for u8 {
 
 /// An action which will execute whenever a rule is triggered.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-action-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -349,7 +349,7 @@ pub enum Action {
 /// Gateway event payload sent when a rule is triggered and an action is executed (e.g. message is
 /// blocked).
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#auto-moderation-action-execution).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -493,7 +493,7 @@ impl Action {
 enum_number! {
     /// See [`Action`]
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-action-object-action-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[non_exhaustive]
     pub enum ActionType {

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -6,7 +6,7 @@ use crate::model::utils::default_true;
 /// Represents a custom guild emoji, which can either be created using the API, or via an
 /// integration. Emojis created using the API only work within the guild it was created in.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/emoji#emoji-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/emoji#emoji-object).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1673,7 +1673,7 @@ impl GuildId {
     ///
     /// May also return [`Error::Json`] if there is an error in deserializing the API response.
     ///
-    /// [Discord's docs]: https://discord.com/developers/docs/resources/guild#modify-guild-incident-actions
+    /// [Discord's docs]: https://docs.discord.com/developers/resources/guild#modify-guild-incident-actions
     pub async fn edit_guild_incident_actions(
         self,
         http: &Http,

--- a/src/model/guild/guild_preview.rs
+++ b/src/model/guild/guild_preview.rs
@@ -2,7 +2,7 @@ use crate::model::prelude::*;
 
 /// Preview [`Guild`] information.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-preview-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-preview-object).
 ///
 /// [`Guild`]: super::Guild
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -4,9 +4,9 @@ use crate::model::prelude::*;
 
 /// Various information about integrations.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-object),
-/// [extra fields 1](https://discord.com/developers/docs/topics/gateway-events#integration-create),
-/// [extra fields 2](https://discord.com/developers/docs/topics/gateway-events#integration-update),
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#integration-object),
+/// [extra fields 1](https://docs.discord.com/developers/events/gateway-events#integration-create),
+/// [extra fields 2](https://docs.discord.com/developers/events/gateway-events#integration-update),
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -37,7 +37,7 @@ pub struct Integration {
 enum_number! {
     /// The behavior once the integration expires.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#integration-object-integration-expire-behaviors).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -57,7 +57,7 @@ impl From<Integration> for IntegrationId {
 
 /// Integration account object.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-account-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#integration-account-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -68,7 +68,7 @@ pub struct IntegrationAccount {
 
 /// Integration application object.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#integration-application-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#integration-application-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -14,8 +14,8 @@ use crate::model::utils::{avatar_url, user_banner_url};
 
 /// Information about a member of a guild.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-member-object),
-/// [extra fields](https://discord.com/developers/docs/topics/gateway-events#guild-member-add-guild-member-add-extra-fields).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-member-object),
+/// [extra fields](https://docs.discord.com/developers/events/gateway-events#guild-member-add-guild-member-add-extra-fields).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
@@ -72,7 +72,7 @@ pub struct Member {
 bitflags! {
     /// Flags for a guild member.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-member-object-guild-member-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct GuildMemberFlags: u32 {
@@ -449,13 +449,12 @@ impl ExtractKey<UserId> for Member {
 ///
 /// This is used in [`Message`]s from [`Guild`]s.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-member-object),
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-member-object),
 /// subset specification unknown (field type "partial member" is used in
-/// [link](https://discord.com/developers/docs/topics/gateway-events#message-create),
-/// [link](https://discord.com/developers/docs/resources/invite#invite-stage-instance-object),
-/// [link](https://discord.com/developers/docs/topics/gateway-events#message-create),
-/// [link](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure),
-/// [link](https://discord.com/developers/docs/interactions/receiving-and-responding#message-interaction-object))
+/// [link](https://docs.discord.com/developers/events/gateway-events#message-create),
+/// [link](https://docs.discord.com/developers/resources/invite#invite-stage-instance-object),
+/// [link](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure),
+/// [link](https://docs.discord.com/developers/interactions/receiving-and-responding#message-interaction-object))
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Deserialize, serde::Serialize)]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -44,7 +44,7 @@ use crate::model::utils::*;
 
 /// A representation of a banning of a user.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#ban-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#ban-object).
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Ban {
@@ -56,7 +56,7 @@ pub struct Ban {
 
 /// The response from [`GuildId::bulk_ban`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#bulk-guild-ban).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#bulk-guild-ban).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -79,8 +79,8 @@ pub struct AfkMetadata {
 
 /// Information about a Discord guild, such as channels, emojis, etc.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object) plus
-/// [extension](https://discord.com/developers/docs/topics/gateway-events#guild-create).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object) plus
+/// [extension](https://docs.discord.com/developers/events/gateway-events#guild-create).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
@@ -133,7 +133,7 @@ pub struct Guild {
     /// The guild features. These are user-invisible options which are used for Discord rollouts
     /// and/or paid benefits. More information is available at [`discord's documentation`].
     ///
-    /// [`discord's documentation`]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
+    /// [`discord's documentation`]: https://docs.discord.com/developers/resources/guild#guild-object-guild-features
     pub features: FixedArray<FixedString>,
     /// Indicator of whether the guild requires multi-factor authentication for [`Role`]s or
     /// [`User`]s with moderation permissions.
@@ -288,10 +288,6 @@ impl Guild {
     /// Only a [`PartialGuild`] will be immediately returned, and a full [`Guild`] will be received
     /// over a [`Shard`].
     ///
-    /// **Note**: This endpoint is usually only available for user accounts. Refer to Discord's
-    /// information for the endpoint [here][whitelist] for more information. If you require this as
-    /// a bot, re-think what you are doing and if it _really_ needs to be doing this.
-    ///
     /// # Examples
     ///
     /// Create a guild called `"test"` in the [US West region] with no icon:
@@ -311,8 +307,7 @@ impl Guild {
     /// Returns [`Error::Http`] if the current user cannot create a Guild.
     ///
     /// [`Shard`]: crate::gateway::Shard
-    /// [whitelist]: https://discord.com/developers/docs/resources/guild#create-guild
-    #[deprecated = "This endpoint has been deprecated by Discord and will stop functioning after July 15, 2025. For more information, see: https://discord.com/developers/docs/change-log#deprecating-guild-creation-by-apps"]
+    #[deprecated = "This endpoint has been deprecated by Discord and will stop functioning after July 15, 2025. For more information, see: https://docs.discord.com/developers/change-log#deprecating-guild-creation-by-apps"]
     pub async fn create(http: &Http, name: &str, icon: Option<ImageHash>) -> Result<PartialGuild> {
         #[derive(serde::Serialize)]
         struct CreateGuild<'a> {
@@ -1022,7 +1017,7 @@ impl Default for CalculatePermissions {
     }
 }
 
-/// Translated from the pseudo code at https://discord.com/developers/docs/topics/permissions#permission-overwrites
+/// Translated from the pseudo code at https://docs.discord.com/developers/topics/permissions#permission-overwrites
 ///
 /// The comments within this file refer to the above link
 #[cfg(feature = "model")]
@@ -1100,7 +1095,7 @@ fn closest_to_origin(origin: &str, word_a: &str, word_b: &str) -> std::cmp::Orde
 
 /// A [`Guild`] widget.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-widget-settings-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-widget-settings-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct GuildWidget {
@@ -1112,7 +1107,7 @@ pub struct GuildWidget {
 
 /// Representation of the number of members that would be pruned by a guild prune operation.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#get-guild-prune-count).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#get-guild-prune-count).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1123,8 +1118,8 @@ pub struct GuildPrune {
 
 /// Variant of [`Guild`] returned from [`Http::get_guilds`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object),
-/// [subset example](https://discord.com/developers/docs/resources/user#get-current-user-guilds-example-partial-guild).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object),
+/// [subset example](https://docs.discord.com/developers/resources/user#get-current-user-guilds-example-partial-guild).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1169,7 +1164,7 @@ impl InviteGuild {
 
 /// Data for an unavailable guild.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#unavailable-guild-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#unavailable-guild-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -1184,7 +1179,7 @@ pub struct UnavailableGuild {
 enum_number! {
     /// Default message notification level for a guild.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-default-message-notification-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -1200,7 +1195,7 @@ enum_number! {
 enum_number! {
     /// Setting used to filter explicit messages from members.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-explicit-content-filter-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -1218,7 +1213,7 @@ enum_number! {
 enum_number! {
     /// Multi-Factor Authentication level for guild moderators.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-mfa-level).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-mfa-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -1235,7 +1230,7 @@ enum_number! {
     /// The level to set as criteria prior to a user being able to send
     /// messages in a [`Guild`].
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-verification-level).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-verification-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -1257,7 +1252,7 @@ enum_number! {
 enum_number! {
     /// The [`Guild`] nsfw level.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-guild-nsfw-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -1293,7 +1288,7 @@ enum_number! {
 
 /// The [`Guild`]'s incident's data.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#incidents-data-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#incidents-data-object).
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[non_exhaustive]

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -12,7 +12,7 @@ use crate::model::utils::icon_url;
 
 /// Partial information about a [`Guild`]. This does not include information like member data.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -96,7 +96,7 @@ pub struct PartialGuild {
     /// - `PRIVATE_THREADS`
     ///
     ///
-    /// [`discord documentation`]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
+    /// [`discord documentation`]: https://docs.discord.com/developers/resources/guild#guild-object-guild-features
     pub features: FixedArray<FixedString>,
     /// Indicator of whether the guild requires multi-factor authentication for [`Role`]s or
     /// [`User`]s with moderation permissions.

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -1,7 +1,7 @@
 enum_number! {
     /// The guild's premium tier, depends on the amount of users boosting the guild currently
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-premium-tier).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-premium-tier).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -15,7 +15,7 @@ use crate::model::utils::is_false;
 /// guild and do not cross over to other guilds in any way, and can have channel-specific
 /// permission overrides in addition to guild-level permissions.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object).
+/// [Discord docs](https://docs.discord.com/developers/topics/permissions#role-object).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -199,7 +199,7 @@ impl From<&Role> for RoleId {
 
 /// The tags of a [`Role`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure).
+/// [Discord docs](https://docs.discord.com/developers/topics/permissions#role-object-role-tags-structure).
 #[bool_to_bitflags::bool_to_bitflags]
 #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]

--- a/src/model/guild/scheduled_event.rs
+++ b/src/model/guild/scheduled_event.rs
@@ -4,7 +4,7 @@ use crate::model::prelude::*;
 
 /// Information about a guild scheduled event.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#guild-scheduled-event-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -62,7 +62,7 @@ impl extract_map::ExtractKey<ScheduledEventId> for ScheduledEvent {
 }
 
 enum_number! {
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -76,7 +76,7 @@ enum_number! {
 }
 
 enum_number! {
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -88,7 +88,7 @@ enum_number! {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -97,7 +97,7 @@ pub struct ScheduledEventMetadata {
     pub location: Option<FixedString>,
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-user-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#guild-scheduled-event-user-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -111,7 +111,7 @@ pub struct ScheduledEventUser {
 enum_number! {
     /// See [`ScheduledEvent::privacy_level`].
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]

--- a/src/model/guild/system_channel.rs
+++ b/src/model/guild/system_channel.rs
@@ -1,7 +1,7 @@
 bitflags! {
     /// Describes a system channel flags.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags).
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-system-channel-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct SystemChannelFlags: u64 {

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -4,7 +4,7 @@ use crate::model::prelude::*;
 
 /// Information relating to a guild's welcome screen.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -19,7 +19,7 @@ pub struct GuildWelcomeScreen {
 
 /// A channel shown in the [`GuildWelcomeScreen`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -89,7 +89,7 @@ impl Serialize for GuildWelcomeChannel {
 
 /// A [`GuildWelcomeScreen`] emoji.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -12,7 +12,7 @@ use crate::http::Http;
 ///
 /// Information can not be accessed for guilds the current user is banned from.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Invite {
@@ -103,7 +103,7 @@ impl Invite {
     /// * `event_id` - An optional server event ID to include with the invite.
     ///
     /// More information about these arguments can be found on Discord's
-    /// [API documentation](https://discord.com/developers/docs/resources/invite#get-invite).
+    /// [API documentation](https://docs.discord.com/developers/resources/invite#get-invite).
     ///
     /// # Errors
     ///
@@ -169,7 +169,7 @@ impl Invite {
 
 /// A minimal amount of information about the channel an invite points to.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-example-invite-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object-example-invite-object).
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InviteChannel {
@@ -181,7 +181,7 @@ pub struct InviteChannel {
 
 /// Subset of [`Guild`] used in [`Invite`].
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-example-invite-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object-example-invite-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteGuild {
@@ -205,7 +205,7 @@ pub struct InviteGuild {
 ///
 /// [Manage Guild]: Permissions::MANAGE_GUILD
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-metadata-object) (extends [`Invite`] fields).
+/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-metadata-object) (extends [`Invite`] fields).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct RichInvite {
@@ -308,7 +308,7 @@ impl RichInvite {
     }
 }
 
-/// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-stage-instance-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-stage-instance-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteStageInstance {
@@ -325,7 +325,7 @@ pub struct InviteStageInstance {
 enum_number! {
     /// Type of target for a voice channel invite.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object-invite-target-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -159,7 +159,7 @@ impl std::str::FromStr for ImageHash {
 
 /// A version of an emoji used only when solely the animated state, Id, and name are known.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway#activity-object-activity-emoji).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#activity-object-activity-emoji).
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[non_exhaustive]
 pub struct EmojiIdentifier {

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -6,7 +6,7 @@ use crate::model::prelude::*;
 
 /// A premium offering that can be made available to an application's users and guilds.
 ///
-/// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/sku#sku-object).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Sku {
     /// The unique ID of the SKU.
@@ -28,7 +28,7 @@ impl Sku {
     /// Returns the store url for this SKU. If included in a message, will render as a rich embed.
     /// See the [Discord docs] for details.
     ///
-    /// [Discord docs]: https://discord.com/developers/docs/monetization/skus#linking-to-your-skus
+    /// [Discord docs]: https://docs.discord.com/developers/monetization/managing-skus#linking-to-a-specific-sku
     #[must_use]
     pub fn url(&self) -> String {
         format!(
@@ -41,7 +41,7 @@ impl Sku {
 enum_number! {
     /// Differentiates between SKU classes.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object-sku-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/sku#sku-object-sku-types).
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[non_exhaustive]
     pub enum SkuKind {
@@ -60,7 +60,7 @@ enum_number! {
 bitflags! {
     /// Differentates between user and server subscriptions.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags).
+    /// [Discord docs](https://docs.discord.com/developers/resources/sku#sku-object-sku-flags).
     #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
     pub struct SkuFlags: u64 {
         /// SKU is available for purchase.
@@ -76,7 +76,7 @@ bitflags! {
 
 /// Represents that a user or guild has access to a premium offering in the application.
 ///
-/// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/entitlement#entitlement-object-entitlement-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Entitlement {
@@ -145,7 +145,7 @@ impl Entitlement {
 enum_number! {
     /// Differentiates between Entitlement types.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/entitlement#entitlement-object-entitlement-types).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[non_exhaustive]

--- a/src/model/permissions.rs
+++ b/src/model/permissions.rs
@@ -254,7 +254,7 @@ pub const PRESET_VOICE: Permissions = Permissions::from_bits_truncate(
 /// A set of permissions that can be assigned to [`User`]s and [`Role`]s via
 /// [`PermissionOverwrite`]s, roles globally in a [`Guild`], and to [`GuildChannel`]s.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags).
+/// [Discord docs](https://docs.discord.com/developers/topics/permissions#permissions-bitwise-permission-flags).
 ///
 /// [`Guild`]: super::guild::Guild
 /// [`GuildChannel`]: super::channel::GuildChannel

--- a/src/model/soundboard.rs
+++ b/src/model/soundboard.rs
@@ -5,7 +5,7 @@ use crate::model::prelude::*;
 /// A representation of a soundboard sound, a kind of audio that users can play
 /// in voice channels.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/soundboard#soundboard-resource).
+/// [Discord docs](https://docs.discord.com/developers/resources/soundboard#soundboard-sound-object-soundboard-sound-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Soundboard {

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -33,7 +33,7 @@ impl StickerId {
 
 /// The smallest amount of data required to render a sticker.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-item-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/sticker#sticker-item-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -61,7 +61,7 @@ impl StickerItem {
 ///
 /// Bots currently can only receive messages with stickers, not send.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-pack-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/sticker#sticker-pack-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct StickerPack {
@@ -102,7 +102,7 @@ fn banner_url(banner_asset_id: StickerPackBannerId) -> String {
 
 /// A sticker sent with a message.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/sticker#sticker-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -219,7 +219,7 @@ impl ExtractKey<StickerId> for Sticker {
 enum_number! {
     /// Differentiates between sticker types.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/sticker#sticker-object-sticker-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -235,7 +235,7 @@ enum_number! {
 enum_number! {
     /// Differentiates between sticker formats.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/sticker#sticker-object-sticker-format-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -115,7 +115,7 @@ pub(crate) mod discriminator {
 
 /// Information about the current user.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#user-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/user#user-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -180,7 +180,7 @@ impl CurrentUser {
 
 /// The representation of a user's status.
 ///
-/// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#update-presence-status-types).
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#update-presence-status-types).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(
     Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
@@ -215,8 +215,8 @@ impl OnlineStatus {
 
 /// Information about a user.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#user-object), existence of
-/// additional partial member field documented [here](https://discord.com/developers/docs/topics/gateway-events#message-create).
+/// [Discord docs](https://docs.discord.com/developers/resources/user#user-object), existence of
+/// additional partial member field documented [here](https://docs.discord.com/developers/events/gateway-events#message-create).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
@@ -280,7 +280,7 @@ pub struct User {
     pub public_flags: Option<UserPublicFlags>,
     /// Only included in [`Message::mentions`] for messages from the gateway.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields).
+    /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#message-create-message-create-extra-fields).
     // Box required to avoid infinitely recursive types
     pub member: Option<Box<PartialMember>>,
     /// The primary guild and tag the user has active.
@@ -304,7 +304,7 @@ enum_number! {
     /// Premium types denote the level of premium a user has. Visit the [Nitro](https://discord.com/nitro)
     /// page to learn more about the premium plans Discord currently offers.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-premium-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/user#user-object-premium-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -320,7 +320,7 @@ enum_number! {
 bitflags! {
     /// User's public flags
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-user-flags).
+    /// [Discord docs](https://docs.discord.com/developers/resources/user#user-object-user-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct UserPublicFlags: u32 {
@@ -364,7 +364,7 @@ bitflags! {
 
 /// User's Primary Guild object
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#user-object-user-primary-guild)
+/// [Discord docs](https://docs.discord.com/developers/resources/user#user-object-user-primary-guild)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -394,7 +394,7 @@ impl PrimaryGuild {
 #[non_exhaustive]
 /// The data for a [`User`]'s avatar decoration.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#avatar-decoration-data-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/user#avatar-decoration-data-object).
 pub struct AvatarDecorationData {
     /// The avatar decoration hash
     pub asset: ImageHash,
@@ -413,7 +413,7 @@ impl AvatarDecorationData {
 
 /// The collectibles the user has, excluding Avatar Decorations and Profile Effects.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#collectibles).
+/// [Discord docs](https://docs.discord.com/developers/resources/user#collectibles).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -424,7 +424,7 @@ pub struct Collectibles {
 
 /// A nameplate, shown on the member list on official clients.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/user#nameplate-nameplate-structure).
+/// [Discord docs](https://docs.discord.com/developers/resources/user#nameplate-nameplate-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/voice.rs
+++ b/src/model/voice.rs
@@ -7,7 +7,7 @@ use crate::model::prelude::*;
 
 /// Information about an available voice region.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/voice#voice-region-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/voice#voice-region-object).
 #[bool_to_bitflags::bool_to_bitflags]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
@@ -26,7 +26,7 @@ pub struct VoiceRegion {
 
 /// A user's state within a voice channel.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/voice#voice-state-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/voice#voice-state-object).
 #[bool_to_bitflags::bool_to_bitflags]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -9,7 +9,7 @@ use crate::model::prelude::*;
 enum_number! {
     /// A representation of a type of webhook.
     ///
-    /// [Discord docs](https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types).
+    /// [Discord docs](https://docs.discord.com/developers/resources/webhook#webhook-object-webhook-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[non_exhaustive]
@@ -40,7 +40,7 @@ impl WebhookType {
 /// A representation of a webhook, which is a low-effort way to post messages to channels. They do
 /// not necessarily require a bot user or authentication to use.
 ///
-/// [Discord docs](https://discord.com/developers/docs/resources/webhook#webhook-object).
+/// [Discord docs](https://docs.discord.com/developers/resources/webhook#webhook-object).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/utils/formatted_timestamp.rs
+++ b/src/utils/formatted_timestamp.rs
@@ -8,7 +8,7 @@ use crate::model::Timestamp;
 
 /// Represents a combination of a timestamp and a style for formatting time in messages.
 ///
-/// [Discord docs](https://discord.com/developers/docs/reference#message-formatting-formats).
+/// [Discord docs](https://docs.discord.com/developers/reference#message-formatting-formats).
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
 pub struct FormattedTimestamp {
     timestamp: i64,
@@ -17,7 +17,8 @@ pub struct FormattedTimestamp {
 
 /// Enum representing various styles for formatting time in messages.
 ///
-/// [Discord docs](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles).
+/// [Discord docs](https://docs.discord.com/developers/reference#message-formatting-formats).
+// TODO: https://docs.discord.com/developers/reference#message-formatting-timestamp-styles
 #[derive(Default, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum FormattedTimestampStyle {
     /// Represents a short time format, e.g., "12:34 PM".

--- a/voice-model/src/opcode.rs
+++ b/voice-model/src/opcode.rs
@@ -2,7 +2,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// An enum representing the [voice opcodes].
 ///
-/// [voice opcodes]: https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice
+/// [voice opcodes]: https://docs.discord.com/developers/topics/opcodes-and-status-codes#voice
 #[derive(
     Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize_repr, Serialize_repr,
 )]


### PR DESCRIPTION
This updates the Discord docs links broken by the recent migration to Mintlify. See [#3486](https://github.com/serenity-rs/serenity/pull/3486) for reference. This PR does the same thing for all links on the `next` branch.

Each link has been manually verified. Fortunately, only two subheadings were missing anchors this time. Once again, in those cases, I:
- linked to the closest relevant anchor (usually the section heading),
- and added a `// TODO: <expected subheading link>` comment on the line below.

This also includes a small fix for the `Publish docs` workflow failure.