### PR TITLE
Allow opting out of a default Rustls crypto provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ tracing_instrument = ["tracing/attributes"]
 # - Rustls Backends
 rustls_backend = [
     "reqwest/rustls",
-    "rustls_backend_no_provider",
+    "tokio-tungstenite/rustls-tls-webpki-roots",
 ]
 rustls_backend_no_provider = [
     "reqwest/rustls-no-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ package = "http"
 [features]
 # Defaults with different backends
 default = ["default_no_backend", "rustls_backend"]
+default_rustls_no_provider = ["default_no_backend", "rustls_backend_no_provider"]
 default_native_tls = ["default_no_backend", "native_tls_backend"]
 
 # Serenity requires a backend, this picks all default features without a backend.
@@ -139,6 +140,10 @@ tracing_instrument = ["tracing/attributes"]
 # - Rustls Backends
 rustls_backend = [
     "reqwest/rustls",
+    "rustls_backend_no_provider",
+]
+rustls_backend_no_provider = [
+    "reqwest/rustls-no-provider",
     "tokio-tungstenite/rustls-tls-webpki-roots",
 ]
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ There are these alternative default features, they require to set `default-featu
 
 - **default_native_tls**: Uses `native_tls_backend` instead of the default `rustls_backend`.
 - **default_no_backend**: Excludes the default backend, pick your own backend instead.
+- **default_rustls_no_provider**: Uses `rustls_backend_no_provider`, requiring manual registration of a Rustls crypto provider.
 
 If you are unsure which to pick, use the default features by not setting `default-features = false`.
 
@@ -167,6 +168,8 @@ the HTTP functions.
 [lavalink-rs][project:lavalink-rs] or [Songbird][project:songbird] are recommended voice plugins.
 - **default_native_tls**: Default features but using `native_tls_backend`
 instead of `rustls_backend`.
+- **default_no_backend**: Defaults features, but does not enable any backend.
+- **default_rustls_no_provider**: Defaults features but using `rustls_backend_no_provider` instead of `rustls_backend`, requiring manual registration of a Rustls crypto provider.
 - **tokio_task_builder**: Enables tokio's `tracing` feature and uses `tokio::task::Builder` to spawn tasks with names if `RUSTFLAGS="--cfg tokio_unstable"` is set.
 - **unstable**: Enables features of the Serenity and Discord API that do not have a stable interface. The features might not have official documentation and are subject to change without a breaking version bump.
 - **temp_cache**: Enables temporary caching in functions that retrieve data via the HTTP API.
@@ -182,6 +185,8 @@ one if you do not use the default features:
 
 - **rustls_backend**: Uses Rustls for all platforms, a pure Rust
 TLS implementation.
+- **rustls_backend_no_provider**: Same as `rustls_backend`, but excludes a default
+crypto provider, therefore requiring manual registration of a Rustls crypto provider.
 - **native_tls_backend**: Uses SChannel on Windows, Secure Transport on macOS,
 and OpenSSL on other platforms.
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ the HTTP functions.
 [lavalink-rs][project:lavalink-rs] or [Songbird][project:songbird] are recommended voice plugins.
 - **default_native_tls**: Default features but using `native_tls_backend`
 instead of `rustls_backend`.
-- **default_no_backend**: Defaults features, but does not enable any backend.
-- **default_rustls_no_provider**: Defaults features but using `rustls_backend_no_provider` instead of `rustls_backend`, requiring manual registration of a Rustls crypto provider.
+- **default_rustls_no_provider**: Default features but using `rustls_backend_no_provider` instead of `rustls_backend`, requiring manual registration of a Rustls crypto provider.
+- **default_no_backend**: Default features, but does not enable any backend.
 - **tokio_task_builder**: Enables tokio's `tracing` feature and uses `tokio::task::Builder` to spawn tasks with names if `RUSTFLAGS="--cfg tokio_unstable"` is set.
 - **unstable**: Enables features of the Serenity and Discord API that do not have a stable interface. The features might not have official documentation and are subject to change without a breaking version bump.
 - **temp_cache**: Enables temporary caching in functions that retrieve data via the HTTP API.

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
 #[cfg(all(
     feature = "http",
-    not(any(feature = "rustls_backend_no_provider", feature = "native_tls_backend"))
+    not(any(
+        feature = "rustls_backend",
+        feature = "rustls_backend_no_provider",
+        feature = "native_tls_backend"
+    ))
 ))]
 compile_error!(
     "You have the `http` feature enabled; either the `rustls_backend`, `rustls_backend_no_provider`, \

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,12 @@
-#[cfg(all(feature = "http", not(any(feature = "rustls_backend", feature = "native_tls_backend"))))]
+#[cfg(all(
+    feature = "http",
+    not(any(feature = "rustls_backend_no_provider", feature = "native_tls_backend"))
+))]
 compile_error!(
-    "You have the `http` feature enabled; either the `rustls_backend` or `native_tls_backend` \
-    feature must be enabled to let Serenity make requests over the network.\n\
+    "You have the `http` feature enabled; either the `rustls_backend`, `rustls_backend_no_provider`, \
+    or `native_tls_backend` feature must be enabled to let Serenity make requests over the network.\n\
     - `rustls_backend` uses Rustls, a pure Rust TLS-implemenation.\n\
+    - `rustls_backend_no_provider` also uses Rustls, but does not register a crypto provider by default.\n\
     - `native_tls_backend` uses SChannel on Windows, Secure Transport on macOS, and OpenSSL on \
     other platforms.\n\
     If you are unsure, go with `rustls_backend`."


### PR DESCRIPTION
Alternative to #3516.

Instead of completely removing the implicit default crypto provider when using the Rustls backend, instead provide an alternative feature set to opt out, essentially mirroring the features `reqwest` provides.

This adds the feature `rustls_backend_no_provider` which is identical to `rustls_backend` except that it includes no provider. Additionally adds `default_rustls_no_provider`, mirroring `default` with the `rustls_backend` replaced by `rustls_backend_no_provider` for convenience.

cc @mkrasnitski 

Note: The goal here is less to not to allow opting into custom crypto providers (that's already possible), it's to avoid compiling in the default when a different provider is included.