### PR TITLE
Document CacheRef deadlock risk across await points

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -64,6 +64,34 @@ enum CacheRefInner<'a, K, V, T> {
     ReadGuard(parking_lot::RwLockReadGuard<'a, V>),
 }
 
+/// A reference to data in the [`Cache`].
+///
+/// This type wraps a reference to cached data and dereferences to `V`. It is deliberately
+/// `!Send` to prevent holding it across `.await` points in most situations, since doing so can
+/// cause deadlocks: the underlying [`DashMap`] shard lock is held for the lifetime of this
+/// reference, so any cache update (e.g. from a gateway event) that needs the same shard will
+/// block indefinitely.
+///
+/// # Deadlock warning
+///
+/// Although `CacheRef` is `!Send`, which makes the compiler reject it across `.await` in
+/// spawned tasks, there are contexts where `!Send` futures are permitted (notably the
+/// `#[tokio::main]` top-level future). In those contexts the compiler will **not** prevent you
+/// from holding a `CacheRef` over an `.await`, but a deadlock can still occur.
+///
+/// As a general rule, never hold a `CacheRef` across an `.await` point. Instead, clone or copy
+/// the data you need and drop the reference before awaiting:
+///
+/// ```rust,no_run
+/// # use serenity::cache::Cache;
+/// # use serenity::model::prelude::*;
+/// # fn example(cache: &Cache, guild_id: GuildId) {
+/// // Good: extract what you need, then drop the reference.
+/// let channel_count = cache.guild(guild_id).map(|g| g.channels.len());
+/// # }
+/// ```
+///
+/// [`DashMap`]: dashmap::DashMap
 pub struct CacheRef<'a, K, V, T = ()> {
     inner: CacheRefInner<'a, K, V, T>,
     phantom: std::marker::PhantomData<*const NotSend>,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -68,11 +68,8 @@ enum CacheRefInner<'a, K, V, T> {
 ///
 /// This type wraps a reference to cached data and dereferences to `V`. It is deliberately
 /// `!Send` to prevent holding it across `.await` points in most situations, since doing so can
-/// cause deadlocks: the underlying [`DashMap`] shard lock is held for the lifetime of this
-/// reference, so any cache update (e.g. from a gateway event) that needs the same shard will
-/// block indefinitely.
-///
-/// # Deadlock warning
+/// cause deadlocks: the underlying read lock is held for the lifetime of this reference, so any
+/// cache update (e.g. from a gateway event) that needs the same lock will block indefinitely.
 ///
 /// Although `CacheRef` is `!Send`, which makes the compiler reject it across `.await` in
 /// spawned tasks, there are contexts where `!Send` futures are permitted (notably the
@@ -90,8 +87,6 @@ enum CacheRefInner<'a, K, V, T> {
 /// let channel_count = cache.guild(guild_id).map(|g| g.channels.len());
 /// # }
 /// ```
-///
-/// [`DashMap`]: dashmap::DashMap
 pub struct CacheRef<'a, K, V, T = ()> {
     inner: CacheRefInner<'a, K, V, T>,
     phantom: std::marker::PhantomData<*const NotSend>,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -66,18 +66,18 @@ enum CacheRefInner<'a, K, V, T> {
 
 /// A reference to data in the [`Cache`].
 ///
-/// This type wraps a reference to cached data and dereferences to `V`. It is deliberately
-/// `!Send` to prevent holding it across `.await` points in most situations, since doing so can
-/// cause deadlocks: the underlying read lock is held for the lifetime of this reference, so any
-/// cache update (e.g. from a gateway event) that needs the same lock will block indefinitely.
+/// This type wraps a reference to cached data and dereferences to `V`. It is deliberately marked
+/// `!Send` to prevent holding it across an `.await` point. Doing so can cause a deadlock: the
+/// underlying read lock is held for the lifetime of the `CacheRef`, so any task that tries taking
+/// the same lock while it is still held (i.e. across an `.await` point) will block indefinitely.
 ///
-/// Although `CacheRef` is `!Send`, which makes the compiler reject it across `.await` in
-/// spawned tasks, there are contexts where `!Send` futures are permitted (notably the
-/// `#[tokio::main]` top-level future). In those contexts the compiler will **not** prevent you
-/// from holding a `CacheRef` over an `.await`, but a deadlock can still occur.
+/// In general, the compiler will reject holding a `CacheRef` across an `.await` point in spawned
+/// tasks because it is `!Send`. Notably, however, the `#[tokio::main]` top-level future permits
+/// `.await`-ing `!Send` futures in its body. In this case the compiler will **not** prevent you
+/// from holding a `CacheRef` over an `.await` point, and a deadlock may still occur.
 ///
-/// As a general rule, never hold a `CacheRef` across an `.await` point. Instead, clone or copy
-/// the data you need and drop the reference before awaiting:
+/// As a rule of thumb, never hold a `CacheRef` across an `.await` point. Instead, clone or copy the
+/// data you need and drop the reference before awaiting:
 ///
 /// ```rust,no_run
 /// # use serenity::cache::Cache;


### PR DESCRIPTION
Closes #3425.

`CacheRef` holds a `DashMap` shard lock for its lifetime, so holding it across an `.await` can deadlock if a gateway event tries to update the same shard. The type is `!Send` which prevents this in most cases, but contexts that allow `!Send` futures (like the `#[tokio::main]` top-level future) aren't caught by the compiler.

This adds a doc comment to `CacheRef` explaining the deadlock risk and recommending users extract the data they need before awaiting. Also includes a short code example showing the suggested pattern.