### PR TITLE
Fix Clippy

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -900,7 +900,7 @@ fn flatten_group_to_string(
     let repeated_indent_str = help_options.indention_prefix.repeat(nest_level);
 
     if nest_level > 0 {
-        writeln!(group_text, "{repeated_indent_str}__**{}**__", group.name,)?;
+        writeln!(group_text, "{repeated_indent_str}__**{}**__", group.name)?;
     }
 
     let mut summary_or_prefixes = false;


### PR DESCRIPTION
Fixes Clippy failure on latest commit ([1e5af4d](https://github.com/serenity-rs/serenity/commit/1e5af4d559a12a12db0e82dbd1463c69c341e3b0)).