### PR TITLE
Remove most dependencies of `http` on `model`

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -60,7 +60,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
             .send_message(
                 &ctx.http,
                 CreateMessage::new()
-                    .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
+                    .add_file(CreateAttachment::url(IMAGE_URL, "testing.png").await?),
             )
             .await?;
         // Pre-PR, this falsely triggered a MODEL_TYPE_CONVERT Discord error
@@ -74,14 +74,14 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
             .send_message(
                 &ctx.http,
                 CreateMessage::new()
-                    .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
+                    .add_file(CreateAttachment::url(IMAGE_URL, "testing.png").await?),
             )
             .await?;
         msg.edit(
             ctx,
             EditMessage::new().attachments(
                 EditAttachments::keep_all(&msg)
-                    .add(CreateAttachment::url(&ctx.http, IMAGE_URL_2, "testing1.png").await?),
+                    .add(CreateAttachment::url(IMAGE_URL_2, "testing1.png").await?),
             ),
         )
         .await?;
@@ -195,7 +195,7 @@ async fn message(ctx: &Context, msg: &Message) -> Result<(), serenity::Error> {
         // As of 2023-04-20, bots are still not allowed to sending voice messages
         let builder = CreateMessage::new()
             .flags(MessageFlags::IS_VOICE_MESSAGE)
-            .add_file(CreateAttachment::url(&ctx.http, audio_url, "testing.ogg").await?);
+            .add_file(CreateAttachment::url(audio_url, "testing.ogg").await?);
 
         msg.author.id.dm(&ctx.http, builder).await?;
     } else if let Some(channel) = msg.content.strip_prefix("movetorootandback") {
@@ -246,9 +246,8 @@ async fn command_interaction(
             .create_response(
                 &ctx.http,
                 CreateInteractionResponse::Message(
-                    CreateInteractionResponseMessage::new().add_file(
-                        CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?,
-                    ),
+                    CreateInteractionResponseMessage::new()
+                        .add_file(CreateAttachment::url(IMAGE_URL, "testing.png").await?),
                 ),
             )
             .await?;
@@ -262,7 +261,7 @@ async fn command_interaction(
                 &ctx.http,
                 EditInteractionResponse::new().attachments(
                     EditAttachments::keep_all(&msg)
-                        .add(CreateAttachment::url(&ctx.http, IMAGE_URL_2, "testing1.png").await?),
+                        .add(CreateAttachment::url(IMAGE_URL_2, "testing1.png").await?),
                 ),
             )
             .await?;
@@ -318,9 +317,8 @@ async fn command_interaction(
             .create_response(
                 &ctx.http,
                 CreateInteractionResponse::Message(
-                    CreateInteractionResponseMessage::new().add_file(
-                        CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?,
-                    ),
+                    CreateInteractionResponseMessage::new()
+                        .add_file(CreateAttachment::url(IMAGE_URL, "testing.png").await?),
                 ),
             )
             .await?;
@@ -328,9 +326,8 @@ async fn command_interaction(
         interaction
             .edit_response(
                 &ctx.http,
-                EditInteractionResponse::new().new_attachment(
-                    CreateAttachment::url(&ctx.http, IMAGE_URL_2, "testing1.png").await?,
-                ),
+                EditInteractionResponse::new()
+                    .new_attachment(CreateAttachment::url(IMAGE_URL_2, "testing1.png").await?),
             )
             .await?;
 
@@ -338,7 +335,7 @@ async fn command_interaction(
             .create_followup(
                 &ctx.http,
                 CreateInteractionResponseFollowup::new()
-                    .add_file(CreateAttachment::url(&ctx.http, IMAGE_URL, "testing.png").await?),
+                    .add_file(CreateAttachment::url(IMAGE_URL, "testing.png").await?),
             )
             .await?;
     } else if interaction.data.name == "editembeds" {

--- a/src/builder/attachments.rs
+++ b/src/builder/attachments.rs
@@ -104,7 +104,7 @@ impl<'a> CreateAttachment<'a> {
     /// [`CreateAttachment::path`], then the file at the specified path was unable to be read. If
     /// instead it's [`CreateAttachment::file`], then cloning the handle to the file failed, likely
     /// due to hitting the system's limit on number of open file handles.
-    pub async fn as_bytes(&self) -> Result<Bytes> {
+    pub async fn to_bytes(&self) -> Result<Bytes> {
         match &self.data.kind {
             AttachmentDataKind::Bytes(bytes) => Ok(bytes.clone()),
             AttachmentDataKind::Path(path) => {
@@ -130,7 +130,7 @@ impl<'a> CreateAttachment<'a> {
         use base64::engine::{Config, Engine};
 
         let prefix = format!("data:{mimetype};base64,");
-        let data = self.as_bytes().await?;
+        let data = self.to_bytes().await?;
 
         let engine = base64::prelude::BASE64_STANDARD;
         let encoded_size = base64::encoded_len(data.len(), engine.config().encode_padding())

--- a/src/builder/attachments.rs
+++ b/src/builder/attachments.rs
@@ -2,18 +2,24 @@ use std::borrow::Cow;
 use std::path::Path;
 
 use bytes::Bytes;
+#[cfg(feature = "http")]
+use reqwest::{Client as ReqwestClient, IntoUrl};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 
 use crate::error::{Error, Result, UrlError};
-#[cfg(feature = "http")]
-use crate::http::Http;
 use crate::model::channel::Message;
 use crate::model::id::AttachmentId;
 
 #[derive(Clone, Debug)]
-pub enum AttachmentData<'a> {
+pub struct AttachmentData<'a> {
+    pub filename: Cow<'static, str>,
+    pub kind: AttachmentDataKind<'a>,
+}
+
+#[derive(Clone, Debug)]
+pub enum AttachmentDataKind<'a> {
     Bytes(Bytes),
     File(&'a File),
     Path(&'a Path),
@@ -26,20 +32,21 @@ pub enum AttachmentData<'a> {
 #[non_exhaustive]
 #[must_use]
 pub struct CreateAttachment<'a> {
-    pub filename: Cow<'static, str>,
-    pub description: Option<Cow<'a, str>>,
-    pub spoiler: bool,
-    pub data: AttachmentData<'a>,
+    description: Option<Cow<'a, str>>,
+    spoiler: bool,
+    data: AttachmentData<'a>,
 }
 
 impl<'a> CreateAttachment<'a> {
     /// Builds an [`CreateAttachment`] from the raw attachment data.
     pub fn bytes(data: impl Into<Bytes>, filename: impl Into<Cow<'static, str>>) -> Self {
         CreateAttachment {
-            filename: filename.into(),
             description: None,
             spoiler: false,
-            data: AttachmentData::Bytes(data.into()),
+            data: AttachmentData {
+                filename: filename.into(),
+                kind: AttachmentDataKind::Bytes(data.into()),
+            },
         }
     }
 
@@ -55,20 +62,24 @@ impl<'a> CreateAttachment<'a> {
             .to_string_lossy()
             .into_owned();
         Ok(CreateAttachment {
-            filename: filename.into(),
             description: None,
             spoiler: false,
-            data: AttachmentData::Path(path),
+            data: AttachmentData {
+                filename: filename.into(),
+                kind: AttachmentDataKind::Path(path),
+            },
         })
     }
 
     /// Builds an [`CreateAttachment`] by reading from a file handler.
     pub fn file(file: &'a File, filename: impl Into<Cow<'static, str>>) -> Self {
         CreateAttachment {
-            filename: filename.into(),
             description: None,
             spoiler: false,
-            data: AttachmentData::File(file),
+            data: AttachmentData {
+                filename: filename.into(),
+                kind: AttachmentDataKind::File(file),
+            },
         }
     }
 
@@ -78,12 +89,8 @@ impl<'a> CreateAttachment<'a> {
     ///
     /// Returns [`Error::Http`] if downloading the data fails.
     #[cfg(feature = "http")]
-    pub async fn url(
-        http: &Http,
-        url: impl reqwest::IntoUrl,
-        filename: impl Into<Cow<'static, str>>,
-    ) -> Result<Self> {
-        let response = http.client.get(url).send().await?;
+    pub async fn url(url: impl IntoUrl, filename: impl Into<Cow<'static, str>>) -> Result<Self> {
+        let response = ReqwestClient::new().get(url).send().await?;
         let data = response.bytes().await?;
 
         Ok(CreateAttachment::bytes(data, filename))
@@ -97,16 +104,16 @@ impl<'a> CreateAttachment<'a> {
     /// [`CreateAttachment::path`], then the file at the specified path was unable to be read. If
     /// instead it's [`CreateAttachment::file`], then cloning the handle to the file failed, likely
     /// due to hitting the system's limit on number of open file handles.
-    pub async fn get_data(&self) -> Result<Bytes> {
-        match &self.data {
-            AttachmentData::Bytes(bytes) => Ok(bytes.clone()),
-            AttachmentData::Path(path) => {
+    pub async fn as_bytes(&self) -> Result<Bytes> {
+        match &self.data.kind {
+            AttachmentDataKind::Bytes(bytes) => Ok(bytes.clone()),
+            AttachmentDataKind::Path(path) => {
                 let mut file = File::open(path).await?;
                 let mut data = Vec::new();
                 file.read_to_end(&mut data).await?;
                 Ok(data.into())
             },
-            AttachmentData::File(file) => {
+            AttachmentDataKind::File(file) => {
                 let mut data = Vec::new();
                 file.try_clone().await?.read_to_end(&mut data).await?;
                 Ok(data.into())
@@ -118,12 +125,12 @@ impl<'a> CreateAttachment<'a> {
     ///
     /// # Errors
     ///
-    /// See [`CreateAttachment::get_data`] for details.
+    /// See [`CreateAttachment::as_bytes`] for details.
     pub async fn encode(&self, mimetype: &str) -> Result<DataUri<'_>> {
         use base64::engine::{Config, Engine};
 
         let prefix = format!("data:{mimetype};base64,");
-        let data = self.get_data().await?;
+        let data = self.as_bytes().await?;
 
         let engine = base64::prelude::BASE64_STANDARD;
         let encoded_size = base64::encoded_len(data.len(), engine.config().encode_padding())
@@ -146,6 +153,12 @@ impl<'a> CreateAttachment<'a> {
     pub fn spoiler(mut self, spoiler: bool) -> Self {
         self.spoiler = spoiler;
         self
+    }
+}
+
+impl<'a> From<CreateAttachment<'a>> for AttachmentData<'a> {
+    fn from(value: CreateAttachment<'a>) -> AttachmentData<'a> {
+        value.data
     }
 }
 
@@ -439,12 +452,12 @@ impl<'a> EditAttachments<'a> {
     /// Clones all new attachments into a new Vec, keeping only data and filename, because those
     /// are needed for the multipart form data.
     #[cfg(feature = "http")]
-    pub(crate) fn new_attachments(&self) -> Vec<CreateAttachment<'a>> {
+    pub(crate) fn new_attachment_data(&self) -> Vec<AttachmentData<'a>> {
         self.inner
             .iter()
             .filter_map(|attachment| {
                 if let EditAttachmentsInner::New(attachment) = &attachment {
-                    Some(attachment.clone())
+                    Some(attachment.data.clone())
                 } else {
                     None
                 }
@@ -482,7 +495,7 @@ impl Serialize for EditAttachments<'_> {
                 EditAttachmentsInner::New(new_attachment) => {
                     let attachment = NewAttachment {
                         id,
-                        filename: &new_attachment.filename,
+                        filename: &new_attachment.data.filename,
                         description: &new_attachment.description,
                         is_spoiler: new_attachment.spoiler,
                     };

--- a/src/builder/attachments.rs
+++ b/src/builder/attachments.rs
@@ -125,7 +125,7 @@ impl<'a> CreateAttachment<'a> {
     ///
     /// # Errors
     ///
-    /// See [`CreateAttachment::as_bytes`] for details.
+    /// See [`CreateAttachment::to_bytes`] for details.
     pub async fn encode(&self, mimetype: &str) -> Result<DataUri<'_>> {
         use base64::engine::{Config, Engine};
 

--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -97,7 +97,7 @@ impl<'a> CreateForumPost<'a> {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, channel_id: ChannelId) -> Result<GuildThread> {
-        let files = self.message.attachments.new_attachments();
+        let files = self.message.attachments.new_attachment_data();
         http.create_forum_post(channel_id, &self, files, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -132,7 +132,9 @@ impl CreateInteractionResponse<'_> {
         let files = match &mut self {
             CreateInteractionResponse::Message(msg)
             | CreateInteractionResponse::Defer(msg)
-            | CreateInteractionResponse::UpdateMessage(msg) => msg.attachments.new_attachments(),
+            | CreateInteractionResponse::UpdateMessage(msg) => {
+                msg.attachments.new_attachment_data()
+            },
             _ => Vec::new(),
         };
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -178,7 +178,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
     ) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.new_attachments();
+        let files = self.attachments.new_attachment_data();
 
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -279,7 +279,7 @@ impl<'a> CreateMessage<'a> {
     pub async fn execute(mut self, http: &Http, channel_id: GenericChannelId) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.new_attachments();
+        let files = self.attachments.new_attachment_data();
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);
         }

--- a/src/builder/create_soundboard.rs
+++ b/src/builder/create_soundboard.rs
@@ -1,8 +1,6 @@
 use std::borrow::Cow;
 
 use super::DataUri;
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
 use crate::model::prelude::*;
 
 /// A builder to create a soundboard sound.

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -86,6 +86,6 @@ impl<'a> CreateSticker<'a> {
             ("description".into(), self.description),
         ];
 
-        http.create_sticker(guild_id, map, self.file, self.audit_log_reason).await
+        http.create_sticker(guild_id, map, self.file.into(), self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_interaction_response.rs
+++ b/src/builder/edit_interaction_response.rs
@@ -125,7 +125,7 @@ impl<'a> EditInteractionResponse<'a> {
         self.0.check_length()?;
 
         let files =
-            self.0.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachments);
+            self.0.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachment_data);
 
         http.edit_original_interaction_response(interaction_token, &self, files).await
     }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -243,7 +243,8 @@ impl<'a> EditMessage<'a> {
             return Err(Error::Model(ModelError::InvalidUser));
         }
 
-        let files = self.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachments);
+        let files =
+            self.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachment_data);
 
         let http = cache_http.http();
         if self.allowed_mentions.is_none() {

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -8,8 +8,6 @@ use super::{
     EditAttachment,
     EditAttachments,
 };
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
 use crate::model::prelude::*;
 
 /// A builder to specify the fields to edit in an existing message.

--- a/src/builder/edit_profile.rs
+++ b/src/builder/edit_profile.rs
@@ -4,9 +4,7 @@ use super::DataUri;
 #[cfg(feature = "http")]
 use crate::http::Http;
 #[cfg(feature = "http")]
-use crate::internal::prelude::*;
-#[cfg(feature = "http")]
-use crate::model::user::CurrentUser;
+use crate::model::prelude::*;
 
 /// A builder to edit the current user's settings, to be used in conjunction with
 /// [`CurrentUser::edit`].

--- a/src/builder/edit_soundboard.rs
+++ b/src/builder/edit_soundboard.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "http")]
-use crate::http::CacheHttp;
 use crate::model::prelude::*;
 
 /// A builder to create or edit a [`Soundboard`] for use with [`GuildId::edit_soundboard`].

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -179,7 +179,8 @@ impl<'a> EditWebhookMessage<'a> {
     ) -> Result<Message> {
         self.check_length()?;
 
-        let files = self.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachments);
+        let files =
+            self.attachments.as_ref().map_or(Vec::new(), EditAttachments::new_attachment_data);
 
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);

--- a/src/builder/entitlements.rs
+++ b/src/builder/entitlements.rs
@@ -6,6 +6,55 @@ use nonmax::NonMaxU8;
 use crate::http::Http;
 use crate::model::prelude::*;
 
+/// Builds a request to create a test [`Entitlement`].
+///
+/// This is a helper for [`Http::create_test_entitlement`].
+///
+/// [`Http::create_test_entitlement`]: crate::http::Http::create_test_entitlement
+#[derive(Clone, Debug, Serialize)]
+#[must_use]
+pub struct CreateTestEntitlement {
+    sku_id: SkuId,
+    owner_id: GenericId,
+    owner_type: u8,
+}
+
+impl CreateTestEntitlement {
+    pub fn new(sku_id: SkuId, owner: EntitlementOwner) -> Self {
+        let (owner_id, owner_type) = owner.deconstruct();
+
+        Self {
+            sku_id,
+            owner_id,
+            owner_type,
+        }
+    }
+
+    /// Creates a test entitlement.
+    ///
+    /// # Errors
+    ///
+    /// May error due to an invalid response from discord, or network error.
+    #[cfg(feature = "http")]
+    pub async fn execute(self, http: &Http) -> Result<Entitlement> {
+        http.create_test_entitlement(&self).await
+    }
+}
+
+pub enum EntitlementOwner {
+    Guild(GuildId),
+    User(UserId),
+}
+
+impl EntitlementOwner {
+    fn deconstruct(self) -> (GenericId, u8) {
+        match self {
+            EntitlementOwner::Guild(id) => (id.get().into(), 1),
+            EntitlementOwner::User(id) => (id.get().into(), 2),
+        }
+    }
+}
+
 /// Builds a request to fetch active and ended [`Entitlement`]s.
 ///
 /// This is a helper for [`Http::get_entitlements`] used via [`Entitlement::list`].

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -357,7 +357,7 @@ impl<'a> ExecuteWebhook<'a> {
     ) -> Result<Option<Message>> {
         self.check_length()?;
 
-        let files = self.attachments.new_attachments();
+        let files = self.attachments.new_attachment_data();
 
         if self.allowed_mentions.is_none() {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -1,7 +1,7 @@
 use nonmax::NonMaxU8;
 
 #[cfg(feature = "http")]
-use crate::http::{CacheHttp, MessagePagination};
+use crate::http::MessagePagination;
 use crate::model::prelude::*;
 
 /// Builds a request to the API to retrieve messages.

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -8,8 +8,6 @@
 #![allow(clippy::option_option)]
 
 #[cfg(feature = "http")]
-use crate::internal::prelude::*;
-#[cfg(feature = "http")]
 use crate::model::ModelError;
 
 #[cfg(feature = "http")]
@@ -17,7 +15,7 @@ pub(crate) fn check_lengths(
     content: Option<&str>,
     embeds: Option<&[CreateEmbed<'_>]>,
     stickers: usize,
-) -> StdResult<(), ModelError> {
+) -> Result<(), ModelError> {
     use crate::model::error::Maximum;
 
     if let Some(content) = content {

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -78,8 +78,8 @@ mod edit_thread;
 mod edit_voice_state;
 mod edit_webhook;
 mod edit_webhook_message;
+mod entitlements;
 mod execute_webhook;
-mod get_entitlements;
 mod get_messages;
 
 pub use add_member::*;
@@ -125,8 +125,8 @@ pub use edit_thread::*;
 pub use edit_voice_state::*;
 pub use edit_webhook::*;
 pub use edit_webhook_message::*;
+pub use entitlements::*;
 pub use execute_webhook::*;
-pub use get_entitlements::*;
 pub use get_messages::*;
 
 macro_rules! button_and_select_menu_convenience_methods {

--- a/src/cache/event.rs
+++ b/src/cache/event.rs
@@ -3,64 +3,8 @@ use std::num::NonZeroU16;
 
 use extract_map::entry::Entry;
 
-use super::{BaseGuildChannel, Cache, CacheUpdate, GenericChannelId, GuildThread};
-use crate::all::{
-    CountDetails,
-    MessageReaction,
-    ReactionAddEvent,
-    ReactionRemoveAllEvent,
-    ReactionRemoveEmojiEvent,
-    ReactionRemoveEvent,
-};
-use crate::internal::prelude::*;
-use crate::model::channel::{ChannelInfoChannel, GuildChannel, Message};
-use crate::model::event::{
-    ChannelCreateEvent,
-    ChannelDeleteEvent,
-    ChannelInfoEvent,
-    ChannelPinsUpdateEvent,
-    ChannelUpdateEvent,
-    GuildCreateEvent,
-    GuildDeleteEvent,
-    GuildEmojisUpdateEvent,
-    GuildMemberAddEvent,
-    GuildMemberRemoveEvent,
-    GuildMemberUpdateEvent,
-    GuildMembersChunkEvent,
-    GuildRoleCreateEvent,
-    GuildRoleDeleteEvent,
-    GuildRoleUpdateEvent,
-    GuildScheduledEventCreateEvent,
-    GuildScheduledEventDeleteEvent,
-    GuildScheduledEventUpdateEvent,
-    GuildStickersUpdateEvent,
-    GuildUpdateEvent,
-    MessageCreateEvent,
-    MessageUpdateEvent,
-    PresenceUpdateEvent,
-    ReadyEvent,
-    ThreadCreateEvent,
-    ThreadDeleteEvent,
-    ThreadListSyncEvent,
-    ThreadUpdateEvent,
-    UserUpdateEvent,
-    VoiceChannelStartTimeUpdateEvent,
-    VoiceChannelStatusUpdateEvent,
-    VoiceStateUpdateEvent,
-};
-use crate::model::gateway::Presence;
-use crate::model::guild::{
-    Guild,
-    GuildMemberFlags,
-    Member,
-    MemberCount,
-    MemberGeneratedFlags,
-    Role,
-    ScheduledEvent,
-};
-use crate::model::id::GuildId;
-use crate::model::user::{Collectibles, CurrentUser, OnlineStatus};
-use crate::model::voice::VoiceState;
+use super::{Cache, CacheUpdate};
+use crate::model::prelude::*;
 
 impl CacheUpdate for ChannelCreateEvent {
     type Output = GuildChannel;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -26,15 +26,6 @@ pub const MEMBER_FETCH_LIMIT: NonMaxU16 = match NonMaxU16::new(1000) {
     None => unreachable!(),
 };
 
-/// The [UserAgent] sent along with every request.
-///
-/// [UserAgent]: ::reqwest::header::USER_AGENT
-pub const USER_AGENT: &str = concat!(
-    "DiscordBot (https://github.com/serenity-rs/serenity, ",
-    env!("CARGO_PKG_VERSION"),
-    ")"
-);
-
 enum_number! {
     /// An enum representing the gateway opcodes.
     ///

--- a/src/gateway/client/context.rs
+++ b/src/gateway/client/context.rs
@@ -15,7 +15,7 @@ use crate::gateway::{
     ShardRunnerInfo,
     ShardRunnerMessage,
 };
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 
 /// A general utility struct provided on event dispatches.

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -283,11 +283,9 @@ impl Http {
         user_id: UserId,
         map: &impl serde::Serialize,
     ) -> Result<Option<Member>> {
-        let body = to_vec(map)?;
-
         let response = self
             .request(Request {
-                body: Some(body),
+                body: Some(to_vec(map)?),
                 multipart: None,
                 headers: None,
                 method: LightMethod::Put,
@@ -396,10 +394,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildChannel> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -436,10 +432,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildThread> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -459,10 +453,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildThread> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -728,10 +720,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Invite> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -751,10 +741,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        let body = to_vec(map)?;
-
         self.wind(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Put,
@@ -772,10 +760,8 @@ impl Http {
         &self,
         map: &impl serde::Serialize,
     ) -> Result<PrivateChannel> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             method: LightMethod::Post,
@@ -790,7 +776,7 @@ impl Http {
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-        reaction_type: &ReactionType,
+        reaction: &str,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -800,7 +786,7 @@ impl Http {
             route: Route::ChannelMessageReactionMe {
                 channel_id,
                 message_id,
-                reaction: &reaction_type.as_data(),
+                reaction,
             },
             params: None,
         })
@@ -811,12 +797,12 @@ impl Http {
     pub async fn create_role(
         &self,
         guild_id: GuildId,
-        body: &impl serde::Serialize,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Role> {
         let mut value: Value = self
             .fire(Request {
-                body: Some(to_vec(body)?),
+                body: Some(to_vec(map)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 method: LightMethod::Post,
@@ -841,9 +827,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<ScheduledEvent> {
-        let body = to_vec(map)?;
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -885,27 +870,8 @@ impl Http {
     /// entitlement will have `starts_at` and `ends_at` both be `None`.
     pub async fn create_test_entitlement(
         &self,
-        sku_id: SkuId,
-        owner: EntitlementOwner,
+        map: &impl serde::Serialize,
     ) -> Result<Entitlement> {
-        #[derive(serde::Serialize)]
-        struct TestEntitlement {
-            sku_id: SkuId,
-            owner_id: u64,
-            owner_type: u8,
-        }
-
-        let (owner_id, owner_type) = match owner {
-            EntitlementOwner::Guild(id) => (id.get(), 1),
-            EntitlementOwner::User(id) => (id.get(), 2),
-        };
-
-        let map = TestEntitlement {
-            sku_id,
-            owner_id,
-            owner_type,
-        };
-
         self.fire(Request {
             body: Some(to_vec(&map)?),
             multipart: None,
@@ -926,10 +892,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Webhook> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -1195,7 +1159,7 @@ impl Http {
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-        reaction_type: &ReactionType,
+        reaction: &str,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -1205,7 +1169,7 @@ impl Http {
             route: Route::ChannelMessageReactionEmoji {
                 channel_id,
                 message_id,
-                reaction: &reaction_type.as_data(),
+                reaction,
             },
             params: None,
         })
@@ -1258,7 +1222,7 @@ impl Http {
         channel_id: GenericChannelId,
         message_id: MessageId,
         user_id: UserId,
-        reaction_type: &ReactionType,
+        reaction: &str,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -1269,7 +1233,7 @@ impl Http {
                 channel_id,
                 message_id,
                 user_id,
-                reaction: &reaction_type.as_data(),
+                reaction,
             },
             params: None,
         })
@@ -1281,7 +1245,7 @@ impl Http {
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-        reaction_type: &ReactionType,
+        reaction: &str,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -1291,7 +1255,7 @@ impl Http {
             route: Route::ChannelMessageReactionMe {
                 channel_id,
                 message_id,
-                reaction: &reaction_type.as_data(),
+                reaction,
             },
             params: None,
         })
@@ -1467,10 +1431,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Emoji> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Patch,
@@ -1589,10 +1551,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<PartialGuild> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Patch,
@@ -1673,7 +1633,7 @@ impl Http {
     pub async fn edit_guild_mfa_level(
         &self,
         guild_id: GuildId,
-        value: &impl serde::Serialize,
+        map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<MfaLevel> {
         #[derive(Deserialize)]
@@ -1681,10 +1641,8 @@ impl Http {
             level: MfaLevel,
         }
 
-        let body = to_vec(value)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -1704,10 +1662,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildWidget> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Patch,
@@ -1726,10 +1682,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildWelcomeScreen> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Patch,
@@ -1749,11 +1703,9 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Member> {
-        let body = to_vec(map)?;
-
         let mut value: Value = self
             .fire(Request {
-                body: Some(body),
+                body: Some(to_vec(map)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 method: LightMethod::Patch,
@@ -1921,10 +1873,8 @@ impl Http {
 
     /// Edits the current user's profile settings.
     pub async fn edit_profile(&self, map: &impl serde::Serialize) -> Result<CurrentUser> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: None,
             method: LightMethod::Patch,
@@ -2008,9 +1958,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<ScheduledEvent> {
-        let body = to_vec(map)?;
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Patch,
@@ -2033,11 +1982,9 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {
-        let body = to_vec(&map)?;
-
         let mut value: Value = self
             .fire(Request {
-                body: Some(body),
+                body: Some(to_vec(map)?),
                 multipart: None,
                 headers: audit_log_reason.map(reason_into_header),
                 method: LightMethod::Patch,
@@ -2103,10 +2050,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        let body = to_vec(map)?;
-
         self.wind(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Put,
@@ -2146,10 +2091,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<Webhook> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Patch,
@@ -2462,7 +2405,7 @@ impl Http {
     pub async fn get_audit_logs(
         &self,
         guild_id: GuildId,
-        action_type: Option<audit_log::Action>,
+        action_type: Option<u16>,
         user_id: Option<UserId>,
         before: Option<AuditLogEntryId>,
         after: Option<AuditLogEntryId>,
@@ -2471,7 +2414,7 @@ impl Http {
         let (action_type_str, before_str, after_str, limit_str, user_id_str);
         let mut params = ArrayVec::<_, 4>::new();
         if let Some(action_type) = action_type {
-            action_type_str = action_type.num().to_arraystring();
+            action_type_str = action_type.to_arraystring();
             params.push(("action_type", action_type_str.as_str()));
         }
         if let Some(before) = before {
@@ -2546,10 +2489,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<AutoModRule> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Post,
@@ -2569,10 +2510,8 @@ impl Http {
         map: &impl serde::Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<AutoModRule> {
-        let body = to_vec(map)?;
-
         self.fire(Request {
-            body: Some(body),
+            body: Some(to_vec(map)?),
             multipart: None,
             headers: audit_log_reason.map(reason_into_header),
             method: LightMethod::Patch,
@@ -3980,7 +3919,7 @@ impl Http {
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-        emoji: &ReactionType,
+        emoji: &str,
         reaction_type: Option<ReactionTypes>,
         limit: Option<NonMaxU8>,
         after: Option<UserId>,
@@ -4011,7 +3950,7 @@ impl Http {
             route: Route::ChannelMessageReactionEmoji {
                 channel_id,
                 message_id,
-                reaction: &emoji.as_data(),
+                reaction: emoji,
             },
             params: Some(&params),
         })

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -32,7 +32,7 @@ use super::{
     MessagePagination,
     UserPagination,
 };
-use crate::builder::{CreateAllowedMentions, CreateAttachment};
+use crate::builder::{AttachmentData, CreateAllowedMentions};
 use crate::constants;
 use crate::model::prelude::*;
 
@@ -471,7 +471,7 @@ impl Http {
         &self,
         channel_id: ChannelId,
         map: &impl serde::Serialize,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<AttachmentData<'_>>,
         audit_log_reason: Option<&str>,
     ) -> Result<GuildThread> {
         self.fire(Request {
@@ -537,7 +537,7 @@ impl Http {
         &self,
         interaction_token: &str,
         map: &impl serde::Serialize,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<AttachmentData<'_>>,
     ) -> Result<Message> {
         let mut request = Request {
             body: None,
@@ -686,7 +686,7 @@ impl Http {
         interaction_id: InteractionId,
         interaction_token: &str,
         map: &impl serde::Serialize,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<AttachmentData<'_>>,
     ) -> Result<()> {
         let mut request = Request {
             body: None,
@@ -845,7 +845,7 @@ impl Http {
         &self,
         guild_id: GuildId,
         fields: Vec<(Cow<'static, str>, Cow<'static, str>)>,
-        file: CreateAttachment<'_>,
+        file: AttachmentData<'_>,
         audit_log_reason: Option<&str>,
     ) -> Result<Sticker> {
         self.fire(Request {
@@ -1475,7 +1475,7 @@ impl Http {
         interaction_token: &str,
         message_id: MessageId,
         map: &impl serde::Serialize,
-        new_attachments: Vec<CreateAttachment<'_>>,
+        new_attachments: Vec<AttachmentData<'_>>,
     ) -> Result<Message> {
         let mut request = Request {
             body: None,
@@ -1732,7 +1732,7 @@ impl Http {
         channel_id: GenericChannelId,
         message_id: MessageId,
         map: &impl serde::Serialize,
-        new_attachments: Vec<CreateAttachment<'_>>,
+        new_attachments: Vec<AttachmentData<'_>>,
     ) -> Result<Message> {
         let mut request = Request {
             body: None,
@@ -1844,7 +1844,7 @@ impl Http {
         &self,
         interaction_token: &str,
         map: &impl serde::Serialize,
-        new_attachments: Vec<CreateAttachment<'_>>,
+        new_attachments: Vec<AttachmentData<'_>>,
     ) -> Result<Message> {
         let mut request = Request {
             body: None,
@@ -2112,7 +2112,7 @@ impl Http {
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<AttachmentData<'_>>,
         map: &impl serde::Serialize,
     ) -> Result<Option<Message>> {
         self.execute_webhook_(webhook_id, thread_id, token, wait, files, map, false).await
@@ -2130,7 +2130,7 @@ impl Http {
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<AttachmentData<'_>>,
         map: &impl serde::Serialize,
     ) -> Result<Option<Message>> {
         self.execute_webhook_(webhook_id, thread_id, token, wait, files, map, true).await
@@ -2143,7 +2143,7 @@ impl Http {
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<AttachmentData<'_>>,
         map: &impl serde::Serialize,
         with_components: bool,
     ) -> Result<Option<Message>> {
@@ -2228,7 +2228,7 @@ impl Http {
         token: &str,
         message_id: MessageId,
         map: &impl serde::Serialize,
-        new_attachments: Vec<CreateAttachment<'_>>,
+        new_attachments: Vec<AttachmentData<'_>>,
     ) -> Result<Message> {
         let thread_id_str;
         let mut params = None;
@@ -4216,7 +4216,7 @@ impl Http {
     pub async fn send_message(
         &self,
         channel_id: GenericChannelId,
-        files: Vec<CreateAttachment<'_>>,
+        files: Vec<AttachmentData<'_>>,
         map: &impl serde::Serialize,
     ) -> Result<Message> {
         let mut request = Request {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -25,7 +25,6 @@ mod multipart;
 mod ratelimiting;
 mod request;
 mod routing;
-mod typing;
 
 use std::sync::Arc;
 
@@ -38,10 +37,9 @@ pub use self::multipart::*;
 pub use self::ratelimiting::*;
 pub use self::request::*;
 pub use self::routing::*;
-pub use self::typing::*;
 #[cfg(feature = "cache")]
 use crate::cache::Cache;
-use crate::model::prelude::*;
+use crate::model::id::*;
 
 /// This trait will be required by functions that need [`Http`] and can optionally use a [`Cache`]
 /// to potentially avoid REST-requests.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -26,8 +26,6 @@ mod ratelimiting;
 mod request;
 mod routing;
 
-use std::sync::Arc;
-
 use reqwest::Method;
 pub use reqwest::StatusCode;
 
@@ -37,67 +35,7 @@ pub use self::multipart::*;
 pub use self::ratelimiting::*;
 pub use self::request::*;
 pub use self::routing::*;
-#[cfg(feature = "cache")]
-use crate::cache::Cache;
 use crate::model::id::*;
-
-/// This trait will be required by functions that need [`Http`] and can optionally use a [`Cache`]
-/// to potentially avoid REST-requests.
-///
-/// If the `cache` feature is enabled, but an implementing type does not have access to a cache,
-/// the [`CacheHttp::cache`] method will simply return `None`.
-pub trait CacheHttp: Send + Sync {
-    fn http(&self) -> &Http;
-
-    #[cfg(feature = "cache")]
-    #[must_use]
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        None
-    }
-}
-
-impl<T> CacheHttp for &T
-where
-    T: CacheHttp,
-{
-    fn http(&self) -> &Http {
-        (*self).http()
-    }
-    #[cfg(feature = "cache")]
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        (*self).cache()
-    }
-}
-
-impl<T> CacheHttp for Arc<T>
-where
-    T: CacheHttp,
-{
-    fn http(&self) -> &Http {
-        (**self).http()
-    }
-    #[cfg(feature = "cache")]
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        (**self).cache()
-    }
-}
-
-#[cfg(feature = "cache")]
-impl CacheHttp for (Option<&Arc<Cache>>, &Http) {
-    fn cache(&self) -> Option<&Arc<Cache>> {
-        self.0
-    }
-
-    fn http(&self) -> &Http {
-        self.1
-    }
-}
-
-impl CacheHttp for Http {
-    fn http(&self) -> &Http {
-        self
-    }
-}
 
 /// An method used for ratelimiting special routes.
 ///

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -3,28 +3,26 @@ use std::borrow::Cow;
 use reqwest::multipart::{Form, Part};
 use tokio::fs::File;
 
-use crate::builder::{AttachmentData, CreateAttachment};
+use crate::builder::{AttachmentData, AttachmentDataKind};
 use crate::internal::prelude::*;
 
-impl CreateAttachment<'_> {
-    async fn into_part(self) -> Result<Part> {
-        let mut part = match self.data {
-            AttachmentData::Bytes(bytes) => Part::stream(bytes),
-            AttachmentData::File(file) => Part::stream(file.try_clone().await?),
-            AttachmentData::Path(path) => Part::stream(File::open(path).await?),
-        };
-        part = guess_mime_str(part, &self.filename)?;
-        part = part.file_name(self.filename);
-        Ok(part)
-    }
+async fn create_part(attachment: AttachmentData<'_>) -> Result<Part> {
+    let mut part = match attachment.kind {
+        AttachmentDataKind::Bytes(bytes) => Part::stream(bytes),
+        AttachmentDataKind::File(file) => Part::stream(file.try_clone().await?),
+        AttachmentDataKind::Path(path) => Part::stream(File::open(path).await?),
+    };
+    part = guess_mime_str(part, &attachment.filename)?;
+    part = part.file_name(attachment.filename);
+    Ok(part)
 }
 
 #[derive(Clone, Debug)]
 pub enum MultipartUpload<'a> {
     /// A file sent with the form data as an individual upload. For example, a sticker.
-    File(CreateAttachment<'a>),
+    File(AttachmentData<'a>),
     /// Files sent with the form as message attachments.
-    Attachments(Vec<CreateAttachment<'a>>),
+    Attachments(Vec<AttachmentData<'a>>),
 }
 
 /// Holder for multipart body. Contains upload data, multipart fields, and payload_json for
@@ -45,11 +43,11 @@ impl Multipart<'_> {
 
         match self.upload {
             MultipartUpload::File(upload_file) => {
-                multipart = multipart.part("file", upload_file.into_part().await?);
+                multipart = multipart.part("file", create_part(upload_file).await?);
             },
             MultipartUpload::Attachments(attachment_files) => {
                 for (idx, file) in attachment_files.into_iter().enumerate() {
-                    let part = file.into_part().await?;
+                    let part = create_part(file).await?;
                     multipart = multipart.part(format!("files[{idx}]"), part);
                 }
             },

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -15,8 +15,16 @@ use tracing::instrument;
 use super::multipart::Multipart;
 use super::routing::Route;
 use super::{HttpError, LightMethod};
-use crate::constants;
 use crate::internal::prelude::*;
+
+/// The [UserAgent] sent along with every request.
+///
+/// [UserAgent]: reqwest::header::USER_AGENT
+pub const SERENITY_USER_AGENT: &str = concat!(
+    "DiscordBot (https://github.com/serenity-rs/serenity, ",
+    env!("CARGO_PKG_VERSION"),
+    ")"
+);
 
 #[derive(Clone, Debug)]
 #[must_use]
@@ -99,7 +107,7 @@ impl<'a> Request<'a> {
         let mut builder = client.request(self.method.reqwest_method(), path);
 
         let mut headers = self.headers.unwrap_or_default();
-        headers.insert(USER_AGENT, HeaderValue::from_static(constants::USER_AGENT));
+        headers.insert(USER_AGENT, HeaderValue::from_static(SERENITY_USER_AGENT));
         if let Some(token) = token {
             headers.insert(
                 AUTHORIZATION,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -27,7 +27,7 @@ use crate::cache::Cache;
 #[cfg(all(feature = "cache", feature = "temp_cache", feature = "model"))]
 use crate::cache::MaybeOwnedArc;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 
 impl ChannelId {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -27,7 +27,7 @@ use crate::cache::Cache;
 #[cfg(all(feature = "cache", feature = "temp_cache", feature = "model"))]
 use crate::cache::MaybeOwnedArc;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http, Typing};
+use crate::http::{CacheHttp, Http};
 use crate::model::prelude::*;
 
 impl ChannelId {
@@ -476,7 +476,7 @@ impl GenericChannelId {
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.create_reaction(self, message_id, &reaction_type.into()).await
+        http.create_reaction(self, message_id, &reaction_type.into().as_data()).await
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
@@ -577,8 +577,10 @@ impl GenericChannelId {
     ) -> Result<()> {
         let reaction_type = reaction_type.into();
         match user_id {
-            Some(user_id) => http.delete_reaction(self, message_id, user_id, &reaction_type).await,
-            None => http.delete_reaction_me(self, message_id, &reaction_type).await,
+            Some(user_id) => {
+                http.delete_reaction(self, message_id, user_id, &reaction_type.as_data()).await
+            },
+            None => http.delete_reaction_me(self, message_id, &reaction_type.as_data()).await,
         }
     }
     /// Deletes all of the [`Reaction`]s associated with the provided message id.
@@ -611,7 +613,7 @@ impl GenericChannelId {
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.delete_message_reaction_emoji(self, message_id, &reaction_type.into()).await
+        http.delete_message_reaction_emoji(self, message_id, &reaction_type.into().as_data()).await
     }
 
     /// Edits a [`Message`] in the channel given its Id.
@@ -861,7 +863,15 @@ impl GenericChannelId {
         limit: Option<NonMaxU8>,
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
-        http.get_reaction_users(self, message_id, &emoji.into(), reaction_type, limit, after).await
+        http.get_reaction_users(
+            self,
+            message_id,
+            &emoji.into().as_data(),
+            reaction_type,
+            limit,
+            after,
+        )
+        .await
     }
 
     /// Sends a message with just the given message content in the channel.

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -17,7 +17,7 @@ use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "model")]
 use crate::constants;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 use crate::model::utils::{StrOrInt, discord_colours};
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -349,7 +349,12 @@ impl Message {
         http: &Http,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.delete_message_reaction_emoji(self.channel_id, self.id, &reaction_type.into()).await
+        http.delete_message_reaction_emoji(
+            self.channel_id,
+            self.id,
+            &reaction_type.into().as_data(),
+        )
+        .await
     }
 
     /// Edits this message, replacing the original content with new content.
@@ -516,7 +521,7 @@ impl Message {
     ///
     /// [Add Reactions]: Permissions::ADD_REACTIONS
     pub async fn react(&self, http: &Http, reaction_type: impl Into<ReactionType>) -> Result<()> {
-        http.create_reaction(self.channel_id, self.id, &reaction_type.into()).await
+        http.create_reaction(self.channel_id, self.id, &reaction_type.into().as_data()).await
     }
 
     /// Uses Discord's inline reply to a user without pinging them.

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -12,7 +12,7 @@ use serde::de::Error as DeError;
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 use crate::model::utils::discord_colours_opt;
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -134,7 +134,8 @@ impl Reaction {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     /// [permissions]: crate::model::permissions
     pub async fn delete_all(&self, http: &Http) -> Result<()> {
-        http.delete_message_reaction_emoji(self.channel_id, self.message_id, &self.emoji).await
+        http.delete_message_reaction_emoji(self.channel_id, self.message_id, &self.emoji.as_data())
+            .await
     }
 
     /// Retrieves the [`Message`] associated with this reaction.
@@ -204,7 +205,7 @@ impl Reaction {
         http.get_reaction_users(
             self.channel_id,
             self.message_id,
-            &self.emoji,
+            &self.emoji.as_data(),
             Some(self.reaction_type),
             limit,
             after,

--- a/src/model/channel/thread.rs
+++ b/src/model/channel/thread.rs
@@ -1,9 +1,9 @@
 use super::*;
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditThread};
-#[cfg(feature = "model")]
-use crate::http::CacheHttp;
 use crate::internal::prelude::*;
+#[cfg(feature = "model")]
+use crate::model::CacheHttp;
 use crate::model::utils::is_false;
 
 impl ThreadId {

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -31,7 +31,7 @@ use crate::builder::{
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http, UserPagination};
+use crate::http::{Http, UserPagination};
 #[cfg(feature = "model")]
 use crate::model::error::Maximum;
 use crate::model::prelude::*;

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -290,7 +290,15 @@ impl GuildId {
         after: Option<AuditLogEntryId>,
         limit: Option<NonMaxU8>,
     ) -> Result<AuditLogs> {
-        http.get_audit_logs(self, action_type, user_id, before, after, limit).await
+        http.get_audit_logs(
+            self,
+            action_type.map(audit_log::Action::num),
+            user_id,
+            before,
+            after,
+            limit,
+        )
+        .await
     }
 
     /// Gets all of the guild's channels over the REST API.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -37,7 +37,7 @@ use crate::builder::EditGuild;
 #[cfg(doc)]
 use crate::constants::LARGE_THRESHOLD;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::*;

--- a/src/model/guild/partial_guild.rs
+++ b/src/model/guild/partial_guild.rs
@@ -4,7 +4,7 @@ use super::IncidentsData;
 #[cfg(feature = "model")]
 use crate::builder::EditGuild;
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::icon_url;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -45,10 +45,79 @@ pub mod user;
 pub mod voice;
 pub mod webhook;
 
+#[cfg(feature = "http")]
+use std::sync::Arc;
+
 pub use self::colour::{Color, Colour};
 pub use self::error::Error as ModelError;
 pub use self::permissions::Permissions;
 pub use self::timestamp::Timestamp;
+#[cfg(all(feature = "http", feature = "cache"))]
+use crate::cache::Cache;
+#[cfg(feature = "http")]
+use crate::http::Http;
+
+/// This trait will be required by functions that need [`Http`] and can optionally use a [`Cache`]
+/// to potentially avoid REST-requests.
+///
+/// If the `cache` feature is enabled, but an implementing type does not have access to a cache,
+/// the [`CacheHttp::cache`] method will simply return `None`.
+#[cfg(feature = "http")]
+pub trait CacheHttp: Send + Sync {
+    fn http(&self) -> &Http;
+
+    #[cfg(feature = "cache")]
+    #[must_use]
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        None
+    }
+}
+
+#[cfg(feature = "http")]
+impl<T> CacheHttp for &T
+where
+    T: CacheHttp,
+{
+    fn http(&self) -> &Http {
+        (*self).http()
+    }
+    #[cfg(feature = "cache")]
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        (*self).cache()
+    }
+}
+
+#[cfg(feature = "http")]
+impl<T> CacheHttp for Arc<T>
+where
+    T: CacheHttp,
+{
+    fn http(&self) -> &Http {
+        (**self).http()
+    }
+    #[cfg(feature = "cache")]
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        (**self).cache()
+    }
+}
+
+#[cfg(all(feature = "http", feature = "cache"))]
+impl CacheHttp for (Option<&Arc<Cache>>, &Http) {
+    fn cache(&self) -> Option<&Arc<Cache>> {
+        self.0
+    }
+
+    fn http(&self) -> &Http {
+        self.1
+    }
+}
+
+#[cfg(feature = "http")]
+impl CacheHttp for Http {
+    fn http(&self) -> &Http {
+        self
+    }
+}
 
 /// The model prelude re-exports all types in the model sub-modules.
 ///
@@ -64,6 +133,9 @@ pub use self::timestamp::Timestamp;
 pub mod prelude {
     pub(crate) use serde::{Deserialize, Deserializer};
 
+    #[cfg(feature = "http")]
+    #[doc(hidden)]
+    pub use super::CacheHttp;
     pub use super::guild::automod::EventType as AutomodEventType;
     #[doc(hidden)]
     pub use super::guild::automod::{

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -39,6 +39,8 @@ pub mod permissions;
 pub mod soundboard;
 pub mod sticker;
 pub mod timestamp;
+#[cfg(feature = "model")]
+pub mod typing;
 pub mod user;
 pub mod voice;
 pub mod webhook;
@@ -74,6 +76,9 @@ pub mod prelude {
         TriggerMetadata,
         TriggerType,
     };
+    #[cfg(feature = "model")]
+    #[doc(hidden)]
+    pub use super::typing::*;
     #[doc(hidden)]
     pub use super::{
         ModelError,

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -169,8 +169,3 @@ enum_number! {
         _ => Unknown(u8),
     }
 }
-
-pub enum EntitlementOwner {
-    Guild(GuildId),
-    User(UserId),
-}

--- a/src/model/typing.rs
+++ b/src/model/typing.rs
@@ -1,13 +1,16 @@
+#[cfg(feature = "model")]
 use std::sync::Arc;
-use std::time::Duration;
 
-use tokio::sync::oneshot::error::TryRecvError;
-use tokio::sync::oneshot::{self, Sender};
-use tokio::time::sleep;
+#[cfg(feature = "model")]
+use tokio::sync::oneshot;
 
+#[cfg(feature = "model")]
 use crate::http::Http;
+#[cfg(feature = "model")]
 use crate::internal::prelude::*;
+#[cfg(feature = "model")]
 use crate::internal::tokio::spawn_named;
+#[cfg(feature = "model")]
 use crate::model::id::GenericChannelId;
 
 /// A struct to start typing in a [`Channel`] for an indefinite period of time.
@@ -27,7 +30,7 @@ use crate::model::id::GenericChannelId;
 /// ## Examples
 ///
 /// ```rust,no_run
-/// # use serenity::{http::{Http, Typing}, Result, model::prelude::*};
+/// # use serenity::{http::Http, Result, model::prelude::*};
 /// # use std::sync::Arc;
 /// #
 /// # fn long_process() {}
@@ -46,9 +49,11 @@ use crate::model::id::GenericChannelId;
 /// ```
 ///
 /// [`Channel`]: crate::model::channel::Channel
+#[cfg(feature = "model")]
 #[derive(Debug)]
-pub struct Typing(Sender<()>);
+pub struct Typing(oneshot::Sender<()>);
 
+#[cfg(feature = "model")]
 impl Typing {
     /// Starts typing in the specified [`Channel`] for an indefinite period of time.
     ///
@@ -67,7 +72,7 @@ impl Typing {
         spawn_named::<_, Result<_>>("typing::start", async move {
             loop {
                 match rx.try_recv() {
-                    Ok(()) | Err(TryRecvError::Closed) => break,
+                    Ok(()) | Err(oneshot::error::TryRecvError::Closed) => break,
                     _ => (),
                 }
 
@@ -75,7 +80,7 @@ impl Typing {
 
                 // It is unclear for how long typing persists after this method is called.
                 // It is generally assumed to be 7 or 10 seconds, so we use 7 to be safe.
-                sleep(Duration::from_secs(7)).await;
+                tokio::time::sleep(std::time::Duration::from_secs(7)).await;
             }
 
             Ok(())

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -12,7 +12,9 @@ use super::prelude::*;
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditProfile};
 #[cfg(feature = "model")]
-use crate::http::{CacheHttp, Http};
+use crate::http::Http;
+#[cfg(feature = "model")]
+use crate::model::CacheHttp;
 use crate::model::utils::deserialize_null_as_default;
 #[cfg(feature = "model")]
 use crate::model::utils::{avatar_url, user_banner_url};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,9 +21,9 @@ pub use crate::gateway::GatewayError;
 #[cfg(feature = "gateway")]
 pub use crate::gateway::client::{Client, Context, EventHandler, RawEventHandler};
 #[cfg(feature = "http")]
-pub use crate::http::CacheHttp;
-#[cfg(feature = "http")]
 pub use crate::http::HttpError;
+#[cfg(feature = "http")]
+pub use crate::model::CacheHttp;
 pub use crate::model::mention::Mentionable;
 #[cfg(feature = "model")]
 pub use crate::model::{ModelError, gateway::GatewayIntents};


### PR DESCRIPTION
This PR removes some dependencies the `http` module had on various model types to prep for splitting it into its own crate. The main changes are:

* Move `http::typing` into `model`
* Move the `CacheHttp` trait into `model`
* Split the `CreateAttachment` builder into an `AttachmentData` struct which `http` now depends on instead of the builder itself
  * Rename `CreateAttachment::get_data` to `as_bytes`
  * Also change `CreateAttachment::url` to build its own reqwest client internally instead of relying on an existing `Http`, to mirror the implementation of `Attachment::download` 
* Change http methods taking `ReactionType` to take `&str` instead
* Add a `CreateTestEntitlement` builder to pass into `Http::create_test_entitlement`
* Move `constants::USER_AGENT` into `http` and rename it `SERENITY_USER_AGENT`

Supersedes #3551 