### PR TITLE
Move dispatch back into per-shard tasks for better performance

### DIFF
--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -6,6 +6,8 @@ use super::{Context, FullEvent};
 use crate::cache::{Cache, CacheUpdate};
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
+#[cfg(feature = "voice")]
+use crate::gateway::VoiceGatewayManager;
 use crate::internal::tokio::spawn_named;
 use crate::model::channel::ChannelType;
 use crate::model::event::Event;
@@ -56,32 +58,88 @@ fn maybe_cache_from_context(ctx: &Context) -> &MaybeCache {
     }
 }
 
-/// Calls the user's event handlers and the framework handler.
-pub(crate) async fn dispatch_model(
-    event: Event,
-    context: Context,
-    #[cfg(feature = "framework")] framework: Option<Arc<dyn Framework>>,
-    event_handler: Option<Arc<dyn EventHandler>>,
-    raw_event_handler: Option<Arc<dyn RawEventHandler>>,
-) {
-    if let Some(raw_handler) = raw_event_handler {
-        raw_handler.raw_event(context.clone(), &event).await;
+pub struct EventDispatcher {
+    pub context: Context,
+    pub event_handler: Option<Arc<dyn EventHandler>>,
+    pub raw_event_handler: Option<Arc<dyn RawEventHandler>>,
+    #[cfg(feature = "framework")]
+    pub framework: Option<Arc<dyn Framework>>,
+    #[cfg(feature = "voice")]
+    pub voice_manager: Option<Arc<dyn VoiceGatewayManager + 'static>>,
+}
+
+impl EventDispatcher {
+    pub async fn dispatch(&self, event: Event) {
+        #[cfg(feature = "voice")]
+        {
+            if let Some(voice_manager) = &self.voice_manager {
+                match &event {
+                    Event::Ready(_) => {
+                        voice_manager
+                            .register_shard(self.context.shard_id.0, self.context.shard.clone())
+                            .await;
+                    },
+                    Event::VoiceServerUpdate(event) => {
+                        voice_manager
+                            .server_update(event.guild_id, event.endpoint.as_deref(), &event.token)
+                            .await;
+                    },
+                    Event::VoiceStateUpdate(event) => {
+                        if let Some(guild_id) = event.voice_state.guild_id {
+                            voice_manager.state_update(guild_id, &event.voice_state).await;
+                        }
+                    },
+                    _ => {},
+                }
+            }
+        }
+
+        if self
+            .event_handler
+            .as_ref()
+            .is_none_or(|handler| handler.filter_event(&self.context, &event))
+            && self
+                .raw_event_handler
+                .as_ref()
+                .is_none_or(|handler| handler.filter_event(&self.context, &event))
+        {
+            #[cfg(feature = "collector")]
+            self.context.collectors.write().retain(|callback| (callback.0)(&event));
+
+            if let Some(raw_handler) = &self.raw_event_handler {
+                raw_handler.raw_event(self.context.clone(), &event).await;
+            }
+
+            let mut extra_event = None;
+            let full_event = update_cache_with_event(
+                maybe_cache_from_context(&self.context),
+                event,
+                &mut extra_event,
+            );
+
+            #[cfg(feature = "framework")]
+            let framework = self.framework.clone();
+            let event_handler = self.event_handler.clone();
+            let context = self.context.clone();
+
+            spawn_named("dispatch::user", async move {
+                #[cfg(feature = "framework")]
+                tokio::join!(
+                    dispatch_framework(&context, framework, &full_event, extra_event.as_ref()),
+                    dispatch_event_handler(
+                        &context,
+                        event_handler,
+                        &full_event,
+                        extra_event.as_ref()
+                    )
+                );
+
+                #[cfg(not(feature = "framework"))]
+                dispatch_event_handler(&context, event_handler, &full_event, extra_event.as_ref())
+                    .await;
+            });
+        }
     }
-
-    let mut extra_event = None;
-    let full_event =
-        update_cache_with_event(maybe_cache_from_context(&context), event, &mut extra_event);
-
-    spawn_named("dispatch::user", async move {
-        #[cfg(feature = "framework")]
-        tokio::join!(
-            dispatch_framework(&context, framework, &full_event, extra_event.as_ref()),
-            dispatch_event_handler(&context, event_handler, &full_event, extra_event.as_ref())
-        );
-
-        #[cfg(not(feature = "framework"))]
-        dispatch_event_handler(&context, event_handler, &full_event, extra_event.as_ref()).await;
-    });
 }
 
 #[cfg(feature = "framework")]

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -26,17 +26,14 @@ use super::{
 use crate::cache::Cache;
 #[cfg(feature = "framework")]
 use crate::framework::Framework;
-#[cfg(feature = "collector")]
-use crate::gateway::CollectorCallback;
 #[cfg(feature = "voice")]
 use crate::gateway::VoiceGatewayManager;
-use crate::gateway::client::dispatch::dispatch_model;
+use crate::gateway::client::dispatch::EventDispatcher;
 use crate::gateway::client::{Context, EventHandler, RawEventHandler};
 use crate::gateway::{GatewayError, PresenceData, TransportCompression};
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
-use crate::model::event::Event;
 use crate::model::gateway::{ConnectionStage, GatewayIntents};
 
 /// The default time to wait between starting each shard or set of shards.
@@ -169,9 +166,6 @@ impl ShardManager {
                         }
                         self.queue_for_start(shard_id);
                     },
-                    ShardManagerMessage::DispatchEvent(shard_id, event) => {
-                        self.dispatch_event(shard_id, *event).await;
-                    },
                     ShardManagerMessage::Quit(res) => return res,
                 }
             }
