### PR TITLE
Update attachment and embed models

### DIFF
--- a/examples/e08_create_message_builder/src/main.rs
+++ b/examples/e08_create_message_builder/src/main.rs
@@ -25,7 +25,7 @@ impl EventHandler for Handler {
                     let embed = CreateEmbed::new()
                         .title("This is a title")
                         .description("This is a description")
-                        .image("attachment://ferris_eyes.png")
+                        .image("attachment://ferris_eyes.png", Some("Ferris with big eyes".into()))
                         .fields([
                             ("This is the first field", "This is a field body", true),
                             ("This is the second field", "Both fields are inline", true),

--- a/examples/testing/src/model_type_sizes.rs
+++ b/examples/testing/src/model_type_sizes.rs
@@ -51,7 +51,6 @@ pub fn print_ranking() {
         ("EmbedFooter", std::mem::size_of::<EmbedFooter>()),
         ("EmbedImage", std::mem::size_of::<EmbedImage>()),
         ("EmbedProvider", std::mem::size_of::<EmbedProvider>()),
-        ("EmbedThumbnail", std::mem::size_of::<EmbedThumbnail>()),
         ("EmbedVideo", std::mem::size_of::<EmbedVideo>()),
         ("Emoji", std::mem::size_of::<Emoji>()),
         ("EmojiId", std::mem::size_of::<EmojiId>()),

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -133,19 +133,39 @@ impl<'a> CreateEmbed<'a> {
 
     /// Set the image associated with the embed.
     ///
-    /// Refer [Discord Documentation](https://docs.discord.com/developers/reference#uploading-files)
+    /// Optionally, include a `description` to set the alt text for the image.
+    ///
+    /// Note that if you specify "attachment://filename.(jpg, png)" for the url, passing a value
+    /// to `description` will have no effect. Alt text for attachments must be set using
+    /// [`CreateAttachment::description`].
+    ///
+    /// Refer to [Discord Documentation](https://docs.discord.com/developers/reference#uploading-files)
     /// for rules on naming local attachments.
-    pub fn image(mut self, url: impl Into<Cow<'a, str>>) -> Self {
+    ///
+    /// [`CreateAttachment::description`]: crate::builder::CreateAttachment::description
+    pub fn image(
+        mut self,
+        url: impl Into<Cow<'a, str>>,
+        description: Option<Cow<'a, str>>,
+    ) -> Self {
         self.image = Some(CreateEmbedImage {
             url: url.into(),
+            description,
         });
         self
     }
 
     /// Set the thumbnail of the embed.
-    pub fn thumbnail(mut self, url: impl Into<Cow<'a, str>>) -> Self {
+    ///
+    /// Optionally, include a `description` to set the alt text for the thumbnail.
+    pub fn thumbnail(
+        mut self,
+        url: impl Into<Cow<'a, str>>,
+        description: Option<Cow<'a, str>>,
+    ) -> Self {
         self.thumbnail = Some(CreateEmbedImage {
             url: url.into(),
+            description,
         });
         self
     }
@@ -183,15 +203,17 @@ impl<'a> CreateEmbed<'a> {
 
     /// Same as calling [`Self::image`] with "attachment://filename.(jpg, png)".
     ///
-    /// Remember to set an attachment with the provided filename via [`CreateAttachment`]
+    /// Remember to set an attachment with the provided filename via [`CreateAttachment`].
+    /// Alt text may be set with [`CreateAttachment::description`].
     ///
-    /// Refer [`Self::image`] for rules on naming local attachments.
+    /// Refer to [`Self::image`] for rules on naming local attachments.
     ///
     /// [`CreateAttachment`]: crate::builder::CreateAttachment
+    /// [`CreateAttachment::description`]: crate::builder::CreateAttachment::description
     pub fn attachment(self, filename: impl Into<String>) -> Self {
         let mut filename = filename.into();
         filename.insert_str(0, "attachment://");
-        self.image(filename)
+        self.image(filename, None)
     }
 
     #[cfg(feature = "http")]
@@ -394,12 +416,14 @@ impl From<EmbedField> for CreateEmbedField<'_> {
 #[derive(Clone, Debug, Serialize)]
 struct CreateEmbedImage<'a> {
     url: Cow<'a, str>,
+    description: Option<Cow<'a, str>>,
 }
 
 impl From<EmbedImage> for CreateEmbedImage<'_> {
     fn from(field: EmbedImage) -> Self {
         Self {
             url: field.url.into(),
+            description: field.description.map(Into::into),
         }
     }
 }

--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -403,11 +403,3 @@ impl From<EmbedImage> for CreateEmbedImage<'_> {
         }
     }
 }
-
-impl From<EmbedThumbnail> for CreateEmbedImage<'_> {
-    fn from(field: EmbedThumbnail) -> Self {
-        Self {
-            url: field.url.into(),
-        }
-    }
-}

--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -34,25 +34,38 @@ where
 pub struct Attachment {
     /// The unique ID given to this attachment.
     pub id: AttachmentId,
-    /// The filename of the file that was uploaded. This is equivalent to what the uploader had
-    /// their file named.
+    /// The name of the file attached.
+    ///
+    /// This `filename` supports ASCII printable characters only. If the original filename
+    /// satisfies this condition, it will be used here.
     pub filename: FixedString,
-    /// Description for the file (max 1024 characters).
+    /// The title of the file.
+    ///
+    /// When the original filename includes characters other than ASCII printable characters, a
+    /// sanitized name is assigned to `filename` and the original name is held in `title`.
+    pub title: Option<FixedString>,
+    /// Description (alt text) for the file (max 1024 characters).
     pub description: Option<FixedString<u16>>,
-    /// If the attachment is an image, then the height of the image is provided.
-    pub height: Option<NonMaxU32>,
-    /// If the attachment is an image, then the width of the image is provided.
-    pub width: Option<NonMaxU32>,
-    /// The proxy URL.
-    pub proxy_url: FixedString,
-    /// The size of the file in bytes.
-    pub size: u32,
-    /// The URL of the uploaded attachment.
-    pub url: FixedString,
     /// The attachment's [media type].
     ///
     /// [media type]: https://en.wikipedia.org/wiki/Media_type
     pub content_type: Option<FixedString>,
+    /// The size of the file in bytes.
+    pub size: u32,
+    /// The source URL of the file.
+    pub url: FixedString,
+    /// A proxied URL of the file.
+    pub proxy_url: FixedString,
+    /// The height of the file (if image or video).
+    pub height: Option<NonMaxU32>,
+    /// The width of the file (if image or video).
+    pub width: Option<NonMaxU32>,
+    /// The [thumbhash] placeholder of the attachment (if image or video).
+    ///
+    /// [thumbhash]: https://evanw.github.io/thumbhash/
+    pub placeholder: Option<FixedString>,
+    /// The version of the placeholder (if image or video).
+    pub placeholder_version: Option<NonMaxU32>,
     /// Whether this attachment is ephemeral.
     ///
     /// Ephemeral attachments will automatically be removed after a set period of time.
@@ -74,6 +87,15 @@ pub struct Attachment {
     /// documentation.
     #[serde(default, deserialize_with = "base64_bytes")]
     pub waveform: Option<Vec<u8>>,
+    /// The attachment flags for this attachment.
+    pub flags: Option<AttachmentFlags>,
+    /// For Clips, an array of the users who were in the stream.
+    #[serde(default)]
+    pub clip_participants: FixedArray<User>,
+    /// For Clips, when the clip was created.
+    pub clip_created_at: Option<Timestamp>,
+    /// For Clips, the application in the stream, if recognized.
+    pub application: Option<MessageApplication>,
 }
 
 #[cfg(feature = "model")]
@@ -154,5 +176,24 @@ impl Attachment {
 impl ExtractKey<AttachmentId> for Attachment {
     fn extract_key(&self) -> &AttachmentId {
         &self.id
+    }
+}
+
+bitflags! {
+    /// Flags for an attachment.
+    ///
+    /// [Discord docs](https://docs.discord.com/developers/resources/message#attachment-object-attachment-flags).
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
+    pub struct AttachmentFlags: u8 {
+        /// This attachment is a Clip from a stream.
+        const IS_CLIP = 1 << 0;
+        /// This attachment is the thumbnail of a thread in a media channel, displayed in the grid
+        /// but not on the message.
+        const IS_THUMBNAIL = 1 << 1;
+        /// This attachment was marked as a spoiler and is blurred until clicked.
+        const IS_SPOILER = 1 << 3;
+        /// This attachment is an animated image.
+        const IS_ANIMATED = 1 << 5;
     }
 }

--- a/src/model/channel/embed.rs
+++ b/src/model/channel/embed.rs
@@ -48,7 +48,7 @@ pub struct Embed {
     pub image: Option<EmbedImage>,
     /// Thumbnail information of the embed.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail: Option<EmbedThumbnail>,
+    pub thumbnail: Option<EmbedImage>,
     /// The embed's video information.
     ///
     /// This is present if the [`Self::kind`] is `"video"`.
@@ -175,6 +175,20 @@ pub struct EmbedImage {
     pub height: Option<NonMaxU32>,
     /// The width of the image.
     pub width: Option<NonMaxU32>,
+    /// The image's [media type].
+    ///
+    /// [media type]: https://en.wikipedia.org/wiki/Media_type
+    pub content_type: Option<FixedString>,
+    /// The [thumbhash] placeholder of the image.
+    ///
+    /// [thumbhash]: https://evanw.github.io/thumbhash/
+    pub placeholder: Option<FixedString>,
+    /// The version of the placeholder.
+    pub placeholder_version: Option<NonMaxU32>,
+    /// The description (alt text) for the image.
+    pub description: Option<FixedString>,
+    /// The embed media flags for the image.
+    pub flags: Option<EmbedMediaFlags>,
 }
 
 /// The provider of an embed.
@@ -190,25 +204,6 @@ pub struct EmbedProvider {
     pub url: Option<FixedString>,
 }
 
-/// The dimensions and URL of an embed thumbnail.
-///
-/// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-thumbnail-structure).
-#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
-pub struct EmbedThumbnail {
-    /// The source URL of the thumbnail.
-    ///
-    /// This only supports HTTP(S) and attachments.
-    pub url: FixedString,
-    /// A proxied URL of the thumbnail.
-    pub proxy_url: Option<FixedString>,
-    /// The height of the thumbnail in pixels.
-    pub height: Option<NonMaxU32>,
-    /// The width of the thumbnail in pixels.
-    pub width: Option<NonMaxU32>,
-}
-
 /// Video information for an embed.
 ///
 /// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-video-structure).
@@ -218,10 +213,36 @@ pub struct EmbedThumbnail {
 pub struct EmbedVideo {
     /// The source URL of the video.
     pub url: FixedString,
-    /// A proxied URL of the thumbnail.
+    /// A proxied URL of the video.
     pub proxy_url: Option<FixedString>,
-    /// The height of the video in pixels.
+    /// The height of the video.
     pub height: Option<NonMaxU32>,
-    /// The width of the video in pixels.
+    /// The width of the video.
     pub width: Option<NonMaxU32>,
+    /// The video's [media type].
+    ///
+    /// [media type]: https://en.wikipedia.org/wiki/Media_type
+    pub content_type: Option<FixedString>,
+    /// The [thumbhash] placeholder of the video.
+    ///
+    /// [thumbhash]: https://evanw.github.io/thumbhash/
+    pub placeholder: Option<FixedString>,
+    /// The version of the placeholder.
+    pub placeholder_version: Option<NonMaxU32>,
+    /// The description (alt text) for the video.
+    pub description: Option<FixedString>,
+    /// The embed media flags for the video.
+    pub flags: Option<EmbedMediaFlags>,
+}
+
+bitflags! {
+    /// Flags for embed media.
+    ///
+    /// [Discord docs](https://docs.discord.com/developers/resources/message#embed-object-embed-media-flags).
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
+    pub struct EmbedMediaFlags: u8 {
+        /// This image is animated.
+        const IS_ANIMATED = 1 << 5;
+    }
 }


### PR DESCRIPTION
Updates attachment and embed models to reflect most of the changes in [Document more attachment flags and fields
#7353](https://github.com/discord/discord-api-docs/pull/7353). `IS_CONTENT_INVENTORY_ENTRY` embed flag (used for outdated clients) and deprecated `IS_REMIX` attachment flag have been omitted.

Verified successful deserialization of all added fields.