### PR TITLE
Update docs for `User::global_name`

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -242,7 +242,6 @@ pub struct User {
     #[serde(default, skip_serializing_if = "Option::is_none", with = "discriminator")]
     pub discriminator: Option<NonZeroU16>,
     /// The account's display name, if it is set.
-    /// For bots this is the application name.
     pub global_name: Option<String>,
     /// Optional avatar hash.
     pub avatar: Option<ImageHash>,


### PR DESCRIPTION
It was removed from the Discord docs as bots do not have that field set.
https://github.com/discord/discord-api-docs/commit/49bf68b66884c858f2027f9adbea7522b6693b0f