### PR TITLE
Refactor and simplify `ShardRunner`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { version = "0.1.44", features = ["log"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 url = { version = "2.5.7", features = ["serde"] }
 tokio = { version = "1.48.0", features = ["macros", "rt", "sync", "time", "io-util"] }
-futures = { version = "0.3.31", default-features = false, features = ["std"] }
+futures = { version = "0.3.32", default-features = false, features = ["std"] }
 time = { version = "0.3.44", features = ["formatting", "parsing", "serde-well-known"] }
 base64 = { version = "0.22.1" }
 zeroize = { version = "1.8.2" } # Not used in serenity, but bumps the minimal version from secrecy

--- a/examples/e07_shard_manager/src/main.rs
+++ b/examples/e07_shard_manager/src/main.rs
@@ -68,11 +68,9 @@ async fn main() {
             sleep(Duration::from_secs(30)).await;
 
             for entry in runners.iter() {
-                let (id, (runner, _)) = entry.pair();
-                println!(
-                    "Shard ID {} is {} with a latency of {:?}",
-                    id, runner.stage, runner.latency,
-                );
+                let (id, runner) = entry.pair();
+                let info = runner.info.read();
+                println!("Shard ID {} is {} with a latency of {:?}", id, info.stage, info.latency,);
             }
         }
     });

--- a/src/gateway/client/context.rs
+++ b/src/gateway/client/context.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use dashmap::DashMap;
 use futures::channel::mpsc::UnboundedSender as Sender;
+use parking_lot::RwLock;
 
 use crate::builder::DataUri;
 #[cfg(feature = "cache")]
@@ -48,8 +48,8 @@ pub struct Context {
     pub http: Arc<Http>,
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,
-    /// Metadata about the initialised shards, and their control channels.
-    pub runners: Arc<DashMap<ShardId, (ShardRunnerInfo, Sender<ShardRunnerMessage>)>>,
+    /// Metadata about the shard.
+    pub runner_info: Arc<RwLock<ShardRunnerInfo>>,
     #[cfg(feature = "collector")]
     pub(crate) collectors: Arc<parking_lot::RwLock<Vec<CollectorCallback>>>,
 }

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -502,6 +502,9 @@ fn update_cache_with_event(ctx: &Context, event: Event) -> FullEvent {
         Event::MessagePollVoteRemove(event) => FullEvent::MessagePollVoteRemove {
             event,
         },
+        Event::ShardStageUpdate(event) => FullEvent::ShardStageUpdate {
+            event,
+        },
     }
 }
 

--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -8,7 +8,6 @@ use strum::{EnumCount, IntoStaticStr, VariantNames};
 use super::context::Context;
 #[cfg(doc)]
 use crate::gateway::ShardRunner;
-use crate::gateway::ShardStageUpdateEvent;
 use crate::http::RatelimitInfo;
 use crate::model::prelude::*;
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -21,6 +21,7 @@ mod ws;
 #[cfg(feature = "http")]
 use reqwest::IntoUrl;
 use reqwest::Url;
+use serde::Serialize;
 
 pub use self::error::Error as GatewayError;
 pub use self::sharding::*;

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -32,7 +32,6 @@ mod shard_manager;
 mod shard_queue;
 mod shard_runner;
 
-use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -53,12 +52,12 @@ pub use self::shard_manager::{
     ShardManagerOptions,
 };
 pub use self::shard_queue::ShardQueue;
-pub use self::shard_runner::{ShardRunner, ShardRunnerMessage, ShardRunnerOptions};
+pub use self::shard_runner::{ShardRunner, ShardRunnerMessage};
 use super::{ActivityData, ChunkGuildFilter, GatewayError, PresenceData, WsClient};
 use crate::constants::{self, CloseCode};
 use crate::internal::prelude::*;
 use crate::model::event::{DeserializedEvent, Event, GatewayEvent};
-use crate::model::gateway::{GatewayIntents, ShardInfo};
+use crate::model::gateway::{ConnectionStage, GatewayIntents, ShardInfo};
 #[cfg(feature = "voice")]
 use crate::model::id::ChannelId;
 use crate::model::id::{ApplicationId, GuildId, ShardId};
@@ -747,103 +746,12 @@ pub struct ShardRunnerInfo {
     pub stage: ConnectionStage,
 }
 
