### PR TITLE
Add shared themes to Message

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -139,6 +139,10 @@ pub struct Message {
     ///
     /// Only present in [`MessageCreateEvent`].
     pub poll: Option<Box<Poll>>,
+    /// The custom client-side theme attached to a message.
+    ///
+    /// Only present in [`MessageCreateEvent`]
+    pub shared_client_theme: Option<Box<SharedClientTheme>>,
 }
 
 #[cfg(feature = "model")]
@@ -1197,6 +1201,41 @@ pub struct MessagePin {
 pub struct MessagePinsPage {
     pub items: Vec<MessagePin>,
     pub has_more: bool,
+}
+
+enum_number! {
+    /// The mode of the shared client theme.
+    ///
+    /// [Discord docs](https://docs.discord.com/developers/resources/message#base-theme-types)
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[non_exhaustive]
+    pub enum BaseTheme {
+        Unset = 0,
+        Dark = 1,
+        Light = 2,
+        Darker = 3,
+        Midnight = 4,
+        _ => Unknown(u8),
+    }
+}
+
+/// A shared client theme that is attached to [`Message`].
+///
+/// [Discord docs](https://docs.discord.com/developers/resources/message#shared-client-theme-object)
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct SharedClientTheme {
+    /// The hexadecimal-encoded colours of the theme.
+    #[serde(rename = "colors", deserialize_with = "discord_colours")]
+    pub colours: FixedArray<Colour>,
+    /// The direction of the theme's colours.
+    pub gradient_angle: u16,
+    /// The intensity of the theme's colours.
+    pub base_mix: u16,
+    /// The mode of the theme.
+    pub base_theme: Option<BaseTheme>,
 }
 
 // all tests here require cache, move if non-cache test is added

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -243,7 +243,7 @@ where
     vec_str
         .into_iter()
         .map(|s| {
-            let s = s.0.strip_prefix('#').ok_or_else(|| DeError::custom("Invalid colour data"))?;
+            let s = s.0.strip_prefix('#').unwrap_or(s.0.as_ref());
 
             if s.len() != 6 {
                 return Err(DeError::custom("Invalid colour data length"));


### PR DESCRIPTION
Adds a new field to Message object for `shared_client_themes`.
Discord docs: https://docs.discord.com/developers/resources/message#shared-client-theme-object

I'm just going to open this as draft until I could try to get the `colours` field to work without serenity throwing the deserialization error, `Failed to deserialize event data: invalid type: string "CA48C8", expected u32 at line 1 column 1887`.