### PR TITLE
Fix deserialization of User::collectibles

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -13,6 +13,7 @@ use super::prelude::*;
 use crate::builder::{CreateMessage, EditProfile};
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
+use crate::model::utils::deserialize_null_as_default;
 #[cfg(feature = "model")]
 use crate::model::utils::{avatar_url, user_banner_url};
 
@@ -292,6 +293,7 @@ pub struct User {
     /// The collectibles the user currently has active, excluding avatar decorations and profile
     /// effects.
     #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
     pub collectibles: Collectibles,
 }
 

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -257,3 +257,11 @@ where
         .try_into()
         .map_err(D::Error::custom)
 }
+
+pub(crate) fn deserialize_null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + serde::Deserialize<'de>,
+{
+    Option::<T>::deserialize(deserializer).map(Option::unwrap_or_default)
+}


### PR DESCRIPTION
I do not understand why `#[serde(default)]` doesn't already do this.