@@ -260,83 +254,39 @@ impl ShardManager {
 
         self.runners.insert(shard_id, ShardRunnerMetadata {
             info: Arc::clone(&runner_info),
-            tx: runner_tx,
-            #[cfg(feature = "collector")]
-            collectors: Arc::default(),
+            tx: runner_tx.clone(),
         });
+
+        let dispatcher = EventDispatcher {
+            context: Context {
+                data: Arc::clone(&self.data),
+                shard: runner_tx,
+                runner_info,
+                manager: self.manager_tx.clone(),
+                shard_id,
+                http: Arc::clone(&self.http),
+                #[cfg(feature = "cache")]
+                cache: Arc::clone(&self.cache),
+                #[cfg(feature = "collector")]
+                collectors: Arc::default(),
+            },
+            event_handler: self.event_handler.clone(),
+            raw_event_handler: self.raw_event_handler.clone(),
+            #[cfg(feature = "framework")]
+            framework: self.framework.get().cloned(),
+            #[cfg(feature = "voice")]
+            voice_manager: self.voice_manager.clone(),
+        };
 
         let mut runner = ShardRunner {
             manager_tx: self.manager_tx.clone(),
             runner_rx,
             shard,
-            runner_info,
+            dispatcher,
         };
         spawn_named("shard_runner::run", async move { runner.run().await });
 
         Ok(())
-    }
-
-    async fn dispatch_event(&self, shard_id: ShardId, event: Event) {
-        let Some(entry) = self.runners.get(&shard_id) else {
-            return;
-        };
-
-        let runner = entry.value();
-
-        #[cfg(feature = "voice")]
-        {
-            if let Some(voice_manager) = &self.voice_manager {
-                match &event {
-                    Event::Ready(_) => {
-                        voice_manager.register_shard(shard_id.0, runner.tx.clone()).await;
-                    },
-                    Event::VoiceServerUpdate(event) => {
-                        voice_manager
-                            .server_update(event.guild_id, event.endpoint.as_deref(), &event.token)
-                            .await;
-                    },
-                    Event::VoiceStateUpdate(event) => {
-                        if let Some(guild_id) = event.voice_state.guild_id {
-                            voice_manager.state_update(guild_id, &event.voice_state).await;
-                        }
-                    },
-                    _ => {},
-                }
-            }
-        }
-
-        let context = Context {
-            data: Arc::clone(&self.data),
-            shard: runner.tx.clone(),
-            runner_info: Arc::clone(&runner.info),
-            manager: self.manager_tx.clone(),
-            shard_id,
-            http: Arc::clone(&self.http),
-            #[cfg(feature = "cache")]
-            cache: Arc::clone(&self.cache),
-            #[cfg(feature = "collector")]
-            collectors: Arc::clone(&runner.collectors),
-        };
-
-        if self.event_handler.as_ref().is_none_or(|handler| handler.filter_event(&context, &event))
-            && self
-                .raw_event_handler
-                .as_ref()
-                .is_none_or(|handler| handler.filter_event(&context, &event))
-        {
-            #[cfg(feature = "collector")]
-            runner.collectors.write().retain(|callback| (callback.0)(&event));
-
-            dispatch_model(
-                event,
-                context,
-                #[cfg(feature = "framework")]
-                self.framework.get().cloned(),
-                self.event_handler.clone(),
-                self.raw_event_handler.clone(),
-            )
-            .await;
-        }
     }
 
     /// Returns the gateway intents used for this gateway connection.
