### PR TITLE
feat(message): add HAS_SNAPSHOT flag

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -955,6 +955,8 @@ bitflags! {
         /// As of 2023-04-20, bots are currently not able to send voice messages
         /// ([source](https://github.com/discord/discord-api-docs/pull/6082)).
         const IS_VOICE_MESSAGE = 1 << 13;
+        /// This message has a snapshot (via Message Forwarding).
+        const HAS_SNAPSHOT = 1 << 14;
         /// Enables support for sending Components V2.
         ///
         /// Setting this flag is required to use V2 components.


### PR DESCRIPTION
Adds `MessageFlags::HAS_SNAPSHOT` (1 << 14). Discord sets this on forwarded messages that carry a snapshot of the referenced message.

Refs: [Message Flags](https://docs.discord.com/developers/resources/message#message-object-message-flags).

```
cargo check --all-features
```
passes.