### PR TITLE
Fix collectibles deserialization

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -56,7 +56,7 @@ use crate::model::guild::{
     ScheduledEvent,
 };
 use crate::model::id::GuildId;
-use crate::model::user::{CurrentUser, OnlineStatus};
+use crate::model::user::{Collectibles, CurrentUser, OnlineStatus};
 use crate::model::voice::VoiceState;
 
 impl CacheUpdate for ChannelCreateEvent {
@@ -214,6 +214,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                 member.banner.clone_from(&self.banner);
                 member.communication_disabled_until.clone_from(&self.communication_disabled_until);
                 member.unusual_dm_activity_until.clone_from(&self.unusual_dm_activity_until);
+                member.collectibles.clone_from(&self.collectibles);
                 member.set_pending(self.pending());
                 member.set_deaf(self.deaf());
                 member.set_mute(self.mute());
@@ -239,6 +240,7 @@ impl CacheUpdate for GuildMemberUpdateEvent {
                     flags: self.flags.unwrap_or_default(),
                     unusual_dm_activity_until: self.unusual_dm_activity_until,
                     avatar_decoration_data: self.avatar_decoration_data,
+                    collectibles: self.collectibles.clone(),
                 };
 
                 new_member.set_pending(self.pending());
@@ -470,6 +472,9 @@ impl CacheUpdate for PresenceUpdateEvent {
                     flags: GuildMemberFlags::default(),
                     unusual_dm_activity_until: None,
                     avatar_decoration_data: None,
+                    collectibles: Collectibles {
+                        nameplate: None,
+                    },
                     __generated_flags: MemberGeneratedFlags::empty(),
                 });
             }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -10,6 +10,7 @@ use strum::{EnumCount, IntoStaticStr, VariantNames};
 
 use crate::constants::Opcode;
 use crate::model::prelude::*;
+use crate::model::utils::deserialize_null_as_default;
 
 /// Requires no gateway intents.
 ///
@@ -257,6 +258,9 @@ pub struct GuildMemberUpdateEvent {
     pub unusual_dm_activity_until: Option<Timestamp>,
     pub flags: Option<GuildMemberFlags>,
     pub avatar_decoration_data: Option<AvatarDecorationData>,
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
+    pub collectibles: Collectibles,
 }
 
 /// Requires no gateway intents.

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -269,6 +269,8 @@ pub struct PresenceUser {
     pub member: Option<Box<PartialMember>>,
     pub primary_guild: Option<PrimaryGuild>,
     pub avatar_decoration_data: Option<AvatarDecorationData>,
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
     pub collectibles: Collectibles,
     // TODO: should really go over these fields at some point and check them.
 }

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -9,8 +9,9 @@ use crate::cache::Cache;
 #[cfg(feature = "model")]
 use crate::http::Http;
 use crate::model::prelude::*;
+use crate::model::utils::deserialize_null_as_default;
 #[cfg(feature = "model")]
-use crate::model::utils::{avatar_url, deserialize_null_as_default, user_banner_url};
+use crate::model::utils::{avatar_url, user_banner_url};
 
 /// Information about a member of a guild.
 ///

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -10,7 +10,7 @@ use crate::cache::Cache;
 use crate::http::Http;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
-use crate::model::utils::{avatar_url, user_banner_url};
+use crate::model::utils::{avatar_url, deserialize_null_as_default, user_banner_url};
 
 /// Information about a member of a guild.
 ///
@@ -67,6 +67,11 @@ pub struct Member {
     pub unusual_dm_activity_until: Option<Timestamp>,
     /// Information about this member's guild specific avatar decoration.
     pub avatar_decoration_data: Option<AvatarDecorationData>,
+    /// The collectibles the member currently has active, excluding avatar decorations and profile
+    /// effects.
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
+    pub collectibles: Collectibles,
 }
 
 bitflags! {
@@ -502,6 +507,11 @@ pub struct PartialMember {
     pub banner: Option<ImageHash>,
     /// Information about this member's avatar decoration.
     pub avatar_decoration_data: Option<AvatarDecorationData>,
+    /// The collectibles the member currently has active, excluding avatar decorations and profile
+    /// effects.
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
+    pub collectibles: Collectibles,
 }
 
 impl From<PartialMember> for Member {
@@ -522,6 +532,7 @@ impl From<PartialMember> for Member {
             guild_id: partial.guild_id.unwrap_or_default(),
             unusual_dm_activity_until: partial.unusual_dm_activity_until,
             avatar_decoration_data: partial.avatar_decoration_data,
+            collectibles: partial.collectibles,
         };
 
         member.set_pending(pending);
@@ -547,6 +558,7 @@ impl From<Member> for PartialMember {
             avatar: member.avatar,
             banner: member.banner,
             avatar_decoration_data: member.avatar_decoration_data,
+            collectibles: member.collectibles,
         };
 
         partial.set_deaf(deaf);


### PR DESCRIPTION
Fixes a deserialization error in bots using the `GUILD_PRESENCES` intent due to `collectibles` missing appropriate serde field attributes in `PresenceUser`. Also adds `collectibles` to `Member` and `PartialMember` and updates `GuildMemberUpdateEvent` in accordance with the changes made in [Add missing collectibles field to Guild Member #8163](https://github.com/discord/discord-api-docs/pull/8163).