### PR TITLE
Update channel models and flags

### DIFF
--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -51,6 +51,8 @@ pub struct CreateChannel<'a> {
     default_forum_layout: Option<ForumLayoutType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_thread_rate_limit_per_user: Option<NonMaxU16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<ChannelFlags>,
 
     #[serde(skip)]
     audit_log_reason: Option<&'a str>,
@@ -80,6 +82,7 @@ impl<'a> CreateChannel<'a> {
             default_sort_order: None,
             default_forum_layout: None,
             default_thread_rate_limit_per_user: None,
+            flags: None,
         }
     }
 
@@ -272,6 +275,14 @@ impl<'a> CreateChannel<'a> {
         default_thread_rate_limit_per_user: NonMaxU16,
     ) -> Self {
         self.default_thread_rate_limit_per_user = Some(default_thread_rate_limit_per_user);
+        self
+    }
+
+    /// Channel flags combined as a bitfield. Currently only [`ChannelFlags::REQUIRE_TAG`]
+    /// (forum only) and [`ChannelFlags::IS_SPOILER_CHANNEL`] (text-based and voice only) are
+    /// supported.
+    pub fn flags(mut self, flags: ChannelFlags) -> Self {
+        self.flags = Some(flags);
         self
     }
 

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -270,7 +270,8 @@ impl<'a> EditChannel<'a> {
         self
     }
 
