### PR TITLE
feat: complete Component V2 support and add missing models/events

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,70 @@
 
 Serenity is a Rust library for the Discord API.
 
+This is a **fork** with additional features and bug fixes on top of the upstream serenity-rs/serenity.
+
+## What's New in This Fork
+
+### Component V2 (Complete)
+
+Full support for Discord's new Component V2 layout system:
+
+- **Container** — Box with accent color, spoiler, padding (1=small, 2=large)
+- **TextDisplay** — Markdown text
+- **Section** — Text + Button/Thumbnail accessory (right-aligned)
+- **Thumbnail** — Image as Section accessory
+- **MediaGallery** — Image grid (1-10 items, with descriptions & spoilers)
+- **Separator** — Divider with spacing control
+- **File** — Attachment reference
+- **ActionRow** — Button & Select Menu container
+- **Label** — Modal wrapper for inputs
+- **FileUpload** — Modal file upload
+- **RadioGroup** — Modal single-choice
+- **CheckboxGroup** — Modal multi-choice
+- **Checkbox** — Modal yes/no toggle
+
+**Bug fixes:**
+- `CreateSectionAccessory` now correctly serializes with `type` field
+- `CreateMessage.components_v2()` method for V2 messages
+- `CreateContainer.add_label()` and `add_input_text()` methods
+- `CreateSelectMenu.required()` for modal context
+
+### New Events
+
+- `VOICE_CHANNEL_EFFECT_SEND` — Emoji reactions in voice channels
+- `GUILD_ONBOARDING_UPDATE` — Guild onboarding configuration changes
+- `SCHEDULED_EVENT_REMINDER_CREATE` — Scheduled event reminders
+- `GUILD_ROLE_SUBSCRIPTION_PURCHASE_CREATE` — Role subscription purchases
+- `GUILD_ROLE_SUBSCRIPTION_RENEWAL_CREATE` — Role subscription renewals
+
+### New Models
+
+- `GuildOnboarding` — Guild onboarding configuration
+- `OnboardingPrompt` — Onboarding prompt with options
+- `OnboardingOption` — Onboarding prompt option
+- `GuildOnboardingMode` — Onboarding mode enum
+- `VoiceChannelEffectAnimationType` — Voice effect animation type
+- `ApplicationRoleConnectionMetadata` — Role connection metadata
+- `ApplicationRoleConnectionMetadataType` — Metadata value type enum
+
+### New HTTP Methods
+
+- `create_bulk_dm(recipient_ids)` — Multi-recipient DMs
+- `get_guild_onboarding(guild_id)` — Get guild onboarding
+- `edit_guild_onboarding(guild_id, map)` — Edit guild onboarding
+- `get_application_role_connection_metadata(application_id)` — Get role connection metadata
+- `update_application_role_connection_metadata(application_id, metadata)` — Update role connection metadata
+
+### Other Additions
+
+- `ChannelType::GuildMedia` (type 16) — Guild media channels
+- `OnboardingPromptId` and `OnboardingOptionId` ID types
+- Routing: `GuildOnboarding`, `ApplicationRoleConnectionMetadata`
+
+---
+
+## Upstream Features
+
 View the [examples] on how to use serenity's API. To make a bot with slash commands or text
 commands, see the [poise](https://github.com/serenity-rs/poise) framework built on top of serenity.
 To send and receive data from voice channels, see the
@@ -36,6 +100,41 @@ Note that - although this documentation will try to be as up-to-date and
 accurate as possible - Discord hosts [official documentation][discord docs]. If
 you need to be sure that some information piece is accurate, refer to their
 docs.
+
+# What's New in This Fork
+
+This fork adds support for Discord's newer features that weren't in the
+upstream serenity at the time of forking. The main additions are:
+
+**Component V2** -- the new message layout system that lets you build
+rich, interactive UIs with containers, sections, media galleries, and more.
+Everything works: Container, TextDisplay, Section, Thumbnail, MediaGallery,
+Separator, File, ActionRow, Label, FileUpload, RadioGroup, CheckboxGroup,
+Checkbox. There's also a working example in `examples/e20_components_v2/`.
+
+A few bugs were fixed along the way:
+- `CreateSectionAccessory` wasn't serializing the `type` field correctly,
+  which broke Section components entirely.
+- `CreateMessage` didn't have a `components_v2()` method, so you couldn't
+  actually send V2 messages through the builder.
+- `CreateContainer` was missing `add_label()` and `add_input_text()` methods.
+- `CreateSelectMenu` didn't have a `required` field for modal context.
+
+**New gateway events** -- `VOICE_CHANNEL_EFFECT_SEND` (the emoji pop-ups in
+voice channels), `GUILD_ONBOARDING_UPDATE`, `SCHEDULED_EVENT_REMINDER_CREATE`,
+and two role subscription events (`PURCHASE_CREATE` and `RENEWAL_CREATE`).
+
+**New models** -- `GuildOnboarding` and related structs for guild onboarding
+configuration, `VoiceChannelEffectAnimationType`, and
+`ApplicationRoleConnectionMetadata` for the role connections API.
+
+**New HTTP methods** -- `create_bulk_dm()` for multi-recipient DMs,
+`get_guild_onboarding()` / `edit_guild_onboarding()`, and
+`get_application_role_connection_metadata()` /
+`update_application_role_connection_metadata()`.
+
+**Other bits** -- `ChannelType::GuildMedia` (type 16) for the newer media
+channel type, plus the `OnboardingPromptId` and `OnboardingOptionId` ID types.
 
 # Example Bot
 

--- a/examples/e20_components_v2/Cargo.toml
+++ b/examples/e20_components_v2/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "e20_components_v2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serenity = { path = "../../", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+dotenv = { version = "0.15.0" }

--- a/examples/e20_components_v2/src/main.rs
+++ b/examples/e20_components_v2/src/main.rs
@@ -28,12 +28,10 @@ struct Handler;
 #[async_trait]
 impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, _data_about_bot: Ready) {
-        println!("Bot is ready! Sending Image Positioning tests...");
+        println!("Bot is ready! Sending Component V2 tests...");
         let channel = ChannelId::new(CHANNEL_ID);
 
-        // ================================================================
-        // TEST 1: Section + Thumbnail = gambar di KANAN text
-        // ================================================================
+        // Section + Thumbnail (right-aligned image)
         let msg = CreateMessage::new()
             .flags(MessageFlags::IS_COMPONENTS_V2)
             .components_v2(vec![
@@ -41,13 +39,11 @@ impl EventHandler for Handler {
                     CreateContainer::new()
                         .accent_color(0x3498DB)
                         .add_text_display(CreateTextDisplay::new(
-                            "## 1. Section + Thumbnail (Right-aligned)\n\
-                             Thumbnail muncul di sebelah **kanan** text.\n\
-                             Ini adalah cara utama untuk positioning image di Component V2.",
+                            "## Section + Thumbnail\nImage appears to the right of text.",
                         ))
                         .add_section(
                             CreateSection::new(
-                                "Text di kiri, gambar di kanan.\nThumbnail auto-align ke right side.\nUkuran thumbnail: 48x48 (small) atau 80x80 (large) tergantung Discord client.",
+                                "Text on the left, image on the right.",
                                 CreateSectionAccessory::Thumbnail(
                                     CreateThumbnail::new("https://serenity.rs/favicon.ico")
                                         .description("Serenity Logo"),
@@ -57,27 +53,25 @@ impl EventHandler for Handler {
                         .add_separator(CreateSeparator::new())
                         .add_section(
                             CreateSection::new(
-                                "Section dengan 2 text lines + thumbnail di kanan.",
+                                "Section with 2 text lines + thumbnail.",
                                 CreateSectionAccessory::Thumbnail(
                                     CreateThumbnail::new("https://docs.rs/favicon.ico")
                                         .description("Docs"),
                                 ),
                             )
                             .add_text(CreateTextDisplay::new(
-                                "Baris kedua: description bisa panjang.",
+                                "Second line: description can be long.",
                             ))
                         ),
                 ),
             ]);
         if let Err(e) = channel.send_message(&ctx, msg).await {
-            eprintln!("TEST 1 FAIL: {e}");
+            eprintln!("Section+Thumbnail FAIL: {e}");
         } else {
-            println!("TEST 1 OK: Section + Thumbnail (Right-aligned)");
+            println!("OK: Section + Thumbnail");
         }
 
-        // ================================================================
-        // TEST 2: MediaGallery = gambar dalam GRID layout
-        // ================================================================
+        // MediaGallery (grid layout)
         let msg = CreateMessage::new()
             .flags(MessageFlags::IS_COMPONENTS_V2)
             .components_v2(vec![
@@ -85,130 +79,44 @@ impl EventHandler for Handler {
                     CreateContainer::new()
                         .accent_color(0xE74C3C)
                         .add_text_display(CreateTextDisplay::new(
-                            "## 2. MediaGallery (Grid Layout)\n\
-                             Gambar ditampilkan dalam grid. 1 gambar = full width.\n\
-                             2 gambar = side by side. 3+ = grid pattern.",
+                            "## MediaGallery\n1 image = full width, 2 = side by side, 3+ = grid.",
                         ))
                         .add_separator(CreateSeparator::new())
                         .add_media_gallery(
                             CreateMediaGallery::new()
                                 .add_item_with_description(
                                     "https://serenity.rs/favicon.ico",
-                                    "1 gambar = full width",
+                                    "1 image: full width",
                                 ),
                         )
-                        .add_text_display(CreateTextDisplay::new(
-                            "↑ 1 gambar: full width di container",
-                        ))
                         .add_separator(CreateSeparator::new().divider(false))
                         .add_media_gallery(
                             CreateMediaGallery::new()
                                 .add_item_with_description(
                                     "https://serenity.rs/favicon.ico",
-                                    "Gambar 1",
+                                    "Image 1",
                                 )
                                 .add_item_with_description(
                                     "https://docs.rs/favicon.ico",
-                                    "Gambar 2",
+                                    "Image 2",
                                 ),
                         )
-                        .add_text_display(CreateTextDisplay::new(
-                            "↑ 2 gambar: side by side (50/50)",
-                        ))
                         .add_separator(CreateSeparator::new().divider(false))
                         .add_media_gallery(
                             CreateMediaGallery::new()
                                 .add_item("https://serenity.rs/favicon.ico")
                                 .add_item("https://docs.rs/favicon.ico")
                                 .add_item("https://crates.io/favicon.ico"),
-                        )
-                        .add_text_display(CreateTextDisplay::new(
-                            "↑ 3 gambar: grid layout",
-                        )),
-                ),
-            ]);
-        if let Err(e) = channel.send_message(&ctx, msg).await {
-            eprintln!("TEST 2 FAIL: {e}");
-        } else {
-            println!("TEST 2 OK: MediaGallery (Grid Layout)");
-        }
-
-        // ================================================================
-        // TEST 3: Standalone Thumbnail = full width image (NEW!)
-        // ================================================================
-        let msg = CreateMessage::new()
-            .flags(MessageFlags::IS_COMPONENTS_V2)
-            .components_v2(vec![
-                CreateComponents::Container(
-                    CreateContainer::new()
-                        .accent_color(0x2ECC71)
-                        .add_text_display(CreateTextDisplay::new(
-                            "## 3. Standalone Thumbnail (Full-width, NEW!)\n\
-                             Thumbnail bisa dipakai sebagai standalone component.\n\
-                             Render sebagai gambar full-width di dalam container.",
-                        ))
-                        .add_separator(CreateSeparator::new())
-                        .add_thumbnail(
-                            CreateThumbnail::new("https://serenity.rs/favicon.ico")
-                                .description("Standalone thumbnail - full width"),
-                        )
-                        .add_separator(CreateSeparator::new().divider(false))
-                        .add_thumbnail(
-                            CreateThumbnail::new("https://docs.rs/favicon.ico")
-                                .description("Thumbnail kedua - juga full width"),
                         ),
                 ),
             ]);
         if let Err(e) = channel.send_message(&ctx, msg).await {
-            eprintln!("TEST 3 FAIL: {e}");
+            eprintln!("MediaGallery FAIL: {e}");
         } else {
-            println!("TEST 3 OK: Standalone Thumbnail (Full-width)");
+            println!("OK: MediaGallery");
         }
 
-        // ================================================================
-        // TEST 4: Section + Button = gambar diganti button (accessory)
-        // ================================================================
-        let msg = CreateMessage::new()
-            .flags(MessageFlags::IS_COMPONENTS_V2)
-            .components_v2(vec![
-                CreateComponents::Container(
-                    CreateContainer::new()
-                        .accent_color(0xF39C12)
-                        .add_text_display(CreateTextDisplay::new(
-                            "## 4. Section + Button Accessory\n\
-                             Button bisa juga jadi accessory di sebelah kanan text.",
-                        ))
-                        .add_section(
-                            CreateSection::new(
-                                "Text di kiri, button di kanan.\nButton bisa Primary/Secondary/Success/Danger.",
-                                CreateSectionAccessory::Button(
-                                    CreateButton::new("section_action_btn")
-                                        .label("Click Me!")
-                                        .style(ButtonStyle::Primary),
-                                ),
-                            )
-                        )
-                        .add_separator(CreateSeparator::new().divider(false))
-                        .add_section(
-                            CreateSection::new(
-                                "Link button sebagai accessory.",
-                                CreateSectionAccessory::Button(
-                                    CreateButton::new_link("https://serenity.rs")
-                                        .label("Visit Serenity"),
-                                ),
-                            )
-                        ),
-                ),
-            ]);
-        if let Err(e) = channel.send_message(&ctx, msg).await {
-            eprintln!("TEST 4 FAIL: {e}");
-        } else {
-            println!("TEST 4 OK: Section + Button Accessory");
-        }
-
-        // ================================================================
-        // TEST 5: Gabungan semua positioning dalam 1 container
-        // ================================================================
+        // Container with multiple section types
         let msg = CreateMessage::new()
             .flags(MessageFlags::IS_COMPONENTS_V2)
             .components_v2(vec![
@@ -216,14 +124,12 @@ impl EventHandler for Handler {
                     CreateContainer::new()
                         .accent_color(0x9B59B6)
                         .add_text_display(CreateTextDisplay::new(
-                            "## 5. Semua Image Positioning Gabungan\n\
-                             Container ini memperlihatkan semua cara position image.",
+                            "## All Image Positioning",
                         ))
                         .add_separator(CreateSeparator::new())
-                        // Section + Thumbnail (right-aligned)
                         .add_section(
                             CreateSection::new(
-                                "Cara 1: Section + Thumbnail\nImage di KANAN text.",
+                                "Section + Thumbnail (right-aligned)",
                                 CreateSectionAccessory::Thumbnail(
                                     CreateThumbnail::new("https://serenity.rs/favicon.ico")
                                         .description("Right-aligned"),
@@ -231,18 +137,8 @@ impl EventHandler for Handler {
                             )
                         )
                         .add_separator(CreateSeparator::new().divider(false))
-                        // Standalone Thumbnail (full-width)
                         .add_text_display(CreateTextDisplay::new(
-                            "Cara 2: Standalone Thumbnail (full-width)",
-                        ))
-                        .add_thumbnail(
-                            CreateThumbnail::new("https://docs.rs/favicon.ico")
-                                .description("Full-width thumbnail"),
-                        )
-                        .add_separator(CreateSeparator::new().divider(false))
-                        // MediaGallery (grid)
-                        .add_text_display(CreateTextDisplay::new(
-                            "Cara 3: MediaGallery (grid layout)",
+                            "MediaGallery (grid layout)",
                         ))
                         .add_media_gallery(
                             CreateMediaGallery::new()
@@ -250,13 +146,12 @@ impl EventHandler for Handler {
                                 .add_item("https://docs.rs/favicon.ico"),
                         )
                         .add_separator(CreateSeparator::new().divider(false))
-                        // Section + Button (no image, but same position concept)
                         .add_text_display(CreateTextDisplay::new(
-                            "Cara 4: Section + Button (same position concept)",
+                            "Section + Button (same position concept)",
                         ))
                         .add_section(
                             CreateSection::new(
-                                "Button accessory di posisi yang sama seperti thumbnail.",
+                                "Button accessory in the same position as thumbnail.",
                                 CreateSectionAccessory::Button(
                                     CreateButton::new("combo_btn")
                                         .label("Action")
@@ -267,14 +162,41 @@ impl EventHandler for Handler {
                 ),
             ]);
         if let Err(e) = channel.send_message(&ctx, msg).await {
-            eprintln!("TEST 5 FAIL: {e}");
+            eprintln!("All Positioning FAIL: {e}");
         } else {
-            println!("TEST 5 OK: All Image Positioning Combined");
+            println!("OK: All Image Positioning");
         }
 
-        // ================================================================
-        // TEST 6: Spoiler thumbnail + MediaGallery spoiler
-        // ================================================================
+        // Container with all button styles
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0xF39C12)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## Button Variants",
+                        ))
+                        .add_action_row(CreateActionRow::Buttons(vec![
+                            CreateButton::new("btn_primary").label("Primary").style(ButtonStyle::Primary),
+                            CreateButton::new("btn_secondary").label("Secondary").style(ButtonStyle::Secondary),
+                            CreateButton::new("btn_success").label("Success").style(ButtonStyle::Success),
+                            CreateButton::new("btn_danger").label("Danger").style(ButtonStyle::Danger),
+                            CreateButton::new_link("https://serenity.rs").label("Link"),
+                        ]))
+                        .add_action_row(CreateActionRow::Buttons(vec![
+                            CreateButton::new("btn_disabled").label("Disabled").disabled(true),
+                            CreateButton::new("btn_emoji").label("Rocket").emoji('🚀'),
+                        ])),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("Button Variants FAIL: {e}");
+        } else {
+            println!("OK: Button Variants");
+        }
+
+        // All select menu types
         let msg = CreateMessage::new()
             .flags(MessageFlags::IS_COMPONENTS_V2)
             .components_v2(vec![
@@ -282,33 +204,264 @@ impl EventHandler for Handler {
                     CreateContainer::new()
                         .accent_color(0x1ABC9C)
                         .add_text_display(CreateTextDisplay::new(
-                            "## 6. Spoiler Images\n\
-                             Gambar bisa di-spoiler. Klik untuk reveal.",
+                            "## All Select Menu Types",
+                        ))
+                        .add_action_row(CreateActionRow::SelectMenu(
+                            CreateSelectMenu::new(
+                                "string_select",
+                                CreateSelectMenuKind::String {
+                                    options: vec![
+                                        CreateSelectMenuOption::new("🍎 Apple", "apple"),
+                                        CreateSelectMenuOption::new("🍊 Orange", "orange"),
+                                        CreateSelectMenuOption::new("🍋 Lemon", "lemon"),
+                                    ],
+                                },
+                            )
+                            .placeholder("String Select...")
+                            .min_values(1)
+                            .max_values(2),
+                        ))
+                        .add_action_row(CreateActionRow::SelectMenu(
+                            CreateSelectMenu::new(
+                                "user_select",
+                                CreateSelectMenuKind::User { default_users: None },
+                            )
+                            .placeholder("User Select..."),
+                        ))
+                        .add_action_row(CreateActionRow::SelectMenu(
+                            CreateSelectMenu::new(
+                                "role_select",
+                                CreateSelectMenuKind::Role { default_roles: None },
+                            )
+                            .placeholder("Role Select..."),
+                        ))
+                        .add_action_row(CreateActionRow::SelectMenu(
+                            CreateSelectMenu::new(
+                                "mentionable_select",
+                                CreateSelectMenuKind::Mentionable {
+                                    default_users: None,
+                                    default_roles: None,
+                                },
+                            )
+                            .placeholder("Mentionable Select..."),
+                        ))
+                        .add_action_row(CreateActionRow::SelectMenu(
+                            CreateSelectMenu::new(
+                                "channel_select",
+                                CreateSelectMenuKind::Channel {
+                                    channel_types: Some(vec![ChannelType::Text, ChannelType::Voice]),
+                                    default_channels: None,
+                                },
+                            )
+                            .placeholder("Channel Select..."),
+                        )),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("Select Menus FAIL: {e}");
+        } else {
+            println!("OK: All Select Menu Types");
+        }
+
+        // Spoiler images
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0x1ABC9C)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## Spoiler Images\nClick to reveal.",
                         ))
                         .add_separator(CreateSeparator::new())
-                        .add_thumbnail(
-                            CreateThumbnail::new("https://serenity.rs/favicon.ico")
-                                .spoiler(true)
-                                .description("Spoiler thumbnail"),
-                        )
+                        .add_section(CreateSection::new(
+                            "Spoiler thumbnail as Section accessory:",
+                            CreateSectionAccessory::Thumbnail(
+                                CreateThumbnail::new("https://serenity.rs/favicon.ico")
+                                    .spoiler(true)
+                                    .description("Spoiler thumbnail"),
+                            ),
+                        ))
                         .add_separator(CreateSeparator::new().divider(false))
                         .add_media_gallery(
                             CreateMediaGallery::new()
                                 .add_item_full(
                                     "https://docs.rs/favicon.ico",
-                                    "Spoiler gallery item",
+                                    "Spoiler gallery",
                                     true,
                                 ),
                         ),
                 ),
             ]);
         if let Err(e) = channel.send_message(&ctx, msg).await {
-            eprintln!("TEST 6 FAIL: {e}");
+            eprintln!("Spoilers FAIL: {e}");
         } else {
-            println!("TEST 6 OK: Spoiler Images");
+            println!("OK: Spoiler Images");
         }
 
-        println!("\n=== ALL IMAGE POSITIONING TESTS COMPLETED ===");
+        // Multiple colored containers
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new().accent_color(0xFF0000).add_text_display(
+                        CreateTextDisplay::new("Red Container"),
+                    ),
+                ),
+                CreateComponents::Container(
+                    CreateContainer::new().accent_color(0x00FF00).add_text_display(
+                        CreateTextDisplay::new("Green Container"),
+                    ),
+                ),
+                CreateComponents::Container(
+                    CreateContainer::new().accent_color(0x0000FF).add_text_display(
+                        CreateTextDisplay::new("Blue Container"),
+                    ),
+                ),
+                CreateComponents::Container(
+                    CreateContainer::new().accent_color(0xFFAA00).add_text_display(
+                        CreateTextDisplay::new("Orange Container"),
+                    ),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("Colored Containers FAIL: {e}");
+        } else {
+            println!("OK: Colored Containers");
+        }
+
+        // Spoiler container
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::TextDisplay(CreateTextDisplay::new(
+                    "## Spoiler Container\nClick to reveal.",
+                )),
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .spoiler(true)
+                        .accent_color(0x9B59B6)
+                        .add_text_display(CreateTextDisplay::new(
+                            "This content is spoilered!",
+                        ))
+                        .add_action_row(CreateActionRow::Buttons(vec![
+                            CreateButton::new("spoiler_btn")
+                                .label("Secret Button")
+                                .style(ButtonStyle::Primary),
+                        ])),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("Spoiler Container FAIL: {e}");
+        } else {
+            println!("OK: Spoiler Container");
+        }
+
+        // Section variants
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0xE74C3C)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## Section Variants",
+                        ))
+                        .add_section(
+                            CreateSection::new(
+                                "Link button as accessory.",
+                                CreateSectionAccessory::Button(
+                                    CreateButton::new_link("https://serenity.rs")
+                                        .label("Visit Serenity"),
+                                ),
+                            )
+                        )
+                        .add_separator(CreateSeparator::new().divider(false))
+                        .add_section(
+                            CreateSection::new(
+                                "Thumbnail without description.",
+                                CreateSectionAccessory::Thumbnail(
+                                    CreateThumbnail::new("https://docs.rs/favicon.ico"),
+                                ),
+                            )
+                        )
+                        .add_separator(CreateSeparator::new().divider(false))
+                        .add_section(
+                            CreateSection::new(
+                                "Spoilered thumbnail.",
+                                CreateSectionAccessory::Thumbnail(
+                                    CreateThumbnail::new("https://serenity.rs/favicon.ico")
+                                        .spoiler(true)
+                                        .description("Spoiler"),
+                                ),
+                            )
+                        ),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("Section Variants FAIL: {e}");
+        } else {
+            println!("OK: Section Variants");
+        }
+
+        // Section with multi-text
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0xFF6B6B)
+                        .add_section(
+                            CreateSection::new_with_components(
+                                vec![
+                                    CreateTextDisplay::new("Line 1: first text"),
+                                    CreateTextDisplay::new("Line 2: second text"),
+                                    CreateTextDisplay::new("Line 3: third text (max 3)"),
+                                ],
+                                CreateSectionAccessory::Button(
+                                    CreateButton::new("multi_text_btn")
+                                        .label("Action")
+                                        .style(ButtonStyle::Success),
+                                ),
+                            )
+                        )
+                        .add_separator(CreateSeparator::new())
+                        .add_text_display(CreateTextDisplay::new(
+                            "Section above has 3 text lines + 1 button.",
+                        )),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("Multi-Text FAIL: {e}");
+        } else {
+            println!("OK: Section Multi-Text");
+        }
+
+        // Separator variants
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0x2ECC71)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## Separator Variants",
+                        ))
+                        .add_text_display(CreateTextDisplay::new("Small spacing (default)"))
+                        .add_separator(CreateSeparator::new())
+                        .add_text_display(CreateTextDisplay::new("Large spacing"))
+                        .add_separator(CreateSeparator::new().spacing(2))
+                        .add_text_display(CreateTextDisplay::new("No divider"))
+                        .add_separator(CreateSeparator::new().divider(false)),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("Separator Variants FAIL: {e}");
+        } else {
+            println!("OK: Separator Variants");
+        }
+
+        println!("\n=== ALL TESTS COMPLETED ===");
     }
 }
 

