### PR TITLE
Remove null entries when deserializing GatewayEvent

### DIFF
--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -1174,6 +1174,7 @@ pub enum GatewayEvent {
 impl<'de> Deserialize<'de> for GatewayEvent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
+        map.retain(|_, v| !v.is_null());
         let seq = remove_from_map_opt(&mut map, "s")?.flatten();
 
         Ok(match remove_from_map(&mut map, "op")? {


### PR DESCRIPTION
If s is null in GatewayEvent then heartbeat payloads will not deserialize correctly. Removing `Value::Null` entries should fix this.
See issue https://github.com/serenity-rs/serenity/issues/3575 for more detail.