### PR TITLE
refactor(model): remove `ACTIVE_DEVELOPER` flag from UserFlags

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -360,8 +360,6 @@ bitflags! {
         /// User's flag for suspected spam activity.
         #[cfg(feature = "unstable")]
         const SPAMMER = 1 << 20;
-        /// User's flag as active developer
-        const ACTIVE_DEVELOPER = 1 << 22;
     }
 }
 


### PR DESCRIPTION
Active Developer Badge has been decommissioned and is no longer obtainable.

Discord API Docs reference: https://github.com/discord/discord-api-docs/pull/8249