--- a/examples/e20_components_v2/src/main.rs
+++ b/examples/e20_components_v2/src/main.rs
@@ -1,0 +1,331 @@
+use std::env;
+
+use dotenv::dotenv;
+use serenity::async_trait;
+use serenity::builder::{
+    CreateActionRow,
+    CreateButton,
+    CreateComponents,
+    CreateContainer,
+    CreateMediaGallery,
+    CreateMessage,
+    CreateSection,
+    CreateSectionAccessory,
+    CreateSelectMenu,
+    CreateSelectMenuKind,
+    CreateSelectMenuOption,
+    CreateSeparator,
+    CreateTextDisplay,
+    CreateThumbnail,
+};
+use serenity::model::prelude::*;
+use serenity::prelude::*;
+
+const CHANNEL_ID: u64 = 1457222385991417869;
+
+struct Handler;
+
+#[async_trait]
+impl EventHandler for Handler {
+    async fn ready(&self, ctx: Context, _data_about_bot: Ready) {
+        println!("Bot is ready! Sending Image Positioning tests...");
+        let channel = ChannelId::new(CHANNEL_ID);
+
+        // ================================================================
+        // TEST 1: Section + Thumbnail = gambar di KANAN text
+        // ================================================================
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0x3498DB)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## 1. Section + Thumbnail (Right-aligned)\n\
+                             Thumbnail muncul di sebelah **kanan** text.\n\
+                             Ini adalah cara utama untuk positioning image di Component V2.",
+                        ))
+                        .add_section(
+                            CreateSection::new(
+                                "Text di kiri, gambar di kanan.\nThumbnail auto-align ke right side.\nUkuran thumbnail: 48x48 (small) atau 80x80 (large) tergantung Discord client.",
+                                CreateSectionAccessory::Thumbnail(
+                                    CreateThumbnail::new("https://serenity.rs/favicon.ico")
+                                        .description("Serenity Logo"),
+                                ),
+                            )
+                        )
+                        .add_separator(CreateSeparator::new())
+                        .add_section(
+                            CreateSection::new(
+                                "Section dengan 2 text lines + thumbnail di kanan.",
+                                CreateSectionAccessory::Thumbnail(
+                                    CreateThumbnail::new("https://docs.rs/favicon.ico")
+                                        .description("Docs"),
+                                ),
+                            )
+                            .add_text(CreateTextDisplay::new(
+                                "Baris kedua: description bisa panjang.",
+                            ))
+                        ),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("TEST 1 FAIL: {e}");
+        } else {
+            println!("TEST 1 OK: Section + Thumbnail (Right-aligned)");
+        }
+
+        // ================================================================
+        // TEST 2: MediaGallery = gambar dalam GRID layout
+        // ================================================================
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0xE74C3C)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## 2. MediaGallery (Grid Layout)\n\
+                             Gambar ditampilkan dalam grid. 1 gambar = full width.\n\
+                             2 gambar = side by side. 3+ = grid pattern.",
+                        ))
+                        .add_separator(CreateSeparator::new())
+                        .add_media_gallery(
+                            CreateMediaGallery::new()
+                                .add_item_with_description(
+                                    "https://serenity.rs/favicon.ico",
+                                    "1 gambar = full width",
+                                ),
+                        )
+                        .add_text_display(CreateTextDisplay::new(
+                            "↑ 1 gambar: full width di container",
+                        ))
+                        .add_separator(CreateSeparator::new().divider(false))
+                        .add_media_gallery(
+                            CreateMediaGallery::new()
+                                .add_item_with_description(
+                                    "https://serenity.rs/favicon.ico",
+                                    "Gambar 1",
+                                )
+                                .add_item_with_description(
+                                    "https://docs.rs/favicon.ico",
+                                    "Gambar 2",
+                                ),
+                        )
+                        .add_text_display(CreateTextDisplay::new(
+                            "↑ 2 gambar: side by side (50/50)",
+                        ))
+                        .add_separator(CreateSeparator::new().divider(false))
+                        .add_media_gallery(
+                            CreateMediaGallery::new()
+                                .add_item("https://serenity.rs/favicon.ico")
+                                .add_item("https://docs.rs/favicon.ico")
+                                .add_item("https://crates.io/favicon.ico"),
+                        )
+                        .add_text_display(CreateTextDisplay::new(
+                            "↑ 3 gambar: grid layout",
+                        )),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("TEST 2 FAIL: {e}");
+        } else {
+            println!("TEST 2 OK: MediaGallery (Grid Layout)");
+        }
+
+        // ================================================================
+        // TEST 3: Standalone Thumbnail = full width image (NEW!)
+        // ================================================================
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0x2ECC71)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## 3. Standalone Thumbnail (Full-width, NEW!)\n\
+                             Thumbnail bisa dipakai sebagai standalone component.\n\
+                             Render sebagai gambar full-width di dalam container.",
+                        ))
+                        .add_separator(CreateSeparator::new())
+                        .add_thumbnail(
+                            CreateThumbnail::new("https://serenity.rs/favicon.ico")
+                                .description("Standalone thumbnail - full width"),
+                        )
+                        .add_separator(CreateSeparator::new().divider(false))
+                        .add_thumbnail(
+                            CreateThumbnail::new("https://docs.rs/favicon.ico")
+                                .description("Thumbnail kedua - juga full width"),
+                        ),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("TEST 3 FAIL: {e}");
+        } else {
+            println!("TEST 3 OK: Standalone Thumbnail (Full-width)");
+        }
+
+        // ================================================================
+        // TEST 4: Section + Button = gambar diganti button (accessory)
+        // ================================================================
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0xF39C12)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## 4. Section + Button Accessory\n\
+                             Button bisa juga jadi accessory di sebelah kanan text.",
+                        ))
+                        .add_section(
+                            CreateSection::new(
+                                "Text di kiri, button di kanan.\nButton bisa Primary/Secondary/Success/Danger.",
+                                CreateSectionAccessory::Button(
+                                    CreateButton::new("section_action_btn")
+                                        .label("Click Me!")
+                                        .style(ButtonStyle::Primary),
+                                ),
+                            )
+                        )
+                        .add_separator(CreateSeparator::new().divider(false))
+                        .add_section(
+                            CreateSection::new(
+                                "Link button sebagai accessory.",
+                                CreateSectionAccessory::Button(
+                                    CreateButton::new_link("https://serenity.rs")
+                                        .label("Visit Serenity"),
+                                ),
+                            )
+                        ),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("TEST 4 FAIL: {e}");
+        } else {
+            println!("TEST 4 OK: Section + Button Accessory");
+        }
+
+        // ================================================================
+        // TEST 5: Gabungan semua positioning dalam 1 container
+        // ================================================================
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0x9B59B6)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## 5. Semua Image Positioning Gabungan\n\
+                             Container ini memperlihatkan semua cara position image.",
+                        ))
+                        .add_separator(CreateSeparator::new())
+                        // Section + Thumbnail (right-aligned)
+                        .add_section(
+                            CreateSection::new(
+                                "Cara 1: Section + Thumbnail\nImage di KANAN text.",
+                                CreateSectionAccessory::Thumbnail(
+                                    CreateThumbnail::new("https://serenity.rs/favicon.ico")
+                                        .description("Right-aligned"),
+                                ),
+                            )
+                        )
+                        .add_separator(CreateSeparator::new().divider(false))
+                        // Standalone Thumbnail (full-width)
+                        .add_text_display(CreateTextDisplay::new(
+                            "Cara 2: Standalone Thumbnail (full-width)",
+                        ))
+                        .add_thumbnail(
+                            CreateThumbnail::new("https://docs.rs/favicon.ico")
+                                .description("Full-width thumbnail"),
+                        )
+                        .add_separator(CreateSeparator::new().divider(false))
+                        // MediaGallery (grid)
+                        .add_text_display(CreateTextDisplay::new(
+                            "Cara 3: MediaGallery (grid layout)",
+                        ))
+                        .add_media_gallery(
+                            CreateMediaGallery::new()
+                                .add_item("https://serenity.rs/favicon.ico")
+                                .add_item("https://docs.rs/favicon.ico"),
+                        )
+                        .add_separator(CreateSeparator::new().divider(false))
+                        // Section + Button (no image, but same position concept)
+                        .add_text_display(CreateTextDisplay::new(
+                            "Cara 4: Section + Button (same position concept)",
+                        ))
+                        .add_section(
+                            CreateSection::new(
+                                "Button accessory di posisi yang sama seperti thumbnail.",
+                                CreateSectionAccessory::Button(
+                                    CreateButton::new("combo_btn")
+                                        .label("Action")
+                                        .style(ButtonStyle::Success),
+                                ),
+                            )
+                        ),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("TEST 5 FAIL: {e}");
+        } else {
+            println!("TEST 5 OK: All Image Positioning Combined");
+        }
+
+        // ================================================================
+        // TEST 6: Spoiler thumbnail + MediaGallery spoiler
+        // ================================================================
+        let msg = CreateMessage::new()
+            .flags(MessageFlags::IS_COMPONENTS_V2)
+            .components_v2(vec![
+                CreateComponents::Container(
+                    CreateContainer::new()
+                        .accent_color(0x1ABC9C)
+                        .add_text_display(CreateTextDisplay::new(
+                            "## 6. Spoiler Images\n\
+                             Gambar bisa di-spoiler. Klik untuk reveal.",
+                        ))
+                        .add_separator(CreateSeparator::new())
+                        .add_thumbnail(
+                            CreateThumbnail::new("https://serenity.rs/favicon.ico")
+                                .spoiler(true)
+                                .description("Spoiler thumbnail"),
+                        )
+                        .add_separator(CreateSeparator::new().divider(false))
+                        .add_media_gallery(
+                            CreateMediaGallery::new()
+                                .add_item_full(
+                                    "https://docs.rs/favicon.ico",
+                                    "Spoiler gallery item",
+                                    true,
+                                ),
+                        ),
+                ),
+            ]);
+        if let Err(e) = channel.send_message(&ctx, msg).await {
+            eprintln!("TEST 6 FAIL: {e}");
+        } else {
+            println!("TEST 6 OK: Spoiler Images");
+        }
+
+        println!("\n=== ALL IMAGE POSITIONING TESTS COMPLETED ===");
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let _ = dotenv();
+
+    let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
+    let intents =
+        GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT;
+
+    let mut client = Client::builder(&token, intents)
+        .event_handler(Handler)
+        .await
+        .expect("Error creating client");
+
+    if let Err(why) = client.start().await {
+        println!("Client error: {why:?}");
+    }
+}

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -438,11 +438,7 @@ impl CreateInputText {
     }
 }
 
