### PR TITLE
Handle unavailable guild object in Guild Create

### DIFF
--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -91,16 +91,24 @@ impl CacheUpdate for GuildCreateEvent {
     type Output = Vec<GuildId>;
 
     fn update(&self, cache: &Cache) -> Option<Self::Output> {
-        cache.unavailable_guilds.remove(&self.guild.id);
-        let guild = self.guild.clone();
+        match &self.guild {
+            GuildCreateGuild::Present(guild) => {
+                cache.unavailable_guilds.remove(&guild.id);
 
-        cache.guilds.insert(self.guild.id, guild);
+                cache.guilds.insert(guild.id, guild.clone());
 
-        if cache.unavailable_guilds.len() == 0 {
-            cache.unavailable_guilds.shrink_to_fit();
-            Some(cache.guilds.iter().map(|i| *i.key()).collect())
-        } else {
-            None
+                if cache.unavailable_guilds.len() == 0 {
+                    cache.unavailable_guilds.shrink_to_fit();
+                    Some(cache.guilds.iter().map(|i| *i.key()).collect())
+                } else {
+                    None
+                }
+            },
+            GuildCreateGuild::Unavailable(unavailable_guild) => {
+                cache.unavailable_guilds.insert(unavailable_guild.id, ());
+                cache.guilds.remove(&unavailable_guild.id);
+                None
+            },
         }
     }
 }

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -92,7 +92,7 @@ impl CacheUpdate for GuildCreateEvent {
 
     fn update(&self, cache: &Cache) -> Option<Self::Output> {
         match &self.guild {
-            GuildCreateGuild::Present(guild) => {
+            GuildCreateGuild::Available(guild) => {
                 cache.unavailable_guilds.remove(&guild.id);
 
                 cache.guilds.insert(guild.id, guild.clone());

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -771,11 +771,11 @@ mod test {
 
         // Test deletion of a guild channel's message cache when a GuildDeleteEvent is received.
         let mut guild_create = GuildCreateEvent {
-            guild: Guild {
+            guild: GuildCreateGuild::Present(Guild {
                 id: GuildId::new(1),
                 channels: ExtractMap::from_iter([channel]),
                 ..Default::default()
-            },
+            }),
         };
         assert!(cache.update(&mut guild_create).is_some());
         assert!(cache.update(&mut event).is_none());

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -771,7 +771,7 @@ mod test {
 
         // Test deletion of a guild channel's message cache when a GuildDeleteEvent is received.
         let mut guild_create = GuildCreateEvent {
-            guild: GuildCreateGuild::Present(Guild {
+            guild: GuildCreateGuild::Available(Guild {
                 id: GuildId::new(1),
                 channels: ExtractMap::from_iter([channel]),
                 ..Default::default()

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1320,6 +1320,7 @@ mod tests {
     use super::{
         Guild,
         GuildChannel,
+        GuildCreateGuild,
         Member,
         Message,
         PermissionOverwrite,
@@ -1382,7 +1383,7 @@ mod tests {
         // Cache, with the guild setup.
         let cache = Cache::new();
         cache.update(&mut GuildCreateEvent {
-            guild,
+            guild: GuildCreateGuild::Present(guild),
         });
 
         // The author should only have the one permission, SEND_MESSAGES.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1383,7 +1383,7 @@ mod tests {
         // Cache, with the guild setup.
         let cache = Cache::new();
         cache.update(&mut GuildCreateEvent {
-            guild: GuildCreateGuild::Present(guild),
+            guild: GuildCreateGuild::Available(guild),
         });
 
         // The author should only have the one permission, SEND_MESSAGES.

--- a/src/model/event/full_event.rs
+++ b/src/model/event/full_event.rs
@@ -1034,7 +1034,7 @@ mod tests {
         assert!(!is_guild_new(&cache, guild_id));
 
         let event = Box::new(Event::GuildCreate(GuildCreateEvent {
-            guild: GuildCreateGuild::Present(Guild {
+            guild: GuildCreateGuild::Available(Guild {
                 __generated_flags: GuildGeneratedFlags::default(),
                 id: guild_id,
                 name: FixedString::new(),
@@ -1104,7 +1104,7 @@ mod tests {
         let guild_id2 = GuildId::new(2);
 
         let event = Box::new(Event::GuildCreate(GuildCreateEvent {
-            guild: GuildCreateGuild::Present(Guild {
+            guild: GuildCreateGuild::Available(Guild {
                 __generated_flags: GuildGeneratedFlags::default(),
                 id: guild_id2,
                 name: FixedString::new(),
@@ -1236,7 +1236,7 @@ mod tests {
         assert!(cache.unavailable_guilds().contains(&guild_id));
 
         let event = Box::new(Event::GuildCreate(GuildCreateEvent {
-            guild: GuildCreateGuild::Present(Guild {
+            guild: GuildCreateGuild::Available(Guild {
                 id: guild_id,
                 ..Default::default()
             }),

--- a/src/model/event/full_event.rs
+++ b/src/model/event/full_event.rs
@@ -59,6 +59,9 @@ full_event! {
     /// This process happens upon starting your bot and should be fairly quick. However, cache
     /// actions performed prior this event may fail as the data could be not inserted yet.
     ///
+    /// **Note:** Because [`GuildCreateEvent`] can include an [`UnavailableGuild`] in the payload,
+    /// this event may be dispatched multiple times.
+    ///
     /// Provides the cached guilds' ids.
     #[cfg(feature = "cache")]
     CacheReady { guilds: Vec<GuildId> };
@@ -108,7 +111,7 @@ full_event! {
     /// Dispatched when a guild is created; or an existing guild's data is sent to us.
     ///
     /// Provides the guild's data and whether the guild is new (only when cache feature is enabled).
-    GuildCreate { guild: Guild, is_new: Option<bool> };
+    GuildCreate { guild: GuildCreateGuild, is_new: Option<bool> };
     /// Dispatched when a guild is deleted.
     ///
     /// Provides the partial data of the guild sent by discord, and the full data from the cache,
@@ -514,7 +517,10 @@ impl FullEvent {
             },
             Event::GuildCreate(event) => {
                 #[cfg(feature = "cache")]
-                let is_new = Some(is_guild_new(cache, event.guild.id));
+                let is_new = Some(is_guild_new(cache, match &event.guild {
+                    GuildCreateGuild::Present(guild) => guild.id,
+                    GuildCreateGuild::Unavailable(unavailable_guild) => unavailable_guild.id,
+                }));
                 #[cfg(not(feature = "cache"))]
                 let is_new = None;
 
@@ -971,12 +977,20 @@ mod tests {
     use crate::cache::Cache;
     use crate::model::Timestamp;
     use crate::model::application::{ApplicationFlags, PartialCurrentApplicationInfo};
-    use crate::model::event::{Event, FullEvent, GuildCreateEvent, ReadyEvent};
+    use crate::model::event::{
+        DeserializedEvent,
+        Event,
+        FullEvent,
+        GatewayEvent,
+        GuildCreateEvent,
+        ReadyEvent,
+    };
     use crate::model::gateway::Ready;
     use crate::model::guild::{
         DefaultMessageNotificationLevel,
         ExplicitContentFilter,
         Guild,
+        GuildCreateGuild,
         GuildGeneratedFlags,
         MemberCount,
         MfaLevel,
@@ -1023,7 +1037,7 @@ mod tests {
         assert!(!is_guild_new(&cache, guild_id));
 
         let event = Box::new(Event::GuildCreate(GuildCreateEvent {
-            guild: Guild {
+            guild: GuildCreateGuild::Present(Guild {
                 __generated_flags: GuildGeneratedFlags::default(),
                 id: guild_id,
                 name: FixedString::new(),
@@ -1072,7 +1086,7 @@ mod tests {
                 stage_instances: FixedArray::new(),
                 threads: ExtractMap::new(),
                 voice_states: ExtractMap::new(),
-            },
+            }),
         }));
 
         assert_eq!(cache.unavailable_guilds().len(), 1);
@@ -1093,7 +1107,7 @@ mod tests {
         let guild_id2 = GuildId::new(2);
 
         let event = Box::new(Event::GuildCreate(GuildCreateEvent {
-            guild: Guild {
+            guild: GuildCreateGuild::Present(Guild {
                 __generated_flags: GuildGeneratedFlags::default(),
                 id: guild_id2,
                 name: FixedString::new(),
@@ -1142,7 +1156,7 @@ mod tests {
                 stage_instances: FixedArray::new(),
                 threads: ExtractMap::new(),
                 voice_states: ExtractMap::new(),
-            },
+            }),
         }));
 
         assert_eq!(cache.unavailable_guilds().len(), 0);
@@ -1157,5 +1171,96 @@ mod tests {
         assert_eq!(cache.unavailable_guilds().len(), 0);
 
         assert!(is_guild_new(&cache, guild_id2));
+
+        let guild_id3 = GuildId::new(3);
+
+        let event = Box::new(Event::GuildCreate(GuildCreateEvent {
+            guild: GuildCreateGuild::Unavailable(UnavailableGuild {
+                id: guild_id3,
+                unavailable: true,
+            }),
+        }));
+
+        assert_eq!(cache.unavailable_guilds().len(), 0);
+
+        let full_event = FullEvent::from_event(event, &mut extra_event, &cache);
+
+        assert!(matches!(full_event, FullEvent::GuildCreate {
+            is_new: Some(true),
+            ..
+        }));
+
+        assert_eq!(cache.unavailable_guilds().len(), 1);
+
+        assert!(!is_guild_new(&cache, guild_id3));
+    }
+
+    #[test]
+    fn unavailable_guild_in_guild_create() {
+        let cache = Cache::new();
+        let mut extra_event = None;
+
+        let guild_id = GuildId::new(1);
+
+        let payload = r#"
+            {
+                "op": 0,
+                "d": {
+                    "id": "1",
+                    "unavailable": true
+                },
+                "s": 42,
+                "t": "GUILD_CREATE"
+            }
+        "#;
+
+        let gateway_event = serde_json::from_str::<GatewayEvent>(payload).unwrap();
+
+        let GatewayEvent::Dispatch {
+            event: DeserializedEvent::Success(event), ..
+        } = gateway_event
+        else {
+            panic!("Event deserialization failed");
+        };
+
+        assert_eq!(cache.guild_count(), 0);
+        assert_eq!(cache.unavailable_guilds().len(), 0);
+
+        let full_event = FullEvent::from_event(event, &mut extra_event, &cache);
+
+        assert!(matches!(full_event, FullEvent::GuildCreate {
+            guild: GuildCreateGuild::Unavailable(_),
+            is_new: Some(true),
+            ..
+        }));
+
+        assert_eq!(cache.guild_count(), 0);
+        assert_eq!(cache.unavailable_guilds().len(), 1);
+        assert!(cache.unavailable_guilds().contains(&guild_id));
+
+        let event = Box::new(Event::GuildCreate(GuildCreateEvent {
+            guild: GuildCreateGuild::Present(Guild {
+                id: guild_id,
+                ..Default::default()
+            }),
+        }));
+
+        let full_event = FullEvent::from_event(event, &mut extra_event, &cache);
+
+        assert!(matches!(full_event, FullEvent::GuildCreate {
+            is_new: Some(false),
+            ..
+        }));
+
+        assert!(matches!(
+            extra_event,
+            Some(FullEvent::CacheReady {
+                guilds: _
+            })
+        ));
+
+        assert_eq!(cache.guild_count(), 1);
+        assert!(cache.guild(guild_id).is_some());
+        assert_eq!(cache.unavailable_guilds().len(), 0);
     }
 }

--- a/src/model/event/full_event.rs
+++ b/src/model/event/full_event.rs
@@ -517,10 +517,7 @@ impl FullEvent {
             },
             Event::GuildCreate(event) => {
                 #[cfg(feature = "cache")]
-                let is_new = Some(is_guild_new(cache, match &event.guild {
-                    GuildCreateGuild::Present(guild) => guild.id,
-                    GuildCreateGuild::Unavailable(unavailable_guild) => unavailable_guild.id,
-                }));
+                let is_new = Some(is_guild_new(cache, event.guild.id()));
                 #[cfg(not(feature = "cache"))]
                 let is_new = None;
 

--- a/src/model/event/mod.rs
+++ b/src/model/event/mod.rs
@@ -168,25 +168,11 @@ pub struct GuildBanRemoveEvent {
 ///
 /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-create).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 #[non_exhaustive]
 pub struct GuildCreateEvent {
-    pub guild: Guild,
-}
-
-// Manual impl needed to insert guild_id fields in GuildChannel, GuildThread, Member, Role
-impl<'de> Deserialize<'de> for GuildCreateEvent {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
-        let mut guild: Guild = Guild::deserialize(deserializer)?;
-        guild.channels.iter_mut().for_each(|x| x.base.guild_id = guild.id);
-        guild.threads.iter_mut().for_each(|x| x.base.guild_id = guild.id);
-        guild.members.iter_mut().for_each(|x| x.guild_id = guild.id);
-        guild.roles.iter_mut().for_each(|x| x.guild_id = guild.id);
-        Ok(Self {
-            guild,
-        })
-    }
+    pub guild: GuildCreateGuild,
 }
 
 /// Requires [`GatewayIntents::GUILDS`].

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -39,6 +39,7 @@ use crate::constants::LARGE_THRESHOLD;
 #[cfg(feature = "model")]
 use crate::http::Http;
 use crate::model::prelude::*;
+use crate::model::utils::deserialize_present_guild;
 #[cfg(feature = "model")]
 use crate::model::utils::*;
 
@@ -1179,6 +1180,23 @@ pub struct UnavailableGuild {
     /// Indicator of whether the guild is unavailable.
     #[serde(default)]
     pub unavailable: bool,
+}
+
+/// Representation of the inner payload of a [`GuildCreateEvent`], which can include either a
+/// [`Guild`] or an [`UnavailableGuild`].
+///
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-create).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Almost always Present so boxing would be counter-productive"
+)]
+pub enum GuildCreateGuild {
+    #[serde(deserialize_with = "deserialize_present_guild")]
+    Present(Guild),
+    Unavailable(UnavailableGuild),
 }
 
 enum_number! {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1208,6 +1208,19 @@ impl GuildCreateGuild {
             GuildCreateGuild::Unavailable(unavailable_guild) => unavailable_guild.id,
         }
     }
+
+    /// Whether this [`GuildCreateGuild`] is unavailable due to an outage.
+    ///
+    /// **Note:** Both [`Guild`] and [`UnavailableGuild`] will be marked as unavailable when
+    /// offline due to an outage. When an [`UnavailableGuild`] is ___not___ marked as unavailable,
+    /// this indicates that the current user has been removed from that guild.
+    #[must_use]
+    pub fn unavailable(&self) -> bool {
+        match self {
+            GuildCreateGuild::Available(guild) => guild.unavailable(),
+            GuildCreateGuild::Unavailable(unavailable_guild) => unavailable_guild.unavailable,
+        }
+    }
 }
 
 enum_number! {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -39,7 +39,7 @@ use crate::constants::LARGE_THRESHOLD;
 #[cfg(feature = "model")]
 use crate::http::Http;
 use crate::model::prelude::*;
-use crate::model::utils::deserialize_present_guild;
+use crate::model::utils::deserialize_available_guild;
 #[cfg(feature = "model")]
 use crate::model::utils::*;
 
@@ -1194,7 +1194,7 @@ pub struct UnavailableGuild {
     reason = "Almost always Present so boxing would be counter-productive"
 )]
 pub enum GuildCreateGuild {
-    #[serde(deserialize_with = "deserialize_present_guild")]
+    #[serde(deserialize_with = "deserialize_available_guild")]
     Available(Guild),
     Unavailable(UnavailableGuild),
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1195,7 +1195,7 @@ pub struct UnavailableGuild {
 )]
 pub enum GuildCreateGuild {
     #[serde(deserialize_with = "deserialize_present_guild")]
-    Present(Guild),
+    Available(Guild),
     Unavailable(UnavailableGuild),
 }
 
@@ -1204,7 +1204,7 @@ impl GuildCreateGuild {
     #[must_use]
     pub fn id(&self) -> GuildId {
         match self {
-            GuildCreateGuild::Present(guild) => guild.id,
+            GuildCreateGuild::Available(guild) => guild.id,
             GuildCreateGuild::Unavailable(unavailable_guild) => unavailable_guild.id,
         }
     }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1199,6 +1199,17 @@ pub enum GuildCreateGuild {
     Unavailable(UnavailableGuild),
 }
 
+impl GuildCreateGuild {
+    /// Returns the [`GuildId`] of the [`GuildCreateGuild`].
+    #[must_use]
+    pub fn id(&self) -> GuildId {
+        match self {
+            GuildCreateGuild::Present(guild) => guild.id,
+            GuildCreateGuild::Unavailable(unavailable_guild) => unavailable_guild.id,
+        }
+    }
+}
+
 enum_number! {
     /// Default message notification level for a guild.
     ///

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -258,6 +258,20 @@ where
         .map_err(D::Error::custom)
 }
 
+// Needed to insert guild_id fields in GuildChannel, GuildThread, Member, and Role when
+// deserializing a [`GuildCreateGuild::Present`] guild.
+pub(crate) fn deserialize_present_guild<'de, D>(deserializer: D) -> Result<Guild, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut guild: Guild = Guild::deserialize(deserializer)?;
+    guild.channels.iter_mut().for_each(|x| x.base.guild_id = guild.id);
+    guild.threads.iter_mut().for_each(|x| x.base.guild_id = guild.id);
+    guild.members.iter_mut().for_each(|x| x.guild_id = guild.id);
+    guild.roles.iter_mut().for_each(|x| x.guild_id = guild.id);
+    Ok(guild)
+}
+
 pub(crate) fn deserialize_null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -259,8 +259,8 @@ where
 }
 
 // Needed to insert guild_id fields in GuildChannel, GuildThread, Member, and Role when
-// deserializing a [`GuildCreateGuild::Present`] guild.
-pub(crate) fn deserialize_present_guild<'de, D>(deserializer: D) -> Result<Guild, D::Error>
+// deserializing a [`GuildCreateGuild::Available`] guild.
+pub(crate) fn deserialize_available_guild<'de, D>(deserializer: D) -> Result<Guild, D::Error>
 where
     D: Deserializer<'de>,
 {


### PR DESCRIPTION
Fixes [#3330](https://github.com/serenity-rs/serenity/issues/3330).

Represents the inner payload of the `GuildCreate` event with a new `GuildCreateGuild` enum, which has two variants: `Present(Guild)` and `Unavailable(UnavailableGuild)`. I chose "Present" instead of "Available" since a `Guild` object sent by the event can also be marked unavailable (see [Guild Create](https://docs.discord.com/developers/events/gateway-events#guild-create)).

`is_new` behavior for the `Unavailable` variant conforms to the intention specified in [#3505](https://github.com/serenity-rs/serenity/pull/3505).

Testing `Present` variant deserialization with my own bot was simple; I added a test for the `Unavailable` variant since it requires special circumstances.