### PR TITLE
Restore Discord docs links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { version = "0.1.40", features = ["log"] }
 serde = { version = "1.0.192", features = ["derive"] }
 url = { version = "2.4.1", features = ["serde"] }
 tokio = { version = "1.34.0", features = ["fs", "macros", "rt", "sync", "time", "io-util"] }
-futures = { version = "0.3.29", default-features = false, features = ["std"] }
+futures = { version = "0.3.32", default-features = false, features = ["std"] }
 time = { version = "0.3.36", features = ["formatting", "parsing", "serde-well-known"] }
 base64 = { version = "0.22.0" }
 secrecy = { version = "0.8.0", features = ["serde"] }

--- a/src/builder/create_attachment.rs
+++ b/src/builder/create_attachment.rs
@@ -15,8 +15,7 @@ use crate::model::id::AttachmentId;
 
 /// A builder for creating a new attachment from a file path, file data, or URL.
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/message#attachment-object).
-// TODO: https://docs.discord.com/developers/resources/message#attachment-object-attachment-structure
+/// [Discord docs](https://docs.discord.com/developers/resources/message#attachment-object-attachment-structure).
 #[derive(Clone, Debug, Serialize, PartialEq)]
 #[non_exhaustive]
 #[must_use]

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -291,8 +291,7 @@ impl CreateSelectMenu {
 
 /// A builder for creating an option of a select menu component in a message
 ///
-/// [Discord docs](https://docs.discord.com/developers/components/reference#string-select)
-// TODO: https://docs.discord.com/developers/components/reference#string-select-select-option-structure
+/// [Discord docs](https://docs.discord.com/developers/components/reference#string-select-select-option-structure)
 #[derive(Clone, Debug, Serialize, PartialEq)]
 #[must_use]
 pub struct CreateSelectMenuOption {
@@ -352,8 +351,7 @@ impl CreateSelectMenuOption {
 
 /// A builder for creating an input text component in a modal
 ///
-/// [Discord docs](https://docs.discord.com/developers/components/reference#text-input).
-// TODO: https://docs.discord.com/developers/components/reference#text-input-text-input-structure
+/// [Discord docs](https://docs.discord.com/developers/components/reference#text-input-text-input-structure).
 #[derive(Clone, Debug, Serialize, PartialEq)]
 #[must_use]
 pub struct CreateInputText(InputText);

--- a/src/builder/create_forum_tag.rs
+++ b/src/builder/create_forum_tag.rs
@@ -1,7 +1,6 @@
 use crate::model::prelude::*;
 
-/// [Discord docs](https://docs.discord.com/developers/resources/channel#forum-tag-object)
-// TODO: https://docs.discord.com/developers/resources/channel#forum-tag-object-forum-tag-structure
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#forum-tag-object-forum-tag-structure)
 /// Contrary to the [`ForumTag`] struct, only the name field is required.
 #[must_use]
 #[derive(Clone, Debug, Serialize)]

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -173,8 +173,7 @@ impl Builder for CreateInteractionResponse {
     }
 }
 
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-messages
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-messages).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateInteractionResponseMessage {
@@ -355,8 +354,7 @@ impl<S: Into<String>> From<S> for AutocompleteChoice {
     }
 }
 
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object)
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-autocomplete
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-autocomplete)
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateAutocompleteResponse {
@@ -429,8 +427,7 @@ impl Builder for CreateAutocompleteResponse {
     }
 }
 
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-modal
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-modal).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct CreateModal {

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -9,8 +9,8 @@ use crate::model::prelude::*;
 
 /// A builder to edit a [`GuildChannel`] for use via [`GuildChannel::edit`].
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/channel#modify-channel).
-// TODO: https://docs.discord.com/developers/resources/channel#modify-channel-json-params-guild-channel
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#modify-channel-json-params-guild-channel).
+///
 /// # Examples
 ///
 /// Edit a channel, providing a new name and topic:

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -85,8 +85,7 @@ impl Builder for EditGuildWelcomeScreen<'_> {
 
 /// A builder for creating a [`GuildWelcomeChannel`].
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object)
-// TODO: https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure)
 #[derive(Clone, Debug, Serialize)]
 #[must_use]
 pub struct CreateGuildWelcomeChannel(GuildWelcomeChannel);

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -6,8 +6,7 @@ use crate::http::CacheHttp;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
-/// [Discord docs](https://docs.discord.com/developers/resources/channel#modify-channel).
-// TODO: https://docs.discord.com/developers/resources/channel#modify-channel-json-params-thread
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#modify-channel-json-params-thread).
 #[derive(Clone, Debug, Default, Serialize)]
 #[must_use]
 pub struct EditThread<'a> {

