### PR TITLE
Remove default rustls provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ tracing_instrument = ["tracing/attributes"]
 # Backends to pick from:
 # - Rustls Backends
 rustls_backend = [
-    "reqwest/rustls",
+    "reqwest/rustls-no-provider",
     "tokio-tungstenite/rustls-tls-webpki-roots",
 ]
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Login with a bot token from the environment
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");
@@ -103,9 +106,21 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
+rustls = "0.23"
 serenity = "0.12"
 tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
 ```
+
+You must additionally register a crypto provider before initializing serenity,
+f.e. by adding this to the top of your app's `main` function:
+
+```rust
+rustls::crypto::aws_lc_rs::default_provider().install_default();
+```
+
+Alternatively, you may use the `native_tls_backend` feature (see the Features
+section), in which case you don't need the `rustls` dependency and don't have
+to register a crypto provider.
 
 ## MSRV Policy
 

--- a/examples/e01_basic_ping_bot/Cargo.toml
+++ b/examples/e01_basic_ping_bot/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -47,6 +47,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e02_transparent_guild_sharding/Cargo.toml
+++ b/examples/e02_transparent_guild_sharding/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -47,6 +47,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e03_struct_utilities/Cargo.toml
+++ b/examples/e03_struct_utilities/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -44,6 +44,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e04_message_builder/Cargo.toml
+++ b/examples/e04_message_builder/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -53,6 +53,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e05_sample_bot_structure/Cargo.toml
+++ b/examples/e05_sample_bot_structure/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["collector", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e05_sample_bot_structure/src/main.rs
+++ b/examples/e05_sample_bot_structure/src/main.rs
@@ -89,6 +89,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e06_env_logging/Cargo.toml
+++ b/examples/e06_env_logging/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 tracing = "0.1.23"
 tracing-subscriber = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e06_env_logging/src/main.rs
+++ b/examples/e06_env_logging/src/main.rs
@@ -35,6 +35,9 @@ impl EventHandler for Handler {
 #[tokio::main]
 #[instrument]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Call tracing_subscriber's initialize function, which configures `tracing` via environment
     // variables.
     //

--- a/examples/e07_shard_manager/Cargo.toml
+++ b/examples/e07_shard_manager/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time"] }
 
 [dependencies.serenity]

--- a/examples/e07_shard_manager/src/main.rs
+++ b/examples/e07_shard_manager/src/main.rs
@@ -48,6 +48,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e08_create_message_builder/Cargo.toml
+++ b/examples/e08_create_message_builder/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "chrono", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -59,6 +59,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e09_collectors/Cargo.toml
+++ b/examples/e09_collectors/Cargo.toml
@@ -9,4 +9,5 @@ features = ["collector", "framework", "rustls_backend"]
 path = "../../"
 
 [dependencies]
+rustls = "0.23"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e09_collectors/src/main.rs
+++ b/examples/e09_collectors/src/main.rs
@@ -155,6 +155,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e10_gateway_intents/Cargo.toml
+++ b/examples/e10_gateway_intents/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e10_gateway_intents/src/main.rs
+++ b/examples/e10_gateway_intents/src/main.rs
@@ -36,6 +36,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e11_global_data/Cargo.toml
+++ b/examples/e11_global_data/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e11_global_data/src/main.rs
+++ b/examples/e11_global_data/src/main.rs
@@ -71,6 +71,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");
 

--- a/examples/e12_parallel_loops/Cargo.toml
+++ b/examples/e12_parallel_loops/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "cache", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 sys-info = "0.9"

--- a/examples/e12_parallel_loops/src/main.rs
+++ b/examples/e12_parallel_loops/src/main.rs
@@ -77,6 +77,9 @@ impl EventHandler for Handler {
 }
 
 async fn log_system_load(ctx: &Context) {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let cpu_load = sys_info::loadavg().unwrap();
     let mem_use = sys_info::mem_info().unwrap();
 

--- a/examples/e13_sqlite_database/Cargo.toml
+++ b/examples/e13_sqlite_database/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite"] }

--- a/examples/e13_sqlite_database/src/main.rs
+++ b/examples/e13_sqlite_database/src/main.rs
@@ -89,6 +89,9 @@ impl EventHandler for Bot {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Configure the client with your Discord bot token in the environment.
     let token =
         Token::from_env("DISCORD_TOKEN").expect("Expected a valid token in the environment");

--- a/examples/e14_message_components/Cargo.toml
+++ b/examples/e14_message_components/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "collector", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 dotenv = { version = "0.15.0" }

--- a/examples/e14_message_components/src/main.rs
+++ b/examples/e14_message_components/src/main.rs
@@ -161,6 +161,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     dotenv().ok();
     // Configure the client with your Discord bot token in the environment.
     let token =

--- a/examples/e15_webhook/Cargo.toml
+++ b/examples/e15_webhook/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["my name <my@email.address>"]
 edition.workspace = true
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["model", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e15_webhook/src/main.rs
+++ b/examples/e15_webhook/src/main.rs
@@ -4,6 +4,9 @@ use serenity::model::webhook::Webhook;
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // You don't need a token when you are only dealing with webhooks.
     let http = Http::without_token();
     let webhook = Webhook::from_url(&http, "https://discord.com/api/webhooks/133742013374206969/hello-there-oPNtRN5UY5DVmBe7m1N0HE-replace-me-Dw9LRkgq3zI7LoW3Rb-k-q")

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
+rustls = "0.23"
 serenity = { path = "../../", default-features = false, features = ["gateway", "model", "cache", "collector", "rustls_backend"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.10.0"

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -418,6 +418,9 @@ impl EventHandler for Handler {
 
 #[tokio::main]
 async fn main() {
+    // Register the crypto provider used for TLS by this application.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     if let Some(arg) = std::env::args().nth(1) {
         if arg == "--print-sizes" {
             model_type_sizes::print_ranking();


### PR DESCRIPTION
Changes the `reqwest` feature enabled by `rustls_backend` to `rustls-no-provider`, therefore requiring that a provider is otherwise selected by the user. This allows opting out of the default `rustls` provider, which is now `aws-lc-rs`.

The README is updated to include the simplest possible guidance: Depending on `rustls` and registering `aws-lc-rs` explicitly, or to use the `native_tls_backend`.

Most of the diff is due to adjusting the examples to include registering the crypto provider.

# Notes

Unless the user directly enables the `reqwest/rustls` feature, a provider has to be registered because `reqwest` does not use `rustls` defaults if `reqwest` is initialized first. Noting this quirk feels too specific and instead guiding the user towards always registering a provider is probably best.

Some examples use an outdated version of `sqlx` that still depends on `rustls` 0.21, so it technically doesn't inherit the provider registered for the bot in the example. Someone that knows `sqlx` better may want to update the examples using it.