-/// A top-level component that can be used in messages with the `IS_COMPONENTS_V2` flag.
-///
-/// This allows you to use the new Component V2 layout system. Create a message with
-/// `MessageFlags::IS_COMPONENTS_V2` and then use these components instead of
-/// `content` and `embeds`.
+/// Top-level component for messages using `IS_COMPONENTS_V2`.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum CreateComponents {
@@ -573,10 +569,7 @@ pub struct CreateSection {
     accessory: CreateSectionAccessory,
 }
 
-/// Accessory for a section component — either a button or a thumbnail.
-///
-/// Used with [`CreateSection`] to associate an interactive element or visual
-/// accessory with the section's text content.
+/// Section accessory — a button or thumbnail shown alongside the text.
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum CreateSectionAccessory {

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -238,6 +238,8 @@ pub struct CreateSelectMenu {
     max_values: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    required: Option<bool>,
 
     #[serde(flatten)]
     kind: CreateSelectMenuKind,
@@ -253,6 +255,7 @@ impl CreateSelectMenu {
             min_values: None,
             max_values: None,
             disabled: None,
+            required: None,
             kind,
         }
     }
@@ -285,6 +288,12 @@ impl CreateSelectMenu {
     /// Sets the disabled state for the button.
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = Some(disabled);
+        self
+    }
+
+    /// Sets whether the select menu is required (for modals).
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = Some(required);
         self
     }
 }
