### PR TITLE
Better span and log information for requests and nicer debug formatting for ShardInfo

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -5205,15 +5205,25 @@ impl Http {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument]
+    #[instrument(
+        skip_all,
+        fields(
+            url.path = %req.route.path(),
+            http.request.method = req.method.reqwest_method().as_str(),
+            http.response.status,
+        )
+    )]
     pub async fn request(&self, req: Request<'_>) -> Result<ReqwestResponse> {
         let method = req.method.reqwest_method();
+        debug!("Performing request: {method} {}", req.route.path());
         let response = if let Some(ratelimiter) = &self.ratelimiter {
             ratelimiter.perform(req).await?
         } else {
             let request = req.build(&self.client, self.token(), self.proxy.as_deref())?.build()?;
             self.client.execute(request).await?
         };
+
+        tracing::Span::current().record("http.response.status", response.status().as_u16());
 
         if response.status().is_success() {
             Ok(response)

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -5210,6 +5210,10 @@ impl Http {
         fields(
             url.path = %req.route.path(),
             http.request.method = req.method.reqwest_method().as_str(),
+            // Setting these otel.* fields allows users of opentelemetry-tracing to have their spans be correctly annotated
+            otel.kind = "client",
+            otel.status_code,
+            otel.status_message,
             http.response.status,
         )
     )]
@@ -5223,11 +5227,17 @@ impl Http {
             self.client.execute(request).await?
         };
 
-        tracing::Span::current().record("http.response.status", response.status().as_u16());
+        let current_span = tracing::Span::current();
+        current_span.record("http.response.status", response.status().as_u16());
 
         if response.status().is_success() {
+            current_span.record("otel.status_code", "OK");
             Ok(response)
         } else {
+            current_span.record("otel.status_code", "ERROR");
+            current_span
+                .record("otel.status_message", format!("HTTP {}", response.status().as_u16()));
+
             Err(Error::Http(HttpError::UnsuccessfulRequest(
                 ErrorResponse::from_response(response, method).await,
             )))

--- a/src/model/gateway.rs
+++ b/src/model/gateway.rs
@@ -390,10 +390,16 @@ pub struct SessionStartLimit {
 }
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct ShardInfo {
     pub id: ShardId,
     pub total: u32,
+}
+
+impl std::fmt::Debug for ShardInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.id.0, self.total)
+    }
 }
 
 impl ShardInfo {


### PR DESCRIPTION
This PR does three things to improve the monitoring workflow for a serenity bot:

- it implements a custom Debug formatter for `ShardInfo` (included in many log lines and span annotations, previously used the standard structure debug formatter, now looks like `Shard(1/1)`)
- Provide detailed span information on `request` function: Allows users of tracing data to more directly filter and analyze tracing data by route or method
- print a debug log in the request-function: This allows easy debugging for when a bot does more requests than you'd expect, giving you insight into which requests fire, when.


If any of this is not desired, I'd be happy to reduce the scope of the PR.

These three small changes would be a noticeable improvement for my workflow, as I'm currently struggling to optimize and understand my bot, partially due to the somewhat useless data that the request span provides me so far.

Thank's for your work, y'all! Serenity is amazing!