### PR TITLE
Reduce type size of Emoji/User

### DIFF
--- a/src/model/application/interaction.rs
+++ b/src/model/application/interaction.rs
@@ -475,7 +475,6 @@ pub struct MessageModalSubmitInteractionMetadata {
 
 /// Metadata about the interaction, including the source of the interaction relevant server and
 /// user IDs.
-#[expect(clippy::large_enum_variant)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -239,10 +239,10 @@ pub enum ReactionType {
         id: EmojiId,
         /// The name of the custom emoji. This is primarily used for decoration and distinguishing
         /// the emoji client-side.
-        name: Option<FixedString>,
+        name: Option<FixedString<u8>>,
     },
     /// A reaction with a twemoji.
-    Unicode(FixedString),
+    Unicode(FixedString<u8>),
 }
 
 // Manual impl needed to decide enum variant by presence of `id`
@@ -253,7 +253,7 @@ impl<'de> Deserialize<'de> for ReactionType {
             #[serde(default)]
             animated: bool,
             id: Option<EmojiId>,
-            name: Option<FixedString>,
+            name: Option<FixedString<u8>>,
         }
         let emoji = PartialEmoji::deserialize(deserializer)?;
         Ok(match (emoji.id, emoji.name) {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -258,9 +258,9 @@ pub struct PresenceUser {
     pub banner: Option<ImageHash>,
     #[serde(rename = "accent_color")]
     pub accent_colour: Option<Colour>,
-    pub locale: Option<FixedString>,
+    pub locale: Option<FixedString<u8>>,
     pub verified: Option<bool>,
-    pub email: Option<FixedString>,
+    pub email: Option<FixedString<u8>>,
     #[serde(default)]
     pub flags: Option<UserPublicFlags>,
     #[serde(default)]
@@ -269,7 +269,7 @@ pub struct PresenceUser {
     pub member: Option<Box<PartialMember>>,
     pub primary_guild: Option<PrimaryGuild>,
     pub avatar_decoration_data: Option<AvatarDecorationData>,
-    pub collectibles: Option<Collectibles>,
+    pub collectibles: Collectibles,
     // TODO: should really go over these fields at some point and check them.
 }
 

--- a/src/model/guild/emoji.rs
+++ b/src/model/guild/emoji.rs
@@ -23,7 +23,7 @@ pub struct Emoji {
     pub id: EmojiId,
     /// The name of the emoji. It must be at least 2 characters long and can only contain
     /// alphanumeric characters and underscores.
-    pub name: FixedString,
+    pub name: FixedString<u8>,
     /// Whether the emoji is managed via an [`Integration`] service.
     ///
     /// [`Integration`]: super::Integration
@@ -37,7 +37,7 @@ pub struct Emoji {
     ///
     /// [`Role`]: super::Role
     #[serde(default)]
-    pub roles: FixedArray<RoleId>,
+    pub roles: FixedArray<RoleId, u8>,
     /// The user who created the emoji.
     pub user: Option<User>,
 }

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -169,7 +169,7 @@ pub struct EmojiIdentifier {
     pub id: EmojiId,
     /// The name of the emoji. It must be at least 2 characters long and can only contain
     /// alphanumeric characters and underscores.
-    pub name: FixedString,
+    pub name: FixedString<u8>,
 }
 
 #[cfg(all(feature = "model", feature = "utils"))]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -261,7 +261,7 @@ pub struct User {
     #[serde(rename = "accent_color")]
     pub accent_colour: Option<Colour>,
     /// The user's chosen language option
-    pub locale: Option<FixedString>,
+    pub locale: Option<FixedString<u8>>,
     /// Whether the email on this account has been verified
     ///
     /// Requires [`Scope::Email`]
@@ -269,7 +269,7 @@ pub struct User {
     /// The user's email
     ///
     /// Requires [`Scope::Email`]
-    pub email: Option<FixedString>,
+    pub email: Option<FixedString<u8>>,
     /// The flags on a user's account
     #[serde(default)]
     pub flags: UserPublicFlags,
@@ -291,7 +291,8 @@ pub struct User {
     pub avatar_decoration_data: Option<AvatarDecorationData>,
     /// The collectibles the user currently has active, excluding avatar decorations and profile
     /// effects.
-    pub collectibles: Option<Collectibles>,
+    #[serde(default)]
+    pub collectibles: Collectibles,
 }
 
 impl ExtractKey<UserId> for User {
@@ -375,7 +376,7 @@ pub struct PrimaryGuild {
     /// system clears the identity, e.g. because the server no longer supports tags.
     pub identity_enabled: Option<bool>,
     /// The text of the [`User`]'s server tag.
-    pub tag: Option<FixedString>,
+    pub tag: Option<FixedString<u8>>,
     /// The hash of the server badge.
     pub badge: Option<ImageHash>,
 }
@@ -415,11 +416,11 @@ impl AvatarDecorationData {
 ///
 /// [Discord docs](https://docs.discord.com/developers/resources/user#collectibles).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Collectibles {
     /// The [`User`]'s nameplate, if they have one.
-    pub nameplate: Option<Nameplate>,
+    pub nameplate: Option<Box<Nameplate>>,
 }
 
 /// A nameplate, shown on the member list on official clients.


### PR DESCRIPTION
I'm running into memory usage issues again, so here's the first low hanging fruit:
| Model | Before | After | 
| -- | -- | -- |
| User |232 |184 | 
| Emoji | 272 | 216 |
