### PR TITLE
docs(Message): update `Message::attachments` description

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -69,7 +69,8 @@ pub struct Message {
     /// [discord-docs]: https://docs.discord.com/developers/resources/message#message-object
     #[serde(default)]
     pub mention_channels: FixedArray<ChannelMention>,
-    /// An vector of the files attached to a message.
+    /// A vector of the files attached to a message that are not referenced in embeds or
+    /// components.
     pub attachments: FixedArray<Attachment>,
     /// Array of embeds sent with the message.
     pub embeds: FixedArray<Embed>,


### PR DESCRIPTION
Update docs for `Message::attachments` to clarify about the behavior of components and embeds.

Discord API Docs reference:
- https://github.com/discord/discord-api-docs/pull/8279