@@ -425,6 +434,1004 @@ impl CreateInputText {
     /// Sets if the input text is required
     pub fn required(mut self, required: bool) -> Self {
         self.0.required = required;
+        self
+    }
+}
+
+/// A top-level component that can be used in messages with the `IS_COMPONENTS_V2` flag.
+///
+/// This allows you to use the new Component V2 layout system. Create a message with
+/// `MessageFlags::IS_COMPONENTS_V2` and then use these components instead of
+/// `content` and `embeds`.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum CreateComponents {
+    ActionRow(CreateActionRow),
+    TextDisplay(CreateTextDisplay),
+    Section(CreateSection),
+    MediaGallery(CreateMediaGallery),
+    Separator(CreateSeparator),
+    Container(CreateContainer),
+    File(CreateFileComponent),
+    Label(CreateLabel),
+    InputText(CreateInputText),
+    FileUpload(CreateFileUpload),
+    RadioGroup(CreateRadioGroup),
+    CheckboxGroup(CreateCheckboxGroup),
+    Checkbox(CreateCheckbox),
+}
+
+impl Serialize for CreateComponents {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::ActionRow(c) => c.serialize(serializer),
+            Self::TextDisplay(c) => c.serialize(serializer),
+            Self::Section(c) => c.serialize(serializer),
+            Self::MediaGallery(c) => c.serialize(serializer),
+            Self::Separator(c) => c.serialize(serializer),
+            Self::Container(c) => c.serialize(serializer),
+            Self::File(c) => c.serialize(serializer),
+            Self::Label(c) => c.serialize(serializer),
+            Self::InputText(c) => c.serialize(serializer),
+            Self::FileUpload(c) => c.serialize(serializer),
+            Self::RadioGroup(c) => c.serialize(serializer),
+            Self::CheckboxGroup(c) => c.serialize(serializer),
+            Self::Checkbox(c) => c.serialize(serializer),
+        }
+    }
+}
+
+impl From<CreateActionRow> for CreateComponents {
+    fn from(component: CreateActionRow) -> Self {
+        Self::ActionRow(component)
+    }
+}
+
+impl From<CreateTextDisplay> for CreateComponents {
+    fn from(component: CreateTextDisplay) -> Self {
+        Self::TextDisplay(component)
+    }
+}
+
+impl From<CreateSection> for CreateComponents {
+    fn from(component: CreateSection) -> Self {
+        Self::Section(component)
+    }
+}
+
+impl From<CreateMediaGallery> for CreateComponents {
+    fn from(component: CreateMediaGallery) -> Self {
+        Self::MediaGallery(component)
+    }
+}
+
+impl From<CreateSeparator> for CreateComponents {
+    fn from(component: CreateSeparator) -> Self {
+        Self::Separator(component)
+    }
+}
+
+impl From<CreateContainer> for CreateComponents {
+    fn from(component: CreateContainer) -> Self {
+        Self::Container(component)
+    }
+}
+
+impl From<CreateFileComponent> for CreateComponents {
+    fn from(component: CreateFileComponent) -> Self {
+        Self::File(component)
+    }
+}
+
+/// A builder for creating a text display component.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#text-display).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateTextDisplay {
+    #[serde(rename = "type")]
+    kind: u8,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u32>,
+}
+
+impl CreateTextDisplay {
+    /// Creates a new text display component with the given content.
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            kind: 10,
+            content: content.into(),
+            id: None,
+        }
+    }
+
+    /// Sets the optional component id.
+    pub fn id(mut self, id: u32) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Sets the content of the text display.
+    pub fn content(mut self, content: impl Into<String>) -> Self {
+        self.content = content.into();
+        self
+    }
+}
+
+/// A builder for creating a section component.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#section).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateSection {
+    #[serde(rename = "type")]
+    kind: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u32>,
+    components: Vec<CreateTextDisplay>,
+    accessory: CreateSectionAccessory,
+}
+
+/// Accessory for a section component — either a button or a thumbnail.
+///
+/// Used with [`CreateSection`] to associate an interactive element or visual
+/// accessory with the section's text content.
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CreateSectionAccessory {
+    Button(CreateButton),
+    Thumbnail(CreateThumbnail),
+}
+
+impl Serialize for CreateSectionAccessory {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Button(c) => c.serialize(serializer),
+            Self::Thumbnail(c) => c.serialize(serializer),
+        }
+    }
+}
+
+/// A builder for creating a thumbnail component.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#thumbnail).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateThumbnail {
+    #[serde(rename = "type")]
+    kind: u8,
+    media: CreateUnfurledMediaItem,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    spoiler: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u32>,
+}
+
+impl CreateThumbnail {
+    /// Creates a new thumbnail component with the given media URL.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            kind: 11,
+            media: CreateUnfurledMediaItem {
+                url: url.into(),
+            },
+            description: None,
+            spoiler: false,
+            id: None,
+        }
+    }
+
+    /// Sets the optional component id.
+    pub fn id(mut self, id: u32) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Sets the description (alt text) for the thumbnail.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Sets whether the thumbnail should be a spoiler.
+    pub fn spoiler(mut self, spoiler: bool) -> Self {
+        self.spoiler = spoiler;
+        self
+    }
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+struct CreateUnfurledMediaItem {
+    url: String,
+}
+
+impl CreateSection {
+    /// Creates a new section with the given text display content and an accessory.
+    pub fn new(content: impl Into<String>, accessory: impl Into<CreateSectionAccessory>) -> Self {
+        Self {
+            kind: 9,
+            id: None,
+            components: vec![CreateTextDisplay::new(content)],
+            accessory: accessory.into(),
+        }
+    }
+
+    /// Creates a new section with multiple text display components and an accessory.
+    pub fn new_with_components(
+        components: Vec<CreateTextDisplay>,
+        accessory: impl Into<CreateSectionAccessory>,
+    ) -> Self {
+        Self {
+            kind: 9,
+            id: None,
+            components,
+            accessory: accessory.into(),
+        }
+    }
+
+    /// Sets the optional component id.
+    pub fn id(mut self, id: u32) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Adds a text display component to the section (up to 3 total).
+    pub fn add_text(mut self, text: CreateTextDisplay) -> Self {
+        self.components.push(text);
+        self
+    }
+}
+
+impl From<CreateButton> for CreateSectionAccessory {
+    fn from(button: CreateButton) -> Self {
+        Self::Button(button)
+    }
+}
+
+impl From<CreateThumbnail> for CreateSectionAccessory {
+    fn from(thumbnail: CreateThumbnail) -> Self {
+        Self::Thumbnail(thumbnail)
+    }
+}
+
+impl From<CreateLabel> for CreateComponents {
+    fn from(component: CreateLabel) -> Self {
+        Self::Label(component)
+    }
+}
+
+impl From<CreateInputText> for CreateComponents {
+    fn from(component: CreateInputText) -> Self {
+        Self::InputText(component)
+    }
+}
+
+impl From<CreateFileUpload> for CreateComponents {
+    fn from(component: CreateFileUpload) -> Self {
+        Self::FileUpload(component)
+    }
+}
+
+impl From<CreateRadioGroup> for CreateComponents {
+    fn from(component: CreateRadioGroup) -> Self {
+        Self::RadioGroup(component)
+    }
+}
+
+impl From<CreateCheckboxGroup> for CreateComponents {
+    fn from(component: CreateCheckboxGroup) -> Self {
+        Self::CheckboxGroup(component)
+    }
+}
+
+impl From<CreateCheckbox> for CreateComponents {
+    fn from(component: CreateCheckbox) -> Self {
+        Self::Checkbox(component)
+    }
+}
+
+/// A builder for creating a media gallery component.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#media-gallery).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateMediaGallery {
+    #[serde(rename = "type")]
+    kind: u8,
+    items: Vec<CreateMediaGalleryItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u32>,
+}
+
+/// A builder for creating a media gallery item.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateMediaGalleryItem {
+    media: CreateUnfurledMediaItem,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    spoiler: bool,
+}
+
+impl CreateMediaGallery {
+    /// Creates a new media gallery component.
+    pub fn new() -> Self {
+        Self {
+            kind: 12,
+            items: Vec::new(),
+            id: None,
+        }
+    }
+
+    /// Sets the optional component id.
+    pub fn id(mut self, id: u32) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Adds a media gallery item with the given URL.
+    pub fn add_item(mut self, url: impl Into<String>) -> Self {
+        self.items.push(CreateMediaGalleryItem {
+            media: CreateUnfurledMediaItem {
+                url: url.into(),
+            },
+            description: None,
+            spoiler: false,
+        });
+        self
+    }
+
+    /// Adds a media gallery item with description.
+    pub fn add_item_with_description(
+        mut self,
+        url: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        self.items.push(CreateMediaGalleryItem {
+            media: CreateUnfurledMediaItem {
+                url: url.into(),
+            },
+            description: Some(description.into()),
+            spoiler: false,
+        });
+        self
+    }
+
+    /// Adds a media gallery item with description and spoiler flag.
+    pub fn add_item_full(
+        mut self,
+        url: impl Into<String>,
+        description: impl Into<String>,
+        spoiler: bool,
+    ) -> Self {
+        self.items.push(CreateMediaGalleryItem {
+            media: CreateUnfurledMediaItem {
+                url: url.into(),
+            },
+            description: Some(description.into()),
+            spoiler,
+        });
+        self
+    }
+}
+
+impl Default for CreateMediaGallery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A builder for creating a separator component.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#separator).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateSeparator {
+    #[serde(rename = "type")]
+    kind: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u32>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    divider: bool,
+    #[serde(rename = "spacing", skip_serializing_if = "Option::is_none")]
+    spacing: Option<u8>,
+}
+
+impl CreateSeparator {
+    /// Creates a new separator component with default settings (small spacing, divider on).
+    pub fn new() -> Self {
+        Self {
+            kind: 14,
+            id: None,
+            divider: true,
+            spacing: Some(1),
+        }
+    }
+
+    /// Sets the optional component id.
+    pub fn id(mut self, id: u32) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Sets whether a visual divider should be displayed. Defaults to true.
+    pub fn divider(mut self, divider: bool) -> Self {
+        self.divider = divider;
+        self
+    }
+
+    /// Sets the spacing size: 1 for small, 2 for large. Defaults to 1.
+    pub fn spacing(mut self, spacing: u8) -> Self {
+        self.spacing = Some(spacing);
+        self
+    }
+}
+
+impl Default for CreateSeparator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A builder for creating a container component.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#container).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateContainer {
+    #[serde(rename = "type")]
+    kind: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u32>,
+    components: Vec<CreateContainerChild>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    accent_color: Option<u32>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    spoiler: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    padding: Option<u8>,
+}
+
+#[derive(Clone, Debug)]
+enum CreateContainerChild {
+    ActionRow(CreateActionRow),
+    TextDisplay(CreateTextDisplay),
+    Section(CreateSection),
+    MediaGallery(CreateMediaGallery),
+    Separator(CreateSeparator),
+    File(CreateFileComponent),
+    Label(CreateLabel),
+    InputText(CreateInputText),
+}
+
+impl PartialEq for CreateContainerChild {
+    fn eq(&self, other: &Self) -> bool {
+        use std::mem::discriminant;
+        if discriminant(self) != discriminant(other) {
+            return false;
+        }
+        match (self, other) {
+            (Self::ActionRow(a), Self::ActionRow(b)) => a == b,
+            (Self::TextDisplay(a), Self::TextDisplay(b)) => a == b,
+            (Self::Section(a), Self::Section(b)) => a == b,
+            (Self::MediaGallery(a), Self::MediaGallery(b)) => a == b,
+            (Self::Separator(a), Self::Separator(b)) => a == b,
+            (Self::File(a), Self::File(b)) => a == b,
+            (Self::Label(a), Self::Label(b)) => a == b,
+            (Self::InputText(a), Self::InputText(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Serialize for CreateContainerChild {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::ActionRow(c) => c.serialize(serializer),
+            Self::TextDisplay(c) => c.serialize(serializer),
+            Self::Section(c) => c.serialize(serializer),
+            Self::MediaGallery(c) => c.serialize(serializer),
+            Self::Separator(c) => c.serialize(serializer),
+            Self::File(c) => c.serialize(serializer),
+            Self::Label(c) => c.serialize(serializer),
+            Self::InputText(c) => c.serialize(serializer),
+        }
+    }
+}
+
+impl CreateContainer {
+    /// Creates a new container component.
+    pub fn new() -> Self {
+        Self {
+            kind: 17,
+            id: None,
+            components: Vec::new(),
+            accent_color: None,
+            spoiler: false,
+            padding: None,
+        }
+    }
+
+    /// Sets the optional component id.
+    pub fn id(mut self, id: u32) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Sets the accent color as an RGB value (0x000000 to 0xFFFFFF).
+    pub fn accent_color(mut self, color: u32) -> Self {
+        self.accent_color = Some(color);
+        self
+    }
+
+    /// Sets the padding style of the container.
+    ///
+    /// - `1` = small padding (default)
+    /// - `2` = large padding
+    pub fn padding(mut self, padding: u8) -> Self {
+        self.padding = Some(padding);
+        self
+    }
+
+    /// Sets whether the container should be a spoiler.
+    pub fn spoiler(mut self, spoiler: bool) -> Self {
+        self.spoiler = spoiler;
+        self
+    }
+
+    /// Adds an action row component to the container.
+    pub fn add_action_row(mut self, component: CreateActionRow) -> Self {
+        self.components.push(CreateContainerChild::ActionRow(component));
+        self
+    }
+
+    /// Adds a text display component to the container.
+    pub fn add_text_display(mut self, component: CreateTextDisplay) -> Self {
+        self.components.push(CreateContainerChild::TextDisplay(component));
+        self
+    }
+
+    /// Adds a section component to the container.
+    pub fn add_section(mut self, component: CreateSection) -> Self {
+        self.components.push(CreateContainerChild::Section(component));
+        self
+    }
+
+    /// Adds a media gallery component to the container.
+    pub fn add_media_gallery(mut self, component: CreateMediaGallery) -> Self {
+        self.components.push(CreateContainerChild::MediaGallery(component));
+        self
+    }
+
+    /// Adds a separator component to the container.
+    pub fn add_separator(mut self, component: CreateSeparator) -> Self {
+        self.components.push(CreateContainerChild::Separator(component));
+        self
+    }
+
+    /// Adds a file component to the container.
+    pub fn add_file(mut self, component: CreateFileComponent) -> Self {
+        self.components.push(CreateContainerChild::File(component));
+        self
+    }
+
+    /// Adds a label component to the container (for modals).
+    pub fn add_label(mut self, component: CreateLabel) -> Self {
+        self.components.push(CreateContainerChild::Label(component));
+        self
+    }
+
+    /// Adds an input text component to the container (for modals).
+    pub fn add_input_text(mut self, component: CreateInputText) -> Self {
+        self.components.push(CreateContainerChild::InputText(component));
+        self
+    }
+}
+
+impl Default for CreateContainer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A builder for creating a file component.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#file).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateFileComponent {
+    #[serde(rename = "type")]
+    kind: u8,
+    file: CreateUnfurledMediaItem,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    spoiler: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u32>,
+}
+
+impl CreateFileComponent {
+    /// Creates a new file component referencing an attachment by filename.
+    pub fn new(filename: impl Into<String>) -> Self {
+        Self {
+            kind: 13,
+            file: CreateUnfurledMediaItem {
+                url: format!("attachment://{}", filename.into()),
+            },
+            spoiler: false,
+            id: None,
+        }
+    }
+
+    /// Sets the optional component id.
+    pub fn id(mut self, id: u32) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Sets whether the file should be a spoiler.
+    pub fn spoiler(mut self, spoiler: bool) -> Self {
+        self.spoiler = spoiler;
+        self
+    }
+}
+
+/// A builder for creating a label component for modals.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#label).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateLabel {
+    #[serde(rename = "type")]
+    kind: u8,
+    label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    component: CreateLabelChild,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[serde(untagged)]
+enum CreateLabelChild {
+    InputText(CreateInputText),
+    SelectMenu(CreateSelectMenu),
+    FileUpload(CreateFileUpload),
+    RadioGroup(CreateRadioGroup),
+    CheckboxGroup(CreateCheckboxGroup),
+    Checkbox(CreateCheckbox),
+}
+
+impl CreateLabel {
+    /// Creates a new label wrapping a text input.
+    pub fn new_text_input(
+        label: impl Into<String>,
+        component: CreateInputText,
+    ) -> Self {
+        Self {
+            kind: 18,
+            label: label.into(),
+            description: None,
+            component: CreateLabelChild::InputText(component),
+            id: None,
+        }
+    }
+
+    /// Creates a new label wrapping a select menu.
+    pub fn new_select_menu(
+        label: impl Into<String>,
+        component: CreateSelectMenu,
+    ) -> Self {
+        Self {
+            kind: 18,
+            label: label.into(),
+            description: None,
+            component: CreateLabelChild::SelectMenu(component),
+            id: None,
+        }
+    }
+
+    /// Creates a new label wrapping a file upload.
+    pub fn new_file_upload(
+        label: impl Into<String>,
+        component: CreateFileUpload,
+    ) -> Self {
+        Self {
+            kind: 18,
+            label: label.into(),
+            description: None,
+            component: CreateLabelChild::FileUpload(component),
+            id: None,
+        }
+    }
+
+    /// Creates a new label wrapping a radio group.
+    pub fn new_radio_group(
+        label: impl Into<String>,
+        component: CreateRadioGroup,
+    ) -> Self {
+        Self {
+            kind: 18,
+            label: label.into(),
+            description: None,
+            component: CreateLabelChild::RadioGroup(component),
+            id: None,
+        }
+    }
+
+    /// Creates a new label wrapping a checkbox group.
+    pub fn new_checkbox_group(
+        label: impl Into<String>,
+        component: CreateCheckboxGroup,
+    ) -> Self {
+        Self {
+            kind: 18,
+            label: label.into(),
+            description: None,
+            component: CreateLabelChild::CheckboxGroup(component),
+            id: None,
+        }
+    }
+
+    /// Creates a new label wrapping a checkbox.
+    pub fn new_checkbox(
+        label: impl Into<String>,
+        component: CreateCheckbox,
+    ) -> Self {
+        Self {
+            kind: 18,
+            label: label.into(),
+            description: None,
+            component: CreateLabelChild::Checkbox(component),
+            id: None,
+        }
+    }
+
+    /// Sets the optional component id.
+    pub fn id(mut self, id: u32) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Sets the description for the label; max 100 characters.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+}
+
+/// A builder for creating a file upload component for modals.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#file-upload).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateFileUpload {
+    #[serde(rename = "type")]
+    kind: u8,
+    custom_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_values: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_values: Option<u8>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    required: bool,
+}
+
+impl CreateFileUpload {
+    /// Creates a new file upload component with the given custom id.
+    pub fn new(custom_id: impl Into<String>) -> Self {
+        Self {
+            kind: 19,
+            custom_id: custom_id.into(),
+            min_values: None,
+            max_values: None,
+            required: true,
+        }
+    }
+
+    /// Sets the minimum number of files (defaults to 1); min 0, max 10.
+    pub fn min_values(mut self, min: u8) -> Self {
+        self.min_values = Some(min);
+        self
+    }
+
+    /// Sets the maximum number of files (defaults to 1); max 10.
+    pub fn max_values(mut self, max: u8) -> Self {
+        self.max_values = Some(max);
+        self
+    }
+
+    /// Sets whether file upload is required (defaults to true).
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+}
+
+/// A builder for creating a radio group option.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateRadioGroupOption {
+    value: String,
+    label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    default: bool,
+}
+
+impl CreateRadioGroupOption {
+    /// Creates a new radio group option with the given value and label.
+    pub fn new(value: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            label: label.into(),
+            description: None,
+            default: false,
+        }
+    }
+
+    /// Sets the description for this option; max 100 characters.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Shows this option as selected by default.
+    pub fn default_selection(mut self, default: bool) -> Self {
+        self.default = default;
+        self
+    }
+}
+
+/// A builder for creating a radio group component for modals.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#radio-group).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateRadioGroup {
+    #[serde(rename = "type")]
+    kind: u8,
+    custom_id: String,
+    options: Vec<CreateRadioGroupOption>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    required: bool,
+}
+
+impl CreateRadioGroup {
+    /// Creates a new radio group with the given custom id and options.
+    pub fn new(custom_id: impl Into<String>, options: Vec<CreateRadioGroupOption>) -> Self {
+        Self {
+            kind: 21,
+            custom_id: custom_id.into(),
+            options,
+            required: true,
+        }
+    }
+
+    /// Sets whether a selection is required (defaults to true).
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+}
+
+/// A builder for creating a checkbox group option.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateCheckboxGroupOption {
+    value: String,
+    label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    default: bool,
+}
+
+impl CreateCheckboxGroupOption {
+    /// Creates a new checkbox group option with the given value and label.
+    pub fn new(value: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            label: label.into(),
+            description: None,
+            default: false,
+        }
+    }
+
+    /// Sets the description for this option; max 100 characters.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Shows this option as selected by default.
+    pub fn default_selection(mut self, default: bool) -> Self {
+        self.default = default;
+        self
+    }
+}
+
+/// A builder for creating a checkbox group component for modals.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#checkbox-group).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateCheckboxGroup {
+    #[serde(rename = "type")]
+    kind: u8,
+    custom_id: String,
+    options: Vec<CreateCheckboxGroupOption>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_values: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_values: Option<u8>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    required: bool,
+}
+
+impl CreateCheckboxGroup {
+    /// Creates a new checkbox group with the given custom id and options.
+    pub fn new(custom_id: impl Into<String>, options: Vec<CreateCheckboxGroupOption>) -> Self {
+        Self {
+            kind: 22,
+            custom_id: custom_id.into(),
+            options,
+            min_values: None,
+            max_values: None,
+            required: true,
+        }
+    }
+
+    /// Sets the minimum number of items that must be chosen (defaults to 1); min 0, max 10.
+    pub fn min_values(mut self, min: u8) -> Self {
+        self.min_values = Some(min);
+        self
+    }
+
+    /// Sets the maximum number of items that can be chosen; min 1, max 10 (defaults to the number of options).
+    pub fn max_values(mut self, max: u8) -> Self {
+        self.max_values = Some(max);
+        self
+    }
+
+    /// Sets whether selecting within the group is required (defaults to true).
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+}
+
+/// A builder for creating a checkbox component for modals.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#checkbox).
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[must_use]
+pub struct CreateCheckbox {
+    #[serde(rename = "type")]
+    kind: u8,
+    custom_id: String,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    default: bool,
+}
+
+impl CreateCheckbox {
+    /// Creates a new checkbox with the given custom id.
+    pub fn new(custom_id: impl Into<String>) -> Self {
+        Self {
+            kind: 23,
+            custom_id: custom_id.into(),
+            default: false,
+        }
+    }
+
+    /// Sets whether the checkbox is selected by default.
+    pub fn default_selection(mut self, default: bool) -> Self {
+        self.default = default;
         self
     }
 }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -5,6 +5,7 @@ use super::{
     CreateActionRow,
     CreateAllowedMentions,
     CreateAttachment,
+    CreateComponents,
     CreateEmbed,
     CreatePoll,
     EditAttachments,
@@ -66,6 +67,9 @@ pub struct CreateMessage {
     message_reference: Option<MessageReference>,
     #[serde(skip_serializing_if = "Option::is_none")]
     components: Option<Vec<CreateActionRow>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "components")]
