### PR TITLE
Re-export `ShardRunnerMetadata`

### DIFF
--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -50,6 +50,7 @@ pub use self::shard_manager::{
     ShardManager,
     ShardManagerMessage,
     ShardManagerOptions,
+    ShardRunnerMetadata,
 };
 pub use self::shard_queue::ShardQueue;
 pub use self::shard_runner::{ShardRunner, ShardRunnerMessage};

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -232,9 +232,6 @@ id_u64! {
 }
 
 /// An identifier for a Shard.
-///
-/// This identifier is special, it simply models internal IDs for type safety and therefore cannot
-/// be deserialized
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct ShardId(pub u16);


### PR DESCRIPTION
This was left out of #3493 and prevented storing a clone of `ShardManager::runners` because the type wasn't publicly accessible. Also adjusted docs on `ShardId` since we implement `Deserialize` for it now.