### PR TITLE
Better trace and log quality through request-span and nicer formatting for ShardInfo

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4644,9 +4644,17 @@ impl Http {
     ///
     /// Returns the raw reqwest Response. Use [`Self::fire`] to deserialize the response into some
     /// type.
-    #[cfg_attr(feature = "tracing_instrument", instrument)]
+    #[cfg_attr(feature = "tracing_instrument", instrument(
+        skip_all,
+        fields(
+            url.path = %req.route.path(),
+            http.request.method = req.method.reqwest_method().as_str(),
+            http.response.status,
+        )
+    ))]
     pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
         let method = req.method.reqwest_method();
+        debug!("Performing request: {method} {}", req.route.path());
         let response = if let Some(ratelimiter) = &self.ratelimiter {
             ratelimiter.perform(&req).await?
         } else {

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -398,6 +398,12 @@ pub struct ShardInfo {
     pub total: NonZeroU16,
 }
 
+impl fmt::Display for ShardInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.id.0, self.total)
+    }
+}
+
 impl Default for ShardInfo {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
This PR does three things to improve the monitoring workflow for a serenity bot:
- it implements a custom Debug formatter for ShardInfo (included in many log lines and span annotations, previously used the standard structure debug formatter, now looks like `Shard(1/1)`)
- Provide detailed span information on `request` function: Allows users of tracing data to more directly filter and analyze tracing data by route or method
- print a debug log in the request-function: This allows easy debugging for when a bot does more requests than you'd expect, giving you insight into _which_ requests fire, when.

If any of this is not desired, I'd be happy to reduce the scope of the PR. These three small changes would be a noticeable improvement for my workflow, as I'm currently struggling to optimize and understand my bot, partially due to the somewhat useless data that the request span provides me so far.

Thank's for your work, y'all! Serenity is amazing!