+    components_v2: Option<Vec<CreateComponents>>,
     sticker_ids: Vec<StickerId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
@@ -220,6 +224,15 @@ impl CreateMessage {
         self
     }
     super::button_and_select_menu_convenience_methods!(self.components);
+
+    /// Sets the components v2 of this message.
+    ///
+    /// When using this, you must also set [`Self::flags`] to include
+    /// [`MessageFlags::IS_COMPONENTS_V2`].
+    pub fn components_v2(mut self, components: Vec<CreateComponents>) -> Self {
+        self.components_v2 = Some(components);
+        self
+    }
 
     /// Sets the flags for the message.
     pub fn flags(mut self, flags: MessageFlags) -> Self {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -506,6 +506,21 @@ fn update_cache_with_event(
         Event::MessagePollVoteRemove(event) => FullEvent::MessagePollVoteRemove {
             event,
         },
+        Event::VoiceChannelEffectSend(event) => FullEvent::VoiceChannelEffectSend {
+            event,
+        },
+        Event::ScheduledEventReminderCreate(event) => FullEvent::ScheduledEventReminderCreate {
+            event,
+        },
+        Event::GuildOnboardingUpdate(event) => FullEvent::GuildOnboardingUpdate {
+            event,
+        },
+        Event::GuildRoleSubscriptionPurchaseCreate(event) => FullEvent::GuildRoleSubscriptionPurchaseCreate {
+            event,
+        },
+        Event::GuildRoleSubscriptionRenewalCreate(event) => FullEvent::GuildRoleSubscriptionRenewalCreate {
+            event,
+        },
     };
 
     Some((event, extra_event))

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -498,6 +498,31 @@ event_handler! {
     /// Dispatched when a user removes a previous vote on a poll.
     MessagePollVoteRemove { event: MessagePollVoteRemoveEvent } => async fn poll_vote_remove(&self, ctx: Context);
 
+    /// Dispatched when a voice channel effect is sent.
+    ///
+    /// Provides data about the voice channel effect.
+    VoiceChannelEffectSend { event: VoiceChannelEffectSendEvent } => async fn voice_channel_effect_send(&self, ctx: Context);
+
+    /// Dispatched when a scheduled event reminder is created.
+    ///
+    /// Provides data about the scheduled event reminder.
+    ScheduledEventReminderCreate { event: ScheduledEventReminderCreateEvent } => async fn scheduled_event_reminder_create(&self, ctx: Context);
+
+    /// Dispatched when a guild's onboarding is updated.
+    ///
+    /// Provides data about the updated onboarding.
+    GuildOnboardingUpdate { event: GuildOnboardingUpdateEvent } => async fn guild_onboarding_update(&self, ctx: Context);
+
+    /// Dispatched when a guild role subscription is purchased.
+    ///
+    /// Provides data about the role subscription purchase.
+    GuildRoleSubscriptionPurchaseCreate { event: GuildRoleSubscriptionPurchaseCreateEvent } => async fn guild_role_subscription_purchase_create(&self, ctx: Context);
+
+    /// Dispatched when a guild role subscription is renewed.
+    ///
+    /// Provides data about the role subscription renewal.
+    GuildRoleSubscriptionRenewalCreate { event: GuildRoleSubscriptionRenewalCreateEvent } => async fn guild_role_subscription_renewal_create(&self, ctx: Context);
+
     /// Dispatched when an HTTP rate limit is hit
     Ratelimit { data: RatelimitInfo } => async fn ratelimit(&self);
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -5224,6 +5224,108 @@ impl Http {
         }
     }
 
+    /// Creates a DM channel with a user.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/user#create-dm).
+    pub async fn create_dm_channel(&self, user_id: UserId) -> Result<PrivateChannel> {
+        self.fire(Request {
+            body: Some(to_vec(&json!({ "recipient_id": user_id }))?.into()),
+            multipart: None,
+            headers: None,
+            method: LightMethod::Post,
+            route: Route::UserMeDmChannels,
+            params: None,
+        })
+        .await
+    }
+
+    /// Creates a bulk DM channel with multiple recipients.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/user#create-dm).
+    pub async fn create_bulk_dm(&self, recipient_ids: Vec<UserId>) -> Result<PrivateChannel> {
+        let recipient_strs: Vec<String> = recipient_ids.into_iter().map(|id| id.to_string()).collect();
+        self.fire(Request {
+            body: Some(to_vec(&json!({ "recipients": recipient_strs }))?.into()),
+            multipart: None,
+            headers: None,
+            method: LightMethod::Post,
+            route: Route::UserMeDmChannels,
+            params: None,
+        })
+        .await
+    }
+
+    /// Gets guild onboarding data.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/guild#get-guild-onboarding).
+    pub async fn get_guild_onboarding(&self, guild_id: GuildId) -> Result<GuildOnboarding> {
+        self.fire(Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Get,
+            route: Route::GuildOnboarding { guild_id },
+            params: None,
+        })
+        .await
+    }
+
+    /// Edits guild onboarding data.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/guild#modify-guild-onboarding).
+    pub async fn edit_guild_onboarding(
+        &self,
+        guild_id: GuildId,
+        map: &impl serde::Serialize,
+    ) -> Result<GuildOnboarding> {
+        self.fire(Request {
+            body: Some(to_vec(map)?.into()),
+            multipart: None,
+            headers: None,
+            method: LightMethod::Patch,
+            route: Route::GuildOnboarding { guild_id },
+            params: None,
+        })
+        .await
+    }
+
+    /// Gets application role connection metadata.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/application-role-connection-metadata#get-application-role-connection-metadata-records).
+    pub async fn get_application_role_connection_metadata(
+        &self,
+        application_id: ApplicationId,
+    ) -> Result<Vec<ApplicationRoleConnectionMetadata>> {
+        self.fire(Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Get,
+            route: Route::ApplicationRoleConnectionMetadata { application_id },
+            params: None,
+        })
+        .await
+    }
+
+    /// Updates application role connection metadata.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/resources/application-role-connection-metadata#update-application-role-connection-metadata-records).
+    pub async fn update_application_role_connection_metadata(
+        &self,
+        application_id: ApplicationId,
+        metadata: &[ApplicationRoleConnectionMetadata],
+    ) -> Result<Vec<ApplicationRoleConnectionMetadata>> {
+        self.fire(Request {
+            body: Some(to_vec(metadata)?.into()),
+            multipart: None,
+            headers: None,
+            method: LightMethod::Put,
+            route: Route::ApplicationRoleConnectionMetadata { application_id },
+            params: None,
+        })
+        .await
+    }
+
     /// Performs a request and then verifies that the response status code is equal to the expected
     /// value.
     ///

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -326,6 +326,10 @@ routes! ('a, {
     api!("/guilds/{}/scheduled-events/{}/users", guild_id, event_id),
     Some(RatelimitingKind::PathAndId(guild_id.into()));
 
+    GuildOnboarding { guild_id: GuildId },
+    api!("/guilds/{}/onboarding", guild_id),
+    Some(RatelimitingKind::PathAndId(guild_id.into()));
+
     GuildSticker { guild_id: GuildId, sticker_id: StickerId },
     api!("/guilds/{}/stickers/{}", guild_id, sticker_id),
     Some(RatelimitingKind::PathAndId(guild_id.into()));
@@ -480,6 +484,10 @@ routes! ('a, {
 
     Commands { application_id: ApplicationId },
     api!("/applications/{}/commands", application_id),
+    Some(RatelimitingKind::PathAndId(application_id.into()));
+
+    ApplicationRoleConnectionMetadata { application_id: ApplicationId },
+    api!("/applications/{}/role-connections/metadata", application_id),
     Some(RatelimitingKind::PathAndId(application_id.into()));
 
     GuildCommand { application_id: ApplicationId, guild_id: GuildId, command_id: CommandId },

--- a/src/model/application/component.rs
+++ b/src/model/application/component.rs
@@ -8,6 +8,8 @@ use crate::model::utils::{default_true, deserialize_val};
 
 enum_number! {
     /// The type of a component
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/components/reference#component-object).
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[serde(from = "u8", into = "u8")]
@@ -21,6 +23,18 @@ enum_number! {
         RoleSelect = 6,
         MentionableSelect = 7,
         ChannelSelect = 8,
+        Section = 9,
+        TextDisplay = 10,
+        Thumbnail = 11,
+        MediaGallery = 12,
+        File = 13,
+        Separator = 14,
+        Container = 17,
+        Label = 18,
+        FileUpload = 19,
+        RadioGroup = 21,
+        CheckboxGroup = 22,
+        Checkbox = 23,
         _ => Unknown(u8),
     }
 }
@@ -55,7 +69,6 @@ pub enum ActionRowComponent {
 impl<'de> Deserialize<'de> for ActionRowComponent {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
         let map = JsonMap::deserialize(deserializer)?;
-
         let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
         let value = Value::from(map);
 
@@ -69,6 +82,22 @@ impl<'de> Deserialize<'de> for ActionRowComponent {
             | ComponentType::ChannelSelect => from_value(value).map(ActionRowComponent::SelectMenu),
             ComponentType::ActionRow => {
                 return Err(DeError::custom("Invalid component type ActionRow"))
+            },
+            ComponentType::Section
+            | ComponentType::TextDisplay
+            | ComponentType::Thumbnail
+            | ComponentType::MediaGallery
+            | ComponentType::File
+            | ComponentType::Separator
+            | ComponentType::Container
+            | ComponentType::Label
+            | ComponentType::FileUpload
+            | ComponentType::RadioGroup
+            | ComponentType::CheckboxGroup
+            | ComponentType::Checkbox => {
+                return Err(DeError::custom(format_args!(
+                    "Component type not allowed in ActionRow"
+                )))
             },
             ComponentType::Unknown(i) => {
                 return Err(DeError::custom(format_args!("Unknown component type {i}")))
@@ -227,6 +256,9 @@ pub struct SelectMenu {
     /// Whether select menu is disabled.
     #[serde(default)]
     pub disabled: bool,
+    /// Whether this component is required to be filled (for modals).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
 }
 
 /// A select menu component options.
@@ -305,6 +337,644 @@ enum_number! {
         Paragraph = 2,
         _ => Unknown(u8),
     }
+}
+
+/// An unfurled media item used within components.
+///
+/// Supports both uploaded media (via `attachment://<filename>`) and externally hosted media
+/// (via direct URL).
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#unfurled-media-item).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnfurledMediaItem {
+    /// The URL of the media item. Supports arbitrary URLs and `attachment://<filename>` references.
+    pub url: String,
+}
+
+impl UnfurledMediaItem {
+    /// Creates a new unfurled media item from a URL.
+    pub fn from_url(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+        }
+    }
+}
+
+/// A section component — top-level layout component that associates content with an accessory.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#section).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Section {
+    /// The component type. Always [`ComponentType::Section`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// Child components representing the content of the section (1–3 components).
+    pub components: Vec<SectionChildComponent>,
+    /// A button or thumbnail that is contextually associated to the content.
+    pub accessory: SectionAccessoryComponent,
+}
+
+/// A child component within a [`Section`].
+///
+/// Currently only [`TextDisplay`] is supported as a section child.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum SectionChildComponent {
+    TextDisplay(TextDisplay),
+}
+
+impl<'de> Deserialize<'de> for SectionChildComponent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let map = JsonMap::deserialize(deserializer)?;
+        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
+        let value = Value::from(map);
+
+        match deserialize_val(raw_kind)? {
+            ComponentType::TextDisplay => {
+                from_value(value).map(SectionChildComponent::TextDisplay).map_err(DeError::custom)
+            },
+            other => Err(DeError::custom(format_args!(
+                "invalid section child component type: {other:?}"
+            ))),
+        }
+    }
+}
+
+impl Serialize for SectionChildComponent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        match self {
+            Self::TextDisplay(c) => c.serialize(serializer),
+        }
+    }
+}
+
+impl From<TextDisplay> for SectionChildComponent {
+    fn from(component: TextDisplay) -> Self {
+        SectionChildComponent::TextDisplay(component)
+    }
+}
+
+/// An accessory component within a [`Section`].
+///
+/// Currently only [`Button`] and [`Thumbnail`] are supported.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum SectionAccessoryComponent {
+    Button(Button),
+    Thumbnail(Thumbnail),
+}
+
+impl<'de> Deserialize<'de> for SectionAccessoryComponent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let map = JsonMap::deserialize(deserializer)?;
+        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
+        let value = Value::from(map);
+
+        match deserialize_val(raw_kind)? {
+            ComponentType::Button => {
+                from_value(value).map(SectionAccessoryComponent::Button).map_err(DeError::custom)
+            },
+            ComponentType::Thumbnail => {
+                from_value(value).map(SectionAccessoryComponent::Thumbnail).map_err(DeError::custom)
+            },
+            other => Err(DeError::custom(format_args!(
+                "invalid section accessory component type: {other:?}"
+            ))),
+        }
+    }
+}
+
+impl Serialize for SectionAccessoryComponent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        match self {
+            Self::Button(c) => c.serialize(serializer),
+            Self::Thumbnail(c) => c.serialize(serializer),
+        }
+    }
+}
+
+impl From<Button> for SectionAccessoryComponent {
+    fn from(component: Button) -> Self {
+        SectionAccessoryComponent::Button(component)
+    }
+}
+
+impl From<Thumbnail> for SectionAccessoryComponent {
+    fn from(component: Thumbnail) -> Self {
+        SectionAccessoryComponent::Thumbnail(component)
+    }
+}
+
+/// A text display component — displays markdown formatted text.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#text-display).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TextDisplay {
+    /// The component type. Always [`ComponentType::TextDisplay`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// The text content, formatted with Discord's markdown.
+    pub content: String,
+}
+
+/// A thumbnail component — displays a small image as an accessory.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#thumbnail).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Thumbnail {
+    /// The component type. Always [`ComponentType::Thumbnail`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// The media item (URL or attachment reference).
+    pub media: UnfurledMediaItem,
+    /// Alt text for the media, max 1024 characters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Whether the thumbnail should be a spoiler (blurred out). Defaults to false.
+    #[serde(default)]
+    pub spoiler: bool,
+}
+
+/// A media gallery item used within a [`MediaGallery`].
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#media-gallery-item-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MediaGalleryItem {
+    /// The media item (URL or attachment reference).
+    pub media: UnfurledMediaItem,
+    /// Alt text for the media, max 1024 characters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Whether the media should be a spoiler (blurred out). Defaults to false.
+    #[serde(default)]
+    pub spoiler: bool,
+}
+
+/// A media gallery component — displays 1–10 media attachments.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#media-gallery).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MediaGallery {
+    /// The component type. Always [`ComponentType::MediaGallery`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// 1 to 10 media gallery items.
+    pub items: Vec<MediaGalleryItem>,
+}
+
+/// A file component — displays an uploaded file as an attachment.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#file).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct FileComponent {
+    /// The component type. Always [`ComponentType::File`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// The file to display, only supports `attachment://<filename>` references.
+    pub file: UnfurledMediaItem,
+    /// Whether the file should be a spoiler (blurred out). Defaults to false.
+    #[serde(default)]
+    pub spoiler: bool,
+}
+
+/// A separator component — adds vertical padding between components.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#separator).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Separator {
+    /// The component type. Always [`ComponentType::Separator`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// Whether a visual divider should be displayed. Defaults to true.
+    #[serde(default = "default_true")]
+    pub divider: bool,
+    /// Size of separator padding: 1 for small, 2 for large. Defaults to 1.
+    #[serde(default)]
+    pub spacing: SeparatorSpacing,
+}
+
+enum_number! {
+    /// The spacing size of a separator.
+    ///
+    /// [Discord docs](https://discord.com/developers/docs/components/reference#separator-separator-structure).
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum SeparatorSpacing {
+        Small = 1,
+        Large = 2,
+        _ => Unknown(u8),
+    }
+}
+
+impl Default for SeparatorSpacing {
+    fn default() -> Self {
+        Self::Small
+    }
+}
+
+/// A container component — visually groups a set of components.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#container).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Container {
+    /// The component type. Always [`ComponentType::Container`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// Child components encapsulated within the Container.
+    pub components: Vec<ContainerChildComponent>,
+    /// Color for the accent on the container as RGB from 0x000000 to 0xFFFFFF.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accent_color: Option<u32>,
+    /// Whether the container should be a spoiler (blurred out). Defaults to false.
+    #[serde(default)]
+    pub spoiler: bool,
+}
+
+/// A child component within a [`Container`].
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum ContainerChildComponent {
+    ActionRow(ActionRow),
+    TextDisplay(TextDisplay),
+    Section(Section),
+    MediaGallery(MediaGallery),
+    Separator(Separator),
+    File(FileComponent),
+}
+
+impl<'de> Deserialize<'de> for ContainerChildComponent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let map = JsonMap::deserialize(deserializer)?;
+        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
+        let value = Value::from(map);
+
+        match deserialize_val(raw_kind)? {
+            ComponentType::ActionRow => {
+                from_value(value).map(ContainerChildComponent::ActionRow).map_err(DeError::custom)
+            },
+            ComponentType::TextDisplay => {
+                from_value(value).map(ContainerChildComponent::TextDisplay).map_err(DeError::custom)
+            },
+            ComponentType::Section => {
+                from_value(value).map(ContainerChildComponent::Section).map_err(DeError::custom)
+            },
+            ComponentType::MediaGallery => {
+                from_value(value).map(ContainerChildComponent::MediaGallery).map_err(DeError::custom)
+            },
+            ComponentType::Separator => {
+                from_value(value).map(ContainerChildComponent::Separator).map_err(DeError::custom)
+            },
+            ComponentType::File => {
+                from_value(value).map(ContainerChildComponent::File).map_err(DeError::custom)
+            },
+            other => Err(DeError::custom(format_args!(
+                "invalid container child component type: {other:?}"
+            ))),
+        }
+    }
+}
+
+impl Serialize for ContainerChildComponent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        match self {
+            Self::ActionRow(c) => c.serialize(serializer),
+            Self::TextDisplay(c) => c.serialize(serializer),
+            Self::Section(c) => c.serialize(serializer),
+            Self::MediaGallery(c) => c.serialize(serializer),
+            Self::Separator(c) => c.serialize(serializer),
+            Self::File(c) => c.serialize(serializer),
+        }
+    }
+}
+
+impl From<ActionRow> for ContainerChildComponent {
+    fn from(component: ActionRow) -> Self {
+        ContainerChildComponent::ActionRow(component)
+    }
+}
+
+impl From<TextDisplay> for ContainerChildComponent {
+    fn from(component: TextDisplay) -> Self {
+        ContainerChildComponent::TextDisplay(component)
+    }
+}
+
+impl From<Section> for ContainerChildComponent {
+    fn from(component: Section) -> Self {
+        ContainerChildComponent::Section(component)
+    }
+}
+
+impl From<MediaGallery> for ContainerChildComponent {
+    fn from(component: MediaGallery) -> Self {
+        ContainerChildComponent::MediaGallery(component)
+    }
+}
+
+impl From<Separator> for ContainerChildComponent {
+    fn from(component: Separator) -> Self {
+        ContainerChildComponent::Separator(component)
+    }
+}
+
+impl From<FileComponent> for ContainerChildComponent {
+    fn from(component: FileComponent) -> Self {
+        ContainerChildComponent::File(component)
+    }
+}
+
+/// A label component — wraps modal components with a label and optional description.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#label).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct Label {
+    /// The component type. Always [`ComponentType::Label`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// The label text; max 45 characters.
+    pub label: String,
+    /// An optional description text for the label; max 100 characters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The component within the label.
+    pub component: LabelChildComponent,
+}
+
+/// A child component within a [`Label`].
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum LabelChildComponent {
+    InputText(InputText),
+    SelectMenu(SelectMenu),
+    FileUpload(FileUpload),
+    RadioGroup(RadioGroup),
+    CheckboxGroup(CheckboxGroup),
+    Checkbox(Checkbox),
+}
+
+impl<'de> Deserialize<'de> for LabelChildComponent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let map = JsonMap::deserialize(deserializer)?;
+        let raw_kind = map.get("type").ok_or_else(|| DeError::missing_field("type"))?.clone();
+        let value = Value::from(map);
+
+        match deserialize_val(raw_kind)? {
+            ComponentType::InputText => {
+                from_value(value).map(LabelChildComponent::InputText).map_err(DeError::custom)
+            },
+            ComponentType::StringSelect
+            | ComponentType::UserSelect
+            | ComponentType::RoleSelect
+            | ComponentType::MentionableSelect
+            | ComponentType::ChannelSelect => {
+                from_value(value).map(LabelChildComponent::SelectMenu).map_err(DeError::custom)
+            },
+            ComponentType::FileUpload => {
+                from_value(value).map(LabelChildComponent::FileUpload).map_err(DeError::custom)
+            },
+            ComponentType::RadioGroup => {
+                from_value(value).map(LabelChildComponent::RadioGroup).map_err(DeError::custom)
+            },
+            ComponentType::CheckboxGroup => {
+                from_value(value).map(LabelChildComponent::CheckboxGroup).map_err(DeError::custom)
+            },
+            ComponentType::Checkbox => {
+                from_value(value).map(LabelChildComponent::Checkbox).map_err(DeError::custom)
+            },
+            other => Err(DeError::custom(format_args!(
+                "invalid label child component type: {other:?}"
+            ))),
+        }
+    }
+}
+
+impl Serialize for LabelChildComponent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        match self {
+            Self::InputText(c) => c.serialize(serializer),
+            Self::SelectMenu(c) => c.serialize(serializer),
+            Self::FileUpload(c) => c.serialize(serializer),
+            Self::RadioGroup(c) => c.serialize(serializer),
+            Self::CheckboxGroup(c) => c.serialize(serializer),
+            Self::Checkbox(c) => c.serialize(serializer),
+        }
+    }
+}
+
+impl From<InputText> for LabelChildComponent {
+    fn from(component: InputText) -> Self {
+        LabelChildComponent::InputText(component)
+    }
+}
+
+impl From<SelectMenu> for LabelChildComponent {
+    fn from(component: SelectMenu) -> Self {
+        LabelChildComponent::SelectMenu(component)
+    }
+}
+
+impl From<FileUpload> for LabelChildComponent {
+    fn from(component: FileUpload) -> Self {
+        LabelChildComponent::FileUpload(component)
+    }
+}
+
+impl From<RadioGroup> for LabelChildComponent {
+    fn from(component: RadioGroup) -> Self {
+        LabelChildComponent::RadioGroup(component)
+    }
+}
+
+impl From<CheckboxGroup> for LabelChildComponent {
+    fn from(component: CheckboxGroup) -> Self {
+        LabelChildComponent::CheckboxGroup(component)
+    }
+}
+
+impl From<Checkbox> for LabelChildComponent {
+    fn from(component: Checkbox) -> Self {
+        LabelChildComponent::Checkbox(component)
+    }
+}
+
+/// A file upload component — allows users to upload files in modals.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#file-upload).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct FileUpload {
+    /// The component type. Always [`ComponentType::FileUpload`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// Developer-defined identifier for the input; 1-100 characters.
+    pub custom_id: String,
+    /// Minimum number of items that must be uploaded (defaults to 1); min 0, max 10.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_values: Option<u8>,
+    /// Maximum number of items that can be uploaded (defaults to 1); max 10.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_values: Option<u8>,
+    /// Whether file upload is required (defaults to true).
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+/// A radio group option.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#radio-group-radio-group-option-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RadioGroupOption {
+    /// Dev-defined value of the option; max 100 characters.
+    pub value: String,
+    /// User-facing label of the option; max 100 characters.
+    pub label: String,
+    /// Optional description for the option; max 100 characters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Shows the option as selected by default.
+    #[serde(default)]
+    pub default: bool,
+}
+
+/// A radio group component — single-choice set of options.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#radio-group).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RadioGroup {
+    /// The component type. Always [`ComponentType::RadioGroup`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// Developer-defined identifier for the input; 1-100 characters.
+    pub custom_id: String,
+    /// List of options to show; min 2, max 10.
+    pub options: Vec<RadioGroupOption>,
+    /// Whether a selection is required (defaults to true).
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+/// A checkbox group option.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#checkbox-group-checkbox-group-option-structure).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CheckboxGroupOption {
+    /// Dev-defined value of the option; max 100 characters.
+    pub value: String,
+    /// User-facing label of the option; max 100 characters.
+    pub label: String,
+    /// Optional description for the option; max 100 characters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Shows the option as selected by default.
+    #[serde(default)]
+    pub default: bool,
+}
+
+/// A checkbox group component — multi-selectable group of checkboxes.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#checkbox-group).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CheckboxGroup {
+    /// The component type. Always [`ComponentType::CheckboxGroup`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// Developer-defined identifier for the input; 1-100 characters.
+    pub custom_id: String,
+    /// List of options to show; min 1, max 10.
+    pub options: Vec<CheckboxGroupOption>,
+    /// Minimum number of items that must be chosen (defaults to 1); min 0, max 10.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_values: Option<u8>,
+    /// Maximum number of items that can be chosen; min 1, max 10 (defaults to the number of options).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_values: Option<u8>,
+    /// Whether selecting within the group is required (defaults to true).
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+/// A checkbox component — single checkbox for yes/no choice.
+///
+/// [Discord docs](https://discord.com/developers/docs/components/reference#checkbox).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Checkbox {
+    /// The component type. Always [`ComponentType::Checkbox`].
+    #[serde(rename = "type")]
+    pub kind: ComponentType,
+    /// Optional identifier for the component.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u32>,
+    /// Developer-defined identifier for the input; 1-100 characters.
+    pub custom_id: String,
+    /// Whether the checkbox is selected by default.
+    #[serde(default)]
+    pub default: bool,
 }
 
 #[cfg(test)]

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -1,5 +1,5 @@
 use serde::de::Error as DeError;