@@ -394,8 +344,6 @@ pub enum ShardManagerMessage {
     /// the queue is operating in concurrent mode (in order to start multiple shards at once),
     /// the shard is not guaranteed to immediately start, until more shards are queued.
     RestartShard(ShardId),
-    /// Indicates that the manager should dispatch an event to the client.
-    DispatchEvent(ShardId, Box<Event>),
     /// Indicates that a shard runner encountered a fatal error and the shard manager should quit.
     Quit(Result<(), GatewayError>),
 }
@@ -406,6 +354,4 @@ pub struct ShardRunnerMetadata {
     pub info: Arc<RwLock<ShardRunnerInfo>>,
     /// A channel for sending messages to the [`ShardRunner`].
     pub tx: Sender<ShardRunnerMessage>,
-    #[cfg(feature = "collector")]
-    collectors: Arc<RwLock<Vec<CollectorCallback>>>,
 }

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -1,18 +1,16 @@
-use std::sync::Arc;
-
 use futures::channel::mpsc::{
     TryRecvError,
     UnboundedReceiver as Receiver,
     UnboundedSender as Sender,
 };
-use parking_lot::RwLock;
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 #[cfg(feature = "tracing_instrument")]
 use tracing::instrument;
 use tracing::{debug, error, trace, warn};
 
-use super::{Shard, ShardAction, ShardManagerMessage, ShardRunnerInfo};
+use super::{Shard, ShardAction, ShardManagerMessage};
+use crate::gateway::client::dispatch::EventDispatcher;
 use crate::gateway::{ActivityData, ChunkGuildFilter, GatewayError};
 use crate::internal::prelude::*;
 use crate::model::event::{Event, GatewayEvent, ShardStageUpdateEvent};
@@ -28,7 +26,7 @@ pub struct ShardRunner {
     // Channel to receive messages from both the shard manager and dispatches
     pub(crate) runner_rx: Receiver<ShardRunnerMessage>,
     pub(crate) shard: Shard,
-    pub(crate) runner_info: Arc<RwLock<ShardRunnerInfo>>,
+    pub(crate) dispatcher: EventDispatcher,
 }
 
 impl ShardRunner {
@@ -93,11 +91,13 @@ impl ShardRunner {
 
             if post != pre {
                 self.update_runner_info();
-                self.dispatch(Box::new(Event::ShardStageUpdate(ShardStageUpdateEvent {
-                    new: post,
-                    old: pre,
-                    shard_id: self.shard.shard_info().id,
-                })));
+                self.dispatcher
+                    .dispatch(Event::ShardStageUpdate(ShardStageUpdateEvent {
+                        new: post,
+                        old: pre,
+                        shard_id: self.shard.shard_info().id,
+                    }))
+                    .await;
             }
 
             if let Some(action) = action {
@@ -131,23 +131,11 @@ impl ShardRunner {
                             }
                         }
                     },
-                    ShardAction::Dispatch(event) => self.dispatch(event),
+                    ShardAction::Dispatch(event) => self.dispatcher.dispatch(*event).await,
                 }
             }
 
             trace!("[ShardRunner {:?}] loop iteration reached the end.", self.shard.shard_info());
-        }
-    }
-
-    #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
-    fn dispatch(&self, event: Box<Event>) {
-        let shard_info = self.shard.shard_info();
-        if let Err(why) =
-            self.manager_tx.unbounded_send(ShardManagerMessage::DispatchEvent(shard_info.id, event))
-        {
-            warn!(
-                "[ShardRunner {shard_info:?}] Failed to send event to shard manager for dispatch: {why:?}",
-            );
         }
     }
 
@@ -338,7 +326,7 @@ impl ShardRunner {
 
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     fn update_runner_info(&self) {
-        let mut runner_info = self.runner_info.write();
+        let mut runner_info = self.dispatcher.context.runner_info.write();
         runner_info.latency = self.shard.heartbeat_latency();
         runner_info.stage = self.shard.stage();
     }


### PR DESCRIPTION
Supersedes #3506 as a follow-up to #3493.

Removes responsibility for dispatch from the `ShardManager`, as spawning all dispatch tasks from a single thread can bottleneck performance for bots connected to many shards at once. In order to avoid adding back all the previously factored-out fields of `ShardRunner`, we put them in a new `EventDispatcher` struct to which event dispatch is delegated.