### PR TITLE
feat(http): add Http::search_guild_messages

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4419,6 +4419,73 @@ impl Http {
         from_value(value).map_err(From::from)
     }
 
+    /// Searches the messages of a guild.
+    ///
+    /// Requires the `View Channel` permission on every channel included in the result.
+    ///
+    /// [Discord docs](https://docs.discord.com/developers/resources/message#search-guild-messages).
+    pub async fn search_guild_messages(
+        &self,
+        guild_id: GuildId,
+        params: &SearchGuildMessagesParams<'_>,
+    ) -> Result<SearchGuildMessagesResult> {
+        let mut storage: Vec<(&'static str, String)> = Vec::new();
+        if let Some(content) = params.content {
+            storage.push(("content", content.to_owned()));
+        }
+        if let Some(include_nsfw) = params.include_nsfw {
+            storage.push(("include_nsfw", include_nsfw.to_string()));
+        }
+        for id in params.channel_ids {
+            storage.push(("channel_id", id.get().to_string()));
+        }
+        for id in params.author_ids {
+            storage.push(("author_id", id.get().to_string()));
+        }
+        for id in params.mentions {
+            storage.push(("mentions", id.get().to_string()));
+        }
+        for h in params.has {
+            storage.push(("has", (*h).to_owned()));
+        }
+        if let Some(min_id) = params.min_id {
+            storage.push(("min_id", min_id.get().to_string()));
+        }
+        if let Some(max_id) = params.max_id {
+            storage.push(("max_id", max_id.get().to_string()));
+        }
+        if let Some(mention_everyone) = params.mention_everyone {
+            storage.push(("mention_everyone", mention_everyone.to_string()));
+        }
+        if let Some(sort_by) = params.sort_by {
+            storage.push(("sort_by", sort_by.to_owned()));
+        }
+        if let Some(sort_order) = params.sort_order {
+            storage.push(("sort_order", sort_order.to_owned()));
+        }
+        if let Some(offset) = params.offset {
+            storage.push(("offset", offset.to_string()));
+        }
+        if let Some(limit) = params.limit {
+            storage.push(("limit", limit.to_string()));
+        }
+
+        let params_slice: Vec<(&str, &str)> =
+            storage.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+        self.fire(Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Get,
+            route: Route::GuildMessagesSearch {
+                guild_id,
+            },
+            params: Some(&params_slice),
+        })
+        .await
+    }
+
     /// Starts removing some members from a guild based on the last time they've been online.
     pub async fn start_guild_prune(
         &self,

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -289,6 +289,10 @@ routes! ('a, {
     api!("/guilds/{}/members/search", guild_id),
     Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
 
+    GuildMessagesSearch { guild_id: GuildId },
+    api!("/guilds/{}/messages/search", guild_id),
+    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+
     GuildMemberMe { guild_id: GuildId },
     api!("/guilds/{}/members/@me", guild_id),
     Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -973,6 +973,64 @@ bitflags! {
     }
 }
 
+/// Query parameters for [`Http::search_guild_messages`].
+///
+/// All fields are optional. Repeatable filters (channels, authors, mentions, and `has` tokens)
+/// map to repeated query-string entries, matching the Discord API shape.
+///
+/// [`Http::search_guild_messages`]: crate::http::Http::search_guild_messages
+/// [Discord docs](https://docs.discord.com/developers/resources/message#search-guild-messages).
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct SearchGuildMessagesParams<'a> {
+    /// Match against the message content.
+    pub content: Option<&'a str>,
+    /// When searching as a user account, whether to include NSFW channel matches.
+    pub include_nsfw: Option<bool>,
+    /// Restrict to the given channel ids.
+    pub channel_ids: &'a [GenericChannelId],
+    /// Restrict to messages authored by any of the given user ids.
+    pub author_ids: &'a [UserId],
+    /// Restrict to messages mentioning any of the given user ids.
+    pub mentions: &'a [UserId],
+    /// Restrict to messages that contain the given `has` filters (e.g. `"attachment"`, `"sound"`,
+    /// `"poll"`).
+    pub has: &'a [&'a str],
+    /// Return messages whose id is greater than this snowflake.
+    pub min_id: Option<MessageId>,
+    /// Return messages whose id is lower than this snowflake.
+    pub max_id: Option<MessageId>,
+    /// Restrict to messages that do (or do not) mention everyone.
+    pub mention_everyone: Option<bool>,
+    /// Sort by field (`"timestamp"` or `"relevance"`). Defaults to Discord's API default when `None`.
+    pub sort_by: Option<&'a str>,
+    /// Sort order (`"asc"` or `"desc"`). Defaults to Discord's API default when `None`.
+    pub sort_order: Option<&'a str>,
+    /// Pagination offset (0 to 5000).
+    pub offset: Option<u16>,
+    /// Number of results to return (1 to 25).
+    pub limit: Option<u8>,
+}
+
+/// Response from [`Http::search_guild_messages`].
+///
+/// Each entry in [`Self::messages`] is a hit group: the matched message plus surrounding
+/// context messages returned by Discord.
+///
+/// [`Http::search_guild_messages`]: crate::http::Http::search_guild_messages
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct SearchGuildMessagesResult {
+    /// Message hit groups returned by Discord.
+    pub messages: Vec<Vec<Message>>,
+    /// Total number of messages matching the query across pages.
+    pub total_results: u64,
+    /// Opaque identifier Discord attaches to the search for analytics purposes.
+    #[serde(default)]
+    pub analytics_id: Option<FixedString<u8>>,
+}
+
 /// Uniquely identifies a message.
 ///
 /// Implements Display to format to a url to the message.


### PR DESCRIPTION
Wraps the Search Guild Messages endpoint introduced in the [March 2026 Discord API changelog](https://discord.com/developers/docs/change-log#search-guild-messages-endpoint):

- `GuildMessagesSearch` route in `http::routing` (`GET /guilds/{id}/messages/search`).
- `Http::search_guild_messages(guild_id, &params)`.
- `SearchGuildMessagesParams<'a>` covering `content`, `include_nsfw`, repeatable `channel_id` / `author_id` / `mentions` / `has`, `min_id`, `max_id`, `mention_everyone`, `sort_by`, `sort_order`, `offset`, `limit`. All fields are optional.
- `SearchGuildMessagesResult` with the hit-group `messages` array, `total_results`, and `analytics_id`.

Docs: https://discord.com/developers/docs/resources/message#search-guild-messages

`cargo check --all-features` passes; `cargo clippy --all-features` produces no new warnings on the added files (the one pre-existing `duration_suboptimal_units` hit in `src/cache/settings.rs` is unrelated to this PR).