### PR TITLE
Add `ReactionTypes` to `get_reaction_users`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3976,17 +3976,23 @@ impl Http {
         .await
     }
 
-    /// Gets user Ids based on their reaction to a message. This endpoint is dumb.
+    /// Gets a list of users who reacted with an emoji.
     pub async fn get_reaction_users(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-        reaction_type: &ReactionType,
+        emoji: &ReactionType,
+        reaction_type: Option<ReactionTypes>,
         limit: u8,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
-        let (limit_str, after_str);
-        let mut params = ArrayVec::<_, 2>::new();
+        let (type_str, limit_str, after_str);
+        let mut params = ArrayVec::<_, 3>::new();
+
+        if let Some(reaction_type) = reaction_type {
+            type_str = reaction_type.0.to_arraystring();
+            params.push(("type", type_str.as_str()));
+        }
 
         limit_str = limit.to_arraystring();
         params.push(("limit", limit_str.as_str()));
@@ -4004,7 +4010,7 @@ impl Http {
             route: Route::ChannelMessageReactionEmoji {
                 channel_id,
                 message_id,
-                reaction: &reaction_type.as_data(),
+                reaction: &emoji.as_data(),
             },
             params: Some(&params),
         })

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3983,7 +3983,7 @@ impl Http {
         message_id: MessageId,
         emoji: &ReactionType,
         reaction_type: Option<ReactionTypes>,
-        limit: u8,
+        limit: Option<NonMaxU8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
         let (type_str, limit_str, after_str);
@@ -3994,8 +3994,10 @@ impl Http {
             params.push(("type", type_str.as_str()));
         }
 
-        limit_str = limit.to_arraystring();
-        params.push(("limit", limit_str.as_str()));
+        if let Some(limit) = limit {
+            limit_str = limit.get().min(100).to_arraystring();
+            params.push(("limit", limit_str.as_str()));
+        }
 
         if let Some(after) = after {
             after_str = after.to_arraystring();

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 
 #[cfg(feature = "model")]
 use futures::stream::Stream;
+#[cfg(feature = "model")]
+use nonmax::NonMaxU8;
 
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -831,9 +833,8 @@ impl GenericChannelId {
     /// The default `reaction_type` is [`ReactionTypes::Normal`]. Specify [`ReactionTypes::Burst`]
     /// to get users who have reacted with the burst variation of the emoji (super reaction).
     ///
-    /// The default `limit` is `50` - specify otherwise to receive a different maximum number of
-    /// users. The maximum that may be retrieved at a time is `100`. If a greater number is
-    /// provided then it is automatically reduced.
+    /// The maximum number of users to retrieve is determined by `limit`. This defaults to `25`
+    /// and is automatically clamped to the API maximum of `100`.
     ///
     /// The optional `after` attribute is to retrieve the users after a certain user. This is
     /// useful for pagination.
@@ -856,11 +857,9 @@ impl GenericChannelId {
         message_id: MessageId,
         emoji: impl Into<ReactionType>,
         reaction_type: Option<ReactionTypes>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
-        let limit = limit.map_or(50, |x| if x > 100 { 100 } else { x });
-
         http.get_reaction_users(self, message_id, &emoji.into(), reaction_type, limit, after).await
     }
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -828,18 +828,21 @@ impl GenericChannelId {
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a certain [`Emoji`].
     ///
+    /// The default `reaction_type` is [`ReactionTypes::Normal`]. Specify [`ReactionTypes::Burst`]
+    /// to get users who have reacted with the burst variation of the emoji (super reaction).
+    ///
     /// The default `limit` is `50` - specify otherwise to receive a different maximum number of
-    /// users. The maximum that may be retrieve at a time is `100`, if a greater number is provided
-    /// then it is automatically reduced.
+    /// users. The maximum that may be retrieved at a time is `100`. If a greater number is
+    /// provided then it is automatically reduced.
     ///
     /// The optional `after` attribute is to retrieve the users after a certain user. This is
     /// useful for pagination.
     ///
     /// **Note**: Requires the [Read Message History] permission.
     ///
-    /// **Note**: If the passed reaction_type is a custom guild emoji, it must contain the name.
-    /// So, [`Emoji`] or [`EmojiIdentifier`] will always work, [`ReactionType`] only if
-    /// [`ReactionType::Custom::name`] is Some, and **[`EmojiId`] will never work**.
+    /// **Note**: If the passed `emoji` is a custom guild emoji, it must contain the name.
+    /// So, [`Emoji`] or [`EmojiIdentifier`] will always work, [`ReactionType`] will only work if
+    /// [`ReactionType::Custom::name`] is `Some`, and **[`EmojiId`] will never work**.
     ///
     /// # Errors
     ///
@@ -851,13 +854,14 @@ impl GenericChannelId {
         self,
         http: &Http,
         message_id: MessageId,
-        reaction_type: impl Into<ReactionType>,
+        emoji: impl Into<ReactionType>,
+        reaction_type: Option<ReactionTypes>,
         limit: Option<u8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
         let limit = limit.map_or(50, |x| if x > 100 { 100 } else { x });
 
-        http.get_reaction_users(self, message_id, &reaction_type.into(), limit, after).await
+        http.get_reaction_users(self, message_id, &emoji.into(), reaction_type, limit, after).await
     }
 
     /// Sends a message with just the given message content in the channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -383,18 +383,21 @@ impl Message {
 
     /// Gets the list of [`User`]s who have reacted to a [`Message`] with a certain [`Emoji`].
     ///
+    /// The default `reaction_type` is [`ReactionTypes::Normal`]. Specify [`ReactionTypes::Burst`]
+    /// to get users who have reacted with the burst variation of the emoji (super reaction).
+    ///
     /// The default `limit` is `50` - specify otherwise to receive a different maximum number of
-    /// users. The maximum that may be retrieve at a time is `100`, if a greater number is provided
-    /// then it is automatically reduced.
+    /// users. The maximum that may be retrieved at a time is `100`. If a greater number is
+    /// provided then it is automatically reduced.
     ///
     /// The optional `after` attribute is to retrieve the users after a certain user. This is
     /// useful for pagination.
     ///
     /// **Note**: Requires the [Read Message History] permission.
     ///
-    /// **Note**: If the passed reaction_type is a custom guild emoji, it must contain the name.
-    /// So, [`Emoji`] or [`EmojiIdentifier`] will always work, [`ReactionType`] only if
-    /// [`ReactionType::Custom::name`] is Some, and **[`EmojiId`] will never work**.
+    /// **Note**: If the passed `emoji` is a custom guild emoji, it must contain the name.
+    /// So, [`Emoji`] or [`EmojiIdentifier`] will always work, [`ReactionType`] will only work if
+    /// [`ReactionType::Custom::name`] is `Some`, and **[`EmojiId`] will never work**.
     ///
     /// # Errors
     ///
@@ -404,11 +407,12 @@ impl Message {
     pub async fn reaction_users(
         &self,
         http: &Http,
-        reaction_type: impl Into<ReactionType>,
+        emoji: impl Into<ReactionType>,
+        reaction_type: Option<ReactionTypes>,
         limit: Option<u8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
-        self.channel_id.reaction_users(http, self.id, reaction_type, limit, after).await
+        self.channel_id.reaction_users(http, self.id, emoji, reaction_type, limit, after).await
     }
 
     /// Returns the associated [`Guild`] for the message if one is in the cache.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -5,6 +5,8 @@ use std::borrow::Cow;
 #[cfg(feature = "model")]
 use std::fmt::Display;
 
+#[cfg(feature = "model")]
+use nonmax::NonMaxU8;
 use nonmax::NonMaxU64;
 use serde::de::Error as _;
 
@@ -386,9 +388,8 @@ impl Message {
     /// The default `reaction_type` is [`ReactionTypes::Normal`]. Specify [`ReactionTypes::Burst`]
     /// to get users who have reacted with the burst variation of the emoji (super reaction).
     ///
-    /// The default `limit` is `50` - specify otherwise to receive a different maximum number of
-    /// users. The maximum that may be retrieved at a time is `100`. If a greater number is
-    /// provided then it is automatically reduced.
+    /// The maximum number of users to retrieve is determined by `limit`. This defaults to `25`
+    /// and is automatically clamped to the API maximum of `100`.
     ///
     /// The optional `after` attribute is to retrieve the users after a certain user. This is
     /// useful for pagination.
@@ -409,7 +410,7 @@ impl Message {
         http: &Http,
         emoji: impl Into<ReactionType>,
         reaction_type: Option<ReactionTypes>,
-        limit: Option<u8>,
+        limit: Option<NonMaxU8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
         self.channel_id.reaction_users(http, self.id, emoji, reaction_type, limit, after).await

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -90,7 +90,7 @@ impl Serialize for Reaction {
 
 #[cfg(feature = "model")]
 impl Reaction {
-    /// Retrieves the associated the reaction was made in.
+    /// Retrieves the [`Channel`] the reaction was made in.
     ///
     /// If the cache is enabled, this will search for the already-cached channel. If not - or the
     /// channel was not found - this will perform a request over the REST API for the channel.
@@ -153,14 +153,14 @@ impl Reaction {
         self.channel_id.message(cache_http, self.message_id).await
     }
 
-    /// Retrieves the user that made the reaction.
+    /// Retrieves the [`User`] who made this reaction.
     ///
     /// If the cache is enabled, this will search for the already-cached user. If not - or the user
     /// was not found - this will perform a request over the REST API for the user.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Http`] if the user that made the reaction is unable to be retrieved from
+    /// Returns [`Error::Http`] if the user who made the reaction is unable to be retrieved from
     /// the API.
     pub async fn user(&self, cache_http: impl CacheHttp) -> Result<User> {
         if let Some(id) = self.user_id {
@@ -179,11 +179,11 @@ impl Reaction {
         }
     }
 
-    /// Retrieves the list of [`User`]s who have reacted to a [`Message`] with a certain [`Emoji`].
+    /// Retrieves the list of [`User`]s who made this reaction.
     ///
     /// The default `limit` is `50` - specify otherwise to receive a different maximum number of
-    /// users. The maximum that may be retrieve at a time is `100`, if a greater number is provided
-    /// then it is automatically reduced.
+    /// users. The maximum that may be retrieved at a time is `100`. If a greater number is
+    /// provided then it is automatically reduced.
     ///
     /// The optional `after` attribute is to retrieve the users after a certain user. This is
     /// useful for pagination.
@@ -201,17 +201,6 @@ impl Reaction {
     pub async fn users(
         &self,
         http: &Http,
-        reaction_type: impl Into<ReactionType>,
-        limit: Option<NonMaxU8>,
-        after: Option<UserId>,
-    ) -> Result<Vec<User>> {
-        self.users_(http, &reaction_type.into(), limit, after).await
-    }
-
-    async fn users_(
-        &self,
-        http: &Http,
-        reaction_type: &ReactionType,
         limit: Option<NonMaxU8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
@@ -222,7 +211,15 @@ impl Reaction {
             warn!("Reaction users limit clamped to 100! (API Restriction)");
         }
 
-        http.get_reaction_users(self.channel_id, self.message_id, reaction_type, limit, after).await
+        http.get_reaction_users(
+            self.channel_id,
+            self.message_id,
+            &self.emoji,
+            Some(self.reaction_type),
+            limit,
+            after,
+        )
+        .await
     }
 }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -10,8 +10,6 @@ use nonmax::NonMaxU8;
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeMap, Serializer};
-#[cfg(feature = "model")]
-use tracing::warn;
 
 #[cfg(feature = "model")]
 use crate::http::{CacheHttp, Http};
@@ -181,9 +179,8 @@ impl Reaction {
 
     /// Retrieves the list of [`User`]s who made this reaction.
     ///
-    /// The default `limit` is `50` - specify otherwise to receive a different maximum number of
-    /// users. The maximum that may be retrieved at a time is `100`. If a greater number is
-    /// provided then it is automatically reduced.
+    /// The maximum number of users to retrieve is determined by `limit`. This defaults to `25`
+    /// and is automatically clamped to the API maximum of `100`.
     ///
     /// The optional `after` attribute is to retrieve the users after a certain user. This is
     /// useful for pagination.
@@ -204,13 +201,6 @@ impl Reaction {
         limit: Option<NonMaxU8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
-        let mut limit = limit.map_or(50, |limit| limit.get());
-
-        if limit > 100 {
-            limit = 100;
-            warn!("Reaction users limit clamped to 100! (API Restriction)");
-        }
-
         http.get_reaction_users(
             self.channel_id,
             self.message_id,


### PR DESCRIPTION
Fixes [#3060](https://github.com/serenity-rs/serenity/issues/3060).

Adds `ReactionTypes` to `Http::get_reaction_users` to allow fetching users who have super reacted to a message. Also fixes `Reaction::users` so that it uses `self.reaction_type` and removed the now-redundant `Reaction::users_`.

I changed the original `reaction_type` to `emoji` so that `emoji` corresponds to `Reaction::emoji` and `reaction_type` corresponds to `Reaction::reaction_type`.