-/// An event denoting that a shard's connection stage was changed.
-///
-/// # Examples
-///
-/// This might happen when a shard changes from [`ConnectionStage::Identifying`] to
-/// [`ConnectionStage::Connected`].
-#[derive(Clone, Debug, Serialize)]
-pub struct ShardStageUpdateEvent {
-    /// The new connection stage.
-    pub new: ConnectionStage,
-    /// The old connection stage.
-    pub old: ConnectionStage,
-    /// The ID of the shard that had its connection stage change.
-    pub shard_id: ShardId,
-}
-
-/// Indicates the current connection stage of a [`Shard`].
-///
-/// This can be useful for knowing which shards are currently "down"/"up".
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[non_exhaustive]
-pub enum ConnectionStage {
-    /// Indicator that the [`Shard`] is normally connected and is not in, e.g., a resume phase.
-    Connected,
-    /// Indicator that the [`Shard`] is connecting and is in, e.g., a resume phase.
-    Connecting,
-    /// Indicator that the [`Shard`] is fully disconnected and is not in a reconnecting phase.
-    Disconnected,
-    /// Indicator that the [`Shard`] is currently initiating a handshake.
-    Handshake,
-    /// Indicator that the [`Shard`] has sent an IDENTIFY packet and is awaiting a READY packet.
-    Identifying,
-    /// Indicator that the [`Shard`] has sent a RESUME packet and is awaiting a RESUMED packet.
-    Resuming,
-}
-
-impl ConnectionStage {
-    /// Whether the stage is a form of connecting.
-    ///
-    /// This will return `true` on:
-    /// - [`Connecting`][`ConnectionStage::Connecting`]
-    /// - [`Handshake`][`ConnectionStage::Handshake`]
-    /// - [`Identifying`][`ConnectionStage::Identifying`]
-    /// - [`Resuming`][`ConnectionStage::Resuming`]
-    ///
-    /// All other variants will return `false`.
-    ///
-    /// # Examples
-    ///
-    /// Assert that [`ConnectionStage::Identifying`] is a connecting stage:
-    ///
-    /// ```rust
-    /// use serenity::gateway::ConnectionStage;
-    ///
-    /// assert!(ConnectionStage::Identifying.is_connecting());
-    /// ```
-    ///
-    /// Assert that [`ConnectionStage::Connected`] is _not_ a connecting stage:
-    ///
-    /// ```rust
-    /// use serenity::gateway::ConnectionStage;
-    ///
-    /// assert!(!ConnectionStage::Connected.is_connecting());
-    /// ```
-    #[must_use]
-    pub fn is_connecting(self) -> bool {
-        use self::ConnectionStage::{Connecting, Handshake, Identifying, Resuming};
-        matches!(self, Connecting | Handshake | Identifying | Resuming)
-    }
-}
-
-impl fmt::Display for ConnectionStage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match *self {
-            Self::Connected => "connected",
-            Self::Connecting => "connecting",
-            Self::Disconnected => "disconnected",
-            Self::Handshake => "handshaking",
-            Self::Identifying => "identifying",
-            Self::Resuming => "resuming",
-        })
-    }
-}
-
 /// Newtype around a callback that will be called on every incoming request. As long as this
 /// collector should still receive events, it should return `true`. Once it returns `false`, it is
 /// removed.
 #[cfg(feature = "collector")]
 #[derive(Clone)]
 pub struct CollectorCallback(pub Arc<dyn Fn(&Event) -> bool + Send + Sync>);
-
-#[cfg(feature = "collector")]
-impl fmt::Debug for CollectorCallback {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("CollectorCallback").finish()
-    }
-}
 
 /// The transport compression method to use.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -262,7 +262,7 @@ impl ShardManager {
             info: Arc::clone(&runner_info),
             tx: runner_tx,
             #[cfg(feature = "collector")]
