### PR TITLE
Fix `is_new` returning `true` for existing guilds

### DIFF
--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -556,33 +556,27 @@ mod tests {
     use extract_map::ExtractMap;
     use small_fixed_array::{FixedArray, FixedString};
 
-    use super::is_guild_new;
-    use crate::all::dispatch::update_cache_with_event;
-    use crate::all::{
-        ApplicationFlags,
-        ApplicationId,
-        Cache,
-        CurrentUser,
+    use super::{is_guild_new, update_cache_with_event};
+    use crate::cache::Cache;
+    use crate::gateway::client::FullEvent;
+    use crate::model::Timestamp;
+    use crate::model::application::{ApplicationFlags, PartialCurrentApplicationInfo};
+    use crate::model::event::{Event, GuildCreateEvent, ReadyEvent};
+    use crate::model::gateway::Ready;
+    use crate::model::guild::{
         DefaultMessageNotificationLevel,
-        Event,
         ExplicitContentFilter,
-        FullEvent,
         Guild,
-        GuildCreateEvent,
         GuildGeneratedFlags,
-        GuildId,
         MfaLevel,
         NsfwLevel,
-        PartialCurrentApplicationInfo,
         PremiumTier,
-        Ready,
-        ReadyEvent,
         SystemChannelFlags,
-        Timestamp,
         UnavailableGuild,
-        UserId,
         VerificationLevel,
     };
+    use crate::model::id::{ApplicationId, GuildId, UserId};
+    use crate::model::user::CurrentUser;
 
     #[test]
     fn guild_is_new() {

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::event_handler::{EventHandler, RawEventHandler};
 use super::{Context, FullEvent};
+use crate::all::{Cache, GuildId};
 #[cfg(feature = "cache")]
 use crate::cache::CacheUpdate;
 #[cfg(feature = "framework")]
@@ -49,7 +50,7 @@ pub(crate) async fn dispatch_model(
     }
 
     let mut extra_event = None;
-    let full_event = update_cache_with_event(&context, event, &mut extra_event);
+    let full_event = update_cache_with_event(&context.cache, event, &mut extra_event);
 
     spawn_named("dispatch::user", async move {
         #[cfg(feature = "framework")]
@@ -94,9 +95,13 @@ async fn dispatch_event_handler(
     }
 }
 
+fn is_guild_new(cache: &Cache, guild_id: GuildId) -> bool {
+    !cache.unavailable_guilds().contains(&guild_id)
+}
+
 /// Updates the cache with the incoming event data and builds the full event data out of it.
 fn update_cache_with_event(
-    ctx: &Context,
+    cache: &Cache,
     event: Event,
     extra_event: &mut Option<FullEvent>,
 ) -> FullEvent {
@@ -117,7 +122,7 @@ fn update_cache_with_event(
             execution: event.execution,
         },
         Event::ChannelCreate(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             let channel = event.channel;
             if channel.base.kind == ChannelType::Category {
@@ -131,7 +136,7 @@ fn update_cache_with_event(
             }
         },
         Event::ChannelDelete(event) => {
-            let cached_messages = if_cache!(update_cache!(&ctx.cache, event));
+            let cached_messages = if_cache!(update_cache!(cache, event));
 
             let channel = event.channel;
             if channel.base.kind == ChannelType::Category {
@@ -149,7 +154,7 @@ fn update_cache_with_event(
             pin: event,
         },
         Event::ChannelUpdate(event) => {
-            let old_channel = if_cache!(update_cache!(&ctx.cache, event));
+            let old_channel = if_cache!(update_cache!(cache, event));
 
             FullEvent::ChannelUpdate {
                 old: old_channel,
@@ -169,11 +174,10 @@ fn update_cache_with_event(
             unbanned_user: event.user,
         },
         Event::GuildCreate(event) => {
-            let is_new =
-                if_cache!(Some(!&ctx.cache.unavailable_guilds().contains(&event.guild.id)));
+            let is_new = if_cache!(Some(is_guild_new(cache, event.guild.id)));
 
             #[cfg(feature = "cache")]
-            if let Some(guilds) = update_cache!(&ctx.cache, event) {
+            if let Some(guilds) = update_cache!(cache, event) {
                 *extra_event = Some(FullEvent::CacheReady {
                     guilds,
                 });
@@ -185,7 +189,7 @@ fn update_cache_with_event(
             }
         },
         Event::GuildDelete(event) => {
-            let full = if_cache!(update_cache!(&ctx.cache, event));
+            let full = if_cache!(update_cache!(cache, event));
 
             FullEvent::GuildDelete {
                 incomplete: event.guild,
@@ -193,7 +197,7 @@ fn update_cache_with_event(
             }
         },
         Event::GuildEmojisUpdate(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::GuildEmojisUpdate {
                 guild_id: event.guild_id,
@@ -204,14 +208,14 @@ fn update_cache_with_event(
             guild_id: event.guild_id,
         },
         Event::GuildMemberAdd(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::GuildMemberAddition {
                 new_member: event.member,
             }
         },
         Event::GuildMemberRemove(event) => {
-            let member = if_cache!(update_cache!(&ctx.cache, event));
+            let member = if_cache!(update_cache!(cache, event));
 
             FullEvent::GuildMemberRemoval {
                 guild_id: event.guild_id,
@@ -220,11 +224,9 @@ fn update_cache_with_event(
             }
         },
         Event::GuildMemberUpdate(event) => {
-            let before = if_cache!(update_cache!(&ctx.cache, event));
+            let before = if_cache!(update_cache!(cache, event));
             let after = if_cache!(
-                ctx.cache
-                    .guild(event.guild_id)
-                    .and_then(|g| g.members.get(&event.user.id).cloned())
+                cache.guild(event.guild_id).and_then(|g| g.members.get(&event.user.id).cloned())
             );
 
             FullEvent::GuildMemberUpdate {
@@ -234,21 +236,21 @@ fn update_cache_with_event(
             }
         },
         Event::GuildMembersChunk(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::GuildMembersChunk {
                 chunk: event,
             }
         },
         Event::GuildRoleCreate(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::GuildRoleCreate {
                 new: event.role,
             }
         },
         Event::GuildRoleDelete(event) => {
-            let role = if_cache!(update_cache!(&ctx.cache, event));
+            let role = if_cache!(update_cache!(cache, event));
 
             FullEvent::GuildRoleDelete {
                 guild_id: event.guild_id,
@@ -257,7 +259,7 @@ fn update_cache_with_event(
             }
         },
         Event::GuildRoleUpdate(event) => {
-            let before = if_cache!(update_cache!(&ctx.cache, event));
+            let before = if_cache!(update_cache!(cache, event));
 
             FullEvent::GuildRoleUpdate {
                 old_data_if_available: before,
@@ -265,7 +267,7 @@ fn update_cache_with_event(
             }
         },
         Event::GuildStickersUpdate(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::GuildStickersUpdate {
                 guild_id: event.guild_id,
@@ -273,7 +275,7 @@ fn update_cache_with_event(
             }
         },
         Event::GuildUpdate(event) => {
-            let before = if_cache!(ctx.cache.guild(event.guild.id).map(|g| g.clone()));
+            let before = if_cache!(cache.guild(event.guild.id).map(|g| g.clone()));
 
             FullEvent::GuildUpdate {
                 old_data_if_available: before,
@@ -287,7 +289,7 @@ fn update_cache_with_event(
             data: event,
         },
         Event::MessageCreate(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::Message {
                 new_message: event.message,
@@ -304,7 +306,7 @@ fn update_cache_with_event(
             guild_id: event.guild_id,
         },
         Event::MessageUpdate(event) => {
-            let before = if_cache!(update_cache!(&ctx.cache, event));
+            let before = if_cache!(update_cache!(cache, event));
 
             FullEvent::MessageUpdate {
                 old_if_available: before,
@@ -312,7 +314,7 @@ fn update_cache_with_event(
             }
         },
         Event::PresenceUpdate(event) => {
-            let old_data = if_cache!(update_cache!(&ctx.cache, event));
+            let old_data = if_cache!(update_cache!(cache, event));
 
             FullEvent::PresenceUpdate {
                 old_data,
@@ -320,7 +322,7 @@ fn update_cache_with_event(
             }
         },
         Event::ReactionAdd(event) => {
-            let old_message_if_available = if_cache!(update_cache!(&ctx.cache, event));
+            let old_message_if_available = if_cache!(update_cache!(cache, event));
 
             FullEvent::ReactionAdd {
                 add_reaction: event.reaction,
@@ -328,7 +330,7 @@ fn update_cache_with_event(
             }
         },
         Event::ReactionRemove(event) => {
-            let old_message_if_available = if_cache!(update_cache!(&ctx.cache, event));
+            let old_message_if_available = if_cache!(update_cache!(cache, event));
 
             FullEvent::ReactionRemove {
                 removed_reaction: event.reaction,
@@ -336,7 +338,7 @@ fn update_cache_with_event(
             }
         },
         Event::ReactionRemoveAll(event) => {
-            let old_message_if_available = if_cache!(update_cache!(&ctx.cache, event));
+            let old_message_if_available = if_cache!(update_cache!(cache, event));
 
             FullEvent::ReactionRemoveAll {
                 guild_id: event.guild_id,
@@ -346,7 +348,7 @@ fn update_cache_with_event(
             }
         },
         Event::ReactionRemoveEmoji(event) => {
-            let old_message_if_available = if_cache!(update_cache!(&ctx.cache, event));
+            let old_message_if_available = if_cache!(update_cache!(cache, event));
 
             FullEvent::ReactionRemoveEmoji {
                 removed_reactions: event.reaction,
@@ -355,7 +357,7 @@ fn update_cache_with_event(
         },
         Event::Ready(event) => {
             #[cfg(feature = "cache")]
-            if let Some(total_shards) = update_cache!(&ctx.cache, event) {
+            if let Some(total_shards) = update_cache!(cache, event) {
                 *extra_event = Some(FullEvent::ShardsReady {
                     total_shards,
                 });
@@ -387,7 +389,7 @@ fn update_cache_with_event(
             event,
         },
         Event::UserUpdate(event) => {
-            let before = if_cache!(update_cache!(&ctx.cache, event));
+            let before = if_cache!(update_cache!(cache, event));
 
             FullEvent::UserUpdate {
                 old_data: before,
@@ -398,7 +400,7 @@ fn update_cache_with_event(
             event,
         },
         Event::VoiceStateUpdate(event) => {
-            let before = if_cache!(update_cache!(&ctx.cache, event));
+            let before = if_cache!(update_cache!(cache, event));
 
             FullEvent::VoiceStateUpdate {
                 old: before,
@@ -406,7 +408,7 @@ fn update_cache_with_event(
             }
         },
         Event::VoiceChannelStatusUpdate(event) => {
-            let old = if_cache!(event.update(&ctx.cache).map(Into::into));
+            let old = if_cache!(event.update(cache).map(Into::into));
 
             FullEvent::VoiceChannelStatusUpdate {
                 old,
@@ -444,7 +446,7 @@ fn update_cache_with_event(
             stage_instance: event.stage_instance,
         },
         Event::ThreadCreate(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::ThreadCreate {
                 thread: event.thread,
@@ -452,7 +454,7 @@ fn update_cache_with_event(
             }
         },
         Event::ThreadUpdate(event) => {
-            let old = if_cache!(update_cache!(&ctx.cache, event));
+            let old = if_cache!(update_cache!(cache, event));
 
             FullEvent::ThreadUpdate {
                 old,
@@ -460,7 +462,7 @@ fn update_cache_with_event(
             }
         },
         Event::ThreadDelete(event) => {
-            let full_thread_data = if_cache!(update_cache!(&ctx.cache, event));
+            let full_thread_data = if_cache!(update_cache!(cache, event));
 
             FullEvent::ThreadDelete {
                 thread: event.thread,
@@ -468,7 +470,7 @@ fn update_cache_with_event(
             }
         },
         Event::ThreadListSync(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::ThreadListSync {
                 thread_list_sync: event,
@@ -481,21 +483,21 @@ fn update_cache_with_event(
             thread_members_update: event,
         },
         Event::GuildScheduledEventCreate(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::GuildScheduledEventCreate {
                 event: event.event,
             }
         },
         Event::GuildScheduledEventUpdate(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::GuildScheduledEventUpdate {
                 event: event.event,
             }
         },
         Event::GuildScheduledEventDelete(event) => {
-            update_cache!(&ctx.cache, event);
+            update_cache!(cache, event);
 
             FullEvent::GuildScheduledEventDelete {
                 event: event.event,
@@ -525,5 +527,209 @@ fn update_cache_with_event(
         Event::ShardStageUpdate(event) => FullEvent::ShardStageUpdate {
             event,
         },
+    }
+}
+
+#[cfg(all(test, feature = "cache"))]
+mod tests {
+    use extract_map::ExtractMap;
+    use small_fixed_array::{FixedArray, FixedString};
+
+    use super::is_guild_new;
+    use crate::all::dispatch::update_cache_with_event;
+    use crate::all::{
+        ApplicationFlags,
+        ApplicationId,
+        Cache,
+        CurrentUser,
+        DefaultMessageNotificationLevel,
+        Event,
+        ExplicitContentFilter,
+        FullEvent,
+        Guild,
+        GuildCreateEvent,
+        GuildGeneratedFlags,
+        GuildId,
+        MfaLevel,
+        NsfwLevel,
+        PartialCurrentApplicationInfo,
+        PremiumTier,
+        Ready,
+        ReadyEvent,
+        SystemChannelFlags,
+        Timestamp,
+        UnavailableGuild,
+        UserId,
+        VerificationLevel,
+    };
+
+    #[test]
+    fn guild_is_new() {
+        let cache = Cache::new();
+
+        let guild_id = GuildId::new(1);
+        let event = Event::Ready(ReadyEvent {
+            ready: Ready {
+                version: 0,
+                user: CurrentUser::default(),
+                guilds: FixedArray::from_vec_trunc(vec![UnavailableGuild {
+                    id: guild_id,
+                    unavailable: true,
+                }]),
+                session_id: FixedString::new(),
+                resume_gateway_url: FixedString::new(),
+                shard: None,
+                application: PartialCurrentApplicationInfo {
+                    id: ApplicationId::new(1),
+                    flags: ApplicationFlags::default(),
+                },
+            },
+        });
+
+        assert_eq!(cache.unavailable_guilds().len(), 0);
+
+        assert!(is_guild_new(&cache, guild_id));
+
+        let mut extra_event = None;
+        update_cache_with_event(&cache, event, &mut extra_event);
+
+        assert_eq!(cache.unavailable_guilds().len(), 1);
+        assert!(!is_guild_new(&cache, guild_id));
+
+        let event = Event::GuildCreate(GuildCreateEvent {
+            guild: Guild {
+                __generated_flags: GuildGeneratedFlags::default(),
+                id: guild_id,
+                name: FixedString::new(),
+                icon: None,
+                icon_hash: None,
+                splash: None,
+                discovery_splash: None,
+                owner_id: UserId::new(1),
+                afk_metadata: None,
+                widget_channel_id: None,
+                verification_level: VerificationLevel::None,
+                default_message_notifications: DefaultMessageNotificationLevel::Mentions,
+                explicit_content_filter: ExplicitContentFilter::None,
+                roles: ExtractMap::new(),
+                emojis: ExtractMap::new(),
+                features: FixedArray::new(),
+                mfa_level: MfaLevel::None,
+                application_id: None,
+                system_channel_id: None,
+                system_channel_flags: SystemChannelFlags::default(),
+                rules_channel_id: None,
+                max_presences: None,
+                max_members: None,
+                vanity_url_code: None,
+                description: None,
+                banner: None,
+                premium_tier: PremiumTier::Tier0,
+                premium_subscription_count: None,
+                preferred_locale: FixedString::new(),
+                public_updates_channel_id: None,
+                max_video_channel_users: None,
+                max_stage_video_channel_users: None,
+                approximate_member_count: None,
+                approximate_presence_count: None,
+                welcome_screen: None,
+                nsfw_level: NsfwLevel::Default,
+                stickers: ExtractMap::new(),
+                joined_at: Timestamp::now(),
+                channels: ExtractMap::new(),
+                member_count: 0,
+                members: ExtractMap::new(),
+                incidents_data: None,
+                presences: ExtractMap::new(),
+                safety_alerts_channel_id: None,
+                scheduled_events: ExtractMap::new(),
+                stage_instances: FixedArray::new(),
+                threads: ExtractMap::new(),
+                voice_states: ExtractMap::new(),
+            },
+        });
+
+        assert_eq!(cache.unavailable_guilds().len(), 1);
+
+        assert!(!is_guild_new(&cache, guild_id));
+
+        let full_event = update_cache_with_event(&cache, event, &mut extra_event);
+
+        assert!(matches!(full_event, FullEvent::GuildCreate {
+            is_new: Some(false),
+            ..
+        }));
+
+        assert_eq!(cache.unavailable_guilds().len(), 0);
+
+        assert!(is_guild_new(&cache, guild_id));
+
+        let guild_id2 = GuildId::new(2);
+
+        let event = Event::GuildCreate(GuildCreateEvent {
+            guild: Guild {
+                __generated_flags: GuildGeneratedFlags::default(),
+                id: guild_id2,
+                name: FixedString::new(),
+                icon: None,
+                icon_hash: None,
+                splash: None,
+                discovery_splash: None,
+                owner_id: UserId::new(1),
+                afk_metadata: None,
+                widget_channel_id: None,
+                verification_level: VerificationLevel::None,
+                default_message_notifications: DefaultMessageNotificationLevel::Mentions,
+                explicit_content_filter: ExplicitContentFilter::None,
+                roles: ExtractMap::new(),
+                emojis: ExtractMap::new(),
+                features: FixedArray::new(),
+                mfa_level: MfaLevel::None,
+                application_id: None,
+                system_channel_id: None,
+                system_channel_flags: SystemChannelFlags::default(),
+                rules_channel_id: None,
+                max_presences: None,
+                max_members: None,
+                vanity_url_code: None,
+                description: None,
+                banner: None,
+                premium_tier: PremiumTier::Tier0,
+                premium_subscription_count: None,
+                preferred_locale: FixedString::new(),
+                public_updates_channel_id: None,
+                max_video_channel_users: None,
+                max_stage_video_channel_users: None,
+                approximate_member_count: None,
+                approximate_presence_count: None,
+                welcome_screen: None,
+                nsfw_level: NsfwLevel::Default,
+                stickers: ExtractMap::new(),
+                joined_at: Timestamp::now(),
+                channels: ExtractMap::new(),
+                member_count: 0,
+                members: ExtractMap::new(),
+                incidents_data: None,
+                presences: ExtractMap::new(),
+                safety_alerts_channel_id: None,
+                scheduled_events: ExtractMap::new(),
+                stage_instances: FixedArray::new(),
+                threads: ExtractMap::new(),
+                voice_states: ExtractMap::new(),
+            },
+        });
+
+        assert_eq!(cache.unavailable_guilds().len(), 0);
+
+        let full_event = update_cache_with_event(&cache, event, &mut extra_event);
+
+        assert!(matches!(full_event, FullEvent::GuildCreate {
+            is_new: Some(true),
+            ..
+        }));
+
+        assert_eq!(cache.unavailable_guilds().len(), 0);
+
+        assert!(is_guild_new(&cache, guild_id2));
     }
 }

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -48,8 +48,8 @@ pub(crate) async fn dispatch_model(
         raw_handler.raw_event(context.clone(), &event).await;
     }
 
-    let extra_event = get_virtual_event(&context, &event);
-    let full_event = update_cache_with_event(&context, event);
+    let mut extra_event: Option<FullEvent> = None;
+    let full_event = update_cache_with_event(&context, event, &mut extra_event);
 
     spawn_named("dispatch::user", async move {
         #[cfg(feature = "framework")]
@@ -95,7 +95,11 @@ async fn dispatch_event_handler(
 }
 
 /// Updates the cache with the incoming event data and builds the full event data out of it.
-fn update_cache_with_event(ctx: &Context, event: Event) -> FullEvent {
+fn update_cache_with_event(
+    ctx: &Context,
+    event: Event,
+    extra_event: &mut Option<FullEvent>,
+) -> FullEvent {
     match event {
         Event::CommandPermissionsUpdate(event) => FullEvent::CommandPermissionsUpdate {
             permission: event.permission,
@@ -167,6 +171,13 @@ fn update_cache_with_event(ctx: &Context, event: Event) -> FullEvent {
         Event::GuildCreate(event) => {
             let is_new =
                 if_cache!(Some(!&ctx.cache.unavailable_guilds().contains(&event.guild.id)));
+
+            #[cfg(feature = "cache")]
+            if let Some(guilds) = update_cache!(&ctx.cache, event) {
+                *extra_event = Some(FullEvent::CacheReady {
+                    guilds,
+                });
+            }
 
             FullEvent::GuildCreate {
                 guild: event.guild,
@@ -342,8 +353,17 @@ fn update_cache_with_event(ctx: &Context, event: Event) -> FullEvent {
                 old_message_if_available,
             }
         },
-        Event::Ready(event) => FullEvent::Ready {
-            data_about_bot: event.ready,
+        Event::Ready(event) => {
+            #[cfg(feature = "cache")]
+            if let Some(total_shards) = update_cache!(&ctx.cache, event) {
+                *extra_event = Some(FullEvent::ShardsReady {
+                    total_shards,
+                });
+            }
+
+            FullEvent::Ready {
+                data_about_bot: event.ready,
+            }
         },
         Event::Resumed(event) => FullEvent::Resume {
             event,
@@ -506,29 +526,4 @@ fn update_cache_with_event(ctx: &Context, event: Event) -> FullEvent {
             event,
         },
     }
-}
-
-fn get_virtual_event(ctx: &Context, event: &Event) -> Option<FullEvent> {
-    match event {
-        Event::GuildCreate(event) =>
-        {
-            #[cfg(feature = "cache")]
-            if let Some(guilds) = update_cache!(&ctx.cache, event) {
-                return Some(FullEvent::CacheReady {
-                    guilds,
-                });
-            }
-        },
-        Event::Ready(event) =>
-        {
-            #[cfg(feature = "cache")]
-            if let Some(total_shards) = update_cache!(&ctx.cache, event) {
-                return Some(FullEvent::ShardsReady {
-                    total_shards,
-                });
-            }
-        },
-        _ => {},
-    }
-    None
 }

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -2,14 +2,15 @@ use std::sync::Arc;
 
 use super::event_handler::{EventHandler, RawEventHandler};
 use super::{Context, FullEvent};
-use crate::all::{Cache, GuildId};
 #[cfg(feature = "cache")]
-use crate::cache::CacheUpdate;
+use crate::cache::{Cache, CacheUpdate};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
 use crate::internal::tokio::spawn_named;
 use crate::model::channel::ChannelType;
 use crate::model::event::Event;
+#[cfg(feature = "cache")]
+use crate::model::id::GuildId;
 
 #[cfg(feature = "cache")]
 macro_rules! if_cache {
@@ -37,6 +38,24 @@ macro_rules! update_cache {
     ($cache:expr, $event:ident) => {};
 }
 
+#[cfg(feature = "cache")]
+type MaybeCache = Cache;
+
+#[cfg(not(feature = "cache"))]
+type MaybeCache = ();
+
+fn maybe_cache_from_context(ctx: &Context) -> &MaybeCache {
+    #[cfg(feature = "cache")]
+    {
+        &ctx.cache
+    }
+
+    #[cfg(not(feature = "cache"))]
+    {
+        &()
+    }
+}
+
 /// Calls the user's event handlers and the framework handler.
 pub(crate) async fn dispatch_model(
     event: Event,
@@ -50,7 +69,8 @@ pub(crate) async fn dispatch_model(
     }
 
     let mut extra_event = None;
-    let full_event = update_cache_with_event(&context.cache, event, &mut extra_event);
+    let full_event =
+        update_cache_with_event(maybe_cache_from_context(&context), event, &mut extra_event);
 
     spawn_named("dispatch::user", async move {
         #[cfg(feature = "framework")]
@@ -95,13 +115,14 @@ async fn dispatch_event_handler(
     }
 }
 
+#[cfg(feature = "cache")]
 fn is_guild_new(cache: &Cache, guild_id: GuildId) -> bool {
     !cache.unavailable_guilds().contains(&guild_id)
 }
 
 /// Updates the cache with the incoming event data and builds the full event data out of it.
 fn update_cache_with_event(
-    cache: &Cache,
+    cache: &MaybeCache,
     event: Event,
     extra_event: &mut Option<FullEvent>,
 ) -> FullEvent {

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -48,7 +48,7 @@ pub(crate) async fn dispatch_model(
         raw_handler.raw_event(context.clone(), &event).await;
     }
 
-    let mut extra_event: Option<FullEvent> = None;
+    let mut extra_event = None;
     let full_event = update_cache_with_event(&context, event, &mut extra_event);
 
     spawn_named("dispatch::user", async move {


### PR DESCRIPTION
Regression introduced in https://github.com/serenity-rs/serenity/pull/3457.

The `is_new` parameter indicates whether the guild notified by `GUILD_CREATE` is a brand new guild that the bot has just joined, or an existing one that it was in already. #3457 separated out the virtual event `CacheReady` for clarity, but this broke the parameter since to tell whether a guild is new or old it checks the list of unavailable guilds supplied from the `READY` event. When a `GUILD_CREATE` is received, the guild is removed from this list. The parameter was being calculated after the guild had already been removed from the list.

This merges the virtual events back as they were before in order to precisely control when the cache gets updated.