### PR TITLE
Add support for editing multiple role positions for given guild

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1900,6 +1900,45 @@ impl Http {
         from_value(value).map_err(From::from)
     }
 
+    /// Edits the positions of a guild's channels.
+    pub async fn edit_roles_positions(&self, guild_id: u64, value: &Value, audit_log_reason: Option<&str>) -> Result<()> {
+        let body = to_vec(value)?;
+
+        // self.wind(204, Request {
+        //     body: Some(&body),
+        //     multipart: None,
+        //     headers: None,
+        //     route: RouteInfo::EditGuildChannels {
+        //         guild_id,
+        //     },
+        // })
+        //     .await
+
+        let mut value = self
+            .request(Request {
+                body: Some(&body),
+                multipart: None,
+                headers: audit_log_reason.map(reason_into_header),
+                route: RouteInfo::EditRolePosition {
+                    guild_id,
+                },
+            })
+            .await?
+            .json::<Value>()
+            .await?;
+
+        if let Some(array) = value.as_array_mut() {
+            for role in array {
+                if let Some(map) = role.as_object_mut() {
+                    map.insert("guild_id".to_string(), from_number(guild_id));
+                }
+            }
+        }
+
+        from_value(value).map_err(From::from)
+
+    }
+
     /// Modifies a scheduled event.
     ///
     /// **Note**: Requires the [Manage Events] permission.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1901,7 +1901,7 @@ impl Http {
     }
 
     /// Edits the positions of a guild's channels.
