### PR TITLE
Move default allowed mentions into the `CacheHttp` trait and out of the `http` module

### DIFF
--- a/examples/e01_basic_ping_bot/src/main.rs
+++ b/examples/e01_basic_ping_bot/src/main.rs
@@ -22,7 +22,7 @@ impl EventHandler for Handler {
                     // Sending a message can fail, due to a network error, an authentication error,
                     // or lack of permissions to post in the channel, so log to
                     // stdout when some error happens, with a description of it.
-                    if let Err(why) = new_message.channel_id.say(&ctx.http, "Pong!").await {
+                    if let Err(why) = new_message.channel_id.say(ctx, "Pong!").await {
                         println!("Error sending message: {why:?}");
                     }
                 }

--- a/examples/e02_transparent_guild_sharding/src/main.rs
+++ b/examples/e02_transparent_guild_sharding/src/main.rs
@@ -30,7 +30,7 @@ impl EventHandler for Handler {
                 new_message, ..
             } => {
                 if new_message.content == "!ping" {
-                    if let Err(why) = new_message.channel_id.say(&ctx.http, "Pong!").await {
+                    if let Err(why) = new_message.channel_id.say(ctx, "Pong!").await {
                         println!("Error sending message: {why:?}");
                     }
                 }

--- a/examples/e03_struct_utilities/src/main.rs
+++ b/examples/e03_struct_utilities/src/main.rs
@@ -23,7 +23,7 @@ impl EventHandler for Handler {
                     // In this case, you can direct message a User directly by simply calling a
                     // method on its instance, with the content of the message.
                     let builder = CreateMessage::new().content("Hello!");
-                    let dm = new_message.author.id.dm(&ctx.http, builder).await;
+                    let dm = new_message.author.id.dm(ctx, builder).await;
 
                     if let Err(why) = dm {
                         println!("Error when direct messaging user: {why:?}");

--- a/examples/e04_message_builder/src/main.rs
+++ b/examples/e04_message_builder/src/main.rs
@@ -35,7 +35,7 @@ impl EventHandler for Handler {
                         .push(" channel")
                         .build();
 
-                    if let Err(why) = new_message.channel_id.say(&ctx.http, &response).await {
+                    if let Err(why) = new_message.channel_id.say(ctx, &response).await {
                         println!("Error sending message: {why:?}");
                     }
                 }

--- a/examples/e05_sample_bot_structure/src/commands/modal.rs
+++ b/examples/e05_sample_bot_structure/src/commands/modal.rs
@@ -17,7 +17,7 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) -> Result<(), 
     response
         .interaction
         .create_response(
-            &ctx.http,
+            ctx,
             CreateInteractionResponse::Message(CreateInteractionResponseMessage::new().content(
                 format!("**Name**: {first_name} {last_name}\n\nHobbies and interests: {hobbies}"),
             )),

--- a/examples/e05_sample_bot_structure/src/main.rs
+++ b/examples/e05_sample_bot_structure/src/main.rs
@@ -41,7 +41,7 @@ impl EventHandler for Handler {
                     if let Some(content) = content {
                         let data = CreateInteractionResponseMessage::new().content(content);
                         let builder = CreateInteractionResponse::Message(data);
-                        if let Err(why) = command.create_response(&ctx.http, builder).await {
+                        if let Err(why) = command.create_response(ctx, builder).await {
                             println!("Cannot respond to slash command: {why}");
                         }
                     }

--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -39,7 +39,7 @@ impl EventHandler for Handler {
                         .content("Hello, World!")
                         .embed(embed)
                         .add_file(CreateAttachment::path("./ferris_eyes.png".as_ref()).unwrap());
-                    let msg = new_message.channel_id.send_message(&ctx.http, builder).await;
+                    let msg = new_message.channel_id.send_message(ctx, builder).await;
 
                     if let Err(why) = msg {
                         println!("Error sending message: {why:?}");

--- a/examples/e09_collectors/src/main.rs
+++ b/examples/e09_collectors/src/main.rs
@@ -24,7 +24,7 @@ impl EventHandler for Handler {
             } => {
                 let mut score = 0u32;
                 let _ = new_message
-                    .reply(&ctx.http, "How was that crusty crab called again? 10 seconds time!")
+                    .reply(ctx, "How was that crusty crab called again? 10 seconds time!")
                     .await;
 
                 // There is a method implemented for some models to conveniently collect replies.
@@ -34,13 +34,13 @@ impl EventHandler for Handler {
                     new_message.author.id.collect_messages(ctx).timeout(Duration::from_secs(10));
                 if let Some(answer) = collector.await {
                     if answer.content.to_lowercase() == "ferris" {
-                        let _ = answer.reply(&ctx.http, "That's correct!").await;
+                        let _ = answer.reply(ctx, "That's correct!").await;
                         score += 1;
                     } else {
-                        let _ = answer.reply(&ctx.http, "Wrong, it's Ferris!").await;
+                        let _ = answer.reply(ctx, "Wrong, it's Ferris!").await;
                     }
                 } else {
-                    let _ = new_message.reply(&ctx.http, "No answer within 10 seconds.").await;
+                    let _ = new_message.reply(ctx, "No answer within 10 seconds.").await;
                 };
 
                 let react_msg = new_message

--- a/examples/e11_global_data/src/main.rs
+++ b/examples/e11_global_data/src/main.rs
@@ -54,7 +54,7 @@ impl EventHandler for Handler {
                         Cow::Owned(format!("OWO Has been said {owo_count} times!"))
                     };
 
-                    if let Err(err) = new_message.reply(&ctx.http, response).await {
+                    if let Err(err) = new_message.reply(ctx, response).await {
                         eprintln!("Error sending response: {err:?}")
                     };
                 }

--- a/examples/e12_parallel_loops/src/main.rs
+++ b/examples/e12_parallel_loops/src/main.rs
@@ -24,7 +24,7 @@ impl EventHandler for Handler {
                 new_message, ..
             } => {
                 if new_message.content == "!ping" {
-                    if let Err(why) = new_message.channel_id.say(&ctx.http, "Pong!").await {
+                    if let Err(why) = new_message.channel_id.say(ctx, "Pong!").await {
                         println!("Error sending message: {why:?}");
                     }
                 }
@@ -95,7 +95,7 @@ async fn log_system_load(ctx: &Context) {
             false,
         );
     let builder = CreateMessage::new().embed(embed);
-    let message = GenericChannelId::new(381926291785383946).send_message(&ctx.http, builder).await;
+    let message = GenericChannelId::new(381926291785383946).send_message(ctx, builder).await;
     if let Err(why) = message {
         eprintln!("Error sending message: {why:?}");
     };

--- a/examples/e13_sqlite_database/src/main.rs
+++ b/examples/e13_sqlite_database/src/main.rs
@@ -38,7 +38,7 @@ impl EventHandler for Bot {
 
                     let response =
                         format!("Successfully added `{task_description}` to your todo list");
-                    new_message.channel_id.say(&ctx.http, response).await.unwrap();
+                    new_message.channel_id.say(ctx, response).await.unwrap();
                 } else if let Some(task_index) = new_message.content.strip_prefix("~todo remove") {
                     let task_index = task_index.trim().parse::<i64>().unwrap() - 1;
 
@@ -60,7 +60,7 @@ impl EventHandler for Bot {
                         .unwrap();
 
                     let response = format!("Successfully completed `{}`!", entry.task);
-                    new_message.channel_id.say(&ctx.http, response).await.unwrap();
+                    new_message.channel_id.say(ctx, response).await.unwrap();
                 } else if new_message.content.trim() == "~todo list" {
                     // "SELECT" will return the task of all rows where user_Id column = user_id in
                     // todo.
@@ -74,7 +74,7 @@ impl EventHandler for Bot {
                         writeln!(response, "{}. {}", i + 1, todo.task).unwrap();
                     }
 
-                    new_message.channel_id.say(&ctx.http, response).await.unwrap();
+                    new_message.channel_id.say(ctx, response).await.unwrap();
                 }
             },
             FullEvent::Ready {

--- a/examples/e14_message_components/src/main.rs
+++ b/examples/e14_message_components/src/main.rs
@@ -44,7 +44,7 @@ impl EventHandler for Handler {
                 let m = new_message
                     .channel_id
                     .send_message(
-                        &ctx.http,
+                        ctx,
                         CreateMessage::new()
                             .content("Please select your favorite animal")
                             .select_menu(

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -58,7 +58,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
     } else if msg.content == "edit" {
         let mut msg = channel_id
             .send_message(
-                &ctx.http,
+                &ctx,
                 CreateMessage::new()
                     .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
@@ -66,13 +66,12 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
         // Pre-PR, this falsely triggered a MODEL_TYPE_CONVERT Discord error
         msg.edit(&ctx, EditMessage::new().attachments(EditAttachments::keep_all(&msg))).await?;
     } else if msg.content == "unifiedattachments" {
-        let mut msg =
-            channel_id.send_message(&ctx.http, CreateMessage::new().content("works")).await?;
+        let mut msg = channel_id.send_message(&ctx, CreateMessage::new().content("works")).await?;
         msg.edit(ctx, EditMessage::new().content("works still")).await?;
 
         let mut msg = channel_id
             .send_message(
-                &ctx.http,
+                &ctx,
                 CreateMessage::new()
                     .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
@@ -99,7 +98,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
     } else if msg.content == "actionrow" {
         channel_id
             .send_message(
-                &ctx.http,
+                &ctx,
                 CreateMessage::new()
                     .button(CreateButton::new("0").label("Foo"))
                     .button(CreateButton::new("1").emoji('🤗').style(ButtonStyle::Secondary))
@@ -119,7 +118,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
         loop {
             let msg = channel_id
                 .send_message(
-                    &ctx.http,
+                    &ctx,
                     CreateMessage::new()
                         .button(CreateButton::new(custom_id.clone()).label(custom_id)),
                 )
@@ -127,7 +126,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
             let button_press =
                 msg.id.collect_component_interactions(ctx).timeout(Duration::from_secs(10)).await;
             match button_press {
-                Some(x) => x.defer(&ctx.http).await?,
+                Some(x) => x.defer(&ctx).await?,
                 None => break,
             }
 
@@ -179,7 +178,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
         use serenity::futures::StreamExt;
 
         let mut msg = channel_id
-            .say(&ctx.http, format!("https://codereview.stackexchange.com/questions/260653/very-slow-discord-bot-to-play-music{}", msg.id))
+            .say(&ctx, format!("https://codereview.stackexchange.com/questions/260653/very-slow-discord-bot-to-play-music{}", msg.id))
             .await?;
 
         let msg_id = msg.id;
@@ -197,7 +196,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
             .flags(MessageFlags::IS_VOICE_MESSAGE)
             .add_file(CreateAttachment::url(&ctx.http, audio_url, "testing.ogg").await?);
 
-        msg.author.id.dm(&ctx.http, builder).await?;
+        msg.author.id.dm(&ctx, builder).await?;
     } else if let Some(channel) = msg.content.strip_prefix("movetorootandback") {
         let mut channel = {
             let channel_id = channel.trim().parse::<ChannelId>().unwrap();
@@ -208,7 +207,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
         channel.edit(&ctx.http, EditChannel::new().category(None)).await?;
         channel.edit(&ctx.http, EditChannel::new().category(Some(parent_id))).await?;
     } else if msg.content == "channelperms" {
-        channel_id.say(&ctx.http, format!("{:?}", msg.author_permissions(&ctx.cache))).await?;
+        channel_id.say(&ctx, format!("{:?}", msg.author_permissions(&ctx.cache))).await?;
     } else if let Some(forum_channel_id) = msg.content.strip_prefix("createforumpostin ") {
         forum_channel_id
             .parse::<ChannelId>()
@@ -225,7 +224,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
     } else if let Some(forum_post_url) = msg.content.strip_prefix("deleteforumpost ") {
         let (_guild_id, channel_id, _message_id) =
             serenity::utils::parse_message_url(forum_post_url).unwrap();
-        msg.channel_id.say(&ctx.http, format!("Deleting <#{channel_id}> in 10 seconds...")).await?;
+        msg.channel_id.say(&ctx, format!("Deleting <#{channel_id}> in 10 seconds...")).await?;
         tokio::time::sleep(Duration::from_secs(10)).await;
         channel_id.delete(&ctx.http, None).await?;
     } else {
@@ -244,7 +243,7 @@ async fn command_interaction(
         // Respond with an image
         interaction
             .create_response(
-                &ctx.http,
+                &ctx,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new().add_file(
                         CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?,
@@ -280,7 +279,7 @@ async fn command_interaction(
     } else if interaction.data.name == "unifiedattachments1" {
         interaction
             .create_response(
-                &ctx.http,
+                &ctx,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new().content("works"),
                 ),
@@ -293,14 +292,14 @@ async fn command_interaction(
 
         interaction
             .create_followup(
-                &ctx.http,
+                &ctx,
                 CreateInteractionResponseFollowup::new().content("still works still"),
             )
             .await?;
     } else if interaction.data.name == "unifiedattachments2" {
         interaction
             .create_response(
-                &ctx.http,
+                &ctx,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new().add_file(
                         CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?,
@@ -320,7 +319,7 @@ async fn command_interaction(
 
         interaction
             .create_followup(
-                &ctx.http,
+                &ctx,
                 CreateInteractionResponseFollowup::new()
                     .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
             )
@@ -328,7 +327,7 @@ async fn command_interaction(
     } else if interaction.data.name == "editembeds" {
         interaction
             .create_response(
-                &ctx.http,
+                &ctx,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
                         .content("hi")
@@ -342,7 +341,7 @@ async fn command_interaction(
     } else if interaction.data.name == "newselectmenu" {
         interaction
             .create_response(
-                &ctx.http,
+                &ctx,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
                         .select_menu(CreateSelectMenu::new("0", CreateSelectMenuKind::String {
@@ -396,7 +395,7 @@ impl EventHandler for Handler {
                 Interaction::Component(i) => println!("{:#?}", i.data),
                 Interaction::Autocomplete(i) => {
                     i.create_response(
-                        &ctx.http,
+                        &ctx,
                         CreateInteractionResponse::Autocomplete(
                             CreateAutocompleteResponse::new().add_choice("suggestion"),
                         ),

--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to add parameters when using [`GuildId::add_member`].

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -5,8 +5,6 @@ use url::Url;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder for constructing an invite link with custom OAuth2 scopes.

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -5,8 +5,6 @@ use nonmax::NonMaxU16;
 use super::CreateForumTag;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder for creating a new [`GuildChannel`] in a [`Guild`].

--- a/src/builder/create_command_permission.rs
+++ b/src/builder/create_command_permission.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder for creating several [`CommandPermission`].

--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -5,8 +5,6 @@ use nonmax::NonMaxU16;
 use super::CreateMessage;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/resources/channel#start-thread-in-forum-or-media-channel).

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -13,8 +13,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::{CacheHttp, Http};
-use crate::internal::prelude::*;
+use crate::http::Http;
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object).

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -13,7 +13,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
@@ -125,7 +125,7 @@ impl CreateInteractionResponse<'_> {
     #[cfg(feature = "http")]
     pub async fn execute(
         mut self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         interaction_id: InteractionId,
         interaction_token: &str,
     ) -> Result<()> {
@@ -140,10 +140,13 @@ impl CreateInteractionResponse<'_> {
         if let Self::Message(msg) | Self::Defer(msg) | Self::UpdateMessage(msg) = &mut self
             && msg.allowed_mentions.is_none()
         {
-            msg.allowed_mentions.clone_from(&http.default_allowed_mentions);
+            msg.allowed_mentions.clone_from(&cache_http.default_allowed_mentions());
         }
 
-        http.create_interaction_response(interaction_id, interaction_token, &self, files).await
+        cache_http
+            .http()
+            .create_interaction_response(interaction_id, interaction_token, &self, files)
+            .await
     }
 }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -10,7 +10,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::Http;
+use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -174,7 +174,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     #[cfg(feature = "http")]
     pub async fn execute(
         mut self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         message_id: Option<MessageId>,
         interaction_token: &str,
     ) -> Result<Message> {
@@ -183,9 +183,10 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         let files = self.attachments.new_attachments();
 
         if self.allowed_mentions.is_none() {
-            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+            self.allowed_mentions.clone_from(&cache_http.default_allowed_mentions());
         }
 
+        let http = cache_http.http();
         match message_id {
             Some(id) => http.edit_followup_message(interaction_token, id, &self, files).await,
             None => http.create_followup_message(interaction_token, &self, files).await,

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -9,10 +9,6 @@ use super::{
     CreatePoll,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#create-followup-message)

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to create an [`Invite`] for use via [`ChannelId::create_invite`].

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -9,10 +9,6 @@ use super::{
     CreatePoll,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to specify the contents of an send message request, primarily meant for use

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -10,7 +10,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::Http;
+use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -278,14 +278,18 @@ impl<'a> CreateMessage<'a> {
     /// [Send Messages]: Permissions::SEND_MESSAGES
     /// [Attach Files]: Permissions::ATTACH_FILES
     #[cfg(feature = "http")]
-    pub async fn execute(mut self, http: &Http, channel_id: GenericChannelId) -> Result<Message> {
+    pub async fn execute(
+        mut self,
+        cache_http: impl CacheHttp,
+        channel_id: GenericChannelId,
+    ) -> Result<Message> {
         self.check_length()?;
 
         let files = self.attachments.new_attachments();
         if self.allowed_mentions.is_none() {
-            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+            self.allowed_mentions.clone_from(&cache_http.default_allowed_mentions());
         }
 
-        http.send_message(channel_id, files, &self).await
+        cache_http.http().send_message(channel_id, files, &self).await
     }
 }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -3,8 +3,6 @@ use std::borrow::Cow;
 use super::DataUri;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#create-guild-scheduled-event)

--- a/src/builder/create_soundboard.rs
+++ b/src/builder/create_soundboard.rs
@@ -1,10 +1,6 @@
 use std::borrow::Cow;
 
 use super::DataUri;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to create a soundboard sound.

--- a/src/builder/create_stage_instance.rs
+++ b/src/builder/create_stage_instance.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Builder for creating a stage instance

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -4,8 +4,6 @@ use super::CreateAttachment;
 #[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
-use crate::internal::prelude::*;
-#[cfg(feature = "http")]
 use crate::model::prelude::*;
 
 /// A builder to create a guild sticker

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -4,8 +4,6 @@ use nonmax::NonMaxU16;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Discord docs:

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -4,8 +4,6 @@ use super::DataUri;
 #[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
-use crate::internal::prelude::*;
-#[cfg(feature = "http")]
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/resources/webhook#create-webhook)

--- a/src/builder/edit_automod_rule.rs
+++ b/src/builder/edit_automod_rule.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::guild::automod::EventType;
 use crate::model::prelude::*;
 

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -5,8 +5,6 @@ use nonmax::NonMaxU16;
 use super::CreateForumTag;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to edit a [`GuildChannel`] for use via [`GuildChannel::edit`].

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -3,8 +3,6 @@ use std::borrow::Cow;
 use super::DataUri;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to optionally edit certain fields of a guild

--- a/src/builder/edit_guild_incident_actions.rs
+++ b/src/builder/edit_guild_incident_actions.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder for editing guild incident actions.

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to edit the welcome screen of a guild

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to specify the fields to edit in a [`GuildWidget`].

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -10,8 +10,6 @@ use super::{
 };
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/interactions/receiving-and-responding#edit-original-interaction-response)

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder which edits the properties of a [`Member`], to be used in conjunction with

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -239,11 +239,10 @@ impl<'a> EditMessage<'a> {
 
         let files = self.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachments);
 
-        let http = cache_http.http();
         if self.allowed_mentions.is_none() {
-            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+            self.allowed_mentions.clone_from(&cache_http.default_allowed_mentions());
         }
 
-        http.edit_message(channel_id, message_id, &self, files).await
+        cache_http.http().edit_message(channel_id, message_id, &self, files).await
     }
 }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -7,10 +7,6 @@ use super::{
     CreateEmbed,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to specify the fields to edit in an existing message.

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -3,10 +3,7 @@ use std::borrow::Cow;
 use super::DataUri;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
-#[cfg(feature = "http")]
-use crate::model::user::CurrentUser;
+use crate::model::prelude::*;
 
 /// A builder to edit the current user's settings, to be used in conjunction with
 /// [`CurrentUser::edit`].

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -3,8 +3,6 @@ use std::borrow::Cow;
 use super::{CreateScheduledEventMetadata, DataUri};
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/resources/guild-scheduled-event#modify-guild-scheduled-event)

--- a/src/builder/edit_soundboard.rs
+++ b/src/builder/edit_soundboard.rs
@@ -1,9 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to create or edit a [`Soundboard`] for use with [`GuildId::edit_soundboard`].

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Edits a [`StageInstance`].

--- a/src/builder/edit_sticker.rs
+++ b/src/builder/edit_sticker.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 #[cfg(any(feature = "http", doc))]
 use crate::model::prelude::*;
 

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -4,8 +4,6 @@ use nonmax::NonMaxU16;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/resources/channel#modify-channel-json-params-thread).

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder which edits a user's voice state, to be used in conjunction with

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -3,8 +3,6 @@ use std::borrow::Cow;
 use super::DataUri;
 #[cfg(feature = "http")]
 use crate::http::Http;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// [Discord docs](https://docs.discord.com/developers/resources/webhook#modify-webhook)

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -8,8 +8,6 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::CacheHttp;
-#[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
 

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -8,7 +8,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::Http;
+use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -166,7 +166,7 @@ impl<'a> EditWebhookMessage<'a> {
     #[cfg(feature = "http")]
     pub async fn execute(
         mut self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         webhook_id: WebhookId,
         webhook_token: &str,
         message_id: MessageId,
@@ -176,17 +176,19 @@ impl<'a> EditWebhookMessage<'a> {
         let files = self.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachments);
 
         if self.allowed_mentions.is_none() {
-            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+            self.allowed_mentions.clone_from(&cache_http.default_allowed_mentions());
         }
 
-        http.edit_webhook_message(
-            webhook_id,
-            self.thread_id,
-            webhook_token,
-            message_id,
-            &self,
-            files,
-        )
-        .await
+        cache_http
+            .http()
+            .edit_webhook_message(
+                webhook_id,
+                self.thread_id,
+                webhook_token,
+                message_id,
+                &self,
+                files,
+            )
+            .await
     }
 }

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -7,10 +7,6 @@ use super::{
     CreateEmbed,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// A builder to create the content for a [`Webhook`]'s execution.

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -8,7 +8,7 @@ use super::{
     EditAttachments,
 };
 #[cfg(feature = "http")]
-use crate::http::Http;
+use crate::http::CacheHttp;
 #[cfg(feature = "http")]
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -352,7 +352,7 @@ impl<'a> ExecuteWebhook<'a> {
     #[cfg(feature = "http")]
     pub async fn execute(
         mut self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         webhook_id: WebhookId,
         webhook_token: &str,
         wait: bool,
@@ -362,9 +362,10 @@ impl<'a> ExecuteWebhook<'a> {
         let files = self.attachments.new_attachments();
 
         if self.allowed_mentions.is_none() {
-            self.allowed_mentions.clone_from(&http.default_allowed_mentions);
+            self.allowed_mentions.clone_from(&cache_http.default_allowed_mentions());
         }
 
+        let http = cache_http.http();
         if self.with_components.unwrap_or_default() {
             http.execute_webhook_with_components(
                 webhook_id,

--- a/src/builder/get_entitlements.rs
+++ b/src/builder/get_entitlements.rs
@@ -4,9 +4,7 @@ use nonmax::NonMaxU8;
 
 #[cfg(feature = "http")]
 use crate::http::Http;
-use crate::internal::prelude::Result;
-use crate::model::id::{EntitlementId, GuildId, SkuId, UserId};
-use crate::model::monetization::Entitlement;
+use crate::model::prelude::*;
 
 /// Builds a request to fetch active and ended [`Entitlement`]s.
 ///

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -1,9 +1,7 @@
 use nonmax::NonMaxU8;
 
 #[cfg(feature = "http")]
-use crate::http::{CacheHttp, MessagePagination};
-#[cfg(feature = "http")]
-use crate::internal::prelude::*;
+use crate::http::MessagePagination;
 use crate::model::prelude::*;
 
 /// Builds a request to the API to retrieve messages.

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -3,62 +3,8 @@ use std::num::NonZeroU16;
 
 use extract_map::entry::Entry;
 
-use super::{BaseGuildChannel, Cache, CacheUpdate, GenericChannelId, GuildThread};
-use crate::all::{
-    CountDetails,
-    MessageReaction,
-    ReactionAddEvent,
-    ReactionRemoveAllEvent,
-    ReactionRemoveEmojiEvent,
-    ReactionRemoveEvent,
-};
-use crate::internal::prelude::*;
-use crate::model::channel::{GuildChannel, Message};
-use crate::model::event::{
-    ChannelCreateEvent,
-    ChannelDeleteEvent,
-    ChannelPinsUpdateEvent,
-    ChannelUpdateEvent,
-    GuildCreateEvent,
-    GuildDeleteEvent,
-    GuildEmojisUpdateEvent,
-    GuildMemberAddEvent,
-    GuildMemberRemoveEvent,
-    GuildMemberUpdateEvent,
-    GuildMembersChunkEvent,
-    GuildRoleCreateEvent,
-    GuildRoleDeleteEvent,
-    GuildRoleUpdateEvent,
-    GuildScheduledEventCreateEvent,
-    GuildScheduledEventDeleteEvent,
-    GuildScheduledEventUpdateEvent,
-    GuildStickersUpdateEvent,
-    GuildUpdateEvent,
-    MessageCreateEvent,
-    MessageUpdateEvent,
-    PresenceUpdateEvent,
-    ReadyEvent,
-    ThreadCreateEvent,
-    ThreadDeleteEvent,
-    ThreadListSyncEvent,
-    ThreadUpdateEvent,
-    UserUpdateEvent,
-    VoiceChannelStatusUpdateEvent,
-    VoiceStateUpdateEvent,
-};
-use crate::model::gateway::Presence;
-use crate::model::guild::{
-    Guild,
-    GuildMemberFlags,
-    Member,
-    MemberCount,
-    MemberGeneratedFlags,
-    Role,
-    ScheduledEvent,
-};
-use crate::model::id::GuildId;
-use crate::model::user::{Collectibles, CurrentUser, OnlineStatus};
-use crate::model::voice::VoiceState;
+use super::{Cache, CacheUpdate};
+use crate::model::prelude::*;
 
 impl CacheUpdate for ChannelCreateEvent {
     type Output = GuildChannel;

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -8,7 +8,6 @@ pub use quick_modal::*;
 
 use crate::gateway::CollectorCallback;
 use crate::gateway::client::Context;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 /// Fundamental collector function. All collector types in this module are just wrappers around

--- a/src/collector/quick_modal.rs
+++ b/src/collector/quick_modal.rs
@@ -10,7 +10,6 @@ use crate::builder::{
 };
 use crate::collector::ModalInteractionCollector;
 use crate::gateway::client::Context;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 pub struct QuickModalResponse {

--- a/src/collector/quick_modal.rs
+++ b/src/collector/quick_modal.rs
@@ -119,7 +119,7 @@ impl<'a> CreateQuickModal<'a> {
         let builder = CreateInteractionResponse::Modal(
             CreateModal::new(interaction_id.to_string(), self.title).components(self.components),
         );
-        builder.execute(&ctx.http, interaction_id, token).await?;
+        builder.execute(&ctx, interaction_id, token).await?;
 
         let collector = ModalInteractionCollector::new(ctx)
             .custom_ids(vec![FixedString::from_str_trunc(&interaction_id.to_string())]);

--- a/src/gateway/client/context.rs
+++ b/src/gateway/client/context.rs
@@ -15,7 +15,7 @@ use crate::gateway::{
     ShardRunnerInfo,
     ShardRunnerMessage,
 };
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 
 /// A general utility struct provided on event dispatches.

--- a/src/gateway/client/context.rs
+++ b/src/gateway/client/context.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use futures::channel::mpsc::UnboundedSender as Sender;
 use parking_lot::RwLock;
 
-use crate::builder::DataUri;
+use crate::builder::{CreateAllowedMentions, DataUri};
 #[cfg(feature = "cache")]
 pub use crate::cache::Cache;
 #[cfg(feature = "collector")]
@@ -46,6 +46,7 @@ pub struct Context {
     /// The ID of the shard this context is related to.
     pub shard_id: ShardId,
     pub http: Arc<Http>,
+    pub(crate) default_allowed_mentions: Option<CreateAllowedMentions<'static>>,
     #[cfg(feature = "cache")]
     pub cache: Arc<Cache>,
     /// Metadata about the shard.
@@ -57,6 +58,9 @@ pub struct Context {
 impl CacheHttp for Context {
     fn http(&self) -> &Http {
         &self.http
+    }
+    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
+        self.default_allowed_mentions.clone()
     }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&Arc<Cache>> {

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -51,6 +51,7 @@ use super::{
     ShardManagerOptions,
     TransportCompression,
 };
+use crate::builder::CreateAllowedMentions;
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
 #[cfg(feature = "cache")]
@@ -72,6 +73,7 @@ pub struct ClientBuilder {
     data: Option<Arc<dyn std::any::Any + Send + Sync>>,
     http: Arc<Http>,
     intents: GatewayIntents,
+    default_allowed_mentions: Option<CreateAllowedMentions<'static>>,
     #[cfg(feature = "cache")]
     cache_settings: CacheSettings,
     #[cfg(feature = "framework")]
@@ -107,6 +109,7 @@ impl ClientBuilder {
             token,
             http,
             intents,
+            default_allowed_mentions: None,
             data: None,
             #[cfg(feature = "cache")]
             cache_settings: CacheSettings::default(),
@@ -231,6 +234,21 @@ impl ClientBuilder {
         self.intents
     }
 
+    /// Sets the [`CreateAllowedMentions`] used by default for each request that would use it.
+    pub fn default_allowed_mentions(
+        mut self,
+        allowed_mentions: CreateAllowedMentions<'static>,
+    ) -> Self {
+        self.default_allowed_mentions = Some(allowed_mentions);
+        self
+    }
+
+    /// Gets the default allowed mentions.
+    #[must_use]
+    pub fn get_default_allowed_mentions(&self) -> Option<&CreateAllowedMentions<'static>> {
+        self.default_allowed_mentions.as_ref()
+    }
+
     /// Sets the event handler where all received gateway events will be dispatched.
     pub fn event_handler(mut self, event_handler: Arc<dyn EventHandler>) -> Self {
         self.event_handler = Some(event_handler);
@@ -337,6 +355,7 @@ impl IntoFuture for ClientBuilder {
                 cache: Arc::clone(&cache),
                 http: Arc::clone(&http),
                 intents,
+                default_allowed_mentions: self.default_allowed_mentions,
                 presence: Some(presence),
                 wait_time_between_shard_start: self.wait_time_between_shard_start,
             });

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -22,6 +22,7 @@ use super::{
     ShardRunnerInfo,
     ShardRunnerMessage,
 };
+use crate::builder::CreateAllowedMentions;
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
 #[cfg(feature = "framework")]
@@ -84,6 +85,7 @@ pub struct ShardManager {
     pub cache: Arc<Cache>,
     pub http: Arc<Http>,
     pub intents: GatewayIntents,
+    pub default_allowed_mentions: Option<CreateAllowedMentions<'static>>,
     pub presence: Option<PresenceData>,
 }
 
@@ -114,6 +116,7 @@ impl ShardManager {
             cache: opt.cache,
             http: opt.http,
             intents: opt.intents,
+            default_allowed_mentions: opt.default_allowed_mentions,
             presence: opt.presence,
             wait_time_between_shard_start: opt.wait_time_between_shard_start,
         }
@@ -265,6 +268,7 @@ impl ShardManager {
                 manager: self.manager_tx.clone(),
                 shard_id,
                 http: Arc::clone(&self.http),
+                default_allowed_mentions: self.default_allowed_mentions.clone(),
                 #[cfg(feature = "cache")]
                 cache: Arc::clone(&self.cache),
                 #[cfg(feature = "collector")]
@@ -333,6 +337,7 @@ pub struct ShardManagerOptions {
     pub cache: Arc<Cache>,
     pub http: Arc<Http>,
     pub intents: GatewayIntents,
+    pub default_allowed_mentions: Option<CreateAllowedMentions<'static>>,
     pub presence: Option<PresenceData>,
 }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -32,7 +32,7 @@ use super::{
     MessagePagination,
     UserPagination,
 };
-use crate::builder::{CreateAllowedMentions, CreateAttachment};
+use crate::builder::CreateAttachment;
 use crate::constants;
 use crate::internal::prelude::*;
 use crate::model::prelude::*;
@@ -86,7 +86,6 @@ pub struct HttpBuilder {
     token: Option<Token>,
     proxy: Option<FixedString<u16>>,
     application_id: Option<ApplicationId>,
-    default_allowed_mentions: Option<CreateAllowedMentions<'static>>,
 }
 
 impl HttpBuilder {
@@ -99,7 +98,6 @@ impl HttpBuilder {
             token: Some(token),
             proxy: None,
             application_id: None,
-            default_allowed_mentions: None,
         }
     }
 
@@ -115,7 +113,6 @@ impl HttpBuilder {
             token: None,
             proxy: None,
             application_id: None,
-            default_allowed_mentions: None,
         }
     }
 
@@ -179,18 +176,6 @@ impl HttpBuilder {
         self
     }
 
-    /// Sets the [`CreateAllowedMentions`] used by default for each request that would use it.
-    ///
-    /// This only takes effect if you are calling through the model or builder methods, not directly
-    /// calling [`Http`] methods, as [`Http`] is simply used as a convenient storage for these.
-    pub fn default_allowed_mentions(
-        mut self,
-        allowed_mentions: CreateAllowedMentions<'static>,
-    ) -> Self {
-        self.default_allowed_mentions = Some(allowed_mentions);
-        self
-    }
-
     /// Use the given configuration to build the `Http` client.
     #[must_use]
     pub fn build(self) -> Http {
@@ -212,7 +197,6 @@ impl HttpBuilder {
             proxy: self.proxy,
             token: self.token,
             application_id,
-            default_allowed_mentions: self.default_allowed_mentions,
         }
     }
 }
@@ -243,7 +227,6 @@ pub struct Http {
     pub proxy: Option<FixedString<u16>>,
     token: Option<Token>,
     application_id: AtomicU64,
-    pub default_allowed_mentions: Option<CreateAllowedMentions<'static>>,
 }
 
 impl Http {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -34,7 +34,6 @@ use super::{
 };
 use crate::builder::CreateAttachment;
 use crate::constants;
-use crate::internal::prelude::*;
 use crate::model::prelude::*;
 
 // NOTE: This cannot be passed in from outside, due to `Cell` being !Send.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -39,6 +39,8 @@ pub use self::ratelimiting::*;
 pub use self::request::*;
 pub use self::routing::*;
 pub use self::typing::*;
+#[cfg(feature = "builder")]
+use crate::builder::CreateAllowedMentions;
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
 use crate::model::prelude::*;
@@ -50,6 +52,11 @@ use crate::model::prelude::*;
 /// the [`CacheHttp::cache`] method will simply return `None`.
 pub trait CacheHttp: Send + Sync {
     fn http(&self) -> &Http;
+
+    #[cfg(feature = "builder")]
+    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
+        None
+    }
 
     #[cfg(feature = "cache")]
     #[must_use]
@@ -65,6 +72,10 @@ where
     fn http(&self) -> &Http {
         (*self).http()
     }
+    #[cfg(feature = "builder")]
+    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
+        (*self).default_allowed_mentions()
+    }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&Arc<Cache>> {
         (*self).cache()
@@ -77,6 +88,10 @@ where
 {
     fn http(&self) -> &Http {
         (**self).http()
+    }
+    #[cfg(feature = "builder")]
+    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
+        (**self).default_allowed_mentions()
     }
     #[cfg(feature = "cache")]
     fn cache(&self) -> Option<&Arc<Cache>> {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -27,8 +27,6 @@ mod request;
 mod routing;
 mod typing;
 
-use std::sync::Arc;
-
 use reqwest::Method;
 pub use reqwest::StatusCode;
 
@@ -39,82 +37,7 @@ pub use self::ratelimiting::*;
 pub use self::request::*;
 pub use self::routing::*;
 pub use self::typing::*;
-#[cfg(feature = "builder")]
-use crate::builder::CreateAllowedMentions;
-#[cfg(feature = "cache")]
-use crate::cache::Cache;
-use crate::model::prelude::*;
-
-/// This trait will be required by functions that need [`Http`] and can optionally use a [`Cache`]
-/// to potentially avoid REST-requests.
-///
-/// If the `cache` feature is enabled, but an implementing type does not have access to a cache,
-/// the [`CacheHttp::cache`] method will simply return `None`.
-pub trait CacheHttp: Send + Sync {
-    fn http(&self) -> &Http;
-
-    #[cfg(feature = "builder")]
-    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
-        None
-    }
-
-    #[cfg(feature = "cache")]
-    #[must_use]
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        None
-    }
-}
-
-impl<T> CacheHttp for &T
-where
-    T: CacheHttp,
-{
-    fn http(&self) -> &Http {
-        (*self).http()
-    }
-    #[cfg(feature = "builder")]
-    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
-        (*self).default_allowed_mentions()
-    }
-    #[cfg(feature = "cache")]
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        (*self).cache()
-    }
-}
-
-impl<T> CacheHttp for Arc<T>
-where
-    T: CacheHttp,
-{
-    fn http(&self) -> &Http {
-        (**self).http()
-    }
-    #[cfg(feature = "builder")]
-    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
-        (**self).default_allowed_mentions()
-    }
-    #[cfg(feature = "cache")]
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        (**self).cache()
-    }
-}
-
-#[cfg(feature = "cache")]
-impl CacheHttp for (Option<&Arc<Cache>>, &Http) {
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        self.0
-    }
-
-    fn http(&self) -> &Http {
-        self.1
-    }
-}
-
-impl CacheHttp for Http {
-    fn http(&self) -> &Http {
-        self
-    }
-}
+use crate::model::id::*;
 
 /// An method used for ratelimiting special routes.
 ///

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -13,7 +13,7 @@ use crate::builder::{
     EditInteractionResponse,
 };
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 
 /// An interaction when a user invokes a slash command.

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -13,7 +13,7 @@ use crate::builder::{
     EditInteractionResponse,
 };
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 use crate::model::prelude::*;
 
 /// An interaction when a user invokes a slash command.
@@ -88,10 +88,10 @@ impl CommandInteraction {
     /// deserializing the API response.
     pub async fn create_response(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         builder: CreateInteractionResponse<'_>,
     ) -> Result<()> {
-        builder.execute(http, self.id, &self.token).await
+        builder.execute(cache_http, self.id, &self.token).await
     }
 
     /// Edits the initial interaction response.
@@ -134,10 +134,10 @@ impl CommandInteraction {
     /// response.
     pub async fn create_followup(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(http, None, &self.token).await
+        builder.execute(cache_http, None, &self.token).await
     }
 
     /// Edits a followup response to the response sent.
@@ -151,11 +151,11 @@ impl CommandInteraction {
     /// response.
     pub async fn edit_followup(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(http, Some(message_id), &self.token).await
+        builder.execute(cache_http, Some(message_id), &self.token).await
     }
 
     /// Deletes a followup message.
@@ -184,9 +184,9 @@ impl CommandInteraction {
     ///
     /// Returns an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is
     /// an error in deserializing the API response.
-    pub async fn defer(&self, http: &Http) -> Result<()> {
+    pub async fn defer(&self, cache_http: impl CacheHttp) -> Result<()> {
         let builder = CreateInteractionResponse::Defer(CreateInteractionResponseMessage::default());
-        self.create_response(http, builder).await
+        self.create_response(cache_http, builder).await
     }
 
     /// Helper function to defer an interaction ephemerally
@@ -195,11 +195,11 @@ impl CommandInteraction {
     ///
     /// May also return an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if
     /// there is an error in deserializing the API response.
-    pub async fn defer_ephemeral(&self, http: &Http) -> Result<()> {
+    pub async fn defer_ephemeral(&self, cache_http: impl CacheHttp) -> Result<()> {
         let builder = CreateInteractionResponse::Defer(
             CreateInteractionResponseMessage::new().ephemeral(true),
         );
-        self.create_response(http, builder).await
+        self.create_response(cache_http, builder).await
     }
 }
 

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -10,7 +10,7 @@ use crate::builder::{
     EditInteractionResponse,
 };
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 
 /// An interaction triggered by a message component.

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -10,7 +10,7 @@ use crate::builder::{
     EditInteractionResponse,
 };
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 use crate::model::prelude::*;
 
 /// An interaction triggered by a message component.
@@ -87,10 +87,10 @@ impl ComponentInteraction {
     /// deserializing the API response.
     pub async fn create_response(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         builder: CreateInteractionResponse<'_>,
     ) -> Result<()> {
-        builder.execute(http, self.id, &self.token).await
+        builder.execute(cache_http, self.id, &self.token).await
     }
 
     /// Edits the initial interaction response.
@@ -133,10 +133,10 @@ impl ComponentInteraction {
     /// response.
     pub async fn create_followup(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(http, None, &self.token).await
+        builder.execute(cache_http, None, &self.token).await
     }
 
     /// Edits a followup response to the response sent.
@@ -150,11 +150,11 @@ impl ComponentInteraction {
     /// response.
     pub async fn edit_followup(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(http, Some(message_id), &self.token).await
+        builder.execute(cache_http, Some(message_id), &self.token).await
     }
 
     /// Deletes a followup message.
@@ -183,8 +183,8 @@ impl ComponentInteraction {
     ///
     /// Returns an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is
     /// an error in deserializing the API response.
-    pub async fn defer(&self, http: &Http) -> Result<()> {
-        self.create_response(http, CreateInteractionResponse::Acknowledge).await
+    pub async fn defer(&self, cache_http: impl CacheHttp) -> Result<()> {
+        self.create_response(cache_http, CreateInteractionResponse::Acknowledge).await
     }
 
     /// Helper function to defer an interaction ephemerally
@@ -193,11 +193,11 @@ impl ComponentInteraction {
     ///
     /// May also return an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if
     /// there is an error in deserializing the API response.
-    pub async fn defer_ephemeral(&self, http: &Http) -> Result<()> {
+    pub async fn defer_ephemeral(&self, cache_http: impl CacheHttp) -> Result<()> {
         let builder = CreateInteractionResponse::Defer(
             CreateInteractionResponseMessage::new().ephemeral(true),
         );
-        self.create_response(http, builder).await
+        self.create_response(cache_http, builder).await
     }
 }
 

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -10,7 +10,7 @@ use crate::builder::{
     EditInteractionResponse,
 };
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 
 /// An interaction triggered by a modal submit.

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -10,7 +10,7 @@ use crate::builder::{
     EditInteractionResponse,
 };
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 use crate::model::prelude::*;
 
 /// An interaction triggered by a modal submit.
@@ -86,10 +86,10 @@ impl ModalInteraction {
     /// deserializing the API response.
     pub async fn create_response(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         builder: CreateInteractionResponse<'_>,
     ) -> Result<()> {
-        builder.execute(http, self.id, &self.token).await
+        builder.execute(cache_http, self.id, &self.token).await
     }
 
     /// Edits the initial interaction response.
@@ -132,10 +132,10 @@ impl ModalInteraction {
     /// response.
     pub async fn create_followup(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(http, None, &self.token).await
+        builder.execute(cache_http, None, &self.token).await
     }
 
     /// Edits a followup response to the response sent.
@@ -149,11 +149,11 @@ impl ModalInteraction {
     /// response.
     pub async fn edit_followup(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         message_id: MessageId,
         builder: CreateInteractionResponseFollowup<'_>,
     ) -> Result<Message> {
-        builder.execute(http, Some(message_id), &self.token).await
+        builder.execute(cache_http, Some(message_id), &self.token).await
     }
 
     /// Deletes a followup message.
@@ -172,8 +172,8 @@ impl ModalInteraction {
     ///
     /// Returns an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if there is
     /// an error in deserializing the API response.
-    pub async fn defer(&self, http: &Http) -> Result<()> {
-        self.create_response(http, CreateInteractionResponse::Acknowledge).await
+    pub async fn defer(&self, cache_http: impl CacheHttp) -> Result<()> {
+        self.create_response(cache_http, CreateInteractionResponse::Acknowledge).await
     }
 
     /// Helper function to defer an interaction ephemerally
@@ -182,11 +182,11 @@ impl ModalInteraction {
     ///
     /// May also return an [`Error::Http`] if the API returns an error, or an [`Error::Json`] if
     /// there is an error in deserializing the API response.
-    pub async fn defer_ephemeral(&self, http: &Http) -> Result<()> {
+    pub async fn defer_ephemeral(&self, cache_http: impl CacheHttp) -> Result<()> {
         let builder = CreateInteractionResponse::Defer(
             CreateInteractionResponseMessage::new().ephemeral(true),
         );
-        self.create_response(http, builder).await
+        self.create_response(cache_http, builder).await
     }
 }
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -27,7 +27,7 @@ use crate::cache::Cache;
 #[cfg(all(feature = "cache", feature = "temp_cache", feature = "model"))]
 use crate::cache::MaybeOwnedArc;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http, Typing};
+use crate::http::{Http, Typing};
 use crate::model::prelude::*;
 
 impl ChannelId {
@@ -642,6 +642,7 @@ impl GenericChannelId {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the channel retrieval request failed.
+    #[cfg_attr(not(feature = "cache"), allow(unused_variables))]
     pub async fn to_channel(
         self,
         cache_http: impl CacheHttp,
@@ -652,14 +653,14 @@ impl GenericChannelId {
 
         #[cfg(feature = "cache")]
         if let Some(cache) = cache_http.cache() {
-            match guild_id.and_then(|id| cache.guild(id)).as_ref().and_then(|g| g.channel(self)) {
-                Some(GenericGuildChannelRef::Channel(chan)) => {
-                    return Ok(Channel::Guild(chan.clone()));
-                },
-                Some(GenericGuildChannelRef::Thread(th)) => {
-                    return Ok(Channel::GuildThread(th.clone()));
-                },
-                None => {},
+            if let Some(id) = guild_id
+                && let Some(guild) = cache.guild(id)
+                && let Some(channel) = guild.channel(self)
+            {
+                return Ok(match channel {
+                    GenericGuildChannelRef::Channel(chan) => Channel::Guild(chan.clone()),
+                    GenericGuildChannelRef::Thread(th) => Channel::GuildThread(th.clone()),
+                });
             }
 
             #[cfg(feature = "temp_cache")]

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -630,11 +630,11 @@ impl GenericChannelId {
     /// reasons.
     pub async fn edit_message(
         self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         message_id: MessageId,
         builder: EditMessage<'_>,
     ) -> Result<Message> {
-        builder.execute(http, self, message_id, None).await
+        builder.execute(cache_http, self, message_id, None).await
     }
 
     /// Attempts to retrieve the channel from the guild cache, otherwise from HTTP/temp cache.
@@ -871,9 +871,13 @@ impl GenericChannelId {
     ///
     /// Returns a [`ModelError::TooLarge`] if the content length is over the above limit. See
     /// [`CreateMessage::execute`] for more details.
-    pub async fn say(self, http: &Http, content: impl Into<Cow<'_, str>>) -> Result<Message> {
+    pub async fn say(
+        self,
+        cache_http: impl CacheHttp,
+        content: impl Into<Cow<'_, str>>,
+    ) -> Result<Message> {
         let builder = CreateMessage::new().content(content);
-        self.send_message(http, builder).await
+        self.send_message(cache_http, builder).await
     }
 
     /// Sends file(s) along with optional message contents. The filename _must_ be specified.
@@ -944,11 +948,11 @@ impl GenericChannelId {
     /// [`File`]: tokio::fs::File
     pub async fn send_files<'a>(
         self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         files: impl IntoIterator<Item = CreateAttachment<'a>>,
         builder: CreateMessage<'a>,
     ) -> Result<Message> {
-        self.send_message(http, builder.files(files)).await
+        self.send_message(cache_http, builder.files(files)).await
     }
 
     /// Sends a message to the channel.
@@ -960,8 +964,12 @@ impl GenericChannelId {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
-    pub async fn send_message(self, http: &Http, builder: CreateMessage<'_>) -> Result<Message> {
-        builder.execute(http, self).await
+    pub async fn send_message(
+        self,
+        cache_http: impl CacheHttp,
+        builder: CreateMessage<'_>,
+    ) -> Result<Message> {
+        builder.execute(cache_http, self).await
     }
 
     /// Starts typing in the channel for an indefinite period of time.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -14,7 +14,7 @@ use crate::builder::{
 #[cfg(feature = "cache")]
 use crate::cache::{self, Cache};
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 
 /// Represents the shared fields between [`GuildChannel`] and [`GuildThread`].

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -14,7 +14,7 @@ use crate::builder::{
 #[cfg(feature = "cache")]
 use crate::cache::{self, Cache};
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 use crate::model::prelude::*;
 
 /// Represents the shared fields between [`GuildChannel`] and [`GuildThread`].
@@ -339,8 +339,12 @@ impl GuildChannel {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
-    pub async fn send_message(&self, http: &Http, builder: CreateMessage<'_>) -> Result<Message> {
-        let mut message = self.id.widen().send_message(http, builder).await?;
+    pub async fn send_message(
+        &self,
+        cache_http: impl CacheHttp,
+        builder: CreateMessage<'_>,
+    ) -> Result<Message> {
+        let mut message = self.id.widen().send_message(cache_http, builder).await?;
         message.guild_id = Some(self.base.guild_id);
         Ok(message)
     }

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -10,14 +10,14 @@ use nonmax::NonMaxU8;
 use nonmax::NonMaxU64;
 use serde::de::Error as _;
 
-#[cfg(all(feature = "model", feature = "utils"))]
+#[cfg(feature = "model")]
 use crate::builder::{CreateAllowedMentions, CreateMessage, EditMessage};
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "model")]
 use crate::constants;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 use crate::model::utils::{StrOrInt, discord_colours};
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -490,8 +490,12 @@ impl Message {
     /// # Errors
     ///
     /// See the documentation of [`CreateMessage::execute`] for possible errors.
-    pub async fn reply(&self, http: &Http, content: impl Into<Cow<'_, str>>) -> Result<Message> {
-        self.reply_(http, content.into(), false).await
+    pub async fn reply(
+        &self,
+        cache_http: impl CacheHttp,
+        content: impl Into<Cow<'_, str>>,
+    ) -> Result<Message> {
+        self.reply_(cache_http, content.into(), false).await
     }
 
     /// Uses Discord's inline reply to a user with a ping.
@@ -504,15 +508,19 @@ impl Message {
     /// See the documentation of [`CreateMessage::execute`] for possible errors.
     pub async fn reply_ping(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         content: impl Into<Cow<'_, str>>,
     ) -> Result<Message> {
-        self.reply_(http, content.into(), true).await
+        self.reply_(cache_http, content.into(), true).await
     }
 
-    async fn reply_(&self, http: &Http, content: Cow<'_, str>, ping_user: bool) -> Result<Message> {
-        let default_allowed_mentions = http.default_allowed_mentions.clone();
-        let allowed_mentions = default_allowed_mentions.unwrap_or_else(|| {
+    async fn reply_(
+        &self,
+        cache_http: impl CacheHttp,
+        content: Cow<'_, str>,
+        ping_user: bool,
+    ) -> Result<Message> {
+        let allowed_mentions = cache_http.default_allowed_mentions().unwrap_or_else(|| {
             CreateAllowedMentions::new().everyone(true).all_users(true).all_roles(true)
         });
 
@@ -521,7 +529,7 @@ impl Message {
             .reference_message(self)
             .allowed_mentions(allowed_mentions.replied_user(ping_user));
 
-        self.channel_id.send_message(http, builder).await
+        self.channel_id.send_message(cache_http, builder).await
     }
 
     /// Checks whether the message mentions passed [`UserId`].

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -12,7 +12,7 @@ use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 use crate::model::utils::discord_colours_opt;
 

--- a/src/model/channel/thread.rs
+++ b/src/model/channel/thread.rs
@@ -208,8 +208,12 @@ impl GuildThread {
     ///
     /// See [`CreateMessage::execute`] for a list of possible errors, and their corresponding
     /// reasons.
-    pub async fn send_message(&self, http: &Http, builder: CreateMessage<'_>) -> Result<Message> {
-        let mut message = self.id.widen().send_message(http, builder).await?;
+    pub async fn send_message(
+        &self,
+        cache_http: impl CacheHttp,
+        builder: CreateMessage<'_>,
+    ) -> Result<Message> {
+        let mut message = self.id.widen().send_message(cache_http, builder).await?;
         message.guild_id = Some(self.base.guild_id);
         Ok(message)
     }

--- a/src/model/channel/thread.rs
+++ b/src/model/channel/thread.rs
@@ -1,9 +1,7 @@
 use super::*;
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditThread};
-#[cfg(feature = "model")]
-use crate::http::CacheHttp;
-use crate::internal::prelude::*;
+use crate::model::prelude::*;
 use crate::model::utils::is_false;
 
 impl ThreadId {

--- a/src/model/event/full_event.rs
+++ b/src/model/event/full_event.rs
@@ -404,6 +404,7 @@ full_event! {
 }
 
 impl FullEvent {
+    #[cfg_attr(not(feature = "cache"), allow(unused_variables))]
     pub fn from_event(
         event: Box<Event>,
         extra_event: &mut Option<Self>,

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -31,7 +31,7 @@ use crate::builder::{
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http, UserPagination};
+use crate::http::{Http, UserPagination};
 #[cfg(feature = "model")]
 use crate::model::error::Maximum;
 use crate::model::prelude::*;

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -37,7 +37,7 @@ use crate::builder::EditGuild;
 #[cfg(doc)]
 use crate::constants::LARGE_THRESHOLD;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::*;

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -4,7 +4,7 @@ use super::IncidentsData;
 #[cfg(feature = "model")]
 use crate::builder::EditGuild;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::icon_url;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -62,6 +62,8 @@ use crate::http::Http;
 ///
 /// If the `cache` feature is enabled, but an implementing type does not have access to a cache,
 /// the [`CacheHttp::cache`] method will simply return `None`.
+///
+/// **Note**: This trait is implemented by [`Http`] only if the `builder` feature is _disabled_.
 #[cfg(feature = "http")]
 pub trait CacheHttp: Send + Sync {
     fn http(&self) -> &Http;
@@ -125,7 +127,7 @@ impl CacheHttp for (Option<&Arc<Cache>>, &Http) {
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(all(feature = "http", not(feature = "builder")))]
 impl CacheHttp for Http {
     fn http(&self) -> &Http {
         self

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -43,10 +43,94 @@ pub mod user;
 pub mod voice;
 pub mod webhook;
 
+#[cfg(feature = "http")]
+use std::sync::Arc;
+
 pub use self::colour::{Color, Colour};
 pub use self::error::Error as ModelError;
 pub use self::permissions::Permissions;
 pub use self::timestamp::Timestamp;
+#[cfg(all(feature = "http", feature = "builder"))]
+use crate::builder::CreateAllowedMentions;
+#[cfg(all(feature = "http", feature = "cache"))]
+use crate::cache::Cache;
+#[cfg(feature = "http")]
+use crate::http::Http;
+
+/// This trait will be required by functions that need [`Http`] and can optionally use a [`Cache`]
+/// to potentially avoid REST-requests.
+///
+/// If the `cache` feature is enabled, but an implementing type does not have access to a cache,
+/// the [`CacheHttp::cache`] method will simply return `None`.
+#[cfg(feature = "http")]
+pub trait CacheHttp: Send + Sync {
+    fn http(&self) -> &Http;
+
+    #[cfg(feature = "builder")]
+    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
+        None
+    }
+
+    #[cfg(feature = "cache")]
+    #[must_use]
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        None
+    }
+}
+
+#[cfg(feature = "http")]
+impl<T> CacheHttp for &T
+where
+    T: CacheHttp,
+{
+    fn http(&self) -> &Http {
+        (*self).http()
+    }
+    #[cfg(feature = "builder")]
+    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
+        (*self).default_allowed_mentions()
+    }
+    #[cfg(feature = "cache")]
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        (*self).cache()
+    }
+}
+
+#[cfg(feature = "http")]
+impl<T> CacheHttp for Arc<T>
+where
+    T: CacheHttp,
+{
+    fn http(&self) -> &Http {
+        (**self).http()
+    }
+    #[cfg(feature = "builder")]
+    fn default_allowed_mentions(&self) -> Option<CreateAllowedMentions<'static>> {
+        (**self).default_allowed_mentions()
+    }
+    #[cfg(feature = "cache")]
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        (**self).cache()
+    }
+}
+
+#[cfg(all(feature = "http", feature = "cache"))]
+impl CacheHttp for (Option<&Arc<Cache>>, &Http) {
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        self.0
+    }
+
+    fn http(&self) -> &Http {
+        self.1
+    }
+}
+
+#[cfg(feature = "http")]
+impl CacheHttp for Http {
+    fn http(&self) -> &Http {
+        self
+    }
+}
 
 /// The model prelude re-exports all types in the model sub-modules.
 ///
@@ -62,6 +146,9 @@ pub use self::timestamp::Timestamp;
 pub mod prelude {
     pub(crate) use serde::{Deserialize, Deserializer};
 
+    #[cfg(feature = "http")]
+    #[doc(hidden)]
+    pub use super::CacheHttp;
     pub use super::guild::automod::EventType as AutomodEventType;
     #[doc(hidden)]
     pub use super::guild::automod::{

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -8,11 +8,11 @@ use std::ops::{Deref, DerefMut};
 
 use serde::{Deserialize, Serialize};
 
-use super::prelude::*;
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditProfile};
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
+use crate::model::prelude::*;
 use crate::model::utils::deserialize_null_as_default;
 #[cfg(feature = "model")]
 use crate::model::utils::{avatar_url, user_banner_url};

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -728,13 +728,17 @@ impl UserId {
         // Do not refactor this to a one liner. The PrivateChannel from `create_dm_channel`
         // should be dropped before the `send_message` call to avoid bloating future sizes.
         let dm_channel_id = self.create_dm_channel(&cache_http).await?.id;
-        dm_channel_id.widen().send_message(cache_http.http(), builder).await
+        dm_channel_id.widen().send_message(cache_http, builder).await
     }
 
     /// This is an alias of [`Self::direct_message`].
     #[expect(clippy::missing_errors_doc)]
-    pub async fn dm(self, http: &Http, builder: CreateMessage<'_>) -> Result<Message> {
-        self.direct_message(http, builder).await
+    pub async fn dm(
+        self,
+        cache_http: impl CacheHttp,
+        builder: CreateMessage<'_>,
+    ) -> Result<Message> {
+        self.direct_message(cache_http, builder).await
     }
 
     /// First attempts to find a [`User`] by its Id in the `temp_cache` if enabled,

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "model")]
 use crate::builder::{EditWebhook, EditWebhookMessage, ExecuteWebhook};
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 
 enum_number! {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "model")]
 use crate::builder::{EditWebhook, EditWebhookMessage, ExecuteWebhook};
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{CacheHttp, Http};
 use crate::model::prelude::*;
 
 enum_number! {
@@ -328,12 +328,12 @@ impl Webhook {
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     pub async fn execute(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         wait: bool,
         builder: ExecuteWebhook<'_>,
     ) -> Result<Option<Message>> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        builder.execute(http, self.id, token, wait).await
+        builder.execute(cache_http, self.id, token, wait).await
     }
 
     /// Gets a previously sent message from the webhook.
@@ -371,12 +371,12 @@ impl Webhook {
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     pub async fn edit_message(
         &self,
-        http: &Http,
+        cache_http: impl CacheHttp,
         message_id: MessageId,
         builder: EditWebhookMessage<'_>,
     ) -> Result<Message> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        builder.execute(http, self.id, token, message_id).await
+        builder.execute(cache_http, self.id, token, message_id).await
     }
 
     /// Deletes a webhook message.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,9 +21,9 @@ pub use crate::gateway::GatewayError;
 #[cfg(feature = "gateway")]
 pub use crate::gateway::client::{Client, Context, EventHandler, RawEventHandler};
 #[cfg(feature = "http")]
-pub use crate::http::CacheHttp;
-#[cfg(feature = "http")]
 pub use crate::http::HttpError;
+#[cfg(feature = "http")]
+pub use crate::model::CacheHttp;
 pub use crate::model::mention::Mentionable;
 #[cfg(feature = "model")]
 pub use crate::model::{ModelError, gateway::GatewayIntents};


### PR DESCRIPTION
To further remove the `http` module's dependency on the rest of serenity, the `default_allowed_mentions` field is moved into the `Client` and passed around inside each `Context`, then forwarded to requests through the `CacheHttp` trait. Unfortunately, it's now possible for a user to accidentally prevent the field from being forwarded by mistakenly passing `ctx.http` to a method expecting `impl CacheHttp`. One solution could be to gate the implementation of `CacheHttp` for Http behind `#[cfg(not(feature = "builder"))]`, but I'm not sure if this is what we want.