### PR TITLE
Add builder to the http feature deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
           - name: builder without model
             features: builder
             dont-test: true
+          - name: http without model
+            features: http rustls_backend
+            dont-test: true
           - name: unstable Discord API (no default features)
             features: unstable_discord_api
             dont-test: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,8 @@ framework = ["client", "model", "utils"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["flate2"]
 # Enables HTTP, which enables bots to execute actions on Discord.
-http = ["mime_guess", "percent-encoding"]
+# Requires "builder" for request body types such as CreateAttachment.
+http = ["builder", "mime_guess", "percent-encoding"]
 # Enables wrapper methods around HTTP requests on model types.
 # Requires "builder" to configure the requests and "http" to execute them.
 # Note: the model type definitions themselves are always active, regardless of this feature.


### PR DESCRIPTION
Fixes #2772

turning on the http feature without builder doesn't compile, http
imports CreateAttachment and a few other types from builder. the client
feature hits it too since it pulls in http. just declaring the dep fixes
it

also added a small CI job that builds http on its own so this doesn't
regress