-    pub async fn edit_roles_positions(&self, guild_id: u64, value: &Value, audit_log_reason: Option<&str>) -> Result<()> {
+    pub async fn edit_roles_positions(&self, guild_id: u64, value: &Value, audit_log_reason: Option<&str>) -> Result<Vec<Role>> {
         let body = to_vec(value)?;
 
         // self.wind(204, Request {
@@ -1938,6 +1938,21 @@ impl Http {
         from_value(value).map_err(From::from)
 
     }
+
+    // /// Edits the positions of a guild's channels.
+    // pub async fn edit_guild_channel_positions(&self, guild_id: u64, value: &Value) -> Result<()> {
+    //     let body = to_vec(value)?;
+    //
+    //     self.wind(204, Request {
+    //         body: Some(&body),
+    //         multipart: None,
+    //         headers: None,
+    //         route: RouteInfo::EditGuildChannels {
+    //             guild_id,
+    //         },
+    //     })
+    //         .await
+    // }
 
     /// Modifies a scheduled event.
     ///

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1758,6 +1758,25 @@ impl Http {
         .await
     }
 
+    /// Reorder roles for the provided [`Guild`] via its Id.
+    pub async fn edit_guild_role_positions(
+        &self,
+        guild_id: u64,
+        value: &Value,
+    ) -> Result<Vec<Role>> {
+        let body = to_vec(value)?;
+
+        self.fire(Request{
+            body: Some(&body),
+            multipart: None,
+            headers: None,
+            route: RouteInfo::EditGuildRolePositions {
+                guild_id
+            }
+        })
+            .await
+    }
+
     /// Follow a News Channel to send messages to a target channel.
     pub async fn follow_news_channel(
         &self,
@@ -1863,7 +1882,7 @@ impl Http {
         from_value(value).map_err(From::from)
     }
 
-    /// Changes the position of a role in a guild.
+    /// Changes the position of a single role in a guild.
     pub async fn edit_role_position(
         &self,
         guild_id: u64,
@@ -1900,19 +1919,13 @@ impl Http {
         from_value(value).map_err(From::from)
     }
 
-    /// Edits the positions of a guild's channels.
+    /// Changes multiple roles positions in a guild.
+    ///
+    /// **Note**: Requires the [Manage Roles] permission.
+    ///
+    /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn edit_roles_positions(&self, guild_id: u64, value: &Value, audit_log_reason: Option<&str>) -> Result<()> {
         let body = to_vec(value)?;
-
-        // self.wind(204, Request {
-        //     body: Some(&body),
-        //     multipart: None,
-        //     headers: None,
-        //     route: RouteInfo::EditGuildChannels {
-        //         guild_id,
-        //     },
-        // })
-        //     .await
 
         let mut value = self
             .request(Request {
@@ -1936,7 +1949,6 @@ impl Http {
         }
 
         from_value(value).map_err(From::from)
-
     }
 
     /// Modifies a scheduled event.

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -461,6 +461,8 @@ pub enum Route {
     ///
     /// [`ChannelId`]: crate::model::id::ChannelId
     StageInstancesChannelId(u64),
+    
+    
     /// Route where no ratelimit headers are in place (i.e. user account-only
     /// routes).
     ///
@@ -1759,6 +1761,9 @@ pub enum RouteInfo<'a> {
         channel_id: u64,
         message_id: u64,
     },
+    EditGuildRolePositions{
+        guild_id: u64,
+    },
 }
 
 impl<'a> RouteInfo<'a> {
@@ -2975,6 +2980,11 @@ impl<'a> RouteInfo<'a> {
                 LightMethod::Delete,
                 Route::ChannelsIdPinsMessageId(channel_id),
                 Cow::from(Route::channel_pin(channel_id, message_id)),
+            ),
+            RouteInfo::EditGuildRolePositions { guild_id } => (
+                LightMethod::Patch,
+                Route::GuildsIdRoles(guild_id),
+                Cow::from(Route::guild_roles(guild_id))
             ),
         }
     }

--- a/src/model/application/interaction/interaction_trait.rs
+++ b/src/model/application/interaction/interaction_trait.rs
@@ -1,0 +1,37 @@
+#[cfg(feature = "http")]
+use crate::builder::{
+    CreateInteractionResponse,
+    EditInteractionResponse,
+};
+#[cfg(feature = "http")]
+use crate::http::Http;
+use crate::internal::prelude::*;
+#[cfg(feature = "http")]
+use crate::model::channel::Message;
+use async_trait::async_trait;
+
+#[async_trait]
+#[cfg(feature = "http")]
+pub trait InteractionResponse {
+    async fn get_interaction_response<'a>(&'a self, http: impl AsRef<Http> + std::marker::Send + std::marker::Sync) -> Result<Message>;
+
+    async fn create_interaction_response<'a, F>(
+        &'a self,
+        http: impl AsRef<Http> + std::marker::Send + std::marker::Sync,
+        f: F,
+    ) -> Result<()>
+        where for<'b> F: FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a> + std::marker::Send;
+
+    async fn edit_original_interaction_response<'a, F>(
+        &'a self,
+        http: impl AsRef<Http> + std::marker::Send + std::marker::Sync,
+        f: F,
+    ) -> Result<Message>
+        where
+            F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse + std::marker::Send;
+
+    async fn delete_original_interaction_response<'a>(&'a self, http: impl AsRef<Http> + std::marker::Send + std::marker::Sync) -> Result<()>;
+
+    async fn defer<'a>(&'a self, http: impl AsRef<Http> + std::marker::Send + std::marker::Sync) -> Result<()>;
+    fn get_locale<'a>(&'a self) -> &str;
+}

--- a/src/model/application/interaction/mod.rs
+++ b/src/model/application/interaction/mod.rs
@@ -3,6 +3,7 @@ pub mod autocomplete;
 pub mod message_component;
 pub mod modal;
 pub mod ping;
+pub mod interaction_trait;
 
 use serde::de::{Deserialize, Deserializer, Error as DeError};
 use serde::ser::{Serialize, Serializer};

--- a/src/model/application/interaction/modal.rs
+++ b/src/model/application/interaction/modal.rs
@@ -24,6 +24,8 @@ use crate::model::id::MessageId;
 use crate::model::id::{ApplicationId, ChannelId, GuildId, InteractionId};
 use crate::model::user::User;
 use crate::model::Permissions;
+use crate::model::prelude::interaction::interaction_trait::InteractionResponse;
+use async_trait::async_trait;
 
 /// An interaction triggered by a modal submit.
 ///