--- a/src/gateway/bridge/shard_runner.rs
+++ b/src/gateway/bridge/shard_runner.rs
@@ -361,13 +361,13 @@ impl ShardRunner {
     #[instrument(skip(self))]
     async fn recv(&mut self) -> bool {
         loop {
-            match self.runner_rx.try_next() {
-                Ok(Some(value)) => {
+            match self.runner_rx.try_recv() {
+                Ok(value) => {
                     if !self.handle_rx_value(value).await {
                         return false;
                     }
                 },
-                Ok(None) => {
+                Err(mpsc::TryRecvError::Closed) => {
                     warn!(
                         "[ShardRunner {:?}] Sending half DC; restarting",
                         self.shard.shard_info(),
@@ -376,7 +376,7 @@ impl ShardRunner {
                     self.request_restart().await;
                     return false;
                 },
-                Err(_) => break,
+                Err(mpsc::TryRecvError::Empty) => break,
             }
         }
 

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -277,8 +277,7 @@ impl Serialize for CommandInteraction {
 
 /// The command data payload.
 ///
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-application-command-data-structure
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-application-command-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -490,8 +489,7 @@ pub enum ResolvedTarget<'a> {
 /// The resolved data of a command data interaction payload. It contains the objects of
 /// [`CommandDataOption`]s.
 ///
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -524,8 +522,7 @@ pub struct CommandDataResolved {
 ///
 /// Their resolved objects can be found on [`CommandData::resolved`].
 ///
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-application-command-interaction-data-option-structure
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-application-command-interaction-data-option-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -42,8 +42,7 @@ pub struct ActionRow {
 
 /// A component which can be inside of an [`ActionRow`].
 ///
-/// [Discord docs](https://docs.discord.com/developers/components/reference#action-row).
-// TODO: https://docs.discord.com/developers/components/reference#action-row-action-row-child-components
+/// [Discord docs](https://docs.discord.com/developers/components/reference#action-row-action-row-child-components).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -159,8 +158,7 @@ impl Serialize for ButtonKind {
 
 /// A button component.
 ///
-/// [Discord docs](https://docs.discord.com/developers/components/reference#button).
-// TODO: https://docs.discord.com/developers/components/reference#button-button-structure
+/// [Discord docs](https://docs.discord.com/developers/components/reference#button-button-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[non_exhaustive]
@@ -233,8 +231,7 @@ pub struct SelectMenu {
 
 /// A select menu component options.
 ///
-/// [Discord docs](https://docs.discord.com/developers/components/reference#string-select)
-// TODO: https://docs.discord.com/developers/components/reference#string-select-select-option-structure
+/// [Discord docs](https://docs.discord.com/developers/components/reference#string-select-select-option-structure)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -254,8 +251,7 @@ pub struct SelectMenuOption {
 
 /// An input text component for modal interactions
 ///
-/// [Discord docs](https://docs.discord.com/developers/components/reference#text-input).
-// TODO: https://docs.discord.com/developers/components/reference#text-input-text-input-structure
+/// [Discord docs](https://docs.discord.com/developers/components/reference#text-input-text-input-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -299,8 +295,7 @@ pub struct InputText {
 enum_number! {
     /// The style of the input text
     ///
-    /// [Discord docs](https://docs.discord.com/developers/components/reference#text-input).
-    // TODO: https://docs.discord.com/developers/components/reference#text-input-text-input-styles
+    /// [Discord docs](https://docs.discord.com/developers/components/reference#text-input-text-input-styles).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -21,8 +21,7 @@ use crate::utils::{CreateQuickModal, QuickModalResponse};
 
 /// An interaction triggered by a message component.
 ///
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-structure
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(remote = "Self")]

--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -276,8 +276,7 @@ impl Serialize for Interaction {
 enum_number! {
     /// The type of an Interaction.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-    // TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-type
+    /// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-type).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
@@ -296,8 +295,7 @@ bitflags! {
     /// The flags for an interaction response message.
     ///
     /// [Discord docs](https://docs.discord.com/developers/resources/message#message-object-message-flags)
-    /// ([only some are valid in this context](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object))
-    // TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-messages
+    /// ([only some are valid in this context](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-messages))
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct InteractionResponseFlags: u64 {
         /// Do not include any embeds when serializing this message.
@@ -312,8 +310,7 @@ bitflags! {
 
 /// A cleaned up enum for determining the authorizing owner for an [`Interaction`].
 ///
-/// [Discord Docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object)
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-authorizing-integration-owners-object
+/// [Discord Docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-authorizing-integration-owners-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -117,8 +117,7 @@ enum_number! {
 enum_number! {
     /// An enum representing the different [interaction contexts].
     ///
-    /// [interaction contexts](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-    // TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-context-types
+    /// [interaction contexts](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-context-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -215,8 +215,7 @@ impl Serialize for ModalInteraction {
 
 /// A modal submit interaction data, provided by [`ModalInteraction::data`]
 ///
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/application/ping_interaction.rs
+++ b/src/model/application/ping_interaction.rs
@@ -4,8 +4,7 @@ use crate::model::id::{ApplicationId, InteractionId};
 
 /// A ping interaction, which can only be received through an endpoint url.
 ///
-/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-structure
+/// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -178,8 +178,7 @@ pub struct GuildChannel {
 enum_number! {
     /// See [`GuildChannel::default_forum_layout`].
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object).
-    // TODO: https://docs.discord.com/developers/resources/channel#channel-object-forum-layout-types
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-forum-layout-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1459,8 +1459,7 @@ pub struct PollResults {
 
 /// The count of a single [`PollAnswer`]'s results.
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-results-object-poll-results-object-structure)
-// TODO: https://docs.discord.com/developers/resources/poll#poll-results-object-poll-answer-count-object-structure
+/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-answer-object-poll-answer-object-structure)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -218,8 +218,7 @@ impl fmt::Display for Channel {
 enum_number! {
     /// A representation of a type of channel.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object).
-    // TODO: https://docs.discord.com/developers/resources/channel#channel-object-channel-types
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-channel-types).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
@@ -351,8 +350,7 @@ pub struct PermissionOverwrite {
 /// If you would like to modify the default permissions of a channel, you can get its [`RoleId`]
 /// from [`GuildId::everyone_role`].
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/channel#overwrite-object) (field `type`).
-// TODO: https://docs.discord.com/developers/resources/channel#overwrite-object-overwrite-structure
+/// [Discord docs](https://docs.discord.com/developers/resources/channel#overwrite-object-overwrite-structure) (field `type`).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
@@ -366,8 +364,7 @@ pub enum PermissionOverwriteType {
 enum_number! {
     /// The video quality mode for a voice channel.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object).
-    // TODO: https://docs.discord.com/developers/resources/channel#channel-object-video-quality-modes
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-video-quality-modes).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
@@ -470,14 +467,10 @@ pub struct ThreadMetadata {
 /// A response to getting several threads channels.
 ///
 /// Discord docs: defined [multiple times](https://docs.discord.com/developers/topics/threads#enumerating-threads):
-/// [1](https://docs.discord.com/developers/resources/guild#list-active-guild-threads),
-// TODO: https://docs.discord.com/developers/resources/guild#list-active-guild-threads-response-body
-/// [2](https://docs.discord.com/developers/resources/channel#list-private-archived-threads),
-// TODO: https://docs.discord.com/developers/resources/channel#list-private-archived-threads-response-body
-/// [3](https://docs.discord.com/developers/resources/channel#list-public-archived-threads),
-// TODO: https://docs.discord.com/developers/resources/channel#list-public-archived-threads-response-body
-/// [4](https://docs.discord.com/developers/resources/channel#list-joined-private-archived-threads)
-// TODO: https://docs.discord.com/developers/resources/channel#list-joined-private-archived-threads-response-body
+/// [1](https://docs.discord.com/developers/resources/guild#list-active-guild-threads-response-body),
+/// [2](https://docs.discord.com/developers/resources/channel#list-private-archived-threads-response-body),
+/// [3](https://docs.discord.com/developers/resources/channel#list-public-archived-threads-response-body),
+/// [4](https://docs.discord.com/developers/resources/channel#list-joined-private-archived-threads-response-body)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -567,8 +560,7 @@ pub struct ForumTag {
 enum_number! {
     /// The sort order for threads in a forum.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object).
-    // TODO: https://docs.discord.com/developers/resources/channel#channel-object-sort-order-types
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-sort-order-types).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
     #[serde(from = "u8", into = "u8")]
@@ -585,8 +577,7 @@ enum_number! {
 bitflags! {
     /// Describes extra features of the channel.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object).
-    // TODO: https://docs.discord.com/developers/resources/channel#channel-object-channel-flags
+    /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-channel-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct ChannelFlags: u64 {

--- a/src/model/channel/partial_channel.rs
+++ b/src/model/channel/partial_channel.rs
@@ -5,8 +5,7 @@ use crate::model::Permissions;
 /// A container for any partial channel.
 ///
 /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object),
-/// [subset specification](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object).
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure
+/// [subset specification](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]

--- a/src/model/guild/integration.rs
+++ b/src/model/guild/integration.rs
@@ -34,8 +34,7 @@ pub struct Integration {
 enum_number! {
     /// The behavior once the integration expires.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#integration-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#integration-object-integration-expire-behaviors
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#integration-object-integration-expire-behaviors).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -73,8 +73,7 @@ pub struct Member {
 bitflags! {
     /// Flags for a guild member.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-member-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-member-object-guild-member-flags
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-member-object-guild-member-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct GuildMemberFlags: u32 {
@@ -580,8 +579,7 @@ impl fmt::Display for Member {
 /// [link](https://docs.discord.com/developers/events/gateway-events#message-create),
 /// [link](https://docs.discord.com/developers/resources/invite#invite-stage-instance-object),
 /// [link](https://docs.discord.com/developers/events/gateway-events#message-create),
-/// [link](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object),
-// TODO: https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure
+/// [link](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure),
 /// [link](https://docs.discord.com/developers/interactions/receiving-and-responding#message-interaction-object))
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -158,8 +158,7 @@ pub struct Guild {
     /// The guild features. These are user-invisible options which are used for Discord rollouts
     /// and/or paid benefits. More information is available at [`discord's documentation`].
     ///
-    /// [`discord's documentation`]: https://docs.discord.com/developers/resources/guild#guild-object
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-guild-features
+    /// [`discord's documentation`]: https://docs.discord.com/developers/resources/guild#guild-object-guild-features
     pub features: Vec<String>,
     /// Indicator of whether the guild requires multi-factor authentication for [`Role`]s or
     /// [`User`]s with moderation permissions.
@@ -2844,8 +2843,7 @@ pub struct UnavailableGuild {
 enum_number! {
     /// Default message notification level for a guild.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-default-message-notification-level
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-default-message-notification-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
@@ -2863,8 +2861,7 @@ enum_number! {
 enum_number! {
     /// Setting used to filter explicit messages from members.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-explicit-content-filter-level
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-explicit-content-filter-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
@@ -2884,8 +2881,7 @@ enum_number! {
 enum_number! {
     /// Multi-Factor Authentication level for guild moderators.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-mfa-level
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-mfa-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
@@ -2904,8 +2900,7 @@ enum_number! {
     /// The level to set as criteria prior to a user being able to send
     /// messages in a [`Guild`].
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-verification-level
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-verification-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
@@ -2929,8 +2924,7 @@ enum_number! {
 enum_number! {
     /// The [`Guild`] nsfw level.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-guild-nsfw-level
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-guild-nsfw-level).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -117,8 +117,7 @@ pub struct PartialGuild {
     /// - `PRIVATE_THREADS`
     ///
     ///
-    /// [`discord documentation`]: https://docs.discord.com/developers/resources/guild#guild-object
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-guild-features
+    /// [`discord documentation`]: https://docs.discord.com/developers/resources/guild#guild-object-guild-features
     pub features: Vec<String>,
     /// Indicator of whether the guild requires multi-factor authentication for [`Role`]s or
     /// [`User`]s with moderation permissions.

--- a/src/model/guild/premium_tier.rs
+++ b/src/model/guild/premium_tier.rs
@@ -1,8 +1,7 @@
 enum_number! {
     /// The guild's premium tier, depends on the amount of users boosting the guild currently
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-premium-tier
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-premium-tier).
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]

--- a/src/model/guild/system_channel.rs
+++ b/src/model/guild/system_channel.rs
@@ -1,8 +1,7 @@
 bitflags! {
     /// Describes a system channel flags.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object).
-    // TODO: https://docs.discord.com/developers/resources/guild#guild-object-system-channel-flags
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-object-system-channel-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
     pub struct SystemChannelFlags: u64 {

--- a/src/model/guild/welcome_screen.rs
+++ b/src/model/guild/welcome_screen.rs
@@ -19,8 +19,7 @@ pub struct GuildWelcomeScreen {
 
 /// A channel shown in the [`GuildWelcomeScreen`].
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object).
-// TODO: https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -90,8 +89,7 @@ impl Serialize for GuildWelcomeChannel {
 
 /// A [`GuildWelcomeScreen`] emoji.
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object).
-// TODO: https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#welcome-screen-object-welcome-screen-channel-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -194,8 +194,7 @@ impl Invite {
 
 /// A minimal amount of information about the channel an invite points to.
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object).
-// TODO: https://docs.discord.com/developers/resources/invite#invite-object-example-invite-object
+/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object-example-invite-object).
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InviteChannel {
@@ -207,8 +206,7 @@ pub struct InviteChannel {
 
 /// Subset of [`Guild`] used in [`Invite`].
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object).
-// TODO: https://docs.discord.com/developers/resources/invite#invite-object-example-invite-object
+/// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object-example-invite-object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct InviteGuild {
@@ -407,8 +405,7 @@ pub struct InviteStageInstance {
 enum_number! {
     /// Type of target for a voice channel invite.
     ///
-    /// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object).
-    // TODO: https://docs.discord.com/developers/resources/invite#invite-object-invite-target-types
+    /// [Discord docs](https://docs.discord.com/developers/resources/invite#invite-object-invite-target-types).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]

--- a/src/utils/formatted_timestamp.rs
+++ b/src/utils/formatted_timestamp.rs
@@ -15,8 +15,7 @@ pub struct FormattedTimestamp {
 
 /// Enum representing various styles for formatting time in messages.
 ///
-/// [Discord docs](https://docs.discord.com/developers/reference#message-formatting).
-// TODO: https://docs.discord.com/developers/reference#message-formatting-timestamp-styles
+/// [Discord docs](https://docs.discord.com/developers/reference#message-formatting-timestamp-styles).
 #[derive(Default, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum FormattedTimestampStyle {
     /// Represents a short time format, e.g., "12:34 PM".


### PR DESCRIPTION
Now that all the anchors have been added in the new Discord docs, this restores the links to their original intended targets.