### PR TITLE
Fix From impl coherence with time 0.3.48

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -346,11 +346,16 @@ impl AutocompleteChoice {
     }
 }
 
-impl<S: Into<String>> From<S> for AutocompleteChoice {
-    fn from(value: S) -> Self {
-        let value = value.into();
+impl From<String> for AutocompleteChoice {
+    fn from(value: String) -> Self {
         let name = value.clone();
         Self::new(name, value)
+    }
+}
+
+impl From<&str> for AutocompleteChoice {
+    fn from(value: &str) -> Self {
+        Self::from(value.to_owned())
     }
 }
 

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1127,12 +1127,24 @@ impl std::fmt::Display for Content {
     }
 }
 
-impl<T: Into<String>> From<T> for Content {
-    fn from(t: T) -> Content {
+impl From<String> for Content {
+    fn from(t: String) -> Content {
         Content {
-            inner: t.into(),
+            inner: t,
             ..Default::default()
         }
+    }
+}
+
+impl From<&str> for Content {
+    fn from(t: &str) -> Content {
+        Self::from(t.to_owned())
+    }
+}
+
+impl From<char> for Content {
+    fn from(t: char) -> Content {
+        Self::from(t.to_string())
     }
 }
 


### PR DESCRIPTION
I work on Radion, a prediction markets trading app. We use serenity for our Discord bot.

When I updated our dependencies, `time 0.3.48` (released 2026-06-12) triggered E0119 coherence errors. This blocked us from shipping the update — we had to pin `time = "=0.3.36"` and patch serenity with a fork just to compile.

The root cause: `time 0.3.48` added generic parameters to all types in the `unit` module and new comparison impls against the generic `Unit` type ([changelog](https://github.com/time-rs/time/blob/main/CHANGELOG.md#0348-2026-06-12)). These new impls conflict with serenity's broad `From<T: Into<String>>` blanket impls on `AutocompleteChoice` and `Content`.

This PR narrows those impls to concrete `String` and `\&str` overloads, removing the overlap. `char` support for `Content` is kept so `MessageBuilder::push('a')` still works.

I saw the discussion in #3484 — I know the long-term plan is to move to Jiff. This is just a fix to unblock downstream users until that lands.

Tested with `cargo check` and `cargo test --lib utils::message_builder::test::push` (no-default-features, builder/model/utils/native_tls_backend).