### PR TITLE
Allow http to compile without model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
       matrix:
         name:
           - builder without model
+          - http without model
           - unstable + typesize
           - unstable (no default features)
           - temp cache
@@ -94,6 +95,8 @@ jobs:
         include:
           - name: builder without model
             features: builder
+          - name: http without model
+            features: http rustls_backend
           - name: unstable + typesize
             features: default unstable typesize
           - name: unstable (no default features)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,8 @@ framework = ["gateway"]
 # Enables gateway support, which allows bots to listen for Discord events.
 gateway = ["model", "flate2", "dashmap"]
 # Enables HTTP, which enables bots to execute actions on Discord.
-http = ["dashmap", "mime", "mime_guess", "percent-encoding"]
+# Requires "builder" for request body types such as CreateAttachment.
+http = ["builder", "dashmap", "mime", "mime_guess", "percent-encoding"]
 # Enables wrapper methods around HTTP requests on model types.
 # Requires "builder" to configure the requests and "http" to execute them.
 # Note: the model type definitions themselves are always active, regardless of this feature.

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -177,9 +177,21 @@ impl<'a> EditRole<'a> {
         };
 
         if let Some(position) = self.position {
-            guild_id
-                .edit_role_positions(http, [(role.id, position)], self.audit_log_reason)
-                .await?;
+            #[derive(Serialize)]
+            struct EditRolePosition {
+                id: RoleId,
+                position: i16,
+            }
+
+            http.edit_role_positions(
+                guild_id,
+                std::iter::once(EditRolePosition {
+                    id: role.id,
+                    position,
+                }),
+                self.audit_log_reason,
+            )
+            .await?;
         }
         Ok(role)
     }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -121,7 +121,6 @@ pub enum Channel {
     Private(PrivateChannel),
 }
 
-#[cfg(feature = "model")]
 impl Channel {
     /// If this is a guild channel, returns it.
     #[must_use]
@@ -164,6 +163,7 @@ impl Channel {
     /// # Errors
     ///
     /// Returns [`Error::Http`] if the current user lacks permission.
+    #[cfg(feature = "model")]
     pub async fn delete(&self, http: &Http, reason: Option<&str>) -> Result<()> {
         match self {
             Self::Guild(public_channel) => {

--- a/src/model/mention.rs
+++ b/src/model/mention.rs
@@ -184,7 +184,6 @@ macro_rules! mentionable {
     };
 }
 
-#[cfg(feature = "model")]
 mentionable!(value: Channel, value.id());
 
 mentionable!(value: GuildChannel, value.id.widen());


### PR DESCRIPTION
the next-branch counterpart to #3568, both for #2772

#2496 already fixed this on current but next drifted back into it.
enabling http without model doesn't compile because:
1. http didn't depend on builder
2. some http gated builder execute methods call model gated helpers

what i did:
- http depends on builder now
- moved the plain Channel accessors (guild/thread/private/category/id/
  guild_id) out from behind the model feature, they're just enum matches.
  only Channel::delete actually needs model. same for the Mentionable
  impl on Channel
- EditRole::execute calls Http::edit_role_positions directly instead of
  the model GuildId helper

heads up: that model helper also did an audit log reason length check
that i dropped. the edit_role/create_role calls right above it already
send the reason without checking, so this just makes execute consistent.
happy to put it back if you'd rather