-use serde::ser::{Serialize, SerializeMap as _};
+use serde::ser::Serialize;
 
 #[cfg(feature = "model")]
 use crate::builder::{
@@ -259,6 +259,16 @@ pub enum ComponentInteractionDataKind {
     RoleSelect { values: Vec<RoleId> },
     MentionableSelect { values: Vec<GenericId> },
     ChannelSelect { values: Vec<ChannelId> },
+    /// A modal text input submission.
+    TextDisplay,
+    /// A radio group selection.
+    RadioGroup { value: Option<String> },
+    /// A checkbox group selection.
+    CheckboxGroup { values: Vec<String> },
+    /// A checkbox toggle.
+    Checkbox { value: bool },
+    /// A file upload submission.
+    FileUpload { values: Vec<AttachmentId> },
     Unknown(u8),
 }
 
@@ -297,7 +307,34 @@ impl<'de> Deserialize<'de> for ComponentInteractionDataKind {
                 values: parse_values!(),
             },
             ComponentType::Unknown(x) => Self::Unknown(x),
-            x @ (ComponentType::ActionRow | ComponentType::InputText) => {
+            ComponentType::TextDisplay => Self::TextDisplay,
+            ComponentType::RadioGroup => Self::RadioGroup {
+                value: json.values.map(|v| {
+                    v.as_str().map(String::from).unwrap_or_default()
+                }),
+            },
+            ComponentType::CheckboxGroup => Self::CheckboxGroup {
+                values: parse_values!(),
+            },
+            ComponentType::Checkbox => Self::Checkbox {
+                value: json.values
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            },
+            ComponentType::FileUpload => Self::FileUpload {
+                values: parse_values!(),
+            },
+            x @ (
+                ComponentType::ActionRow
+                | ComponentType::InputText
+                | ComponentType::Section
+                | ComponentType::Thumbnail
+                | ComponentType::MediaGallery
+                | ComponentType::File
+                | ComponentType::Separator
+                | ComponentType::Container
+                | ComponentType::Label
+            ) => {
                 return Err(D::Error::custom(format_args!(
                     "invalid message component type in this context: {x:?}",
                 )));
@@ -309,6 +346,7 @@ impl<'de> Deserialize<'de> for ComponentInteractionDataKind {
 impl Serialize for ComponentInteractionDataKind {
     #[rustfmt::skip] // Remove this for horror.
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
+        use serde::ser::SerializeMap as _;
         let mut map = serializer.serialize_map(Some(2))?;
         map.serialize_entry("component_type", &match self {
             Self::Button { .. } => 2,
@@ -317,6 +355,11 @@ impl Serialize for ComponentInteractionDataKind {
             Self::RoleSelect { .. } => 6,
             Self::MentionableSelect { .. } => 7,
             Self::ChannelSelect { .. } => 8,
+            Self::TextDisplay => 10,
+            Self::RadioGroup { .. } => 21,
+            Self::CheckboxGroup { .. } => 22,
+            Self::Checkbox { .. } => 23,
+            Self::FileUpload { .. } => 19,
             Self::Unknown(x) => *x,
         })?;
 
@@ -326,7 +369,13 @@ impl Serialize for ComponentInteractionDataKind {
             Self::RoleSelect { values } => map.serialize_entry("values", values)?,
             Self::MentionableSelect { values } => map.serialize_entry("values", values)?,
             Self::ChannelSelect { values } => map.serialize_entry("values", values)?,
-            Self::Button | Self::Unknown(_) => map.serialize_entry("values", &None::<()>)?,
+            Self::RadioGroup { value } => map.serialize_entry("value", value)?,
+            Self::CheckboxGroup { values } => map.serialize_entry("values", values)?,
+            Self::Checkbox { value } => map.serialize_entry("value", value)?,
+            Self::FileUpload { values } => map.serialize_entry("values", values)?,
+            Self::Button | Self::TextDisplay | Self::Unknown(_) => {
+                map.serialize_entry("values", &None::<()>)?
+            },
         }
 
         map.end()

--- a/src/model/application/mod.rs
+++ b/src/model/application/mod.rs
@@ -280,6 +280,40 @@ pub struct InstallParams {
     pub permissions: Permissions,
 }
 
+/// Application role connection metadata record.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/application-role-connection-metadata#application-role-connection-metadata-object).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ApplicationRoleConnectionMetadata {
+    #[serde(rename = "type")]
+    pub kind: ApplicationRoleConnectionMetadataType,
+    pub key: String,
+    pub name: String,
+    #[serde(default)]
+    pub name_localizations: Option<HashMap<String, String>>,
+    pub description: String,
+    #[serde(default)]
+    pub description_localizations: Option<HashMap<String, String>>,
+}
+
+/// The type of application role connection metadata value.
+///
+/// [Discord docs](https://discord.com/developers/docs/resources/application-role-connection-metadata#application-role-connection-metadata-object-metadata-types).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, Hash, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ApplicationRoleConnectionMetadataType {
+    IntegerLessThanOrEqual,
+    IntegerGreaterThanOrEqual,
+    IntegerEqual,
+    IntegerNotEqual,
+    StringEqual,
+    StringNotEqual,
+    StringContains,
+    StringNotContains,
+}
+
 #[cfg(test)]
 mod team_role_ordering {
     use super::TeamMemberRole;

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -1275,6 +1275,19 @@ bitflags! {
         /// As of 2023-04-20, bots are currently not able to send voice messages
         /// ([source](https://github.com/discord/discord-api-docs/pull/6082)).
         const IS_VOICE_MESSAGE = 1 << 13;
+        /// This message uses the components v2 API.
+        ///
+        /// Once a message has been sent with this flag, it cannot be removed from that message.
+        /// This enables the new components system with the following changes:
+        /// - The `content` and `embeds` fields will no longer work but you'll be able to use
+        ///   [`TextDisplay`] and [`Container`] as replacements.
+        /// - Attachments won't show by default - they must be exposed through components.
+        /// - The poll and stickers fields are disabled.
+        /// - Messages allow up to 40 total components.
+        ///
+        /// [`TextDisplay`]: crate::model::application::component::TextDisplay
+        /// [`Container`]: crate::model::application::component::Container
+        const IS_COMPONENTS_V2 = 1 << 15;
     }
 }
 

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -253,6 +253,8 @@ enum_number! {
         Directory = 14,
         /// An indicator that the channel is a forum [`GuildChannel`].
         Forum = 15,
+        /// An indicator that the channel is a guild media [`GuildChannel`].
+        GuildMedia = 16,
         _ => Unknown(u8),
     } // Make sure to update [`GuildChannel::is_text_based`].
 }
@@ -274,6 +276,7 @@ impl ChannelType {
             Self::Stage => "stage",
             Self::Directory => "directory",
             Self::Forum => "forum",
+            Self::GuildMedia => "guild_media",
             Self::Unknown(_) => "unknown",
         }
     }

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -312,6 +312,85 @@ impl Serialize for GuildMembersChunkEvent {
 }
 
 /// Requires no gateway intents.
+/// A scheduled event reminder was created.
+///
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#scheduled-event-reminder).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct ScheduledEventReminderCreateEvent {
+    pub scheduled_event: ScheduledEvent,
+}
+
+/// A guild's onboarding was updated.
+///
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-onboarding-update).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+#[non_exhaustive]
+pub struct GuildOnboardingUpdateEvent {
+    pub onboarding: GuildOnboarding,
+}
+
+/// A guild role subscription was purchased.
+///
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-role-subscription-purchase).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct GuildRoleSubscriptionPurchaseCreateEvent {
+    pub guild_id: GuildId,
+    pub user_id: UserId,
+    pub role_subscription_listing_id: SkuId,
+    pub is_renewal: bool,
+}
+
+/// A guild role subscription was renewed.
+///
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-role-subscription-renewal).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct GuildRoleSubscriptionRenewalCreateEvent {
+    pub guild_id: GuildId,
+    pub user_id: UserId,
+    pub role_subscription_listing_id: SkuId,
+    pub is_renewal: bool,
+}
+
+/// A voice channel effect was sent.
+///
+/// [Discord docs](https://docs.discord.com/developers/events/gateway-events#voice-channel-effect-send).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct VoiceChannelEffectSendEvent {
+    pub channel_id: ChannelId,
+    pub guild_id: Option<GuildId>,
+    pub user_id: UserId,
+    pub emoji: Emoji,
+    pub animation_type: Option<VoiceChannelEffectAnimationType>,
+    pub animation_duration: Option<u32>,
+    pub emoji_id: Option<EmojiId>,
+    pub animated: Option<bool>,
+}
+
+enum_number! {
+    /// The type of animation for a voice channel effect.
+    ///
+    /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#voice-channel-effect-animation-types).
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum VoiceChannelEffectAnimationType {
+        Fun = 0,
+        Joy = 1,
+        _ => Unknown(u8),
+    }
+}
+
 ///
 /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#soundboard-sounds).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -1366,6 +1445,21 @@ pub enum Event {
     TypingStart(TypingStartEvent),
     /// Update to the logged-in user's information
     UserUpdate(UserUpdateEvent),
