### PR TITLE
Fix TextDisplay deserialization

### DIFF
--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -233,6 +233,7 @@ pub struct TextDisplay {
     #[serde(rename = "type")]
     pub kind: ComponentType,
     /// The text content of this component.
+    #[serde(default)]
     pub content: FixedString<u16>,
 }
 


### PR DESCRIPTION
Fixes a deserialization error by deserializing `content` as the default value when it is missing from the interaction response.