@@ -72,104 +74,6 @@ pub struct ModalSubmitInteraction {
 
 #[cfg(feature = "model")]
 impl ModalSubmitInteraction {
-    /// Gets the interaction response.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Http`] if there is no interaction response.
-    pub async fn get_interaction_response(&self, http: impl AsRef<Http>) -> Result<Message> {
-        http.as_ref().get_original_interaction_response(&self.token).await
-    }
-
-    /// Creates a response to the interaction received.
-    ///
-    /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Model`] if the message content is too long.
-    /// May also return an [`Error::Http`] if the API returns an error,
-    /// or an [`Error::Json`] if there is an error in deserializing the
-    /// API response.
-    pub async fn create_interaction_response<'a, F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<()>
-    where
-        for<'b> F:
-            FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>,
-    {
-        let mut interaction_response = CreateInteractionResponse::default();
-        f(&mut interaction_response);
-
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
-        if interaction_response.1.is_empty() {
-            http.as_ref()
-                .create_interaction_response(self.id.0, &self.token, &Value::from(map))
-                .await
-        } else {
-            http.as_ref()
-                .create_interaction_response_with_files(
-                    self.id.0,
-                    &self.token,
-                    &Value::from(map),
-                    interaction_response.1,
-                )
-                .await
-        }
-    }
-
-    /// Edits the initial interaction response.
-    ///
-    /// `application_id` will usually be the bot's [`UserId`], except in cases of bots being very old.
-    ///
-    /// Refer to Discord's docs for Edit Webhook Message for field information.
-    ///
-    /// **Note**: Message contents must be under 2000 unicode code points.
-    ///
-    /// [`UserId`]: crate::model::id::UserId
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Model`] if the edited content is too long.
-    /// May also return [`Error::Http`] if the API returns an error,
-    /// or an [`Error::Json`] if there is an error deserializing the response.
-    pub async fn edit_original_interaction_response<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> Result<Message>
-    where
-        F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse,
-    {
-        let mut interaction_response = EditInteractionResponse::default();
-        f(&mut interaction_response);
-
-        let map = json::hashmap_to_json_map(interaction_response.0);
-
-        Message::check_content_length(&map)?;
-        Message::check_embed_length(&map)?;
-
-        http.as_ref().edit_original_interaction_response(&self.token, &Value::from(map)).await
-    }
-
-    /// Deletes the initial interaction response.
-    ///
-    /// Does not work on ephemeral messages.
-    ///
-    /// # Errors
-    ///
-    /// May return [`Error::Http`] if the API returns an error.
-    /// Such as if the response was already deleted.
-    pub async fn delete_original_interaction_response(&self, http: impl AsRef<Http>) -> Result<()> {
-        http.as_ref().delete_original_interaction_response(&self.token).await
-    }
-
     /// Creates a followup response to the response sent.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
@@ -246,6 +150,106 @@ impl ModalSubmitInteraction {
     ) -> Result<()> {
         http.as_ref().delete_followup_message(&self.token, message_id.into().into()).await
     }
+}
+
+#[async_trait]
+#[cfg(feature = "http")]
+impl<'m> InteractionResponse for &'m ModalSubmitInteraction {
+    /// Gets the interaction response.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if there is no interaction response.
+    async fn get_interaction_response(&self, http: impl AsRef<Http> + std::marker::Send + std::marker::Sync) -> Result<Message> {
+        http.as_ref().get_original_interaction_response(&self.token).await
+    }
+
+    /// Creates a response to the interaction received.
+    ///
+    /// **Note**: Message contents must be under 2000 unicode code points.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Model`] if the message content is too long.
+    /// May also return an [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error in deserializing the
+    /// API response.
+    async fn create_interaction_response<'a, F>(
+        &'a self,
+        http: impl AsRef<Http> + std::marker::Send + std::marker::Sync,
+        f: F,
+    ) -> Result<()>
+        where
+                for<'b> F:
+        FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a> + std::marker::Send,
+    {
+        let mut interaction_response = CreateInteractionResponse::default();
+        f(&mut interaction_response);
+
+        let map = json::hashmap_to_json_map(interaction_response.0);
+
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
+
+        if interaction_response.1.is_empty() {
+            http.as_ref()
+                .create_interaction_response(self.id.0, &self.token, &Value::from(map))
+                .await
+        } else {
+            http.as_ref()
+                .create_interaction_response_with_files(
+                    self.id.0,
+                    &self.token,
+                    &Value::from(map),
+                    interaction_response.1,
+                )
+                .await
+        }
+    }
+
+    /// Edits the initial interaction response.
+    ///
+    /// `application_id` will usually be the bot's [`UserId`], except in cases of bots being very old.
+    ///
+    /// Refer to Discord's docs for Edit Webhook Message for field information.
+    ///
+    /// **Note**:   Message contents must be under 2000 unicode code points.
+    ///
+    /// [`UserId`]: crate::model::id::UserId
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Model`] if the edited content is too long.
+    /// May also return [`Error::Http`] if the API returns an error,
+    /// or an [`Error::Json`] if there is an error deserializing the response.
+    async fn edit_original_interaction_response<F>(
+        &self,
+        http: impl AsRef<Http> + std::marker::Send + std::marker::Sync,
+        f: F,
+    ) -> Result<Message>
+        where
+            F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse + std::marker::Send,
+    {
+        let mut interaction_response = EditInteractionResponse::default();
+        f(&mut interaction_response);
+
+        let map = json::hashmap_to_json_map(interaction_response.0);
+
+        Message::check_content_length(&map)?;
+        Message::check_embed_length(&map)?;
+
+        http.as_ref().edit_original_interaction_response(&self.token, &Value::from(map)).await
+    }
+
+    /// Deletes the initial interaction response.
+    ///
+    /// # Errors
+    ///
+    /// May return [`Error::Http`] if the API returns an error.
+    /// Such as if the response was already deleted.
+    async fn delete_original_interaction_response(&self, http: impl AsRef<Http> + std::marker::Send + std::marker::Sync) -> Result<()> {
+        http.as_ref().delete_original_interaction_response(&self.token).await
+    }
     /// Helper function to defer an interaction
     ///
     /// # Errors
@@ -253,26 +257,15 @@ impl ModalSubmitInteraction {
     /// May also return an [`Error::Http`] if the API returns an error,
     /// or an [`Error::Json`] if there is an error in deserializing the
     /// API response.
-    pub async fn defer(&self, http: impl AsRef<Http>) -> Result<()> {
+    async fn defer(&self, http: impl AsRef<Http> + std::marker::Send + std::marker::Sync) -> Result<()> {
         self.create_interaction_response(http, |f| {
             f.kind(InteractionResponseType::DeferredUpdateMessage)
         })
-        .await
+            .await
     }
 
-    /// Helper function to defer an interaction ephemerally
-    ///
-    /// # Errors
-    ///
-    /// May also return an [`Error::Http`] if the API returns an error,
-    /// or an [`Error::Json`] if there is an error in deserializing the
-    /// API response.
-    pub async fn defer_ephemeral(&self, http: impl AsRef<Http>) -> Result<()> {
-        self.create_interaction_response(http, |f| {
-            f.kind(InteractionResponseType::DeferredChannelMessageWithSource)
-                .interaction_response_data(|f| f.ephemeral(true))
-        })
-        .await
+    fn get_locale<'a>(&'a self) -> &str{
+        self.locale.as_str()
     }
 }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -855,6 +855,24 @@ impl GuildId {
         http.as_ref().edit_role_position(self.0, role_id.into().0, position, None).await
     }
 
+    pub async fn reorder_roles<It>(self, http: impl AsRef<Http>, roles: It) -> Result<()>
+        where
+            It: IntoIterator<Item = (RoleId, u64)>,
+    {
+        let items = roles
+            .into_iter()
+            .map(|(id, pos)| {
+                json!({
+                    "id": id,
+                    "position": pos,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        http.as_ref().edit_roles_positions(self.0, &Value::from(items), None).await
+    }
+
+
     /// Edits the [`GuildWelcomeScreen`].
     ///
     /// # Errors

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -855,7 +855,7 @@ impl GuildId {
         http.as_ref().edit_role_position(self.0, role_id.into().0, position, None).await
     }
 
-    pub async fn reorder_roles<It>(self, http: impl AsRef<Http>, roles: It) -> Result<()>
+    pub async fn reorder_roles<It>(self, http: impl AsRef<Http>, roles: It) -> Result<Vec<Role>>
         where
             It: IntoIterator<Item = (RoleId, u64)>,
     {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -828,7 +828,7 @@ impl GuildId {
         http.as_ref().edit_sticker(self.0, sticker_id.into().0, &map, None).await
     }
 
-    /// Edits the order of [`Role`]s
+    /// Edits the order of a single [`Role`]
     /// Requires the [Manage Roles] permission.
     ///
     /// # Examples
@@ -855,7 +855,24 @@ impl GuildId {
         http.as_ref().edit_role_position(self.0, role_id.into().0, position, None).await
     }
 
-    pub async fn reorder_roles<It>(self, http: impl AsRef<Http>, roles: It) -> Result<()>
+    /// Edits the order of given [`Role`]s
+    /// Requires the [Manage Roles] permission.
+    ///
+    /// # Examples
+    ///
+    /// Change the order of a role:
+    ///
+    /// ```rust,ignore
+    /// use serenity::model::{GuildId, RoleId};
+    /// GuildId(7).edit_role_positions(&context, Vec::new((RoleId(8), 2));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the current user lacks permission.
+    ///
+    /// [Manage Roles]: Permissions::MANAGE_ROLES
+    pub async fn edit_role_positions<It>(self, http: impl AsRef<Http>, roles: It) -> Result<()>
         where
             It: IntoIterator<Item = (RoleId, u64)>,
     {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -918,6 +918,11 @@ impl PartialGuild {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
+    ///
+    /// # Note
+    /// This function can have unexpected results if multiple roles have not been ordered
+    /// previously.
+    /// Use edit_roles_positions instead to order multiple roles at once.
     #[inline]
     pub async fn edit_role_position(
         &self,
@@ -926,6 +931,27 @@ impl PartialGuild {
         position: u64,
     ) -> Result<Vec<Role>> {
         self.id.edit_role_position(&http, role_id, position).await
+    }
+
+    /// Re-orders the roles of the guild.
+    ///
+    /// Although not required, you should specify all roles' positions,
+    /// regardless of whether they were updated. Otherwise, positioning can
+    /// be not as expected.
+    ///
+    /// **Note**: Requires the [Manage Roles] permission.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the current user is lacking permission.
+    ///
+    /// [Manage Channels]: Permissions::MANAGE_ROLES
+    #[inline]
+    pub async fn edit_roles_positions<It>(&self, http: impl AsRef<Http>, roles: It) -> Result<Vec<Role>>
+        where
+            It: IntoIterator<Item = (RoleId, u64)>,
+    {
+        self.id.edit_roles_positions(&http, roles).await
     }
 
     /// Edits a sticker, optionally setting its fields.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -947,11 +947,11 @@ impl PartialGuild {
     ///
     /// [Manage Channels]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn edit_roles_positions<It>(&self, http: impl AsRef<Http>, roles: It) -> Result<Vec<Role>>
+    pub async fn edit_roles_positions<It>(&self, http: impl AsRef<Http>, roles: It) -> Result<()>
         where
             It: IntoIterator<Item = (RoleId, u64)>,
     {
-        self.id.edit_roles_positions(&http, roles).await
+        self.id.reorder_roles(&http, roles).await
     }
 
     /// Edits a sticker, optionally setting its fields.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -947,7 +947,7 @@ impl PartialGuild {
     ///
     /// [Manage Channels]: Permissions::MANAGE_ROLES
     #[inline]
-    pub async fn edit_roles_positions<It>(&self, http: impl AsRef<Http>, roles: It) -> Result<()>
+    pub async fn edit_roles_positions<It>(&self, http: impl AsRef<Http>, roles: It) -> Result<Vec<Role>>
         where
             It: IntoIterator<Item = (RoleId, u64)>,
     {

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -951,7 +951,7 @@ impl PartialGuild {
         where
             It: IntoIterator<Item = (RoleId, u64)>,
     {
-        self.id.reorder_roles(&http, roles).await
+        self.id.edit_role_positions(&http, roles).await
     }
 
     /// Edits a sticker, optionally setting its fields.


### PR DESCRIPTION
This change introduces support for editing multiple role positions for a guild.
This enhancement streamlines role management and reduces inconsistent updates.