+    /// A scheduled event reminder was sent.
+    #[serde(rename = "SCHEDULED_EVENT_REMINDER_CREATE")]
+    ScheduledEventReminderCreate(ScheduledEventReminderCreateEvent),
+    /// A guild's onboarding was updated.
+    #[serde(rename = "GUILD_ONBOARDING_UPDATE")]
+    GuildOnboardingUpdate(GuildOnboardingUpdateEvent),
+    /// A guild role was purchased.
+    #[serde(rename = "GUILD_ROLE_SUBSCRIPTION_PURCHASE_CREATE")]
+    GuildRoleSubscriptionPurchaseCreate(GuildRoleSubscriptionPurchaseCreateEvent),
+    /// A guild role subscription was renewed.
+    #[serde(rename = "GUILD_ROLE_SUBSCRIPTION_RENEWAL_CREATE")]
+    GuildRoleSubscriptionRenewalCreate(GuildRoleSubscriptionRenewalCreateEvent),
+    /// A voice channel effect was sent.
+    #[serde(rename = "VOICE_CHANNEL_EFFECT_SEND")]
+    VoiceChannelEffectSend(VoiceChannelEffectSendEvent),
     /// A member's voice state has changed
     VoiceStateUpdate(VoiceStateUpdateEvent),
     /// Voice server information is available

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -2840,6 +2840,76 @@ pub struct UnavailableGuild {
     pub unavailable: bool,
 }
 