-            collectors: Default::default(),
+            collectors: Arc::default(),
         });
 
         let mut runner = ShardRunner {

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use dashmap::DashMap;
 use futures::StreamExt;
 use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
+use parking_lot::RwLock;
 use tokio::time::{sleep, timeout};
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
@@ -20,20 +21,23 @@ use super::{
     ShardRunner,
     ShardRunnerInfo,
     ShardRunnerMessage,
-    ShardRunnerOptions,
 };
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
+#[cfg(feature = "collector")]
+use crate::gateway::CollectorCallback;
 #[cfg(feature = "voice")]
 use crate::gateway::VoiceGatewayManager;
-use crate::gateway::client::{EventHandler, RawEventHandler};
-use crate::gateway::{ConnectionStage, GatewayError, PresenceData, TransportCompression};
+use crate::gateway::client::dispatch::dispatch_model;
+use crate::gateway::client::{Context, EventHandler, RawEventHandler};
+use crate::gateway::{GatewayError, PresenceData, TransportCompression};
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
-use crate::model::gateway::GatewayIntents;
+use crate::model::event::Event;
+use crate::model::gateway::{ConnectionStage, GatewayIntents};
 
 /// The default time to wait between starting each shard or set of shards.
 pub const DEFAULT_WAIT_BETWEEN_SHARD_START: Duration = Duration::from_secs(5);
@@ -67,7 +71,7 @@ pub struct ShardManager {
     ///
     /// **Note**: It is highly recommended to not mutate this yourself unless you need to. Instead
     /// prefer to use methods on this struct that are provided where possible.
-    pub runners: Arc<DashMap<ShardId, (ShardRunnerInfo, Sender<ShardRunnerMessage>)>>,
+    pub runners: Arc<DashMap<ShardId, ShardRunnerMetadata>>,
     /// A copy of the client's voice manager.
     #[cfg(feature = "voice")]
     pub voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
@@ -158,7 +162,16 @@ impl ShardManager {
                 timeout(self.wait_time_between_shard_start, self.manager_rx.next()).await
             {
                 match msg {
-                    ShardManagerMessage::Boot(shard_id) => self.queue_for_start(shard_id),
+                    ShardManagerMessage::RestartShard(shard_id) => {
+                        #[cfg(feature = "voice")]
+                        if let Some(voice_manager) = &self.voice_manager {
+                            voice_manager.deregister_shard(shard_id.0).await;
+                        }
+                        self.queue_for_start(shard_id);
+                    },
+                    ShardManagerMessage::DispatchEvent(shard_id, event) => {
+                        self.dispatch_event(shard_id, *event).await;
+                    },
                     ShardManagerMessage::Quit(res) => return res,
                 }
             }
@@ -239,32 +252,91 @@ impl ShardManager {
         let cloned_http = Arc::clone(&self.http);
         shard.set_application_id_callback(move |id| cloned_http.set_application_id(id));
 
-        let mut runner = ShardRunner::new(ShardRunnerOptions {
-            data: Arc::clone(&self.data),
-            event_handler: self.event_handler.clone(),
-            raw_event_handler: self.raw_event_handler.clone(),
-            #[cfg(feature = "framework")]
-            framework: self.framework.get().cloned(),
-            runners: Arc::clone(&self.runners),
-            manager_tx: self.manager_tx.clone(),
-            #[cfg(feature = "voice")]
-            voice_manager: self.voice_manager.clone(),
-            shard,
-            #[cfg(feature = "cache")]
-            cache: Arc::clone(&self.cache),
-            http: Arc::clone(&self.http),
-        });
-
-        let runner_info = ShardRunnerInfo {
+        let (runner_tx, runner_rx) = mpsc::unbounded();
+        let runner_info = Arc::new(RwLock::new(ShardRunnerInfo {
             latency: None,
             stage: ConnectionStage::Disconnected,
+        }));
+
+        self.runners.insert(shard_id, ShardRunnerMetadata {
+            info: Arc::clone(&runner_info),
+            tx: runner_tx,
+            #[cfg(feature = "collector")]
+            collectors: Default::default(),
+        });
+
+        let mut runner = ShardRunner {
+            manager_tx: self.manager_tx.clone(),
+            runner_rx,
+            shard,
+            runner_info,
         };
-
-        self.runners.insert(shard_id, (runner_info, runner.runner_tx()));
-
         spawn_named("shard_runner::run", async move { runner.run().await });
 
         Ok(())
+    }
+
+    async fn dispatch_event(&self, shard_id: ShardId, event: Event) {
+        let Some(entry) = self.runners.get(&shard_id) else {
+            return;
+        };
+
+        let runner = entry.value();
+
+        #[cfg(feature = "voice")]
+        {
+            if let Some(voice_manager) = &self.voice_manager {
+                match &event {
+                    Event::Ready(_) => {
+                        voice_manager.register_shard(shard_id.0, runner.tx.clone()).await;
+                    },
+                    Event::VoiceServerUpdate(event) => {
+                        voice_manager
+                            .server_update(event.guild_id, event.endpoint.as_deref(), &event.token)
+                            .await;
+                    },
+                    Event::VoiceStateUpdate(event) => {
+                        if let Some(guild_id) = event.voice_state.guild_id {
+                            voice_manager.state_update(guild_id, &event.voice_state).await;
+                        }
+                    },
+                    _ => {},
+                }
+            }
+        }
+
+        let context = Context {
+            data: Arc::clone(&self.data),
+            shard: runner.tx.clone(),
+            runner_info: Arc::clone(&runner.info),
+            manager: self.manager_tx.clone(),
+            shard_id,
+            http: Arc::clone(&self.http),
+            #[cfg(feature = "cache")]
+            cache: Arc::clone(&self.cache),
+            #[cfg(feature = "collector")]
+            collectors: Arc::clone(&runner.collectors),
+        };
+
+        if self.event_handler.as_ref().is_none_or(|handler| handler.filter_event(&context, &event))
+            && self
+                .raw_event_handler
+                .as_ref()
+                .is_none_or(|handler| handler.filter_event(&context, &event))
+        {
+            #[cfg(feature = "collector")]
+            runner.collectors.write().retain(|callback| (callback.0)(&event));
+
+            dispatch_model(
+                event,
+                context,
+                #[cfg(feature = "framework")]
+                self.framework.get().cloned(),
+                self.event_handler.clone(),
+                self.raw_event_handler.clone(),
+            )
+            .await;
+        }
     }
 
     /// Returns the gateway intents used for this gateway connection.
@@ -284,9 +356,9 @@ impl Drop for ShardManager {
         info!("Shutting down all shards");
 
         for entry in self.runners.iter() {
-            let (shard_id, (_, tx)) = entry.pair();
+            let (shard_id, runner) = entry.pair();
             info!("Shutting down shard {}", shard_id);
-            if let Err(why) = tx.unbounded_send(ShardRunnerMessage::Shutdown(1000)) {
+            if let Err(why) = runner.tx.unbounded_send(ShardRunnerMessage::Shutdown(1000)) {
                 warn!("Failed to send shutdown signal to shard {shard_id}: {why:?}");
             }
         }
@@ -316,12 +388,24 @@ pub struct ShardManagerOptions {
 
 /// A message indicating what action the [`ShardManager`] should take.
 pub enum ShardManagerMessage {
-    /// Indicates that the manager should attempt to start a shard.
+    /// Indicates that the manager should attempt to restart a shard.
     ///
     /// Note that this makes use of the manager's shard queue for batching shards together, and if
     /// the queue is operating in concurrent mode (in order to start multiple shards at once),
     /// the shard is not guaranteed to immediately start, until more shards are queued.
-    Boot(ShardId),
+    RestartShard(ShardId),
+    /// Indicates that the manager should dispatch an event to the client.
+    DispatchEvent(ShardId, Box<Event>),
     /// Indicates that a shard runner encountered a fatal error and the shard manager should quit.
     Quit(Result<(), GatewayError>),
+}
+
+/// Metadata about a [`ShardRunner`].
+pub struct ShardRunnerMetadata {
+    /// Information about the shard itself.
+    pub info: Arc<RwLock<ShardRunnerInfo>>,
+    /// A channel for sending messages to the [`ShardRunner`].
+    pub tx: Sender<ShardRunnerMessage>,
+    #[cfg(feature = "collector")]
+    collectors: Arc<RwLock<Vec<CollectorCallback>>>,
 }

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -183,6 +183,7 @@ impl ShardRunner {
             // Do not block if the channel is empty
             let msg = match self.runner_rx.try_recv() {
                 Ok(msg) => msg,
+                Err(TryRecvError::Empty) => return true,
                 Err(TryRecvError::Closed) => {
                     // This should never happen, because `ShardManager::runners` always holds a
                     // copy of the other end of the channel, and it's only dropped if the shard is
@@ -195,7 +196,6 @@ impl ShardRunner {
                     self.restart().await;
                     return false;
                 },
-                Err(TryRecvError::Empty) => return true,
             };
 
             let res = match msg {

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -1,87 +1,37 @@
 use std::sync::Arc;
 
-use dashmap::DashMap;
-use dashmap::try_result::TryResult;
-use futures::channel::mpsc::{self, UnboundedReceiver as Receiver, UnboundedSender as Sender};
+use futures::channel::mpsc::{
+    TryRecvError,
+    UnboundedReceiver as Receiver,
+    UnboundedSender as Sender,
+};
+use parking_lot::RwLock;
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
 use tracing::{debug, error, trace, warn};
 
-#[cfg(feature = "collector")]
-use super::CollectorCallback;
-use super::{Shard, ShardAction, ShardManagerMessage, ShardRunnerInfo, ShardStageUpdateEvent};
-#[cfg(feature = "cache")]
-use crate::cache::Cache;
-#[cfg(feature = "framework")]
-use crate::framework::Framework;
-#[cfg(feature = "voice")]
-use crate::gateway::VoiceGatewayManager;
-use crate::gateway::client::dispatch::dispatch_model;
-use crate::gateway::client::{Context, EventHandler, RawEventHandler};
+use super::{Shard, ShardAction, ShardManagerMessage, ShardRunnerInfo};
 use crate::gateway::{ActivityData, ChunkGuildFilter, GatewayError};
-use crate::http::Http;
 use crate::internal::prelude::*;
-use crate::internal::tokio::spawn_named;
-#[cfg(feature = "voice")]
-use crate::model::event::Event;
-use crate::model::event::GatewayEvent;
+use crate::model::event::{Event, GatewayEvent, ShardStageUpdateEvent};
 #[cfg(feature = "voice")]
 use crate::model::id::ChannelId;
-use crate::model::id::{GuildId, ShardId};
+use crate::model::id::GuildId;
 use crate::model::user::OnlineStatus;
 
 /// A runner for managing a [`Shard`] and its respective WebSocket client.
 pub struct ShardRunner {
-    data: Arc<dyn std::any::Any + Send + Sync>,
-    event_handler: Option<Arc<dyn EventHandler>>,
-    raw_event_handler: Option<Arc<dyn RawEventHandler>>,
-    #[cfg(feature = "framework")]
-    framework: Option<Arc<dyn Framework>>,
-    runners: Arc<DashMap<ShardId, (ShardRunnerInfo, Sender<ShardRunnerMessage>)>>,
-    // channel to send messages back to the shard manager
-    manager_tx: Sender<ShardManagerMessage>,
-    // channel to receive messages from the shard manager and dispatches
-    runner_rx: Receiver<ShardRunnerMessage>,
-    // channel to send messages to the shard runner from the shard manager
-    runner_tx: Sender<ShardRunnerMessage>,
+    // Channel to send messages back to the shard manager
+    pub(crate) manager_tx: Sender<ShardManagerMessage>,
+    // Channel to receive messages from both the shard manager and dispatches
+    pub(crate) runner_rx: Receiver<ShardRunnerMessage>,
     pub(crate) shard: Shard,
-    #[cfg(feature = "voice")]
-    voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
-    #[cfg(feature = "cache")]
-    pub cache: Arc<Cache>,
-    pub http: Arc<Http>,
-    #[cfg(feature = "collector")]
-    pub(crate) collectors: Arc<parking_lot::RwLock<Vec<CollectorCallback>>>,
+    pub(crate) runner_info: Arc<RwLock<ShardRunnerInfo>>,
 }
 
 impl ShardRunner {
-    /// Creates a new runner for a Shard.
-    pub fn new(opt: ShardRunnerOptions) -> Self {
-        let (tx, rx) = mpsc::unbounded();
-
-        Self {
-            data: opt.data,
-            event_handler: opt.event_handler,
-            raw_event_handler: opt.raw_event_handler,
-            #[cfg(feature = "framework")]
-            framework: opt.framework,
-            runners: opt.runners,
-            manager_tx: opt.manager_tx,
-            runner_rx: rx,
-            runner_tx: tx,
-            shard: opt.shard,
-            #[cfg(feature = "voice")]
-            voice_manager: opt.voice_manager,
-            #[cfg(feature = "cache")]
-            cache: opt.cache,
-            http: opt.http,
-            #[cfg(feature = "collector")]
-            collectors: Arc::new(parking_lot::RwLock::new(vec![])),
-        }
-    }
-
     /// A wrapper around [`ShardRunner::start_loop`] that starts the runner's main loop and
     /// monitors for errors.
     ///
@@ -143,27 +93,11 @@ impl ShardRunner {
 
             if post != pre {
                 self.update_runner_info();
-
-                if let Some(event_handler) = &self.event_handler {
-                    let event_handler = Arc::clone(event_handler);
-                    let context = self.make_context();
-                    let event = ShardStageUpdateEvent {
-                        new: post,
-                        old: pre,
-                        shard_id: self.shard.shard_info().id,
-                    };
-
-                    spawn_named("dispatch::event_handler::shard_stage_update", async move {
-                        event_handler
-                            .dispatch(
-                                &context,
-                                &crate::gateway::client::FullEvent::ShardStageUpdate {
-                                    event,
-                                },
-                            )
-                            .await;
-                    });
-                }
+                self.dispatch(Box::new(Event::ShardStageUpdate(ShardStageUpdateEvent {
+                    new: post,
+                    old: pre,
+                    shard_id: self.shard.shard_info().id,
+                })));
             }
 
             if let Some(action) = action {
@@ -197,40 +131,23 @@ impl ShardRunner {
                             }
                         }
                     },
-                    ShardAction::Dispatch(event) => {
-                        #[cfg(feature = "voice")]
-                        {
-                            self.handle_voice_event(&event).await;
-                        }
-
-                        let context = self.make_context();
-                        if self
-                            .event_handler
-                            .as_ref()
-                            .is_none_or(|handler| handler.filter_event(&context, &event))
-                            && self
-                                .raw_event_handler
-                                .as_ref()
-                                .is_none_or(|handler| handler.filter_event(&context, &event))
-                        {
-                            #[cfg(feature = "collector")]
-                            self.collectors.write().retain(|callback| (callback.0)(&event));
-
-                            dispatch_model(
-                                *event,
-                                context,
-                                #[cfg(feature = "framework")]
-                                self.framework.clone(),
-                                self.event_handler.clone(),
-                                self.raw_event_handler.clone(),
-                            )
-                            .await;
-                        }
-                    },
+                    ShardAction::Dispatch(event) => self.dispatch(event),
                 }
             }
 
             trace!("[ShardRunner {:?}] loop iteration reached the end.", self.shard.shard_info());
+        }
+    }
+
+    #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
+    fn dispatch(&self, event: Box<Event>) {
+        let shard_info = self.shard.shard_info();
+        if let Err(why) =
+            self.manager_tx.unbounded_send(ShardManagerMessage::DispatchEvent(shard_info.id, event))
+        {
+            warn!(
+                "[ShardRunner {shard_info:?}] Failed to send event to shard manager for dispatch: {why:?}",
+            );
         }
     }
 
@@ -256,48 +173,29 @@ impl ShardRunner {
         );
     }
 
-    #[cfg(feature = "voice")]
-    #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
-    async fn handle_voice_event(&self, event: &Event) {
-        if let Some(voice_manager) = &self.voice_manager {
-            match event {
-                Event::Ready(_) => {
-                    voice_manager
-                        .register_shard(self.shard.shard_info().id.0, self.runner_tx.clone())
-                        .await;
-                },
-                Event::VoiceServerUpdate(event) => {
-                    voice_manager
-                        .server_update(event.guild_id, event.endpoint.as_deref(), &event.token)
-                        .await;
-                },
-                Event::VoiceStateUpdate(event) => {
-                    if let Some(guild_id) = event.voice_state.guild_id {
-                        voice_manager.state_update(guild_id, &event.voice_state).await;
-                    }
-                },
-                _ => {},
-            }
-        }
-    }
-
     // Receives messages over the internal `runner_rx` channel and handles them. Will loop over all
     // queued messages until the channel is empty. Requests a restart if handling a message fails.
     //
     // Returns whether the shard runner can continue executing its main loop.
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     async fn recv(&mut self) -> bool {
-        while let Ok(msg) = self.runner_rx.try_next() {
-            let Some(msg) = msg else {
-                // This should never happen, because `self.runner_tx` always holds a copy of the
-                // other end of the channel.
-                warn!(
-                    "[ShardRunner {:?}] Internal channel tx dropped; restarting",
-                    self.shard.shard_info(),
-                );
+        loop {
+            // Do not block if the channel is empty
+            let msg = match self.runner_rx.try_recv() {
+                Ok(msg) => msg,
+                Err(TryRecvError::Closed) => {
+                    // This should never happen, because `ShardManager::runners` always holds a
+                    // copy of the other end of the channel, and it's only dropped if the shard is
+                    // stopped/restarted (which drops the corresponding `ShardRunner`).
+                    warn!(
+                        "[ShardRunner {:?}] Internal channel closed; restarting",
+                        self.shard.shard_info(),
+                    );
 
-                self.restart().await;
-                return false;
+                    self.restart().await;
+                    return false;
+                },
+                Err(TryRecvError::Empty) => return true,
             };
 
             let res = match msg {
@@ -353,8 +251,6 @@ impl ShardRunner {
                 return false;
             }
         }
-
-        true
     }
 
     /// Returns a received event, as well as whether reading the potentially present event was
@@ -427,68 +323,25 @@ impl ShardRunner {
 
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     async fn restart(&mut self) {
-        let shard_id = self.shard.shard_info().id;
-
-        #[cfg(feature = "voice")]
-        if let Some(voice_manager) = &self.voice_manager {
-            voice_manager.deregister_shard(shard_id.0).await;
-        }
+        let shard_info = self.shard.shard_info();
 
         self.shutdown(4000).await;
 
-        if let Err(why) = self.manager_tx.unbounded_send(ShardManagerMessage::Boot(shard_id)) {
+        if let Err(why) =
+            self.manager_tx.unbounded_send(ShardManagerMessage::RestartShard(shard_info.id))
+        {
             warn!(
-                "[ShardRunner {:?}] Failed to send boot request back to shard manager: {why:?}",
-                self.shard.shard_info(),
+                "[ShardRunner {shard_info:?}] Failed to send boot request back to shard manager: {why:?}",
             );
         }
     }
 
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     fn update_runner_info(&self) {
-        if let TryResult::Present(mut entry) = self.runners.try_get_mut(&self.shard.info.id) {
-            let (runner_info, _) = entry.value_mut();
-
-            runner_info.latency = self.shard.heartbeat_latency();
-            runner_info.stage = self.shard.stage();
-        }
+        let mut runner_info = self.runner_info.write();
+        runner_info.latency = self.shard.heartbeat_latency();
+        runner_info.stage = self.shard.stage();
     }
-
-    fn make_context(&self) -> Context {
-        Context {
-            data: Arc::clone(&self.data),
-            shard: self.runner_tx.clone(),
-            manager: self.manager_tx.clone(),
-            shard_id: self.shard.shard_info().id,
-            http: Arc::clone(&self.http),
-            #[cfg(feature = "cache")]
-            cache: Arc::clone(&self.cache),
-            runners: Arc::clone(&self.runners),
-            #[cfg(feature = "collector")]
-            collectors: Arc::clone(&self.collectors),
-        }
-    }
-
-    pub(super) fn runner_tx(&self) -> Sender<ShardRunnerMessage> {
-        self.runner_tx.clone()
-    }
-}
-
-/// Options to be passed to [`ShardRunner::new`].
-pub struct ShardRunnerOptions {
-    pub data: Arc<dyn std::any::Any + Send + Sync>,
-    pub event_handler: Option<Arc<dyn EventHandler>>,
-    pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
-    #[cfg(feature = "framework")]
-    pub framework: Option<Arc<dyn Framework>>,
-    pub runners: Arc<DashMap<ShardId, (ShardRunnerInfo, Sender<ShardRunnerMessage>)>>,
-    pub manager_tx: Sender<ShardManagerMessage>,
-    pub shard: Shard,
-    #[cfg(feature = "voice")]
-    pub voice_manager: Option<Arc<dyn VoiceGatewayManager>>,
-    #[cfg(feature = "cache")]
-    pub cache: Arc<Cache>,
-    pub http: Arc<Http>,
 }
 
 /// A message to send from a shard over a WebSocket.

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -3,8 +3,8 @@
 //! Every event includes the gateway intent required to receive it, as well as a link to the
 //! Discord documentation for the event.
 
-use serde::Serialize;
 use serde::de::Error as DeError;
+use serde::{Serialize, Serializer};
 use serde_json::value::RawValue;
 use strum::{EnumCount, IntoStaticStr, VariantNames};
 
@@ -987,6 +987,24 @@ pub struct MessagePollVoteRemoveEvent {
     pub answer_id: AnswerId,
 }
 
+/// An internal event denoting that a shard's connection stage was changed.
+///
+/// # Examples
+///
+/// This might happen when a shard changes from [`ConnectionStage::Identifying`] to
+/// [`ConnectionStage::Connected`].
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ShardStageUpdateEvent {
+    /// The new connection stage.
+    pub new: ConnectionStage,
+    /// The old connection stage.
+    pub old: ConnectionStage,
+    /// The ID of the shard that had its connection stage change.
+    pub shard_id: ShardId,
+}
+
 /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#payload-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Debug, Clone, Serialize)]
@@ -1024,7 +1042,7 @@ pub struct UnknownEvent {
 }
 
 impl Serialize for UnknownEvent {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
         self.data.serialize(serializer)
     }
 }
@@ -1240,6 +1258,8 @@ pub enum Event {
     MessagePollVoteAdd(MessagePollVoteAddEvent),
     /// A user has removed a previous vote on a Message Poll.
     MessagePollVoteRemove(MessagePollVoteRemoveEvent),
+    /// A shard has changed its connection stage.
+    ShardStageUpdate(ShardStageUpdateEvent),
 }
 
 impl Event {

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -995,7 +995,6 @@ pub struct MessagePollVoteRemoveEvent {
 /// [`ConnectionStage::Connected`].
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
 pub struct ShardStageUpdateEvent {
     /// The new connection stage.
     pub new: ConnectionStage,

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -1,5 +1,6 @@
 //! Models pertaining to the gateway.
 
+use std::fmt;
 use std::num::{NonZeroU16, NonZeroU64};
 
 use serde::ser::SerializeSeq;
@@ -419,6 +420,75 @@ impl serde::Serialize for ShardInfo {
         seq.serialize_element(&self.id.0)?;
         seq.serialize_element(&self.total)?;
         seq.end()
+    }
+}
+
+/// Indicates the current connection stage of a shard.
+///
+/// This can be useful for knowing which shards are currently "down"/"up".
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[non_exhaustive]
+pub enum ConnectionStage {
+    /// Indicator that the shard is normally connected and is not in, e.g., a resume phase.
+    Connected,
+    /// Indicator that the shard is connecting and is in, e.g., a resume phase.
+    Connecting,
+    /// Indicator that the shard is fully disconnected and is not in a reconnecting phase.
+    Disconnected,
+    /// Indicator that the shard is currently initiating a handshake.
+    Handshake,
+    /// Indicator that the shard has sent an IDENTIFY packet and is awaiting a READY packet.
+    Identifying,
+    /// Indicator that the shard has sent a RESUME packet and is awaiting a RESUMED packet.
+    Resuming,
+}
+
+impl ConnectionStage {
+    /// Whether the stage is a form of connecting.
+    ///
+    /// This will return `true` on:
+    /// - [`Connecting`][`ConnectionStage::Connecting`]
+    /// - [`Handshake`][`ConnectionStage::Handshake`]
+    /// - [`Identifying`][`ConnectionStage::Identifying`]
+    /// - [`Resuming`][`ConnectionStage::Resuming`]
+    ///
+    /// All other variants will return `false`.
+    ///
+    /// # Examples
+    ///
+    /// Assert that [`ConnectionStage::Identifying`] is a connecting stage:
+    ///
+    /// ```rust
+    /// use serenity::gateway::ConnectionStage;
+    ///
+    /// assert!(ConnectionStage::Identifying.is_connecting());
+    /// ```
+    ///
+    /// Assert that [`ConnectionStage::Connected`] is _not_ a connecting stage:
+    ///
+    /// ```rust
+    /// use serenity::gateway::ConnectionStage;
+    ///
+    /// assert!(!ConnectionStage::Connected.is_connecting());
+    /// ```
+    #[must_use]
+    pub fn is_connecting(self) -> bool {
+        use self::ConnectionStage::{Connecting, Handshake, Identifying, Resuming};
+        matches!(self, Connecting | Handshake | Identifying | Resuming)
+    }
+}
+
+impl fmt::Display for ConnectionStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match *self {
+            Self::Connected => "connected",
+            Self::Connecting => "connecting",
+            Self::Disconnected => "disconnected",
+            Self::Handshake => "handshaking",
+            Self::Identifying => "identifying",
+            Self::Resuming => "resuming",
+        })
     }
 }
 

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -460,7 +460,7 @@ impl ConnectionStage {
     /// Assert that [`ConnectionStage::Identifying`] is a connecting stage:
     ///
     /// ```rust
-    /// use serenity::gateway::ConnectionStage;
+    /// use serenity::model::gateway::ConnectionStage;
     ///
     /// assert!(ConnectionStage::Identifying.is_connecting());
     /// ```
@@ -468,7 +468,7 @@ impl ConnectionStage {
     /// Assert that [`ConnectionStage::Connected`] is _not_ a connecting stage:
     ///
     /// ```rust
-    /// use serenity::gateway::ConnectionStage;
+    /// use serenity::model::gateway::ConnectionStage;
     ///
     /// assert!(!ConnectionStage::Connected.is_connecting());
     /// ```

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -236,7 +236,7 @@ id_u64! {
 /// This identifier is special, it simply models internal IDs for type safety and therefore cannot
 /// be deserialized
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct ShardId(pub u16);
 
 impl ShardId {


### PR DESCRIPTION
Moves responsibility for dispatching events to the `ShardManager` and adds a `ShardManagerMessage::DispatchEvent`, rendering most of the fields on `ShardRunner` no longer necessary and removing the need for `ShardRunnerOptions`. In order to facilitate this, I added a `ShardStageUpdateEvent` variant to `Event` - even though connection stage updates are purely internal, they are still a consequence of gateway activity. Note that sending a `Box<Event>` across a channel is cheap and doesn't move the `Event` on the heap.

Also, renames `ShardManagerMessage::Boot` to `RestartShard`, and refactors `ShardManager::runners` to store additional metadata about each runner that simplifies how the `Context` is initialized. By wrapping `ShardRunnerInfo` in `Arc<RwLock<T>>`, we can give a copy to both the runner and to the `Context` without cloning the entire `runner` map.