### PR TITLE
Allow EventHandler::filter_event to mutate the event

### DIFF
--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -69,7 +69,7 @@ pub struct EventDispatcher {
 }
 
 impl EventDispatcher {
-    pub async fn dispatch(&self, event: Event) {
+    pub async fn dispatch(&self, mut event: Box<Event>) {
         #[cfg(feature = "voice")]
         {
             if let Some(voice_manager) = &self.voice_manager {
@@ -94,14 +94,22 @@ impl EventDispatcher {
             }
         }
 
-        if self
-            .event_handler
-            .as_ref()
-            .is_none_or(|handler| handler.filter_event(&self.context, &event))
-            && self
-                .raw_event_handler
-                .as_ref()
-                .is_none_or(|handler| handler.filter_event(&self.context, &event))
+        if let Some(handler) = self.event_handler.as_ref() {
+            if let Some(new_event) = handler.filter_event(&self.context, event) {
+                event = new_event;
+            } else {
+                return;
+            }
+        }
+
+        if let Some(handler) = self.raw_event_handler.as_ref() {
+            if let Some(new_event) = handler.filter_event(&self.context, event) {
+                event = new_event;
+            } else {
+                return;
+            }
+        }
+
         {
             #[cfg(feature = "collector")]
             self.context.collectors.write().retain(|callback| (callback.0)(&event));
@@ -181,10 +189,10 @@ fn is_guild_new(cache: &Cache, guild_id: GuildId) -> bool {
 /// Updates the cache with the incoming event data and builds the full event data out of it.
 fn update_cache_with_event(
     cache: &MaybeCache,
-    event: Event,
+    event: Box<Event>,
     extra_event: &mut Option<FullEvent>,
 ) -> FullEvent {
-    match event {
+    match *event {
         Event::CommandPermissionsUpdate(event) => FullEvent::CommandPermissionsUpdate {
             permission: event.permission,
         },
@@ -641,7 +649,7 @@ mod tests {
         let cache = Cache::new();
 
         let guild_id = GuildId::new(1);
-        let event = Event::Ready(ReadyEvent {
+        let event = Box::new(Event::Ready(ReadyEvent {
             ready: Ready {
                 version: 0,
                 user: CurrentUser::default(),
@@ -657,7 +665,7 @@ mod tests {
                     flags: ApplicationFlags::default(),
                 },
             },
-        });
+        }));
 
         assert_eq!(cache.unavailable_guilds().len(), 0);
 
@@ -669,7 +677,7 @@ mod tests {
         assert_eq!(cache.unavailable_guilds().len(), 1);
         assert!(!is_guild_new(&cache, guild_id));
 
-        let event = Event::GuildCreate(GuildCreateEvent {
+        let event = Box::new(Event::GuildCreate(GuildCreateEvent {
             guild: Guild {
                 __generated_flags: GuildGeneratedFlags::default(),
                 id: guild_id,
@@ -720,7 +728,7 @@ mod tests {
                 threads: ExtractMap::new(),
                 voice_states: ExtractMap::new(),
             },
-        });
+        }));
 
         assert_eq!(cache.unavailable_guilds().len(), 1);
 
@@ -739,7 +747,7 @@ mod tests {
 
         let guild_id2 = GuildId::new(2);
 
-        let event = Event::GuildCreate(GuildCreateEvent {
+        let event = Box::new(Event::GuildCreate(GuildCreateEvent {
             guild: Guild {
                 __generated_flags: GuildGeneratedFlags::default(),
                 id: guild_id2,
@@ -790,7 +798,7 @@ mod tests {
                 threads: ExtractMap::new(),
                 voice_states: ExtractMap::new(),
             },
-        });
+        }));
 
         assert_eq!(cache.unavailable_guilds().len(), 0);
 

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -73,7 +73,7 @@ impl EventDispatcher {
         #[cfg(feature = "voice")]
         {
             if let Some(voice_manager) = &self.voice_manager {
-                match &event {
+                match &*event {
                     Event::Ready(_) => {
                         voice_manager
                             .register_shard(self.context.shard_id.0, self.context.shard.clone())

--- a/src/gateway/client/dispatch.rs
+++ b/src/gateway/client/dispatch.rs
@@ -110,43 +110,36 @@ impl EventDispatcher {
             }
         }
 
-        {
-            #[cfg(feature = "collector")]
-            self.context.collectors.write().retain(|callback| (callback.0)(&event));
+        #[cfg(feature = "collector")]
+        self.context.collectors.write().retain(|callback| (callback.0)(&event));
 
-            if let Some(raw_handler) = &self.raw_event_handler {
-                raw_handler.raw_event(self.context.clone(), &event).await;
-            }
+        if let Some(raw_handler) = &self.raw_event_handler {
+            raw_handler.raw_event(self.context.clone(), &event).await;
+        }
 
-            let mut extra_event = None;
-            let full_event = update_cache_with_event(
-                maybe_cache_from_context(&self.context),
-                event,
-                &mut extra_event,
+        let mut extra_event = None;
+        let full_event = update_cache_with_event(
+            maybe_cache_from_context(&self.context),
+            event,
+            &mut extra_event,
+        );
+
+        #[cfg(feature = "framework")]
+        let framework = self.framework.clone();
+        let event_handler = self.event_handler.clone();
+        let context = self.context.clone();
+
+        spawn_named("dispatch::user", async move {
+            #[cfg(feature = "framework")]
+            tokio::join!(
+                dispatch_framework(&context, framework, &full_event, extra_event.as_ref()),
+                dispatch_event_handler(&context, event_handler, &full_event, extra_event.as_ref())
             );
 
-            #[cfg(feature = "framework")]
-            let framework = self.framework.clone();
-            let event_handler = self.event_handler.clone();
-            let context = self.context.clone();
-
-            spawn_named("dispatch::user", async move {
-                #[cfg(feature = "framework")]
-                tokio::join!(
-                    dispatch_framework(&context, framework, &full_event, extra_event.as_ref()),
-                    dispatch_event_handler(
-                        &context,
-                        event_handler,
-                        &full_event,
-                        extra_event.as_ref()
-                    )
-                );
-
-                #[cfg(not(feature = "framework"))]
-                dispatch_event_handler(&context, event_handler, &full_event, extra_event.as_ref())
-                    .await;
-            });
-        }
+            #[cfg(not(feature = "framework"))]
+            dispatch_event_handler(&context, event_handler, &full_event, extra_event.as_ref())
+                .await;
+        });
     }
 }
 

--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -13,17 +13,20 @@ use crate::model::prelude::*;
 
 #[async_trait]
 pub trait EventHandler: Send + Sync {
-    /// Checks if the `event` should be dispatched or ignored. Returns `true` by default.
+    /// Checks if the `event` should be dispatched or ignored. Returns Some(event) by default
     ///
-    /// Returning `false` will drop an event and prevent it being dispatched by any
-    /// frameworks and will exclude it from any collectors.
+    /// Returning `None` will drop the event and never process it.
+    ///
+    /// Returning a mutated `Some` is a supported use case, but may cause contradictions to
+    /// documented behaviour or otherwise case unexpected errors within serenity/library
+    /// consumers. Mutate at extreme caution.
     ///
     /// ## Warning
     ///
     /// Similar to [`RawEventHandler`], this method runs synchronously to the [`ShardRunner`], keep
     /// runtime complexity low.
-    fn filter_event(&self, _context: &Context, _event: &Event) -> bool {
-        true
+    fn filter_event(&self, _context: &Context, event: Box<Event>) -> Option<Box<Event>> {
+        Some(event)
     }
 
     /// Dispatches an event through this handler, allowing for event matching and handling
@@ -445,12 +448,14 @@ pub trait RawEventHandler: Send + Sync {
     /// Dispatched when any event occurs
     async fn raw_event(&self, _ctx: Context, _ev: &Event) {}
 
-    /// Checks if the `event` should be dispatched or ignored. Returns `true` by default.
+    /// Checks if the `event` should be dispatched or ignored. Returns Some(event) by default.
     ///
-    /// Returning `false` will drop an event and prevent it being dispatched by any frameworks and
-    /// will exclude it from any collectors.
-    fn filter_event(&self, _context: &Context, _event: &Event) -> bool {
-        // Suppress unused argument warnings
-        true
+    /// Returning `None` will drop the event and never process it.
+    ///
+    /// Returning a mutated `Some` is a supported use case, but may cause contradictions to
+    /// documented behaviour or otherwise case unexpected errors within serenity/library
+    /// consumers. Mutate at extreme caution.
+    fn filter_event(&self, _context: &Context, event: Box<Event>) -> Option<Box<Event>> {
+        Some(event)
     }
 }

--- a/src/gateway/client/event_handler.rs
+++ b/src/gateway/client/event_handler.rs
@@ -13,13 +13,13 @@ use crate::model::prelude::*;
 
 #[async_trait]
 pub trait EventHandler: Send + Sync {
-    /// Checks if the `event` should be dispatched or ignored. Returns Some(event) by default
+    /// Checks if the `event` should be dispatched or ignored. Returns Some(event) by default.
     ///
     /// Returning `None` will drop the event and never process it.
     ///
     /// Returning a mutated `Some` is a supported use case, but may cause contradictions to
-    /// documented behaviour or otherwise case unexpected errors within serenity/library
-    /// consumers. Mutate at extreme caution.
+    /// documented behaviour or otherwise cause unexpected errors within serenity/library
+    /// consumers. Mutate with extreme caution.
     ///
     /// ## Warning
     ///
@@ -453,8 +453,8 @@ pub trait RawEventHandler: Send + Sync {
     /// Returning `None` will drop the event and never process it.
     ///
     /// Returning a mutated `Some` is a supported use case, but may cause contradictions to
-    /// documented behaviour or otherwise case unexpected errors within serenity/library
-    /// consumers. Mutate at extreme caution.
+    /// documented behaviour or otherwise cause unexpected errors within serenity/library
+    /// consumers. Mutate with extreme caution.
     fn filter_event(&self, _context: &Context, event: Box<Event>) -> Option<Box<Event>> {
         Some(event)
     }

--- a/src/gateway/sharding/shard_runner.rs
+++ b/src/gateway/sharding/shard_runner.rs
@@ -92,11 +92,11 @@ impl ShardRunner {
             if post != pre {
                 self.update_runner_info();
                 self.dispatcher
-                    .dispatch(Event::ShardStageUpdate(ShardStageUpdateEvent {
+                    .dispatch(Box::new(Event::ShardStageUpdate(ShardStageUpdateEvent {
                         new: post,
                         old: pre,
                         shard_id: self.shard.shard_info().id,
-                    }))
+                    })))
                     .await;
             }
 
@@ -131,7 +131,7 @@ impl ShardRunner {
                             }
                         }
                     },
-                    ShardAction::Dispatch(event) => self.dispatcher.dispatch(*event).await,
+                    ShardAction::Dispatch(event) => self.dispatcher.dispatch(event).await,
                 }
             }
 


### PR DESCRIPTION
This was discussed in the lib-dev channel and would allow saving 8gb+ of ram in production TTS Bot.