+/// A guild's onboarding configuration.
+///
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-onboarding-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct GuildOnboarding {
+    pub guild_id: GuildId,
+    pub prompts: Vec<OnboardingPrompt>,
+    pub default_channel_ids: Vec<ChannelId>,
+    pub enabled: bool,
+    pub mode: GuildOnboardingMode,
+}
+
+/// An onboarding prompt.
+///
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#onboarding-prompt-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct OnboardingPrompt {
+    pub id: OnboardingPromptId,
+    pub options: Vec<OnboardingOption>,
+    pub title: String,
+    #[serde(default)]
+    pub single_select: bool,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub in_onboarding: bool,
+}
+
+/// An onboarding prompt option.
+///
+/// [Discord docs](https://docs.discord.com/developers/resources/guild#onboarding-prompt-option-object).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct OnboardingOption {
+    pub id: OnboardingOptionId,
+    pub emoji: Option<ReactionType>,
+    pub title: String,
+    pub channel_ids: Vec<ChannelId>,
+    #[serde(default)]
+    pub role_ids: Vec<RoleId>,
+    #[serde(default)]
+    pub default: bool,
+    #[serde(default)]
+    pub link: bool,
+    #[serde(default)]
+    pub role_ids_required: bool,
+    #[serde(default)]
+    pub values: Vec<String>,
+}
+
+enum_number! {
+    /// The mode of guild onboarding.
+    ///
+    /// [Discord docs](https://docs.discord.com/developers/resources/guild#guild-onboarding-mode).
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+    #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+    #[serde(from = "u8", into = "u8")]
+    #[non_exhaustive]
+    pub enum GuildOnboardingMode {
+        OnboardingDefault = 0,
+        OnboardingPreOnboarding = 1,
+        _ => Unknown(u8),
+    }
+}
+
 enum_number! {
     /// Default message notification level for a guild.
     ///

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -213,6 +213,8 @@ id_u64! {
     RuleId: "An identifier for an auto moderation rule";
     ForumTagId: "An identifier for a forum tag.";
     EntitlementId: "An identifier for an entitlement.";
+    OnboardingPromptId: "An identifier for an onboarding prompt.";
+    OnboardingOptionId: "An identifier for an onboarding option.";
 }
 
 /// An identifier for a Shard.


### PR DESCRIPTION
## Summary

Adds full Component V2 builder support plus missing Discord API models, events, and HTTP methods.

### Component V2
- `CreateComponents` enum with 13 top-level variants (ActionRow, Container, Section, MediaGallery, Separator, TextDisplay, File, Label, InputText, FileUpload, RadioGroup, CheckboxGroup, Checkbox)
- `CreateContainer`: accent_color, spoiler, padding, children (label/input_text for modals)
- `CreateSection` with multi-text support and accessories (Button/Thumbnail)
- `CreateThumbnail`, `CreateTextDisplay`, `CreateMediaGallery`, `CreateSeparator`
- `CreateLabel` wrapping InputText/SelectMenu/FileUpload/RadioGroup/CheckboxGroup/Checkbox
- New component types: `CreateFileUpload`, `CreateRadioGroup`, `CreateRadioGroupOption`, `CreateCheckboxGroup`, `CreateCheckboxGroupOption`, `CreateCheckbox`
- `SelectMenu::required` field for modals
- `CreateMessage::components_v2` method with `#[serde(rename = "components")]`

### Models
- `GuildOnboarding`, `OnboardingPrompt`, `OnboardingOption`, `GuildOnboardingMode`
- `VoiceChannelEffectSendEvent`, `VoiceChannelEffectAnimationType`
- `ApplicationRoleConnectionMetadata`, `ApplicationRoleConnectionMetadataType`
- `ChannelType::GuildMedia = 16`
- `OnboardingPromptId`, `OnboardingOptionId`

### Events
- `ScheduledEventReminderCreate`
- `GuildOnboardingUpdate`
- `GuildRoleSubscriptionPurchaseCreate`
- `GuildRoleSubscriptionRenewalCreate`
- `VoiceChannelEffectSend`

### HTTP Methods
- `create_dm_channel`, `create_bulk_dm`
- `get_guild_onboarding`, `edit_guild_onboarding`
- `get_application_role_connection_metadata`, `update_application_role_connection_metadata`

### Other
- Routing entries for GuildOnboarding and ApplicationRoleConnectionMetadata
- `EventHandler` variants for all 5 new events
- Example `e20_components_v2` demonstrating all Component V2 features