### PR TITLE
Add edit roles positions

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2227,7 +2227,7 @@ impl Http {
             headers: None,
             method: LightMethod::Patch,
             route: Route::GuildRoles {
-                guild_id
+                guild_id,
             },
             params: None,
         })

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2221,7 +2221,7 @@ impl Http {
     ) -> Result<Vec<Role>> {
         let body = to_vec(value)?;
 
-        self.fire(Request{
+        self.fire(Request {
             body: Some(body),
             multipart: None,
             headers: None,
@@ -2231,7 +2231,7 @@ impl Http {
             },
             params: None,
         })
-            .await
+        .await
     }
 
     /// Modifies a scheduled event.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -2209,6 +2209,31 @@ impl Http {
         from_value(value)
     }
 
+    /// Reorder roles for the provided [`Guild`] via its Id.
+    ///
+    /// **Note**: Requires the [Manage Roles] permission.
+    ///
+    /// [Manage Roles]: Permissions::MANAGE_ROLES
+    pub async fn edit_guild_roles_positions(
+        &self,
+        guild_id: GuildId,
+        value: &Value,
+    ) -> Result<Vec<Role>> {
+        let body = to_vec(value)?;
+
+        self.fire(Request{
+            body: Some(body),
+            multipart: None,
+            headers: None,
+            method: LightMethod::Patch,
+            route: Route::GuildRoles {
+                guild_id
+            },
+            params: None,
+        })
+            .await
+    }
+
     /// Modifies a scheduled event.
     ///
     /// **Note**: Requires the [Manage Events] permission.

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -882,6 +882,42 @@ impl GuildId {
         http.as_ref().edit_role_position(self, role_id.into(), position, None).await
     }
 
+    /// Edit the position of [`Role`]s by the given positions in the [`Guild`].
+    ///
+    /// **Note**: Requires the [Manage Roles] permission.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use serenity::model::{GuildId, RoleId};
+    /// GuildId::new(7).edit_roles_positions(&context, Vec::new((RoleId::new(8), 2)));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::Http`] if the current user lacks permission.
+    ///
+    /// [Manage Roles]: Permissions::MANAGE_ROLES
+    #[inline]
+    pub async fn edit_roles_positions(
+        self,
+        http: impl AsRef<Http>,
+        roles: impl IntoIterator<Item = (RoleId, Option<u64>)>,
+    ) -> Result<Vec<Role>> {
+        let items: Value = roles
+            .into_iter()
+            .map(|(id, index)| {
+                json!({
+                    "id": id.get(),
+                    "position": index
+                })
+            })
+            .collect::<Vec<_>>()
+            .into();
+
+        http.as_ref().edit_guild_roles_positions(self, &items).await
+    }
+
     /// Edits the guild's welcome screen.
     ///
     /// **Note**: Requires the [Manage Guild] permission.

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -959,7 +959,8 @@ impl PartialGuild {
         http: impl AsRef<Http>,
         roles: impl IntoIterator<Item = (RoleId, Option<u64>)>,
     ) -> Result<Vec<Role>> {
-        self.id.edit_roles_positions(http, roles).await }
+        self.id.edit_roles_positions(http, roles).await
+    }
 
     /// Edits a sticker.
     ///

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -911,7 +911,7 @@ impl PartialGuild {
         self.id.edit_role(cache_http, role_id, builder).await
     }
 
-    /// Edits the order of [`Role`]s. Requires the [Manage Roles] permission.
+    /// Edits the order of a single [`Role`]. Requires the [Manage Roles] permission.
     ///
     /// # Examples
     ///
@@ -936,6 +936,30 @@ impl PartialGuild {
     ) -> Result<Vec<Role>> {
         self.id.edit_role_position(http, role_id, position).await
     }
+
+    /// Edits the order of multiple [`Role`]s. Requires the [Manage Roles] permission.
+    ///
+    /// # Examples
+    ///
+    /// Change the order of a role:
+    ///
+    /// ```rust,ignore
+    /// use serenity::model::id::RoleId;
+    /// partial_guild.edit_roles_positions(&context, Vec::new((RoleId::new(8), 2)));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Http`] if the current user lacks permission.
+    ///
+    /// [Manage Roles]: Permissions::MANAGE_ROLES
+    #[inline]
+    pub async fn edit_roles_positions(
+        &self,
+        http: impl AsRef<Http>,
+        roles: impl IntoIterator<Item = (RoleId, Option<u64>)>,
+    ) -> Result<Vec<Role>> {
+        self.id.edit_roles_positions(http, roles).await }
 
     /// Edits a sticker.
     ///


### PR DESCRIPTION
Add edit roles positions to reorder multiple roles at once according to https://docs.discord.com/developers/resources/guild#modify-guild-role-positions