### PR TITLE
Update CV2 to match API

### DIFF
--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::collapsible_match)]
 use std::sync::Arc;
 
 use serenity::async_trait;

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -1,4 +1,4 @@
-#![expect(clippy::collapsible_if)]
+#![expect(clippy::collapsible_if, clippy::collapsible_match)]
 use std::sync::Arc;
 
 use serenity::async_trait;

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::collapsible_match)]
 use std::sync::Arc;
 
 use serenity::async_trait;

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::collapsible_match)]
 use std::sync::Arc;
 
 use serenity::async_trait;

--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::collapsible_match)]
 use std::sync::Arc;
 
 use serenity::async_trait;
@@ -14,34 +15,36 @@ impl EventHandler for Handler {
         match event {
             FullEvent::Message {
                 new_message, ..
-            } if new_message.content == "!hello" => {
-                // The create message builder allows you to easily create embeds and messages
-                // using a builder syntax.
-                // This example will create a message that says "Hello, World!", with an embed
-                // that has a title, description, an image, three fields,
-                // and a footer.
-                let footer = CreateEmbedFooter::new("This is a footer");
-                let embed = CreateEmbed::new()
-                    .title("This is a title")
-                    .description("This is a description")
-                    .image("attachment://ferris_eyes.png")
-                    .fields([
-                        ("This is the first field", "This is a field body", true),
-                        ("This is the second field", "Both fields are inline", true),
-                    ])
-                    .field("This is the third field", "This is not an inline field", false)
-                    .footer(footer)
-                    // Add a timestamp for the current time
-                    // This also accepts a rfc3339 Timestamp
-                    .timestamp(Timestamp::now());
-                let builder = CreateMessage::new()
-                    .content("Hello, World!")
-                    .embed(embed)
-                    .add_file(CreateAttachment::path("./ferris_eyes.png".as_ref()).unwrap());
-                let msg = new_message.channel_id.send_message(&ctx.http, builder).await;
+            } => {
+                if new_message.content == "!hello" {
+                    // The create message builder allows you to easily create embeds and messages
+                    // using a builder syntax.
+                    // This example will create a message that says "Hello, World!", with an embed
+                    // that has a title, description, an image, three fields,
+                    // and a footer.
+                    let footer = CreateEmbedFooter::new("This is a footer");
+                    let embed = CreateEmbed::new()
+                        .title("This is a title")
+                        .description("This is a description")
+                        .image("attachment://ferris_eyes.png")
+                        .fields([
+                            ("This is the first field", "This is a field body", true),
+                            ("This is the second field", "Both fields are inline", true),
+                        ])
+                        .field("This is the third field", "This is not an inline field", false)
+                        .footer(footer)
+                        // Add a timestamp for the current time
+                        // This also accepts a rfc3339 Timestamp
+                        .timestamp(Timestamp::now());
+                    let builder = CreateMessage::new()
+                        .content("Hello, World!")
+                        .embed(embed)
+                        .add_file(CreateAttachment::path("./ferris_eyes.png".as_ref()).unwrap());
+                    let msg = new_message.channel_id.send_message(&ctx.http, builder).await;
 
-                if let Err(why) = msg {
-                    println!("Error sending message: {why:?}");
+                    if let Err(why) = msg {
+                        println!("Error sending message: {why:?}");
+                    }
                 }
             },
             FullEvent::Ready {

--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -14,36 +14,34 @@ impl EventHandler for Handler {
         match event {
             FullEvent::Message {
                 new_message, ..
-            } => {
-                if new_message.content == "!hello" {
-                    // The create message builder allows you to easily create embeds and messages
-                    // using a builder syntax.
-                    // This example will create a message that says "Hello, World!", with an embed
-                    // that has a title, description, an image, three fields,
-                    // and a footer.
-                    let footer = CreateEmbedFooter::new("This is a footer");
-                    let embed = CreateEmbed::new()
-                        .title("This is a title")
-                        .description("This is a description")
-                        .image("attachment://ferris_eyes.png")
-                        .fields([
-                            ("This is the first field", "This is a field body", true),
-                            ("This is the second field", "Both fields are inline", true),
-                        ])
-                        .field("This is the third field", "This is not an inline field", false)
-                        .footer(footer)
-                        // Add a timestamp for the current time
-                        // This also accepts a rfc3339 Timestamp
-                        .timestamp(Timestamp::now());
-                    let builder = CreateMessage::new()
-                        .content("Hello, World!")
-                        .embed(embed)
-                        .add_file(CreateAttachment::path("./ferris_eyes.png".as_ref()).unwrap());
-                    let msg = new_message.channel_id.send_message(&ctx.http, builder).await;
+            } if new_message.content == "!hello" => {
+                // The create message builder allows you to easily create embeds and messages
+                // using a builder syntax.
+                // This example will create a message that says "Hello, World!", with an embed
+                // that has a title, description, an image, three fields,
+                // and a footer.
+                let footer = CreateEmbedFooter::new("This is a footer");
+                let embed = CreateEmbed::new()
+                    .title("This is a title")
+                    .description("This is a description")
+                    .image("attachment://ferris_eyes.png")
+                    .fields([
+                        ("This is the first field", "This is a field body", true),
+                        ("This is the second field", "Both fields are inline", true),
+                    ])
+                    .field("This is the third field", "This is not an inline field", false)
+                    .footer(footer)
+                    // Add a timestamp for the current time
+                    // This also accepts a rfc3339 Timestamp
+                    .timestamp(Timestamp::now());
+                let builder = CreateMessage::new()
+                    .content("Hello, World!")
+                    .embed(embed)
+                    .add_file(CreateAttachment::path("./ferris_eyes.png".as_ref()).unwrap());
+                let msg = new_message.channel_id.send_message(&ctx.http, builder).await;
 
-                    if let Err(why) = msg {
-                        println!("Error sending message: {why:?}");
-                    }
+                if let Err(why) = msg {
+                    println!("Error sending message: {why:?}");
                 }
             },
             FullEvent::Ready {

--- a/examples/e12_parallel_loops/src/main.rs
+++ b/examples/e12_parallel_loops/src/main.rs
@@ -1,4 +1,4 @@
-#![expect(clippy::collapsible_if)]
+#![expect(clippy::collapsible_if, clippy::collapsible_match)]
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -168,7 +168,7 @@ pub struct CreateTextDisplay<'a> {
 impl<'a> CreateTextDisplay<'a> {
     /// Creates a new text display component.
     ///
-    /// Note: All components on a message shares the same **4000** character limit.
+    /// Note: All components on a message share the same **4000** character limit.
     pub fn new(content: impl Into<Cow<'a, str>>) -> Self {
         CreateTextDisplay {
             kind: ComponentType::TextDisplay,
@@ -179,7 +179,7 @@ impl<'a> CreateTextDisplay<'a> {
     /// Sets the content of this text display component. Replaces the current value as set in
     /// [`Self::new`].
     ///
-    /// Note: All components on a message shares the same **4000** character limit.
+    /// Note: All components on a message share the same **4000** character limit.
     #[must_use]
     pub fn content(mut self, content: impl Into<Cow<'a, str>>) -> Self {
         self.content = content.into();
@@ -284,7 +284,7 @@ impl<'a> CreateMediaGallery<'a> {
     /// Sets the items of the gallery. Replaces the current value as set in [`Self::new`].
     ///
     /// **Note**: This will replace all existing items. Use [`Self::add_item()`] to add additional
-    /// items
+    /// items.
     pub fn items(mut self, items: impl Into<Cow<'a, [CreateMediaGalleryItem<'a>]>>) -> Self {
         self.items = items.into();
         self
@@ -368,7 +368,7 @@ pub struct CreateFile<'a> {
 }
 
 impl<'a> CreateFile<'a> {
-    /// Create a new builder for the file component. Refer to this builders documentation for
+    /// Create a new builder for the file component. Refer to this builder's documentation for
     /// limits.
     pub fn new(file: CreateUnfurledMediaItem<'a>) -> Self {
         CreateFile {
@@ -378,8 +378,8 @@ impl<'a> CreateFile<'a> {
         }
     }
 
-    // Only supports `attachment://filename.extension` format, refer to this builders documentation
-    // for more details. Replaces the current value as set in [`Self::new`].
+    /// Only supports `attachment://filename.extension` format. Refer to this builder's
+    /// documentation for more details. Replaces the current value as set in [`Self::new`].
     pub fn file(mut self, file: CreateUnfurledMediaItem<'a>) -> Self {
         self.file = file;
         self
@@ -451,7 +451,7 @@ impl<'a> CreateContainer<'a> {
         }
     }
 
-    // Set the colour of the left-hand side of the container.
+    /// Set the colour of the left-hand side of the container.
     pub fn accent_colour<C: Into<Colour>>(mut self, colour: C) -> Self {
         self.accent_color = Some(colour.into());
         self
@@ -504,7 +504,8 @@ pub enum CreateContainerComponent<'a> {
     Separator(CreateSeparator),
 }
 
-/// A builder for creating a label that can hold an [`InputText`] or [`SelectMenu`].
+/// A builder for creating a label, a top-level layout component that wraps modal
+/// components with a text label and optional description.
 ///
 /// [Discord docs](https://docs.discord.com/developers/components/reference#label).
 #[derive(Clone, Debug, Serialize)]
@@ -581,7 +582,8 @@ impl<'a> CreateLabel<'a> {
         }
     }
 
-    /// Sets the description of this component, which will display underneath the label text.
+    /// Sets the description of this component, which will display below the label text.
+    /// May display above or below the component depending on the platform.
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
         self.description = Some(description.into());
         self

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -400,7 +400,7 @@ pub struct CreateSeparator {
     kind: ComponentType,
     divider: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    spacing: Option<Spacing>,
+    spacing: Option<SeparatorSpacingSize>,
 }
 
 impl CreateSeparator {
@@ -421,7 +421,7 @@ impl CreateSeparator {
     }
 
     /// Sets the spacing of this separator.
-    pub fn spacing(mut self, spacing: Spacing) -> Self {
+    pub fn spacing(mut self, spacing: SeparatorSpacingSize) -> Self {
         self.spacing = Some(spacing);
         self
     }
@@ -886,17 +886,6 @@ impl<'a> CreateCheckbox<'a> {
     pub fn default_selected(mut self, default: bool) -> Self {
         self.default = Some(default);
         self
-    }
-}
-
-enum_number! {
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
-    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-    #[non_exhaustive]
-    pub enum Spacing {
-        Small = 1,
-        Large = 2,
-        _ => Unknown(u8),
     }
 }
 

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -398,25 +398,25 @@ impl<'a> CreateFile<'a> {
 pub struct CreateSeparator {
     #[serde(rename = "type")]
     kind: ComponentType,
-    divider: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    divider: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     spacing: Option<SeparatorSpacingSize>,
 }
 
 impl CreateSeparator {
-    /// Creates a new separator, with or without a divider.
-    pub fn new(divider: bool) -> Self {
+    /// Creates a new separator.
+    pub fn new() -> Self {
         CreateSeparator {
             kind: ComponentType::Separator,
-            divider,
+            divider: None,
             spacing: None,
         }
     }
 
-    /// Sets if this separator should have a divider or not. Replaces the current value as set in
-    /// [`Self::new`].
+    /// Sets if this separator should have a divider or not.
     pub fn divider(mut self, divider: bool) -> Self {
-        self.divider = divider;
+        self.divider = Some(divider);
         self
     }
 
@@ -424,6 +424,12 @@ impl CreateSeparator {
     pub fn spacing(mut self, spacing: SeparatorSpacingSize) -> Self {
         self.spacing = Some(spacing);
         self
+    }
+}
+
+impl Default for CreateSeparator {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -962,9 +968,9 @@ impl<'a> CreateButton<'a> {
     /// Sets the custom id of the button, a developer-defined identifier. Replaces the current
     /// value as set in [`Self::new`].
     ///
-    /// Has no effect on link buttons and premium buttons.
+    /// Has no effect on link buttons or premium buttons.
     pub fn custom_id(mut self, id: impl Into<Cow<'a, str>>) -> Self {
-        if self.url.is_none() {
+        if self.url.is_none() && self.sku_id.is_none() {
             self.custom_id = Some(id.into());
         }
 
@@ -973,9 +979,9 @@ impl<'a> CreateButton<'a> {
 
     /// Sets the style of this button.
     ///
-    /// Has no effect on link buttons and premium buttons.
+    /// Has no effect on link buttons or premium buttons.
     pub fn style(mut self, new_style: ButtonStyle) -> Self {
-        if self.url.is_none() {
+        if self.url.is_none() && self.sku_id.is_none() {
             self.style = new_style;
         }
 
@@ -983,14 +989,24 @@ impl<'a> CreateButton<'a> {
     }
 
     /// Sets label of the button.
+    ///
+    /// Has no effect on premium buttons.
     pub fn label(mut self, label: impl Into<Cow<'a, str>>) -> Self {
-        self.label = Some(label.into());
+        if self.sku_id.is_none() {
+            self.label = Some(label.into());
+        }
+
         self
     }
 
     /// Sets emoji of the button.
+    ///
+    /// Has no effect on premium buttons.
     pub fn emoji(mut self, emoji: impl Into<ReactionType>) -> Self {
-        self.emoji = Some(emoji.into());
+        if self.sku_id.is_none() {
+            self.emoji = Some(emoji.into());
+        }
+
         self
     }
 

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -232,12 +232,8 @@ pub struct TextDisplay {
     /// Always [`ComponentType::TextDisplay`]
     #[serde(rename = "type")]
     pub kind: ComponentType,
-
-    /// Discord’s official documentation does not mention this field; however, it is currently
-    /// returned by the API and represents meaningful data, so it is included here. This
-    /// behavior is undocumented and may change or be removed by Discord at any time.
-    #[cfg(feature = "unstable")]
-    pub content: Option<String>,
+    /// The text content of this component.
+    pub content: String,
 }
 
 /// A Media Gallery is a component that allows you to display media attachments in an organized

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -279,7 +279,8 @@ pub struct Separator {
     #[serde(rename = "type")]
     pub kind: ComponentType,
     /// Whether or not this contains a separating divider.
-    pub divider: Option<bool>,
+    #[serde(default = "default_true")]
+    pub divider: bool,
     /// The spacing of the separator.
     pub spacing: Option<SeparatorSpacingSize>,
 }

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -678,7 +678,7 @@ enum_number! {
         Secondary = 2,
         Success = 3,
         Danger = 4,
-        // No Link, because we represent Link using enum variants
+        // No Link or Premium, because we represent Link and Premium using enum variants.
         _ => Unknown(u8),
     }
 }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1161,8 +1161,7 @@ pub struct PollResults {
 
 /// The count of a single [`PollAnswer`]'s results.
 ///
-/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-results-object-poll-results-object-structure)
-// TODO: https://docs.discord.com/developers/resources/poll#poll-results-object-poll-answer-count-object-structure
+/// [Discord docs](https://docs.discord.com/developers/resources/poll#poll-results-object-poll-answer-count-object-structure)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]


### PR DESCRIPTION
This PR introduces several small fixes to V2 components:

- Remove the `unstable` flag from the `content` field of `TextDisplay`, since it is now [documented](https://docs.discord.com/developers/components/reference#text-display-text-display-structure).
- Align the `Separator` builder with the API by making `divider` optional.
- Remove the redundant `Spacing` enum and use the more appropriate `SeparatorSpacingSize` instead. This mismatch made using a `Separator` component to configure a `CreateSeparator` builder awkward since you had to convert between the types for no reason.
- Update `Button` builder to align with [requirements for Premium buttons](https://docs.discord.com/developers/components/reference#button-button-structure).
- Various documentation fixes.