-    /// Channel flags combined as a bitfield. Currently only [`ChannelFlags::REQUIRE_TAG`] is
+    /// Channel flags combined as a bitfield. Currently only [`ChannelFlags::REQUIRE_TAG`]
+    /// (forum only) and [`ChannelFlags::IS_SPOILER_CHANNEL`] (text-based and voice only) are
     /// supported.
     pub fn flags(mut self, flags: ChannelFlags) -> Self {
         self.flags = Some(flags);

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -104,10 +104,6 @@ pub struct GuildChannel {
     /// Default duration for newly created threads, in minutes, to automatically archive the thread
     /// after recent activity.
     pub default_auto_archive_duration: Option<AutoArchiveDuration>,
-    /// Computed permissions for the invoking user in the channel, including overwrites.
-    ///
-    /// Only included inside [`CommandDataResolved`].
-    pub permissions: Option<Permissions>,
     /// Extra information about the channel
     ///
     /// **Note**: This is only available in forum channels.

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -104,9 +104,7 @@ pub struct GuildChannel {
     /// Default duration for newly created threads, in minutes, to automatically archive the thread
     /// after recent activity.
     pub default_auto_archive_duration: Option<AutoArchiveDuration>,
-    /// Extra information about the channel
-    ///
-    /// **Note**: This is only available in forum channels.
+    /// Extra information about the channel.
     #[serde(default)]
     pub flags: ChannelFlags,
     /// The set of available tags.

--- a/src/model/channel/interaction_channel.rs
+++ b/src/model/channel/interaction_channel.rs
@@ -1,3 +1,5 @@
+use nonmax::NonMaxU16;
+
 use crate::model::prelude::*;
 
 /// Represents the shared fields between a [`InteractionChannel`] and a [`InteractionGuildThread`].
@@ -5,13 +7,35 @@ use crate::model::prelude::*;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct BaseInteractionChannel {
-    /// The channel name.
-    pub name: Option<FixedString>,
     /// The channel type.
     #[serde(rename = "type")]
     pub kind: ChannelType,
-    /// The channel permissions.
+    /// The Id of the guild the channel is located in.
+    #[serde(default)]
+    pub guild_id: GuildId,
+    /// The channel name.
+    pub name: Option<FixedString>,
+    /// The Id of the last message sent in the channel (or thread for forum channels).
+    ///
+    /// **Note:** May not point to an existing or valid message or thread.
+    pub last_message_id: Option<MessageId>,
+    /// Amount of seconds a user has to wait before sending another message.
+    ///
+    /// Bots, as well as users with the [`BYPASS_SLOWMODE`] permission, are unaffected.
+    ///
+    /// [`BYPASS_SLOWMODE`]: Permissions::BYPASS_SLOWMODE
+    #[doc(alias = "slowmode")]
+    #[serde(default)]
+    pub rate_limit_per_user: Option<NonMaxU16>,
+    /// The timestamp of the time the last pinned message was pinned.
+    pub last_pin_timestamp: Option<Timestamp>,
+    /// Computed permissions for the invoking user in the channel, including overwrites.
     pub permissions: Option<Permissions>,
+    /// Computed permissions for the bot user in the channel, including overwrites.
+    pub app_permissions: Option<Permissions>,
+    /// Extra information about the channel.
+    #[serde(default)]
+    pub flags: ChannelFlags,
 }
 
 /// Represents a partial channel from an interaction.
@@ -27,6 +51,20 @@ pub struct InteractionChannel {
     pub base: BaseInteractionChannel,
     /// The channel Id.
     pub id: ChannelId,
+    /// Sorting position of the channel. Channels with the same position are sorted by Id.
+    ///
+    /// The default text channel will _almost always_ have a position of `0`.
+    #[serde(default)]
+    pub position: u16,
+    /// The topic of the channel.
+    pub topic: Option<FixedString<u16>>,
+    /// Whether the channel is age-restricted.
+    #[serde(default)]
+    pub nsfw: bool,
+    /// The Id of the parent category.
+    ///
+    /// **Note**: This is only available for channels in a category.
+    pub parent_id: Option<ChannelId>,
 }
 
 /// Represents a partial thread from an interaction.
@@ -42,12 +80,12 @@ pub struct InteractionGuildThread {
     pub base: BaseInteractionChannel,
     /// The thread Id.
     pub id: ThreadId,
+    /// The Id of the parent text channel.
+    pub parent_id: ChannelId,
     /// The thread metadata.
     ///
     /// **Note**: This is only available on thread channels.
     pub thread_metadata: ThreadMetadata,
-    /// The parent text channel.
-    pub parent_id: ChannelId,
 }
 
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -578,12 +578,15 @@ bitflags! {
     /// [Discord docs](https://docs.discord.com/developers/resources/channel#channel-object-channel-flags).
     #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
     #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
-    pub struct ChannelFlags: u8 {
-        /// This thread is pinned to the top of its parent GUILD_FORUM channel
+    pub struct ChannelFlags: u32 {
+        /// This thread is pinned to the top of its parent `GUILD_FORUM` channel.
         const PINNED = 1 << 1;
-        /// Whether a tag is required to be specified when creating a
-        /// thread in a GUILD_FORUM channel. Tags are specified in the applied_tags field.
+        /// Whether a tag is required to be specified when creating a thread in a `GUILD_FORUM`
+        /// channel. Tags are specified in the `applied_tags` field.
         const REQUIRE_TAG = 1 << 4;
+        /// Whether the channel is a spoiler channel. Can be set on text-based guild channels and
+        /// voice channels. Cannot be set if `nsfw` is true.
+        const IS_SPOILER_CHANNEL = 1 << 21;
     }
 }
 


### PR DESCRIPTION
~~Opening as draft pending merge of discord-api-docs [#8443](https://github.com/discord/discord-api-docs/pull/8443) and [#8465](https://github.com/discord/discord-api-docs/pull/8465).~~

This PR primarily updates `BaseInteractionChannel` and `InteractionChannel` models:
- Adds `app_permissions` ([#8443](https://github.com/discord/discord-api-docs/pull/8443))
- Adds `last_message_id`, `last_pin_timestamp`, `nsfw`, `parent_id`, `guild_id`, `flags`, `rate_limit_per_user`, `topic`, and `position` (documented in [#7836](https://github.com/discord/discord-api-docs/pull/7836))

It also:
- Removes `permissions` from `GuildChannel` since the field is only available for `InteractionChannel`
- Adds the `IS_SPOILER_CHANNEL` flag ([#8465](https://github.com/discord/discord-api-docs/pull/8465))
- Adds `flags` field and method to `CreateChannel` builder

It does not:
- Update `GuildId::reorder_channels`. This currently only takes a channel id and position, and does not support the `lock_permissions`, `parent_id`, or `flags` params. Do we want to add support for [all params](https://docs.discord.com/developers/resources/guild#modify-guild-channel-positions-json-params)? If so, do we want to just extend the tuple to avoid a new `builder` dependency in `http`?

All fields deserialize successfully, and setting `IS_SPOILER_CHANNEL` confirmed working via both `CreateChannel` and `EditChannel`.