### PR TITLE
feat: make `GuildId::everyone_role` const

### DIFF
--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -941,8 +941,8 @@ impl GuildId {
     /// Gets the default permission role (@everyone) from the guild.
     #[inline]
     #[must_use]
-    pub fn everyone_role(&self) -> RoleId {
-        RoleId::from(self.get())
+    pub const fn everyone_role(&self) -> RoleId {
+        RoleId::new(self.get())
     }
 
     /// Tries to find the [`Guild`] by its Id in the cache.


### PR DESCRIPTION
There should be no forward compatibility concerns as it's not more than just changing the id wrapper.